### PR TITLE
chore(model,api): move DeleteInstance struct from model to api

### DIFF
--- a/crates/api-model/src/instance/mod.rs
+++ b/crates/api-model/src/instance/mod.rs
@@ -53,9 +53,3 @@ pub struct NewInstance<'a> {
     pub extension_services_config_version: ConfigVersion,
     pub nvlink_config_version: ConfigVersion,
 }
-
-pub struct DeleteInstance {
-    pub instance_id: InstanceId,
-    pub issue: Option<rpc::forge::Issue>,
-    pub is_repair_tenant: Option<bool>,
-}

--- a/crates/api-model/src/rpc_conv/instance/mod.rs
+++ b/crates/api-model/src/rpc_conv/instance/mod.rs
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use rpc::errors::RpcDataConversionError;
 
-use crate::instance::{DeleteInstance, InstanceSearchFilter};
+use crate::instance::InstanceSearchFilter;
 use crate::metadata::LabelFilter;
 
 pub mod config;
@@ -31,21 +30,6 @@ impl From<rpc::forge::InstanceSearchFilter> for InstanceSearchFilter {
             vpc_id: filter.vpc_id,
             instance_type_id: filter.instance_type_id,
         }
-    }
-}
-
-impl TryFrom<rpc::InstanceReleaseRequest> for DeleteInstance {
-    type Error = RpcDataConversionError;
-
-    fn try_from(value: rpc::InstanceReleaseRequest) -> Result<Self, Self::Error> {
-        let instance_id = value
-            .id
-            .ok_or(RpcDataConversionError::MissingArgument("id"))?;
-        Ok(DeleteInstance {
-            instance_id,
-            issue: value.issue,
-            is_repair_tenant: value.is_repair_tenant,
-        })
     }
 }
 

--- a/crates/api/src/handlers/instance.rs
+++ b/crates/api/src/handlers/instance.rs
@@ -17,6 +17,7 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
+use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge::{self as rpc, AdminForceDeleteMachineResponse};
 use carbide_redfish::libredfish::RedfishAuth;
 use carbide_uuid::infiniband::IBPartitionId;
@@ -30,7 +31,6 @@ use health_report::{
 };
 use itertools::Itertools as _;
 use model::ConfigValidationError;
-use model::instance::DeleteInstance;
 use model::instance::config::InstanceConfig;
 use model::instance::config::extension_services::InstanceExtensionServicesConfig;
 use model::instance::config::infiniband::InstanceInfinibandConfig;
@@ -669,15 +669,18 @@ pub(crate) async fn release(
     request: Request<rpc::InstanceReleaseRequest>,
 ) -> Result<Response<rpc::InstanceReleaseResult>, Status> {
     log_request_data(&request);
-    let delete_instance = DeleteInstance::try_from(request.into_inner())?;
+    let delete_instance = request.into_inner();
+    let instance_id = delete_instance
+        .id
+        .ok_or(RpcDataConversionError::MissingArgument("id"))?;
 
     let mut txn = api.txn_begin().await?;
 
-    let instance = db::instance::find_by_id(&mut txn, delete_instance.instance_id)
+    let instance = db::instance::find_by_id(&mut txn, instance_id)
         .await?
         .ok_or_else(|| CarbideError::NotFoundError {
             kind: "instance",
-            id: delete_instance.instance_id.to_string(),
+            id: instance_id.to_string(),
         })?;
 
     log_machine_id(&instance.machine_id);
@@ -697,7 +700,7 @@ pub(crate) async fn release(
     // Instance Release called from the Repair tenant.
     if delete_instance.is_repair_tenant == Some(true) {
         tracing::info!(
-            instance_id = %delete_instance.instance_id,
+            %instance_id,
             machine_id = %instance.machine_id,
             has_issues = delete_instance.issue.is_some(),
             "Instance release requested by repair tenant"
@@ -749,7 +752,7 @@ pub(crate) async fn release(
 
     if instance.deleted.is_some() {
         tracing::info!(
-            instance_id = %delete_instance.instance_id,
+            %instance_id,
             "Instance is already marked for deletion.",
         );
         txn.commit().await?;
@@ -759,7 +762,7 @@ pub(crate) async fn release(
     // TODO: This is racy. If the instance just got deleted we still
     // see an error here that is not returned as `NotFound` error. Ideally
     // we convert this case of the DatabaseError into NotFound too.
-    db::instance::mark_as_deleted(delete_instance.instance_id, &mut txn).await?;
+    db::instance::mark_as_deleted(instance_id, &mut txn).await?;
 
     txn.commit().await?;
 


### PR DESCRIPTION
## Description

This struct is only used by one function. So, it can be defined locally in that function instead of defining it in separate crate.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
