### PR TITLE
fix: grant Vault machine credential writes

### DIFF
--- a/docs/getting-started/installation-options/reference-install.md
+++ b/docs/getting-started/installation-options/reference-install.md
@@ -370,7 +370,7 @@ Once Vault is running and unsealed, the `vault-pki-config` Job (Helm post-instal
 1. Enables the `forgeca` PKI secrets engine, tunes it to a 10-year max TTL.
 2. Imports `site-root` (cert + key) into Vault PKI — Vault becomes an intermediate CA under the same trust root.
 3. Creates PKI role `forge-cluster` — allows any name, allows SPIFFE URI SANs, 720h max TTL, EC P-256.
-4. Enables Kubernetes auth and writes two policies: `cert-manager-forge-policy` (sign via PKI) and `forge-vault-policy` (read KV secrets).
+4. Enables Kubernetes auth and writes two policies: `cert-manager-forge-policy` (sign via PKI) and `forge-vault-policy` (read KV secrets, issue PKI certs, and manage machine/UFM/NMXM credentials).
 5. Enables KV v2 at `secrets/` and AppRole auth for the `carbide` role.
 
 `vault-forge-issuer` is then created as a cert-manager ClusterIssuer authenticating to Vault via Kubernetes auth. All NCX Core workload SPIFFE certificates and the site-agent's gRPC client certificate are issued through this issuer.

--- a/docs/getting-started/installation-options/reference-install.md
+++ b/docs/getting-started/installation-options/reference-install.md
@@ -370,7 +370,7 @@ Once Vault is running and unsealed, the `vault-pki-config` Job (Helm post-instal
 1. Enables the `forgeca` PKI secrets engine, tunes it to a 10-year max TTL.
 2. Imports `site-root` (cert + key) into Vault PKI — Vault becomes an intermediate CA under the same trust root.
 3. Creates PKI role `forge-cluster` — allows any name, allows SPIFFE URI SANs, 720h max TTL, EC P-256.
-4. Enables Kubernetes auth and writes two policies: `cert-manager-forge-policy` (sign via PKI) and `forge-vault-policy` (read KV secrets, issue PKI certs, and manage machine/UFM/NMXM credentials).
+4. Enables Kubernetes auth and writes two policies: `cert-manager-forge-policy` (sign via PKI) and `forge-vault-policy` (read KV secrets).
 5. Enables KV v2 at `secrets/` and AppRole auth for the `carbide` role.
 
 `vault-forge-issuer` is then created as a cert-manager ClusterIssuer authenticating to Vault via Kubernetes auth. All NCX Core workload SPIFFE certificates and the site-agent's gRPC client certificate are issued through this issuer.

--- a/helm-prereqs/templates/vault-config-job.yaml
+++ b/helm-prereqs/templates/vault-config-job.yaml
@@ -219,11 +219,36 @@ spec:
 
               echo "Writing nico-vault-policy..."
               vault policy write nico-vault-policy - << 'POLICY'
-              path "{{ .Values.vault.kvMount }}/data/*" {
+              path "{{ .Values.vault.pkiMount }}*" {
                 capabilities = ["read", "list"]
+              }
+              path "{{ .Values.vault.pkiMount }}/sign/{{ .Values.vault.pkiRole }}" {
+                capabilities = ["create", "update"]
               }
               path "{{ .Values.vault.pkiMount }}/issue/{{ .Values.vault.pkiRole }}" {
                 capabilities = ["create", "update"]
+              }
+
+              path "{{ .Values.vault.kvMount }}/data/*" {
+                capabilities = ["read", "list"]
+              }
+              path "{{ .Values.vault.kvMount }}/data/machines*" {
+                capabilities = ["create", "read", "patch", "list", "update", "delete"]
+              }
+              path "{{ .Values.vault.kvMount }}/data/machines/*" {
+                capabilities = ["create", "read", "patch", "list", "update", "delete"]
+              }
+              path "{{ .Values.vault.kvMount }}/metadata/machines/*" {
+                capabilities = ["delete"]
+              }
+              path "{{ .Values.vault.kvMount }}/destroy/machines/*" {
+                capabilities = ["delete"]
+              }
+              path "{{ .Values.vault.kvMount }}/data/ufm/*" {
+                capabilities = ["create", "read", "patch", "list", "update", "delete"]
+              }
+              path "{{ .Values.vault.kvMount }}/data/nmxm/*" {
+                capabilities = ["create", "read", "patch", "list", "update", "delete"]
               }
               POLICY
 
@@ -239,8 +264,8 @@ spec:
               # ---- K8s auth role for nico-api ----
               # nico-api authenticates to in-cluster Vault via its SA JWT
               # (vault SDK auto-detects /var/run/secrets/kubernetes.io/serviceaccount/token)
-              # and reads BMC credentials from the KV mount (nico-vault-policy
-              # grants read on {{ .Values.vault.kvMount }}/data/*).
+              # and manages machine credentials in the KV mount (nico-vault-policy
+              # grants read/list plus scoped writes for machine, UFM, and NMXM secrets).
               echo "Creating K8s auth role for nico-api..."
               vault write auth/kubernetes/role/{{ .Values.vault.nicoApiK8sAuth.serviceAccountName }} \
                 bound_service_account_names={{ .Values.vault.nicoApiK8sAuth.serviceAccountName }} \

--- a/helm-prereqs/values.yaml
+++ b/helm-prereqs/values.yaml
@@ -51,8 +51,8 @@ vault:
     enabled: false
     name: "nico-cli-client"
     organization: ""
-  ## Kubernetes auth role for nico-api to read from Vault KV
-  ## (e.g., BMC credentials for SiteExplorer).
+  ## Kubernetes auth role for nico-api to read and manage Vault KV
+  ## credentials used by SiteExplorer and related credential flows.
   nicoApiK8sAuth:
     enabled: false
     serviceAccountName: "nico-api"


### PR DESCRIPTION
## Description
Updates helm-prereqs Vault configuration so `forge-vault-policy` supports the credential operations that `carbide-api` performs for machine, UFM, and NMXM secrets. This fixes Vault permission failures when `carbide-api` handles credential creation and related credential management flows.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
N/A

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Manual validation:
- `helm lint ./helm-prereqs`
- `helm template carbide-prereqs ./helm-prereqs --set vault.carbideApiK8sAuth.enabled=true`

## Additional Notes
The policy remains scoped to the existing `forge-vault-policy` consumers and adds machine credential CRUD plus KV v2 metadata/destroy delete paths required by credential deletion flows. It also updates docs/comments so the policy is no longer described as read-only.