### PR TITLE
feat: adhoc endpoint exploration

### DIFF
--- a/crates/admin-cli/src/site_explorer/mod.rs
+++ b/crates/admin-cli/src/site_explorer/mod.rs
@@ -24,6 +24,7 @@ pub mod get_report;
 mod have_credentials;
 mod is_bmc_in_managed_host;
 mod re_explore;
+mod refresh_endpoint;
 mod remediation;
 
 #[cfg(test)]
@@ -48,6 +49,11 @@ pub enum Cmd {
         about = "Asks carbide-api to explore a single host in the next exploration cycle. The results will be stored."
     )]
     ReExplore(re_explore::Args),
+    #[clap(
+        name = "refresh",
+        about = "Immediately probes a BMC endpoint and persists the report."
+    )]
+    RefreshEndpoint(refresh_endpoint::Args),
     #[clap(about = "Clear the last known error for the BMC in the latest site exploration report.")]
     ClearError(clear_error::Args),
     #[clap(about = "Delete an explored endpoint from the database.")]

--- a/crates/admin-cli/src/site_explorer/refresh_endpoint/args.rs
+++ b/crates/admin-cli/src/site_explorer/refresh_endpoint/args.rs
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    #[clap(help = "BMC IP address")]
+    pub address: String,
+}

--- a/crates/admin-cli/src/site_explorer/refresh_endpoint/cmd.rs
+++ b/crates/admin-cli/src/site_explorer/refresh_endpoint/cmd.rs
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::CarbideCliResult;
+use ::rpc::forge::RefreshEndpointReportRequest;
+
+use super::args::Args;
+use crate::rpc::ApiClient;
+
+pub async fn refresh_endpoint(api_client: &ApiClient, opts: Args) -> CarbideCliResult<()> {
+    let address = opts.address;
+    eprintln!("Starting report refresh for endpoint {address}...");
+    let endpoint = api_client
+        .0
+        .refresh_endpoint_report(RefreshEndpointReportRequest {
+            ip_address: address.clone(),
+        })
+        .await?;
+    println!("{}", serde_json::to_string_pretty(&endpoint)?);
+    eprintln!("Report persisted for endpoint {address}.");
+    Ok(())
+}

--- a/crates/admin-cli/src/site_explorer/refresh_endpoint/mod.rs
+++ b/crates/admin-cli/src/site_explorer/refresh_endpoint/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use ::rpc::admin_cli::CarbideCliResult;
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::refresh_endpoint(&ctx.api_client, self).await
+    }
+}

--- a/crates/api-db/src/explored_endpoints.rs
+++ b/crates/api-db/src/explored_endpoints.rs
@@ -294,17 +294,28 @@ WHERE address=$4 AND version=$5";
     Ok(query_result.rows_affected() > 0)
 }
 
