### PR TITLE
web-ui improvements for machine-interface displaying

### DIFF
--- a/crates/api/src/web/interface.rs
+++ b/crates/api/src/web/interface.rs
@@ -41,14 +41,93 @@ struct InterfaceRowDisplay {
     interface_type: String,
     mac_address: String,
     ip_address: String,
+    association_type: String,
     machine_id: String,
+    switch_id: String,
+    power_shelf_id: String,
     hostname: String,
     vendor: String,
     domain_name: String,
 }
 
+struct InterfaceAssociationDisplay {
+    association_type: String,
+    machine_id: String,
+    switch_id: String,
+    power_shelf_id: String,
+}
+
+impl From<&forgerpc::MachineInterface> for InterfaceAssociationDisplay {
+    fn from(mi: &forgerpc::MachineInterface) -> Self {
+        let machine_id = mi
+            .machine_id
+            .as_ref()
+            .map(|id| id.to_string())
+            .unwrap_or_default();
+        let switch_id = mi
+            .switch_id
+            .as_ref()
+            .map(|id| id.to_string())
+            .unwrap_or_default();
+        let power_shelf_id = mi
+            .power_shelf_id
+            .as_ref()
+            .map(|id| id.to_string())
+            .unwrap_or_default();
+        let association_type = mi
+            .association_type
+            .and_then(|value| forgerpc::InterfaceAssociationType::try_from(value).ok());
+        let association_type = association_type.or({
+            if !machine_id.is_empty() {
+                Some(forgerpc::InterfaceAssociationType::Machine)
+            } else if !switch_id.is_empty() {
+                Some(forgerpc::InterfaceAssociationType::Switch)
+            } else if !power_shelf_id.is_empty() {
+                Some(forgerpc::InterfaceAssociationType::Powershelf)
+            } else {
+                None
+            }
+        });
+        let (association_type, machine_id, switch_id, power_shelf_id) = match association_type {
+            Some(forgerpc::InterfaceAssociationType::Machine) => (
+                "Machine".to_string(),
+                machine_id,
+                String::new(),
+                String::new(),
+            ),
+            Some(forgerpc::InterfaceAssociationType::Switch) => (
+                "Switch".to_string(),
+                String::new(),
+                switch_id,
+                String::new(),
+            ),
+            Some(forgerpc::InterfaceAssociationType::Powershelf) => (
+                "Powershelf".to_string(),
+                String::new(),
+                String::new(),
+                power_shelf_id,
+            ),
+            Some(forgerpc::InterfaceAssociationType::None) | None => (
+                "None".to_string(),
+                String::new(),
+                String::new(),
+                String::new(),
+            ),
+        };
+
+        Self {
+            association_type,
+            machine_id,
+            switch_id,
+            power_shelf_id,
+        }
+    }
+}
+
 impl From<forgerpc::MachineInterface> for InterfaceRowDisplay {
     fn from(mi: forgerpc::MachineInterface) -> Self {
+        let association = InterfaceAssociationDisplay::from(&mi);
+
         Self {
             id: mi.id.unwrap_or_default().to_string(),
             interface_type: if mi.interface_type == Some(forgerpc::InterfaceType::Bmc as i32) {
@@ -58,11 +137,10 @@ impl From<forgerpc::MachineInterface> for InterfaceRowDisplay {
             },
             mac_address: mi.mac_address,
             ip_address: mi.address.join(","),
-            machine_id: mi
-                .machine_id
-                .as_ref()
-                .map(|id| id.to_string())
-                .unwrap_or_default(),
+            association_type: association.association_type,
+            machine_id: association.machine_id,
+            switch_id: association.switch_id,
+            power_shelf_id: association.power_shelf_id,
             hostname: mi.hostname,
             vendor: mi.vendor.unwrap_or_default(),
             domain_name: String::new(), // filled in later
@@ -152,8 +230,12 @@ async fn fetch_machine_interfaces(
 #[template(path = "interface_detail.html")]
 struct InterfaceDetail {
     id: String,
+    interface_type: String,
     dpu_machine_id: String,
+    association_type: String,
     machine_id: String,
+    switch_id: String,
+    power_shelf_id: String,
     segment_id: String,
     mac_address: String,
     ip_address: String,
@@ -164,11 +246,11 @@ struct InterfaceDetail {
     is_primary: bool,
     created: String,
     last_dhcp: String,
-    is_bmc: bool,
 }
 
 impl From<forgerpc::MachineInterface> for InterfaceDetail {
     fn from(mi: forgerpc::MachineInterface) -> Self {
+        let association = InterfaceAssociationDisplay::from(&mi);
         let created: DateTime<Utc> = mi
             .created
             .expect("machine_interfaces.created is NOT NULL in DB, should exist")
@@ -180,16 +262,20 @@ impl From<forgerpc::MachineInterface> for InterfaceDetail {
         };
         Self {
             id: mi.id.unwrap_or_default().to_string(),
+            interface_type: if mi.interface_type == Some(forgerpc::InterfaceType::Bmc as i32) {
+                "BMC".to_string()
+            } else {
+                "Data".to_string()
+            },
             dpu_machine_id: mi
                 .attached_dpu_machine_id
                 .as_ref()
                 .map(|id| id.to_string())
                 .unwrap_or_default(),
-            machine_id: mi
-                .machine_id
-                .as_ref()
-                .map(|id| id.to_string())
-                .unwrap_or_default(),
+            association_type: association.association_type,
+            machine_id: association.machine_id,
+            switch_id: association.switch_id,
+            power_shelf_id: association.power_shelf_id,
             segment_id: mi.segment_id.unwrap_or_default().to_string(),
             mac_address: mi.mac_address,
             ip_address: mi.address.join(","),
@@ -204,7 +290,6 @@ impl From<forgerpc::MachineInterface> for InterfaceDetail {
             last_dhcp: last_dhcp
                 .map(|d| d.format("%F %T %Z").to_string())
                 .unwrap_or_default(),
-            is_bmc: mi.interface_type == Some(forgerpc::InterfaceType::Bmc as i32),
         }
     }
 }

--- a/crates/api/templates/interface_detail.html
+++ b/crates/api/templates/interface_detail.html
@@ -8,8 +8,21 @@
 
 <table class="sortable overview">
 	<tr><th>ID</th><td>{{ id }}</td></tr>
-	<tr><th>DPU ID</th><td>{{ dpu_machine_id|machine_id_link|safe }}{% if is_bmc && !dpu_machine_id.is_empty() %} (BMC){% endif %}</td></tr>
-	<tr><th>Machine ID</th><td>{{ machine_id|machine_id_link|safe }}{% if is_bmc && !machine_id.is_empty() %} (BMC){% endif %}</td></tr>
+	<tr><th>Interface Type</th><td>{{ interface_type }}</td></tr>
+	<tr><th>Association Type</th><td>{{ association_type }}</td></tr>
+	<tr>
+		<th>Association ID</th>
+		<td>
+			{% if !machine_id.is_empty() %}
+				{{ machine_id|machine_id_link|safe }}
+			{% else if !switch_id.is_empty() %}
+				{{ switch_id|switch_id_link|safe }}
+			{% else if !power_shelf_id.is_empty() %}
+				{{ power_shelf_id|power_shelf_id_link|safe }}
+			{% endif %}
+		</td>
+	</tr>
+	<tr><th>Attached DPU ID</th><td>{{ dpu_machine_id|machine_id_link|safe }}</td></tr>
 	<tr><th>Segment ID</th><td><a href="/admin/network-segment/{{ segment_id }}">{{ segment_id }}</a></td></tr>
 	<tr><th>Domain ID</th><td><a href="/admin/domain">{{ domain_id }}</a></td></tr>
 	<tr><th>Domain Name</th><td>{{ domain_name }}</td></tr>

--- a/crates/api/templates/interface_show.html
+++ b/crates/api/templates/interface_show.html
@@ -9,10 +9,11 @@
 	<thead>
 	<tr>
 		<th>ID</th>
-		<th>Type</th>
 		<th>MAC Address</th>
 		<th>IP Address</th>
-		<th>Machine ID</th>
+		<th>Association Type</th>
+		<th>Association ID</th>
+		<th>Type</th>
 		<th>Hostname</th>
 		<th>Vendor</th>
 		<th>Domain Name</th>
@@ -22,10 +23,19 @@
 	{% for iface in interfaces %}
 		<tr>
 			<td><a href="/admin/interface/{{ iface.id }}">{{ iface.id }}</a></td>
-			<td>{{ iface.interface_type }}</td>
 			<td>{{ iface.mac_address }}</td>
 			<td>{{ iface.ip_address }}</td>
-			<td>{{ iface.machine_id|machine_id_link|safe }}</td>
+			<td>{{ iface.association_type }}</td>
+			<td>
+				{% if !iface.machine_id.is_empty() %}
+				{{ iface.machine_id|machine_id_link|safe }}
+				{% else if !iface.switch_id.is_empty() %}
+				{{ iface.switch_id|switch_id_link|safe }}
+				{% else if !iface.power_shelf_id.is_empty() %}
+				{{ iface.power_shelf_id|power_shelf_id_link|safe }}
+				{% endif %}
+			</td>
+			<td>{{ iface.interface_type }}</td>
 			<td>{{ iface.hostname }}</td>
 			<td>{{ iface.vendor }}</td>
 			<td>{{ iface.domain_name }}</td>

--- a/crates/api/templates/machine_detail.html
+++ b/crates/api/templates/machine_detail.html
@@ -152,6 +152,9 @@
 {% set bmc_action_redirect_to = Some(format!("/admin/machine/{}#bmc_info_view", self.id)) %}
 <table class="detailsview">
 	<tr><th>IP</th><td><a href="/admin/explored-endpoint/{{ bmc_ip }}">{{ bmc_ip }}</a></td></tr>
+	{% if let Some(machine_interface_id) = bmc_info.machine_interface_id %}
+	<tr><th>Machine Interface ID</th><td><a href="/admin/interface/{{ machine_interface_id }}">{{ machine_interface_id }}</a></td></tr>
+	{% endif %}
 	<tr><th>Port</th><td>{{ bmc_info.port|option_fmt }}</td></tr>
 	<tr><th>MAC Address</th><td>{{ bmc_info.mac|option_fmt }}</td></tr>
 	<tr><th>Version</th><td>{{ bmc_info.version|option_fmt }}</td></tr>


### PR DESCRIPTION
## Description

- Show machine_interface ID that is associated with a BMC in machine details view
- Link from interfaces table and details views not only to Machines, but also to Powershelves and Switches

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

