### PR TITLE
fix(dhcp): align Kea memfile with NICo via lease4_select and lease4_renew hooks

### DIFF
--- a/crates/dhcp/src/kea/callouts.cc
+++ b/crates/dhcp/src/kea/callouts.cc
@@ -471,6 +471,22 @@ int pkt4_receive(CalloutHandle &handle) {
     return 1;
   }
 
+  /*
+   * machine_get_interface_address returns the IPv4 address as a u32 in
+   * network byte order, or 0 if Carbide didn't return a parseable IPv4
+   * address. 0.0.0.0 is not a valid allocation, and pkt4_receive is the
+   * packet-level hook where NEXT_STEP_DROP reliably stops processing before
+   * Kea can select, renew, or persist a lease.
+   */
+  if (machine_get_interface_address(machine) == 0) {
+    LOG_ERROR(logger, isc::log::LOG_CARBIDE_PKT4_RECEIVE)
+        .arg("Carbide returned no usable IPv4 address; dropping packet");
+    machine_free(machine);
+    handle.setStatus(CalloutHandle::NEXT_STEP_DROP);
+    carbide_increment_dropped_requests("NoUsableIPv4Address");
+    return 1;
+  }
+
   // On success, we set the pointer to the machine in the request context to
   // be retrieved later
   boost::shared_ptr<Machine> machinePtr(machine, [](Machine *ptr) {
@@ -550,6 +566,152 @@ int lease4_expire(CalloutHandle &handle) {
       ip_str.c_str(), mac_str.empty() ? nullptr : mac_str.c_str());
   if (result != LeaseExpirationResult::Success) {
     LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE_EXPIRE_ERROR).arg(ip_str);
+  }
+
+  return 0;
+}
+
+int lease4_select(CalloutHandle &handle) {
+  /*
+   * lease4_select fires for both DHCPDISCOVER (fake_allocation=true) and
+   * DHCPREQUEST (fake_allocation=false). For DISCOVER the lease is built
+   * for the OFFER response but is not persisted to memfile. For REQUEST it
+   * is persisted.
+   *
+   * Either way, we want to take Kea's proposed lease and replace its address
+   * with the one Carbide allocated. The Machine was stashed on the callout
+   * handle context in pkt4_receive, so it's already cached.
+   */
+  Lease4Ptr lease4;
+  handle.getArgument("lease4", lease4);
+
+  // Get the rest of the hook arguments for context. We only really need
+  // them for logging here, but `fake_allocation` is also relevant if we
+  // ever want different behavior between DISCOVER and REQUEST.
+  bool fake_allocation = false;
+  try {
+    handle.getArgument("fake_allocation", fake_allocation);
+  } catch (...) {
+    // Some Kea versions may not always pass this, that's fine.
+  }
+
+  if (!lease4) {
+    LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE4_SELECT)
+        .arg("Missing lease4 argument");
+    // At lease4_select, SKIP means Kea will not assign its selected lease.
+    handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    return 1;
+  }
+
+  // Load the Machine cached in pkt4_receive. If it's missing, pkt4_receive
+  // either failed or wasn't called for this exchange; in either case we
+  // can't authoritatively assign an address, so fail closed.
+  //
+  // (pkt4_receive would normally have already set NEXT_STEP_DROP in this
+  // failure path, so the fact that we got here at all suggests something
+  // unusual; we still want to defend Kea's memfile against accepting an
+  // un-authorized allocation.)
+  boost::shared_ptr<Machine> machine;
+  handle.getContext("machine", machine);
+  if (!machine) {
+    LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE4_SELECT)
+        .arg("Missing machine object from handle context");
+    handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    return 1;
+  }
+
+  // machine_get_interface_address returns the IPv4 address as a u32 in
+  // network byte order, or 0 if Carbide didn't return a parseable IPv4
+  // address. 0.0.0.0 is not a valid allocation, so treat it as a failure.
+  uint32_t carbide_u32 = machine_get_interface_address(machine.get());
+  if (carbide_u32 == 0) {
+    LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE4_SELECT)
+        .arg("Carbide returned no usable IPv4 address; refusing to allocate");
+    handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    return 1;
+  }
+
+  isc::asiolink::IOAddress carbide_addr(carbide_u32);
+
+  // If Kea's allocator already picked the same address Carbide returned,
+  // no override needed -- but the common case is that they differ (Kea's
+  // allocator is bidding from the 0.0.0.0/0 pool independently of what
+  // Carbide chose).
+  if (lease4->addr_ != carbide_addr) {
+    LOG_INFO(logger, isc::log::LOG_CARBIDE_LEASE4_SELECT)
+        .arg(std::string("overriding ") + lease4->addr_.toText() + " -> " +
+             carbide_addr.toText() +
+             (fake_allocation ? " (DISCOVER, not persisted)"
+                              : " (REQUEST, will persist)"));
+    lease4->addr_ = carbide_addr;
+    // Push the modified lease back. Lease4Ptr is a shared_ptr so mutating
+    // through it already affects Kea's copy, but calling setArgument is
+    // explicit about our intent and survives any future Kea changes to
+    // how it tracks lease-object mutation.
+    handle.setArgument("lease4", lease4);
+  } else {
+    LOG_INFO(logger, isc::log::LOG_CARBIDE_LEASE4_SELECT)
+        .arg(std::string("lease addr already matches Carbide (") +
+             carbide_addr.toText() + ")");
+  }
+
+  return 0;
+}
+
+int lease4_renew(CalloutHandle &handle) {
+  /*
+   * lease4_renew fires when Kea is extending an existing lease, i.e. a
+   * DHCPREQUEST in RENEWING (T1 expired, unicast) or REBINDING (T2
+   * expired, broadcast) state. Unlike lease4_select there's no
+   * `fake_allocation` distinction -- renewals are always persisted.
+   *
+   * Our goal here is the same as lease4_select: keep Kea's memfile lease
+   * address aligned with whatever Carbide currently considers the
+   * binding for this MAC. In the common case (Carbide's allocation is
+   * stable) this is a no-op; the interesting case is when an operator
+   * has changed `machine_interfaces.address` while a lease is live, and
+   * we want the memfile to track the change rather than drift.
+   */
+  Lease4Ptr lease4;
+  handle.getArgument("lease4", lease4);
+
+  if (!lease4) {
+    LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE4_RENEW)
+        .arg("Missing lease4 argument");
+    // At lease4_renew, SKIP means Kea will not update the lease database.
+    handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    return 1;
+  }
+
+  boost::shared_ptr<Machine> machine;
+  handle.getContext("machine", machine);
+  if (!machine) {
+    LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE4_RENEW)
+        .arg("Missing machine object from handle context");
+    handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    return 1;
+  }
+
+  uint32_t carbide_u32 = machine_get_interface_address(machine.get());
+  if (carbide_u32 == 0) {
+    LOG_ERROR(logger, isc::log::LOG_CARBIDE_LEASE4_RENEW)
+        .arg("Carbide returned no usable IPv4 address; refusing to renew");
+    handle.setStatus(CalloutHandle::NEXT_STEP_SKIP);
+    return 1;
+  }
+
+  isc::asiolink::IOAddress carbide_addr(carbide_u32);
+
+  if (lease4->addr_ != carbide_addr) {
+    LOG_INFO(logger, isc::log::LOG_CARBIDE_LEASE4_RENEW)
+        .arg(std::string("overriding ") + lease4->addr_.toText() + " -> " +
+             carbide_addr.toText() + " on renewal");
+    lease4->addr_ = carbide_addr;
+    handle.setArgument("lease4", lease4);
+  } else {
+    LOG_INFO(logger, isc::log::LOG_CARBIDE_LEASE4_RENEW)
+        .arg(std::string("renewing, lease addr already matches Carbide (") +
+             carbide_addr.toText() + ")");
   }
 
   return 0;