-/// clear_last_known_error clears the last known error in explored_endpoints for the BMC identified by IP
+/// Clears `LastExplorationError` on the endpoint's report and sets
+/// `waiting_for_explorer_refresh = true` so preingestion waits for a fresh probe.
+///
+/// Intentionally does NOT bump `version`: clearing an operator-visible error
+/// does not freshen the underlying Redfish data, so the report's age (used by
+/// the UI "Last updated" bubble and by the periodic loop's oldest-first
+/// rotation) must keep tracking the last real probe. Leaves `exploration_requested`
+/// untouched so a previously queued priority probe is not cancelled.
 pub async fn clear_last_known_error(
     address: IpAddr,
     txn: &mut PgConnection,
 ) -> Result<(), DatabaseError> {
-    for row in find_all_by_ip(address, txn).await? {
-        let mut report = row.report;
-        report.last_exploration_error = None;
-        try_update(address, row.report_version, &report, true, txn).await?;
-    }
-
+    let query = "
+UPDATE explored_endpoints
+SET exploration_report = jsonb_set(exploration_report, '{LastExplorationError}', 'null'::jsonb),
+    waiting_for_explorer_refresh = true
+WHERE address = $1";
+    sqlx::query(query)
+        .bind(address)
+        .execute(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
     Ok(())
 }
 

--- a/crates/api/src/api.rs
+++ b/crates/api/src/api.rs
@@ -953,6 +953,13 @@ impl Forge for Api {
         crate::handlers::site_explorer::re_explore_endpoint(self, request).await
     }
 
+    async fn refresh_endpoint_report(
+        &self,
+        request: Request<rpc::RefreshEndpointReportRequest>,
+    ) -> Result<Response<::rpc::site_explorer::ExploredEndpoint>, Status> {
+        crate::handlers::site_explorer::refresh_endpoint_report(self, request).await
+    }
+
     async fn delete_explored_endpoint(
         &self,
         request: Request<rpc::DeleteExploredEndpointRequest>,

--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -254,6 +254,7 @@ impl InternalRBACRules {
         x.perm("IsBmcInManagedHost", vec![ForgeAdminCLI]);
         x.perm("Explore", vec![ForgeAdminCLI, Flow]);
         x.perm("ReExploreEndpoint", vec![ForgeAdminCLI, Flow]);
+        x.perm("RefreshEndpointReport", vec![ForgeAdminCLI, Flow]);
         x.perm("DeleteExploredEndpoint", vec![ForgeAdminCLI]);
         x.perm("PauseExploredEndpointRemediation", vec![ForgeAdminCLI]);
         x.perm("FindExploredEndpointIds", vec![ForgeAdminCLI, Flow]);

--- a/crates/api/src/errors.rs
+++ b/crates/api/src/errors.rs
@@ -234,6 +234,9 @@ pub enum CarbideError {
     #[error("Permission denied: {0}")]
     PermissionDeniedError(String),
 
+    #[error("{0}")]
+    AlreadyInProgress(String),
+
     #[error("Attestation Error: {0}")]
     AttestationError(String),
 }
@@ -392,6 +395,7 @@ impl From<CarbideError> for tonic::Status {
             }
             CarbideError::UnavailableError(msg) => Status::unavailable(msg),
             CarbideError::PermissionDeniedError(msg) => Status::permission_denied(msg),
+            CarbideError::AlreadyInProgress(msg) => Status::already_exists(msg),
             other => Status::internal(other.to_string()),
         }
     }

--- a/crates/api/src/handlers/site_explorer.rs
+++ b/crates/api/src/handlers/site_explorer.rs
@@ -15,11 +15,14 @@
  * limitations under the License.
  */
 
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 
 use ::rpc::forge::{self as rpc, IsBmcInManagedHostResponse};
+use carbide_site_explorer::{endpoint_exploration_work_key, enrich_endpoint_exploration_report};
 use config_version::ConfigVersion;
+use db::work_lock_manager::AcquireLockError;
+use model::expected_entity::ExpectedEntity;
 use tokio::net::lookup_host;
 use tonic::{Request, Response, Status};
 
@@ -218,6 +221,161 @@ pub(crate) async fn re_explore_endpoint(
     txn.commit().await?;
 
     Ok(Response::new(()))
+}
+
+pub(crate) async fn refresh_endpoint_report(
+    api: &Api,
+    request: Request<rpc::RefreshEndpointReportRequest>,
+) -> Result<Response<::rpc::site_explorer::ExploredEndpoint>, tonic::Status> {
+    log_request_data(&request);
+    let req = request.into_inner();
+
+    let bmc_ip = IpAddr::from_str(&req.ip_address).map_err(CarbideError::from)?;
+    let bmc_addr = SocketAddr::new(bmc_ip, 443);
+
+    let mut txn = api.txn_begin().await?;
+
+    let existing = db::explored_endpoints::find_all_by_ip(bmc_ip, &mut txn).await?;
+    let existing_ep = existing
+        .into_iter()
+        .next()
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "explored_endpoint",
+            id: bmc_ip.to_string(),
+        })?;
+
+    let boot_interface_mac = existing_ep.boot_interface_mac;
+    let existing_report = existing_ep.report.clone();
+
+    let bmc_interface = db::machine_interface::find_by_ip(&mut txn, bmc_ip)
+        .await?
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "machine_interface",
+            id: bmc_ip.to_string(),
+        })?;
+
+    txn.commit().await?;
+
+    let expected = if let Some(expected_machine) =
+        crate::handlers::expected_machine::query(api, bmc_interface.mac_address).await?
+    {
+        Some(ExpectedEntity::Machine(expected_machine))
+    } else if let Some(expected_switch) =
+        crate::handlers::expected_switch::query(api, bmc_interface.mac_address).await?
+    {
+        Some(ExpectedEntity::Switch(expected_switch))
+    } else {
+        crate::handlers::expected_power_shelf::query(api, bmc_interface.mac_address)
+            .await?
+            .map(ExpectedEntity::PowerShelf)
+    };
+
+    // Acquire the per-endpoint work lock before probing. If the periodic site-explorer
+    // loop (or another concurrent refresh) is already probing this endpoint, return an
+    // error immediately rather than running a redundant Redfish call.
+    let work_lock = match api
+        .work_lock_manager_handle
+        .try_acquire_lock(endpoint_exploration_work_key(bmc_ip))
+        .await
+    {
+        Ok(lock) => lock,
+        Err(AcquireLockError::WorkAlreadyLocked(_)) => {
+            return Err(CarbideError::AlreadyInProgress(format!(
+                "Endpoint refresh already in progress for {bmc_ip}"
+            ))
+            .into());
+        }
+        Err(e) => {
+            return Err(CarbideError::internal(format!(
+                "Failed to acquire endpoint work lock for {bmc_ip}: {e}"
+            ))
+            .into());
+        }
+    };
+
+    // Run the probe + persist on a detached tokio task that owns the work lock.
+    // Awaiting the JoinHandle preserves the synchronous UX. Even if the caller navigates
+    // away mid-fetch, the probe will still run to completion.
+    let endpoint_explorer = api.endpoint_explorer.clone();
+    let database_connection = api.database_connection.clone();
+    let runtime_config = api.runtime_config.clone();
+
+    let join_handle = tokio::spawn(async move {
+        let _work_lock = work_lock;
+
+        let start = std::time::Instant::now();
+        let result = endpoint_explorer
+            .explore_endpoint(
+                bmc_addr,
+                &bmc_interface,
+                expected.as_ref(),
+                existing_report.last_exploration_error.as_ref(),
+                boot_interface_mac,
+            )
+            .await;
+
+        let report = match result {
+            Ok(mut report) => {
+                report.last_exploration_latency = Some(start.elapsed());
+                let fw_config_snapshot = runtime_config.get_firmware_config().create_snapshot();
+                enrich_endpoint_exploration_report(&mut report, &fw_config_snapshot);
+                report
+            }
+            Err(e) => {
+                let mut report = existing_report.clone();
+                report.last_exploration_error = Some(e);
+                report.last_exploration_latency = Some(start.elapsed());
+                report
+            }
+        };
+
+        let mut txn = db::Transaction::begin(&database_connection).await?;
+
+        let current = db::explored_endpoints::find_all_by_ip(bmc_ip, &mut txn).await?;
+        let current_version = current
+            .first()
+            .ok_or_else(|| {
+                tonic::Status::from(CarbideError::NotFoundError {
+                    kind: "explored_endpoint",
+                    id: bmc_ip.to_string(),
+                })
+            })?
+            .report_version;
+
+        let updated =
+            db::explored_endpoints::try_update(bmc_ip, current_version, &report, false, &mut txn)
+                .await?;
+
+        if !updated {
+            return Err(tonic::Status::from(
+                CarbideError::ConcurrentModificationError(
+                    "explored_endpoint",
+                    current_version.to_string(),
+                ),
+            ));
+        }
+
+        let endpoints = db::explored_endpoints::find_all_by_ip(bmc_ip, &mut txn).await?;
+
+        txn.commit().await?;
+
+        let ep = endpoints.into_iter().next().ok_or_else(|| {
+            tonic::Status::from(CarbideError::internal(format!(
+                "Endpoint {bmc_ip} not found after update"
+            )))
+        })?;
+
+        Ok::<_, tonic::Status>(ep)
+    });
+
+    match join_handle.await {
+        Ok(Ok(ep)) => Ok(Response::new(ep.into())),
+        Ok(Err(status)) => Err(status),
+        Err(join_err) => Err(CarbideError::internal(format!(
+            "refresh_endpoint_report background task failed for {bmc_ip}: {join_err}"
+        ))
+        .into()),
+    }
 }
 
 pub(crate) async fn pause_explored_endpoint_remediation(

--- a/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/endpoint_explorer.rs
@@ -39,9 +39,15 @@ pub struct MockEndpointExplorer {
     /// mode) so tests can assert the auto-correct path fired with the
     /// right arguments. Cleared on each `insert_endpoints` reset.
     pub set_nic_mode_calls: Arc<Mutex<Vec<(SocketAddr, NicMode)>>>,
+    /// Records IPs that `explore_endpoint` was called for.
+    pub explore_endpoint_calls: Arc<Mutex<Vec<IpAddr>>>,
 }
 
 impl MockEndpointExplorer {
+    pub fn explore_endpoint_call_count(&self) -> usize {
+        self.explore_endpoint_calls.lock().unwrap().len()
+    }
+
     pub fn insert_endpoints(&self, endpoints: Vec<(IpAddr, EndpointExplorationReport)>) {
         self.insert_endpoint_results(
             endpoints
@@ -90,6 +96,10 @@ impl EndpointExplorer for MockEndpointExplorer {
         _boot_interface_mac: Option<MacAddress>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
         tracing::info!("Endpoint {bmc_ip_address} is getting explored");
+        self.explore_endpoint_calls
+            .lock()
+            .unwrap()
+            .push(bmc_ip_address.ip());
         let guard = self.reports.lock().unwrap();
         let res = guard.get(&bmc_ip_address.ip()).unwrap();
         res.clone()

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1764,6 +1764,7 @@ pub async fn create_test_env_with_overrides(
         power_states: Arc::new(std::sync::Mutex::new(Default::default())),
         redfish_power_control_calls: Arc::new(std::sync::Mutex::new(Default::default())),
         set_nic_mode_calls: Arc::new(std::sync::Mutex::new(Default::default())),
+        explore_endpoint_calls: Arc::new(std::sync::Mutex::new(Default::default())),
     };
 
     // The API server is launched with a disabled site-explorer config so that it doesn't launch one

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -20,8 +20,8 @@ use std::net::IpAddr;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use carbide_site_explorer::SiteExplorer;
 use carbide_site_explorer::config::{SiteExplorerConfig, SiteExplorerExploreMode};
+use carbide_site_explorer::{SiteExplorer, endpoint_exploration_work_key};
 use carbide_utils::test_support::test_meter::TestMeter;
 use carbide_uuid::network::NetworkSegmentId;
 use common::api_fixtures::TestEnv;
@@ -1281,7 +1281,8 @@ async fn test_site_explorer_reexplore(
         assert!(!report.exploration_requested);
     }
 
-    // Re-exploring the first endpoint should prioritize it over exploring another endpoint
+    // Re-exploring the first endpoint should prioritize it while preserving
+    // routine capacity for another endpoint.
     env.api
         .re_explore_endpoint(tonic::Request::new(rpc::forge::ReExploreEndpointRequest {
             ip_address: explored_ip.to_string(),
@@ -1300,22 +1301,23 @@ async fn test_site_explorer_reexplore(
         assert!(report.exploration_requested);
     }
 
-    // The 2nd iteration should just update the version number of the initial explored
-    // endpoint - but not find anything new
+    // The 2nd iteration updates the priority endpoint and still uses the
+    // routine budget to discover another endpoint.
     explorer.run_single_iteration().await.unwrap();
     let mut txn = env.pool.begin().await?;
     let explored = db::explored_endpoints::find_all(txn.as_mut())
         .await
         .unwrap();
     txn.commit().await?;
-    assert_eq!(explored.len(), 1);
+    assert_eq!(explored.len(), 2);
 
-    for report in &explored {
-        assert_eq!(report.address, explored_ip);
-        assert_eq!(report.report_version.version_nr(), 2);
-        assert!(!report.exploration_requested);
-    }
-    let current_version = explored[0].report_version;
+    let reexplored = explored
+        .iter()
+        .find(|report| report.address == explored_ip)
+        .unwrap();
+    assert_eq!(reexplored.report_version.version_nr(), 2);
+    assert!(!reexplored.exploration_requested);
+    let current_version = reexplored.report_version;
 
     // Using if_version_match with an incorrect version does nothing
     let unexpected_version = current_version.increment();
@@ -1360,18 +1362,20 @@ async fn test_site_explorer_reexplore(
         .await
         .unwrap();
     txn.commit().await?;
-    for report in &explored {
-        assert!(report.exploration_requested);
-    }
+    let reexplored = explored
+        .iter()
+        .find(|report| report.address == explored_ip)
+        .unwrap();
+    assert!(reexplored.exploration_requested);
 
-    // 3rd iteration still yields 1 result
+    // 3rd iteration still yields the same two known endpoints.
     explorer.run_single_iteration().await.unwrap();
     let mut txn = env.pool.begin().await?;
     let explored = db::explored_endpoints::find_all(txn.as_mut())
         .await
         .unwrap();
     txn.commit().await?;
-    assert_eq!(explored.len(), 1);
+    assert_eq!(explored.len(), 2);
 
     Ok(())
 }
@@ -5110,6 +5114,238 @@ async fn test_orphan_managed_host_alert_emitted(
     assert!(
         !alerts.iter().any(|a| a.id == "OrphanManagedHost"),
         "expected no OrphanManagedHost alert after re-adding expected_machines, got: {alerts:#?}"
+    );
+
+    Ok(())
+}
+
+async fn host_bmc_ip(
+    env: &TestEnv,
+    mh: &api_fixtures::TestManagedHost,
+) -> Result<IpAddr, Box<dyn std::error::Error>> {
+    let mut txn = env.pool.begin().await?;
+    let bmc_ip = mh.host().bmc_ip(&mut txn).await.unwrap();
+    txn.commit().await?;
+    Ok(bmc_ip)
+}
+
+async fn explored_endpoint(
+    env: &TestEnv,
+    bmc_ip: IpAddr,
+) -> Result<ExploredEndpoint, Box<dyn std::error::Error>> {
+    let mut txn = env.pool.begin().await?;
+    let endpoint = db::explored_endpoints::find_by_ips(txn.as_mut(), vec![bmc_ip])
+        .await?
+        .into_iter()
+        .next()
+        .unwrap();
+    txn.commit().await?;
+    Ok(endpoint)
+}
+
+fn endpoint_explore_call_count(env: &TestEnv, bmc_ip: IpAddr) -> usize {
+    env.endpoint_explorer
+        .explore_endpoint_calls
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|ip| **ip == bmc_ip)
+        .count()
+}
+
+#[crate::sqlx_test]
+async fn test_refresh_endpoint_report_bumps_report_version(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+    let bmc_ip = host_bmc_ip(&env, &mh).await?;
+    let initial_version = explored_endpoint(&env, bmc_ip).await?.report_version;
+
+    env.api
+        .refresh_endpoint_report(Request::new(rpc::forge::RefreshEndpointReportRequest {
+            ip_address: bmc_ip.to_string(),
+        }))
+        .await?;
+
+    let refreshed = explored_endpoint(&env, bmc_ip).await?;
+    assert!(
+        refreshed.report_version.version_nr() > initial_version.version_nr(),
+        "refresh should bump report version from {} to a newer version, got {}",
+        initial_version.version_nr(),
+        refreshed.report_version.version_nr()
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_refresh_endpoint_report_rejects_nonexistent_endpoint(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+
+    let err = env
+        .api
+        .refresh_endpoint_report(Request::new(rpc::forge::RefreshEndpointReportRequest {
+            ip_address: "99.99.99.99".to_string(),
+        }))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code(), tonic::Code::NotFound);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_refresh_endpoint_report_rejects_duplicate_refresh(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+    let bmc_ip = host_bmc_ip(&env, &mh).await?;
+    let _endpoint_lock = env
+        .api
+        .work_lock_manager_handle
+        .try_acquire_lock(endpoint_exploration_work_key(bmc_ip))
+        .await?;
+
+    let err = env
+        .api
+        .refresh_endpoint_report(Request::new(rpc::forge::RefreshEndpointReportRequest {
+            ip_address: bmc_ip.to_string(),
+        }))
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code(), tonic::Code::AlreadyExists);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_refresh_endpoint_report_lock_blocks_periodic_probe(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+    let bmc_ip = host_bmc_ip(&env, &mh).await?;
+
+    env.api
+        .re_explore_endpoint(Request::new(rpc::forge::ReExploreEndpointRequest {
+            ip_address: bmc_ip.to_string(),
+            if_version_match: None,
+        }))
+        .await?;
+
+    let calls_before = endpoint_explore_call_count(&env, bmc_ip);
+    let _endpoint_lock = env
+        .api
+        .work_lock_manager_handle
+        .try_acquire_lock(endpoint_exploration_work_key(bmc_ip))
+        .await?;
+
+    env.run_site_explorer_iteration().await;
+
+    assert_eq!(
+        endpoint_explore_call_count(&env, bmc_ip),
+        calls_before,
+        "periodic site explorer probe should be skipped while refresh lock is held"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_refresh_endpoint_report_failure_persists_error_and_bumps_version(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+    let bmc_ip = host_bmc_ip(&env, &mh).await?;
+    let initial_version = explored_endpoint(&env, bmc_ip).await?.report_version;
+    env.endpoint_explorer.insert_endpoint_result(
+        bmc_ip,
+        Err(EndpointExplorationError::Unreachable {
+            details: Some("refresh failure".to_string()),
+        }),
+    );
+    env.api
+        .refresh_endpoint_report(Request::new(rpc::forge::RefreshEndpointReportRequest {
+            ip_address: bmc_ip.to_string(),
+        }))
+        .await?;
+
+    let refreshed = explored_endpoint(&env, bmc_ip).await?;
+    assert!(
+        refreshed.report_version.version_nr() > initial_version.version_nr(),
+        "failed refresh should still bump report version"
+    );
+    assert!(
+        refreshed.report.last_exploration_error.is_some(),
+        "failed refresh should persist the exploration error"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_refresh_endpoint_report_clears_pending_requested_exploration(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+    let bmc_ip = host_bmc_ip(&env, &mh).await?;
+
+    env.api
+        .re_explore_endpoint(Request::new(rpc::forge::ReExploreEndpointRequest {
+            ip_address: bmc_ip.to_string(),
+            if_version_match: None,
+        }))
+        .await?;
+    assert!(explored_endpoint(&env, bmc_ip).await?.exploration_requested);
+
+    env.api
+        .refresh_endpoint_report(Request::new(rpc::forge::RefreshEndpointReportRequest {
+            ip_address: bmc_ip.to_string(),
+        }))
+        .await?;
+
+    assert!(
+        !explored_endpoint(&env, bmc_ip).await?.exploration_requested,
+        "refresh should clear the pending requested exploration so the endpoint is not immediately probed again as priority work"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_refresh_endpoint_report_lock_is_per_endpoint(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    let mh_a = common::api_fixtures::create_managed_host(&env).await;
+    let mh_b = common::api_fixtures::create_managed_host(&env).await;
+    let bmc_ip_a = host_bmc_ip(&env, &mh_a).await?;
+    let bmc_ip_b = host_bmc_ip(&env, &mh_b).await?;
+    let initial_version_b = explored_endpoint(&env, bmc_ip_b).await?.report_version;
+    let _endpoint_lock = env
+        .api
+        .work_lock_manager_handle
+        .try_acquire_lock(endpoint_exploration_work_key(bmc_ip_a))
+        .await?;
+
+    env.api
+        .refresh_endpoint_report(Request::new(rpc::forge::RefreshEndpointReportRequest {
+            ip_address: bmc_ip_b.to_string(),
+        }))
+        .await?;
+
+    let refreshed_b = explored_endpoint(&env, bmc_ip_b).await?;
+    assert!(
+        refreshed_b.report_version.version_nr() > initial_version_b.version_nr(),
+        "lock for endpoint {bmc_ip_a} should not block refresh for endpoint {bmc_ip_b}"
     );
 
     Ok(())

--- a/crates/api/src/web/explored_endpoint.rs
+++ b/crates/api/src/web/explored_endpoint.rs
@@ -402,7 +402,14 @@ impl From<ExploredEndpointInfo> for ExploredEndpointDetail<'_> {
         let report_age =
             config_version::ConfigVersion::from_str(&endpoint_info.endpoint.report_version)
                 .ok()
-                .map(|v| v.since_state_change_humanized())
+                .map(|v| {
+                    let elapsed = v.since_state_change();
+                    if elapsed.num_seconds() <= 0 {
+                        "just now".to_string()
+                    } else {
+                        format!("{} ago", v.since_state_change_humanized())
+                    }
+                })
                 .unwrap_or_else(|| "unknown".to_string());
 
         let pause_remediation = endpoint_info.endpoint.pause_remediation;
@@ -598,6 +605,47 @@ pub async fn re_explore(
     }
 
     Redirect::to(&view_url)
+}
+
+pub async fn refresh_endpoint(
+    AxumState(state): AxumState<Arc<Api>>,
+    AxumPath(endpoint_ip): AxumPath<String>,
+) -> impl IntoResponse {
+    match state
+        .refresh_endpoint_report(tonic::Request::new(
+            rpc::forge::RefreshEndpointReportRequest {
+                ip_address: endpoint_ip.clone(),
+            },
+        ))
+        .await
+    {
+        Ok(response) => {
+            let ep = response.into_inner();
+            let has_error = ep
+                .report
+                .as_ref()
+                .and_then(|r| r.last_exploration_error.as_ref())
+                .is_some();
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({ "has_exploration_error": has_error })),
+            )
+                .into_response()
+        }
+        Err(err) => {
+            let status_code = match err.code() {
+                tonic::Code::AlreadyExists => StatusCode::CONFLICT,
+                tonic::Code::NotFound => StatusCode::NOT_FOUND,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            tracing::error!(%err, endpoint_ip, "refresh_endpoint");
+            (
+                status_code,
+                Json(serde_json::json!({ "error": err.message() })),
+            )
+                .into_response()
+        }
+    }
 }
 
 pub async fn pause_remediation(

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -449,6 +449,10 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
                 post(explored_endpoint::re_explore),
             )
             .route(
+                "/explored-endpoint/{endpoint_ip}/refresh",
+                post(explored_endpoint::refresh_endpoint),
+            )
+            .route(
                 "/explored-endpoint/{endpoint_ip}/power-control",
                 post(explored_endpoint::power_control),
             )

--- a/crates/api/templates/base.html
+++ b/crates/api/templates/base.html
@@ -189,10 +189,10 @@
 				if (e.persisted) hideActionSpinner();
 			});
 
-			function showToast(message) {
+			function showToast(message, isError) {
 				hideActionSpinner();
 				const toast = document.createElement('div');
-				toast.className = 'action-toast';
+				toast.className = 'action-toast' + (isError ? ' action-toast-error' : '');
 				const text = document.createElement('span');
 				text.className = 'action-toast-text';
 				text.textContent = message;
@@ -201,7 +201,7 @@
 				setTimeout(function() {
 					toast.classList.add('dismissing');
 					setTimeout(function() { toast.remove(); }, 300);
-				}, 3000);
+				}, 5000);
 			}
 
 			function prettifyErrorMsg(raw) {
@@ -303,7 +303,13 @@
 				if (!jsonLink) {
 					return;
 				}
-				jsonLink.href = window.location.href + ".json";
+				// JSON endpoints don't honor UI query state (e.g. ?tab=),
+				// so target the path-only ".json" variant of this page.
+				const url = new URL(window.location.href);
+				url.pathname = url.pathname + ".json";
+				url.search = "";
+				url.hash = "";
+				jsonLink.href = url.toString();
 			}
 
 			function prettifyJSONs() {

--- a/crates/api/templates/explored_endpoint_detail.html
+++ b/crates/api/templates/explored_endpoint_detail.html
@@ -4,13 +4,20 @@
 
 {% block content %}
 <div id="json">
-    {% if has_machine %}
-    <a id="delete-link" class="disabled" href="#" onclick="return false;">Delete</a>
-    {% else %}
+    {% if !has_machine %}
     <a id="delete-link" href="#" onclick="if(confirm('Are you sure you want to delete this endpoint?')) { document.getElementById('delete-form').submit(); } return false;">Delete</a>
     {% endif %}
     <a id="logs-link" href="" target="_blank">Logs</a>
     <a id="json-link" href="">JSON</a>
+    <a id="refresh-endpoint" href="#" title="Refresh this endpoint's report immediately. If you stay on this page, you will see the status message and spinner until the refresh finishes." aria-label="Refresh endpoint report">
+        <span>Refresh</span>
+        <svg class="refresh-icon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21.5 2v6h-6"/>
+            <path d="M2.5 22v-6h6"/>
+            <path d="M2.5 11.5a10 10 0 0 1 18.8-4.3"/>
+            <path d="M21.5 12.5a10 10 0 0 1-18.8 4.2"/>
+        </svg>
+    </a>
 </div>
 
 <form id="delete-form" method="POST" action="/admin/explored-endpoint/{{ endpoint.address }}/delete" hidden>
@@ -69,7 +76,7 @@
 			{% if has_exploration_error %}
 			<span class="bubble error">Error while exploring endpoint, report may be outdated</span>
 			{% else %}
-			<span class="bubble">Last updated {{ report_age }} ago</span>
+			<span class="bubble">Last updated {{ report_age }}</span>
 			{% endif %}
 		</td></tr>
 	</table>
@@ -91,20 +98,6 @@
 			</td>
 		</tr>
 		{% endif %}
-		<tr>
-			<th>Exploration Requested</th>
-			<td class="action-cell">
-				<div><span class="bubble {% if endpoint.exploration_requested %}warning{% endif %}">{{ endpoint.exploration_requested }}</span></div>
-				{% if !endpoint.exploration_requested %}
-				<div>
-					<form id="reexplore_action" method="POST" action="/admin/explored-endpoint/{{ endpoint.address }}/reexplore">
-						<input type="hidden" name="if_version_match" value="{{ endpoint.report_version }}"/>
-						<input type="submit" value="Request re-exploration">
-					</form>
-				</div>
-				{% endif %}
-			</td>
-		</tr>
 		<tr>
 			<th>Power Actions</th>
 			<td class="action-cell">
@@ -183,6 +176,18 @@
 						<form id="clear_credentials" method="POST" action="/admin/explored-endpoint/{{ endpoint.address }}/clear-credentials" class="config-card-action">
 							<div class="config-card-reminder">Deletes credentials from vault.</div>
 							<input type="submit" class="delete-button" value="Clear Credentials">
+							<span class="action-spinner"></span>
+						</form>
+					</div>
+					<!-- Exploration Requested Card -->
+					<div class="config-card">
+						<div class="config-card-header">
+							<div class="config-card-title">Exploration</div>
+							<span class="bubble {% if endpoint.exploration_requested %}warning{% endif %}">{% if endpoint.exploration_requested %}Queued{% else %}Not queued{% endif %}</span>
+						</div>
+						<div class="config-card-reminder">Prioritizes endpoint in next run.</div>
+						<form id="reexplore_action" method="POST" action="/admin/explored-endpoint/{{ endpoint.address }}/reexplore" class="config-card-action">
+							<input type="submit" value="Request Re-Exploration"{% if endpoint.exploration_requested %} class="disabled" disabled title="Re-exploration already queued for this endpoint"{% endif %}>
 							<span class="action-spinner"></span>
 						</form>
 					</div>
@@ -486,6 +491,47 @@
 document.addEventListener('DOMContentLoaded', function() {
 	const bmcIp = "{{ endpoint.address }}";
 	document.getElementById('logs-link').href = buildGrafanaLogsUrl(bmcIp);
+
+	var refreshToast = sessionStorage.getItem('refreshToast');
+	if (refreshToast) {
+		sessionStorage.removeItem('refreshToast');
+		try {
+			var t = JSON.parse(refreshToast);
+			showToast(t.message, t.error);
+		} catch(e) {
+			showToast(refreshToast);
+		}
+	}
+
+	var refreshBtn = document.getElementById('refresh-endpoint');
+	if (refreshBtn) {
+		window.addEventListener('pageshow', function(e) {
+			if (e.persisted) refreshBtn.classList.remove('refresh-spinning');
+		});
+		refreshBtn.addEventListener('click', function(e) {
+			e.preventDefault();
+			if (refreshBtn.classList.contains('refresh-spinning')) return;
+			refreshBtn.classList.add('refresh-spinning');
+			fetch('/admin/explored-endpoint/' + encodeURIComponent(bmcIp) + '/refresh', { method: 'POST' })
+				.then(function(res) {
+					return res.json().catch(function() { return {}; }).then(function(body) {
+						if (res.ok) {
+							sessionStorage.setItem('refreshToast', JSON.stringify({
+								message: 'Report Refreshed',
+								error: body.has_exploration_error || false
+							}));
+						} else {
+							sessionStorage.setItem('refreshToast', JSON.stringify({
+								message: body.error || 'Refresh failed',
+								error: true
+							}));
+						}
+						window.location.reload();
+					});
+				})
+				.catch(function() { window.location.reload(); });
+		});
+	}
 });
 </script>
 

--- a/crates/api/templates/static/carbide.css
+++ b/crates/api/templates/static/carbide.css
@@ -1412,6 +1412,10 @@ pre:not(div[style*="overflow: auto"] > pre):not(td > div > pre) {
   background: var(--accent, #76b900);
 }
 
+.action-toast.action-toast-error::before {
+  background: #d9534f;
+}
+
 .action-toast-text {
   padding: 0.85rem 1.25rem;
   font-size: 0.95rem;
@@ -1525,6 +1529,45 @@ select.disabled {
 }
 
 /* ------------------------------------------------------------------------
+   Refresh Endpoint Icon
+   ------------------------------------------------------------------------ */
+.refresh-icon {
+  display: block;
+}
+
+div#json a#refresh-endpoint {
+  align-items: center;
+  display: inline-flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  gap: 0.5rem;
+  justify-content: center;
+  padding: 0.5rem 1.25rem;
+  white-space: nowrap;
+}
+
+div#json a#refresh-endpoint .refresh-icon {
+  flex-shrink: 0;
+}
+
+div#json a#refresh-endpoint:hover {
+  background-color: var(--accent-green);
+  box-shadow: var(--shadow-md);
+  border-color: var(--accent-green-hover);
+}
+
+@keyframes refresh-spin {
+  0%   { transform: rotate(0deg); }
+  75%  { transform: rotate(360deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.refresh-spinning .refresh-icon {
+  animation: refresh-spin 1s ease-in-out infinite;
+  transform-origin: center;
+}
+
+/* ------------------------------------------------------------------------
    Tab System
    ------------------------------------------------------------------------ */
 
@@ -1631,4 +1674,4 @@ select.disabled {
     font-size: 0.85rem;
     white-space: nowrap;
   }
-} 
+}

--- a/crates/api/templates/static/tabs.js
+++ b/crates/api/templates/static/tabs.js
@@ -59,10 +59,21 @@
             history.replaceState(null, '', url.toString());
         }
 
-        const initial = nav.querySelector('.tab-button.active')
-            || nav.querySelector('.tab-button');
-        if (initial) {
-            moveIndicator(initial);
+        // Restore the active tab from the URL on initial load so refreshing
+        // or following a bookmarked link lands on the same tab.
+        const tabFromUrl = new URLSearchParams(window.location.search).get('tab');
+        const urlButton = tabFromUrl
+            ? nav.querySelector('.tab-button[data-tab="' + CSS.escape(tabFromUrl) + '"]')
+            : null;
+
+        if (urlButton && !urlButton.classList.contains('active')) {
+            setActive(urlButton);
+        } else {
+            const initial = nav.querySelector('.tab-button.active')
+                || nav.querySelector('.tab-button');
+            if (initial) {
+                moveIndicator(initial);
+            }
         }
 
         nav.addEventListener('click', function(e) {

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -278,6 +278,12 @@ service Forge {
   // Prioritizes the exploration of a certain endpoint in the next regular site-explorer run
   // The results of this run will be persisted in the database
   rpc ReExploreEndpoint(ReExploreEndpointRequest) returns (google.protobuf.Empty);
+  // Immediately probes a single BMC endpoint via Redfish, enriches the report
+  // (machine_id, model, position), and persists it. The next site-explorer tick
+  // picks up the freshly persisted report for downstream processing (pairing,
+  // remediation, audit). Returns AlreadyExists
+  // if a concurrent refresh or periodic probe is already in progress.
+  rpc RefreshEndpointReport(RefreshEndpointReportRequest) returns (site_explorer.ExploredEndpoint);
   // Delete an explored endpoint from the database
   rpc DeleteExploredEndpoint(DeleteExploredEndpointRequest) returns (DeleteExploredEndpointResponse);
   // Pause or unpause remediation actions for an explored endpoint
@@ -3651,6 +3657,11 @@ message ReExploreEndpointRequest {
   // If this is set, it will schedule re-exploration of the endpoint only if the
   // report version number is equivalent to the version in the request
   optional string if_version_match = 2;
+}
+
+message RefreshEndpointReportRequest {
+  // The IP address of the BMC endpoint to probe and refresh
+  string ip_address = 1;
 }
 
 message DeleteExploredEndpointRequest {

--- a/crates/site-explorer/src/config.rs
+++ b/crates/site-explorer/src/config.rs
@@ -50,10 +50,14 @@ pub struct SiteExplorerConfig {
     /// Default is 5.
     #[serde(default = "SiteExplorerConfig::default_concurrent_explorations")]
     pub concurrent_explorations: u64,
-    /// How many nodes should be explored in a single run.
-    /// Default is 10.
-    /// This number divided by `concurrent_explorations` will determine how many
-    /// exploration batches are needed inside a run.
+    /// How many routine (non-requested) endpoints should be explored in a single run.
+    /// Default is 90.
+    /// This bounds only the background refresh work: previously unseen endpoints
+    /// and stale endpoints whose reports we want to update. Endpoints with the
+    /// `exploration_requested` flag set are always attempted, regardless of this
+    /// value, because operators rely on that flag for guaranteed next-tick attempts.
+    /// Parallelism for both routine and requested explorations is still bounded by
+    /// `concurrent_explorations`.
     /// If the value is set too high the site exploration will take a lot of time
     /// and the exploration report will be updated less frequent. Therefore it
     /// is recommended to reduce `run_interval` instead of increasing

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
 
-use carbide_firmware::FirmwareConfig;
+use carbide_firmware::{FirmwareConfig, FirmwareConfigSnapshot};
 use carbide_network::sanitized_mac;
 use carbide_redfish::libredfish::conv::IntoModel;
 use carbide_utils::periodic_timer::PeriodicTimer;
@@ -72,7 +72,7 @@ pub use machine_creator::MachineCreator;
 pub mod explored_endpoint_index;
 mod managed_host;
 use db::ObjectColumnFilter;
-use db::work_lock_manager::WorkLockManagerHandle;
+use db::work_lock_manager::{AcquireLockError, WorkLockManagerHandle};
 pub use managed_host::is_endpoint_in_managed_host;
 use model::expected_machine::DpuMode;
 use model::firmware::FirmwareComponentType;
@@ -112,6 +112,45 @@ pub fn new_bmc_explorer(
         mode,
     )
     .into()
+}
+
+pub fn enrich_endpoint_exploration_report(
+    report: &mut EndpointExplorationReport,
+    fw_config_snapshot: &FirmwareConfigSnapshot,
+) {
+    if !report.is_power_shelf() {
+        if let Err(error) = report.generate_machine_id(false) {
+            tracing::error!(%error, "Can not generate MachineId for explored endpoint");
+        }
+        report.model = report.model();
+        if let Some(fw_info) = fw_config_snapshot.find_fw_info_for_host_report(report) {
+            let components_without_version = report.parse_versions(&fw_info);
+            if !components_without_version.is_empty() {
+                tracing::debug!(
+                    "Can not find firmware version for component(s): {:?}",
+                    components_without_version
+                );
+            }
+        } else {
+            // It's possible that we knew about this host type before but do not now, so make sure we
+            // do not keep stale data.
+            report.versions = HashMap::default();
+            tracing::debug!(
+                "Can not find firmware info for: vendor: {:?}; model: {:?}",
+                report.vendor,
+                report.model()
+            );
+        }
+
+        // Go through the chassis entries and get what at least one of them says.
+        report.parse_position_info()
+    } else {
+        tracing::info!("Generating PowerShelfId for power shelf");
+        if let Err(error) = report.generate_power_shelf_id() {
+            tracing::error!(%error, "Can not generate PowerShelfId for explored power shelf endpoint");
+        }
+        report.versions = HashMap::default();
+    }
 }
 
 /// Ensures a rack row exists for the given `rack_id`.
@@ -202,6 +241,14 @@ impl<'a> Endpoint<'a> {
 }
 
 pub type SiteIdentifiedHosts = Vec<(ExploredManagedHost, EndpointExplorationReport)>;
+
+/// Work-lock key for a single endpoint exploration.
+///
+/// Both the site-explorer loop (`update_explored_endpoints`) and the adhoc
+/// `RefreshEndpointReport` handler acquire this key before probing Redfish.
+pub fn endpoint_exploration_work_key(bmc_ip: IpAddr) -> String {
+    format!("SiteExplorer::endpoint_exploration::{bmc_ip}")
+}
 
 /// The SiteExplorer periodically runs [modules](machine_update_module::MachineUpdateModule) to initiate upgrades of machine components.
 /// On each iteration the SiteExplorer will:
@@ -1495,13 +1542,15 @@ impl SiteExplorer {
         let num_explore_endpoints = (self.config.explorations_per_run as usize)
             .min(unexplored_endpoints.len() + update_endpoints.len());
 
-        let mut explore_endpoint_data = Vec::with_capacity(num_explore_endpoints);
+        let mut explore_endpoint_data =
+            Vec::with_capacity(priority_update_endpoints.len() + num_explore_endpoints);
 
-        // We prioritize existing endpoints which have the `exploration_requested` flag set
-        for (address, iface, endpoint) in priority_update_endpoints
-            .into_iter()
-            .take(num_explore_endpoints)
-        {
+        // Existing endpoints with `exploration_requested` are enqueued
+        // unconditionally and sit outside the per-iteration count budget.
+        // Operators set this flag to request a guaranteed next-tick attempt, so
+        // we must not let the routine refresh budget delay them. Concurrency is
+        // still bounded by the `concurrent_explorations` semaphore below.
+        for (address, iface, endpoint) in priority_update_endpoints {
             explore_endpoint_data.push(Endpoint {
                 address,
                 iface,
@@ -1511,8 +1560,10 @@ impl SiteExplorer {
             });
         }
 
+        let routine_start = explore_endpoint_data.len();
+
         // Next priority are all endpoints that we've never looked at
-        let remaining_explore_endpoints = num_explore_endpoints - explore_endpoint_data.len();
+        let remaining_explore_endpoints = num_explore_endpoints;
         for (address, iface) in unexplored_endpoints
             .iter()
             .take(remaining_explore_endpoints)
@@ -1529,7 +1580,8 @@ impl SiteExplorer {
         }
 
         // If we have any capacity available, we update knowledge about endpoints we looked at earlier on
-        let remaining_explore_endpoints = num_explore_endpoints - explore_endpoint_data.len();
+        let remaining_explore_endpoints =
+            num_explore_endpoints - (explore_endpoint_data.len() - routine_start);
         if remaining_explore_endpoints != 0 {
             // Sort endpoints so that we will replace the oldest report first
             update_endpoints.sort_by_key(|(_address, _machine_interface, endpoint)| {
@@ -1568,6 +1620,7 @@ impl SiteExplorer {
             let bmc_target_addr = SocketAddr::new(endpoint.address, bmc_target_port);
             let fw_config_snapshot = fw_config_snapshot.clone();
             let database_connection = self.database_connection.clone();
+            let work_lock_manager_handle = self.work_lock_manager_handle.clone();
 
             task_set.push(
                 async move {
@@ -1582,6 +1635,26 @@ impl SiteExplorer {
                         .acquire()
                         .await
                         .expect("Semaphore can't be closed");
+
+                    // If the endpoint is locked, we skip exploration.
+                    let work_key = endpoint_exploration_work_key(endpoint.address);
+                    let _work_lock = match work_lock_manager_handle.try_acquire_lock(work_key).await
+                    {
+                        Ok(work_lock) => work_lock,
+                        Err(AcquireLockError::WorkAlreadyLocked(_)) => {
+                            tracing::info!(
+                                address = %endpoint.address,
+                                "Skipping periodic endpoint exploration; adhoc refresh already in progress"
+                            );
+                            return Ok(None);
+                        }
+                        Err(e) => {
+                            return Err(SiteExplorerError::internal(format!(
+                                "Failed to acquire per-endpoint work lock for {}: {e}",
+                                endpoint.address
+                            )));
+                        }
+                    };
 
                     let mut result = endpoint_explorer
                         .explore_endpoint(
@@ -1607,38 +1680,11 @@ impl SiteExplorer {
                         tracing::info!(%error, "Failed to explore {}: {}{}", bmc_target_addr, error, machine_state);
                     }
 
-                    // Try to generate a MachineId and parsed version info based on the retrieved data
                     if let Ok(report) = &mut result {
-                        if !report.is_power_shelf() {
-                            if let Err(error) = report.generate_machine_id(false) {
-                                tracing::error!(%error, "Can not generate MachineId for explored endpoint");
-                            }
-                            report.model = report.model();
-                            if let Some(fw_info) = fw_config_snapshot.find_fw_info_for_host_report(report)
-                            {
-                                let components_without_version = report.parse_versions(&fw_info);
-                                if !components_without_version.is_empty() {
-                                    tracing::debug!("Can not find firmware version for component(s): {:?}", components_without_version);
-                                }
-                            } else {
-                                // It's possible that we knew about this host type before but do not now, so make sure we
-                                // do not keep stale data.
-                                report.versions = HashMap::default();
-                                tracing::debug!("Can not find firmware info for: vendor: {:?}; model: {:?}", report.vendor, report.model());
-                            }
-
-                            // Go through the chassis entries and get what at least one of them says
-                            report.parse_position_info()
-                        } else {
-                            tracing::info!("Generating PowerShelfId for power shelf");
-                            if let Err(error) = report.generate_power_shelf_id() {
-                                tracing::error!(%error, "Can not generate PowerShelfId for explored power shelf endpoint");
-                            }
-                            report.versions = HashMap::default();
-                        }
+                        enrich_endpoint_exploration_report(report, &fw_config_snapshot);
                     }
 
-                    (endpoint, result, start.elapsed())
+                    Ok(Some((endpoint, result, start.elapsed())))
                 }
                     .in_current_span(),
             );
@@ -1650,14 +1696,18 @@ impl SiteExplorer {
         // even thought the next controller iteration already started.
         // Therefore we drain the `task_set` here completely and record all errors
         // before returning.
-        let exploration_results = task_set.collect::<Vec<_>>().await;
+        let exploration_results = task_set
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<SiteExplorerResult<Vec<_>>>()?;
 
         // All subtasks finished. We now update the database
         let mut txn = self.txn_begin().await?;
 
         let mut redfish_errors = Vec::new();
 
-        for (endpoint, result, exploration_duration) in exploration_results.into_iter() {
+        for (endpoint, result, exploration_duration) in exploration_results.into_iter().flatten() {
             let address = endpoint.address;
             let mut redfish_error = None;
 


### PR DESCRIPTION
## Description
Ever had to wait forever for site explorer to refresh your endpoint report? This PR adds an on-demand endpoint refresh API, so operators can immediately probe a BMC, persist the refreshed report, and receive the new report or exploration error. It:

- Adds a `Refresh` button to the explored endpoint UI with spinner state, toast feedback, and automatic reload after refresh completes.
   - If a user navigates away during the refresh, it keeps happening in the background and persists to the db but they will lose the spinner state and success/error feedback. The `Last Updated` bubble in the report version row still remains the primary indicator of the refresh.
- Keeps downstream site explorer processing on the next normal tick: pairing, remediation, audit, and other follow-up work consume the freshly persisted endpoint report when the periodic loop runs. 
   - Because the refresh bumps the report version, that endpoint moves to the back of the oldest-first refresh queue, making it unlikely to be probed again on the very next tick unless an operator explicitly requests re-exploration.
- Uses a per-endpoint `WorkLock` shared with the periodic site explorer loop, preventing adhoc refreshes and background probes from racing or duplicating Redfish calls.
- Changes `exploration_requested` handling so requested re-explorations are attempted _outside_ the regular per-run exploration budget, preserving unexplored/re-explore capacity while honoring operator-prioritized work.
- Clears queued `exploration_requested` state after an adhoc refresh so the same endpoint is not immediately probed again as priority work.

Ways to refresh:
```
./carbide-admin-cli site-explorer refresh <bmc-ip>
```
<img width="1112" height="806" alt="Screenshot 2026-05-13 at 11 01 49 AM" src="https://github.com/user-attachments/assets/b97f28a2-592c-4cf6-a96f-ac7a3389c022" />


If a refresh is requested while site-explorer is actively working on the endpoint:

<img width="1647" height="354" alt="image" src="https://github.com/user-attachments/assets/252e6dd9-f55c-4ca0-a16c-5d092bfe6d5d" />

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

