### PR TITLE
fix(api,agent): Make vpc vrf loopback a config option

### DIFF
--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -2360,7 +2360,7 @@ mod tests {
                 )
                 .unwrap()
                 .map(|ip| ip.to_string()),
-                tenant_vrf_loopback_ip: Some("10.217.5.124".to_string()),
+                tenant_vrf_loopback_ip: None,
                 is_l2_segment: true,
                 network_security_group: None,
                 internal_uuid: None,
@@ -2390,7 +2390,7 @@ mod tests {
                 )
                 .unwrap()
                 .map(|ip| ip.to_string()),
-                tenant_vrf_loopback_ip: Some("10.217.5.125".to_string()),
+                tenant_vrf_loopback_ip: None,
                 is_l2_segment: second_interface_l2,
                 network_security_group: if !include_network_security_group {
                     None

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -241,6 +241,7 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
     }
 
     let mut has_any_vpc_tenant_host_leak_to_underlay = false;
+    let mut has_any_vpc_vrf_loopback = false;
     let mut fmds_gateway_matched = false;
 
     for (base_i, network) in conf.ct_port_configs.into_iter().enumerate() {
@@ -314,6 +315,9 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
         let (vpc_peer_ipv4, vpc_peer_ipv6) =
             split_prefixes_by_family(&network.vpc_peer_prefixes, 1);
 
+        has_any_vpc_vrf_loopback =
+            has_any_vpc_vrf_loopback || network.tenant_vrf_loopback_ip.is_some();
+
         vpc_configs
             .entry(network.l3_vni.unwrap_or_default())
             .and_modify(|v| {
@@ -324,6 +328,7 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
             .or_insert_with(|| TmplVpc {
                 VrfName: port.VrfName.clone(),
                 L3VNI: network.l3_vni.unwrap_or_default(),
+                HasVrfLoopback: network.tenant_vrf_loopback_ip.is_some(),
                 VrfLoopback: network.tenant_vrf_loopback_ip.unwrap_or_default(),
                 // TODO: This is wasteful because it should be specific to a VPC.
                 // Otherwise, all VPCs will have a BGP peer config for each
@@ -476,6 +481,7 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
         VfInterceptHbnRepresentorIp: vf_intercept_hbn_representor_ip,
         VfInterceptBridgeSf: conf.vf_intercept_bridge_sf.unwrap_or_default(),
         HasAnyVpcTenantHostLeakToUnderlay: has_any_vpc_tenant_host_leak_to_underlay,
+        HasAnyVpcVrfLoopback: has_any_vpc_vrf_loopback,
         TrafficInterceptPublicPrefixes: traffic_intercept_ipv4,
         TrafficInterceptPublicPrefixesIpv6: traffic_intercept_ipv6,
         ASN: conf.asn,
@@ -1160,6 +1166,9 @@ struct TmplNvue {
     /// tenant routes should leak to the underlay?
     HasAnyVpcTenantHostLeakToUnderlay: bool,
 
+    /// Does any VPC have a VRF loopback?
+    HasAnyVpcVrfLoopback: bool,
+
     /// The size of the of the prefix used for the internal
     /// bridge routing.
     InterceptBridgePrefixLen: u8,
@@ -1372,6 +1381,7 @@ struct TmplVpc {
     // from a dedicated resource-pool, handed out as un-related /32s, and
     // interfaces in FNN get /31s.
     /// The tenant loopback IP assigned to each DPU.
+    HasVrfLoopback: bool,
     VrfLoopback: String,
 
     HostInterfaces: Vec<TmplHostInterfaces>,

--- a/crates/agent/templates/nvue_startup_fnn.conf
+++ b/crates/agent/templates/nvue_startup_fnn.conf
@@ -284,11 +284,15 @@
           DPU_TO_EVPN_DROP_PREFIX_LIST:
             rule:
               {{- if not (eq (len $tenant.Vpcs) 0) }}
+                {{- if $nvueConfig.HasAnyVpcVrfLoopback }}
               '10':
                 action: permit{{/* This means 'match', not 'allow' */}}
                 match:
-                {{- range $vpc := $tenant.Vpcs }}
+                  {{- range $vpc := $tenant.Vpcs }}
+                      {{- if $vpc.VrfLoopback }}
                   {{ $vpc.VrfLoopback }}/32: {}{{/* Still not clear we really even need a loopback on the VRF for our use-case, and we allow duplication between sites, so keep the type-5 route for it out of the overlay. */}}
+                      {{- end}}
+                  {{- end }}
                 {{- end }}
               {{- end }}
               '65535':
@@ -757,10 +761,12 @@
           enable: on
           vni:
             {{ if $nvueConfig.HasSiteGlobalVpcVni }}'{{$nvueConfig.SiteGlobalVpcVni}}'{{ else }}'{{ $vpc.L3VNI }}'{{ end }}: {} {{/* A VRF (VPC) needs a unique VNI to create the tenant separation */}}
+        {{- if $vpc.VrfLoopback }}
         loopback:
           ip:
             address:
               {{ $vpc.VrfLoopback }}/32: {} {{/* Every VRF on each DPU requires a unique loopback address */}}
+        {{- end }}
         router:
         {{- if $nvueConfig.UseAdminNetwork }}
           static:

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
@@ -164,11 +164,6 @@
                   any: {}
           DPU_TO_EVPN_DROP_PREFIX_LIST:
             rule:
-              '10':
-                action: permit
-                match:
-                  10.217.5.125/32: {}
-                  10.217.5.124/32: {}
               '65535':
                 action: deny
                 match:
@@ -510,10 +505,6 @@
           enable: on
           vni:
             '1025186': {} 
-        loopback:
-          ip:
-            address:
-              10.217.5.125/32: {} 
         router:
           bgp:
             path-selection:
@@ -613,10 +604,6 @@
           enable: on
           vni:
             '1025197': {} 
-        loopback:
-          ip:
-            address:
-              10.217.5.124/32: {} 
         router:
           bgp:
             path-selection:

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
@@ -172,11 +172,6 @@
                   any: {}
           DPU_TO_EVPN_DROP_PREFIX_LIST:
             rule:
-              '10':
-                action: permit
-                match:
-                  10.217.5.125/32: {}
-                  10.217.5.124/32: {}
               '65535':
                 action: deny
                 match:
@@ -520,10 +515,6 @@
           enable: on
           vni:
             '3109': {} 
-        loopback:
-          ip:
-            address:
-              10.217.5.125/32: {} 
         router:
           bgp:
             path-selection:
@@ -623,10 +614,6 @@
           enable: on
           vni:
             '3109': {} 
-        loopback:
-          ip:
-            address:
-              10.217.5.124/32: {} 
         router:
           bgp:
             path-selection:

--- a/crates/agent/templates/tests/nvue_startup_fnn_with_leaks.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_with_leaks.yaml.expected
@@ -169,11 +169,6 @@
                   any: {}
           DPU_TO_EVPN_DROP_PREFIX_LIST:
             rule:
-              '10':
-                action: permit
-                match:
-                  10.217.5.125/32: {}
-                  10.217.5.124/32: {}
               '65535':
                 action: deny
                 match:
@@ -687,10 +682,6 @@
           enable: on
           vni:
             '1025186': {} 
-        loopback:
-          ip:
-            address:
-              10.217.5.125/32: {} 
         router:
           bgp:
             path-selection:
@@ -802,10 +793,6 @@
           enable: on
           vni:
             '1025197': {} 
-        loopback:
-          ip:
-            address:
-              10.217.5.124/32: {} 
         router:
           bgp:
             path-selection:

--- a/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
@@ -184,11 +184,6 @@
                   any: {}
           DPU_TO_EVPN_DROP_PREFIX_LIST:
             rule:
-              '10':
-                action: permit
-                match:
-                  10.217.5.125/32: {}
-                  10.217.5.124/32: {}
               '65535':
                 action: deny
                 match:
@@ -532,10 +527,6 @@
           enable: on
           vni:
             '1025186': {} 
-        loopback:
-          ip:
-            address:
-              10.217.5.125/32: {} 
         router:
           bgp:
             path-selection:
@@ -635,10 +626,6 @@
           enable: on
           vni:
             '1025197': {} 
-        loopback:
-          ip:
-            address:
-              10.217.5.124/32: {} 
         router:
           bgp:
             path-selection:

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -953,6 +953,12 @@ pub struct FnnConfig {
     /// Named routing profiles that define per-VPC route target import/export policies.
     #[serde(default)]
     pub routing_profiles: HashMap<String, FnnRoutingProfileConfig>,
+
+    /// Whether IPs should be allocated for VPC loopbacks.
+    /// The VPC loopback pool will not be used if this false and
+    /// no VPC/VRF loopback IP will be sent to the DPU.
+    #[serde(default)]
+    pub use_vpc_vrf_loopback: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Default)]

--- a/crates/api/src/ethernet_virtualization.rs
+++ b/crates/api/src/ethernet_virtualization.rs
@@ -205,6 +205,7 @@ pub async fn admin_network(
     fnn_enabled_on_admin: bool,
     common_pools: &CommonPools,
     booturl: &Option<String>,
+    use_vpc_vrf_loopback: bool,
 ) -> Result<(rpc::FlatInterfaceConfig, MachineInterfaceId), tonic::Status> {
     let admin_segments = db::network_segment::admin(txn).await?;
     let admin_segment_ids = admin_segments
@@ -314,16 +315,22 @@ pub async fn admin_network(
                 let vpc = vpcs.remove(0);
                 match vpc.status.and_then(|v| v.vni) {
                     Some(vpc_vni) => {
-                        let tenant_loopback_ip =
-                            db::vpc_dpu_loopback::get_or_allocate_loopback_ip_for_vpc(
-                                common_pools,
-                                txn,
-                                dpu_machine_id,
-                                &vpc.id,
+                        let tenant_loopback_ip = if use_vpc_vrf_loopback {
+                            Some(
+                                db::vpc_dpu_loopback::get_or_allocate_loopback_ip_for_vpc(
+                                    common_pools,
+                                    txn,
+                                    dpu_machine_id,
+                                    &vpc.id,
+                                )
+                                .await?
+                                .to_string(),
                             )
-                            .await?;
+                        } else {
+                            None
+                        };
 
-                        (vpc_vni as u32, Some(tenant_loopback_ip.to_string()))
+                        (vpc_vni as u32, tenant_loopback_ip)
                     }
                     None => {
                         // if FNN is enabled, VPC must be created and updated in admin_segment.

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -180,6 +180,11 @@ pub(crate) async fn get_managed_host_network_config_inner(
         use_fnn_over_admin_nw = true;
         network_virtualization_type = VpcVirtualizationType::Fnn;
     }
+    let use_vpc_vrf_loopback = api
+        .runtime_config
+        .fnn
+        .as_ref()
+        .is_some_and(|c| c.use_vpc_vrf_loopback);
 
     let booturl_override = if snapshot
         .host_snapshot
@@ -200,6 +205,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
         use_fnn_over_admin_nw,
         &api.common_pools,
         &booturl_override,
+        use_vpc_vrf_loopback,
     )
     .await?;
 
@@ -361,7 +367,9 @@ pub(crate) async fn get_managed_host_network_config_inner(
 
             // TODO: VPC loopbacks are currently blocked from being advertised out on the DPU.
             // This must become per-interface/per-VPC before VPC loopbacks can be allowed out.
-            let tenant_loopback_ip = if VpcVirtualizationType::Fnn == network_virtualization_type {
+            let tenant_loopback_ip = if VpcVirtualizationType::Fnn == network_virtualization_type
+                && use_vpc_vrf_loopback
+            {
                 let tenant_loopback_ip = db::vpc_dpu_loopback::get_or_allocate_loopback_ip_for_vpc(
                     &api.common_pools,
                     &mut txn,

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -317,6 +317,7 @@ impl TestEnvOverrides {
                         },
                     ),
                 ]),
+                use_vpc_vrf_loopback: false,
             })
         });
 

--- a/crates/api/src/tests/machine_network.rs
+++ b/crates/api/src/tests/machine_network.rs
@@ -30,7 +30,9 @@ use model::machine::network::ManagedHostQuarantineMode;
 use rpc::Metadata;
 use rpc::forge::forge_server::Forge;
 
-use crate::cfg::file::{FnnConfig, FnnRoutingProfileConfig, PrefixFilterPolicyEntry};
+use crate::cfg::file::{
+    AdminFnnConfig, FnnConfig, FnnRoutingProfileConfig, PrefixFilterPolicyEntry,
+};
 use crate::tests::common;
 use crate::tests::common::api_fixtures::TestEnvOverrides;
 use crate::tests::common::api_fixtures::site_explorer::MockExploredHost;
@@ -127,6 +129,7 @@ async fn test_managed_host_network_config_includes_routing_profile_accepted_leak
                     ..Default::default()
                 },
             )]),
+            use_vpc_vrf_loopback: false,
         })),
     )
     .await;
