### PR TITLE
fix(site-explorer): use ExpectedMachine.host_nics when minting predicted interfaces

### DIFF
--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -22,7 +22,9 @@ use db::{ObjectColumnFilter, Transaction};
 use forge_secrets::credentials::{
     BmcCredentialType, CredentialKey, CredentialManager, Credentials,
 };
+use itertools::Itertools;
 use librms::RmsApi;
+use mac_address::MacAddress;
 use model::bmc_info::BmcInfo;
 use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
 use model::hardware_info::HardwareInfo;
@@ -308,7 +310,7 @@ impl MachineCreator {
         // If there's already a machine with the same MAC address as this endpoint, return false. We
         // can't rely on matching the machine_id, as it may have migrated to a stable MachineID
         // already.
-        let mac_addresses = report.all_mac_addresses();
+        let mac_addresses = host_mac_addresses_for_predicted_machine(report, machine_data);
         for mac_address in &mac_addresses {
             if db::machine::find_by_mac_address(txn, mac_address)
                 .await?
@@ -802,5 +804,34 @@ impl MachineCreator {
         .await?;
 
         Ok(predicted_machine_id)
+    }
+}
+
+/// Host inband MACs used when minting `predicted_machine_interface` rows for zero-DPU hosts.
+/// Prefers Redfish-reported System EthernetInterfaces; falls back to `ExpectedMachine.host_nics`
+/// when the BMC omits them from Redfish.
+fn host_mac_addresses_for_predicted_machine(
+    report: &EndpointExplorationReport,
+    machine_data: Option<&ExpectedMachineData>,
+) -> Vec<MacAddress> {
+    let from_redfish = report.all_mac_addresses();
+    match from_redfish.as_slice() {
+        [_, ..] => from_redfish,
+        [] => machine_data
+            .filter(|_| !(report.is_dpu() || report.is_switch() || report.is_power_shelf()))
+            .map(|data| data.host_nics.as_slice())
+            .filter(|host_nics| !host_nics.is_empty())
+            .map(|host_nics| {
+                tracing::info!(
+                    host_nic_count = host_nics.len(),
+                    "System EthernetInterfaces missing from Redfish; using ExpectedMachine.host_nics for predicted machine interfaces"
+                );
+                host_nics
+                    .iter()
+                    .map(|nic| nic.mac_address)
+                    .dedup()
+                    .collect()
+            })
+            .unwrap_or_default(),
     }
 }


### PR DESCRIPTION
## Problem

Zero-DPU host ingestion in site-explorer mints `predicted_machine_interface`
rows from MAC addresses discovered during BMC exploration. Those rows let
DHCP discovery (`discover_dhcp`) associate a host's first inband lease
with the predicted machine before Redfish has exposed full host topology.

`create_zero_dpu_machine()` previously sourced MACs exclusively from
`EndpointExplorationReport::all_mac_addresses()`, which collects MACs from
Redfish System `EthernetInterfaces`. Some BMC firmware omits that
collection entirely, so exploration succeeds but returns no host NIC MACs.

Sites already configure the same MACs on `ExpectedMachine.host_nics` (used
today for static-IP preallocation in the site-explorer reconcile loop).
Without a bridge between those configured MACs and predicted-interface
creation, zero-DPU hosts on such BMCs never receive
`predicted_machine_interface` rows and cannot be matched at DHCP time.

## Solution

Add `host_mac_addresses_for_predicted_machine()` and call it from
`create_zero_dpu_machine()` instead of `report.all_mac_addresses()`
directly.

Resolution order:
1. Prefer Redfish-reported System EthernetInterface MACs when any exist.
2. If the report has no host MACs, fall back to
   `ExpectedMachineData.host_nics` MAC addresses.
3. Skip fallback when the report represents a DPU, switch, or power shelf.
4. Skip fallback when `host_nics` is empty or `machine_data` is absent.
5. Emit an info log when the expected-machine fallback path is taken.

Exploration reports are intentionally left unchanged as faithful Redfish
snapshots. The fallback is scoped to predicted-machine creation, where
site configuration is the appropriate source of truth for interfaces the
BMC failed to enumerate.

## Scope

- Affects only zero-DPU managed-host creation in `MachineCreator`.
- DPU-backed hosts continue to derive host identity from DPU hardware info
  and proactive host-interface creation; unchanged by this commit.
- No API, schema, or exploration-report shape changes.

## Testing

- `cargo check -p carbide-site-explorer -p bmc-explorer-cli`

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

