### PR TITLE
feat(api): integrate auto network config for zero-DPU instance allocation

### DIFF
--- a/crates/api-db/src/instance_network_config.rs
+++ b/crates/api-db/src/instance_network_config.rs
@@ -26,7 +26,7 @@ use model::machine::Machine;
 use model::network_segment::NetworkSegmentType;
 use sqlx::PgConnection;
 
-use crate::DatabaseResult;
+use crate::{DatabaseError, DatabaseResult};
 /// Allocate IP's for this network config, filling the InstanceInterfaceConfigs with the newly
 /// allocated IP's.
 pub async fn with_allocated_ips(
@@ -36,32 +36,6 @@ pub async fn with_allocated_ips(
     machine: &Machine,
 ) -> DatabaseResult<InstanceNetworkConfig> {
     crate::instance_address::allocate(txn, instance_id, value, machine).await
-}
-
-/// Find any host_inband segments on the given machine, and replicate them into this instance
-/// network config. This is because allocation requests do not need to explicitly enumerate
-/// a host's in-band (non-dpu) network segments: they cannot be configured through carbide.
-pub async fn with_inband_interfaces_from_machine(
-    value: InstanceNetworkConfig,
-    txn: &mut PgConnection,
-    machine_id: &::carbide_uuid::machine::MachineId,
-) -> DatabaseResult<InstanceNetworkConfig> {
-    let inband_segments_map = crate::network_segment::batch_find_ids_by_machine_ids(
-        txn,
-        &[*machine_id],
-        Some(NetworkSegmentType::HostInband),
-    )
-    .await?;
-
-    let host_inband_segment_ids = inband_segments_map
-        .get(machine_id)
-        .cloned()
-        .unwrap_or_default();
-
-    Ok(add_inband_interfaces_to_config(
-        value,
-        &host_inband_segment_ids,
-    ))
 }
 
 /// Batch find host_inband segments for multiple machines and return a map.
@@ -80,32 +54,47 @@ pub async fn batch_get_inband_segments_by_machine_ids(
 
 /// Add inband interfaces to a network config based on segment IDs.
 /// This is a pure function that can be used after batch querying.
+///
+/// This only injects when `auto` is true. If we get a non-auto
+/// config, just leave as-is and return it unchanged (as in, there
+/// are no inband interfaces to add).
+///
+/// Additionally, an `auto` config that arrives with non-empty
+/// `interfaces` is rejected. We have a TryFrom implementation
+/// for rpc::InstanceNetworkConfig that makes sure we're not in
+/// this state to begin with, but we still check here anyway.
 pub fn add_inband_interfaces_to_config(
-    mut value: InstanceNetworkConfig,
+    mut network_config: InstanceNetworkConfig,
     host_inband_segment_ids: &[NetworkSegmentId],
-) -> InstanceNetworkConfig {
-    for host_inband_segment_id in host_inband_segment_ids {
-        // Only add it to the instance config if there isn't already an interface in this segment
-        if !value
-            .interfaces
-            .iter()
-            .any(|i| i.network_segment_id == Some(*host_inband_segment_id))
-        {
-            value.interfaces.push(InstanceInterfaceConfig {
-                function_id: InterfaceFunctionId::Physical {},
-                network_segment_id: Some(*host_inband_segment_id),
-                network_details: None,
-                ip_addrs: Default::default(),
-                interface_prefixes: Default::default(),
-                network_segment_gateways: Default::default(),
-                host_inband_mac_address: None,
-                device_locator: None,
-                internal_uuid: uuid::Uuid::new_v4(),
-                requested_ip_addr: None,
-                ipv6_interface_config: None,
-            })
-        }
+) -> DatabaseResult<InstanceNetworkConfig> {
+    if !network_config.auto {
+        return Ok(network_config);
     }
 
-    value
+    if !network_config.interfaces.is_empty() {
+        return Err(DatabaseError::InvalidArgument(format!(
+            "InstanceNetworkConfig.auto reached the resolver with {} \
+             pre-existing interfaces; auto requests must arrive with an \
+             empty interfaces list",
+            network_config.interfaces.len(),
+        )));
+    }
+
+    for host_inband_segment_id in host_inband_segment_ids {
+        network_config.interfaces.push(InstanceInterfaceConfig {
+            function_id: InterfaceFunctionId::Physical {},
+            network_segment_id: Some(*host_inband_segment_id),
+            network_details: None,
+            ip_addrs: Default::default(),
+            interface_prefixes: Default::default(),
+            network_segment_gateways: Default::default(),
+            host_inband_mac_address: None,
+            device_locator: None,
+            internal_uuid: uuid::Uuid::new_v4(),
+            requested_ip_addr: None,
+            ipv6_interface_config: None,
+        });
+    }
+
+    Ok(network_config)
 }

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -572,9 +572,10 @@ async fn test_machine_a_tron_zerodpu(
                     .expect("Machine ID should be set if host is ready");
                 tracing::info!("Machine {machine_id} has made it to Ready, allocating instance");
 
-                // Zero-DPU tenants don't pass any network config; the allocator instead
-                // auto-picks a HostInband segment for them (which is covered as part of
-                // the test_zero_dpu_instance_allocation_no_network_config test).
+                // Zero-DPU tenants pass `auto: true` with empty interfaces; the
+                // allocator resolves the host's HostInband segment(s) from the
+                // machine snapshot (which is also covered in unit tests as
+                // `test_zero_dpu_instance_allocation_auto`).
                 let instance_id = instance::create(
                     carbide_api_addrs,
                     &machine_id,
@@ -633,7 +634,9 @@ async fn test_machine_a_tron_singledpu_nic_mode(
 
                 // For a DPU in NIC-mode, the DPU is treated as a plain NIC, meaning
                 // allocation goes through HostInband the same way the zero-DPU path
-                // allocation does; no network config, and the allocator auto-picks.
+                // allocation does; the request carries `auto: true` with empty
+                // interfaces, and Carbide resolves from the host's HostInband
+                // segment(s).
                 let instance_id = instance::create(
                     carbide_api_addrs,
                     &machine_id,

--- a/crates/api-model/src/instance/config/network.rs
+++ b/crates/api-model/src/instance/config/network.rs
@@ -108,6 +108,22 @@ pub struct InstanceNetworkConfig {
     /// auto-resolve the instance's network interfaces from the host's
     /// HostInband network segments. Only valid for instances on zero-DPU
     /// hosts (well, no DPU, *or* DPU in NIC mode).
+    ///
+    /// It is also important to note that on the wire (request AND response),
+    /// `auto: true` only travels with `interfaces: []`, but internally some
+    /// other things are happening.
+    ///
+    /// On allocation/update, NICo resolves the empty interfaces: [] into
+    /// one entry per HostInband segment on the host, then stores the
+    /// fully-resolved config internally (allowing storage, status, IP
+    /// bookkeeping, config diffs, etc to all operate on real interfaces).
+    ///
+    /// Then, at the model <-> RPC boundary, the resolved interfaces are
+    /// stripped off to `[]`, so callers reading the instance config back
+    /// simply see what they originally sent (`auto: true` with no interfaces).
+    ///
+    /// The resolved per-interface details (IP, MAC, gateway, prefix) appear in
+    /// `Instance.status.network.interfaces` like usual.
     #[serde(default)]
     pub auto: bool,
 }
@@ -200,7 +216,35 @@ impl InstanceNetworkConfig {
         }
     }
 
-    /// Validates the network configuration
+    /// Returns this config as it should appear on the wire: for `auto`
+    /// configs, the resolved interfaces are stripped so external callers see
+    /// just their request (`{ auto: true, interfaces: [] }`). The fully-
+    /// resolved interfaces still drive `InstanceNetworkStatus` population
+    /// from the internal model. For non-auto configs, returns `self`
+    /// unchanged.
+    ///
+    /// This exists to keep the input config from the user represented
+    /// back to them as they sent it, and mask any internal interface
+    /// resolution that happened as a result of `auto`.
+    pub fn into_external_view(self) -> Self {
+        if self.auto {
+            Self {
+                interfaces: vec![],
+                auto: true,
+            }
+        } else {
+            self
+        }
+    }
+
+    /// Validates the network configuration.
+    ///
+    /// Note: this is also called on POST-resolution configs (i.e. after
+    /// `add_inband_interfaces_to_config` has expanded an `auto` request into
+    /// underlying interfaces), so it must not reject the combination
+    /// `auto: true` + non-empty interfaces here. The "auto must arrive with
+    /// empty interfaces" rule is enforced in RPC <-> model conversion, which
+    /// only runs on user input.
     pub fn validate(&self, allow_instance_vf: bool) -> Result<(), ConfigValidationError> {
         if !allow_instance_vf
             && self

--- a/crates/api-model/src/instance/status/network.rs
+++ b/crates/api-model/src/instance/status/network.rs
@@ -49,9 +49,16 @@ use crate::network_security_group::NetworkSecurityGroupStatusObservation;
 pub struct InstanceNetworkStatus {
     /// Status for each configured interface
     ///
-    /// Each entry in this status array maps to its corresponding entry in the
-    /// Config section. E.g. `instance.status.network.interface_status[1]`
-    /// would map to `instance.config.network.interface_configs[1]`.
+    /// For non-auto configs: each entry in this status array maps to its
+    /// corresponding entry in the Config section. E.g.
+    /// `instance.status.network.interfaces[1]` maps to
+    /// `instance.config.network.interfaces[1]`.
+    ///
+    /// For auto configs (`InstanceNetworkConfig.auto = true`): on the wire
+    /// the config-side `interfaces` is always empty (the request is
+    /// preserved verbatim), so this array stands alone and describes the
+    /// interfaces Carbide resolved from the host's HostInband segments.
+    /// There is no positional relationship to consult on the config side.
     pub interfaces: Vec<InstanceInterfaceStatus>,
 
     /// Whether all desired network changes that the user has applied have taken effect

--- a/crates/api-model/src/rpc_conv/instance/config/network.rs
+++ b/crates/api-model/src/rpc_conv/instance/config/network.rs
@@ -299,6 +299,10 @@ impl TryFrom<InstanceNetworkConfig> for rpc::InstanceNetworkConfig {
     type Error = RpcDataConversionError;
 
     fn try_from(config: InstanceNetworkConfig) -> Result<rpc::InstanceNetworkConfig, Self::Error> {
+        // This is where we prep the interface for "external" viewing,
+        // stripping resolved interfaces in the case of an auto config,
+        // but leaving them untouched otherwise.
+        let config = config.into_external_view();
         let auto = config.auto;
         let mut interfaces = Vec::with_capacity(config.interfaces.len());
         for iface in config.interfaces.into_iter() {

--- a/crates/api-test-helper/src/instance.rs
+++ b/crates/api-test-helper/src/instance.rs
@@ -67,10 +67,17 @@ pub async fn create(
             },
             "os": os,
         }),
-        // omit network from config if we're not specifying a segment (in
-        // the zero-DPU case, the allocator auto-picks a HostInband segment).
+        // segment_id is None, i.e. this is the zero-DPU path.
+        // The allocator requires `auto: true` and an empty `interfaces`
+        // list, and will resolve the host's HostInband segments into
+        // the stored config (status reflects the resolved per-interface
+        // details).
         None => serde_json::json!({
             "tenant": tenant,
+            "network": {
+                "interfaces": [],
+                "auto": true,
+            },
             "os": os,
         }),
     };

--- a/crates/api/src/handlers/instance.rs
+++ b/crates/api/src/handlers/instance.rs
@@ -1266,7 +1266,7 @@ pub(crate) async fn update_instance_config(
             .unwrap_or(true),
         &instance,
         &mut config.network,
-        mh_snapshot.host_snapshot.current_state(),
+        &mh_snapshot,
         &mut txn,
     )
     .await?;
@@ -1322,11 +1322,55 @@ async fn update_instance_network_config(
     allow_instance_vf: bool,
     instance: &InstanceSnapshot,
     network: &mut InstanceNetworkConfig,
-    mh_state: &ManagedHostState,
+    mh_snapshot: &ManagedHostStateSnapshot,
     txn: &mut sqlx::Transaction<'_, sqlx::Postgres>,
 ) -> Result<(), CarbideError> {
     if instance.update_network_config_request.is_some() {
         return Err(ConfigValidationError::InstanceNetworkConfigUpdateAlreadyInProgress.into());
+    }
+
+    // Auto-ness can't change for an existing instance. If a tenant has created
+    // an instance with auto, it must remain auto until it is released. Maybe
+    // eventually this can change, but for now this is what we support.
+    if network.auto != instance.config.network.auto {
+        return Err(CarbideError::InvalidArgument(format!(
+            "cannot change `InstanceNetworkConfig.auto` on an existing instance (was {}, update requested {})",
+            instance.config.network.auto, network.auto,
+        )));
+    }
+
+    // For auto instances, simply re-resolve from the machine's current
+    // HostInband segments before any diff check. Same machine state == no-op
+    // via the diff check below. Operator-added or removed HostInband segments
+    // since allocation == reflected in the update.
+    if network.auto {
+        // Just to make sure, an auto instance should still be on a zero-DPU
+        // host. If this machine suddenly has DPUs, we should yell, at least
+        // for now. I guess there's a world where we might have a primary NIC
+        // that is a dumb NIC (or DPU in NIC mode), and also happens to have
+        // a secondary DPU into some other leg of the network, but we can
+        // think about that later; that would mean we'd support a mix of
+        // auto AND non-auto interfaces.
+        if !mh_snapshot.is_zero_dpu() {
+            return Err(CarbideError::InvalidArgument(format!(
+                "instance was allocated with `auto: true` but host {} is no longer zero-DPU; cannot update via the auto path",
+                instance.machine_id,
+            )));
+        }
+
+        let inband_segment_ids =
+            db::instance_network_config::batch_get_inband_segments_by_machine_ids(
+                txn.as_mut(),
+                &[instance.machine_id],
+            )
+            .await?
+            .get(&instance.machine_id)
+            .cloned()
+            .unwrap_or_default();
+        *network = db::instance_network_config::add_inband_interfaces_to_config(
+            network.clone(),
+            &inband_segment_ids,
+        )?;
     }
 
     if !instance
@@ -1338,7 +1382,7 @@ async fn update_instance_network_config(
     }
 
     if !matches!(
-        mh_state,
+        mh_snapshot.host_snapshot.current_state(),
         ManagedHostState::Assigned {
             instance_state: InstanceState::Ready,
         }
@@ -1359,17 +1403,6 @@ async fn update_instance_network_config(
     network
         .validate(allow_instance_vf)
         .map_err(CarbideError::from)?;
-
-    let mh_snapshot = db::managed_host::load_snapshot(
-        txn.as_mut(),
-        &instance.machine_id,
-        LoadSnapshotOptions::default(),
-    )
-    .await?
-    .ok_or(CarbideError::NotFoundError {
-        kind: "machine",
-        id: instance.machine_id.to_string(),
-    })?;
 
     // Allocate IPs and add them to the network config
     let updated_network_config = db::instance_network_config::with_allocated_ips(

--- a/crates/api/src/instance/mod.rs
+++ b/crates/api/src/instance/mod.rs
@@ -860,12 +860,25 @@ pub async fn batch_allocate_instances(
                 .unwrap_or(true),
         )?;
 
-        // Reject instance configs whose network interfaces reference segments
-        // the host can't actually serve. For a zero-DPU host, this means
-        // anything beyond its HostInband segments; there's no DPU to handle
-        // overlay/tenant networking, so accepting the request would leave a
-        // zero-DPU instance stuck in Provisioning with no path to completion.
+        // Zero-DPU hosts (no DPU, or DPU in NIC mode) MUST use `auto`, because
+        // their only valid attachments are HostInband segments, and NICo knows
+        // which one(s) the host is on. Conversely, hosts with DPUs cannot use
+        // `auto`, and are expected to enumerate their interfaces explicitly.
         if mh_snapshot.is_zero_dpu() {
+            if !request.config.network.auto {
+                return Err(CarbideError::InvalidArgument(format!(
+                    "zero-DPU host {} requires `InstanceNetworkConfig.auto = true`; cannot allocate an instance with explicitly-listed interfaces or with `auto = false`",
+                    mh_snapshot.host_snapshot.id,
+                )));
+            }
+
+            // ...and eeven though gRPC <-> model validation rejects
+            // auto + non-empty interfaces, double-check here so a future
+            // refactor can't silently sneak unsupported segment references
+            // past this point. For a zero-DPU host, the only valid
+            // attachments are HostInband segments; nothing else can be
+            // served by a host with no DPU to handle overlay/tenant
+            // networking.
             let allowed_segment_ids: HashSet<_> = mh_snapshot
                 .host_snapshot
                 .interfaces
@@ -898,6 +911,11 @@ pub async fn batch_allocate_instances(
                     mh_snapshot.host_snapshot.id,
                 )));
             }
+        } else if request.config.network.auto {
+            return Err(CarbideError::InvalidArgument(format!(
+                "host {} has DPUs; `InstanceNetworkConfig.auto` is only valid on zero-DPU hosts",
+                mh_snapshot.host_snapshot.id,
+            )));
         }
 
         processed_requests.push((request, mh_snapshot));
@@ -958,7 +976,7 @@ pub async fn batch_allocate_instances(
         let updated_network_config = db::instance_network_config::add_inband_interfaces_to_config(
             request.config.network.clone(),
             inband_segment_ids,
-        );
+        )?;
 
         // Allocate IPs
         let updated_network_config = db::instance_network_config::with_allocated_ips(

--- a/crates/api/src/tests/instance_allocate.rs
+++ b/crates/api/src/tests/instance_allocate.rs
@@ -178,8 +178,12 @@ async fn create_test_env_for_instance_allocation(
     env
 }
 
+/// Zero-DPU instance allocation that supplies explicit interfaces (instead
+/// of `auto: true`) must be rejected. The requirement on zero-DPU hosts is
+/// to send auto:true with empty interfaces, and we populate them. There's
+/// no supported path for a tenant to configure interfaces on their own.
 #[crate::sqlx_test]
-async fn test_zero_dpu_instance_allocation_explicit_network_config(
+async fn test_zero_dpu_instance_allocation_rejects_explicit_interfaces(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
@@ -238,8 +242,75 @@ async fn test_zero_dpu_instance_allocation_explicit_network_config(
             allow_unhealthy_machine: false,
         }),
     )
+    .await;
+
+    let err = instance.expect_err("zero-DPU allocation without auto: true must be rejected");
+    assert_eq!(err.code(), tonic::Code::InvalidArgument, "got: {err}");
+    assert!(
+        err.message().contains("auto"),
+        "error should mention auto, got: {}",
+        err.message()
+    );
+    Ok(())
+}
+
+/// The `auto: true` path: a zero-DPU host with one HostInband segment, allocated
+/// with empty interfaces and `auto: true`. NICo resolves the segment from the
+/// host snapshot and stores the resolved interface internally. What the caller
+/// sees on the wire is stripped back to `{ auto: true, interfaces: [] }`, while
+/// `instance.status.network.interfaces` reflects the resolved details.
+#[crate::sqlx_test]
+async fn test_zero_dpu_instance_allocation_auto(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
+    let config = ManagedHostConfig::with_dpus(vec![]);
+
+    // Ingest zero DPU host
+    let zero_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
+
+    let host_inband_segment =
+        db::network_segment::find_by_name(env.pool.begin().await?.deref_mut(), "HOST_INBAND")
+            .await?;
+
+    let instance = crate::handlers::instance::allocate(
+        env.api.as_ref(),
+        tonic::Request::new(forge::InstanceAllocationRequest {
+            machine_id: Some(zero_dpu_host.host_snapshot.id),
+            instance_type_id: None,
+            config: Some(forge::InstanceConfig {
+                tenant: Some(forge::TenantConfig {
+                    tenant_organization_id: "2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string(),
+                    hostname: None,
+                    tenant_keyset_ids: vec![],
+                }),
+                network_security_group_id: None,
+                os: Some(forge::InstanceOperatingSystemConfig {
+                    phone_home_enabled: false,
+                    run_provisioning_instructions_on_every_boot: false,
+                    user_data: None,
+                    variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
+                        forge::InlineIpxe {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
+                }),
+                network: Some(forge::InstanceNetworkConfig {
+                    interfaces: vec![],
+                    auto: true,
+                }),
+                infiniband: None,
+                dpu_extension_services: None,
+                nvlink: None,
+            }),
+            instance_id: None,
+            metadata: None,
+            allow_unhealthy_machine: false,
+        }),
+    )
     .await
-    .expect("Instance allocation with no network config should have been successful")
+    .expect("zero-DPU instance allocation with auto: true should succeed")
     .into_inner();
 
     // Make sure getting the Machine over RPC has the correct instance network restrictions. While
@@ -262,44 +333,50 @@ async fn test_zero_dpu_instance_allocation_explicit_network_config(
         "Machine that was just ingested should have instance network restrictions listing its network segment ID's",
     );
 
-    let interfaces = instance.config.unwrap().network.unwrap().interfaces;
-    assert_eq!(
-        interfaces.len(),
-        1,
-        "New instance should have one interface"
+    // On the wire: `auto: true` with empty interfaces. The resolved
+    // interface lives in status, not config, which takes place as
+    // part of `into_external_view()`.
+    let network = instance.config.unwrap().network.unwrap();
+    assert!(
+        network.auto,
+        "auto must round-trip back to the caller as true"
     );
-    assert_eq!(
-        interfaces[0].network_segment_id,
-        Some(host_inband_segment.id),
-        "New instance should have an interface on the HOST_INBAND network"
+    assert!(
+        network.interfaces.is_empty(),
+        "external view of an auto config must have empty interfaces, got: {:?}",
+        network.interfaces
     );
 
+    let status_interfaces = instance.status.unwrap().network.unwrap().interfaces;
+    assert_eq!(
+        status_interfaces.len(),
+        1,
+        "status should reflect one resolved interface for the single HostInband segment"
+    );
     Ok(())
 }
 
+/// Zero-DPU instance allocation without `auto: true` (and without any network
+/// config at all) is the previous "send nothing" path, which was mainly because
+/// it worked, not because it was decided to be that way. Lets make sure it
+/// doesn't work anymore by accident.
 #[crate::sqlx_test]
-async fn test_zero_dpu_instance_allocation_no_network_config(
+async fn test_zero_dpu_instance_allocation_rejects_missing_auto(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
     let config = ManagedHostConfig::with_dpus(vec![]);
 
-    // Ingest zero DPU host
     let zero_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
 
-    let host_inband_segment =
-        db::network_segment::find_by_name(env.pool.begin().await?.deref_mut(), "HOST_INBAND")
-            .await?;
-
-    // Allocate an instance without specifying a network config
-    let instance = crate::handlers::instance::allocate(
+    let result = crate::handlers::instance::allocate(
         env.api.as_ref(),
         tonic::Request::new(forge::InstanceAllocationRequest {
             machine_id: Some(zero_dpu_host.host_snapshot.id),
             instance_type_id: None,
             config: Some(forge::InstanceConfig {
                 tenant: Some(forge::TenantConfig {
-                    tenant_organization_id: "2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string(), // from sql fixture
+                    tenant_organization_id: "2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string(),
                     hostname: None,
                     tenant_keyset_ids: vec![],
                 }),
@@ -314,7 +391,7 @@ async fn test_zero_dpu_instance_allocation_no_network_config(
                         },
                     )),
                 }),
-                network: None, // code under test: Network config is None
+                network: None,
                 infiniband: None,
                 nvlink: None,
                 network_security_group_id: None,
@@ -325,27 +402,19 @@ async fn test_zero_dpu_instance_allocation_no_network_config(
             allow_unhealthy_machine: false,
         }),
     )
-    .await
-    .expect("Instance allocation with no network config should have been successful")
-    .into_inner();
+    .await;
 
-    let interfaces = instance.config.unwrap().network.unwrap().interfaces;
-    assert_eq!(
-        interfaces.len(),
-        1,
-        "New instance should have one interface"
-    );
-    assert_eq!(
-        interfaces[0].network_segment_id,
-        Some(host_inband_segment.id),
-        "New instance should have an interface on the HOST_INBAND network"
-    );
-
+    let err = result
+        .expect_err("zero-DPU allocation with no network config (no auto signal) must be rejected");
+    assert_eq!(err.code(), tonic::Code::InvalidArgument, "got: {err}");
     Ok(())
 }
 
+/// `auto: true` on a multi-NIC zero-DPU host must resolve to one resolved
+/// interface per HostInband segment, with each interface inheriting the
+/// host's already-assigned IP for that segment.
 #[crate::sqlx_test]
-async fn test_zero_dpu_instance_allocation_multi_segment_no_network_config(
+async fn test_zero_dpu_instance_allocation_auto_multi_segment(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
@@ -410,7 +479,10 @@ async fn test_zero_dpu_instance_allocation_multi_segment_no_network_config(
                         },
                     )),
                 }),
-                network: None, // code under test: Network config is None
+                network: Some(forge::InstanceNetworkConfig {
+                    interfaces: vec![],
+                    auto: true,
+                }),
                 infiniband: None,
                 nvlink: None,
                 network_security_group_id: None,
@@ -422,7 +494,7 @@ async fn test_zero_dpu_instance_allocation_multi_segment_no_network_config(
         }),
     )
     .await
-    .expect("Instance allocation with no network config should have been successful")
+    .expect("zero-DPU instance allocation with auto: true should succeed on a multi-NIC host")
     .into_inner();
 
     let (host_inband_segment_1, host_inband_segment_2) = (
@@ -432,13 +504,25 @@ async fn test_zero_dpu_instance_allocation_multi_segment_no_network_config(
             .await?,
     );
 
-    let interfaces = instance.config.unwrap().network.unwrap().interfaces;
-    assert_eq!(
-        interfaces.len(),
-        2,
-        "New instance should have two interface"
+    // On the wire: auto: true with empty interfaces, regardless of how many
+    // HostInband segments resolved. The resolved-per-interface details
+    // surface in status, not config.
+    let rpc_network = instance.config.unwrap().network.unwrap();
+    assert!(rpc_network.auto, "auto must round-trip back as true");
+    assert!(
+        rpc_network.interfaces.is_empty(),
+        "external view of an auto config must have empty interfaces, got: {:?}",
+        rpc_network.interfaces
     );
 
+    let status_interfaces = instance.status.unwrap().network.unwrap().interfaces;
+    assert_eq!(
+        status_interfaces.len(),
+        2,
+        "status should reflect both resolved HostInband interfaces"
+    );
+
+    // Internal model: the persisted config has the fully-resolved interfaces.
     let host_snapshot_after_allocate = db::managed_host::load_snapshot(
         env.pool.begin().await?.deref_mut(),
         &zero_dpu_host.host_snapshot.id,
@@ -452,10 +536,14 @@ async fn test_zero_dpu_instance_allocation_multi_segment_no_network_config(
         .instance
         .expect("zero-dpu host snapshot should have an assigned instance");
 
+    assert!(
+        instance_snapshot.config.network.auto,
+        "internal model must preserve auto: true through resolution"
+    );
     assert_eq!(
         instance_snapshot.config.network.interfaces.len(),
         2,
-        "Instance should have 2 interfaces"
+        "internal model must hold the fully-resolved interfaces, not just the wire-stripped view"
     );
 
     let interface_in_segment_1 = instance_snapshot
@@ -1010,10 +1098,6 @@ async fn test_zero_dpu_instance_surfaces_underlay_ip_in_status(
     let config = ManagedHostConfig::with_dpus(vec![]);
     let zero_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
 
-    let host_inband_segment =
-        db::network_segment::find_by_name(env.pool.begin().await?.deref_mut(), "HOST_INBAND")
-            .await?;
-
     crate::handlers::instance::allocate(
         env.api.as_ref(),
         tonic::Request::new(forge::InstanceAllocationRequest {
@@ -1037,9 +1121,12 @@ async fn test_zero_dpu_instance_surfaces_underlay_ip_in_status(
                         },
                     )),
                 }),
-                // Tenant submits no network config -- server auto-fills with
-                // the HostInband interface for the zero-DPU host.
-                network: None,
+                // Tenant signals `auto: true` with no interfaces; NICo
+                // resolves the HostInband segment from the host snapshot.
+                network: Some(forge::InstanceNetworkConfig {
+                    interfaces: vec![],
+                    auto: true,
+                }),
                 infiniband: None,
                 dpu_extension_services: None,
                 nvlink: None,
@@ -1103,22 +1190,24 @@ async fn test_zero_dpu_instance_surfaces_underlay_ip_in_status(
         "one prefix should be reported per address; got: {iface:?}",
     );
 
-    // The synthesized status should mirror the (auto-filled) config side.
-    let cfg_interfaces = instance
+    // On-the-wire contract for auto: config.interfaces is empty (preserved
+    // verbatim from the request), while status.interfaces carries the
+    // resolved per-interface details. The HostInband segment that drove
+    // resolution shows up in `instance_network_restrictions` rather than the
+    // config.
+    let cfg_network = instance
         .config
         .as_ref()
         .and_then(|c| c.network.as_ref())
-        .map(|n| n.interfaces.as_slice())
-        .unwrap_or(&[]);
-    assert_eq!(
-        cfg_interfaces.len(),
-        net_status.interfaces.len(),
-        "config.network.interfaces and status.network.interfaces must have the same length",
+        .expect("instance.config.network should be set");
+    assert!(
+        cfg_network.auto,
+        "auto must round-trip back to the caller as true",
     );
-    assert_eq!(
-        cfg_interfaces[0].network_segment_id,
-        Some(host_inband_segment.id),
-        "auto-filled config interface should be on the HostInband segment",
+    assert!(
+        cfg_network.interfaces.is_empty(),
+        "external view of an auto config must have empty interfaces; got: {:?}",
+        cfg_network.interfaces,
     );
 
     Ok(())
@@ -1184,5 +1273,139 @@ async fn test_reject_zero_dpu_instance_with_extension_services(
         ),
     };
 
+    Ok(())
+}
+
+/// `auto: true` combined with a non-empty `interfaces` list is structurally
+/// invalid: auto is mutually exclusive with caller-supplied interfaces.
+#[crate::sqlx_test]
+async fn test_instance_allocation_rejects_auto_with_explicit_interfaces(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
+    let config = ManagedHostConfig::with_dpus(vec![]);
+
+    let zero_dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
+    let host_inband_segment =
+        db::network_segment::find_by_name(env.pool.begin().await?.deref_mut(), "HOST_INBAND")
+            .await?;
+
+    let result = crate::handlers::instance::allocate(
+        env.api.as_ref(),
+        tonic::Request::new(forge::InstanceAllocationRequest {
+            machine_id: Some(zero_dpu_host.host_snapshot.id),
+            instance_type_id: None,
+            config: Some(forge::InstanceConfig {
+                tenant: Some(forge::TenantConfig {
+                    tenant_organization_id: "2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string(),
+                    hostname: None,
+                    tenant_keyset_ids: vec![],
+                }),
+                network_security_group_id: None,
+                os: Some(forge::InstanceOperatingSystemConfig {
+                    phone_home_enabled: false,
+                    run_provisioning_instructions_on_every_boot: false,
+                    user_data: None,
+                    variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
+                        forge::InlineIpxe {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
+                }),
+                network: Some(forge::InstanceNetworkConfig {
+                    interfaces: vec![forge::InstanceInterfaceConfig {
+                        function_type: forge::InterfaceFunctionType::Physical as i32,
+                        network_segment_id: Some(host_inband_segment.id),
+                        network_details: None,
+                        device: None,
+                        device_instance: 0u32,
+                        virtual_function_id: None,
+                        ip_address: None,
+                        ipv6_interface_config: None,
+                    }],
+                    auto: true,
+                }),
+                infiniband: None,
+                dpu_extension_services: None,
+                nvlink: None,
+            }),
+            instance_id: None,
+            metadata: None,
+            allow_unhealthy_machine: false,
+        }),
+    )
+    .await;
+
+    let err = result.expect_err("auto: true + non-empty interfaces must be rejected");
+    assert_eq!(err.code(), tonic::Code::InvalidArgument, "got: {err}");
+    assert!(
+        err.message().contains("auto"),
+        "error should mention auto, got: {}",
+        err.message()
+    );
+    Ok(())
+}
+
+/// `auto: true` is rejected on a host that has DPUs. The auto-resolution path
+/// is specifically for zero-DPU hosts; DPU-managed hosts are expected to
+/// enumerate their tenant overlay interfaces explicitly.
+#[crate::sqlx_test]
+async fn test_instance_allocation_rejects_auto_on_dpu_host(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::tests::common::api_fixtures::dpu::DpuConfig;
+
+    let env = create_test_env_for_instance_allocation(pool.clone(), None).await;
+    // Default ManagedHostConfig has one DPU.
+    let config = ManagedHostConfig::with_dpus(vec![DpuConfig::default()]);
+
+    let dpu_host = api_fixtures::site_explorer::new_host(&env, config).await?;
+
+    let result = crate::handlers::instance::allocate(
+        env.api.as_ref(),
+        tonic::Request::new(forge::InstanceAllocationRequest {
+            machine_id: Some(dpu_host.host_snapshot.id),
+            instance_type_id: None,
+            config: Some(forge::InstanceConfig {
+                tenant: Some(forge::TenantConfig {
+                    tenant_organization_id: "2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string(),
+                    hostname: None,
+                    tenant_keyset_ids: vec![],
+                }),
+                network_security_group_id: None,
+                os: Some(forge::InstanceOperatingSystemConfig {
+                    phone_home_enabled: false,
+                    run_provisioning_instructions_on_every_boot: false,
+                    user_data: None,
+                    variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
+                        forge::InlineIpxe {
+                            ipxe_script: "exit".to_string(),
+                            user_data: None,
+                        },
+                    )),
+                }),
+                network: Some(forge::InstanceNetworkConfig {
+                    interfaces: vec![],
+                    auto: true,
+                }),
+                infiniband: None,
+                dpu_extension_services: None,
+                nvlink: None,
+            }),
+            instance_id: None,
+            metadata: None,
+            allow_unhealthy_machine: false,
+        }),
+    )
+    .await;
+
+    let err = result.expect_err("auto: true on a DPU host must be rejected");
+    assert_eq!(err.code(), tonic::Code::InvalidArgument, "got: {err}");
+    assert!(
+        err.message().contains("DPU") || err.message().contains("zero-DPU"),
+        "error should mention DPU semantics, got: {}",
+        err.message()
+    );
     Ok(())
 }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -2630,7 +2630,18 @@ message InstanceNetworkConfig {
   // When true, NICO (or potentially some pluggable SDN backend) will
   // auto-resolve the instance's network interfaces from the host's
   // HostInband network segments. Only valid for instances on zero-DPU
-  // hosts (well, no DPU, *or* DPU in NIC mode).
+  // hosts (well, no DPU, *or* DPU in NIC mode). When set, `interfaces`
+  // MUST be empty on the request.
+  //
+  // Callers reading the instance back also see `auto = true` with an empty
+  // `interfaces` list (what they sent is preserved verbatim). The
+  // resolved per-interface details -- IP, MAC, gateway, prefix -- surface
+  // in `Instance.status.network.interfaces` instead.
+  //
+  // On update, sending `auto: true` re-resolves interfaces from the host's
+  // current HostInband segments. If nothing has changed, this is a no-op.
+  // If the host's segments have been added/removed by the operator, the
+  // update reflects that change.
   bool auto = 2;
 }
 
@@ -2747,9 +2758,16 @@ message InstanceStatus {
 message InstanceNetworkStatus {
   // Status for each configured interface
   //
-  // Each entry in this status array maps to its corresponding entry in the
-  // Config section. E.g. `instance.status.network.interface_status[1]`
-  // would map to `instance.config.network.interface_configs[1]`.
+  // For non-auto configs: each entry in this status array maps to its
+  // corresponding entry in the Config section. E.g.
+  // `instance.status.network.interfaces[1]` would map to
+  // `instance.config.network.interfaces[1]`.
+  //
+  // For auto configs (`InstanceNetworkConfig.auto = true`): the config-side
+  // `interfaces` is always empty on the wire (it's preserved verbatim from
+  // the request), so this status array stands alone and describes the
+  // interfaces Carbide resolved from the host's HostInband segments. There
+  // is no positional relationship to consult on the config side.
   repeated InstanceInterfaceStatus interfaces = 1;
 
   // Whether all desired network changes that the user has applied have taken effect


### PR DESCRIPTION
This closes #1533, wiring up the auto field that was plumbed through in #1576.

When a tenant sets `auto: true`, NICo now resolves the instance's interfaces from the host's `HostInband` segments and stores the resolved config internally, instead of magically just doing things. A tenant can set `auto:true` without `interfaces`, or leave `auto:false` and set `interfaces`, but it cannot do both.

On the wire, `auto` callers will still see `{ auto: true, interfaces: [] }` as their "stored" config, just like they originally sent (via a new `::into_external_view()` helper, even though internally we are storing them; the resolved details will surface in `instance.status.network.interfaces`, just like they do today for hosts with DPUs.

Additional tweaks include:
 - `add_inband_interfaces_to_config` is gated on `network_config.auto`, and no longer auto-fills silently.
 - Instance allocate gates `auto`-ness on host class: zero DPU hosts are expected to be `auto`, DPU hosts are not.
 - Instance update path re-resolves on `auto: true` against the host's current `HostInband` segments. No-op if nothing changed, but a real update if the operator added/removed segments since allocation.
-  `with_inband_interfaces_from_machine` was dead code so its going away.

I've got some `machine-a-tron` stuff I'll do after this PR.

Tests added/updated!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic network interface resolution for instances on zero-DPU hosts using `auto: true` configuration.

* **Bug Fixes**
  * Enforced immutability of automatic network configuration flag for existing instances.
  * Stricter validation: `auto` mode now only valid on zero-DPU hosts and rejects explicit interface specifications.

* **Documentation**
  * Clarified network configuration behavior and interface mappings for automatic and manual modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/infra-controller-core/pull/1674)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #1533
