### PR TITLE
fix: Make DSX Exchange MQTT client identifiers unique per process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6710,6 +6710,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -955,10 +955,15 @@ pub async fn initialize_and_start_controllers<'a>(
                 }
             };
 
+            // Suffix the broker-level client identifier so multiple replicas
+            // (or a new pod coming up while the old one is still terminating)
+            // do not race for the same MQTT session and ping-pong each other
+            // off the broker.
+            let client_id = mqttea::unique_client_id("carbide-dsx-exchange-event-bus");
             let client = mqttea::MqtteaClient::new(
                 &config.mqtt_endpoint,
                 config.mqtt_broker_port,
-                "carbide-dsx-exchange-event-bus",
+                &client_id,
                 Some(options),
             )
             .map_err(|e| eyre::eyre!("Failed to create DSX Exchange Event Bus MQTT client: {e}"))

--- a/crates/dsx-exchange-consumer/src/mqtt_consumer.rs
+++ b/crates/dsx-exchange-consumer/src/mqtt_consumer.rs
@@ -70,14 +70,9 @@ pub async fn connect(
     // pod coming up while the old one is still terminating) do not race for
     // the same MQTT session and ping-pong each other off the broker.
     let client_id = mqttea::unique_client_id(&config.client_id);
-    let client = MqtteaClient::new(
-        &config.endpoint,
-        config.port,
-        &client_id,
-        Some(options),
-    )
-    .await
-    .map_err(|e| DsxConsumerError::Mqtt(e.to_string()))?;
+    let client = MqtteaClient::new(&config.endpoint, config.port, &client_id, Some(options))
+        .await
+        .map_err(|e| DsxConsumerError::Mqtt(e.to_string()))?;
 
     // Register message types with distinct suffix patterns.
     // mqttea converts simple strings to suffix regex: "Metadata" -> "/Metadata$"

--- a/crates/dsx-exchange-consumer/src/mqtt_consumer.rs
+++ b/crates/dsx-exchange-consumer/src/mqtt_consumer.rs
@@ -66,10 +66,14 @@ pub async fn connect(
         }
     };
 
+    // Suffix the broker-level client identifier so multiple replicas (or a new
+    // pod coming up while the old one is still terminating) do not race for
+    // the same MQTT session and ping-pong each other off the broker.
+    let client_id = mqttea::unique_client_id(&config.client_id);
     let client = MqtteaClient::new(
         &config.endpoint,
         config.port,
-        &config.client_id,
+        &client_id,
         Some(options),
     )
     .await

--- a/crates/mqttea/Cargo.toml
+++ b/crates/mqttea/Cargo.toml
@@ -40,6 +40,7 @@ chrono = { features = ["serde"], workspace = true }
 regex = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+uuid = { features = ["v4"], workspace = true }
 
 # OAuth2 support
 oauth2 = { workspace = true }

--- a/crates/mqttea/src/client_id.rs
+++ b/crates/mqttea/src/client_id.rs
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Helpers for constructing MQTT broker-level client identifiers.
+//!
+//! MQTT brokers use the client identifier in the CONNECT packet to detect and
+//! disconnect duplicate sessions. When two processes connect with the same
+//! client identifier (for example two replicas of the same Deployment, or a
+//! new pod coming up while the old one is still terminating), the broker
+//! disconnects the older session and the loser auto-reconnects, producing a
+//! ping-pong loop that looks like an outage even though OAuth2 authentication
+//! and authorization are both healthy.
+//!
+//! [`unique_client_id`] returns `<base>-<8-hex-suffix>` where the suffix is
+//! drawn from a fresh v4 UUID. Each process therefore picks a stable client
+//! identifier for its lifetime, but two processes are vanishingly unlikely to
+//! collide on the broker.
+
+use uuid::Uuid;
+
+/// Length of the random suffix appended to the base client identifier.
+///
+/// 8 hex characters give 32 bits of entropy, enough to avoid collisions across
+/// the small handful of replicas a single MQTT-using deployment runs in
+/// practice while keeping the resulting identifier short enough to read in
+/// broker logs.
+const SUFFIX_LEN: usize = 8;
+
+/// Return `<base>-<random-suffix>` so each process picks a unique broker-level
+/// client identifier.
+///
+/// # Example
+///
+/// ```
+/// use mqttea::client_id::unique_client_id;
+///
+/// let id = unique_client_id("carbide-dsx-exchange-event-bus");
+/// assert!(id.starts_with("carbide-dsx-exchange-event-bus-"));
+/// assert_eq!(id.len(), "carbide-dsx-exchange-event-bus-".len() + 8);
+/// ```
+pub fn unique_client_id(base: &str) -> String {
+    let suffix: String = Uuid::new_v4()
+        .simple()
+        .to_string()
+        .chars()
+        .take(SUFFIX_LEN)
+        .collect();
+    format!("{base}-{suffix}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_base_and_appends_suffix() {
+        let id = unique_client_id("base");
+        assert!(id.starts_with("base-"), "got {id}");
+        assert_eq!(id.len(), "base-".len() + SUFFIX_LEN);
+    }
+
+    #[test]
+    fn empty_base_still_produces_unique_suffix() {
+        let id = unique_client_id("");
+        assert!(id.starts_with('-'));
+        assert_eq!(id.len(), 1 + SUFFIX_LEN);
+    }
+
+    #[test]
+    fn suffix_is_hex() {
+        let id = unique_client_id("base");
+        let suffix = &id["base-".len()..];
+        assert!(
+            suffix.chars().all(|c| c.is_ascii_hexdigit()),
+            "expected hex suffix, got {suffix}"
+        );
+    }
+
+    #[test]
+    fn two_calls_almost_never_collide() {
+        let a = unique_client_id("base");
+        let b = unique_client_id("base");
+        assert_ne!(a, b);
+    }
+}

--- a/crates/mqttea/src/lib.rs
+++ b/crates/mqttea/src/lib.rs
@@ -20,6 +20,7 @@
 
 pub mod auth;
 pub mod client;
+pub mod client_id;
 pub mod errors;
 pub mod message_types;
 pub mod registry;
@@ -33,6 +34,7 @@ pub use auth::{
     OAuth2TokenProvider, StaticCredentials, TokenCredentialsProvider, TokenProvider,
 };
 pub use client::{MqtteaClient, TopicPatterns};
+pub use client_id::unique_client_id;
 pub use errors::MqtteaClientError;
 pub use message_types::RawMessage;
 pub use registry::{MessageTypeInfo, MqttRegistry, SerializationFormat};


### PR DESCRIPTION
During my tests of the mqtt integration, the producer and consumer services both used the same client id, this caused them to compete for the client and only one of them was able to connect. This also prevents collisions when running multiple instances of these mqtt clients that connect to a single event bus.