### PR TITLE
fix: Strip port in SSH host string

### DIFF
--- a/crates/ssh/src/ssh.rs
+++ b/crates/ssh/src/ssh.rs
@@ -31,7 +31,7 @@ async fn execute_command(
     let auth = AuthConfig::Password { password };
     let client = crate::ssh_client::SshClientConfig {
         host: &host,
-        port: ip_address.port(),
+        port: 22,
         username: &username,
         auth: Some(&auth),
         known_hosts_file: None,

--- a/crates/ssh/src/ssh.rs
+++ b/crates/ssh/src/ssh.rs
@@ -27,11 +27,11 @@ async fn execute_command(
     username: String,
     password: String,
 ) -> Result<(String, u32), SshError> {
-    let host = ip_address.to_string();
+    let host = ip_address.ip().to_string();
     let auth = AuthConfig::Password { password };
     let client = crate::ssh_client::SshClientConfig {
         host: &host,
-        port: 22,
+        port: ip_address.port(),
         username: &username,
         auth: Some(&auth),
         known_hosts_file: None,


### PR DESCRIPTION
## Description
PR to fix the failure with `site-explorer copy-bfb-to-dpu-rshim` failing with `Failed { reason: "BFB copy failed: Error: failed query RSHIM status on on <ip_address>:22: SSH error: failed to lookup address information: Name or service not known. Re-run `site-explorer copy-bfb-to-dpu-rshim` to retry." }`

`crates/ssh/src/ssh.rs:30`:
  ```rust
  let host = ip_address.to_string();   // SocketAddr → "<ip_address>:22"
```
  The resulting string contains a colon and so is not a valid IpAddr literal. When russh::client::connect((host, 22), ...) invokes ToSocketAddrs, the (&str, u16) impl tries IpAddr::from_str first, fails, and falls back to getaddrinfo, which returns EAI_NONAME. The SSH transport never opens, so the wrapped command (systemctl is-active rshim) is never sent.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

