### PR TITLE
fix: hardware-health propper use of health keys

### DIFF
--- a/crates/health/src/collectors/runtime.rs
+++ b/crates/health/src/collectors/runtime.rs
@@ -333,7 +333,7 @@ impl Collector {
 
         let mut runner = C::new_runner(bmc, endpoint.clone(), config)?;
 
-        let endpoint_key = endpoint.hash_key().to_string();
+        let endpoint_key = endpoint.key();
         let const_labels = HashMap::from([
             (
                 "collector_type".to_string(),
@@ -473,7 +473,7 @@ impl Collector {
         let mut collector = S::new_runner(Arc::clone(&bmc), endpoint.clone(), config)?;
         let event_context = EventContext::from_endpoint(&endpoint, collector.collector_type());
 
-        let endpoint_key = endpoint.hash_key().to_string();
+        let endpoint_key = endpoint.key();
         let const_labels = HashMap::from([
             (
                 "collector_type".to_string(),

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -41,7 +41,7 @@ pub(super) async fn spawn_collectors_for_endpoint(
     data_sink: Option<Arc<dyn DataSink>>,
     metrics_prefix: &str,
 ) -> Result<(), HealthError> {
-    let key = endpoint.hash_key();
+    let key = endpoint.key();
     let endpoint_arc = endpoint.clone();
     if let Configurable::Enabled(sensor_cfg) = &ctx.sensors_config
         && !ctx.collectors.contains(CollectorKind::Sensor, &key)
@@ -69,7 +69,7 @@ pub(super) async fn spawn_collectors_for_endpoint(
         ) {
             Ok(monitor) => {
                 ctx.collectors
-                    .insert(CollectorKind::Sensor, key.clone(), monitor);
+                    .insert(CollectorKind::Sensor, key.clone().into(), monitor);
                 tracing::info!(
                     endpoint_key = %key,
                     total_collectors = ctx.collectors.len(CollectorKind::Sensor),
@@ -89,10 +89,10 @@ pub(super) async fn spawn_collectors_for_endpoint(
     if let Configurable::Enabled(logs_cfg) = &ctx.logs_config
         && !ctx.collectors.contains(CollectorKind::Logs, &key)
     {
-        let collector_registry = Arc::new(ctx.metrics_manager.create_collector_registry(
-            format!("log_collector_{}", endpoint.hash_key()),
-            metrics_prefix,
-        )?);
+        let collector_registry = Arc::new(
+            ctx.metrics_manager
+                .create_collector_registry(format!("log_collector_{key}"), metrics_prefix)?,
+        );
 
         let result = match logs_cfg.mode {
             LogCollectionMode::Sse => {
@@ -147,7 +147,7 @@ pub(super) async fn spawn_collectors_for_endpoint(
         match result {
             Some(Ok(collector)) => {
                 ctx.collectors
-                    .insert(CollectorKind::Logs, key.clone(), collector);
+                    .insert(CollectorKind::Logs, key.clone().into(), collector);
                 tracing::info!(
                     endpoint_key = %key,
                     mode = ?logs_cfg.mode,
@@ -190,7 +190,7 @@ pub(super) async fn spawn_collectors_for_endpoint(
         ) {
             Ok(collector) => {
                 ctx.collectors
-                    .insert(CollectorKind::Firmware, key.clone(), collector);
+                    .insert(CollectorKind::Firmware, key.clone().into(), collector);
                 tracing::info!(
                     endpoint_key = %key,
                     total_firmware_collectors = ctx.collectors.len(CollectorKind::Firmware),
@@ -232,7 +232,7 @@ pub(super) async fn spawn_collectors_for_endpoint(
         ) {
             Ok(collector) => {
                 ctx.collectors
-                    .insert(CollectorKind::LeakDetector, key.clone(), collector);
+                    .insert(CollectorKind::LeakDetector, key.clone().into(), collector);
                 tracing::info!(
                     endpoint_key = %key,
                     total_leak_detector_collectors =
@@ -275,7 +275,7 @@ pub(super) async fn spawn_collectors_for_endpoint(
         ) {
             Ok(handle) => {
                 ctx.collectors
-                    .insert(CollectorKind::Nmxt, key.clone(), handle);
+                    .insert(CollectorKind::Nmxt, key.clone().into(), handle);
                 tracing::info!(
                     endpoint_key = %key,
                     total_nmxt_collectors = ctx.collectors.len(CollectorKind::Nmxt),
@@ -318,7 +318,7 @@ pub(super) async fn spawn_collectors_for_endpoint(
         ) {
             Ok(handle) => {
                 ctx.collectors
-                    .insert(CollectorKind::NvueRest, key.clone(), handle);
+                    .insert(CollectorKind::NvueRest, key.clone().into(), handle);
                 tracing::info!(
                     endpoint_key = %key,
                     total_nvue_rest_collectors = ctx.collectors.len(CollectorKind::NvueRest),

--- a/crates/health/src/endpoint/model.rs
+++ b/crates/health/src/endpoint/model.rs
@@ -64,12 +64,16 @@ pub struct BmcEndpoint {
 }
 
 impl BmcEndpoint {
+    pub fn key(&self) -> String {
+        self.addr.mac.to_string()
+    }
+
     pub fn hash_key(&self) -> Cow<'static, str> {
         Cow::Owned(
             self.rack_id
                 .as_ref()
                 .map(|id| id.to_string())
-                .unwrap_or_else(|| self.addr.mac.to_string()),
+                .unwrap_or_else(|| self.key()),
         )
     }
 

--- a/crates/health/src/metrics.rs
+++ b/crates/health/src/metrics.rs
@@ -167,7 +167,8 @@ pub struct CollectorRegistry {
 
 impl CollectorRegistry {
     fn new(id: String, parent: Registry, prefix: impl Into<String>) -> Result<Self, HealthError> {
-        let desc = Desc::new(id.clone(), id, Vec::new(), HashMap::new())?;
+        let fq_id = id.replace(|c: char| !c.is_ascii_alphanumeric(), "_");
+        let desc = Desc::new(fq_id, id, Vec::new(), HashMap::new())?;
 
         let registry = Box::new(SubRegistry {
             registry: Registry::new(),
@@ -507,5 +508,34 @@ pub fn sanitize_unit(unit: &str) -> String {
                 }
             })
             .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collector_registry_sanitizes_descriptor_fq_name() {
+        for (id, expected_fq_name) in [
+            (
+                "sensor_collector_10.0.0.1:443",
+                "sensor_collector_10_0_0_1_443",
+            ),
+            (
+                "log_collector_bmc-01.example.com",
+                "log_collector_bmc_01_example_com",
+            ),
+            (
+                "collector with spaces/slashes",
+                "collector_with_spaces_slashes",
+            ),
+        ] {
+            let registry = CollectorRegistry::new(id.to_string(), Registry::new(), "test_prefix")
+                .expect("collector registry should accept sanitized id");
+
+            assert_eq!(registry.registry.desc.fq_name, expected_fq_name);
+            assert_eq!(registry.registry.desc.help, id);
+        }
     }
 }

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -50,7 +50,7 @@ pub struct EventContext {
 impl EventContext {
     pub fn from_endpoint(endpoint: &BmcEndpoint, collector_type: &'static str) -> Self {
         Self {
-            endpoint_key: endpoint.hash_key().into_owned(),
+            endpoint_key: endpoint.key(),
             addr: endpoint.addr.clone(),
             collector_type,
             metadata: endpoint.metadata.clone(),


### PR DESCRIPTION
## Description
Fixes issue where carbide health, in env where it had racks ingested used hash_key to create metric collectors, which prevented propper collector creation and leaked rack name into collector name.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
Closes https://github.com/NVIDIA/infra-controller-core/issues/1623

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

