### PR TITLE
add web-ui JSON buttons for rack components

### DIFF
--- a/crates/api/templates/power_shelf_show.html
+++ b/crates/api/templates/power_shelf_show.html
@@ -3,6 +3,8 @@
 {% block title %}Power Shelves{% endblock %}
 
 {% block content %}
+<div id="json"><a id="json-link" href="">JSON</a></div>
+
 <div class="container-fluid">
     <div class="row">
         <div class="col">

--- a/crates/api/templates/rack_show.html
+++ b/crates/api/templates/rack_show.html
@@ -3,6 +3,8 @@
 {% block title %}Racks{% endblock %}
 
 {% block content %}
+<div id="json"><a id="json-link" href="">JSON</a></div>
+
 <div class="container-fluid">
     <div class="row">
         <div class="col">

--- a/crates/api/templates/switch_show.html
+++ b/crates/api/templates/switch_show.html
@@ -3,6 +3,8 @@
 {% block title %}Switches{% endblock %}
 
 {% block content %}
+<div id="json"><a id="json-link" href="">JSON</a></div>
+
 <div class="container-fluid">
     <div class="row">
         <div class="col">


### PR DESCRIPTION
## Description

The /rack, /switch and /powershelf endpoints on the admin web ui all supported JSON views already via attaching `.json` to the endpoint. There was however not yet a button which links it. This adds the missing buttons.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

