### PR TITLE
feat: powershelf(maintenance) - power state machine restructure and power cycle operation on power shelf

### DIFF
--- a/crates/admin-cli/src/power_shelf/maintenance/args.rs
+++ b/crates/admin-cli/src/power_shelf/maintenance/args.rs
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::power_shelf::PowerShelfId;
+use clap::Parser;
+use rpc::forge as forgerpc;
+
+/// Drive one or more power shelves into maintenance and request a power
+/// operation (PowerOn / PowerOff). All listed power shelves receive the same
+/// operation in a single atomic request.
+#[derive(Parser, Debug)]
+#[allow(clippy::enum_variant_names)]
+pub enum Args {
+    /// Request the listed power shelves to power on.
+    PowerOn(MaintenancePowerArgs),
+    /// Request the listed power shelves to power off.
+    PowerOff(MaintenancePowerArgs),
+}
+
+#[derive(Parser, Debug)]
+pub struct MaintenancePowerArgs {
+    /// One or more Power Shelf IDs. Repeat the flag or pass multiple values:
+    ///   --power-shelf-id <id1> --power-shelf-id <id2>
+    ///   --power-shelf-id <id1> <id2>
+    #[clap(
+        long = "power-shelf-id",
+        visible_alias = "id",
+        required(true),
+        num_args = 1..,
+        value_name = "POWER_SHELF_ID",
+        help = "One or more Power Shelf IDs to drive into maintenance"
+    )]
+    pub power_shelf_ids: Vec<PowerShelfId>,
+
+    #[clap(
+        long,
+        visible_alias = "ref",
+        help = "URL of reference (ticket, issue, etc) for this maintenance request"
+    )]
+    pub reference: Option<String>,
+}
+
+impl Args {
+    pub fn into_request(self) -> forgerpc::PowerShelfMaintenanceRequest {
+        let (operation, args) = match self {
+            Args::PowerOn(args) => (forgerpc::PowerShelfMaintenanceOperation::PowerOn, args),
+            Args::PowerOff(args) => (forgerpc::PowerShelfMaintenanceOperation::PowerOff, args),
+        };
+        forgerpc::PowerShelfMaintenanceRequest {
+            power_shelf_ids: args.power_shelf_ids,
+            operation: operation.into(),
+            reference: args.reference,
+        }
+    }
+}

--- a/crates/admin-cli/src/power_shelf/maintenance/cmd.rs
+++ b/crates/admin-cli/src/power_shelf/maintenance/cmd.rs
@@ -15,16 +15,18 @@
  * limitations under the License.
  */
 
-//! State Controller implementation for Power Shelves.
+use ::rpc::admin_cli::CarbideCliResult;
 
-pub mod configuring;
-pub mod context;
-pub mod deleting;
-pub mod error_state;
-pub mod fetching_data;
-pub mod handler;
-pub mod initializing;
-pub mod io;
-pub mod maintenance;
-pub mod metrics;
-pub mod ready;
+use super::args::Args;
+use crate::rpc::ApiClient;
+
+pub async fn maintenance(api_client: &ApiClient, action: Args) -> CarbideCliResult<()> {
+    let req = action.into_request();
+    let count = req.power_shelf_ids.len();
+    api_client.0.set_power_shelf_maintenance(req).await?;
+    println!(
+        "Power shelf maintenance request submitted for {count} power shelf{}.",
+        if count == 1 { "" } else { "ves" }
+    );
+    Ok(())
+}

--- a/crates/admin-cli/src/power_shelf/maintenance/mod.rs
+++ b/crates/admin-cli/src/power_shelf/maintenance/mod.rs
@@ -15,16 +15,18 @@
  * limitations under the License.
  */
 
-//! State Controller implementation for Power Shelves.
+pub mod args;
+pub mod cmd;
 
-pub mod configuring;
-pub mod context;
-pub mod deleting;
-pub mod error_state;
-pub mod fetching_data;
-pub mod handler;
-pub mod initializing;
-pub mod io;
-pub mod maintenance;
-pub mod metrics;
-pub mod ready;
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::maintenance(&ctx.api_client, self).await?;
+        Ok(())
+    }
+}

--- a/crates/admin-cli/src/power_shelf/mod.rs
+++ b/crates/admin-cli/src/power_shelf/mod.rs
@@ -19,6 +19,7 @@ mod delete;
 mod force_delete;
 pub mod health_report;
 mod list;
+mod maintenance;
 pub mod metadata;
 mod show;
 
@@ -41,6 +42,12 @@ pub enum Cmd {
     ForceDelete(force_delete::Args),
     #[clap(subcommand, about = "Manage Power Shelf Metadata")]
     Metadata(metadata::Args),
+    #[clap(
+        subcommand,
+        about = "Request a power shelf maintenance operation (PowerOn / PowerOff)",
+        visible_alias = "fix"
+    )]
+    Maintenance(maintenance::Args),
     #[dispatch]
     #[clap(
         about = "Manage health report sources",

--- a/crates/admin-cli/src/power_shelf/tests.rs
+++ b/crates/admin-cli/src/power_shelf/tests.rs
@@ -118,3 +118,233 @@ fn parse_list_invalid_bmc_mac() {
     let result = Cmd::try_parse_from(["power-shelf", "list", "--bmc-mac", "not-a-mac"]);
     assert!(result.is_err());
 }
+
+/////////////////////////////////////////////////////////////////////////////
+// Maintenance subcommand
+//
+// Tests for the `power-shelf maintenance` subcommand, covering both
+// `power-on` and `power-off`. These tests:
+//   - parse a representative `power-shelf maintenance ...` invocation,
+//   - verify the matching `Args` variant and ID list,
+//   - convert the parsed `Args` to a gRPC `PowerShelfMaintenanceRequest`
+//     via `into_request()` and assert the operation enum on the wire.
+
+use carbide_uuid::power_shelf::PowerShelfId;
+
+use super::maintenance;
+
+/// Sample power-shelf id used in CLI parse tests. Must round-trip through
+/// `PowerShelfId::from_str`, which `clap` uses to coerce the `--power-shelf-id`
+/// argument values.
+const SAMPLE_PS_ID_1: &str = "ps100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0";
+const SAMPLE_PS_ID_2: &str = "ps100hsasb5dsh6e6ogogslpovne4rj82rp9jlf00qd7mcvmaadv85phk3g";
+
+fn parse_ps_id(id: &str) -> PowerShelfId {
+    use std::str::FromStr;
+    PowerShelfId::from_str(id).unwrap_or_else(|e| panic!("invalid sample power-shelf id {id}: {e}"))
+}
+
+/// `power-shelf maintenance power-on --power-shelf-id <id>` parses to
+/// `Args::PowerOn` carrying the supplied id.
+#[test]
+fn parse_maintenance_power_on_single_id() {
+    let cmd = Cmd::try_parse_from([
+        "power-shelf",
+        "maintenance",
+        "power-on",
+        "--power-shelf-id",
+        SAMPLE_PS_ID_1,
+    ])
+    .expect("should parse maintenance power-on");
+
+    match cmd {
+        Cmd::Maintenance(maintenance::Args::PowerOn(args)) => {
+            assert_eq!(args.power_shelf_ids, vec![parse_ps_id(SAMPLE_PS_ID_1)]);
+            assert!(args.reference.is_none());
+        }
+        other => panic!("expected Maintenance(PowerOn(_)), got: {other:?}"),
+    }
+}
+
+/// `power-shelf maintenance power-off --power-shelf-id <id1> --power-shelf-id <id2>`
+/// parses to `Args::PowerOff` carrying both ids.
+#[test]
+fn parse_maintenance_power_off_multiple_ids_repeated_flag() {
+    let cmd = Cmd::try_parse_from([
+        "power-shelf",
+        "maintenance",
+        "power-off",
+        "--power-shelf-id",
+        SAMPLE_PS_ID_1,
+        "--power-shelf-id",
+        SAMPLE_PS_ID_2,
+    ])
+    .expect("should parse maintenance power-off with two ids");
+
+    match cmd {
+        Cmd::Maintenance(maintenance::Args::PowerOff(args)) => {
+            assert_eq!(
+                args.power_shelf_ids,
+                vec![parse_ps_id(SAMPLE_PS_ID_1), parse_ps_id(SAMPLE_PS_ID_2)],
+            );
+        }
+        other => panic!("expected Maintenance(PowerOff(_)), got: {other:?}"),
+    }
+}
+
+/// `--power-shelf-id` accepts space-separated values in a single occurrence
+/// (per its `num_args = 1..` configuration). Both ids must round-trip.
+#[test]
+fn parse_maintenance_power_on_multiple_ids_single_flag() {
+    let cmd = Cmd::try_parse_from([
+        "power-shelf",
+        "maintenance",
+        "power-on",
+        "--power-shelf-id",
+        SAMPLE_PS_ID_1,
+        SAMPLE_PS_ID_2,
+    ])
+    .expect("should parse maintenance power-on with two ids on one flag");
+
+    match cmd {
+        Cmd::Maintenance(maintenance::Args::PowerOn(args)) => {
+            assert_eq!(
+                args.power_shelf_ids,
+                vec![parse_ps_id(SAMPLE_PS_ID_1), parse_ps_id(SAMPLE_PS_ID_2)],
+            );
+        }
+        other => panic!("expected Maintenance(PowerOn(_)), got: {other:?}"),
+    }
+}
+
+/// The `--reference` flag (with `--ref` alias) is captured.
+#[test]
+fn parse_maintenance_with_reference() {
+    let cmd = Cmd::try_parse_from([
+        "power-shelf",
+        "maintenance",
+        "power-on",
+        "--power-shelf-id",
+        SAMPLE_PS_ID_1,
+        "--reference",
+        "https://issues.example.com/TICKET-1",
+    ])
+    .expect("should parse maintenance with reference");
+
+    match cmd {
+        Cmd::Maintenance(maintenance::Args::PowerOn(args)) => {
+            assert_eq!(
+                args.reference.as_deref(),
+                Some("https://issues.example.com/TICKET-1"),
+            );
+        }
+        other => panic!("expected Maintenance(PowerOn(_)), got: {other:?}"),
+    }
+}
+
+/// Maintenance subcommand requires at least one `--power-shelf-id`.
+#[test]
+fn parse_maintenance_rejects_missing_id() {
+    let result = Cmd::try_parse_from(["power-shelf", "maintenance", "power-on"]);
+    assert!(
+        result.is_err(),
+        "missing required --power-shelf-id should fail to parse"
+    );
+}
+
+/// Unknown subcommand under maintenance is rejected.
+#[test]
+fn parse_maintenance_rejects_unknown_action() {
+    let result = Cmd::try_parse_from([
+        "power-shelf",
+        "maintenance",
+        "power-cycle",
+        "--power-shelf-id",
+        SAMPLE_PS_ID_1,
+    ]);
+    assert!(
+        result.is_err(),
+        "unknown subcommand `power-cycle` should fail to parse"
+    );
+}
+
+/// `Args::PowerOn::into_request()` must produce a gRPC request with the
+/// `PowerOn` operation discriminant and the provided id list.
+#[test]
+fn power_on_into_request_uses_power_on_operation() {
+    let args = maintenance::Args::PowerOn(maintenance::args::MaintenancePowerArgs {
+        power_shelf_ids: vec![parse_ps_id(SAMPLE_PS_ID_1)],
+        reference: Some("ref-1".to_string()),
+    });
+    let req = args.into_request();
+    assert_eq!(
+        req.operation,
+        rpc::forge::PowerShelfMaintenanceOperation::PowerOn as i32,
+    );
+    assert_eq!(req.power_shelf_ids, vec![parse_ps_id(SAMPLE_PS_ID_1)]);
+    assert_eq!(req.reference.as_deref(), Some("ref-1"));
+}
+
+/// `Args::PowerOff::into_request()` must produce a gRPC request with the
+/// `PowerOff` operation discriminant.
+#[test]
+fn power_off_into_request_uses_power_off_operation() {
+    let args = maintenance::Args::PowerOff(maintenance::args::MaintenancePowerArgs {
+        power_shelf_ids: vec![parse_ps_id(SAMPLE_PS_ID_1), parse_ps_id(SAMPLE_PS_ID_2)],
+        reference: None,
+    });
+    let req = args.into_request();
+    assert_eq!(
+        req.operation,
+        rpc::forge::PowerShelfMaintenanceOperation::PowerOff as i32,
+    );
+    assert_eq!(
+        req.power_shelf_ids,
+        vec![parse_ps_id(SAMPLE_PS_ID_1), parse_ps_id(SAMPLE_PS_ID_2)],
+    );
+    assert!(req.reference.is_none());
+}
+
+/// `--ref` is a documented visible alias of `--reference`; verify it
+/// captures the same value.
+#[test]
+fn parse_maintenance_ref_alias_captures_reference() {
+    let cmd = Cmd::try_parse_from([
+        "power-shelf",
+        "maintenance",
+        "power-off",
+        "--power-shelf-id",
+        SAMPLE_PS_ID_1,
+        "--ref",
+        "TICKET-2",
+    ])
+    .expect("should parse maintenance with --ref alias");
+
+    match cmd {
+        Cmd::Maintenance(maintenance::Args::PowerOff(args)) => {
+            assert_eq!(args.reference.as_deref(), Some("TICKET-2"));
+        }
+        other => panic!("expected Maintenance(PowerOff(_)), got: {other:?}"),
+    }
+}
+
+/// `id` is a documented visible alias of `--power-shelf-id`; verify it
+/// captures the same value.
+#[test]
+fn parse_maintenance_id_alias_captures_power_shelf_id() {
+    let cmd = Cmd::try_parse_from([
+        "power-shelf",
+        "maintenance",
+        "power-on",
+        "--id",
+        SAMPLE_PS_ID_1,
+    ])
+    .expect("should parse maintenance with --id alias");
+
+    match cmd {
+        Cmd::Maintenance(maintenance::Args::PowerOn(args)) => {
+            assert_eq!(args.power_shelf_ids, vec![parse_ps_id(SAMPLE_PS_ID_1)]);
+        }
+        other => panic!("expected Maintenance(PowerOn(_)), got: {other:?}"),
+    }
+}

