### PR TITLE
fix(api): Make VF count a DpuConfig option

### DIFF
--- a/crates/api/files/bf.cfg
+++ b/crates/api/files/bf.cfg
@@ -134,22 +134,9 @@ write_files:
     content: |
       [iptables]
       -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0hpf_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf0_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf1_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf2_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf3_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf4_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf5_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf6_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf7_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf8_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf9_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf10_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf11_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf12_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf13_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf14_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf15_if -m comment --comment 'offload:0' -j DROP
+      {% for vf_id in range(end=num_of_vfs|int) %}
+      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf{{ vf_id }}_if -m comment --comment 'offload:0' -j DROP
+      {% endfor %}
 
   - path: /etc/sysctl.d/98-hbn.conf
     permissions: '0644'
@@ -187,7 +174,7 @@ write_files:
       ip vrf exec mgmt curl --retry 5 --retry-all-errors -v -o /opt/forge/forge_root.pem {{ pxe_url }}/api/v0/tls/root_ca
       echo "downloaded forge root cert"
       /usr/bin/mlxprivhost -d /dev/mst/mt*_pciconf0 r --disable_rshim --disable_tracer --disable_counter_rd --disable_port_owner
-      bash -c '/usr/bin/mlxconfig -y -d /dev/mst/mt*_pciconf0 s SRIOV_EN=True NUM_OF_VFS=16 HIDE_PORT2_PF=True NUM_OF_PF=1'
+      bash -c '/usr/bin/mlxconfig -y -d /dev/mst/mt*_pciconf0 s SRIOV_EN=True NUM_OF_VFS={{ num_of_vfs }} HIDE_PORT2_PF=True NUM_OF_PF=1'
       bash -c '/usr/bin/mlxconfig -y -d /dev/mst/mt*_pciconf0 set LINK_TYPE_P1=2 LINK_TYPE_P2=2' || true # not all BF2s have VPI so ignore the error if it does not
       dpkg -i /opt/forge/forge-dpu.deb
       mkdir -p /etc/apt/sources.list.d

--- a/crates/api/src/cfg/README.md
+++ b/crates/api/src/cfg/README.md
@@ -244,6 +244,7 @@ Extends `StateControllerConfig` with:
 | `dpu_models` | `HashMap<String, Firmware>` | *(BF2+BF3 defaults)* | DPU model firmware definitions. |
 | `dpu_nic_firmware_update_versions` | `Vec<String>` | *(BF2+BF3 NIC versions)* | DPU NIC firmware version strings. |
 | `dpu_enable_secure_boot` | `bool` | `false` | Enable secure boot flow for DPU provisioning via Redfish. |
+| `num_of_vfs` | `u32` | `16` | Number of VFs configured per DPU PF during BlueField provisioning. Max `126`. |
 
 ### `NetworkSecurityGroupConfig`
 

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -63,6 +63,8 @@ static BF3_NIC: &str = "32.47.2682";
 static BF3_BMC: &str = "BF-25.10-20";
 static BF3_CEC: &str = "00.02.0195.0000_n02";
 static BF3_UEFI: &str = "4.13.2-12-g943a91640d";
+pub(crate) const DEFAULT_DPU_NUM_OF_VFS: u32 = 16;
+pub(crate) const MAX_DPU_NUM_OF_VFS: u32 = 126;
 
 /// nico-api configuration file content
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1725,6 +1727,11 @@ pub struct DpuConfig {
     /// Default is false.
     #[serde(default)]
     pub dpu_enable_secure_boot: bool,
+
+    /// Number of virtual functions configured per DPU PF during BlueField provisioning.
+    /// Defaults to 16 and must not exceed 126.
+    #[serde(default)]
+    pub num_of_vfs: u32,
 }
 
 impl DpuConfig {
@@ -1762,10 +1769,18 @@ impl<'de> Deserialize<'de> for DpuConfig {
             dpu_nic_firmware_update_versions: Option<Vec<String>>,
             #[serde(default)]
             dpu_enable_secure_boot: Option<bool>,
+            #[serde(default)]
+            num_of_vfs: Option<u32>,
         }
 
         let partial = PartialDpuConfig::deserialize(deserializer)?;
         let default = DpuConfig::default();
+        let num_of_vfs = partial.num_of_vfs.unwrap_or(default.num_of_vfs);
+        if num_of_vfs > MAX_DPU_NUM_OF_VFS {
+            return Err(serde::de::Error::custom(format!(
+                "dpu_config.num_of_vfs must be <= {MAX_DPU_NUM_OF_VFS}"
+            )));
+        }
 
         Ok(DpuConfig {
             dpu_nic_firmware_initial_update_enabled: partial
@@ -1781,6 +1796,7 @@ impl<'de> Deserialize<'de> for DpuConfig {
             dpu_enable_secure_boot: partial
                 .dpu_enable_secure_boot
                 .unwrap_or(default.dpu_enable_secure_boot),
+            num_of_vfs,
         })
     }
 }
