### PR TITLE
chore(model): MaintenanceOverride::maintenance_start_time to chrono

### DIFF
--- a/crates/api-model/src/machine/health_override.rs
+++ b/crates/api-model/src/machine/health_override.rs
@@ -21,7 +21,7 @@ pub const HARDWARE_HEALTH_OVERRIDE_PREFIX: &str = "hardware-health.";
 
 pub struct MaintenanceOverride {
     pub maintenance_reference: String,
-    pub maintenance_start_time: Option<rpc::Timestamp>,
+    pub maintenance_start_time: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// Machine-specific methods for HealthReportSources.
@@ -38,7 +38,7 @@ impl HealthReportSources {
             .find(|alert| alert.id == maintenance_alert_id)?;
         Some(MaintenanceOverride {
             maintenance_reference: alert.message.clone(),
-            maintenance_start_time: alert.in_alert_since.map(rpc::Timestamp::from),
+            maintenance_start_time: alert.in_alert_since,
         })
     }
 

--- a/crates/api-model/src/rpc_conv/machine/mod.rs
+++ b/crates/api-model/src/rpc_conv/machine/mod.rs
@@ -237,7 +237,7 @@ impl From<Machine> for rpc::forge::Machine {
                 .network_status_observation
                 .and_then(|obs| obs.agent_version),
             maintenance_reference,
-            maintenance_start_time,
+            maintenance_start_time: maintenance_start_time.map(rpc::Timestamp::from),
             associated_host_machine_id: None, // Gets filled in the `ManagedHostStateSnapshot` conversion
             associated_dpu_machine_ids,
             inventory: Some(machine.inventory.unwrap_or_default().into()),


### PR DESCRIPTION
## Description

Change type of maintenance_start_time to chrono that matches data type
of HealthProbeAlert::in_alert_since that is source for this field.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
