### PR TITLE
fix: hw-health use key instead of hash key for endpoint

### DIFF
--- a/crates/health/src/discovery/iteration.rs
+++ b/crates/health/src/discovery/iteration.rs
@@ -30,7 +30,10 @@ use crate::sharding::ShardManager;
 use crate::sink::DataSink;
 
 fn active_keys(sharded_endpoints: &[Arc<BmcEndpoint>]) -> HashSet<Cow<'static, str>> {
-    sharded_endpoints.iter().map(|e| e.hash_key()).collect()
+    sharded_endpoints
+        .iter()
+        .map(|endpoint| Cow::Owned(endpoint.key()))
+        .collect()
 }
 
 pub async fn run_discovery_iteration(
@@ -93,6 +96,7 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr};
     use std::str::FromStr;
 
+    use carbide_uuid::rack::RackId;
     use mac_address::MacAddress;
 
     use super::*;
@@ -123,11 +127,16 @@ mod tests {
 
     #[test]
     fn test_active_keys_includes_all_endpoints() {
-        let ep1 = endpoint(MacAddress::from_str("42:9e:b1:bd:9d:dd").unwrap(), false);
+        let mut ep1 = endpoint(MacAddress::from_str("42:9e:b1:bd:9d:dd").unwrap(), false);
+        Arc::get_mut(&mut ep1).unwrap().rack_id = Some(RackId::new("rack-a"));
         let ep2 = endpoint(MacAddress::from_str("11:22:33:44:55:66").unwrap(), true);
 
         let keys = active_keys(&[ep1.clone(), ep2.clone()]);
 
-        assert_eq!(keys, HashSet::from([ep1.hash_key(), ep2.hash_key()]));
+        assert_eq!(
+            keys,
+            HashSet::from([Cow::Owned(ep1.key()), Cow::Owned(ep2.key())])
+        );
+        assert_ne!(ep1.hash_key(), Cow::<str>::Owned(ep1.key()));
     }
 }


### PR DESCRIPTION
## Description
After changing how keys handled in hw-health, hash key no longer be used to remove stale endpoints.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