@@ -1903,6 +1919,7 @@ impl Default for DpuConfig {
             ]),
             dpu_nic_firmware_update_versions: vec![BF2_NIC.to_string(), BF3_NIC.to_string()],
             dpu_enable_secure_boot: false,
+            num_of_vfs: DEFAULT_DPU_NUM_OF_VFS,
         }
     }
 }
@@ -3213,6 +3230,7 @@ mod tests {
         );
         assert_eq!(config.tls.as_ref().unwrap().root_cafile_path, "/path/to/ca");
         assert!(!config.auth.as_ref().unwrap().permissive_mode);
+        assert_eq!(config.dpu_config.num_of_vfs, DEFAULT_DPU_NUM_OF_VFS);
         assert_eq!(
             config
                 .auth
@@ -3801,6 +3819,7 @@ mqtt_endpoint = "mqtt.forge"
         let toml = r#"
 [dpu_config]
 dpu_enable_secure_boot = true
+num_of_vfs = 64
 "#;
 
         let config: CarbideConfig = Figment::new()
@@ -3810,7 +3829,32 @@ dpu_enable_secure_boot = true
             .unwrap();
 
         assert!(config.dpu_config.dpu_enable_secure_boot);
+        assert_eq!(config.dpu_config.num_of_vfs, 64);
         assert!(!config.dpu_config.dpu_models.is_empty());
+    }
+
+    /// Validates the hard limit on generated BlueField virtual functions.
+    #[test]
+    fn deserialize_dpu_config_rejects_too_many_vfs() {
+        let toml = r#"
+[dpu_config]
+num_of_vfs = 127
+"#;
+
+        // Extracting the config should fail before runtime provisioning.
+        let error = Figment::new()
+            .merge(Toml::file(format!("{TEST_DATA_DIR}/full_config.toml")))
+            .merge(Toml::string(toml))
+            .extract::<CarbideConfig>()
+            .unwrap_err();
+
+        // Surface a clear operator-facing message for the invalid value.
+        assert!(
+            error
+                .to_string()
+                .contains("dpu_config.num_of_vfs must be <= 126"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/crates/api/src/handlers/client_resolution.rs
+++ b/crates/api/src/handlers/client_resolution.rs
@@ -245,6 +245,7 @@ pub(crate) async fn resolve_cloud_init_instructions(
                                 .map(|b| b.vf_intercept_bridge_sf.clone())
                         },
                     ),
+                    num_of_vfs: Some(api.runtime_config.dpu_config.num_of_vfs),
                 }),
                 metadata,
                 api_url_override,

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1223,6 +1223,7 @@ pub fn get_config() -> CarbideConfig {
             dpu_models: dpu_fw_example(),
             dpu_nic_firmware_update_versions: vec!["24.42.1000".to_string()],
             dpu_enable_secure_boot: true,
+            num_of_vfs: crate::cfg::file::DEFAULT_DPU_NUM_OF_VFS,
         },
         host_models: host_firmware_example(),
         firmware_global: FirmwareGlobal::test_default(),

--- a/crates/api/src/tests/ipxe.rs
+++ b/crates/api/src/tests/ipxe.rs
@@ -438,6 +438,46 @@ async fn test_cloud_init_when_machine_is_not_created(pool: sqlx::PgPool) {
     assert!(cloud_init_cfg.discovery_instructions.is_some());
 }
 