@@ -188,6 +191,214 @@ async fn test_managed_host_network_config_includes_routing_profile_accepted_leak
         .map(|leak| leak.prefix)
         .collect();
     assert_eq!(actual_leaks, expected_leaks);
+}
+
+#[crate::sqlx_test]
+async fn test_managed_host_network_config_omits_fnn_vrf_loopback_by_default(pool: sqlx::PgPool) {
+    let env = api_fixtures::create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::default().with_fnn_config(None),
+    )
+    .await;
+
+    // Create a tenant and FNN segment with the default disabled loopback setting.
+    let tenant = env
+        .api
+        .create_tenant(tonic::Request::new(rpc::forge::CreateTenantRequest {
+            organization_id: "fnn-loopback-default".to_string(),
+            routing_profile_type: Some("INTERNAL".to_string()),
+            metadata: Some(rpc::forge::Metadata {
+                name: "fnn-loopback-default".to_string(),
+                ..Default::default()
+            }),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .tenant
+        .unwrap();
+
+    let segment_id = env
+        .create_vpc_and_tenant_segment_with_vpc_details(
+            VpcCreationRequest::builder(tenant.organization_id.as_str())
+                .metadata(Metadata {
+                    name: "fnn loopback default vpc".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .routing_profile_type("INTERNAL".to_string())
+                .rpc(),
+        )
+        .await;
+
+    // Allocate a managed host on the FNN segment.
+    let mh = create_managed_host(&env).await;
+    let dpu_machine_id = mh.dpu().id;
+    mh.instance_builer(&env)
+        .tenant_org(tenant.organization_id)
+        .single_interface_network_config(segment_id)
+        .build()
+        .await;
+
+    // Fetch the DPU config and verify no tenant VRF loopback is sent.
+    let response = env
+        .api
+        .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
+            dpu_machine_id: Some(dpu_machine_id),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(!response.tenant_interfaces.is_empty());
+    assert!(
+        response
+            .tenant_interfaces
+            .iter()
+            .all(|iface| iface.tenant_vrf_loopback_ip.is_none())
+    );
+
+    // Verify the DB did not allocate a VPC/DPU loopback row.
+    let mut txn = env.db_txn().await;
+    let vpc = db::vpc::find_by_segment(txn.as_mut(), segment_id)
+        .await
+        .unwrap();
+    let loopback = db::vpc_dpu_loopback::find(txn.as_mut(), &dpu_machine_id, &vpc.id)
+        .await
+        .unwrap();
+    assert!(loopback.is_none());
+}
+
+#[crate::sqlx_test]
+async fn test_managed_host_network_config_includes_fnn_vrf_loopback_when_enabled(
+    pool: sqlx::PgPool,
+) {
+    let mut overrides = TestEnvOverrides::default().with_fnn_config(None);
+    overrides.fnn_config.as_mut().unwrap().use_vpc_vrf_loopback = true;
+
+    let env = api_fixtures::create_test_env_with_overrides(pool, overrides).await;
+
+    // Create a tenant and FNN segment with loopback allocation enabled.
+    let tenant = env
+        .api
+        .create_tenant(tonic::Request::new(rpc::forge::CreateTenantRequest {
+            organization_id: "fnn-loopback-enabled".to_string(),
+            routing_profile_type: Some("INTERNAL".to_string()),
+            metadata: Some(rpc::forge::Metadata {
+                name: "fnn-loopback-enabled".to_string(),
+                ..Default::default()
+            }),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .tenant
+        .unwrap();
+
+    let segment_id = env
+        .create_vpc_and_tenant_segment_with_vpc_details(
+            VpcCreationRequest::builder(tenant.organization_id.as_str())
+                .metadata(Metadata {
+                    name: "fnn loopback enabled vpc".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .routing_profile_type("INTERNAL".to_string())
+                .rpc(),
+        )
+        .await;
+
+    // Allocate a managed host on the FNN segment.
+    let mh = create_managed_host(&env).await;
+    let dpu_machine_id = mh.dpu().id;
+    mh.instance_builer(&env)
+        .tenant_org(tenant.organization_id)
+        .single_interface_network_config(segment_id)
+        .build()
+        .await;
+
+    // Fetch the DPU config and verify the tenant VRF loopback is sent.
+    let response = env
+        .api
+        .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
+            dpu_machine_id: Some(dpu_machine_id),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    let loopback_ip = response.tenant_interfaces[0]
+        .tenant_vrf_loopback_ip
+        .clone()
+        .expect("loopback should be present when enabled");
+
+    // Verify the DB allocation matches the response.
+    let mut txn = env.db_txn().await;
+    let vpc = db::vpc::find_by_segment(txn.as_mut(), segment_id)
+        .await
+        .unwrap();
+    let loopback = db::vpc_dpu_loopback::find(txn.as_mut(), &dpu_machine_id, &vpc.id)
+        .await
+        .unwrap()
+        .expect("loopback allocation should be persisted");
+    assert_eq!(loopback.loopback_ip.to_string(), loopback_ip);
+}
+
+#[crate::sqlx_test]
+async fn test_managed_host_network_config_omits_admin_fnn_vrf_loopback_by_default(
+    pool: sqlx::PgPool,
+) {
+    let mut overrides = TestEnvOverrides::default().with_fnn_config(None);
+    overrides.fnn_config.as_mut().unwrap().admin_vpc = Some(AdminFnnConfig {
+        enabled: true,
+        vpc_vni: Some(10000),
+        routing_profile: FnnRoutingProfileConfig::default(),
+    });
+
+    let env = api_fixtures::create_test_env_with_overrides(pool, overrides).await;
+
+    // Attach the FNN admin VPC because test env setup does not run production setup hooks.
+    crate::db_init::create_admin_vpc(&env.pool, Some(10000))
+        .await
+        .unwrap();
+    crate::db_init::update_network_segments_svi_ip(&env.pool)
+        .await
+        .unwrap();
+
+    // Create a managed host that stays on the admin network.
+    let mh = create_managed_host(&env).await;
+    let dpu_machine_id = mh.dpu().id;
+
+    // Fetch the DPU config and verify the FNN admin interface has no loopback.
+    let response = env
+        .api
+        .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
+            dpu_machine_id: Some(dpu_machine_id),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    let admin_interface = response
+        .admin_interface
+        .as_ref()
+        .expect("admin interface should be present");
+
+    assert!(response.use_admin_network);
+    assert_eq!(admin_interface.vpc_vni, 10000);
+    assert!(admin_interface.tenant_vrf_loopback_ip.is_none());
+
+    // Verify the admin VPC also did not allocate a VPC/DPU loopback row.
+    let mut txn = env.db_txn().await;
+    let admin_segment = db::network_segment::admin(txn.as_mut())
+        .await
+        .unwrap()
+        .remove(0);
+    let admin_vpc_id = admin_segment
+        .vpc_id
+        .expect("admin segment should be attached to an FNN VPC");
+    let loopback = db::vpc_dpu_loopback::find(txn.as_mut(), &dpu_machine_id, &admin_vpc_id)
+        .await
+        .unwrap();
+    assert!(loopback.is_none());
 }
 
 #[crate::sqlx_test]

--- a/crates/api/src/tests/vpc.rs
+++ b/crates/api/src/tests/vpc.rs
@@ -137,6 +137,7 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
                     },
                 ),
             ]),
+            use_vpc_vrf_loopback: false,
         })),
     )
     .await;


### PR DESCRIPTION
## Description

VPC VRF loopbacks can eat an additional IP when FNN is used but they aren't truly required and only help debugging.  Most deployments very likely don't need them, and the same debugging can be done by just allocating a small slice of IPs for using as needed when debugging on a DPU.

Currently, the IPs are blocked from being advertised out on the DPU, so they truly serve no purpose right now.  We should default to them not being allocated or used, and allow users to opt-in.

They're already pulled from an optional resource pool and allocated at run-time as needed, so a deployment can opt-in at any time without needing to redeploy.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

