### PR TITLE
chore(model): tenant: separate type for client basic secret json

### DIFF
--- a/crates/api-model/src/rpc_conv/tenant.rs
+++ b/crates/api-model/src/rpc_conv/tenant.rs
@@ -23,10 +23,10 @@ use rpc::errors::RpcDataConversionError;
 use rpc::forge as rpc_forge;
 
 use crate::tenant::{
-    IdentityConfig, IdentityConfigValidationBounds, IdentityConfigValidationError, PublicKey,
-    Tenant, TenantIdentityConfigDecrypted, TenantKeyset, TenantKeysetContent, TenantKeysetId,
-    TenantKeysetIdentifier, TenantKeysetSearchFilter, TenantPublicKey,
-    TenantPublicKeyValidationRequest, TenantSearchFilter, TokenDelegation,
+    ClientSecretBasic, IdentityConfig, IdentityConfigValidationBounds,
+    IdentityConfigValidationError, PublicKey, Tenant, TenantIdentityConfigDecrypted, TenantKeyset,
+    TenantKeysetContent, TenantKeysetId, TenantKeysetIdentifier, TenantKeysetSearchFilter,
+    TenantPublicKey, TenantPublicKeyValidationRequest, TenantSearchFilter, TokenDelegation,
     TokenDelegationAuthMethod, TokenDelegationAuthMethodConfig, TokenDelegationValidationBounds,
     TokenDelegationValidationError, UpdateTenantKeyset, compute_client_secret_hash,
     truncate_hash_for_display,
@@ -272,7 +272,7 @@ impl TryFrom<rpc::forge::UpdateTenantKeysetRequest> for UpdateTenantKeyset {
 /// Only used when auth_method is ClientSecretBasic; for None the oneof is omitted.
 pub fn stored_to_response_auth_config(
     auth_method: TokenDelegationAuthMethod,
-    stored: Option<rpc_forge::ClientSecretBasic>,
+    stored: Option<ClientSecretBasic>,
 ) -> Option<rpc_forge::token_delegation_response::AuthMethodConfig> {
     match auth_method {
         TokenDelegationAuthMethod::ClientSecretBasic => {
@@ -363,7 +363,7 @@ impl TryFrom<TenantIdentityConfigDecrypted> for rpc_forge::TokenDelegationRespon
             .auth_method
             .ok_or(RpcDataConversionError::MissingArgument("token_delegation"))?;
 
-        let stored: Option<rpc_forge::ClientSecretBasic> = value
+        let stored: Option<ClientSecretBasic> = value
             .auth_method_config
             .as_ref()
             .and_then(|s| serde_json::from_str(s).ok());
@@ -535,7 +535,7 @@ mod tests {
 
     #[test]
     fn test_stored_to_response_auth_config_client_secret_basic() {
-        let stored = rpc_forge::ClientSecretBasic {
+        let stored = ClientSecretBasic {
             client_id: "my-client".to_string(),
             client_secret: "secret".to_string(),
         };
@@ -552,7 +552,7 @@ mod tests {
 
     #[test]
     fn test_stored_to_response_auth_config_omits_cleartext() {
-        let stored = rpc_forge::ClientSecretBasic {
+        let stored = ClientSecretBasic {
             client_id: "my-client".to_string(),
             client_secret: "secret".to_string(),
         };
@@ -568,7 +568,7 @@ mod tests {
 
     #[test]
     fn test_stored_to_response_auth_config_client_secret_empty_returns_none() {
-        let stored = rpc_forge::ClientSecretBasic {
+        let stored = ClientSecretBasic {
             client_id: "x".to_string(),
             client_secret: String::new(),
         };
@@ -593,7 +593,7 @@ mod tests {
         };
         let (auth_method, config_json) = config.to_db_format();
         assert_eq!(auth_method, TokenDelegationAuthMethod::ClientSecretBasic);
-        let stored: rpc_forge::ClientSecretBasic = serde_json::from_str(&config_json).unwrap();
+        let stored: ClientSecretBasic = serde_json::from_str(&config_json).unwrap();
         assert_eq!(stored.client_id, "client");
         assert_eq!(stored.client_secret, "secret");
         // Hash is computed on the fly when retrieving

--- a/crates/api-model/src/tenant/mod.rs
+++ b/crates/api-model/src/tenant/mod.rs
@@ -22,7 +22,6 @@ use carbide_uuid::instance::InstanceId;
 use chrono::{DateTime, Utc};
 use config_version::ConfigVersion;
 use itertools::Itertools;
-use rpc::forge as rpc_forge;
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
 use sqlx::postgres::PgRow;
@@ -449,7 +448,7 @@ impl TokenDelegation {
                 client_id,
                 client_secret,
             } => {
-                let stored = rpc_forge::ClientSecretBasic {
+                let stored = ClientSecretBasic {
                     client_id: client_id.clone(),
                     client_secret: client_secret.clone(),
                 };
@@ -460,6 +459,13 @@ impl TokenDelegation {
         }
     }
 }
+
+#[derive(Serialize, Deserialize)]
+pub struct ClientSecretBasic {
+    pub client_id: String,
+    pub client_secret: String,
+}
+
 pub struct TenantPublicKeyValidationRequest {
     pub instance_id: InstanceId,
     pub public_key: String,

--- a/crates/api/src/machine_identity/crypto.rs
+++ b/crates/api/src/machine_identity/crypto.rs
@@ -19,11 +19,11 @@
 //! (signing private key + token delegation auth JSON), and parsing of stored delegation
 //! `client_secret_basic` JSON for outbound token exchange.
 
-use ::rpc::forge::ClientSecretBasic;
 use forge_secrets::credentials::{CredentialKey, CredentialReader, Credentials};
 use forge_secrets::key_encryption;
 use model::tenant::{
-    EncryptedTokenDelegationAuthConfig, EncryptionKeyId, TokenDelegationAuthMethod,
+    ClientSecretBasic, EncryptedTokenDelegationAuthConfig, EncryptionKeyId,
+    TokenDelegationAuthMethod,
 };
 use tonic::Status;
 


### PR DESCRIPTION
## Description
Tenant model reuses autogenerated RPC type to serialize / deserialize JSON that is stored in database. This is not obvious coupling between changes that can be made in RPC that will be transfered to DB representation.

For example, in RPC we can rename fields keeping backward compatibility. However, we cannot do this for jsons. This can cause subtle bugs that will not be caught by compiler.

This change decouples JSON and RPC types. In addition, it removes dependency of model types from rpc types.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