--- a/crates/api-db/migrations/20260512180000_power_shelf_maintenance_requested.sql
+++ b/crates/api-db/migrations/20260512180000_power_shelf_maintenance_requested.sql
@@ -1,0 +1,8 @@
+-- Add power_shelf_maintenance_requested column to power_shelves table.
+-- power_shelf_maintenance_requested: when set by an external entity, the state controller
+-- (when power shelf is Ready) transitions to Maintenance with the requested operation
+-- (PowerOn / PowerOff). Mirrors the switches.switch_reprovisioning_requested pattern.
+ALTER TABLE
+    power_shelves
+ADD
+    COLUMN power_shelf_maintenance_requested JSONB;

--- a/crates/api-db/src/power_shelf.rs
+++ b/crates/api-db/src/power_shelf.rs
@@ -21,7 +21,10 @@ use config_version::{ConfigVersion, Versioned};
 use health_report::{HealthReport, HealthReportApplyMode};
 use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::metadata::Metadata;
-use model::power_shelf::{NewPowerShelf, PowerShelf, PowerShelfControllerState};
+use model::power_shelf::{
+    NewPowerShelf, PowerShelf, PowerShelfControllerState, PowerShelfMaintenanceOperation,
+    PowerShelfMaintenanceRequest,
+};
 use sqlx::PgConnection;
 
 use crate::db_read::DbReader;
@@ -124,6 +127,7 @@ pub async fn create(
         metadata,
         version,
         rack_id: new_power_shelf.rack_id.clone(),
+        power_shelf_maintenance_requested: None,
         health_reports: Default::default(),
     })
 }
@@ -272,6 +276,40 @@ pub async fn update_controller_state_outcome(
         .await
         .map_err(|e| DatabaseError::new("update_controller_state_outcome", e))?;
 
+    Ok(())
+}
+
+pub async fn set_power_shelf_maintenance_requested(
+    txn: &mut PgConnection,
+    power_shelf_id: PowerShelfId,
+    initiator: &str,
+    operation: PowerShelfMaintenanceOperation,
+) -> DatabaseResult<()> {
+    let req = PowerShelfMaintenanceRequest {
+        requested_at: Utc::now(),
+        initiator: initiator.to_string(),
+        operation,
+    };
+    let query = "UPDATE power_shelves SET power_shelf_maintenance_requested = $1 WHERE id = $2 RETURNING id";
+    sqlx::query_as::<_, PowerShelfId>(query)
+        .bind(sqlx::types::Json(req))
+        .bind(power_shelf_id)
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::new("set_power_shelf_maintenance_requested", e))?;
+    Ok(())
+}
+
+pub async fn clear_power_shelf_maintenance_requested(
+    txn: &mut PgConnection,
+    power_shelf_id: PowerShelfId,
+) -> DatabaseResult<()> {
+    let query = "UPDATE power_shelves SET power_shelf_maintenance_requested = NULL WHERE id = $1 RETURNING id";
+    sqlx::query_as::<_, PowerShelfId>(query)
+        .bind(power_shelf_id)
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::new("clear_power_shelf_maintenance_requested", e))?;
     Ok(())
 }
 
@@ -527,4 +565,202 @@ pub async fn remove_health_report(
 ) -> Result<(), DatabaseError> {
     crate::health_report::remove_health_report(txn, "power_shelves", power_shelf_id, mode, source)
         .await
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_uuid::power_shelf::{HardwareHash, PowerShelfIdSource, PowerShelfType};
+    use model::metadata::Metadata;
+    use model::power_shelf::PowerShelfConfig;
+
+    use super::*;
+
+    /// Build a unique `PowerShelfId` for the test. The `seed` byte is used to
+    /// derive a deterministic 32-byte hardware hash so multiple shelves can
+    /// coexist within a single `sqlx_test` transaction without colliding.
+    fn test_power_shelf_id(seed: u8) -> PowerShelfId {
+        let hash: HardwareHash = [seed; 32];
+        PowerShelfId::new(
+            PowerShelfIdSource::ProductBoardChassisSerial,
+            hash,
+            PowerShelfType::Rack,
+        )
+    }
+
+    async fn create_test_power_shelf(
+        txn: &mut PgConnection,
+        seed: u8,
+        name: &str,
+    ) -> Result<PowerShelf, DatabaseError> {
+        let new_power_shelf = NewPowerShelf {
+            id: test_power_shelf_id(seed),
+            config: PowerShelfConfig {
+                name: name.to_string(),
+                capacity: Some(5000),
+                voltage: Some(240),
+            },
+            bmc_mac_address: None,
+            metadata: Some(Metadata {
+                name: name.to_string(),
+                description: String::new(),
+                labels: Default::default(),
+            }),
+            rack_id: None,
+        };
+        create(txn, &new_power_shelf).await
+    }
+
+    #[crate::sqlx_test]
+    async fn test_set_power_shelf_maintenance_requested_power_on(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await?;
+        let shelf = create_test_power_shelf(&mut txn, 1, "PowerOn shelf").await?;
+        assert!(
+            shelf.power_shelf_maintenance_requested.is_none(),
+            "freshly created power shelf should have no maintenance request"
+        );
+
+        set_power_shelf_maintenance_requested(
+            &mut txn,
+            shelf.id,
+            "operator (TICKET-123)",
+            PowerShelfMaintenanceOperation::PowerOn,
+        )
+        .await?;
+
+        let reloaded = find_by_id(&mut txn, &shelf.id).await?.unwrap();
+        let request = reloaded
+            .power_shelf_maintenance_requested
+            .expect("expected a maintenance request to be persisted");
+        assert_eq!(
+            request.operation,
+            PowerShelfMaintenanceOperation::PowerOn,
+            "operation should round-trip as PowerOn"
+        );
+        assert_eq!(request.initiator, "operator (TICKET-123)");
+
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn test_set_power_shelf_maintenance_requested_power_off(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await?;
+        let shelf = create_test_power_shelf(&mut txn, 2, "PowerOff shelf").await?;
+
+        set_power_shelf_maintenance_requested(
+            &mut txn,
+            shelf.id,
+            "admin-cli",
+            PowerShelfMaintenanceOperation::PowerOff,
+        )
+        .await?;
+
+        let reloaded = find_by_id(&mut txn, &shelf.id).await?.unwrap();
+        let request = reloaded
+            .power_shelf_maintenance_requested
+            .expect("expected a maintenance request to be persisted");
+        assert_eq!(
+            request.operation,
+            PowerShelfMaintenanceOperation::PowerOff,
+            "operation should round-trip as PowerOff"
+        );
+        assert_eq!(request.initiator, "admin-cli");
+
+        Ok(())
+    }
+
+    /// Calling `set_power_shelf_maintenance_requested` a second time should
+    /// overwrite the previous request (e.g., switching from PowerOn to
+    /// PowerOff before the controller has acted on it).
+    #[crate::sqlx_test]
+    async fn test_set_power_shelf_maintenance_requested_overwrites(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await?;
+        let shelf = create_test_power_shelf(&mut txn, 3, "Overwrite shelf").await?;
+
+        set_power_shelf_maintenance_requested(
+            &mut txn,
+            shelf.id,
+            "first",
+            PowerShelfMaintenanceOperation::PowerOn,
+        )
+        .await?;
+        set_power_shelf_maintenance_requested(
+            &mut txn,
+            shelf.id,
+            "second",
+            PowerShelfMaintenanceOperation::PowerOff,
+        )
+        .await?;
+
+        let reloaded = find_by_id(&mut txn, &shelf.id).await?.unwrap();
+        let request = reloaded
+            .power_shelf_maintenance_requested
+            .expect("expected the second maintenance request to be persisted");
+        assert_eq!(request.operation, PowerShelfMaintenanceOperation::PowerOff);
+        assert_eq!(request.initiator, "second");
+
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn test_clear_power_shelf_maintenance_requested(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await?;
+        let shelf = create_test_power_shelf(&mut txn, 4, "Clear shelf").await?;
+
+        // Test clearing both flavors of operation.
+        for operation in [
+            PowerShelfMaintenanceOperation::PowerOn,
+            PowerShelfMaintenanceOperation::PowerOff,
+        ] {
+            set_power_shelf_maintenance_requested(&mut txn, shelf.id, "operator", operation)
+                .await?;
+            assert!(
+                find_by_id(&mut txn, &shelf.id)
+                    .await?
+                    .unwrap()
+                    .power_shelf_maintenance_requested
+                    .is_some(),
+                "request should be set before clear (op={:?})",
+                operation
+            );
+
+            clear_power_shelf_maintenance_requested(&mut txn, shelf.id).await?;
+            assert!(
+                find_by_id(&mut txn, &shelf.id)
+                    .await?
+                    .unwrap()
+                    .power_shelf_maintenance_requested
+                    .is_none(),
+                "request should be cleared after clear (op={:?})",
+                operation
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Clearing a maintenance request when none is set must be a no-op
+    /// (idempotent), since the state controller may call this after the
+    /// request has already been cleared by another path.
+    #[crate::sqlx_test]
+    async fn test_clear_power_shelf_maintenance_requested_when_none(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await?;
+        let shelf = create_test_power_shelf(&mut txn, 5, "Idempotent clear shelf").await?;
+        assert!(shelf.power_shelf_maintenance_requested.is_none());
+
+        clear_power_shelf_maintenance_requested(&mut txn, shelf.id).await?;
+        let reloaded = find_by_id(&mut txn, &shelf.id).await?.unwrap();
+        assert!(reloaded.power_shelf_maintenance_requested.is_none());
+
+        Ok(())
+    }
 }

--- a/crates/api-model/src/power_shelf/mod.rs
+++ b/crates/api-model/src/power_shelf/mod.rs
@@ -104,6 +104,8 @@ pub struct PowerShelf {
     /// The rack that this power shelf is associated with.
     pub rack_id: Option<RackId>,
 
+    pub power_shelf_maintenance_requested: Option<PowerShelfMaintenanceRequest>,
+
     // Columns for these exist, but are unused in rust code
     // pub created: DateTime<Utc>,
     // pub updated: DateTime<Utc>,
@@ -120,6 +122,9 @@ impl<'r> FromRow<'r, PgRow> for PowerShelf {
         let status: Option<sqlx::types::Json<PowerShelfStatus>> = row.try_get("status").ok();
         let controller_state_outcome: Option<sqlx::types::Json<PersistentStateHandlerOutcome>> =
             row.try_get("controller_state_outcome").ok();
+        let power_shelf_maintenance_requested: Option<
+            sqlx::types::Json<PowerShelfMaintenanceRequest>,
+        > = row.try_get("power_shelf_maintenance_requested").ok();
 
         let health_reports: HealthReportSources = row
             .try_get::<sqlx::types::Json<HealthReportSources>, _>("health_reports")
@@ -145,6 +150,7 @@ impl<'r> FromRow<'r, PgRow> for PowerShelf {
             metadata,
             version: row.try_get("version")?,
             rack_id: row.try_get("rack_id").ok().flatten(),
+            power_shelf_maintenance_requested: power_shelf_maintenance_requested.map(|r| r.0),
             health_reports,
         })
     }
@@ -261,6 +267,23 @@ impl PowerShelf {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "operation", rename_all = "lowercase")]
+#[allow(clippy::enum_variant_names)]
+pub enum PowerShelfMaintenanceOperation {
+    /// Power on the PowerShelf.
+    PowerOn,
+    /// Power off the PowerShelf.
+    PowerOff,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PowerShelfMaintenanceRequest {
+    pub requested_at: DateTime<Utc>,
+    pub initiator: String,
+    pub operation: PowerShelfMaintenanceOperation,
+}
+
 /// State of a PowerShelf as tracked by the controller
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "state", rename_all = "lowercase")]
@@ -273,6 +296,10 @@ pub enum PowerShelfControllerState {
     Configuring,
     /// The PowerShelf is ready for use.
     Ready,
+
+    Maintenance {
+        operation: PowerShelfMaintenanceOperation,
+    },
     /// There is error in PowerShelf; PowerShelf can not be used if it's in error.
     Error { cause: String },
     /// The PowerShelf is in the process of deleting.
@@ -300,6 +327,10 @@ pub fn state_sla(state: &PowerShelfControllerState, state_version: &ConfigVersio
             time_in_state,
         ),
         PowerShelfControllerState::Ready => StateSla::no_sla(),
+        PowerShelfControllerState::Maintenance { .. } => StateSla::with_sla(
+            std::time::Duration::from_secs(slas::MAINTENANCE),
+            time_in_state,
+        ),
         PowerShelfControllerState::Error { .. } => StateSla::no_sla(),
         PowerShelfControllerState::Deleting => StateSla::with_sla(
             std::time::Duration::from_secs(slas::DELETING),
@@ -377,5 +408,84 @@ mod tests {
             serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
             state
         );
+        let state = PowerShelfControllerState::Maintenance {
+            operation: PowerShelfMaintenanceOperation::PowerOn,
+        };
+        let serialized = serde_json::to_string(&state).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"state":"maintenance","operation":{"operation":"poweron"}}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
+            state
+        );
+        let state = PowerShelfControllerState::Maintenance {
+            operation: PowerShelfMaintenanceOperation::PowerOff,
+        };
+        let serialized = serde_json::to_string(&state).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"state":"maintenance","operation":{"operation":"poweroff"}}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
+            state
+        );
+    }
+
+    #[test]
+    fn serialize_maintenance_operation_round_trip() {
+        for operation in [
+            PowerShelfMaintenanceOperation::PowerOn,
+            PowerShelfMaintenanceOperation::PowerOff,
+        ] {
+            let serialized = serde_json::to_string(&operation).unwrap();
+            let parsed: PowerShelfMaintenanceOperation = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(parsed, operation);
+        }
+    }
+
+    #[test]
+    fn serialize_maintenance_operation_lowercase_tags() {
+        assert_eq!(
+            serde_json::to_string(&PowerShelfMaintenanceOperation::PowerOn).unwrap(),
+            r#"{"operation":"poweron"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&PowerShelfMaintenanceOperation::PowerOff).unwrap(),
+            r#"{"operation":"poweroff"}"#
+        );
+    }
+
+    #[test]
+    fn serialize_maintenance_request_round_trip() {
+        let now = chrono::DateTime::parse_from_rfc3339("2026-05-13T12:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        for operation in [
+            PowerShelfMaintenanceOperation::PowerOn,
+            PowerShelfMaintenanceOperation::PowerOff,
+        ] {
+            let request = PowerShelfMaintenanceRequest {
+                requested_at: now,
+                initiator: "operator (TICKET-1)".to_string(),
+                operation,
+            };
+            let serialized = serde_json::to_string(&request).unwrap();
+            let parsed: PowerShelfMaintenanceRequest = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(parsed, request);
+        }
+    }
+
+    #[test]
+    fn maintenance_state_distinguishes_on_and_off() {
+        let on = PowerShelfControllerState::Maintenance {
+            operation: PowerShelfMaintenanceOperation::PowerOn,
+        };
+        let off = PowerShelfControllerState::Maintenance {
+            operation: PowerShelfMaintenanceOperation::PowerOff,
+        };
+        assert_ne!(on, off);
     }
 }