--- a/crates/dhcp/src/kea/callouts.h
+++ b/crates/dhcp/src/kea/callouts.h
@@ -105,6 +105,7 @@ extern "C" {
 int pkt4_receive(CalloutHandle &handle);
 int subnet4_select(CalloutHandle &handle);
 int lease4_select(CalloutHandle &handle);
+int lease4_renew(CalloutHandle &handle);
 int pkt4_send(CalloutHandle &handle);
 int lease4_expire(CalloutHandle &handle);
 int lease6_expire(CalloutHandle &handle);

--- a/crates/dhcp/src/kea/carbide_logger.cc
+++ b/crates/dhcp/src/kea/carbide_logger.cc
@@ -29,6 +29,7 @@ extern const isc::log::MessageID LOG_CARBIDE_INITIALIZATION = "LOG_CARBIDE_INITI
 extern const isc::log::MessageID LOG_CARBIDE_INVALID_HANDLE = "LOG_CARBIDE_INVALID_HANDLE";
 extern const isc::log::MessageID LOG_CARBIDE_INVALID_NEXTSERVER_IPV4 = "LOG_CARBIDE_INVALID_NEXTSERVER_IPV4";
 extern const isc::log::MessageID LOG_CARBIDE_LEASE4_SELECT = "LOG_CARBIDE_LEASE4_SELECT";
+extern const isc::log::MessageID LOG_CARBIDE_LEASE4_RENEW = "LOG_CARBIDE_LEASE4_RENEW";
 extern const isc::log::MessageID LOG_CARBIDE_LEASE_EXPIRE = "LOG_CARBIDE_LEASE_EXPIRE";
 extern const isc::log::MessageID LOG_CARBIDE_LEASE_EXPIRE_ERROR = "LOG_CARBIDE_LEASE_EXPIRE_ERROR";
 extern const isc::log::MessageID LOG_CARBIDE_PKT4_RECEIVE = "LOG_CARBIDE_PKT4_RECEIVE";
@@ -45,6 +46,7 @@ const char* values[] = {
     "LOG_CARBIDE_INVALID_HANDLE", "Carbide hook shim_load() was called with an invalid LibraryHandle",
     "LOG_CARBIDE_INVALID_NEXTSERVER_IPV4", "Invalid provisioning server IPv4 address: %1",
     "LOG_CARBIDE_LEASE4_SELECT", "Carbide hook called for DHCPv4 lease selected from %1",
+    "LOG_CARBIDE_LEASE4_RENEW", "Carbide hook called for DHCPv4 lease renew from %1",
     "LOG_CARBIDE_LEASE_EXPIRE", "Carbide releasing expired DHCP lease for %1",
     "LOG_CARBIDE_LEASE_EXPIRE_ERROR", "Carbide failed to release expired DHCP lease for %1",
     "LOG_CARBIDE_PKT4_RECEIVE", "Carbide hook called for DHCPv4 packet receive from %1",

--- a/crates/dhcp/src/kea/carbide_logger.h
+++ b/crates/dhcp/src/kea/carbide_logger.h
@@ -30,6 +30,7 @@ extern const isc::log::MessageID LOG_CARBIDE_INITIALIZATION;
 extern const isc::log::MessageID LOG_CARBIDE_INVALID_HANDLE;
 extern const isc::log::MessageID LOG_CARBIDE_INVALID_NEXTSERVER_IPV4;
 extern const isc::log::MessageID LOG_CARBIDE_LEASE4_SELECT;
+extern const isc::log::MessageID LOG_CARBIDE_LEASE4_RENEW;
 extern const isc::log::MessageID LOG_CARBIDE_LEASE_EXPIRE;
 extern const isc::log::MessageID LOG_CARBIDE_LEASE_EXPIRE_ERROR;
 extern const isc::log::MessageID LOG_CARBIDE_PKT4_RECEIVE;

--- a/crates/dhcp/src/kea/loader.cc
+++ b/crates/dhcp/src/kea/loader.cc
@@ -126,6 +126,19 @@ extern "C" {
         }
 
 		handle->registerCallout("pkt4_receive", pkt4_receive);
+		// lease4_select fires between pkt4_receive and pkt4_send, and is the
+		// only place where we can override the IP that Kea will persist into
+		// its lease memfile. The pkt4_send hook still runs and still sets
+		// yiaddr/options on the outgoing packet, but lease4_select is what
+		// keeps the Kea memfile aligned with the NICo database regardless of
+		// what address the client requested (option 50 / ciaddr), because
+        // just because the client requested it doesn't mean that's what
+        // they're going to get, and that's ok.
+		handle->registerCallout("lease4_select", lease4_select);
+		// lease4_renew is the renewal-time side of lease4_select.
+		// Together they keep the Kea memfile aligned with the NICo
+		// database through both initial allocation and renewal.
+		handle->registerCallout("lease4_renew", lease4_renew);
 		handle->registerCallout("pkt4_send", pkt4_send);
 		handle->registerCallout("lease4_expire", lease4_expire);
 		handle->registerCallout("lease6_expire", lease6_expire);

--- a/crates/dhcp/src/mock_api_server.rs
+++ b/crates/dhcp/src/mock_api_server.rs
@@ -68,9 +68,24 @@ pub fn base_dhcp_response(mac_address: MacAddress) -> rpc::DhcpRecord {
 
 // Encode a DhcpRecord to match gRPC HTTP/2 DATA frame that API server (via hyper) produces.
 pub fn dhcp_response(mac_address_str: &str) -> Vec<u8> {
+    dhcp_response_with_override(mac_address_str, None)
+}
+
+/// Same as `dhcp_response` but allows the caller to override the `address`
+/// field on the response. `Some("")` is meaningful: it simulates a Machine
+/// that has no IPv4 binding (which the lease4 hooks should treat as
+/// "refuse to allocate").
+pub fn dhcp_response_with_override(
+    mac_address_str: &str,
+    address_override: Option<String>,
+) -> Vec<u8> {
     let mac_address = mac_address_str.parse::<MacAddress>().unwrap();
 
     let mut r = base_dhcp_response(mac_address);
+
+    if let Some(addr) = address_override {
+        r.address = addr;
+    }
 
     // Specialization of response based on mac address
     // Meant to be extended, if let ()... isn't what we want here
@@ -109,6 +124,10 @@ pub struct MockAPIServer {
     tx: Option<tokio::sync::oneshot::Sender<()>>,
     local_addr: String,
     inject_failure: Arc<Mutex<bool>>,
+    /// Per-MAC override for the `address` field of the DhcpRecord response.
+    /// A value of `""` is meaningful: it simulates a Machine with no IPv4
+    /// binding, which the lease4_* hooks should treat as "refuse to allocate".
+    address_overrides: Arc<Mutex<HashMap<String, String>>>,
 }
 
 #[derive(Debug)]
@@ -135,6 +154,8 @@ impl MockAPIServer {
         let i2 = inject_failure.clone();
         let calls = Arc::new(Mutex::new(HashMap::new()));
         let c2 = calls.clone();
+        let address_overrides = Arc::new(Mutex::new(HashMap::<String, String>::new()));
+        let a2 = address_overrides.clone();
         let listener = TcpListener::bind(addr).await.unwrap();
         let local_addr = listener.local_addr().unwrap().to_string();
         let (tx, mut rx) = tokio::sync::oneshot::channel::<()>();
@@ -142,6 +163,7 @@ impl MockAPIServer {
             loop {
                 let c3 = c2.clone();
                 let i3 = i2.clone();
+                let a3 = a2.clone();
                 tokio::select! {
                     result = listener.accept() => {
                         let (stream, _) = result.unwrap();
@@ -149,8 +171,9 @@ impl MockAPIServer {
                             http2::Builder::new(TokioExecutor::new()).serve_connection(TokioIo::new(stream), service_fn(move |req: Request<body::Incoming>| {
                                 let c3 = c3.clone();
                                 let i3 = i3.clone();
+                                let a3 = a3.clone();
                                 async move {
-                                    Ok::<Response<GrpcBody>, hyper::Error>(MockAPIServer::handler(req, c3.clone(), i3.clone()).await.unwrap())
+                                    Ok::<Response<GrpcBody>, hyper::Error>(MockAPIServer::handler(req, c3.clone(), i3.clone(), a3.clone()).await.unwrap())
                                 }
                             })).await.inspect_err(|e| eprintln!("ERROR: {e:?}")).unwrap()
                         });
@@ -169,7 +192,17 @@ impl MockAPIServer {
             local_addr: format!("http://{local_addr}"),
             tx: Some(tx),
             inject_failure,
+            address_overrides,
         }
+    }
+
+    /// Override what address the mock returns for a specific MAC on subsequent
+    /// `DiscoverDhcp` calls. Pass `""` to simulate "Machine has no IPv4 binding".
+    pub fn set_address_override(&self, mac_address: &str, address: &str) {
+        self.address_overrides
+            .lock()
+            .unwrap()
+            .insert(mac_address.to_string(), address.to_string());
     }
 
     // The HTTP address of the server
@@ -195,6 +228,7 @@ impl MockAPIServer {
         req: Request<Incoming>,
         calls: Arc<Mutex<HashMap<String, usize>>>,
         fail: Arc<Mutex<bool>>,
+        address_overrides: Arc<Mutex<HashMap<String, String>>>,
     ) -> Result<Response<GrpcBody>, MockAPIServerError> {
         let path = req.uri().path();
         calls
@@ -210,7 +244,9 @@ impl MockAPIServer {
                 if inject_failure {
                     Err(MockAPIServerError::MockAPIFetchMachineError)
                 } else {
-                    Ok(grpc_response(MockAPIServer::discover_dhcp(req).await))
+                    Ok(grpc_response(
+                        MockAPIServer::discover_dhcp(req, address_overrides).await,
+                    ))
                 }
             }
             ENDPOINT_EXPIRE_DHCP_LEASE => {
@@ -229,12 +265,20 @@ impl MockAPIServer {
         }
     }
 
-    async fn discover_dhcp(req: Request<Incoming>) -> Vec<u8> {
+    async fn discover_dhcp(
+        req: Request<Incoming>,
+        address_overrides: Arc<Mutex<HashMap<String, String>>>,
+    ) -> Vec<u8> {
         let input_bytes = req.into_body().collect().await.unwrap().to_bytes();
 
         // slice is to strip the gRPC parts: 1 byte is_compressed and a 4 byte message length
         let disco = rpc::DhcpDiscovery::decode(input_bytes.slice(5..)).unwrap();
-        dhcp_response(&disco.mac_address)
+        let override_for_mac = address_overrides
+            .lock()
+            .unwrap()
+            .get(&disco.mac_address)
+            .cloned();
+        dhcp_response_with_override(&disco.mac_address, override_for_mac)
     }
 }
 

--- a/crates/dhcp/tests/common/dhcp_factory.rs
+++ b/crates/dhcp/tests/common/dhcp_factory.rs
@@ -35,6 +35,14 @@ impl DHCPFactory {
     // Make and encode a relayed DHCP_DISCOVER packet
     // The idx is used as the last byte of the MAC and Link addresses to make them unique.
     pub fn discover(idx: u8) -> Message {
+        Self::base_relayed_message(idx, v4::MessageType::Discover)
+    }
+
+    /// Build a relayed DHCPv4 message of the given type with the test harness's
+    /// standard MAC, vendor class, and relay options. Callers can mutate the
+    /// returned `Message` further (e.g. set ciaddr, insert option 50/54) to
+    /// shape it into REQUEST sub-states.
+    pub fn base_relayed_message(idx: u8, msg_type: v4::MessageType) -> Message {
         // 0x02 prefix is a 'locally administered address'
         let mac = vec![0x02, 0x00, 0x00, 0x00, 0x00, idx];
 
@@ -59,7 +67,7 @@ impl DHCPFactory {
         opts.insert(ClassIdentifier(uefi_vendor_class)); // 60
         opts.insert(RelayAgentInformation(relay_agent)); // 82
         opts.insert(ClientSystemArchitecture(v4::Architecture::Intelx86PC)); // 93
-        opts.insert(MessageType(v4::MessageType::Discover));
+        opts.insert(MessageType(msg_type));
 
         msg
     }

--- a/crates/dhcp/tests/common/kea.rs
+++ b/crates/dhcp/tests/common/kea.rs
@@ -16,7 +16,7 @@
  */
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
-use std::net::UdpSocket;
+use std::net::{Ipv4Addr, UdpSocket};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::thread;
@@ -25,8 +25,26 @@ use std::time::{Duration, Instant};
 use serde_json::json;
 use tempfile::TempDir;
 
+/// One row from kea's memfile CSV (kea-leases4.csv). Only the fields the
+/// lease4 hook tests care about are exposed.
+//
+// dead_code is allowed because not every test binary that includes `common`
+// inspects the lease file -- the existing booturl/multithreaded tests only
+// look at packets.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct LeaseEntry {
+    pub address: Ipv4Addr,
+    pub hwaddr: String,
+    /// 0 = default (active). Other states (declined, expired-reclaimed)
+    /// shouldn't appear in our tests but are exposed for completeness.
+    pub state: u32,
+}
+
 pub struct Kea {
     temp_conf_file: PathBuf,
+    #[allow(dead_code)] // only read by tests that inspect the memfile
+    lease_file: PathBuf,
 
     dhcp_in_port: u16,
     dhcp_out_port: u16,
@@ -48,20 +66,92 @@ impl Kea {
         let temp_base_directory = tempfile::tempdir()?;
 
         let temp_conf_file = temp_base_directory.path().join("kea-dhcp4.conf");
+        let lease_file = temp_base_directory.path().join("kea-leases4.csv");
 
         let mut temp_conf_fd = File::create(&temp_conf_file)?;
-        temp_conf_fd.write_all(Kea::config(api_server_url).as_bytes())?;
+        temp_conf_fd.write_all(Kea::config(api_server_url, &lease_file).as_bytes())?;
 
         // Close the file so it's updated for Kea.
         drop(temp_conf_fd);
 
         Ok(Kea {
             temp_conf_file,
+            lease_file,
             temp_base_directory,
             dhcp_in_port,
             dhcp_out_port,
             process: None,
         })
+    }
+
+    /// Path to the persistent lease file Kea writes (memfile backend with persist=true).
+    /// Used by tests to assert on what got persisted.
+    #[allow(dead_code)]
+    pub fn lease_file_path(&self) -> &Path {
+        &self.lease_file
+    }
+
+    /// Read kea-leases4.csv and return all entries. Skips the header row.
+    /// Returns an empty Vec if the file doesn't exist yet (Kea writes it
+    /// lazily on first lease event).
+    #[allow(dead_code)]
+    pub fn read_leases(&self) -> Vec<LeaseEntry> {
+        let Ok(file) = File::open(&self.lease_file) else {
+            return Vec::new();
+        };
+        let mut entries = Vec::new();
+        for (i, line) in BufReader::new(file).lines().enumerate() {
+            let Ok(line) = line else { continue };
+            // Header is "address,hwaddr,client_id,...,state,user_context,pool_id"
+            if i == 0 || line.is_empty() {
+                continue;
+            }
+            let cols: Vec<&str> = line.split(',').collect();
+            if cols.len() < 10 {
+                continue;
+            }
+            let Ok(address) = cols[0].parse::<Ipv4Addr>() else {
+                continue;
+            };
+            let Ok(state) = cols[9].parse::<u32>() else {
+                continue;
+            };
+            entries.push(LeaseEntry {
+                address,
+                hwaddr: cols[1].to_string(),
+                state,
+            });
+        }
+        entries
+    }
+
+    /// Convenience: find the active lease entry for a given MAC string
+    /// (kea writes MAC as colon-separated lowercase hex, e.g. "02:00:00:00:00:01").
+    #[allow(dead_code)]
+    pub fn find_lease(&self, hwaddr: &str) -> Option<LeaseEntry> {
+        self.read_leases()
+            .into_iter()
+            .find(|l| l.hwaddr == hwaddr && l.state == 0)
+    }
+
+    /// Poll the lease file for an entry matching `hwaddr` whose address is
+    /// `expected`, up to `timeout`. Returns true if found, false if the
+    /// deadline passes. Useful because Kea's persist-to-disk can lag the
+    /// gRPC ACK by a few ms.
+    #[allow(dead_code)]
+    pub fn wait_for_lease(&self, hwaddr: &str, expected: Ipv4Addr, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(lease) = self.find_lease(hwaddr)
+                && lease.address == expected
+            {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
     }
 
     pub fn run(&mut self) -> Result<(), eyre::Report> {
@@ -115,25 +205,47 @@ impl Kea {
         Ok(())
     }
 
-    fn config(api_server_url: &str) -> String {
-        let hook_lib_d = format!(
-            "{}/../../target/debug/libdhcp.so",
-            env!("CARGO_MANIFEST_DIR")
-        );
-        let hook_lib_r = format!(
-            "{}/../../target/release/libdhcp.so",
-            env!("CARGO_MANIFEST_DIR")
-        );
-        let hook_lib = if Path::new(&hook_lib_r).exists() {
-            hook_lib_r
-        } else if Path::new(&hook_lib_d).exists() {
-            hook_lib_d
-        } else {
-            // If `cargo build` has not been run yet (after a `cargo clean`), the `build.rs` script won't have
-            // generated libdhcp.so. So we do it ourselves.
-            println!("Could not find Kea hooks dynamic library at '{hook_lib_d}'. Building.");
-            test_cdylib::build_current_project();
-            hook_lib_d
+    fn config(api_server_url: &str, lease_file: &Path) -> String {
+        // Locate libdhcp.so. Cargo may put it under either `target/debug/`
+        // (default) or `target/...something.../debug/` (when CARGO_BUILD_TARGET
+        // is set in the env). Check release before debug so a `--release`
+        // test build wins.
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let candidates: Vec<String> = {
+            let target_triple = std::env::var("CARGO_BUILD_TARGET").ok();
+            let triple_subdir = target_triple
+                .as_deref()
+                .map(|t| format!("{t}/"))
+                .unwrap_or_default();
+            // NOTE: cargo only updates the non-deps `libdhcp.so` on the first
+            // build after a clean; subsequent rebuilds touch `deps/libdhcp.so`
+            // only. Prefer the deps copy so we always pick up fresh rebuilds.
+            vec![
+                format!("{manifest_dir}/../../target/{triple_subdir}release/deps/libdhcp.so"),
+                format!("{manifest_dir}/../../target/release/deps/libdhcp.so"),
+                format!("{manifest_dir}/../../target/{triple_subdir}debug/deps/libdhcp.so"),
+                format!("{manifest_dir}/../../target/debug/deps/libdhcp.so"),
+                format!("{manifest_dir}/../../target/{triple_subdir}release/libdhcp.so"),
+                format!("{manifest_dir}/../../target/release/libdhcp.so"),
+                format!("{manifest_dir}/../../target/{triple_subdir}debug/libdhcp.so"),
+                format!("{manifest_dir}/../../target/debug/libdhcp.so"),
+            ]
+        };
+        let hook_lib = match candidates.iter().find(|p| Path::new(p).exists()) {
+            Some(p) => p.clone(),
+            None => {
+                // If `cargo build` has not been run yet (after a `cargo clean`),
+                // the `build.rs` script won't have generated libdhcp.so, so lets
+                // do it ourselves.
+                println!(
+                    "Could not find Kea hooks dynamic library in any of {candidates:?}. Building."
+                );
+                test_cdylib::build_current_project();
+                candidates
+                    .into_iter()
+                    .find(|p| Path::new(p).exists())
+                    .expect("test_cdylib build did not produce libdhcp.so at any expected path")
+            }
         };
 
         let conf = json!({
@@ -144,7 +256,8 @@ impl Kea {
             },
             "lease-database": {
                 "type": "memfile",
-                "persist": false,
+                "persist": true,
+                "name": lease_file.to_string_lossy(),
                 "lfc-interval": 3600
             },
             "multi-threading": {

--- a/crates/dhcp/tests/common/mod.rs
+++ b/crates/dhcp/tests/common/mod.rs
@@ -19,3 +19,5 @@ mod kea;
 
 pub use dhcp_factory::{DHCPFactory, RELAY_IP};
 pub use kea::Kea;
+#[allow(unused_imports)] // not every test binary inspects lease entries
+pub use kea::LeaseEntry;

--- a/crates/dhcp/tests/lease4_hook_test.rs
+++ b/crates/dhcp/tests/lease4_hook_test.rs
@@ -1,0 +1,430 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Integration tests for the lease4_select and lease4_renew hook callouts.
+//!
+//! These tests boot a real Kea process with our hook library loaded, send DHCP
+//! packets at it, and assert on what ends up in Kea's memfile lease file
+//! (kea-leases4.csv). The point is to verify that the memfile stays aligned
+//! with what Carbide returns from DiscoverDhcp -- regardless of what address
+//! the client requested in option 50 or ciaddr.
+
+use std::net::{Ipv4Addr, UdpSocket};
+use std::time::Duration;
+
+use dhcp::mock_api_server;
+use dhcproto::{Decodable, Decoder, v4};
+
+mod common;
+
+use common::{DHCPFactory, Kea, RELAY_IP};
+
+const READ_TIMEOUT: Duration = Duration::from_millis(500);
+/// Memfile writes are usually flushed within a few ms of the ACK.
+/// Trying to be generous to avoid flakiness on slow CI runners,
+/// which happens for other things (like Posrgres).
+const MEMFILE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Send one packet and read one response. Returns the parsed response message.
+fn send_and_recv(socket: &UdpSocket, msg: v4::Message) -> Option<v4::Message> {
+    let pkt = DHCPFactory::encode(msg).unwrap();
+    socket.send(&pkt).unwrap();
+    let mut buf = [0u8; 1500];
+    let n = socket.recv(&mut buf).ok()?;
+    Some(v4::Message::decode(&mut Decoder::new(&buf[..n])).unwrap())
+}
+
+/// Build a SELECTING-state DHCPREQUEST (the REQUEST that follows an OFFER).
+/// Sets option 50 (requested-address) and option 54 (server-identifier) so
+/// Kea recognizes it as the client picking up an OFFER it just received.
+fn request_selecting(idx: u8, requested_addr: Ipv4Addr, server_id: Ipv4Addr) -> v4::Message {
+    let mut msg = DHCPFactory::base_relayed_message(idx, v4::MessageType::Request);
+    let opts = msg.opts_mut();
+    opts.insert(v4::DhcpOption::RequestedIpAddress(requested_addr));
+    opts.insert(v4::DhcpOption::ServerIdentifier(server_id));
+    msg
+}
+
+/// Build a RENEWING-state DHCPREQUEST: ciaddr set to the current lease IP,
+/// no option 50, no option 54. Per RFC 2131 this would be unicast to the
+/// server, but our test harness pretends to be the relay so we send it
+/// through the same relayed path as everything else.
+fn request_renewing(idx: u8, ciaddr: Ipv4Addr) -> v4::Message {
+    let mut msg = DHCPFactory::base_relayed_message(idx, v4::MessageType::Request);
+    msg.set_ciaddr(ciaddr);
+    msg
+}
+
+/// Extract option 54 (server-identifier) from a DHCP message. Tests need this
+/// to send a SELECTING-state REQUEST that Kea will accept.
+fn server_identifier(msg: &v4::Message) -> Ipv4Addr {
+    match msg.opts().get(v4::OptionCode::ServerIdentifier) {
+        Some(v4::DhcpOption::ServerIdentifier(addr)) => *addr,
+        other => panic!("OFFER did not include option 54 (server-identifier): {other:?}"),
+    }
+}
+
+/// MAC string in the format Kea writes to kea-leases4.csv (lowercase hex,
+/// colon-separated). Matches the format produced by `DHCPFactory::discover`
+/// and friends for a given idx.
+fn mac_for_idx(idx: u8) -> String {
+    format!("02:00:00:00:00:{idx:02x}")
+}
+
+/// The mock returns 172.20.0.X by default, where X is the MAC's last byte.
+fn default_mock_addr(idx: u8) -> Ipv4Addr {
+    Ipv4Addr::new(172, 20, 0, idx)
+}
+
+/// tokio rt + mock API + Kea + socket pretending to be the relay.
+struct Harness {
+    _rt: tokio::runtime::Runtime,
+    api_server: mock_api_server::MockAPIServer,
+    kea: Kea,
+    socket: UdpSocket,
+}
+
+impl Harness {
+    fn new(in_port: u16, out_port: u16) -> Self {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let api_server = rt.block_on(mock_api_server::MockAPIServer::start());
+
+        let mut kea = Kea::new(api_server.local_http_addr(), in_port, out_port).unwrap();
+        kea.run().unwrap();
+
+        let socket = UdpSocket::bind(format!("{RELAY_IP}:{out_port}")).unwrap();
+        socket.connect(format!("127.0.0.1:{in_port}")).unwrap();
+        socket.set_read_timeout(Some(READ_TIMEOUT)).unwrap();
+
+        Harness {
+            _rt: rt,
+            api_server,
+            kea,
+            socket,
+        }
+    }
+}
+
+// Make sure the happy path is good here -- standard DORA.
+// Carbide and Kea agree on the address from the start.
+// Verify the memfile ends up with Carbide's IP.
+#[test]
+fn lease4_select_persists_carbide_ip_on_happy_path() -> Result<(), eyre::Report> {
+    let idx = 0x20;
+    let h = Harness::new(7100, 7101);
+
+    // DISCOVER → OFFER
+    let offer = send_and_recv(&h.socket, DHCPFactory::discover(idx))
+        .expect("kea did not respond to DISCOVER");
+    assert_eq!(offer.opts().msg_type().unwrap(), v4::MessageType::Offer);
+    assert_eq!(offer.yiaddr(), default_mock_addr(idx));
+    let server_id = server_identifier(&offer);
+
+    // REQUEST (SELECTING) → ACK
+    let ack = send_and_recv(
+        &h.socket,
+        request_selecting(idx, default_mock_addr(idx), server_id),
+    )
+    .expect("kea did not respond to REQUEST");
+    assert_eq!(ack.opts().msg_type().unwrap(), v4::MessageType::Ack);
+    assert_eq!(ack.yiaddr(), default_mock_addr(idx));
+
+    // Memfile must contain the carbide address (not whatever Kea would have
+    // picked on its own from the 0.0.0.0/0 pool).
+    assert!(
+        h.kea
+            .wait_for_lease(&mac_for_idx(idx), default_mock_addr(idx), MEMFILE_TIMEOUT),
+        "expected memfile entry ({}, {})",
+        mac_for_idx(idx),
+        default_mock_addr(idx)
+    );
+
+    Ok(())
+}
+
+// Now test the rogue scenario. Client sends a REQUEST with option 50
+// set to a *different* IP than what the OFFER carried (simulating a client
+// that accepted a rogue server's offer, but is broadcasting the REQUEST so we
+// see it). Without lease4_select, Kea would honor option 50 and persist the
+// wrong address. With lease4_select, the memfile gets Carbide's IP.
+#[test]
+fn lease4_select_overrides_rogue_option_50_in_memfile() -> Result<(), eyre::Report> {
+    let idx = 0x21;
+    let rogue_ip = Ipv4Addr::new(192, 168, 99, 99);
+    let h = Harness::new(7102, 7103);
+
+    // DISCOVER → OFFER (so kea has a state for this MAC and accepts the
+    // following REQUEST). The OFFER's yiaddr is the carbide-allocated IP.
+    let offer = send_and_recv(&h.socket, DHCPFactory::discover(idx))
+        .expect("kea did not respond to DISCOVER");
+    assert_eq!(offer.yiaddr(), default_mock_addr(idx));
+    let server_id = server_identifier(&offer);
+
+    // REQUEST with option 50 = rogue_ip (≠ what was offered). Option 54 still
+    // points at kea so kea processes the REQUEST.
+    let ack = send_and_recv(&h.socket, request_selecting(idx, rogue_ip, server_id))
+        .expect("kea did not respond to REQUEST");
+    assert_eq!(ack.opts().msg_type().unwrap(), v4::MessageType::Ack);
+    // Wire is correct because pkt4_send rewrites yiaddr regardless.
+    // ...but still need to do our assertion on the memfile below.
+    assert_eq!(ack.yiaddr(), default_mock_addr(idx));
+
+    // The memfile must hold Carbide's IP, not the rogue value the client
+    // asked for in option 50. This is what lease4_select uniquely enforces.
+    assert!(
+        h.kea
+            .wait_for_lease(&mac_for_idx(idx), default_mock_addr(idx), MEMFILE_TIMEOUT),
+        "memfile should contain carbide IP {} for MAC {}, not the rogue option-50 value {rogue_ip}",
+        default_mock_addr(idx),
+        mac_for_idx(idx),
+    );
+
+    // And specifically nothing in the memfile should have the rogue address.
+    let leases = h.kea.read_leases();
+    assert!(
+        !leases.iter().any(|l| l.address == rogue_ip),
+        "rogue IP {rogue_ip} should never be persisted, but found in leases: {leases:?}",
+    );
+
+    Ok(())
+}
+
+// And now the failure path. Carbide returns a Machine with no IPv4 address
+// (address=""). pkt4_receive must drop before lease selection; specifically,
+// the REQUEST path must not create an active memfile lease for the MAC.
+#[test]
+fn pkt4_receive_drops_when_carbide_returns_no_address() -> Result<(), eyre::Report> {
+    let idx = 0x22;
+    let helper_idx = 0x24;
+    let h = Harness::new(7104, 7105);
+
+    // Learn Kea's server identifier from a different MAC. The failure case
+    // below needs a SELECTING-state REQUEST so it exercises the persistence
+    // path, not just DISCOVER's fake allocation path.
+    let helper_offer = send_and_recv(&h.socket, DHCPFactory::discover(helper_idx))
+        .expect("kea did not respond to helper DISCOVER");
+    let server_id = server_identifier(&helper_offer);
+
+    // Tell the mock to return an empty address for this MAC, which the API
+    // side translates to machine_get_interface_address()==0.
+    h.api_server.set_address_override(&mac_for_idx(idx), "");
+
+    // Send a REQUEST directly so this would be persisted if pkt4_receive did
+    // not stop processing before Kea's allocator.
+    if let Some(msg) = send_and_recv(
+        &h.socket,
+        request_selecting(idx, default_mock_addr(idx), server_id),
+    ) {
+        let mtype = msg.opts().msg_type();
+        // If Kea did send a response, it must not be an ACK/OFFER with a usable
+        // yiaddr (that would mean we allocated despite the drop).
+        if matches!(mtype, Some(v4::MessageType::Ack | v4::MessageType::Offer)) {
+            assert_eq!(
+                msg.yiaddr(),
+                Ipv4Addr::UNSPECIFIED,
+                "should not allocate a real address when Carbide returned none, got {msg}"
+            );
+        }
+    }
+
+    // Key assertion: no active memfile entry for this MAC. Wait a beat so we
+    // don't race a lazy memfile flush in the success-but-not-yet-visible case.
+    std::thread::sleep(Duration::from_millis(200));
+    let leases = h.kea.read_leases();
+    assert!(
+        !leases
+            .iter()
+            .any(|l| l.hwaddr == mac_for_idx(idx) && l.state == 0),
+        "expected no active lease for {}, found: {leases:?}",
+        mac_for_idx(idx),
+    );
+
+    Ok(())
+}
+
+// Test lease4_renew is wired up and doesn't break the renewal path. After
+// a successful DORA, send a RENEWING-state DHCPREQUEST (ciaddr=current IP, no
+// option 50, no option 54) and verify the memfile entry survives.
+//
+// Note: the override branch of lease4_renew (mock returning a different IP at
+// renewal time) is not exercised here because the carbide-dhcp client-side
+// cache has a 60s TTL and busting it for a test would require either waiting
+// or invasive test hooks. The override logic itself is structurally identical
+// to lease4_select, which tests A/B/C exercise thoroughly. This test verifies
+// lease4_renew is registered, fires, and is a safe no-op on the steady-state
+// renewal path.
+// ─────────────────────────────────────────────────────────────────────────────
+#[test]
+fn lease4_renew_preserves_memfile_on_steady_state_renewal() -> Result<(), eyre::Report> {
+    let idx = 0x23;
+    let h = Harness::new(7106, 7107);
+
+    // Initial DORA.
+    let offer = send_and_recv(&h.socket, DHCPFactory::discover(idx))
+        .expect("kea did not respond to DISCOVER");
+    let server_id = server_identifier(&offer);
+    let ack = send_and_recv(
+        &h.socket,
+        request_selecting(idx, default_mock_addr(idx), server_id),
+    )
+    .expect("kea did not respond to REQUEST");
+    assert_eq!(ack.opts().msg_type().unwrap(), v4::MessageType::Ack);
+    assert!(
+        h.kea
+            .wait_for_lease(&mac_for_idx(idx), default_mock_addr(idx), MEMFILE_TIMEOUT)
+    );
+
+    // Renewing REQUEST: ciaddr = the IP we currently hold.
+    let renew_ack = send_and_recv(&h.socket, request_renewing(idx, default_mock_addr(idx)))
+        .expect("kea did not respond to renewing REQUEST");
+    assert_eq!(renew_ack.opts().msg_type().unwrap(), v4::MessageType::Ack);
+    assert_eq!(renew_ack.yiaddr(), default_mock_addr(idx));
+
+    // Memfile still has the carbide IP. The lease4_renew hook fired (we'd see
+    // a NAK or no response if it failed) and was a no-op on this matching path.
+    let lease = h
+        .kea
+        .find_lease(&mac_for_idx(idx))
+        .expect("active lease should still exist after renewal");
+    assert_eq!(lease.address, default_mock_addr(idx));
+
+    Ok(())
+}
+
+// Verify how kea handles a REQUEST whose Option 54 (server-identifier)
+// does not match kea's own identifier -- i.e. the case where a client
+// picked a competing server's OFFER and is broadcasting its REQUEST,
+// naming that other server.
+//
+// Per RFC 2131 the server MUST silently discard such a REQUEST. This test
+// verifies kea honors that behavior in our config (authoritative + 0.0.0.0/0
+// pool) and documents the outcome. If kea ever stops honoring Option 54,
+// this test will fail and we'll know lease4_select needs to start enforcing
+// it. The rogue option-50 IP MUST NOT end up in the memfile.
+#[test]
+fn check_memfile_on_option_54() -> Result<(), eyre::Report> {
+    let idx = 0x24;
+    let bogus_request_ip = Ipv4Addr::new(192, 168, 99, 99);
+    let fake_server_id = Ipv4Addr::new(10, 99, 99, 99); // not kea's identifier
+    let h = Harness::new(7108, 7109);
+
+    // DISCOVER first, so kea has cached per-packet state for this MAC.
+    let offer = send_and_recv(&h.socket, DHCPFactory::discover(idx))
+        .expect("kea did not respond to DISCOVER");
+    assert_eq!(offer.yiaddr(), default_mock_addr(idx));
+
+    // REQUEST naming a fake server.
+    // Option 50 is a rogue IP that should not reach the memfile.
+    let pkt = DHCPFactory::encode(request_selecting(idx, bogus_request_ip, fake_server_id))?;
+    h.socket.send(&pkt)?;
+    let mut buf = [0u8; 1500];
+    match h.socket.recv(&mut buf) {
+        Ok(n) => {
+            let msg = v4::Message::decode(&mut Decoder::new(&buf[..n])).unwrap();
+            println!(
+                "kea responded to mismatched-server-id REQUEST: type={:?} yiaddr={}",
+                msg.opts().msg_type(),
+                msg.yiaddr()
+            );
+        }
+        Err(_) => {
+            println!("kea silently dropped REQUEST with mismatched server-id (RFC behavior)");
+        }
+    }
+
+    // Whatever kea did, the rogue IP shouldn't be persisted.
+    std::thread::sleep(Duration::from_millis(200));
+    let leases = h.kea.read_leases();
+    assert!(
+        !leases.iter().any(|l| l.address == bogus_request_ip),
+        "bogus option-50 IP {bogus_request_ip} should never appear in memfile, found: {leases:?}",
+    );
+
+    // And if there *is* an active entry for this MAC, it must be NICo's IP.
+    if let Some(lease) = h.kea.find_lease(&mac_for_idx(idx)) {
+        assert_eq!(
+            lease.address,
+            default_mock_addr(idx),
+            "if memfile has an entry for {}, it must be the carbide IP",
+            mac_for_idx(idx)
+        );
+    }
+
+    Ok(())
+}
+
+// The motivating bug pattern in production. A client (e.g. a BMC) previously
+// got an IP from some other source -- a rogue DHCP server, stale config,
+// pre-deployment state, etc. -- and remembered that address in non-volatile
+// storage. On reboot it sends a DHCPREQUEST with option 50 = remembered IP,
+// no ciaddr, and crucially no Option 54 (it's not picking from offers, it's
+// just confirming a remembered IP). This is INIT-REBOOT state per RFC 2131.
+//
+// Option 54 doesn't apply here, so kea has nothing to filter on. Without the
+// pkt4_receive early drop + lease4_select override, kea would allocate per
+// option 50 and seed the memfile with the wrong IP. This test verifies the
+// fix protects against exactly this flow.
+#[test]
+fn reboot_with_stale_remembered_ip_does_not_pollute_memfile() -> Result<(), eyre::Report> {
+    let idx = 0x27;
+    let remembered_wrong_ip = Ipv4Addr::new(192, 168, 99, 99);
+    let h = Harness::new(7112, 7113);
+
+    // No prior DISCOVER -- this is the BMC's first packet after reboot.
+    // INIT-REBOOT REQUEST: option 50 set, no ciaddr, no Option 54.
+    let mut req = DHCPFactory::base_relayed_message(idx, v4::MessageType::Request);
+    req.opts_mut()
+        .insert(v4::DhcpOption::RequestedIpAddress(remembered_wrong_ip));
+    let response = send_and_recv(&h.socket, req);
+
+    // Kea's specific response is config-dependent (may NAK, may ACK with
+    // overridden yiaddr, may drop). What we care about is the persistence
+    // outcome.
+    if let Some(msg) = response {
+        println!(
+            "kea responded to INIT-REBOOT: type={:?} yiaddr={}",
+            msg.opts().msg_type(),
+            msg.yiaddr()
+        );
+    } else {
+        println!("kea did not respond to INIT-REBOOT (silent drop)");
+    }
+
+    std::thread::sleep(Duration::from_millis(200));
+    let leases = h.kea.read_leases();
+
+    // The remembered wrong IP must never be persisted.
+    assert!(
+        !leases.iter().any(|l| l.address == remembered_wrong_ip),
+        "remembered wrong IP {remembered_wrong_ip} must not be persisted, found: {leases:?}",
+    );
+
+    // If anything was persisted for this MAC, it must be carbide's IP.
+    if let Some(lease) = h.kea.find_lease(&mac_for_idx(idx)) {
+        assert_eq!(
+            lease.address,
+            default_mock_addr(idx),
+            "if memfile has an entry for {}, it must be the carbide IP, not the remembered one",
+            mac_for_idx(idx)
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

The `carbide-dhcp` *Kea*-based server aligns DHCP responses with the backend `carbide-api` allocation via `pkt4_send` (which rewrites `yiaddr` on the `DHCPOFFER`/`DHCPACK` right before the packet leaves *Kea*), BUT! ..it doesn't ensure *Kea*'s internal memfile (lease db) is in sync and reflects the same address that is actually in `carbide-api`.

"*But the memfile IS in sync!*" you say.

So, the reason it *does* appear in sync is because, as part of the the `DHCPDISCOVER`, *we* (`carbide-api`) effectively allocate the IP address at that point -- the lease, for all intents and purposes, happens during `DHCPDISCOVER`, because that's when we create the `machine_interface`. We send back the newly allocated IP to *Kea*, where our hook packs it in as the `yiaddr` using `pkt4_send`, and client gets back `yiaddr`. Then, on its subsequent `DHCPREQUEST` (from the client, w/ Option 50 set per it's `yiaddr` offer), *Kea* looks at its own leases, says "oh yeah that IP is free", does a callout to `carbide-api` to get the `yiaddr` again, and shoves it in its memfile as a lease. BUT! **it's not shoving the IP it got back from `carbide-api`, it's shoving the IP it saw in Option 50 from the client**.

Now in almost all cases, this has never been a problem, but in a recent situation with a rogue DHCP server, things got suuuper wonky. Clients would broadcast `DHCPDISCOVER`, the rogue DHCP server would send it back a DHCP offer with one IP, `carbide-api` would allocate another IP (since we do it during `DHCPDISCOVER`), and then the client would subsequently broadcast a `DHCPREQUEST` w/ an Option 50  of the `yiaddr` it got from the rogue DHCP server. *Kea* would see Option 50 set, pass along the request to `carbide-api`, `carbide-api` would return with its `machine_interface_address` IP, *Kea* writes the rogue Option 50 into its memfile, and then RETURNS the IP from `carbide-api` to the client.

The resulting behavior is that clients who got their IP allocations from *Kea* actually DID get the ones we allocated in `carbide-api` (because *Kea always rewrites to the `carbide-api` IP*), but the *Kea memfile* was full of the rogue IPs. It was suuuuuper confusing to track down and figure out what in the world was going on. Again, luckily the actual IP honored is the `carbide-api` one, and the *Kea* memfile is effectively useless, but it's an opportunity to be a little more explicit here.

So, this PR hooks in two additional *Kea* callouts:
- `lease4_select`, which fires on new allocations, and puts the IP from `carbide-api` into its memfile.
- `lease4_renew`, which fires on renewals, doing the same.

To do this, I'm using the per-packet handle context (which has already been populated by `pkt4_receive`), compares it's *Kea*-selected `lease4->addr_` to what `carbide-api` sent down for the MAC, and overrides the lease address with the `carbide-api` address. The memfile now always reflects the `carbide-api` binding.

Fwiw, our existing `pkt4_send`-based `yiaddr` rewrite is intentionally left in place as defense in depth, because hey, it works! With the new hooks doing the memfile work, it's now redundant for alignment (i.e. we could just rely on the `lease*` hooks and have *Kea* fully rely on memfile -> client, BUT it still defends against any future code path that bypasses `lease4_select`.

On a final note, the memfile had historically been pretty much ignored -- only recently did we start trying to sync with it as part of the `lease4_expire` hook, which dispatches an API call to `ExpireDhcpLease(mac, ip)`. The reason we did that is because we realized we were permanently leaking IP addresses in high-churn environments. In *most* cases it didn't matter, but over time, for very long-running environments, we'd see interfaces come and go, but never did anything about the "go" part.

This includes four integration tests that test against:
- The *Kea* + mock-api harness covering happy path.
- An option-50 override scenario.
- The failure path with no NICo IP being sent back.
- Renewal-time consistency.

The *Kea* test harness was also updated to persist its memfile to a known path so tests can assert directly on what got written.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

