### PR TITLE
feat: site-level ntp_servers config for dhcp server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6524,7 +6524,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.10#3c5bd928414892355e0dd3ce4fd5120c31477857"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.11#677c18d32be6abff6fbd82dcce86b1845e680899"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.10" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.11" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.13" }
 ansi-to-html = "0.2.2"
 

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -138,6 +138,52 @@ pub struct ServiceAddresses {
     pub nameservers: Vec<IpAddr>,
 }
 
+fn build_dhcp_ntp_servers(
+    nc: &rpc::ManagedHostNetworkConfigResponse,
+    service_addrs: &ServiceAddresses,
+) -> Vec<Ipv4Addr> {
+    // Start with the NTP servers from the service addresses, which is read from carbide-ntp.forge.
+    let mut ntp_servers = service_addrs
+        .ntpservers
+        .iter()
+        .filter_map(|x| match x {
+            IpAddr::V4(x) => Some(*x),
+            _ => None,
+        })
+        .collect::<Vec<Ipv4Addr>>();
+
+    // If the site has configured NTP servers, use them instead.
+    if !nc.ntp_servers.is_empty() {
+        let site_ntp_servers: Vec<Ipv4Addr> = nc.ntp_servers
+        .iter()
+        .filter_map(|s| match IpAddr::from_str(s) {
+            Ok(IpAddr::V4(ip)) => Some(ip),
+            Ok(IpAddr::V6(_)) => {
+                tracing::debug!(
+                    ntp_server = %s,
+                    "IPv6 NTP server from ManagedHostNetworkConfigResponse is ignored for DHCPv4 config"
+                );
+                None
+            }
+            Err(e) => {
+                tracing::debug!(
+                    ntp_server = %s,
+                    error = %e,
+                    "Invalid NTP server IP from ManagedHostNetworkConfigResponse, ignoring"
+                );
+                None
+            }
+        })
+        .collect();
+
+        if !site_ntp_servers.is_empty() {
+            ntp_servers = site_ntp_servers;
+        }
+    }
+
+    ntp_servers
+}
+
 /// How we tell HBN to notice the new file we wrote
 #[derive(Debug)]
 struct PostAction {
@@ -1029,14 +1075,7 @@ async fn update_dhcp_via_grpc(
         })
         .collect::<Vec<Ipv4Addr>>();
 
-    let ntpservers_v4 = service_addrs
-        .ntpservers
-        .iter()
-        .filter_map(|x| match x {
-            IpAddr::V4(x) => Some(*x),
-            _ => None,
-        })
-        .collect::<Vec<Ipv4Addr>>();
+    let ntpservers_v4 = build_dhcp_ntp_servers(network_config, service_addrs);
 
     let pxe_ip_v4 = service_addrs
         .pxe_ips
@@ -1445,14 +1484,7 @@ fn write_dhcp_v4_server_config(
         })
         .collect::<Vec<Ipv4Addr>>();
 
-    let ntpservers_v4 = service_addrs
-        .ntpservers
-        .iter()
-        .filter_map(|x| match x {
-            IpAddr::V4(x) => Some(*x),
-            _ => None,
-        })
-        .collect::<Vec<Ipv4Addr>>();
+    let ntpservers_v4 = build_dhcp_ntp_servers(nc, service_addrs);
 
     let pxe_ip_v4 = service_addrs
         .pxe_ips