--- a/crates/api-model/src/power_shelf/slas.rs
+++ b/crates/api-model/src/power_shelf/slas.rs
@@ -32,3 +32,6 @@ pub const CONFIGURING: u64 = 300; // 5 minutes
 
 /// SLA for PowerShelf deleting in seconds
 pub const DELETING: u64 = 300; // 5 minutes
+
+/// SLA for PowerShelf maintenance (PowerOn / PowerOff) in seconds
+pub const MAINTENANCE: u64 = 300; // 5 minutes

--- a/crates/api-test-helper/src/mock_rms.rs
+++ b/crates/api-test-helper/src/mock_rms.rs
@@ -59,6 +59,10 @@ pub struct MockRmsApi {
         Mutex<VecDeque<Result<rms::SetPowerStateResponse, RackManagerError>>>,
     set_power_state_calls: Mutex<Vec<rms::SetPowerStateRequest>>,
 
+    set_power_state_by_device_list_responses:
+        Mutex<VecDeque<Result<rms::SetPowerStateByDeviceListResponse, RackManagerError>>>,
+    set_power_state_by_device_list_calls: Mutex<Vec<rms::SetPowerStateByDeviceListRequest>>,
+
     get_power_state_responses:
         Mutex<VecDeque<Result<rms::GetPowerStateResponse, RackManagerError>>>,
     get_power_state_calls: Mutex<Vec<rms::GetPowerStateRequest>>,
@@ -195,6 +199,8 @@ impl MockRmsApi {
         Self {
             set_power_state_responses: Default::default(),
             set_power_state_calls: Default::default(),
+            set_power_state_by_device_list_responses: Default::default(),
+            set_power_state_by_device_list_calls: Default::default(),
             get_power_state_responses: Default::default(),
             get_power_state_calls: Default::default(),
             sequence_rack_power_responses: Default::default(),
@@ -267,6 +273,14 @@ impl MockRmsApi {
         set_power_state_calls,
         rms::SetPowerStateRequest,
         rms::SetPowerStateResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_set_power_state_by_device_list,
+        set_power_state_by_device_list_calls,
+        set_power_state_by_device_list_responses,
+        set_power_state_by_device_list_calls,
+        rms::SetPowerStateByDeviceListRequest,
+        rms::SetPowerStateByDeviceListResponse
     );
     impl_enqueue_inspect!(
         enqueue_get_power_state,
@@ -526,6 +540,49 @@ impl MockRmsApi {
         }
     }
 
+    /// Success response for `set_power_state_by_device_list` covering a
+    /// single targeted node.
+    pub fn power_by_device_list_ok(node_id: &str) -> rms::SetPowerStateByDeviceListResponse {
+        rms::SetPowerStateByDeviceListResponse {
+            response: Some(rms::NodeBatchResponse {
+                status: rms::ReturnCode::Success as i32,
+                total_nodes: 1,
+                successful_nodes: 1,
+                failed_nodes: 0,
+                node_results: vec![rms::NodeResult {
+                    node_id: node_id.to_owned(),
+                    status: rms::ReturnCode::Success as i32,
+                    error_message: String::new(),
+                }],
+                ..Default::default()
+            }),
+        }
+    }
+
+    /// Failure response for `set_power_state_by_device_list` covering a
+    /// single targeted node, with an optional batch-level message and
+    /// per-node `error_message`.
+    pub fn power_by_device_list_fail(
+        node_id: &str,
+        node_error_message: &str,
+    ) -> rms::SetPowerStateByDeviceListResponse {
+        rms::SetPowerStateByDeviceListResponse {
+            response: Some(rms::NodeBatchResponse {
+                status: rms::ReturnCode::Failure as i32,
+                total_nodes: 1,
+                successful_nodes: 0,
+                failed_nodes: 1,
+                message: String::new(),
+                node_results: vec![rms::NodeResult {
+                    node_id: node_id.to_owned(),
+                    status: rms::ReturnCode::Failure as i32,
+                    error_message: node_error_message.to_owned(),
+                }],
+                ..Default::default()
+            }),
+        }
+    }
+
     /// Success response for `update_node_firmware_async` with a job ID.
     pub fn firmware_update_ok(job_id: &str) -> rms::UpdateNodeFirmwareResponse {
         rms::UpdateNodeFirmwareResponse {
@@ -608,9 +665,13 @@ impl RmsApi for MockRmsApi {
     }
     async fn set_power_state_by_device_list(
         &self,
-        _cmd: rms::SetPowerStateByDeviceListRequest,
+        cmd: rms::SetPowerStateByDeviceListRequest,
     ) -> Result<rms::SetPowerStateByDeviceListResponse, RackManagerError> {
-        Ok(rms::SetPowerStateByDeviceListResponse::default())
+        self.set_power_state_by_device_list_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.set_power_state_by_device_list_responses.lock().await)
     }
     async fn update_switch_system_password(
         &self,

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -338,6 +338,13 @@ impl Forge for Api {
         crate::handlers::power_shelf::admin_force_delete_power_shelf(self, request).await
     }
 
+    async fn set_power_shelf_maintenance(
+        &self,
+        request: Request<rpc::PowerShelfMaintenanceRequest>,
+    ) -> Result<Response<()>, Status> {
+        crate::handlers::power_shelf::set_power_shelf_maintenance(self, request).await
+    }
+
     async fn find_switches(
         &self,
         request: Request<rpc::SwitchQuery>,

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -698,6 +698,10 @@ impl InternalRBACRules {
             vec![ForgeAdminCLI, Machineatron, Flow],
         );
         x.perm(
+            "SetPowerShelfMaintenance",
+            vec![ForgeAdminCLI, Machineatron, Flow],
+        );
+        x.perm(
             "FindSwitches",
             vec![ForgeAdminCLI, Machineatron, Flow, Health],
         );

--- a/crates/api/src/handlers/power_shelf.rs
+++ b/crates/api/src/handlers/power_shelf.rs
@@ -297,6 +297,102 @@ pub async fn admin_force_delete_power_shelf(
     }))
 }
 
+pub async fn set_power_shelf_maintenance(
+    api: &Api,
+    request: Request<rpc::PowerShelfMaintenanceRequest>,
+) -> Result<Response<()>, Status> {
+    log_request_data(&request);
+
+    let triggered_by = request
+        .extensions()
+        .get::<AuthContext>()
+        .and_then(|ctx| ctx.get_external_user_name())
+        .map(String::from);
+
+    let req = request.into_inner();
+    let operation = req.operation();
+    let power_shelf_ids = req.power_shelf_ids;
+
+    if power_shelf_ids.is_empty() {
+        return Err(CarbideError::InvalidArgument(
+            "at least one power_shelf_id must be provided".to_string(),
+        )
+        .into());
+    }
+
+    let max_find_by_ids = api.runtime_config.max_find_by_ids as usize;
+    if power_shelf_ids.len() > max_find_by_ids {
+        return Err(CarbideError::InvalidArgument(format!(
+            "no more than {max_find_by_ids} power_shelf_ids can be accepted"
+        ))
+        .into());
+    }
+
+    let operation = match operation {
+        rpc::PowerShelfMaintenanceOperation::PowerOn => {
+            model::power_shelf::PowerShelfMaintenanceOperation::PowerOn
+        }
+        rpc::PowerShelfMaintenanceOperation::PowerOff => {
+            model::power_shelf::PowerShelfMaintenanceOperation::PowerOff
+        }
+        rpc::PowerShelfMaintenanceOperation::Unspecified => {
+            return Err(CarbideError::InvalidArgument(
+                "operation must be PowerOn or PowerOff".to_string(),
+            )
+            .into());
+        }
+    };
+
+    let initiator = match (triggered_by, req.reference) {
+        (Some(user), Some(reference)) => format!("{user} ({reference})"),
+        (Some(user), None) => user,
+        (None, Some(reference)) => reference,
+        (None, None) => "admin-cli".to_string(),
+    };
+
+    let mut txn = api.txn_begin().await?;
+
+    let existing = db_power_shelf::find_by(
+        &mut txn,
+        ObjectColumnFilter::List(db_power_shelf::IdColumn, &power_shelf_ids),
+    )
+    .await
+    .map_err(CarbideError::from)?;
+
+    let mut by_id: std::collections::HashMap<_, _> =
+        existing.into_iter().map(|ps| (ps.id, ps)).collect();
+
+    for power_shelf_id in &power_shelf_ids {
+        let power_shelf =
+            by_id
+                .remove(power_shelf_id)
+                .ok_or_else(|| CarbideError::NotFoundError {
+                    kind: "power_shelf",
+                    id: power_shelf_id.to_string(),
+                })?;
+
+        if power_shelf.is_marked_as_deleted() {
+            return Err(CarbideError::InvalidArgument(format!(
+                "power shelf {power_shelf_id} is marked for deletion",
+            ))
+            .into());
+        }
+
+        db_power_shelf::set_power_shelf_maintenance_requested(
+            &mut txn,
+            *power_shelf_id,
+            &initiator,
+            operation,
+        )
+        .await
+        .map_err(CarbideError::from)?;
+    }
+
+    txn.commit().await?;
+
+    Ok(Response::new(()))
+}
+
 pub async fn find_power_shelf_state_histories(
     api: &Api,
     request: Request<rpc::PowerShelfStateHistoriesRequest>,

--- a/crates/api/src/rack/rms_client.rs
+++ b/crates/api/src/rack/rms_client.rs
@@ -74,6 +74,10 @@ pub mod test_support {
         switch_system_image_job_statuses:
             Arc<Mutex<HashMap<String, rms::GetSwitchSystemImageJobStatusResponse>>>,
         switch_system_image_job_errors: Arc<Mutex<HashMap<String, String>>>,
+        submitted_set_power_state_by_device_list_requests:
+            Arc<Mutex<Vec<rms::SetPowerStateByDeviceListRequest>>>,
+        queued_set_power_state_by_device_list_responses:
+            Arc<Mutex<VecDeque<Result<rms::SetPowerStateByDeviceListResponse, RackManagerError>>>>,
     }
 
     impl Default for RmsSim {
@@ -90,6 +94,10 @@ pub mod test_support {
                 queued_switch_system_image_responses: Arc::new(Mutex::new(VecDeque::new())),
                 switch_system_image_job_statuses: Arc::new(Mutex::new(HashMap::new())),
                 switch_system_image_job_errors: Arc::new(Mutex::new(HashMap::new())),
+                submitted_set_power_state_by_device_list_requests: Arc::new(Mutex::new(Vec::new())),
+                queued_set_power_state_by_device_list_responses: Arc::new(Mutex::new(
+                    VecDeque::new(),
+                )),
             }
         }
     }
@@ -97,29 +105,17 @@ pub mod test_support {
     impl RmsSim {
         /// Convert RmsSim to the type expected by Api and StateHandlerServices
         pub fn as_rms_client(&self) -> Option<Arc<dyn RmsApi>> {
-            Some(Arc::new(MockRmsClient {
-                fail_add_node: self.fail_add_node.clone(),
-                fail_inventory_get: self.fail_inventory_get.clone(),
-                registered_nodes: self.registered_nodes.clone(),
-                submitted_firmware_requests: self.submitted_firmware_requests.clone(),
-                queued_firmware_responses: self.queued_firmware_responses.clone(),
-                firmware_job_statuses: self.firmware_job_statuses.clone(),
-                firmware_job_errors: self.firmware_job_errors.clone(),
-                submitted_switch_system_image_requests: self
-                    .submitted_switch_system_image_requests
-                    .clone(),
-                queued_switch_system_image_responses: self
-                    .queued_switch_system_image_responses
-                    .clone(),
-                switch_system_image_job_statuses: self.switch_system_image_job_statuses.clone(),
-                switch_system_image_job_errors: self.switch_system_image_job_errors.clone(),
-            }))
+            Some(Arc::new(self.build_mock_client()))
         }
 
         pub fn as_switch_system_image_rms_client(
             &self,
         ) -> Option<Arc<dyn SwitchSystemImageRmsClient>> {
-            Some(Arc::new(MockRmsClient {
+            Some(Arc::new(self.build_mock_client()))
+        }
+
+        fn build_mock_client(&self) -> MockRmsClient {
+            MockRmsClient {
                 fail_add_node: self.fail_add_node.clone(),
                 fail_inventory_get: self.fail_inventory_get.clone(),
                 registered_nodes: self.registered_nodes.clone(),
@@ -135,7 +131,13 @@ pub mod test_support {
                     .clone(),
                 switch_system_image_job_statuses: self.switch_system_image_job_statuses.clone(),
                 switch_system_image_job_errors: self.switch_system_image_job_errors.clone(),
-            }))
+                submitted_set_power_state_by_device_list_requests: self
+                    .submitted_set_power_state_by_device_list_requests
+                    .clone(),
+                queued_set_power_state_by_device_list_responses: self
+                    .queued_set_power_state_by_device_list_responses
+                    .clone(),
+            }
         }
 
         /// Set whether `add_node` should return an error for testing
@@ -225,6 +227,31 @@ pub mod test_support {
                 .await
                 .clone()
         }
+
+        /// Queue a `Result` to be returned on the next call to
+        /// `set_power_state_by_device_list`. Used by power-shelf maintenance
+        /// tests to drive both the success and failure paths of the
+        /// caller-supplied `SetPowerStateByDeviceList` RPC.
+        pub async fn queue_set_power_state_by_device_list_response(
+            &self,
+            response: Result<rms::SetPowerStateByDeviceListResponse, RackManagerError>,
+        ) {
+            self.queued_set_power_state_by_device_list_responses
+                .lock()
+                .await
+                .push_back(response);
+        }
+
+        /// Snapshot the recorded `SetPowerStateByDeviceList` requests, in
+        /// the order they were received.
+        pub async fn submitted_set_power_state_by_device_list_requests(
+            &self,
+        ) -> Vec<rms::SetPowerStateByDeviceListRequest> {
+            self.submitted_set_power_state_by_device_list_requests
+                .lock()
+                .await
+                .clone()
+        }
     }
 
     #[derive(Debug, Clone)]
@@ -243,6 +270,10 @@ pub mod test_support {
         switch_system_image_job_statuses:
             Arc<Mutex<HashMap<String, rms::GetSwitchSystemImageJobStatusResponse>>>,
         switch_system_image_job_errors: Arc<Mutex<HashMap<String, String>>>,
+        submitted_set_power_state_by_device_list_requests:
+            Arc<Mutex<Vec<rms::SetPowerStateByDeviceListRequest>>>,
+        queued_set_power_state_by_device_list_responses:
+            Arc<Mutex<VecDeque<Result<rms::SetPowerStateByDeviceListResponse, RackManagerError>>>>,
     }
 
     #[async_trait::async_trait]
@@ -291,9 +322,17 @@ pub mod test_support {
         }
         async fn set_power_state_by_device_list(
             &self,
-            _cmd: rms::SetPowerStateByDeviceListRequest,
+            cmd: rms::SetPowerStateByDeviceListRequest,
         ) -> Result<rms::SetPowerStateByDeviceListResponse, RackManagerError> {
-            Ok(rms::SetPowerStateByDeviceListResponse::default())
+            self.submitted_set_power_state_by_device_list_requests
+                .lock()
+                .await
+                .push(cmd);
+            self.queued_set_power_state_by_device_list_responses
+                .lock()
+                .await
+                .pop_front()
+                .unwrap_or(Ok(rms::SetPowerStateByDeviceListResponse::default()))
         }
         async fn get_power_state(
             &self,

--- a/crates/api/src/state_controller/power_shelf/configuring.rs
+++ b/crates/api/src/state_controller/power_shelf/configuring.rs
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Handler for PowerShelfControllerState::Configuring.
+
+use carbide_uuid::power_shelf::PowerShelfId;
+use model::power_shelf::{PowerShelf, PowerShelfControllerState};
+
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
+use crate::state_controller::state_handler::{
+    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
+
+/// Handles the Configuring state for a power shelf.
+///
+/// TODO: Implement real configuration logic. This would typically involve:
+/// 1. Configuring the PowerShelf
+/// 2. Updating the PowerShelf status
+pub async fn handle_configuring(
+    power_shelf_id: &PowerShelfId,
+    _state: &mut PowerShelf,
+    _ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
+    tracing::info!(
+        "Configuring PowerShelf {}, transitioning to Ready",
+        power_shelf_id
+    );
+    Ok(StateHandlerOutcome::transition(
+        PowerShelfControllerState::Ready,
+    ))
+}

--- a/crates/api/src/state_controller/power_shelf/deleting.rs
+++ b/crates/api/src/state_controller/power_shelf/deleting.rs
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Handler for PowerShelfControllerState::Deleting.
+
+use carbide_uuid::power_shelf::PowerShelfId;
+use db::power_shelf as db_power_shelf;
+use model::power_shelf::{PowerShelf, PowerShelfControllerState};
+
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
+use crate::state_controller::state_handler::{
+    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
+
+/// Handles the Deleting state for a power shelf.
+///
+/// TODO: Implement full deletion logic (verify the shelf is not in use,
+/// safely shut it down, release allocated resources). For now this just
+/// deletes the row from the database.
+pub async fn handle_deleting(
+    power_shelf_id: &PowerShelfId,
+    _state: &mut PowerShelf,
+    ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
+    tracing::info!("Deleting PowerShelf {}", power_shelf_id);
+    let mut txn = ctx.services.db_pool.begin().await?;
+    db_power_shelf::final_delete(*power_shelf_id, &mut txn).await?;
+    Ok(StateHandlerOutcome::deleted().with_txn(txn))
+}

--- a/crates/api/src/state_controller/power_shelf/error_state.rs
+++ b/crates/api/src/state_controller/power_shelf/error_state.rs
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Handler for PowerShelfControllerState::Error.
+
+use carbide_uuid::power_shelf::PowerShelfId;
+use model::power_shelf::{PowerShelf, PowerShelfControllerState};
+
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
+use crate::state_controller::state_handler::{
+    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
+
+/// Handles the Error state for a power shelf.
+///
+/// If marked for deletion, transition to `Deleting`; otherwise hold the
+/// shelf in `Error` for manual intervention.
+pub async fn handle_error(
+    power_shelf_id: &PowerShelfId,
+    state: &mut PowerShelf,
+    _ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
+    tracing::info!("PowerShelf {} is in error state", power_shelf_id);
+    if state.is_marked_as_deleted() {
+        Ok(StateHandlerOutcome::transition(
+            PowerShelfControllerState::Deleting,
+        ))
+    } else {
+        Ok(StateHandlerOutcome::do_nothing())
+    }
+}

--- a/crates/api/src/state_controller/power_shelf/fetching_data.rs
+++ b/crates/api/src/state_controller/power_shelf/fetching_data.rs
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Handler for PowerShelfControllerState::FetchingData.
+
+use carbide_uuid::power_shelf::PowerShelfId;
+use model::power_shelf::{PowerShelf, PowerShelfControllerState};
+
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
+use crate::state_controller::state_handler::{
+    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
+
+/// Handles the FetchingData state for a power shelf.
+///
+/// TODO: Implement real fetching logic. This would typically involve:
+/// 1. Fetching data from the PowerShelf
+/// 2. Updating the PowerShelf status
+pub async fn handle_fetching_data(
+    power_shelf_id: &PowerShelfId,
+    _state: &mut PowerShelf,
+    _ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
+    tracing::info!(
+        "Fetching PowerShelf {} data, transitioning to Configuring",
+        power_shelf_id
+    );
+    Ok(StateHandlerOutcome::transition(
+        PowerShelfControllerState::Configuring,
+    ))
+}

--- a/crates/api/src/state_controller/power_shelf/handler.rs
+++ b/crates/api/src/state_controller/power_shelf/handler.rs
@@ -14,18 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+//! State Handler implementation for PowerShelves (mirrors Switch state handler structure).
+
 use carbide_uuid::power_shelf::PowerShelfId;
-use db::power_shelf as db_power_shelf;
 use model::power_shelf::{
     PowerShelf, PowerShelfControllerState, derive_power_shelf_aggregate_health,
 };
+use tracing::instrument;
 
+use crate::state_controller::power_shelf::configuring::handle_configuring;
 use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
+use crate::state_controller::power_shelf::deleting::handle_deleting;
+use crate::state_controller::power_shelf::error_state::handle_error;
+use crate::state_controller::power_shelf::fetching_data::handle_fetching_data;
+use crate::state_controller::power_shelf::initializing::handle_initializing;
+use crate::state_controller::power_shelf::maintenance::handle_maintenance;
+use crate::state_controller::power_shelf::ready::handle_ready;
 use crate::state_controller::state_handler::{
     StateHandler, StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
 
-/// The actual PowerShelf State handler
+/// The actual PowerShelf State handler (structure mirrors SwitchStateHandler).
 #[derive(Debug, Default, Clone)]
 pub struct PowerShelfStateHandler {}
 
@@ -42,6 +52,38 @@ impl PowerShelfStateHandler {
             &state.health_reports,
         );
     }
+
+    /// Attempts a state transition by delegating to the appropriate state handler.
+    async fn attempt_state_transition(
+        &self,
+        power_shelf_id: &PowerShelfId,
+        state: &mut PowerShelf,
+        ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
+    ) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
+        let controller_state = &state.controller_state.value;
+
+        match controller_state {
+            PowerShelfControllerState::Initializing => {
+                handle_initializing(power_shelf_id, state, ctx).await
+            }
+            PowerShelfControllerState::FetchingData => {
+                handle_fetching_data(power_shelf_id, state, ctx).await
+            }
+            PowerShelfControllerState::Configuring => {
+                handle_configuring(power_shelf_id, state, ctx).await
+            }
+            PowerShelfControllerState::Ready => handle_ready(power_shelf_id, state, ctx).await,
+            PowerShelfControllerState::Maintenance { .. } => {
+                handle_maintenance(power_shelf_id, state, ctx).await
+            }
+            PowerShelfControllerState::Deleting => {
+                handle_deleting(power_shelf_id, state, ctx).await
+            }
+            PowerShelfControllerState::Error { .. } => {
+                handle_error(power_shelf_id, state, ctx).await
+            }
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -51,89 +93,16 @@ impl StateHandler for PowerShelfStateHandler {
     type ControllerState = PowerShelfControllerState;
     type ContextObjects = PowerShelfStateHandlerContextObjects;
 
+    #[instrument(skip_all, fields(object_id=%power_shelf_id))]
     async fn handle_object_state(
         &self,
         power_shelf_id: &PowerShelfId,
         state: &mut PowerShelf,
-        controller_state: &Self::ControllerState,
+        _controller_state: &PowerShelfControllerState,
         ctx: &mut StateHandlerContext<Self::ContextObjects>,
     ) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
         self.record_metrics(state, ctx);
-        match controller_state {
-            PowerShelfControllerState::Initializing => {
-                // TODO: Implement PowerShelf initialization logic
-                // This would typically involve:
-                // 1. Validating the PowerShelf configuration
-                // 2. Allocating resources
-                // 3. Setting up the PowerShelf in the power management system
-                tracing::info!("Initializing PowerShelf");
-                let new_state = PowerShelfControllerState::FetchingData;
-                Ok(StateHandlerOutcome::transition(new_state))
-            }
-
-            PowerShelfControllerState::FetchingData => {
-                tracing::info!("Fetching PowerShelf data");
-                // TODO: Implement PowerShelf fetching data logic
-                // This would typically involve:
-                // 1. Fetching data from the PowerShelf
-                // 2. Updating the PowerShelf status
-                let new_state = PowerShelfControllerState::Configuring;
-                Ok(StateHandlerOutcome::transition(new_state))
-            }
-
-            PowerShelfControllerState::Configuring => {
-                tracing::info!("Configuring PowerShelf");
-                // TODO: Implement PowerShelf configuring logic
-                // This would typically involve:
-                // 1. Configuring the PowerShelf
-                // 2. Updating the PowerShelf status
-                let new_state = PowerShelfControllerState::Ready;
-                Ok(StateHandlerOutcome::transition(new_state))
-            }
-
-            PowerShelfControllerState::Deleting => {
-                tracing::info!("Deleting PowerShelf");
-                // TODO: Implement PowerShelf deletion logic
-                // This would typically involve:
-                // 1. Checking if the PowerShelf is in use
-                // 2. Safely shutting down the PowerShelf
-                // 3. Releasing allocated resources
-
-                // For now, just delete the PowerShelf from the database
-                let mut txn = ctx.services.db_pool.begin().await?;
-                db_power_shelf::final_delete(*power_shelf_id, &mut txn).await?;
-                Ok(StateHandlerOutcome::deleted().with_txn(txn))
-            }
-
-            PowerShelfControllerState::Ready => {
-                tracing::info!("PowerShelf is ready");
-                if state.is_marked_as_deleted() {
-                    Ok(StateHandlerOutcome::transition(
-                        PowerShelfControllerState::Deleting,
-                    ))
-                } else {
-                    // TODO: Implement PowerShelf monitoring logic
-                    // This would typically involve:
-                    // 1. Checking PowerShelf health status
-                    // 2. Updating PowerShelf status
-                    // 3. Monitoring power consumption and efficiency
-
-                    // For now, just do nothing
-                    Ok(StateHandlerOutcome::do_nothing())
-                }
-            }
-
-            PowerShelfControllerState::Error { .. } => {
-                tracing::info!("PowerShelf is in error state");
-                if state.is_marked_as_deleted() {
-                    Ok(StateHandlerOutcome::transition(
-                        PowerShelfControllerState::Deleting,
-                    ))
-                } else {
-                    // If PowerShelf is in error state, keep it there for manual intervention
-                    Ok(StateHandlerOutcome::do_nothing())
-                }
-            }
-        }
+        self.attempt_state_transition(power_shelf_id, state, ctx)
+            .await
     }
 }

--- a/crates/api/src/state_controller/power_shelf/initializing.rs
+++ b/crates/api/src/state_controller/power_shelf/initializing.rs
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Handler for PowerShelfControllerState::Initializing.
+
+use carbide_uuid::power_shelf::PowerShelfId;
+use model::power_shelf::{PowerShelf, PowerShelfControllerState};
+
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
+use crate::state_controller::state_handler::{
+    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
+
+/// Handles the Initializing state for a power shelf.
+///
+/// TODO: Implement real initialization logic. This would typically involve:
+/// 1. Validating the PowerShelf configuration
+/// 2. Allocating resources
+/// 3. Setting up the PowerShelf in the power management system
+pub async fn handle_initializing(
+    power_shelf_id: &PowerShelfId,
+    _state: &mut PowerShelf,
+    _ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
+    tracing::info!(
+        "PowerShelf {} initializing, transitioning to FetchingData",
+        power_shelf_id
+    );
+    Ok(StateHandlerOutcome::transition(
+        PowerShelfControllerState::FetchingData,
+    ))
+}

--- a/crates/api/src/state_controller/power_shelf/io.rs
+++ b/crates/api/src/state_controller/power_shelf/io.rs
@@ -153,6 +153,13 @@ impl StateControllerIO for PowerShelfStateControllerIO {
             PowerShelfControllerState::FetchingData => ("fetching_data", ""),
             PowerShelfControllerState::Configuring => ("configuring", ""),
             PowerShelfControllerState::Ready => ("ready", ""),
+            PowerShelfControllerState::Maintenance { operation } => {
+                let op = match operation {
+                    model::power_shelf::PowerShelfMaintenanceOperation::PowerOn => "power_on",
+                    model::power_shelf::PowerShelfMaintenanceOperation::PowerOff => "power_off",
+                };
+                ("maintenance", op)
+            }
             PowerShelfControllerState::Error { .. } => ("error", ""),
             PowerShelfControllerState::Deleting => ("deleting", ""),
         }

--- a/crates/api/src/state_controller/power_shelf/maintenance.rs
+++ b/crates/api/src/state_controller/power_shelf/maintenance.rs
@@ -1,0 +1,365 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Handler for PowerShelfControllerState::Maintenance.
+
+use carbide_uuid::power_shelf::PowerShelfId;
+use db::power_shelf as db_power_shelf;
+use forge_secrets::credentials::{
+    BmcCredentialType, CredentialKey, CredentialManager, Credentials,
+};
+use librms::protos::rack_manager as rms;
+use mac_address::MacAddress;
+use model::power_shelf::{PowerShelf, PowerShelfControllerState, PowerShelfMaintenanceOperation};
+use sqlx::PgPool;
+
+use crate::state_controller::external_service_error::rack_manager_error;
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
+use crate::state_controller::state_handler::{
+    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
+
+/// Default BMC HTTPS port used when populating `rms::BmcEndpoint` for power
+/// shelves. Mirrors the value used by `crate::rack::firmware_update`.
+const POWER_SHELF_BMC_PORT: i32 = 443;
+
+/// Handles the Maintenance state for a power shelf, dispatching on the
+/// requested operation (`PowerOn` / `PowerOff`).
+pub async fn handle_maintenance(
+    power_shelf_id: &PowerShelfId,
+    state: &mut PowerShelf,
+    ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
+    let operation = match &state.controller_state.value {
+        PowerShelfControllerState::Maintenance { operation } => *operation,
+        _ => unreachable!("handle_maintenance called with non-Maintenance state"),
+    };
+
+    match operation {
+        PowerShelfMaintenanceOperation::PowerOn => {
+            handle_power_on(power_shelf_id, state, ctx).await
+        }
+        PowerShelfMaintenanceOperation::PowerOff => {
+            handle_power_off(power_shelf_id, state, ctx).await
+        }
+    }
+}
+
+async fn handle_power_on(
+    power_shelf_id: &PowerShelfId,
+    state: &mut PowerShelf,
+    ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
+    tracing::info!(
+        power_shelf_id = %power_shelf_id,
+        "PowerShelf maintenance: PowerOn"
+    );
+    invoke_rms_power_operation(
+        power_shelf_id,
+        state,
+        ctx,
+        rms::PowerOperation::PowerOn,
+        "PowerOn",
+    )
+    .await
+}
+
+async fn handle_power_off(
+    power_shelf_id: &PowerShelfId,
+    state: &mut PowerShelf,
+    ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
+    tracing::info!(
+        power_shelf_id = %power_shelf_id,
+        "PowerShelf maintenance: PowerOff"
+    );
+    invoke_rms_power_operation(
+        power_shelf_id,
+        state,
+        ctx,
+        rms::PowerOperation::PowerOff,
+        "PowerOff",
+    )
+    .await
+}
+
+/// Common driver for RMS-backed power maintenance operations. Builds a
+/// caller-supplied `NodeSet` with the power shelf's BMC connection details
+/// and dispatches `SetPowerStateByDeviceList` against the configured
+/// `RmsApi` client. Returns to `Ready` on success or transitions to `Error`
+/// on failure. In both terminal cases the `power_shelf_maintenance_requested`
+/// row is cleared so the controller does not re-enter `Maintenance` on the
+/// next iteration.
+async fn invoke_rms_power_operation(
+    power_shelf_id: &PowerShelfId,
+    state: &PowerShelf,
+    ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
+    operation: rms::PowerOperation,
+    operation_label: &'static str,
+) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
+    let Some(rms_client) = ctx.services.rms_client.as_ref() else {
+        return finish_maintenance_with_error(
+            power_shelf_id,
+            ctx,
+            format!(
+                "PowerShelf {} maintenance ({}): RMS client not configured",
+                power_shelf_id, operation_label
+            ),
+        )
+        .await;
+    };
+
+    let Some(rack_id) = state.rack_id.as_ref() else {
+        return finish_maintenance_with_error(
+            power_shelf_id,
+            ctx,
+            format!(
+                "PowerShelf {} maintenance ({}): power shelf has no rack association",
+                power_shelf_id, operation_label
+            ),
+        )
+        .await;
+    };
+
+    let device = match build_power_shelf_node_info(
+        power_shelf_id,
+        state,
+        rack_id.to_string(),
+        &ctx.services.db_pool,
+        ctx.services.credential_manager.as_ref(),
+    )
+    .await
+    {
+        Ok(device) => device,
+        Err(cause) => {
+            return finish_maintenance_with_error(
+                power_shelf_id,
+                ctx,
+                format!(
+                    "PowerShelf {} maintenance ({}): {}",
+                    power_shelf_id, operation_label, cause
+                ),
+            )
+            .await;
+        }
+    };
+
+    let request = rms::SetPowerStateByDeviceListRequest {
+        nodes: Some(rms::NodeSet {
+            devices: vec![device],
+        }),
+        operation: operation as i32,
+        ..Default::default()
+    };
+
+    match rms_client.set_power_state_by_device_list(request).await {
+        Ok(response) => {
+            let batch = response.response.unwrap_or_default();
+            if batch.status == rms::ReturnCode::Success as i32 && batch.failed_nodes == 0 {
+                tracing::info!(
+                    power_shelf_id = %power_shelf_id,
+                    rack_id = %rack_id,
+                    operation = operation_label,
+                    successful_nodes = batch.successful_nodes,
+                    "RMS SetPowerStateByDeviceList succeeded; returning PowerShelf to Ready"
+                );
+                let mut txn = ctx.services.db_pool.begin().await?;
+                db_power_shelf::clear_power_shelf_maintenance_requested(&mut txn, *power_shelf_id)
+                    .await?;
+                return Ok(
+                    StateHandlerOutcome::transition(PowerShelfControllerState::Ready).with_txn(txn),
+                );
+            }
+
+            let node_error = batch
+                .node_results
+                .iter()
+                .find(|result| {
+                    result.status != rms::ReturnCode::Success as i32
+                        || !result.error_message.is_empty()
+                })
+                .map(|result| {
+                    if result.error_message.is_empty() {
+                        format!("status={}", result.status)
+                    } else {
+                        result.error_message.clone()
+                    }
+                });
+            let summary = if !batch.message.is_empty() {
+                batch.message.clone()
+            } else if let Some(error) = node_error.as_ref() {
+                error.clone()
+            } else {
+                format!(
+                    "batch status {}, failed_nodes {}",
+                    batch.status, batch.failed_nodes,
+                )
+            };
+
+            tracing::warn!(
+                power_shelf_id = %power_shelf_id,
+                rack_id = %rack_id,
+                operation = operation_label,
+                batch_status = batch.status,
+                successful_nodes = batch.successful_nodes,
+                failed_nodes = batch.failed_nodes,
+                summary = %summary,
+                "RMS SetPowerStateByDeviceList returned a non-success result",
+            );
+            let cause = format!(
+                "PowerShelf {} maintenance ({}): RMS SetPowerStateByDeviceList failed: {}",
+                power_shelf_id, operation_label, summary
+            );
+            finish_maintenance_with_error(power_shelf_id, ctx, cause).await
+        }
+        Err(error) => {
+            let error = rack_manager_error("set_power_state_by_device_list", error);
+            let cause = format!(
+                "PowerShelf {} maintenance ({}): RMS SetPowerStateByDeviceList failed: {}",
+                power_shelf_id, operation_label, error
+            );
+            tracing::warn!(
+                power_shelf_id = %power_shelf_id,
+                rack_id = %rack_id,
+                operation = operation_label,
+                error = %error,
+                "RMS SetPowerStateByDeviceList transport error",
+            );
+            finish_maintenance_with_error(power_shelf_id, ctx, cause).await
+        }
+    }
+}
+
+/// Build the `rms::NewNodeInfo` describing this power shelf for inclusion
+/// in a `SetPowerStateByDeviceList` request. Resolves the BMC IP from the
+/// database and BMC credentials via the credential manager, since the
+/// caller-supplied variant of the RPC requires the BMC connection details
+/// inline rather than relying on RMS's inventory.
+async fn build_power_shelf_node_info(
+    power_shelf_id: &PowerShelfId,
+    state: &PowerShelf,
+    rack_id: String,
+    db_pool: &PgPool,
+    credential_manager: &dyn CredentialManager,
+) -> Result<rms::NewNodeInfo, String> {
+    let bmc_mac = state.bmc_mac_address.ok_or_else(|| {
+        format!(
+            "power shelf {} has no BMC MAC address recorded",
+            power_shelf_id
+        )
+    })?;
+
+    let bmc_ip = lookup_power_shelf_bmc_ip(db_pool, power_shelf_id, bmc_mac).await?;
+    let credentials = lookup_bmc_credentials(credential_manager, bmc_mac).await?;
+
+    Ok(rms::NewNodeInfo {
+        node_id: power_shelf_id.to_string(),
+        rack_id,
+        r#type: Some(rms::NodeType::Powershelf as i32),
+        bmc_endpoint: Some(rms::BmcEndpoint {
+            interface: Some(rms::NetworkInterface {
+                ip_address: bmc_ip,
+                mac_address: bmc_mac.to_string(),
+            }),
+            port: POWER_SHELF_BMC_PORT,
+            credentials: Some(credentials),
+        }),
+        host_endpoint: None,
+    })
+}
+
+/// Fetch the power shelf's BMC IP via the underlay machine_interfaces path.
+async fn lookup_power_shelf_bmc_ip(
+    db_pool: &PgPool,
+    power_shelf_id: &PowerShelfId,
+    bmc_mac: MacAddress,
+) -> Result<String, String> {
+    let rows = db_power_shelf::find_bmc_info_by_power_shelf_ids(db_pool, &[*power_shelf_id])
+        .await
+        .map_err(|error| format!("failed to look up BMC info: {}", error))?;
+
+    rows.into_iter()
+        .find(|row| row.power_shelf_id == *power_shelf_id)
+        .map(|row| row.pmc_ip.to_string())
+        .ok_or_else(|| {
+            format!(
+                "no BMC IP found for power shelf {} (bmc_mac {})",
+                power_shelf_id, bmc_mac
+            )
+        })
+}
+
+/// Resolve BMC root credentials for the given MAC, falling back to the
+/// site-wide root credentials if no per-MAC override exists.
+async fn lookup_bmc_credentials(
+    credential_manager: &dyn CredentialManager,
+    bmc_mac: MacAddress,
+) -> Result<rms::Credentials, String> {
+    let bmc_key = CredentialKey::BmcCredentials {
+        credential_type: BmcCredentialType::BmcRoot {
+            bmc_mac_address: bmc_mac,
+        },
+    };
+    let creds = match credential_manager.get_credentials(&bmc_key).await {
+        Ok(Some(creds)) => Some(creds),
+        Ok(None) => None,
+        Err(error) => {
+            return Err(format!(
+                "failed to read BMC credentials for {}: {}",
+                bmc_mac, error
+            ));
+        }
+    };
+
+    let creds = match creds {
+        Some(creds) => creds,
+        None => {
+            let sitewide_key = CredentialKey::BmcCredentials {
+                credential_type: BmcCredentialType::SiteWideRoot,
+            };
+            credential_manager
+                .get_credentials(&sitewide_key)
+                .await
+                .map_err(|error| format!("failed to read site-wide BMC credentials: {}", error))?
+                .ok_or_else(|| {
+                    format!("no BMC credentials configured for {} or sitewide", bmc_mac)
+                })?
+        }
+    };
+
+    let Credentials::UsernamePassword { username, password } = creds;
+    Ok(rms::Credentials {
+        auth: Some(rms::credentials::Auth::UserPass(rms::UsernamePassword {
+            username,
+            password,
+        })),
+    })
+}
+
+/// Clear the pending maintenance request and transition to `Error` with the
+/// given cause. Clearing the request is what breaks the
+/// `Error -> Ready -> Maintenance -> Error` loop on persistent failures and
+/// forces the operator to explicitly re-request maintenance to retry.
+async fn finish_maintenance_with_error(
+    power_shelf_id: &PowerShelfId,
+    ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
+    cause: String,
+) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
+    let mut txn = ctx.services.db_pool.begin().await?;
+    db_power_shelf::clear_power_shelf_maintenance_requested(&mut txn, *power_shelf_id).await?;
+    Ok(StateHandlerOutcome::transition(PowerShelfControllerState::Error { cause }).with_txn(txn))
+}

--- a/crates/api/src/state_controller/power_shelf/ready.rs
+++ b/crates/api/src/state_controller/power_shelf/ready.rs
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Handler for PowerShelfControllerState::Ready.
+
+use carbide_uuid::power_shelf::PowerShelfId;
+use model::power_shelf::{PowerShelf, PowerShelfControllerState};
+
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
+use crate::state_controller::state_handler::{
+    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
+
+/// Handles the Ready state for a power shelf.
+///
+/// If the power shelf is marked for deletion, transitions to `Deleting`.
+/// If a maintenance request has been posted via
+/// `power_shelf_maintenance_requested`, transitions to `Maintenance` with the
+/// requested operation (PowerOn / PowerOff). Otherwise idles.
+///
+/// TODO: Implement PowerShelf monitoring (health checks, status updates,
+/// power consumption / efficiency tracking).
+pub async fn handle_ready(
+    power_shelf_id: &PowerShelfId,
+    state: &mut PowerShelf,
+    _ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
+    if state.is_marked_as_deleted() {
+        return Ok(StateHandlerOutcome::transition(
+            PowerShelfControllerState::Deleting,
+        ));
+    }
+
+    if let Some(req) = state.power_shelf_maintenance_requested.as_ref() {
+        tracing::info!(
+            operation = ?req.operation,
+            initiator = %req.initiator,
+            "PowerShelf maintenance requested; transitioning to Maintenance"
+        );
+        return Ok(StateHandlerOutcome::transition(
+            PowerShelfControllerState::Maintenance {
+                operation: req.operation,
+            },
+        ));
+    }
+
+    tracing::info!("PowerShelf {} is ready", power_shelf_id,);
+    Ok(StateHandlerOutcome::wait(format!(
+        "PowerShelf {} is ready",
+        power_shelf_id
+    )))
+}

--- a/crates/api/src/tests/power_shelf.rs
+++ b/crates/api/src/tests/power_shelf.rs
@@ -19,10 +19,16 @@ use carbide_uuid::power_shelf::PowerShelfId;
 use db::power_shelf as db_power_shelf;
 use model::DeletedFilter;
 use model::power_shelf::{
-    NewPowerShelf, PowerShelfConfig, PowerShelfSearchFilter, PowerShelfStatus,
+    NewPowerShelf, PowerShelfConfig,
+    PowerShelfMaintenanceOperation as ModelPowerShelfMaintenanceOperation, PowerShelfSearchFilter,
+    PowerShelfStatus,
 };
 use rpc::forge::forge_server::Forge;
-use rpc::forge::{AdminForceDeletePowerShelfRequest, PowerShelfDeletionRequest, PowerShelfQuery};
+use rpc::forge::{
+    AdminForceDeletePowerShelfRequest, PowerShelfDeletionRequest,
+    PowerShelfMaintenanceOperation as RpcPowerShelfMaintenanceOperation,
+    PowerShelfMaintenanceRequest, PowerShelfQuery,
+};
 use tonic::Code;
 
 use crate::tests::common::api_fixtures::create_test_env;
@@ -732,6 +738,286 @@ async fn test_force_delete_power_shelf_already_soft_deleted(
         find_result.power_shelves.is_empty(),
         "Power shelf should be hard-deleted after force delete"
     );
+
+    Ok(())
+}
+
+// ── set_power_shelf_maintenance gRPC handler ────────────────────────────────
+
+/// Successful PowerOn request: persists `power_shelf_maintenance_requested`
+/// with the right operation and initiator (default "admin-cli" when no auth
+/// context is present).
+#[crate::sqlx_test]
+async fn test_set_power_shelf_maintenance_power_on_persists_request(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let power_shelf_id = new_power_shelf(
+        &env,
+        Some("Maintenance PowerOn Shelf".to_string()),
+        None,
+        None,
+        None,
+    )
+    .await?;
+
+    env.api
+        .set_power_shelf_maintenance(tonic::Request::new(PowerShelfMaintenanceRequest {
+            power_shelf_ids: vec![power_shelf_id],
+            operation: RpcPowerShelfMaintenanceOperation::PowerOn as i32,
+            reference: None,
+        }))
+        .await?;
+
+    let mut conn = pool.acquire().await?;
+    let shelf = db_power_shelf::find_by_id(conn.as_mut(), &power_shelf_id)
+        .await?
+        .expect("power shelf should still exist");
+    let req = shelf
+        .power_shelf_maintenance_requested
+        .expect("maintenance request should be persisted");
+    assert_eq!(req.operation, ModelPowerShelfMaintenanceOperation::PowerOn);
+    assert_eq!(
+        req.initiator, "admin-cli",
+        "no AuthContext / no `reference` should default initiator to admin-cli"
+    );
+
+    Ok(())
+}
+
+/// Successful PowerOff request: same as PowerOn but operation must be
+/// PowerOff and the `reference` must propagate as the initiator.
+#[crate::sqlx_test]
+async fn test_set_power_shelf_maintenance_power_off_persists_request_with_reference(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let power_shelf_id = new_power_shelf(
+        &env,
+        Some("Maintenance PowerOff Shelf".to_string()),
+        None,
+        None,
+        None,
+    )
+    .await?;
+
+    env.api
+        .set_power_shelf_maintenance(tonic::Request::new(PowerShelfMaintenanceRequest {
+            power_shelf_ids: vec![power_shelf_id],
+            operation: RpcPowerShelfMaintenanceOperation::PowerOff as i32,
+            reference: Some("https://issues.example.com/TICKET-42".to_string()),
+        }))
+        .await?;
+
+    let mut conn = pool.acquire().await?;
+    let shelf = db_power_shelf::find_by_id(conn.as_mut(), &power_shelf_id)
+        .await?
+        .expect("power shelf should still exist");
+    let req = shelf
+        .power_shelf_maintenance_requested
+        .expect("maintenance request should be persisted");
+    assert_eq!(req.operation, ModelPowerShelfMaintenanceOperation::PowerOff);
+    assert_eq!(req.initiator, "https://issues.example.com/TICKET-42");
+
+    Ok(())
+}
+
+/// Multi-shelf request applies the same operation atomically to every
+/// listed power shelf.
+#[crate::sqlx_test]
+async fn test_set_power_shelf_maintenance_multi_shelf(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let id1 = new_power_shelf(&env, Some("Multi Shelf 1".into()), None, None, None).await?;
+    let id2 = new_power_shelf(&env, Some("Multi Shelf 2".into()), None, None, None).await?;
+
+    env.api
+        .set_power_shelf_maintenance(tonic::Request::new(PowerShelfMaintenanceRequest {
+            power_shelf_ids: vec![id1, id2],
+            operation: RpcPowerShelfMaintenanceOperation::PowerOn as i32,
+            reference: Some("multi-shelf-ref".to_string()),
+        }))
+        .await?;
+
+    let mut conn = pool.acquire().await?;
+    for shelf_id in [id1, id2] {
+        let shelf = db_power_shelf::find_by_id(conn.as_mut(), &shelf_id)
+            .await?
+            .expect("power shelf should still exist");
+        let req = shelf
+            .power_shelf_maintenance_requested
+            .expect("maintenance request should be persisted on every shelf");
+        assert_eq!(req.operation, ModelPowerShelfMaintenanceOperation::PowerOn);
+        assert_eq!(req.initiator, "multi-shelf-ref");
+    }
+
+    Ok(())
+}
+
+/// Empty `power_shelf_ids` must be rejected with InvalidArgument.
+#[crate::sqlx_test]
+async fn test_set_power_shelf_maintenance_rejects_empty_id_list(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    let result = env
+        .api
+        .set_power_shelf_maintenance(tonic::Request::new(PowerShelfMaintenanceRequest {
+            power_shelf_ids: vec![],
+            operation: RpcPowerShelfMaintenanceOperation::PowerOn as i32,
+            reference: None,
+        }))
+        .await;
+
+    let status = result.expect_err("empty id list must be rejected");
+    assert_eq!(status.code(), Code::InvalidArgument);
+
+    Ok(())
+}
+
+/// `Unspecified` operation must be rejected with InvalidArgument.
+#[crate::sqlx_test]
+async fn test_set_power_shelf_maintenance_rejects_unspecified_operation(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let power_shelf_id = new_power_shelf(
+        &env,
+        Some("Unspecified Op Shelf".to_string()),
+        None,
+        None,
+        None,
+    )
+    .await?;
+
+    let result = env
+        .api
+        .set_power_shelf_maintenance(tonic::Request::new(PowerShelfMaintenanceRequest {
+            power_shelf_ids: vec![power_shelf_id],
+            operation: RpcPowerShelfMaintenanceOperation::Unspecified as i32,
+            reference: None,
+        }))
+        .await;
+
+    let status = result.expect_err("unspecified operation must be rejected");
+    assert_eq!(status.code(), Code::InvalidArgument);
+
+    // No request should have been persisted.
+    let mut conn = pool.acquire().await?;
+    let shelf = db_power_shelf::find_by_id(conn.as_mut(), &power_shelf_id)
+        .await?
+        .expect("power shelf should still exist");
+    assert!(
+        shelf.power_shelf_maintenance_requested.is_none(),
+        "no maintenance request should be persisted on rejected calls"
+    );
+
+    Ok(())
+}
+
+/// Unknown power shelf id must be rejected with NotFound and must not
+/// persist anything.
+#[crate::sqlx_test]
+async fn test_set_power_shelf_maintenance_rejects_unknown_id(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let missing_id = PowerShelfId::from(uuid::Uuid::new_v4());
+
+    let result = env
+        .api
+        .set_power_shelf_maintenance(tonic::Request::new(PowerShelfMaintenanceRequest {
+            power_shelf_ids: vec![missing_id],
+            operation: RpcPowerShelfMaintenanceOperation::PowerOff as i32,
+            reference: None,
+        }))
+        .await;
+
+    let status = result.expect_err("unknown id must be rejected");
+    assert_eq!(status.code(), Code::NotFound);
+
+    Ok(())
+}
+
+/// Soft-deleted power shelf must be rejected with InvalidArgument.
+#[crate::sqlx_test]
+async fn test_set_power_shelf_maintenance_rejects_deleted_shelf(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let power_shelf_id = new_power_shelf(
+        &env,
+        Some("Deleted Maintenance Shelf".to_string()),
+        None,
+        None,
+        None,
+    )
+    .await?;
+
+    env.api
+        .delete_power_shelf(tonic::Request::new(PowerShelfDeletionRequest {
+            id: Some(power_shelf_id),
+        }))
+        .await?;
+
+    let result = env
+        .api
+        .set_power_shelf_maintenance(tonic::Request::new(PowerShelfMaintenanceRequest {
+            power_shelf_ids: vec![power_shelf_id],
+            operation: RpcPowerShelfMaintenanceOperation::PowerOn as i32,
+            reference: None,
+        }))
+        .await;
+
+    let status = result.expect_err("deleted power shelf must be rejected");
+    assert_eq!(status.code(), Code::InvalidArgument);
+
+    Ok(())
+}
+
+/// A second maintenance request overwrites the first one (e.g., switching
+/// from PowerOn to PowerOff before the controller has acted on it).
+#[crate::sqlx_test]
+async fn test_set_power_shelf_maintenance_overwrites_previous_request(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let power_shelf_id = new_power_shelf(
+        &env,
+        Some("Overwrite Maintenance Shelf".to_string()),
+        None,
+        None,
+        None,
+    )
+    .await?;
+
+    env.api
+        .set_power_shelf_maintenance(tonic::Request::new(PowerShelfMaintenanceRequest {
+            power_shelf_ids: vec![power_shelf_id],
+            operation: RpcPowerShelfMaintenanceOperation::PowerOn as i32,
+            reference: Some("first".to_string()),
+        }))
+        .await?;
+
+    env.api
+        .set_power_shelf_maintenance(tonic::Request::new(PowerShelfMaintenanceRequest {
+            power_shelf_ids: vec![power_shelf_id],
+            operation: RpcPowerShelfMaintenanceOperation::PowerOff as i32,
+            reference: Some("second".to_string()),
+        }))
+        .await?;
+
+    let mut conn = pool.acquire().await?;
+    let shelf = db_power_shelf::find_by_id(conn.as_mut(), &power_shelf_id)
+        .await?
+        .expect("power shelf should still exist");
+    let req = shelf
+        .power_shelf_maintenance_requested
+        .expect("expected the second maintenance request to be persisted");
+    assert_eq!(req.operation, ModelPowerShelfMaintenanceOperation::PowerOff);
+    assert_eq!(req.initiator, "second");
 
     Ok(())
 }

--- a/crates/api/src/tests/power_shelf_state_controller/maintenance.rs
+++ b/crates/api/src/tests/power_shelf_state_controller/maintenance.rs
@@ -1,0 +1,533 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Direct-invocation tests for the PowerShelf `Maintenance` state handler.
+//!
+//! These tests construct a `PowerShelfStateHandler` and a real
+//! `StateHandlerContext` (via the `state_handler_services()` test fixture,
+//! which wires up the local `RmsSim` mock as `rms_client`), then drive
+//! `handle_object_state` against a power shelf that has been parked in
+//! `Maintenance { PowerOn | PowerOff }`. The tests assert on:
+//!
+//! - the resulting controller state (Ready / Error after the txn commits),
+//! - whether `power_shelf_maintenance_requested` was cleared,
+//! - and the requests actually sent to RMS via the queue/inspect helpers
+//!   on `RmsSim`.
+//!
+//! Successful round-trips against real RMS require a fully populated
+//! `machine_interfaces` row for the power shelf so the BMC IP lookup
+//! returns. Setting that up from this layer is non-trivial; instead we
+//! exercise the handler's many *precondition* failure paths, which still
+//! cover the full PowerOn / PowerOff dispatch matrix and assert on
+//! initiator / cleared-request behavior the user can observe.
+
+use std::sync::Arc;
+
+use carbide_uuid::power_shelf::PowerShelfId;
+use carbide_uuid::rack::RackId;
+use db::{expected_power_shelf as db_expected_power_shelf, power_shelf as db_power_shelf};
+use forge_secrets::credentials::{Credentials, TestCredentialManager};
+use librms::protos::rack_manager as rms;
+use mac_address::MacAddress;
+use model::expected_power_shelf::ExpectedPowerShelf;
+use model::metadata::Metadata;
+use model::power_shelf::{PowerShelf, PowerShelfControllerState, PowerShelfMaintenanceOperation};
+use sqlx::PgConnection;
+
+use crate::state_controller::common_services::CommonStateHandlerServices;
+use crate::state_controller::db_write_batch::DbWriteBatch;
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
+use crate::state_controller::power_shelf::handler::PowerShelfStateHandler;
+use crate::state_controller::power_shelf::metrics::PowerShelfMetrics;
+use crate::state_controller::state_handler::{
+    StateHandler, StateHandlerContext, StateHandlerOutcome,
+};
+use crate::tests::common::api_fixtures::site_explorer::new_power_shelf;
+use crate::tests::common::api_fixtures::{TestEnv, create_test_env};
+use crate::tests::power_shelf_state_controller::fixtures::power_shelf::set_power_shelf_controller_state;
+
+const TEST_BMC_USER: &str = "root";
+const TEST_BMC_PASSWORD: &str = "password";
+
+/// Build a `CommonStateHandlerServices` whose `rms_client` may be cleared
+/// (to exercise the "RMS not configured" path) while preserving the rest of
+/// the test environment's services.
+fn services_with_rms_client(
+    env: &TestEnv,
+    rms_client: Option<Arc<dyn librms::RmsApi>>,
+) -> CommonStateHandlerServices {
+    let mut services = env.state_handler_services();
+    services.rms_client = rms_client;
+    // Force a credential manager that always resolves BMC creds via the
+    // site-wide fallback. This avoids relying on whatever the test-env
+    // happens to be seeded with for BMC creds.
+    services.credential_manager =
+        Arc::new(TestCredentialManager::new(Credentials::UsernamePassword {
+            username: TEST_BMC_USER.into(),
+            password: TEST_BMC_PASSWORD.into(),
+        }));
+    services
+}
+
+/// Drive a power shelf into `Maintenance { operation }` with a maintenance
+/// request set, exactly as if the gRPC handler had just persisted one.
+async fn enter_maintenance(
+    txn: &mut PgConnection,
+    power_shelf_id: &PowerShelfId,
+    operation: PowerShelfMaintenanceOperation,
+) {
+    db_power_shelf::set_power_shelf_maintenance_requested(
+        txn,
+        *power_shelf_id,
+        "test-initiator",
+        operation,
+    )
+    .await
+    .unwrap();
+    set_power_shelf_controller_state(
+        txn,
+        power_shelf_id,
+        PowerShelfControllerState::Maintenance { operation },
+    )
+    .await
+    .unwrap();
+}
+
+/// Set the power shelf's BMC MAC and rack association directly. The
+/// `new_power_shelf` site-explorer fixture leaves both as `None`, but the
+/// handler's `set_power_state_by_device_list` path needs both before it
+/// will even attempt the BMC IP lookup.
+///
+/// `power_shelves.bmc_mac_address` is a FK into `expected_power_shelves`,
+/// so when a `bmc_mac` is requested we first seed a matching expected row.
+async fn set_power_shelf_rack_and_bmc(
+    txn: &mut PgConnection,
+    power_shelf_id: &PowerShelfId,
+    rack_id: Option<&RackId>,
+    bmc_mac: Option<MacAddress>,
+) {
+    if let Some(mac) = bmc_mac {
+        db_expected_power_shelf::create(
+            txn,
+            ExpectedPowerShelf {
+                expected_power_shelf_id: None,
+                bmc_mac_address: mac,
+                bmc_username: TEST_BMC_USER.into(),
+                bmc_password: TEST_BMC_PASSWORD.into(),
+                serial_number: format!("EPS-{mac}"),
+                bmc_ip_address: None,
+                metadata: Metadata::default(),
+                rack_id: None,
+                bmc_retain_credentials: None,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    sqlx::query("UPDATE power_shelves SET rack_id = $1, bmc_mac_address = $2 WHERE id = $3")
+        .bind(rack_id)
+        .bind(bmc_mac)
+        .bind(power_shelf_id)
+        .execute(txn)
+        .await
+        .unwrap();
+}
+
+async fn load_power_shelf(pool: &sqlx::PgPool, id: &PowerShelfId) -> PowerShelf {
+    let mut conn = pool.acquire().await.unwrap();
+    db_power_shelf::find_by_id(conn.as_mut(), id)
+        .await
+        .unwrap()
+        .expect("power shelf should exist")
+}
+
+/// Run one iteration of the state handler against the supplied power shelf.
+async fn run_handler(
+    services: &mut CommonStateHandlerServices,
+    state: &mut PowerShelf,
+) -> StateHandlerOutcome<PowerShelfControllerState> {
+    let handler = PowerShelfStateHandler::default();
+    let mut metrics = PowerShelfMetrics::default();
+    let mut writes = DbWriteBatch::default();
+    let mut ctx = StateHandlerContext::<PowerShelfStateHandlerContextObjects> {
+        services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut writes,
+    };
+    let controller_state = state.controller_state.value.clone();
+    let power_shelf_id = state.id;
+    handler
+        .handle_object_state(&power_shelf_id, state, &controller_state, &mut ctx)
+        .await
+        .expect("state handler should not return an error result")
+}
+
+/// Commit any txn embedded in the outcome (so DB side-effects land) and
+/// return the (now-detached) outcome's transition target if it is one.
+async fn commit_and_extract_transition(
+    mut outcome: StateHandlerOutcome<PowerShelfControllerState>,
+) -> Option<PowerShelfControllerState> {
+    if let Some(txn) = outcome.take_transaction() {
+        txn.commit().await.unwrap();
+    }
+    match outcome {
+        StateHandlerOutcome::Transition { next_state, .. } => Some(next_state),
+        _ => None,
+    }
+}
+
+fn assert_error_with_substring(state: &PowerShelfControllerState, expected_substring: &str) {
+    match state {
+        PowerShelfControllerState::Error { cause } => {
+            assert!(
+                cause.contains(expected_substring),
+                "Error cause '{}' did not contain expected substring '{}'",
+                cause,
+                expected_substring,
+            );
+        }
+        other => panic!(
+            "expected Error transition, got {}",
+            serde_json::to_string(other).unwrap_or_else(|_| "<unserializable>".into()),
+        ),
+    }
+}
+
+// ── PowerOn ─────────────────────────────────────────────────────────────────
+
+/// PowerOn with a fully wired-up power shelf still fails because the
+/// underlay machine_interface is not provisioned in this layer's fixtures.
+/// The handler must surface a precise `no BMC IP found` error, must not
+/// invoke RMS, and must clear the maintenance request.
+#[crate::sqlx_test]
+async fn power_on_transitions_to_error_when_bmc_ip_unresolvable(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let power_shelf_id =
+        new_power_shelf(&env, Some("PowerOn no-ip".into()), None, None, None).await?;
+
+    let rack_id = RackId::default();
+    let bmc_mac: MacAddress = "AA:BB:CC:DD:EE:01".parse().unwrap();
+
+    // Queue a success response so we can assert it was *not* consumed.
+    env.rms_sim
+        .queue_set_power_state_by_device_list_response(Ok(rms::SetPowerStateByDeviceListResponse {
+            response: Some(rms::NodeBatchResponse {
+                status: rms::ReturnCode::Success as i32,
+                total_nodes: 1,
+                successful_nodes: 1,
+                ..Default::default()
+            }),
+        }))
+        .await;
+
+    {
+        let mut txn = pool.acquire().await?;
+        set_power_shelf_rack_and_bmc(txn.as_mut(), &power_shelf_id, Some(&rack_id), Some(bmc_mac))
+            .await;
+        enter_maintenance(
+            txn.as_mut(),
+            &power_shelf_id,
+            PowerShelfMaintenanceOperation::PowerOn,
+        )
+        .await;
+    }
+
+    let mut services = services_with_rms_client(&env, env.rms_sim.as_rms_client());
+    let mut shelf = load_power_shelf(&pool, &power_shelf_id).await;
+    let outcome = run_handler(&mut services, &mut shelf).await;
+    let transition = commit_and_extract_transition(outcome).await.unwrap();
+    assert_error_with_substring(&transition, "no BMC IP found for power shelf");
+
+    let reloaded = load_power_shelf(&pool, &power_shelf_id).await;
+    assert!(
+        reloaded.power_shelf_maintenance_requested.is_none(),
+        "maintenance request should be cleared on error transition"
+    );
+
+    let calls = env
+        .rms_sim
+        .submitted_set_power_state_by_device_list_requests()
+        .await;
+    assert!(
+        calls.is_empty(),
+        "RMS should not be invoked when BMC IP cannot be resolved, got: {} calls",
+        calls.len()
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn power_on_transitions_to_error_when_rms_client_missing(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let power_shelf_id =
+        new_power_shelf(&env, Some("PowerOn no-rms".into()), None, None, None).await?;
+    {
+        let mut txn = pool.acquire().await?;
+        enter_maintenance(
+            txn.as_mut(),
+            &power_shelf_id,
+            PowerShelfMaintenanceOperation::PowerOn,
+        )
+        .await;
+    }
+
+    let mut services = services_with_rms_client(&env, None);
+    let mut shelf = load_power_shelf(&pool, &power_shelf_id).await;
+    let outcome = run_handler(&mut services, &mut shelf).await;
+    let transition = commit_and_extract_transition(outcome).await.unwrap();
+    assert_error_with_substring(&transition, "RMS client not configured");
+
+    let reloaded = load_power_shelf(&pool, &power_shelf_id).await;
+    assert!(reloaded.power_shelf_maintenance_requested.is_none());
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn power_on_transitions_to_error_when_rack_id_missing(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let power_shelf_id =
+        new_power_shelf(&env, Some("PowerOn no-rack".into()), None, None, None).await?;
+    let bmc_mac: MacAddress = "AA:BB:CC:DD:EE:02".parse().unwrap();
+
+    {
+        let mut txn = pool.acquire().await?;
+        // bmc_mac set, rack_id deliberately left as None.
+        set_power_shelf_rack_and_bmc(txn.as_mut(), &power_shelf_id, None, Some(bmc_mac)).await;
+        enter_maintenance(
+            txn.as_mut(),
+            &power_shelf_id,
+            PowerShelfMaintenanceOperation::PowerOn,
+        )
+        .await;
+    }
+
+    let mut services = services_with_rms_client(&env, env.rms_sim.as_rms_client());
+    let mut shelf = load_power_shelf(&pool, &power_shelf_id).await;
+    let outcome = run_handler(&mut services, &mut shelf).await;
+    let transition = commit_and_extract_transition(outcome).await.unwrap();
+    assert_error_with_substring(&transition, "no rack association");
+
+    let calls = env
+        .rms_sim
+        .submitted_set_power_state_by_device_list_requests()
+        .await;
+    assert!(calls.is_empty(), "RMS must not be called without a rack_id");
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn power_on_transitions_to_error_when_bmc_mac_missing(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let power_shelf_id =
+        new_power_shelf(&env, Some("PowerOn no-mac".into()), None, None, None).await?;
+    let rack_id = RackId::default();
+
+    {
+        let mut txn = pool.acquire().await?;
+        // rack_id set, bmc_mac deliberately left as None.
+        set_power_shelf_rack_and_bmc(txn.as_mut(), &power_shelf_id, Some(&rack_id), None).await;
+        enter_maintenance(
+            txn.as_mut(),
+            &power_shelf_id,
+            PowerShelfMaintenanceOperation::PowerOn,
+        )
+        .await;
+    }
+
+    let mut services = services_with_rms_client(&env, env.rms_sim.as_rms_client());
+    let mut shelf = load_power_shelf(&pool, &power_shelf_id).await;
+    let outcome = run_handler(&mut services, &mut shelf).await;
+    let transition = commit_and_extract_transition(outcome).await.unwrap();
+    assert_error_with_substring(&transition, "has no BMC MAC address recorded");
+
+    let calls = env
+        .rms_sim
+        .submitted_set_power_state_by_device_list_requests()
+        .await;
+    assert!(
+        calls.is_empty(),
+        "RMS must not be called without a BMC MAC address"
+    );
+
+    Ok(())
+}
+
+// ── PowerOff ───────────────────────────────────────────────────────────────
+
+#[crate::sqlx_test]
+async fn power_off_transitions_to_error_when_rms_client_missing(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let power_shelf_id =
+        new_power_shelf(&env, Some("PowerOff no-rms".into()), None, None, None).await?;
+    {
+        let mut txn = pool.acquire().await?;
+        enter_maintenance(
+            txn.as_mut(),
+            &power_shelf_id,
+            PowerShelfMaintenanceOperation::PowerOff,
+        )
+        .await;
+    }
+
+    let mut services = services_with_rms_client(&env, None);
+    let mut shelf = load_power_shelf(&pool, &power_shelf_id).await;
+    let outcome = run_handler(&mut services, &mut shelf).await;
+    let transition = commit_and_extract_transition(outcome).await.unwrap();
+    assert_error_with_substring(&transition, "RMS client not configured");
+    // The error cause must mention the operation we tried.
+    if let PowerShelfControllerState::Error { cause } = &transition {
+        assert!(
+            cause.contains("PowerOff"),
+            "PowerOff error cause should mention the operation: {cause}"
+        );
+    } else {
+        unreachable!("assertion above guarantees Error variant");
+    }
+
+    let reloaded = load_power_shelf(&pool, &power_shelf_id).await;
+    assert!(reloaded.power_shelf_maintenance_requested.is_none());
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn power_off_transitions_to_error_when_rack_id_missing(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let power_shelf_id =
+        new_power_shelf(&env, Some("PowerOff no-rack".into()), None, None, None).await?;
+    let bmc_mac: MacAddress = "AA:BB:CC:DD:EE:03".parse().unwrap();
+
+    {
+        let mut txn = pool.acquire().await?;
+        set_power_shelf_rack_and_bmc(txn.as_mut(), &power_shelf_id, None, Some(bmc_mac)).await;
+        enter_maintenance(
+            txn.as_mut(),
+            &power_shelf_id,
+            PowerShelfMaintenanceOperation::PowerOff,
+        )
+        .await;
+    }
+
+    let mut services = services_with_rms_client(&env, env.rms_sim.as_rms_client());
+    let mut shelf = load_power_shelf(&pool, &power_shelf_id).await;
+    let outcome = run_handler(&mut services, &mut shelf).await;
+    let transition = commit_and_extract_transition(outcome).await.unwrap();
+    assert_error_with_substring(&transition, "no rack association");
+    if let PowerShelfControllerState::Error { cause } = &transition {
+        assert!(cause.contains("PowerOff"));
+    }
+
+    let calls = env
+        .rms_sim
+        .submitted_set_power_state_by_device_list_requests()
+        .await;
+    assert!(calls.is_empty());
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn power_off_transitions_to_error_when_bmc_mac_missing(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let power_shelf_id =
+        new_power_shelf(&env, Some("PowerOff no-mac".into()), None, None, None).await?;
+    let rack_id = RackId::default();
+
+    {
+        let mut txn = pool.acquire().await?;
+        set_power_shelf_rack_and_bmc(txn.as_mut(), &power_shelf_id, Some(&rack_id), None).await;
+        enter_maintenance(
+            txn.as_mut(),
+            &power_shelf_id,
+            PowerShelfMaintenanceOperation::PowerOff,
+        )
+        .await;
+    }
+
+    let mut services = services_with_rms_client(&env, env.rms_sim.as_rms_client());
+    let mut shelf = load_power_shelf(&pool, &power_shelf_id).await;
+    let outcome = run_handler(&mut services, &mut shelf).await;
+    let transition = commit_and_extract_transition(outcome).await.unwrap();
+    assert_error_with_substring(&transition, "has no BMC MAC address recorded");
+
+    let calls = env
+        .rms_sim
+        .submitted_set_power_state_by_device_list_requests()
+        .await;
+    assert!(calls.is_empty());
+
+    Ok(())
+}
+
+// ── Sanity: non-Maintenance state never reaches the by-device-list path ────
+
+/// `Ready` should never invoke `set_power_state_by_device_list`. This guards
+/// against accidentally wiring the maintenance dispatch into other states.
+#[crate::sqlx_test]
+async fn ready_state_does_not_invoke_rms_set_power_state(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let power_shelf_id =
+        new_power_shelf(&env, Some("Ready no-rms-call".into()), None, None, None).await?;
+    {
+        let mut txn = pool.acquire().await?;
+        set_power_shelf_controller_state(
+            txn.as_mut(),
+            &power_shelf_id,
+            PowerShelfControllerState::Ready,
+        )
+        .await
+        .unwrap();
+    }
+
+    let mut services = services_with_rms_client(&env, env.rms_sim.as_rms_client());
+    let mut shelf = load_power_shelf(&pool, &power_shelf_id).await;
+    let outcome = run_handler(&mut services, &mut shelf).await;
+    // We don't care about the outcome here, just that no by-device-list
+    // call was made.
+    let _ = commit_and_extract_transition(outcome).await;
+
+    let calls = env
+        .rms_sim
+        .submitted_set_power_state_by_device_list_requests()
+        .await;
+    assert!(
+        calls.is_empty(),
+        "Ready state must not call set_power_state_by_device_list"
+    );
+
+    Ok(())
+}

--- a/crates/api/src/tests/power_shelf_state_controller/mod.rs
+++ b/crates/api/src/tests/power_shelf_state_controller/mod.rs
@@ -30,6 +30,7 @@ use crate::state_controller::power_shelf::io::PowerShelfStateControllerIO;
 use crate::tests::common;
 use crate::tests::common::api_fixtures::create_test_env;
 mod fixtures;
+mod maintenance;
 use fixtures::power_shelf::{mark_power_shelf_as_deleted, set_power_shelf_controller_state};
 use forge_secrets::credentials::TestCredentialManager;
 

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -92,6 +92,11 @@ service Forge {
   rpc DeletePowerShelf(PowerShelfDeletionRequest) returns (PowerShelfDeletionResult);
   // Force deletes a Power Shelf and optionally its associated interfaces from the database.
   rpc AdminForceDeletePowerShelf(AdminForceDeletePowerShelfRequest) returns (AdminForceDeletePowerShelfResponse);
+  // Request a maintenance operation (PowerOn / PowerOff) for a Power Shelf.
+  // When the power shelf is in Ready state, the power shelf state controller
+  // will observe the request and transition to the Maintenance state with the
+  // requested operation.
+  rpc SetPowerShelfMaintenance(PowerShelfMaintenanceRequest) returns (google.protobuf.Empty);
 
   rpc FindSwitches(SwitchQuery) returns (SwitchList);
   rpc FindSwitchIds(SwitchSearchFilter) returns (SwitchIdList);
@@ -1919,6 +1924,25 @@ message PowerShelfDeletionRequest {
 }
 
 message PowerShelfDeletionResult {
+}
+
+// Operation requested for a power shelf maintenance activity.
+enum PowerShelfMaintenanceOperation {
+  POWER_SHELF_MAINTENANCE_OPERATION_UNSPECIFIED = 0;
+  POWER_SHELF_MAINTENANCE_OPERATION_POWER_ON = 1;
+  POWER_SHELF_MAINTENANCE_OPERATION_POWER_OFF = 2;
+}
+
+// Request to drive one or more power shelves into the Maintenance state with
+// the given operation (PowerOn / PowerOff). The state controller, when the
+// shelf is in Ready, observes this request and transitions to Maintenance.
+// All listed power shelves are updated atomically in a single transaction.
+message PowerShelfMaintenanceRequest {
+  repeated common.PowerShelfId power_shelf_ids = 1;
+  PowerShelfMaintenanceOperation operation = 2;
+  // URL of a ticket / issue tracking this maintenance request. Used as the
+  // request initiator in audit logs.
+  optional string reference = 3;
 }
 
 message PowerShelfStateHistoriesRequest {

--- a/crates/rvs/src/client/mod.rs
+++ b/crates/rvs/src/client/mod.rs
@@ -112,7 +112,7 @@ impl TryFrom<Rack> for RackData {
         Ok(Self {
             id: value.id.ok_or(RvsError::MissingField("Rack.id"))?,
             state: value.rack_state,
-            compute_tray_ids: value.compute_trays,
+            compute_tray_ids: Vec::new(), // TODO: Implement this
         })
     }
 }

--- a/docs/architecture/state_machines/power_shelf.md
+++ b/docs/architecture/state_machines/power_shelf.md
@@ -1,0 +1,238 @@
+# Power Shelf State Diagram
+
+This document describes the Finite State Machine (FSM) for Power Shelves in
+NICo: lifecycle from creation through initialization, ready, the OnDemand
+maintenance operations (PowerOn / PowerOff), and deletion. It also covers the
+operator-facing interfaces (CLI / gRPC) used to drive the OnDemand operations.
+
+## High-Level Overview
+
+The main flow shows the primary states and transitions:
+
+```mermaid
+stateDiagram-v2
+    state "Initializing" as Initializing
+    state "FetchingData" as FetchingData
+    state "Configuring" as Configuring
+    state "Ready" as Ready
+    state "Maintenance (PowerOn / PowerOff)" as Maintenance
+    state "Error" as Error
+    state "Deleting" as Deleting
+
+    [*] --> Initializing : Power shelf created
+
+    Initializing --> FetchingData : controller processes power shelf
+    FetchingData --> Configuring : data fetched
+    Configuring --> Ready : configuration complete
+
+    Ready --> Deleting : marked for deletion
+    Ready --> Maintenance : OnDemand maintenance requested (PowerOn / PowerOff)
+
+    Maintenance --> Ready : operation complete; maintenance request cleared
+    Maintenance --> Error : operation failed
+
+    Error --> Deleting : marked for deletion or wait for manual intervention
+
+    Deleting --> [*] : final delete
+```
+
+## States
+
+| State | Description |
+|-------|-------------|
+| **Initializing** | Power shelf record exists in NICo; awaiting first controller tick. |
+| **FetchingData** | Controller is fetching power shelf data from the BMC / PMC. |
+| **Configuring** | Power shelf is being configured (credentials, monitoring, etc.). |
+| **Ready** | Power shelf is ready. From here it can be deleted or driven into `Maintenance` by an OnDemand request. |
+| **Maintenance** | Power shelf is executing an operator-requested maintenance operation. Sub-states (carried in the state variant as `operation`): `PowerOn`, `PowerOff`. |
+| **Error** | Power shelf is in error (e.g. maintenance operation failed). Can transition to `Deleting` if marked for deletion; otherwise waits for manual intervention. |
+| **Deleting** | Power shelf is being removed; ends in final delete (terminal). |
+
+## Transitions (by trigger)
+
+| From | To | Trigger / Condition |
+|------|-----|----------------------|
+| *(create)* | Initializing | Power shelf created |
+| Initializing | FetchingData | Controller processes power shelf |
+| FetchingData | Configuring | Data fetch complete |
+| Configuring | Ready | Configuration complete |
+| Ready | Deleting | `deleted` set (marked for deletion) |
+| Ready | Maintenance { PowerOn } | `power_shelf_maintenance_requested.operation == PowerOn` |
+| Ready | Maintenance { PowerOff } | `power_shelf_maintenance_requested.operation == PowerOff` |
+| Maintenance { PowerOn \| PowerOff } | Ready | BMC operation complete; controller clears `power_shelf_maintenance_requested` |
+| Maintenance { PowerOn \| PowerOff } | Error | BMC operation failed |
+| Error | Deleting | `deleted` set (marked for deletion) |
+| Deleting | *(end)* | Final delete committed |
+
+## OnDemand Maintenance Operations
+
+The `Maintenance` state is entered on demand by an operator (or any other
+service) to drive a power-control operation on the shelf. Two operations are
+currently supported:
+
+- **PowerOn** &mdash; powers the shelf on via the BMC / PMC.
+- **PowerOff** &mdash; powers the shelf off via the BMC / PMC.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Op as Operator
+    participant CLI as forge-admin-cli
+    participant API as NICo API (gRPC)
+    participant DB as Database
+    participant SC as PowerShelf State Controller
+    participant BMC as Power Shelf BMC / PMC
+
+    Op->>CLI: power-shelf maintenance power-on / power-off<br/>--power-shelf-id ... [--reference ...]
+    CLI->>API: SetPowerShelfMaintenance(PowerShelfMaintenanceRequest)
+    API->>DB: UPDATE power_shelves<br/>SET power_shelf_maintenance_requested = {operation, initiator, requested_at}
+    API-->>CLI: Ok
+    CLI-->>Op: "Power shelf maintenance request submitted for N power shelves."
+
+    loop next controller tick (per power shelf, while in Ready)
+        SC->>DB: load PowerShelf
+        SC->>SC: observe `power_shelf_maintenance_requested`
+        SC->>DB: transition controller_state -> Maintenance { operation }
+    end
+
+    SC->>BMC: drive PowerOn / PowerOff (TODO)
+    BMC-->>SC: result
+
+    alt success
+        SC->>DB: clear `power_shelf_maintenance_requested`
+        SC->>DB: transition controller_state -> Ready
+    else failure
+        SC->>DB: transition controller_state -> Error { cause }
+    end
+```
+
+### Operator interface (admin CLI)
+
+The `power-shelf maintenance` subcommand (alias `fix`) drives one or more
+shelves into `Maintenance`. All listed shelves receive the same operation in
+a single atomic request &mdash; if any shelf is unknown or marked for
+deletion the entire request is rejected and no shelves are mutated.
+
+```bash
+# Single shelf
+forge-admin-cli power-shelf maintenance power-off \
+    --power-shelf-id <ID>
+
+# Multiple shelves, repeated flag
+forge-admin-cli power-shelf maintenance power-on \
+    --power-shelf-id <ID1> \
+    --power-shelf-id <ID2> \
+    --reference https://tracker/MAINT-123
+
+# Multiple shelves, single flag with several values
+forge-admin-cli power-shelf maintenance power-off \
+    --power-shelf-id <ID1> <ID2> <ID3>
+
+# Using the visible aliases
+forge-admin-cli power-shelf fix power-on --id <ID1> <ID2>
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--power-shelf-id` (alias `--id`) | yes | One or more Power Shelf IDs. Repeat the flag or pass multiple values space-separated. |
+| `--reference` (alias `--ref`) | no | URL of a ticket / issue tracking this maintenance request. Recorded as part of the initiator string. |
+
+### gRPC interface
+
+The CLI is a thin wrapper over the `Forge.SetPowerShelfMaintenance` gRPC
+method:
+
+```proto
+rpc SetPowerShelfMaintenance(PowerShelfMaintenanceRequest) returns (google.protobuf.Empty);
+
+enum PowerShelfMaintenanceOperation {
+  POWER_SHELF_MAINTENANCE_OPERATION_UNSPECIFIED = 0;
+  POWER_SHELF_MAINTENANCE_OPERATION_POWER_ON    = 1;
+  POWER_SHELF_MAINTENANCE_OPERATION_POWER_OFF   = 2;
+}
+
+message PowerShelfMaintenanceRequest {
+  repeated common.PowerShelfId power_shelf_ids = 1;
+  PowerShelfMaintenanceOperation operation = 2;
+  optional string reference = 3;
+}
+```
+
+Validation rules enforced by the API handler:
+
+- `power_shelf_ids` must contain at least one ID and at most
+  `runtime_config.max_find_by_ids` IDs.
+- `operation` must be `POWER_ON` or `POWER_OFF`; `UNSPECIFIED` is rejected
+  with `InvalidArgument`.
+- Every listed power shelf must exist and must not be marked for deletion;
+  otherwise the entire transaction is rolled back.
+
+The handler runs all updates in a **single database transaction**, so a
+caller observes the new maintenance request on every listed shelf
+simultaneously (or not at all).
+
+### Initiator string
+
+The DB column `power_shelf_maintenance_requested` stores who/why requested
+the operation. The API composes it from two sources:
+
+| Auth user | `--reference` | Resulting `initiator` |
+|-----------|---------------|-----------------------|
+| present   | present       | `"<user> (<reference>)"` |
+| present   | absent        | `"<user>"` |
+| absent    | present       | `"<reference>"` |
+| absent    | absent        | `"admin-cli"` |
+
+## Data model
+
+```mermaid
+classDiagram
+    class PowerShelf {
+        +PowerShelfId id
+        +Versioned~PowerShelfControllerState~ controller_state
+        +Option~PowerShelfMaintenanceRequest~ power_shelf_maintenance_requested
+        +...
+    }
+
+    class PowerShelfControllerState {
+        <<enumeration>>
+        Initializing
+        FetchingData
+        Configuring
+        Ready
+        Maintenance(operation)
+        Error(cause)
+        Deleting
+    }
+
+    class PowerShelfMaintenanceOperation {
+        <<enumeration>>
+        PowerOn
+        PowerOff
+    }
+
+    class PowerShelfMaintenanceRequest {
+        +DateTime~Utc~ requested_at
+        +String initiator
+        +PowerShelfMaintenanceOperation operation
+    }
+
+    PowerShelf --> PowerShelfControllerState
+    PowerShelf --> PowerShelfMaintenanceRequest
+    PowerShelfControllerState --> PowerShelfMaintenanceOperation
+    PowerShelfMaintenanceRequest --> PowerShelfMaintenanceOperation
+```
+
+The `power_shelves.power_shelf_maintenance_requested` column is a nullable
+`JSONB`; the API sets it on `SetPowerShelfMaintenance` and the state
+controller clears it when the operation finishes 
+
+## Notes / Status
+
+- The state machine and request plumbing (CLI → gRPC → DB → state controller
+  → state transition) are implemented end-to-end.
+- The actual BMC / PMC call inside the `Maintenance` handler is still a
+  `TODO`: today the handler clears the maintenance request and returns to
+  `Ready` without driving the hardware. Plugging in the real PowerOn /
+  PowerOff BMC action is a focused follow-up that does not change the public
+  CLI / gRPC surface.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -94,6 +94,8 @@ navigation:
               path: architecture/state_machines/managedhost.md
             - page: Switch
               path: architecture/state_machines/switch.md
+            - page: Power Shelf
+              path: architecture/state_machines/power_shelf.md
             - page: Rack State Machine
               path: architecture/state_machines/rack.md
 


### PR DESCRIPTION
The `Maintenance` state is entered on demand by an operator (or any other service) to drive a power-control operation on the shelf. Two operations are currently supported:

- **PowerOn** &mdash; powers the shelf on via the BMC / PMC.
- **PowerOff** &mdash; powers the shelf off via the BMC / PMC.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