+/// Verifies cloud-init discovery instructions carry the configured DPU VF count.
+#[crate::sqlx_test]
+async fn test_cloud_init_uses_configured_num_of_vfs(pool: sqlx::PgPool) {
+    let mut config = get_config();
+    config.dpu_config.num_of_vfs = 64;
+    let env = create_test_env_with_overrides(pool, TestEnvOverrides::with_config(config)).await;
+
+    // Discover an unassigned interface so the API returns discovery instructions.
+    let mac_address = "FF:FF:FF:FF:FF:FE".to_string();
+    env.api
+        .discover_dhcp(DhcpDiscovery::builder(&mac_address, "192.0.2.1").tonic_request())
+        .await
+        .unwrap();
+
+    // Look up the allocated IP address to request cloud-init instructions.
+    let mut txn = env.pool.begin().await.unwrap();
+    let interfaces = db::machine_interface::find_by_mac_address(
+        txn.as_mut(),
+        mac_address.parse::<MacAddress>().unwrap(),
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    let cloud_init_cfg = env
+        .api
+        .get_cloud_init_instructions(tonic::Request::new(CloudInitInstructionsRequest {
+            ip: interfaces[0].addresses[0].to_string(),
+        }))
+        .await
+        .expect("get_cloud_init_instructions returned an error")
+        .into_inner();
+
+    // The configured value should pass through to carbide-pxe unchanged.
+    let discovery_instructions = cloud_init_cfg
+        .discovery_instructions
+        .expect("expected discovery instructions");
+    assert_eq!(discovery_instructions.num_of_vfs, Some(64));
+}
+
 #[crate::sqlx_test]
 async fn test_cloud_init_after_dpu_update(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;

--- a/crates/pxe/src/routes/cloud_init.rs
+++ b/crates/pxe/src/routes/cloud_init.rs
@@ -30,6 +30,9 @@ use rpc::forge;
 use rpc::forge::PxeDomain;
 
 use crate::common::{AppState, Machine};
+
+const DEFAULT_NUM_OF_VFS: u32 = 16;
+
 /// Generates the content of the /etc/forge/config.toml file.
 ///
 /// When `api_url_override` is provided (for external hosts on the
@@ -69,6 +72,7 @@ fn user_data_handler(
     domain: PxeDomain,
     hbn_reps: Option<String>,
     hbn_sfs: Option<String>,
+    num_of_vfs: Option<u32>,
     vf_intercept_bridge_name: Option<String>,
     host_intercept_bridge_name: Option<String>,
     host_intercept_bridge_port: Option<String>,
@@ -134,6 +138,9 @@ fn user_data_handler(
     if let Some(hbn_sfs) = hbn_sfs {
         context.insert("forge_hbn_sfs".to_string(), hbn_sfs);
     }
+
+    let num_of_vfs = num_of_vfs.unwrap_or(DEFAULT_NUM_OF_VFS);
+    context.insert("num_of_vfs".to_string(), num_of_vfs.to_string());
 
     if let Some(vf_intercept_bridge_name) = vf_intercept_bridge_name {
         context.insert(
@@ -215,6 +222,7 @@ pub async fn user_data(machine: Machine, state: State<AppState>) -> impl IntoRes
                         domain,
                         discovery_instructions.hbn_reps,
                         discovery_instructions.hbn_sfs,
+                        discovery_instructions.num_of_vfs,
                         discovery_instructions.vf_intercept_bridge_name,
                         discovery_instructions.host_intercept_bridge_name,
                         discovery_instructions.host_intercept_bridge_port,
@@ -366,5 +374,63 @@ mod tests {
                 .unwrap(),
             interface_id.to_string().as_str(),
         );
+    }
+
+    /// Verifies the real user-data template renders VF settings from the configured count.
+    #[test]
+    fn user_data_template_uses_configured_num_of_vfs() {
+        let template_glob = concat!(env!("CARGO_MANIFEST_DIR"), "/../../pxe/templates/**/*");
+        let tera = tera::Tera::new(template_glob).unwrap();
+
+        // Use the same string-valued context shape the route handler passes to Tera.
+        let context = HashMap::from([
+            (
+                "api_url".to_string(),
+                "https://carbide-api.forge".to_string(),
+            ),
+            (
+                "forge_agent_config_b64".to_string(),
+                "W21hY2hpbmVdCg==".to_string(),
+            ),
+            ("forge_bmc_fw_update".to_string(), String::new()),
+            ("forge_hbn_reps".to_string(), String::new()),
+            ("forge_hbn_sfs".to_string(), String::new()),
+            (
+                "forge_host_intercept_bridge_name".to_string(),
+                String::new(),
+            ),
+            (
+                "forge_host_intercept_bridge_port".to_string(),
+                String::new(),
+            ),
+            ("forge_vf_intercept_bridge_name".to_string(), String::new()),
+            ("forge_vf_intercept_bridge_port".to_string(), String::new()),
+            ("hostname".to_string(), "test-host".to_string()),
+            (
+                "interface_id".to_string(),
+                "91609f10-c91d-470d-a260-6293ea0c1234".to_string(),
+            ),
+            ("num_of_vfs".to_string(), "3".to_string()),
+            (
+                "pxe_url".to_string(),
+                "http://carbide-pxe.forge".to_string(),
+            ),
+            ("seconds_since_epoch".to_string(), "0".to_string()),
+        ]);
+        let rendered = tera
+            .render(
+                "user-data",
+                &tera::Context::from_serialize(context).unwrap(),
+            )
+            .unwrap();
+
+        // The mlxconfig value and DHCP drop rules should use the configured count.
+        assert!(rendered.contains("NUM_OF_VFS=3"));
+        assert!(!rendered.contains("NUM_OF_VFS=16"));
+        assert_eq!(rendered.matches("--physdev-in pf0vf").count(), 3);
+        assert!(rendered.contains("--physdev-in pf0vf0_if"));
+        assert!(rendered.contains("--physdev-in pf0vf1_if"));
+        assert!(rendered.contains("--physdev-in pf0vf2_if"));
+        assert!(!rendered.contains("--physdev-in pf0vf3_if"));
     }
 }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4634,6 +4634,10 @@ message CloudInitDiscoveryInstructions {
   // The representor that will plug into the HBN container to connect it to br-hbn
   // to open connectivity between all the VFs.
   optional string vf_intercept_bridge_sf = 9;
+
+  // Number of VFs to configure per DPU PF during BlueField provisioning.
+  // If absent, carbide-pxe uses the legacy default of 16 for rolling upgrades.
+  optional uint32 num_of_vfs = 10;
 }
 
 message CloudInitMetaData {

--- a/helm/charts/nico-api/files/carbide-api-config.toml
+++ b/helm/charts/nico-api/files/carbide-api-config.toml
@@ -30,6 +30,10 @@ attestation_enabled = true
 # its more specific config for anycast_site_prefixes.
 anycast_site_prefixes = ["0.0.0.0/0"]
 
+[dpu_config]
+# Number of VFs configured per DPU PF during BlueField provisioning.
+num_of_vfs = 16
+
 [host_health]
 hardware_health_reports = "MonitorOnly"
 

--- a/pxe/templates/user-data
+++ b/pxe/templates/user-data
@@ -164,22 +164,9 @@ write_files:
     content: |
       [iptables]
       -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0hpf_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf0_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf1_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf2_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf3_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf4_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf5_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf6_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf7_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf8_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf9_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf10_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf11_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf12_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf13_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf14_if -m comment --comment 'offload:0' -j DROP
-      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf15_if -m comment --comment 'offload:0' -j DROP
+      {% for vf_id in range(end=num_of_vfs|int) %}
+      -t filter -A FORWARD -p udp -d 255.255.255.255 --dport 67 -m physdev --physdev-in pf0vf{{ vf_id }}_if -m comment --comment 'offload:0' -j DROP
+      {% endfor %}
 
   - path: /etc/sysctl.d/98-hbn.conf
     permissions: '0644'
@@ -218,7 +205,7 @@ write_files:
       ip vrf exec mgmt curl --retry 5 --retry-all-errors -v -o /opt/forge/forge_root.pem {{ pxe_url }}/api/v0/tls/root_ca
       echo "downloaded forge root cert"
       /usr/bin/mlxprivhost -d /dev/mst/mt*_pciconf0 r --disable_rshim --disable_tracer --disable_counter_rd --disable_port_owner
-      bash -c '/usr/bin/mlxconfig -y -d /dev/mst/mt*_pciconf0 s SRIOV_EN=True NUM_OF_VFS=16 HIDE_PORT2_PF=True NUM_OF_PF=1'
+      bash -c '/usr/bin/mlxconfig -y -d /dev/mst/mt*_pciconf0 s SRIOV_EN=True NUM_OF_VFS={{ num_of_vfs }} HIDE_PORT2_PF=True NUM_OF_PF=1'
       bash -c '/usr/bin/mlxconfig -y -d /dev/mst/mt*_pciconf0 set LINK_TYPE_P1=2 LINK_TYPE_P2=2' || true # not all BF2s have VPI so ignore the error if it does not
       dpkg -i /opt/forge/forge-dpu.deb
       mkdir -p /etc/apt/sources.list.d


### PR DESCRIPTION
## Description

This allows the number of VFs created during DPU provisioning to be configurable.  Defaults to 16 (the old hard-coded value) and allows up to 126 (the documented limit).

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