@@ -1909,6 +1941,54 @@ mod tests {
     #[ctor::ctor(unsafe)]
     fn setup() {
         carbide_host_support::init_logging("nico-dpu-agent").unwrap();
+    }
+
+    #[test]
+    fn test_build_dhcp_ntp_servers() {
+        let service_addrs = ServiceAddresses {
+            pxe_ips: vec![],
+            ntpservers: vec![IpAddr::from([192, 0, 2, 20])],
+            nameservers: vec![],
+        };
+        let nc = rpc::ManagedHostNetworkConfigResponse {
+            ntp_servers: vec!["198.51.100.1".to_string(), "198.51.100.2".to_string()],
+            ..Default::default()
+        };
+
+        let out = build_dhcp_ntp_servers(&nc, &service_addrs);
+        assert_eq!(
+            out,
+            vec![
+                Ipv4Addr::from([198, 51, 100, 1]),
+                Ipv4Addr::from([198, 51, 100, 2])
+            ]
+        );
+    }
+
+    #[test]
+    fn test_build_dhcp_ntp_servers_fallback() {
+        let service_addrs = ServiceAddresses {
+            pxe_ips: vec![],
+            ntpservers: vec![IpAddr::from([192, 0, 2, 20])],
+            nameservers: vec![],
+        };
+
+        let empty_nc = rpc::ManagedHostNetworkConfigResponse::default();
+
+        assert_eq!(
+            build_dhcp_ntp_servers(&empty_nc, &service_addrs),
+            vec![Ipv4Addr::from([192, 0, 2, 20])]
+        );
+
+        let invalid_nc = rpc::ManagedHostNetworkConfigResponse {
+            ntp_servers: vec!["not-an-ip".to_string(), "2001:db8::1".to_string()],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            build_dhcp_ntp_servers(&invalid_nc, &service_addrs),
+            vec![Ipv4Addr::from([192, 0, 2, 20])]
+        );
     }
 
     #[test]
@@ -2935,6 +3015,7 @@ mod tests {
 
             // yes it's in there twice I dunno either
             dhcp_servers: vec!["10.217.5.197".to_string(), "10.217.5.197".to_string()],
+            ntp_servers: vec![],
             vni_device: "vxlan48".to_string(),
 
             managed_host_config: Some(netconf),
@@ -3421,6 +3502,7 @@ mod tests {
 
             // yes it's in there twice I dunno either
             dhcp_servers: vec!["10.217.5.197".to_string(), "10.217.5.197".to_string()],
+            ntp_servers: vec![],
             vni_device: "vxlan48".to_string(),
 
             managed_host_config: Some(netconf),
@@ -3616,6 +3698,7 @@ mod tests {
             routing_profile: None,
             traffic_intercept_config: None,
             dhcp_servers: vec![],
+            ntp_servers: vec![],
             vni_device: "vxlan48".to_string(),
             managed_host_config: Some(netconf),
             managed_host_config_version: "V1-T1".to_string(),

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -885,6 +885,7 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
         }),
 
         dhcp_servers: vec!["127.0.0.1".to_string()],
+        ntp_servers: vec![],
         vni_device: "".to_string(),
 
         managed_host_config: Some(rpc::forge::ManagedHostNetworkConfig {

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -128,6 +128,10 @@ pub struct CarbideConfig {
     #[serde(default)]
     pub dhcp_servers: Vec<Ipv4Addr>,
 
+    /// NTP server IP addresses for the site.
+    #[serde(default)]
+    pub ntp_servers: Vec<Ipv4Addr>,
+
     /// Route server IP addresses for L2VPN (Ethernet
     /// Virtual) network support on DPUs.
     #[serde(default)]
@@ -2862,6 +2866,10 @@ mod tests {
         assert_eq!(
             config.dhcp_servers,
             vec![Ipv4Addr::new(1, 2, 3, 4), Ipv4Addr::new(5, 6, 7, 8)]
+        );
+        assert_eq!(
+            config.ntp_servers,
+            vec![Ipv4Addr::new(10, 20, 30, 40), Ipv4Addr::new(50, 60, 70, 80)]
         );
         assert_eq!(config.vpc_peering_policy, Some(VpcPeeringPolicy::Exclusive));
         assert_eq!(

--- a/crates/api-core/src/cfg/test_data/full_config.toml
+++ b/crates/api-core/src/cfg/test_data/full_config.toml
@@ -4,6 +4,7 @@ database_url = "postgres://a:b@postgresql"
 max_database_connections = 1222
 asn = 123
 dhcp_servers = ["1.2.3.4", "5.6.7.8"]
+ntp_servers = ["10.20.30.40", "50.60.70.80"]
 route_servers = ["9.10.11.12"]
 rapid_iterations = false
 initial_domain_name = "forge.local"

--- a/crates/api-core/src/dhcp/discover.rs
+++ b/crates/api-core/src/dhcp/discover.rs
@@ -52,6 +52,7 @@ async fn handle_overlay_from_dpa(
     dpa_if: &mut DpaInterface,
     macaddr: MacAddress,
     desired_addr: IpAddr,
+    ntp_servers: &[Ipv4Addr],
 ) -> Result<Option<Response<rpc::DhcpRecord>>, CarbideError> {
     let IpAddr::V4(ip_v4_addr) = desired_addr else {
         return Err(CarbideError::internal(
@@ -80,6 +81,7 @@ async fn handle_overlay_from_dpa(
         mtu: SPX_MTU,
         fqdn: String::new(),
         prefix,
+        ntp_servers: ntp_servers.iter().map(ToString::to_string).collect(),
     })))
 }
 
@@ -90,6 +92,7 @@ async fn handle_underlay_from_dpa(
     dpa_if: &mut DpaInterface,
     macaddr: MacAddress,
     relay_address: String,
+    ntp_servers: &[Ipv4Addr],
 ) -> Result<Option<Response<rpc::DhcpRecord>>, CarbideError> {
     // The relay address and the mac address should differ only in bit 0
     let relay_addr = Ipv4Addr::from_str(&relay_address)?;
@@ -119,6 +122,7 @@ async fn handle_underlay_from_dpa(
         mtu: SPX_MTU,
         fqdn: String::new(),
         prefix,
+        ntp_servers: ntp_servers.iter().map(ToString::to_string).collect(),
     })))
 }
 
@@ -156,10 +160,24 @@ async fn handle_dhcp_from_dpa(
     let mut dpa_if = dpa_ifs.remove(0);
 
     if let Some(addr) = desired_address {
-        return handle_overlay_from_dpa(txn, &mut dpa_if, macaddr, addr).await;
+        return handle_overlay_from_dpa(
+            txn,
+            &mut dpa_if,
+            macaddr,
+            addr,
+            &api.runtime_config.ntp_servers,
+        )
+        .await;
     }
 
-    handle_underlay_from_dpa(txn, &mut dpa_if, macaddr, relay_address).await
+    handle_underlay_from_dpa(
+        txn,
+        &mut dpa_if,
+        macaddr,
+        relay_address,
+        &api.runtime_config.ntp_servers,
+    )
+    .await
 }
 
 pub async fn discover_dhcp(
@@ -437,7 +455,7 @@ pub async fn discover_dhcp(
 
     let mut txn = api.txn_begin().await?;
 
-    let record: rpc::DhcpRecord = db::dhcp_record::find_by_mac_address(
+    let mut record: rpc::DhcpRecord = db::dhcp_record::find_by_mac_address(
         &mut txn,
         &parsed_mac,
         &machine_interface.segment_id,
@@ -447,5 +465,13 @@ pub async fn discover_dhcp(
     .into();
 
     txn.commit().await?;
+
+    record.ntp_servers = api
+        .runtime_config
+        .ntp_servers
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+
     Ok(Response::new(record))
 }

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -595,6 +595,12 @@ pub(crate) async fn get_managed_host_network_config_inner(
             .map(|addr| addr.to_string())
             .collect(),
         route_servers,
+        ntp_servers: api
+            .runtime_config
+            .ntp_servers
+            .iter()
+            .map(|addr| addr.to_string())
+            .collect(),
         // TODO: Automatically add the prefix(es?) from the IPv4 loopback
         // pool to deny_prefixes. The database stores the pool in an
         // exploded representation, so we either need to reconstruct the

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -1448,6 +1448,7 @@ async fn initialize_and_start_controllers<'a>(
         Some(upload_limiter),
         Some(api_service.credential_manager.clone()),
         work_lock_manager_handle.clone(),
+        carbide_config.ntp_servers.clone(),
     )
     .start(join_set, cancel_token.clone())?;
 

--- a/crates/api-core/src/test_support/default_config.rs
+++ b/crates/api-core/src/test_support/default_config.rs
@@ -252,6 +252,7 @@ pub fn get() -> CarbideConfig {
         initial_objects_file: None,
         config_ctx: None,
         tracing: TracingConfig::default(),
+        ntp_servers: vec![],
     }
 }
 

--- a/crates/api-core/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api-core/src/tests/host_bmc_firmware_test.rs
@@ -77,6 +77,7 @@ async fn test_preingestion_bmc_upgrade(
         None,
         None,
         env.api.work_lock_manager_handle.clone(),
+        env.config.ntp_servers.clone(),
     );
 
     let mut txn = pool.begin().await.unwrap();
@@ -267,6 +268,7 @@ async fn test_preingestion_upgrade_script(
         None,
         None,
         env.api.work_lock_manager_handle.clone(),
+        env.config.ntp_servers.clone(),
     );
 
     let response = env
@@ -978,6 +980,7 @@ async fn test_preingestion_preupdate_powercycling(
         None,
         None,
         env.api.work_lock_manager_handle.clone(),
+        env.config.ntp_servers.clone(),
     );
 
     let mut txn = pool.begin().await.unwrap();
@@ -2307,6 +2310,7 @@ async fn test_preingestion_time_sync_ok(
         None,
         None,
         env.api.work_lock_manager_handle.clone(),
+        env.config.ntp_servers.clone(),
     );
 
     let mut txn = pool.begin().await.unwrap();
@@ -2358,6 +2362,7 @@ async fn test_preingestion_time_sync_reset_flow(
         None,
         None,
         env.api.work_lock_manager_handle.clone(),
+        env.config.ntp_servers.clone(),
     );
 
     let response = env
@@ -2399,6 +2404,12 @@ async fn test_preingestion_time_sync_reset_flow(
     assert!(
         all_actions.contains(&RedfishSimAction::SetUtcTimezone),
         "Expected SetUtcTimezone action to be called during TimeSyncReset Start phase"
+    );
+    assert!(
+        all_actions
+            .iter()
+            .any(|a| matches!(a, RedfishSimAction::SetNtpServers(_))),
+        "Expected SetNtpServers action to be called during TimeSyncReset Start phase"
     );
 
     let mut txn = pool.begin().await.unwrap();
@@ -2483,6 +2494,7 @@ async fn test_preingestion_time_sync_check_error_fails(
         None,
         None,
         env.api.work_lock_manager_handle.clone(),
+        env.config.ntp_servers.clone(),
     );
 
     let response = env
@@ -2539,6 +2551,7 @@ async fn test_preingestion_time_sync_retry_logic(
         None,
         None,
         env.api.work_lock_manager_handle.clone(),
+        env.config.ntp_servers.clone(),
     );
 
     let response = env
@@ -2626,6 +2639,7 @@ async fn test_time_sync_retry_reenters_reset_before_failing(
         None,
         None,
         env.api.work_lock_manager_handle.clone(),
+        env.config.ntp_servers.clone(),
     );
 
     let response = env
@@ -2696,6 +2710,7 @@ async fn test_time_sync_fails_after_max_attempts(
         None,
         None,
         env.api.work_lock_manager_handle.clone(),
+        env.config.ntp_servers.clone(),
     );
 
     let response = env

--- a/crates/api-core/src/tests/machine_dhcp.rs
+++ b/crates/api-core/src/tests/machine_dhcp.rs
@@ -209,6 +209,54 @@ async fn test_non_primary_admin_interface_dhcp_is_rejected(
 }
 
 #[crate::sqlx_test]
+async fn test_discover_dhcp_includes_site_ntp_server_ips(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = get_config();
+    config.ntp_servers = vec![
+        "198.51.100.10".parse().unwrap(),
+        "198.51.100.11".parse().unwrap(),
+    ];
+    let env =
+        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(config)).await;
+
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder("FF:FF:FF:FF:FF:FF", FIXTURE_DHCP_RELAY_ADDRESS).tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    assert_eq!(
+        response.ntp_servers,
+        vec!["198.51.100.10".to_string(), "198.51.100.11".to_string()]
+    );
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_discover_dhcp_returns_empty_ntp_servers_when_site_not_configured(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = get_config();
+    config.ntp_servers = vec![];
+    let env =
+        create_test_env_with_overrides(pool.clone(), TestEnvOverrides::with_config(config)).await;
+
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder("FF:FF:FF:FF:FF:EE", FIXTURE_DHCP_RELAY_ADDRESS).tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    assert_eq!(response.ntp_servers, Vec::<String>::new());
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn test_multiple_machines_dhcp_with_api(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/api-core/src/tests/preingestion_dpu_nic_mode.rs
+++ b/crates/api-core/src/tests/preingestion_dpu_nic_mode.rs
@@ -123,6 +123,7 @@ fn build_preingestion_manager(env: &common::api_fixtures::TestEnv) -> Preingesti
         None,
         None,
         env.api.work_lock_manager_handle.clone(),
+        env.config.ntp_servers.clone(),
     )
 }
 

--- a/crates/dhcp-server/src/main.rs
+++ b/crates/dhcp-server/src/main.rs
@@ -553,6 +553,7 @@ impl Test {
             gateway: Some("10.217.132.193".to_string()),
             booturl: None,
             last_invalidation_time: None,
+            ntp_servers: vec!["1.2.3.4".to_string(), "5.6.7.8".to_string()],
         })
     }
 }

--- a/crates/dhcp-server/src/modes/dpu.rs
+++ b/crates/dhcp-server/src/modes/dpu.rs
@@ -44,6 +44,7 @@ fn from_host_conf(value: &InterfaceInfo, interface_id: MachineInterfaceId) -> Dh
         gateway: Some(value.gateway.to_string()),
         booturl: value.booturl.clone(),
         last_invalidation_time: None,
+        ntp_servers: vec![],
     }
 }
 

--- a/crates/dhcp/src/lib.rs
+++ b/crates/dhcp/src/lib.rs
@@ -186,7 +186,8 @@ pub unsafe extern "C" fn carbide_set_config_mqtt_server(mqttserver: *const c_cha
     }
 }
 
-/// Take the NTP servers for configuring NTP in the dhcp responses
+/// Take the NTP servers configuring NTP in the dhcp responses as fallback when the Carbide API `DhcpRecord` does not
+/// have `ntp_servers` set.
 ///
 /// # Safety
 /// Function is unsafe as it dereferences a raw pointer given to it.  Caller is responsible

--- a/crates/dhcp/src/machine.rs
+++ b/crates/dhcp/src/machine.rs
@@ -258,8 +258,15 @@ pub extern "C" fn machine_get_nameservers(ctx: *mut Machine) -> *mut libc::c_cha
 pub extern "C" fn machine_get_ntpservers(ctx: *mut Machine) -> *mut libc::c_char {
     assert!(!ctx.is_null());
 
-    let ntpservers =
-        CString::new(crate::format_ipv4_list(&CONFIG.read().unwrap().ntpservers)).unwrap();
+    let machine = unsafe { &*ctx };
+
+    let ntp_csv = if !machine.inner.ntp_servers.is_empty() {
+        machine.inner.ntp_servers.join(",")
+    } else {
+        crate::format_ipv4_list(&CONFIG.read().unwrap().ntpservers)
+    };
+
+    let ntpservers = CString::new(ntp_csv).unwrap();
     log::debug!("Ntp servers are {ntpservers:?}");
 
     ntpservers.into_raw()
@@ -438,8 +445,9 @@ mod test {
 
     use rpc::forge as rpc;
 
+    use crate::carbide_set_config_ntp;
     use crate::discovery::Discovery;
-    use crate::machine::{Machine, machine_get_filename};
+    use crate::machine::{Machine, machine_get_filename, machine_get_ntpservers};
     use crate::vendor_class::VendorClass;
 
     #[test]
@@ -506,5 +514,64 @@ mod test {
         let cstr = unsafe { CString::from_raw(out as *mut _) };
 
         assert_eq!(cstr, CString::new("https://foobar").unwrap());
+    }
+
+    #[test]
+    fn test_machine_get_ntpservers() {
+        unsafe {
+            let s = CString::new("10.0.0.1").unwrap();
+            carbide_set_config_ntp(s.as_ptr());
+        }
+
+        // Test with ntp servers in the dhcp record
+        let mut machine = Box::new(Machine {
+            inner: rpc::DhcpRecord {
+                ntp_servers: vec!["198.51.100.1".to_string(), "198.51.100.2".to_string()],
+                ..Default::default()
+            },
+            discovery_info: Discovery {
+                relay_address: "127.0.0.1".parse().unwrap(),
+                mac_address: "00:00:00:00:00:01".parse().unwrap(),
+                _client_system: None,
+                vendor_class: None,
+                link_select_address: None,
+                circuit_id: None,
+                remote_id: None,
+                desired_address: None,
+            },
+            vendor_class: None,
+        });
+
+        let raw = machine_get_ntpservers(&mut *machine);
+        let cstr = unsafe { CString::from_raw(raw) };
+        assert_eq!(cstr.to_str().unwrap(), "198.51.100.1,198.51.100.2");
+
+        // Test with no ntp servers in the dhcp record
+        unsafe {
+            let s = CString::new("10.0.0.2,10.0.0.3").unwrap();
+            carbide_set_config_ntp(s.as_ptr());
+        }
+
+        let mut machine = Box::new(Machine {
+            inner: rpc::DhcpRecord {
+                ntp_servers: vec![],
+                ..Default::default()
+            },
+            discovery_info: Discovery {
+                relay_address: "127.0.0.1".parse().unwrap(),
+                mac_address: "00:00:00:00:00:02".parse().unwrap(),
+                _client_system: None,
+                vendor_class: None,
+                link_select_address: None,
+                circuit_id: None,
+                remote_id: None,
+                desired_address: None,
+            },
+            vendor_class: None,
+        });
+
+        let raw = machine_get_ntpservers(&mut *machine);
+        let cstr = unsafe { CString::from_raw(raw) };
+        assert_eq!(cstr.to_str().unwrap(), "10.0.0.2,10.0.0.3");
     }
 }

--- a/crates/dhcp/src/mock_api_server.rs
+++ b/crates/dhcp/src/mock_api_server.rs
@@ -63,6 +63,7 @@ pub fn base_dhcp_response(mac_address: MacAddress) -> rpc::DhcpRecord {
         gateway: Some("172.20.0.1".to_string()),
         booturl: None,
         last_invalidation_time: None,
+        ntp_servers: vec!["198.51.100.10".to_string(), "198.51.100.11".to_string()],
     }
 }
 

--- a/crates/preingestion-manager/src/lib.rs
+++ b/crates/preingestion-manager/src/lib.rs
@@ -23,7 +23,7 @@ mod metrics;
 use std::collections::HashMap;
 use std::default::Default;
 use std::io;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -95,6 +95,7 @@ struct PreingestionManagerStatic {
     bfb_rshim_copier: Arc<BfbRshimCopier>,
     bfb_copy_state: Arc<BfbCopyManager>,
     bfb_copy_limiter: Arc<Semaphore>,
+    ntp_servers: Vec<Ipv4Addr>,
 }
 
 impl PreingestionManager {
@@ -113,6 +114,7 @@ impl PreingestionManager {
         upload_limiter: Option<Arc<Semaphore>>,
         credential_reader: Option<Arc<dyn CredentialReader>>,
         work_lock_manager_handle: WorkLockManagerHandle,
+        ntp_servers: Vec<Ipv4Addr>,
     ) -> PreingestionManager {
         let hold_period = config
             .run_interval
@@ -133,6 +135,7 @@ impl PreingestionManager {
                 bfb_rshim_copier,
                 bfb_copy_state: Default::default(),
                 bfb_copy_limiter: Arc::new(Semaphore::new(config.max_concurrent_bfb_copies)),
+                ntp_servers,
                 config,
             }),
             metric_holder,
@@ -1680,6 +1683,16 @@ impl PreingestionManagerStatic {
                 if let Err(e) = redfish_client.set_utc_timezone().await {
                     tracing::error!("Could not set UTC timezone on {}: {e}", endpoint.address);
                     return Err(PreingestionManagerError::RedfishError(e));
+                }
+                if !self.ntp_servers.is_empty() {
+                    let ntp_servers: Vec<String> =
+                        self.ntp_servers.iter().map(ToString::to_string).collect();
+                    if let Err(e) = redfish_client.set_ntp_servers(&ntp_servers).await {
+                        tracing::warn!(
+                            "Could not set NTP servers on {}: {e}; continuing time sync reset",
+                            endpoint.address
+                        );
+                    }
                 }
                 if !self
                     .execute_power_off_and_bmc_reset(redfish_client.as_ref(), endpoint)

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -199,6 +199,7 @@ pub enum RedfishSimAction {
     Power(libredfish::SystemPowerControl),
     BmcReset,
     SetUtcTimezone,
+    SetNtpServers(Vec<String>),
     MachineSetup {
         oem_manager_profiles: libredfish::BiosProfileVendor,
         /// The boot interface the setup call targeted (`None` when the caller
@@ -1782,6 +1783,23 @@ impl Redfish for RedfishSimClient {
                 .unwrap()
                 .actions
                 .push(RedfishSimAction::SetUtcTimezone);
+            Ok(())
+        })
+    }
+
+    fn set_ntp_servers<'a>(
+        &'a self,
+        servers: &'a [String],
+    ) -> libredfish::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            self.state
+                .lock()
+                .unwrap()
+                .hosts
+                .get_mut(&self._host)
+                .unwrap()
+                .actions
+                .push(RedfishSimAction::SetNtpServers(servers.to_vec()));
             Ok(())
         })
     }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -3843,6 +3843,9 @@ message DhcpRecord {
 
   // The last time any underlay or admin DHCP record managed by Forge got invalidated
   optional google.protobuf.Timestamp last_invalidation_time = 12;
+
+  // Per site NTP server IPs
+  repeated string ntp_servers = 13;
 }
 
 message NetworkSegmentList {
@@ -4043,6 +4046,10 @@ message ManagedHostNetworkConfigResponse {
   // should perform any extra config to prepare
   // for them.
   bool stateful_acls_enabled = 21;
+
+  // site-level configured NTP server IPs 
+  // If empty, the agent may fall back to resolving carbide-ntp.forge for compatibility.
+  repeated string ntp_servers = 22;
 
   // Enable forge DHCP on HBN.
   // Deprecated: It is always enabled now.

--- a/crates/rpc/src/model/dhcp_record.rs
+++ b/crates/rpc/src/model/dhcp_record.rs
@@ -34,6 +34,7 @@ impl From<DhcpRecord> for rpc::forge::DhcpRecord {
             gateway: record.gateway.map(|gw| gw.to_string()),
             booturl: None, // TODO(ajf): extend database, synthesize URL
             last_invalidation_time: Some(record.last_invalidation_time.into()),
+            ntp_servers: vec![],
         }
     }
 }


### PR DESCRIPTION
## Description
- Add site-level `ntp_servers` config and plumb it into the `DhcpRecord` response of `DiscoverDhcp` RPC call.
- Update Kea DHCP config to prefer API-provided `DhcpRecord.ntp_servers` for Option 42, while keeping the old workflow (read ntp_servers from kea dhcp config) for fallback. 
- Add site level `ntp_servers` into `ManagedHostNetworkConfigResponse` and have DPU agent use it for DHCP server. 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues
https://github.com/NVIDIA/infra-controller-core/issues/548

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
