### PR TITLE
fix: drive storage cleanup through reset before discovery (#5555701)

### DIFF
--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -617,6 +617,36 @@ pub async fn update_cleanup_time(
     Ok(())
 }
 
+pub async fn set_cleanup_time(
+    machine_id: &MachineId,
+    cleanup_time: DateTime<Utc>,
+    txn: &mut PgConnection,
+) -> Result<(), DatabaseError> {
+    let query = "UPDATE machines SET last_cleanup_time=$1 WHERE id=$2 RETURNING id";
+    let _id = sqlx::query_as::<_, MachineId>(query)
+        .bind(cleanup_time)
+        .bind(machine_id)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(())
+}
+
+pub async fn clear_cleanup_time(
+    machine_id: &MachineId,
+    txn: &mut PgConnection,
+) -> Result<(), DatabaseError> {
+    let query = "UPDATE machines SET last_cleanup_time=NULL WHERE id=$1 RETURNING id";
+    let _id = sqlx::query_as::<_, MachineId>(query)
+        .bind(machine_id)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(())
+}
+
 pub async fn update_bios_password_set_time(
     machine_id: &MachineId,
     txn: &mut PgConnection,

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1101,6 +1101,8 @@ pub enum ManagedHostState {
     // This is host specific state. We expect DPU to be in Ready state.
     WaitingForCleanup {
         cleanup_state: CleanupState,
+        #[serde(default)]
+        cleanup_context: CleanupContext,
     },
 
     /// A forced deletion process has been triggered by the admin CLI
@@ -1830,6 +1832,14 @@ pub enum CleanupState {
     // Unused
     DisableBIOSBMCLockdown,
 }
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum CleanupContext {
+    #[default]
+    Deprovision,
+    InitialDiscovery,
+}
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, EnumIter)]
 #[serde(rename_all = "lowercase")]
 pub enum LockdownState {
@@ -2109,7 +2119,7 @@ impl Display for ManagedHostState {
                     write!(f, "Assigned/{instance_state}")
                 }
             },
-            ManagedHostState::WaitingForCleanup { cleanup_state } => {
+            ManagedHostState::WaitingForCleanup { cleanup_state, .. } => {
                 write!(f, "WaitingForCleanup/{cleanup_state}")
             }
             ManagedHostState::ForceDeletion => write!(f, "ForceDeletion"),
@@ -2200,7 +2210,7 @@ impl ManagedHostState {
                 }
                 _ => format!("Assigned/{instance_state}"),
             },
-            ManagedHostState::WaitingForCleanup { cleanup_state } => {
+            ManagedHostState::WaitingForCleanup { cleanup_state, .. } => {
                 format!("WaitingForCleanup/{cleanup_state}")
             }
             ManagedHostState::ForceDeletion => "ForceDeletion".to_string(),

--- a/crates/api/src/handlers/machine_scout.rs
+++ b/crates/api/src/handlers/machine_scout.rs
@@ -18,9 +18,9 @@ use ::rpc::forge::ForgeAgentControlResponse;
 use ::rpc::{forge as rpc, forge_agent_control_response as fac};
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
-    BomValidating, CleanupState, FailureCause, FailureDetails, FailureSource, HostReprovisionState,
-    InstanceState, MachineState, MachineValidatingState, ManagedHostState, MeasuringState,
-    ValidationState,
+    BomValidating, CleanupContext, CleanupState, FailureCause, FailureDetails, FailureSource,
+    HostReprovisionState, InstanceState, MachineState, MachineValidatingState, ManagedHostState,
+    MeasuringState, StateMachineArea, ValidationState,
 };
 use model::machine_validation::{MachineValidationState, MachineValidationStatus};
 use model::rpc_conv::machine::get_action_for_dpu_state;
@@ -70,13 +70,29 @@ pub(crate) async fn cleanup_machine_completed(
             error = %err,
             "Storage cleanup failed"
         );
+        let failure_source = match machine.current_state() {
+            ManagedHostState::WaitingForCleanup {
+                cleanup_context: CleanupContext::InitialDiscovery,
+                ..
+            } => FailureSource::StateMachineArea(StateMachineArea::HostInit),
+            ManagedHostState::Failed {
+                details:
+                    FailureDetails {
+                        cause: FailureCause::NVMECleanFailed { .. },
+                        source: FailureSource::StateMachineArea(StateMachineArea::HostInit),
+                        ..
+                    },
+                ..
+            } => FailureSource::StateMachineArea(StateMachineArea::HostInit),
+            _ => FailureSource::Scout,
+        };
         db::machine::update_failure_details(
             &machine,
             &mut txn,
             FailureDetails {
                 cause: FailureCause::NVMECleanFailed { err },
                 failed_at: chrono::Utc::now(),
-                source: FailureSource::Scout,
+                source: failure_source,
             },
         )
         .await?;
@@ -222,8 +238,15 @@ pub(crate) async fn forge_agent_control(
             }
             ManagedHostState::HostInit {
                 machine_state: MachineState::WaitingForDiscovery,
+            } => {
+                if host_machine.last_cleanup_time.is_some() {
+                    (Action::discovery(), Some(txn))
+                } else {
+                    tracing::info!("Waiting for initial storage cleanup before host discovery");
+                    (Action::retry(), Some(txn))
+                }
             }
-            | ManagedHostState::Failed {
+            ManagedHostState::Failed {
                 details:
                     FailureDetails {
                         cause: FailureCause::Discovery { .. },
@@ -241,6 +264,7 @@ pub(crate) async fn forge_agent_control(
             } => (Action::measure(), Some(txn)),
             ManagedHostState::WaitingForCleanup {
                 cleanup_state: CleanupState::HostCleanup { .. },
+                ..
             }
             | ManagedHostState::Failed {
                 details:

--- a/crates/api/src/handlers/machine_scout.rs
+++ b/crates/api/src/handlers/machine_scout.rs
@@ -75,6 +75,8 @@ pub(crate) async fn cleanup_machine_completed(
                 cleanup_context: CleanupContext::InitialDiscovery,
                 ..
             } => FailureSource::StateMachineArea(StateMachineArea::HostInit),
+            // Preserve the original HostInit context across cleanup retries so recovery returns to
+            // HostInit/WaitingForDiscovery instead of the deprovision cleanup flow.
             ManagedHostState::Failed {
                 details:
                     FailureDetails {

--- a/crates/api/src/handlers/machine_scout.rs
+++ b/crates/api/src/handlers/machine_scout.rs
@@ -32,8 +32,8 @@ use crate::api::{Api, log_request_data};
 use crate::compat::BuildAndFillLegacyFields;
 use crate::handlers::utils::convert_and_log_machine_id;
 
-// Transitions the machine to Ready state.
-// Called by 'forge-scout discovery' once cleanup succeeds.
+// Records Scout cleanup success/failure and wakes the host state controller.
+// The state controller decides whether cleanup returns to discovery or deprovision flow.
 pub(crate) async fn cleanup_machine_completed(
     api: &Api,
     request: Request<rpc::MachineCleanupInfo>,

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -68,11 +68,11 @@ use model::machine::infiniband::{IbConfigNotSyncedReason, ib_config_synced};
 use model::machine::nvlink::nvlink_config_synced;
 use model::machine::{
     AttestationMode, BiosConfigInfo, BiosConfigState, BomValidating, BomValidatingContext,
-    CleanupState, CreateBossVolumeContext, CreateBossVolumeState, DpuDiscoveringState,
-    DpuInitNextStateResolver, DpuInitState, FailureCause, FailureDetails, FailureSource,
-    HostPlatformConfigurationState, HostReprovisionState, InitialResetPhase, InstallDpuOsState,
-    InstanceNextStateResolver, InstanceState, LockdownInfo, LockdownState, Machine,
-    MachineLastRebootRequested, MachineLastRebootRequestedMode, MachineNextStateResolver,
+    CleanupContext, CleanupState, CreateBossVolumeContext, CreateBossVolumeState,
+    DpuDiscoveringState, DpuInitNextStateResolver, DpuInitState, FailureCause, FailureDetails,
+    FailureSource, HostPlatformConfigurationState, HostReprovisionState, InitialResetPhase,
+    InstallDpuOsState, InstanceNextStateResolver, InstanceState, LockdownInfo, LockdownState,
+    Machine, MachineLastRebootRequested, MachineLastRebootRequestedMode, MachineNextStateResolver,
     MachineState, ManagedHostState, ManagedHostStateSnapshot, MeasuringState,
     NetworkConfigUpdateState, NextStateBFBSupport, PerformPowerOperation, PowerDrainState,
     PowerState, ReprovisionState, RetryInfo, SecureEraseBossContext, SecureEraseBossState,
@@ -970,7 +970,10 @@ impl MachineStateHandler {
                     .await
             }
 
-            ManagedHostState::WaitingForCleanup { cleanup_state } => {
+            ManagedHostState::WaitingForCleanup {
+                cleanup_state,
+                cleanup_context,
+            } => {
                 let redfish_client = ctx
                     .services
                     .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
@@ -984,27 +987,27 @@ impl MachineStateHandler {
                                 .await
                                 .map_err(|e| redfish_error("get_boss_controller", e))?
                         {
-                            let next_state: ManagedHostState =
-                                ManagedHostState::WaitingForCleanup {
-                                    cleanup_state: CleanupState::SecureEraseBoss {
-                                        secure_erase_boss_context: SecureEraseBossContext {
-                                            boss_controller_id,
-                                            secure_erase_jid: None,
-                                            secure_erase_boss_state:
-                                                SecureEraseBossState::UnlockHost,
-                                            iteration: Some(0),
-                                        },
+                            let next_state = waiting_for_cleanup_state(
+                                CleanupState::SecureEraseBoss {
+                                    secure_erase_boss_context: SecureEraseBossContext {
+                                        boss_controller_id,
+                                        secure_erase_jid: None,
+                                        secure_erase_boss_state: SecureEraseBossState::UnlockHost,
+                                        iteration: Some(0),
                                     },
-                                };
+                                },
+                                *cleanup_context,
+                            );
 
                             return Ok(StateHandlerOutcome::transition(next_state));
                         }
 
-                        let next_state: ManagedHostState = ManagedHostState::WaitingForCleanup {
-                            cleanup_state: CleanupState::HostCleanup {
+                        let next_state = waiting_for_cleanup_state(
+                            CleanupState::HostCleanup {
                                 boss_controller_id: None,
                             },
-                        };
+                            *cleanup_context,
+                        );
 
                         Ok(StateHandlerOutcome::transition(next_state))
                     }
@@ -1021,18 +1024,18 @@ impl MachineStateHandler {
                                     .await
                                     .map_err(|e| redfish_error("set_idrac_lockdown", e))?;
 
-                                let next_state: ManagedHostState =
-                                    ManagedHostState::WaitingForCleanup {
-                                        cleanup_state: CleanupState::SecureEraseBoss {
-                                            secure_erase_boss_context: SecureEraseBossContext {
-                                                boss_controller_id,
-                                                secure_erase_jid: None,
-                                                secure_erase_boss_state:
-                                                    SecureEraseBossState::SecureEraseBoss,
-                                                iteration: secure_erase_boss_context.iteration,
-                                            },
+                                let next_state = waiting_for_cleanup_state(
+                                    CleanupState::SecureEraseBoss {
+                                        secure_erase_boss_context: SecureEraseBossContext {
+                                            boss_controller_id,
+                                            secure_erase_jid: None,
+                                            secure_erase_boss_state:
+                                                SecureEraseBossState::SecureEraseBoss,
+                                            iteration: secure_erase_boss_context.iteration,
                                         },
-                                    };
+                                    },
+                                    *cleanup_context,
+                                );
 
                                 Ok(StateHandlerOutcome::transition(next_state))
                             }
@@ -1046,18 +1049,18 @@ impl MachineStateHandler {
                                         redfish_error("decommission_storage_controller", e)
                                     })?;
 
-                                let next_state: ManagedHostState =
-                                    ManagedHostState::WaitingForCleanup {
-                                        cleanup_state: CleanupState::SecureEraseBoss {
-                                            secure_erase_boss_context: SecureEraseBossContext {
-                                                boss_controller_id,
-                                                secure_erase_jid: jid,
-                                                secure_erase_boss_state:
-                                                    SecureEraseBossState::WaitForJobCompletion,
-                                                iteration: secure_erase_boss_context.iteration,
-                                            },
+                                let next_state = waiting_for_cleanup_state(
+                                    CleanupState::SecureEraseBoss {
+                                        secure_erase_boss_context: SecureEraseBossContext {
+                                            boss_controller_id,
+                                            secure_erase_jid: jid,
+                                            secure_erase_boss_state:
+                                                SecureEraseBossState::WaitForJobCompletion,
+                                            iteration: secure_erase_boss_context.iteration,
                                         },
-                                    };
+                                    },
+                                    *cleanup_context,
+                                );
 
                                 Ok(StateHandlerOutcome::transition(next_state))
                             }
@@ -1102,8 +1105,8 @@ impl MachineStateHandler {
                         .await?;
 
                         let next_state = match boss_controller_id {
-                            Some(boss_controller_id) => ManagedHostState::WaitingForCleanup {
-                                cleanup_state: CleanupState::CreateBossVolume {
+                            Some(boss_controller_id) => waiting_for_cleanup_state(
+                                CleanupState::CreateBossVolume {
                                     create_boss_volume_context: CreateBossVolumeContext {
                                         boss_controller_id: boss_controller_id.to_string(),
                                         create_boss_volume_jid: None,
@@ -1112,15 +1115,9 @@ impl MachineStateHandler {
                                         iteration: Some(0),
                                     },
                                 },
-                            },
-                            None => ManagedHostState::BomValidating {
-                                bom_validating_state: BomValidating::UpdatingInventory(
-                                    BomValidatingContext {
-                                        machine_validation_context: Some("Cleanup".to_string()),
-                                        ..BomValidatingContext::default()
-                                    },
-                                ),
-                            },
+                                *cleanup_context,
+                            ),
+                            None => post_cleanup_state(*cleanup_context),
                         };
 
                         Ok(StateHandlerOutcome::transition(next_state))
@@ -1140,18 +1137,18 @@ impl MachineStateHandler {
                                     .await
                                     .map_err(|e| redfish_error("create_storage_volume", e))?;
 
-                                let next_state: ManagedHostState =
-                                    ManagedHostState::WaitingForCleanup {
-                                        cleanup_state: CleanupState::CreateBossVolume {
-                                            create_boss_volume_context: CreateBossVolumeContext {
-                                                boss_controller_id,
-                                                create_boss_volume_jid: jid,
-                                                create_boss_volume_state:
-                                                    CreateBossVolumeState::WaitForJobScheduled,
-                                                iteration: create_boss_volume_context.iteration,
-                                            },
+                                let next_state = waiting_for_cleanup_state(
+                                    CleanupState::CreateBossVolume {
+                                        create_boss_volume_context: CreateBossVolumeContext {
+                                            boss_controller_id,
+                                            create_boss_volume_jid: jid,
+                                            create_boss_volume_state:
+                                                CreateBossVolumeState::WaitForJobScheduled,
+                                            iteration: create_boss_volume_context.iteration,
                                         },
-                                    };
+                                    },
+                                    *cleanup_context,
+                                );
 
                                 Ok(StateHandlerOutcome::transition(next_state))
                             }
@@ -1180,20 +1177,20 @@ impl MachineStateHandler {
                                     .await
                                     .map_err(|e| redfish_error("ForceRestart", e))?;
 
-                                let next_state: ManagedHostState =
-                                    ManagedHostState::WaitingForCleanup {
-                                        cleanup_state: CleanupState::CreateBossVolume {
-                                            create_boss_volume_context: CreateBossVolumeContext {
-                                                boss_controller_id,
-                                                create_boss_volume_jid: create_boss_volume_context
-                                                    .create_boss_volume_jid
-                                                    .clone(),
-                                                create_boss_volume_state:
-                                                    CreateBossVolumeState::WaitForJobCompletion,
-                                                iteration: create_boss_volume_context.iteration,
-                                            },
+                                let next_state = waiting_for_cleanup_state(
+                                    CleanupState::CreateBossVolume {
+                                        create_boss_volume_context: CreateBossVolumeContext {
+                                            boss_controller_id,
+                                            create_boss_volume_jid: create_boss_volume_context
+                                                .create_boss_volume_jid
+                                                .clone(),
+                                            create_boss_volume_state:
+                                                CreateBossVolumeState::WaitForJobCompletion,
+                                            iteration: create_boss_volume_context.iteration,
                                         },
-                                    };
+                                    },
+                                    *cleanup_context,
+                                );
 
                                 Ok(StateHandlerOutcome::transition(next_state))
                             }
@@ -1210,17 +1207,7 @@ impl MachineStateHandler {
                                     .await
                                     .map_err(|e| redfish_error("set_idrac_lockdown", e))?;
 
-                                let next_state: ManagedHostState =
-                                    ManagedHostState::BomValidating {
-                                        bom_validating_state: BomValidating::UpdatingInventory(
-                                            BomValidatingContext {
-                                                machine_validation_context: Some(
-                                                    "Cleanup".to_string(),
-                                                ),
-                                                ..BomValidatingContext::default()
-                                            },
-                                        ),
-                                    };
+                                let next_state = post_cleanup_state(*cleanup_context);
 
                                 Ok(StateHandlerOutcome::transition(next_state))
                             }
@@ -1347,8 +1334,20 @@ impl MachineStateHandler {
                                 .unwrap_or_default()
                         {
                             // Cleaned up successfully after a failure.
-                            let next_state = ManagedHostState::WaitingForCleanup {
-                                cleanup_state: CleanupState::Init,
+                            let cleanup_context = match &details.source {
+                                FailureSource::StateMachineArea(StateMachineArea::HostInit) => {
+                                    CleanupContext::InitialDiscovery
+                                }
+                                _ => CleanupContext::Deprovision,
+                            };
+                            let next_state = match cleanup_context {
+                                CleanupContext::InitialDiscovery => {
+                                    initial_discovery_waiting_state()
+                                }
+                                CleanupContext::Deprovision => waiting_for_cleanup_state(
+                                    CleanupState::Init,
+                                    CleanupContext::Deprovision,
+                                ),
                             };
                             let mut txn = ctx.services.db_pool.begin().await?;
                             db::machine::clear_failure_details(machine_id, &mut txn).await?;
@@ -1541,9 +1540,10 @@ impl MachineStateHandler {
                     AttestationMode::SpdmAttestation {
                         spdm_measuring_state,
                     } => {
-                        let next_skip_state = ManagedHostState::WaitingForCleanup {
-                            cleanup_state: CleanupState::Init,
-                        };
+                        let next_skip_state = waiting_for_cleanup_state(
+                            CleanupState::Init,
+                            CleanupContext::Deprovision,
+                        );
                         if !ctx.services.site_config.spdm.enabled {
                             return Ok(StateHandlerOutcome::transition(next_skip_state));
                         }
@@ -4460,6 +4460,49 @@ fn cleanedup_after_state_transition(
     last_cleanup_time.unwrap_or_default() > version.timestamp()
 }
 
+fn waiting_for_cleanup_state(
+    cleanup_state: CleanupState,
+    cleanup_context: CleanupContext,
+) -> ManagedHostState {
+    ManagedHostState::WaitingForCleanup {
+        cleanup_state,
+        cleanup_context,
+    }
+}
+
+fn initial_discovery_waiting_state() -> ManagedHostState {
+    ManagedHostState::HostInit {
+        machine_state: MachineState::WaitingForDiscovery,
+    }
+}
+
+fn post_cleanup_state(cleanup_context: CleanupContext) -> ManagedHostState {
+    match cleanup_context {
+        CleanupContext::Deprovision => ManagedHostState::BomValidating {
+            bom_validating_state: BomValidating::UpdatingInventory(BomValidatingContext {
+                machine_validation_context: Some("Cleanup".to_string()),
+                ..BomValidatingContext::default()
+            }),
+        },
+        CleanupContext::InitialDiscovery => initial_discovery_waiting_state(),
+    }
+}
+
+fn current_cleanup_context(
+    mh_snapshot: &ManagedHostStateSnapshot,
+) -> Result<CleanupContext, StateHandlerError> {
+    match &mh_snapshot.host_snapshot.state.value {
+        ManagedHostState::WaitingForCleanup {
+            cleanup_context, ..
+        } => Ok(*cleanup_context),
+        _ => Err(StateHandlerError::GenericError(eyre::eyre!(
+            "unexpected host state for {}: {:#?}",
+            mh_snapshot.host_snapshot.id,
+            mh_snapshot.host_snapshot.state,
+        ))),
+    }
+}
+
 /// A `StateHandler` implementation for host machines
 #[derive(Debug, Clone)]
 pub struct HostMachineStateHandler {
@@ -5019,6 +5062,13 @@ impl StateHandler for HostMachineStateHandler {
                     }
                 }
                 MachineState::WaitingForDiscovery => {
+                    if mh_snapshot.host_snapshot.last_cleanup_time.is_none() {
+                        return Ok(StateHandlerOutcome::transition(waiting_for_cleanup_state(
+                            CleanupState::Init,
+                            CleanupContext::InitialDiscovery,
+                        )));
+                    }
+
                     if !discovered_after_state_transition(
                         mh_snapshot.host_snapshot.state.version,
                         mh_snapshot.host_snapshot.last_discovery_time,
@@ -8560,7 +8610,10 @@ fn get_next_state_boss_job_failure(
     mh_snapshot: &ManagedHostStateSnapshot,
 ) -> Result<(ManagedHostState, PowerState), StateHandlerError> {
     let (next_state, expected_power_state) = match &mh_snapshot.host_snapshot.state.value {
-        ManagedHostState::WaitingForCleanup { cleanup_state } => match cleanup_state {
+        ManagedHostState::WaitingForCleanup {
+            cleanup_state,
+            cleanup_context,
+        } => match cleanup_state {
             CleanupState::SecureEraseBoss {
                 secure_erase_boss_context,
             } => match &secure_erase_boss_context.secure_erase_boss_state {
@@ -8569,8 +8622,8 @@ fn get_next_state_boss_job_failure(
                     power_state,
                 } => match power_state {
                     PowerState::Off => (
-                        ManagedHostState::WaitingForCleanup {
-                            cleanup_state: CleanupState::SecureEraseBoss {
+                        waiting_for_cleanup_state(
+                            CleanupState::SecureEraseBoss {
                                 secure_erase_boss_context: SecureEraseBossContext {
                                     boss_controller_id: secure_erase_boss_context
                                         .boss_controller_id
@@ -8584,12 +8637,13 @@ fn get_next_state_boss_job_failure(
                                         },
                                 },
                             },
-                        },
+                            *cleanup_context,
+                        ),
                         *power_state,
                     ),
                     PowerState::On => (
-                        ManagedHostState::WaitingForCleanup {
-                            cleanup_state: CleanupState::SecureEraseBoss {
+                        waiting_for_cleanup_state(
+                            CleanupState::SecureEraseBoss {
                                 secure_erase_boss_context: SecureEraseBossContext {
                                     boss_controller_id: secure_erase_boss_context
                                         .boss_controller_id
@@ -8601,7 +8655,8 @@ fn get_next_state_boss_job_failure(
                                     secure_erase_boss_state: SecureEraseBossState::SecureEraseBoss,
                                 },
                             },
-                        },
+                            *cleanup_context,
+                        ),
                         *power_state,
                     ),
                     _ => {
@@ -8628,8 +8683,8 @@ fn get_next_state_boss_job_failure(
                     power_state,
                 } => match power_state {
                     PowerState::Off => (
-                        ManagedHostState::WaitingForCleanup {
-                            cleanup_state: CleanupState::CreateBossVolume {
+                        waiting_for_cleanup_state(
+                            CleanupState::CreateBossVolume {
                                 create_boss_volume_context: CreateBossVolumeContext {
                                     boss_controller_id: create_boss_volume_context
                                         .boss_controller_id
@@ -8643,12 +8698,13 @@ fn get_next_state_boss_job_failure(
                                         },
                                 },
                             },
-                        },
+                            *cleanup_context,
+                        ),
                         *power_state,
                     ),
                     PowerState::On => (
-                        ManagedHostState::WaitingForCleanup {
-                            cleanup_state: CleanupState::CreateBossVolume {
+                        waiting_for_cleanup_state(
+                            CleanupState::CreateBossVolume {
                                 create_boss_volume_context: CreateBossVolumeContext {
                                     boss_controller_id: create_boss_volume_context
                                         .boss_controller_id
@@ -8662,7 +8718,8 @@ fn get_next_state_boss_job_failure(
                                         CreateBossVolumeState::CreateBossVolume,
                                 },
                             },
-                        },
+                            *cleanup_context,
+                        ),
                         *power_state,
                     ),
                     _ => {
@@ -8704,6 +8761,7 @@ fn handle_boss_controller_job_error(
     boss_controller_id: String,
     iterations: u32,
     secure_erase_boss_controller: bool,
+    cleanup_context: CleanupContext,
     err: StateHandlerError,
     time_since_state_change: chrono::TimeDelta,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
@@ -8760,7 +8818,7 @@ fn handle_boss_controller_job_error(
         },
     };
 
-    let next_state: ManagedHostState = ManagedHostState::WaitingForCleanup { cleanup_state };
+    let next_state = waiting_for_cleanup_state(cleanup_state, cleanup_context);
 
     Ok(StateHandlerOutcome::transition(next_state))
 }
@@ -8772,6 +8830,7 @@ async fn wait_for_boss_controller_job_to_scheduled(
     job_id: String,
     iteration: Option<u32>,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let cleanup_context = current_cleanup_context(mh_snapshot)?;
     let job_state = match redfish_client.get_job_state(&job_id).await {
         Ok(state) => state,
         Err(e) => {
@@ -8779,6 +8838,7 @@ async fn wait_for_boss_controller_job_to_scheduled(
                 boss_controller_id,
                 iteration.unwrap_or_default(),
                 false,
+                cleanup_context,
                 redfish_error("get_job_state", e),
                 mh_snapshot.host_snapshot.state.version.since_state_change(),
             );
@@ -8786,8 +8846,8 @@ async fn wait_for_boss_controller_job_to_scheduled(
     };
 
     let next_state = match job_state {
-        libredfish::JobState::Scheduled => ManagedHostState::WaitingForCleanup {
-            cleanup_state: CleanupState::CreateBossVolume {
+        libredfish::JobState::Scheduled => waiting_for_cleanup_state(
+            CleanupState::CreateBossVolume {
                 create_boss_volume_context: CreateBossVolumeContext {
                     boss_controller_id,
                     create_boss_volume_jid: Some(job_id),
@@ -8795,7 +8855,8 @@ async fn wait_for_boss_controller_job_to_scheduled(
                     iteration,
                 },
             },
-        },
+            cleanup_context,
+        ),
         libredfish::JobState::Completed => {
             tracing::warn!(
                 "CreateBossVolume: job {} for {} completed before being scheduled, skipping reboot",
@@ -8803,8 +8864,8 @@ async fn wait_for_boss_controller_job_to_scheduled(
                 mh_snapshot.host_snapshot.id,
             );
 
-            ManagedHostState::WaitingForCleanup {
-                cleanup_state: CleanupState::CreateBossVolume {
+            waiting_for_cleanup_state(
+                CleanupState::CreateBossVolume {
                     create_boss_volume_context: CreateBossVolumeContext {
                         boss_controller_id,
                         create_boss_volume_jid: Some(job_id),
@@ -8812,13 +8873,15 @@ async fn wait_for_boss_controller_job_to_scheduled(
                         iteration,
                     },
                 },
-            }
+                cleanup_context,
+            )
         }
         libredfish::JobState::ScheduledWithErrors | libredfish::JobState::CompletedWithErrors => {
             return handle_boss_controller_job_error(
                 boss_controller_id,
                 iteration.unwrap_or_default(),
                 false,
+                cleanup_context,
                 StateHandlerError::GenericError(eyre::eyre!(
                     "CreateBossVolume: job {} failed for {} with state {job_state:#?}",
                     job_id,
@@ -8842,9 +8905,10 @@ async fn wait_for_boss_controller_job_to_complete(
     redfish_client: &dyn Redfish,
     mh_snapshot: &ManagedHostStateSnapshot,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let cleanup_context = current_cleanup_context(mh_snapshot)?;
     let (boss_controller_id, boss_job_id, iterations, secure_erase_boss_controller) =
         match &mh_snapshot.host_snapshot.state.value {
-            ManagedHostState::WaitingForCleanup { cleanup_state } => match cleanup_state {
+            ManagedHostState::WaitingForCleanup { cleanup_state, .. } => match cleanup_state {
                 CleanupState::SecureEraseBoss {
                     secure_erase_boss_context,
                 } => match &secure_erase_boss_context.secure_erase_boss_state {
@@ -8906,6 +8970,7 @@ async fn wait_for_boss_controller_job_to_complete(
                 boss_controller_id,
                 iterations,
                 secure_erase_boss_controller,
+                cleanup_context,
                 redfish_error("get_job_state", e),
                 mh_snapshot.host_snapshot.state.version.since_state_change(),
             );
@@ -8933,7 +8998,7 @@ async fn wait_for_boss_controller_job_to_complete(
                 },
             };
 
-            let next_state = ManagedHostState::WaitingForCleanup { cleanup_state };
+            let next_state = waiting_for_cleanup_state(cleanup_state, cleanup_context);
             Ok(StateHandlerOutcome::transition(next_state))
         }
         // The job has failed; handle error
@@ -8942,6 +9007,7 @@ async fn wait_for_boss_controller_job_to_complete(
                 boss_controller_id,
                 iterations,
                 secure_erase_boss_controller,
+                cleanup_context,
                 StateHandlerError::GenericError(eyre::eyre!(
                     "job {job_id} will not complete because it is in a failure state: {job_state:#?}",
                 )),

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -1334,17 +1334,11 @@ impl MachineStateHandler {
                                 .unwrap_or_default()
                         {
                             // Cleaned up successfully after a failure.
-                            let cleanup_context = match &details.source {
+                            let next_state = match &details.source {
                                 FailureSource::StateMachineArea(StateMachineArea::HostInit) => {
-                                    CleanupContext::InitialDiscovery
-                                }
-                                _ => CleanupContext::Deprovision,
-                            };
-                            let next_state = match cleanup_context {
-                                CleanupContext::InitialDiscovery => {
                                     initial_discovery_waiting_state()
                                 }
-                                CleanupContext::Deprovision => waiting_for_cleanup_state(
+                                _ => waiting_for_cleanup_state(
                                     CleanupState::Init,
                                     CleanupContext::Deprovision,
                                 ),

--- a/crates/api/src/state_controller/machine/io.rs
+++ b/crates/api/src/state_controller/machine/io.rs
@@ -285,7 +285,7 @@ impl StateControllerIO for MachineStateControllerIO {
             ManagedHostState::Assigned { instance_state } => {
                 ("assigned", instance_state_name(instance_state))
             }
-            ManagedHostState::WaitingForCleanup { cleanup_state } => {
+            ManagedHostState::WaitingForCleanup { cleanup_state, .. } => {
                 ("waitingforcleanup", cleanup_state_name(cleanup_state))
             }
             ManagedHostState::Created => ("created", ""),

--- a/crates/api/src/tests/common/api_fixtures/instance.rs
+++ b/crates/api/src/tests/common/api_fixtures/instance.rs
@@ -29,7 +29,8 @@ use model::instance::snapshot::InstanceSnapshot;
 use model::instance::status::network::InstanceNetworkStatusObservation;
 use model::machine::health_override::HARDWARE_HEALTH_OVERRIDE_PREFIX;
 use model::machine::{
-    CleanupState, Machine, MachineState, MachineValidatingState, ManagedHostState, ValidationState,
+    CleanupContext, CleanupState, Machine, MachineState, MachineValidatingState, ManagedHostState,
+    ValidationState,
 };
 use rpc::forge::InstanceDpuExtensionServicesConfig;
 use rpc::forge::forge_server::Forge;
@@ -537,6 +538,7 @@ pub async fn handle_delete_post_bootingwithdiscoveryimage(env: &TestEnv, mh: &Te
             cleanup_state: CleanupState::HostCleanup {
                 boss_controller_id: None,
             },
+            cleanup_context: CleanupContext::Deprovision,
         },
     )
     .await;

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -37,10 +37,10 @@ use model::expected_machine::ExpectedMachine;
 use model::hardware_info::HardwareInfo;
 use model::machine::health_override::HARDWARE_HEALTH_OVERRIDE_PREFIX;
 use model::machine::{
-    BomValidating, BomValidatingContext, DpfState, DpuInitState, FailureCause, FailureDetails,
-    FailureSource, LockdownInfo, LockdownMode, LockdownState, MachineState, MachineValidatingState,
-    ManagedHostState, ManagedHostStateSnapshot, MeasuringState, SpdmMeasuringState,
-    ValidationState,
+    BomValidating, BomValidatingContext, CleanupContext, CleanupState, DpfState, DpuInitState,
+    FailureCause, FailureDetails, FailureSource, LockdownInfo, LockdownMode, LockdownState,
+    MachineState, MachineValidatingState, ManagedHostState, ManagedHostStateSnapshot,
+    MeasuringState, SpdmMeasuringState, ValidationState,
 };
 use model::power_shelf::power_shelf_id::from_hardware_info;
 use model::power_shelf::{NewPowerShelf, PowerShelfConfig};
@@ -73,6 +73,81 @@ use crate::tests::common::api_fixtures::{
 };
 use crate::tests::common::mac_address_pool::EXPECTED_SWITCH_NVOS_MAC_ADDRESS_POOL;
 use crate::tests::common::rpc_builder::DhcpDiscovery;
+
+async fn complete_initial_discovery_cleanup_if_needed(env: &TestEnv, host_machine_id: MachineId) {
+    // Keep the shared fixture usable with both lifecycle shapes: older flows stay in discovery,
+    // while newer flows require state-machine-owned cleanup before discovery can complete.
+    let state = env
+        .run_machine_state_controller_iteration_until_state_condition(
+            &host_machine_id,
+            1,
+            |machine| {
+                matches!(
+                    machine.current_state(),
+                    ManagedHostState::HostInit {
+                        machine_state: MachineState::WaitingForDiscovery
+                    } | ManagedHostState::WaitingForCleanup {
+                        cleanup_context: CleanupContext::InitialDiscovery,
+                        ..
+                    }
+                )
+            },
+        )
+        .await;
+
+    if matches!(
+        state,
+        ManagedHostState::HostInit {
+            machine_state: MachineState::WaitingForDiscovery
+        }
+    ) {
+        return;
+    }
+
+    if !matches!(
+        state,
+        ManagedHostState::WaitingForCleanup {
+            cleanup_state: CleanupState::HostCleanup { .. },
+            cleanup_context: CleanupContext::InitialDiscovery,
+        }
+    ) {
+        env.run_machine_state_controller_iteration_until_state_condition(
+            &host_machine_id,
+            3,
+            |machine| {
+                matches!(
+                    machine.current_state(),
+                    ManagedHostState::WaitingForCleanup {
+                        cleanup_state: CleanupState::HostCleanup { .. },
+                        cleanup_context: CleanupContext::InitialDiscovery,
+                    }
+                )
+            },
+        )
+        .await;
+    }
+
+    let response = forge_agent_control(env, host_machine_id).await;
+    assert!(matches!(response.action, Some(Action::Reset(_))));
+    assert_eq!(response.legacy_action, LegacyAction::Reset as i32);
+
+    env.api
+        .cleanup_machine_completed(Request::new(rpc::MachineCleanupInfo {
+            machine_id: host_machine_id.into(),
+            ..Default::default()
+        }))
+        .await
+        .unwrap();
+
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &host_machine_id,
+        3,
+        ManagedHostState::HostInit {
+            machine_state: MachineState::WaitingForDiscovery,
+        },
+    )
+    .await;
+}
 
 /// MockExploredHost presents a fluent interface for declaring a mock host and running it through
 /// the site-explorer ingestion lifecycle. Its methods are intended to be chained together to
@@ -700,6 +775,7 @@ impl<'a> MockExploredHost<'a> {
             .await
             .expect("Failed to add hardware health report to newly created machine");
 
+        complete_initial_discovery_cleanup_if_needed(self.test_env, host_machine_id).await;
         discovery_completed(self.test_env, host_machine_id).await;
         self.test_env.run_ib_fabric_monitor_iteration().await;
         host_uefi_setup(self.test_env, &host_machine_id).await;
@@ -924,6 +1000,7 @@ impl<'a> MockExploredHost<'a> {
             .await
             .expect("Failed to add hardware health report to newly created machine");
 
+        complete_initial_discovery_cleanup_if_needed(self.test_env, host_machine_id).await;
         discovery_completed(self.test_env, host_machine_id).await;
         self.test_env.run_ib_fabric_monitor_iteration().await;
         host_uefi_setup(self.test_env, &host_machine_id).await;

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -74,13 +74,33 @@ use crate::tests::common::api_fixtures::{
 use crate::tests::common::mac_address_pool::EXPECTED_SWITCH_NVOS_MAC_ADDRESS_POOL;
 use crate::tests::common::rpc_builder::DhcpDiscovery;
 
+async fn current_host_state_and_cleanup_needed(
+    env: &TestEnv,
+    host_machine_id: MachineId,
+) -> (ManagedHostState, bool) {
+    let mut txn = env.db_txn().await;
+    let machine = db::machine::find_one(
+        txn.as_mut(),
+        &host_machine_id,
+        model::machine::machine_search_config::MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    (
+        machine.current_state().clone(),
+        machine.last_cleanup_time.is_none(),
+    )
+}
+
 async fn complete_initial_discovery_cleanup_if_needed(env: &TestEnv, host_machine_id: MachineId) {
     // Keep the shared fixture usable with both lifecycle shapes: older flows stay in discovery,
     // while newer flows require state-machine-owned cleanup before discovery can complete.
-    let state = env
+    let mut state = env
         .run_machine_state_controller_iteration_until_state_condition(
             &host_machine_id,
-            1,
+            20,
             |machine| {
                 matches!(
                     machine.current_state(),
@@ -101,7 +121,23 @@ async fn complete_initial_discovery_cleanup_if_needed(env: &TestEnv, host_machin
             machine_state: MachineState::WaitingForDiscovery
         }
     ) {
-        return;
+        let (_, needs_initial_cleanup) =
+            current_host_state_and_cleanup_needed(env, host_machine_id).await;
+        if !needs_initial_cleanup {
+            return;
+        }
+
+        env.run_machine_state_controller_iteration().await;
+        (state, _) = current_host_state_and_cleanup_needed(env, host_machine_id).await;
+
+        if matches!(
+            state,
+            ManagedHostState::HostInit {
+                machine_state: MachineState::WaitingForDiscovery
+            }
+        ) {
+            return;
+        }
     }
 
     if !matches!(
@@ -750,15 +786,7 @@ impl<'a> MockExploredHost<'a> {
             }
         }
 
-        self.test_env
-            .run_machine_state_controller_iteration_until_state_matches(
-                &host_machine_id,
-                20,
-                ManagedHostState::HostInit {
-                    machine_state: MachineState::WaitingForDiscovery,
-                },
-            )
-            .await;
+        complete_initial_discovery_cleanup_if_needed(self.test_env, host_machine_id).await;
 
         self.test_env
             .api
@@ -775,7 +803,6 @@ impl<'a> MockExploredHost<'a> {
             .await
             .expect("Failed to add hardware health report to newly created machine");
 
-        complete_initial_discovery_cleanup_if_needed(self.test_env, host_machine_id).await;
         discovery_completed(self.test_env, host_machine_id).await;
         self.test_env.run_ib_fabric_monitor_iteration().await;
         host_uefi_setup(self.test_env, &host_machine_id).await;
@@ -975,15 +1002,7 @@ impl<'a> MockExploredHost<'a> {
             .machine_id
             .unwrap();
         let mut machine_validation_result = machine_validation_result_data.unwrap_or_default();
-        self.test_env
-            .run_machine_state_controller_iteration_until_state_matches(
-                &host_machine_id,
-                10,
-                ManagedHostState::HostInit {
-                    machine_state: MachineState::WaitingForDiscovery,
-                },
-            )
-            .await;
+        complete_initial_discovery_cleanup_if_needed(self.test_env, host_machine_id).await;
 
         self.test_env
             .api
@@ -1000,7 +1019,6 @@ impl<'a> MockExploredHost<'a> {
             .await
             .expect("Failed to add hardware health report to newly created machine");
 
-        complete_initial_discovery_cleanup_if_needed(self.test_env, host_machine_id).await;
         discovery_completed(self.test_env, host_machine_id).await;
         self.test_env.run_ib_fabric_monitor_iteration().await;
         host_uefi_setup(self.test_env, &host_machine_id).await;

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -2717,7 +2717,7 @@ async fn test_manual_firmware_upgrade_workflow(pool: sqlx::PgPool) -> CarbideRes
 }
 
 #[crate::sqlx_test]
-async fn test_forge_agent_control_waiting_for_scout_upgrade_returns_typed_and_legacy_task(
+async fn test_forge_agent_control_waiting_for_scout_upgrade_returns_task_without_cleanup_timestamp(
     pool: sqlx::PgPool,
 ) -> CarbideResult<()> {
     let env = create_test_env(pool).await;
@@ -2756,6 +2756,15 @@ async fn test_forge_agent_control_waiting_for_scout_upgrade_returns_typed_and_le
         retry_count: 0,
     };
     db::machine::advance(&host, &mut txn, &waiting_state, None).await?;
+    sqlx::query("UPDATE machines SET last_cleanup_time = NULL WHERE id = $1")
+        .bind(mh.host().id)
+        .execute(txn.as_mut())
+        .await?;
+    txn.commit().await.unwrap();
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    assert!(host.last_cleanup_time.is_none());
     txn.commit().await.unwrap();
 
     let response = env

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -2756,9 +2756,7 @@ async fn test_forge_agent_control_waiting_for_scout_upgrade_returns_task_without
         retry_count: 0,
     };
     db::machine::advance(&host, &mut txn, &waiting_state, None).await?;
-    sqlx::query("UPDATE machines SET last_cleanup_time = NULL WHERE id = $1")
-        .bind(mh.host().id)
-        .execute(txn.as_mut())
+    db::machine::clear_cleanup_time(&mh.host().id, &mut txn)
         .await
         .unwrap();
     txn.commit().await.unwrap();

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -2759,7 +2759,8 @@ async fn test_forge_agent_control_waiting_for_scout_upgrade_returns_task_without
     sqlx::query("UPDATE machines SET last_cleanup_time = NULL WHERE id = $1")
         .bind(mh.host().id)
         .execute(txn.as_mut())
-        .await?;
+        .await
+        .unwrap();
     txn.commit().await.unwrap();
 
     let mut txn = env.pool.begin().await.unwrap();

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -61,7 +61,7 @@ use model::instance::status::network::{
     InstanceInterfaceStatusObservation, InstanceNetworkStatusObservation,
 };
 use model::machine::{
-    AttestationMode, CleanupState, FailureDetails, InstanceState, MachineState,
+    AttestationMode, CleanupContext, CleanupState, FailureDetails, InstanceState, MachineState,
     MachineValidatingState, ManagedHostState, MeasuringState, NetworkConfigUpdateState,
     SpdmMeasuringState, ValidationState,
 };
@@ -679,6 +679,7 @@ async fn test_measurement_assigned_ready_to_waiting_for_measurements_to_ca_faile
             cleanup_state: CleanupState::HostCleanup {
                 boss_controller_id: None,
             },
+            cleanup_context: CleanupContext::Deprovision,
         },
     )
     .await;

--- a/crates/api/src/tests/ipxe.rs
+++ b/crates/api/src/tests/ipxe.rs
@@ -24,7 +24,9 @@ use common::api_fixtures::{
 use db::{self};
 use futures_util::FutureExt;
 use mac_address::MacAddress;
-use model::machine::{DpuInitState, HostReprovisionState, MachineState, ManagedHostState};
+use model::machine::{
+    CleanupContext, DpuInitState, HostReprovisionState, MachineState, ManagedHostState,
+};
 use rpc::forge::CloudInitInstructionsRequest;
 use rpc::forge::forge_server::Forge;
 
@@ -362,6 +364,7 @@ async fn test_pxe_host(pool: sqlx::PgPool) {
         host_id,
         &ManagedHostState::WaitingForCleanup {
             cleanup_state: model::machine::CleanupState::Init,
+            cleanup_context: CleanupContext::Deprovision,
         },
         &env.pool,
     )

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -42,12 +42,14 @@ use measured_boot::pcr::PcrRegisterValue;
 use measured_boot::records::MeasurementBundleState;
 use measured_boot::report::MeasurementReport;
 use model::controller_outcome::PersistentStateHandlerOutcome;
+use model::firmware::FirmwareComponentType;
 use model::hardware_info::TpmEkCertificate;
 use model::machine::health_override::HARDWARE_HEALTH_OVERRIDE_PREFIX;
 use model::machine::{
     CleanupContext, CleanupState, DpuInitState, DpuReprovisionStates, FailureCause, FailureDetails,
-    FailureSource, InstanceState, LockdownMode, MachineState, MachineValidatingState,
-    ManagedHostState, MeasuringState, RetryInfo, SpdmMeasuringState, ValidationState,
+    FailureSource, HostReprovisionState, InstanceState, LockdownMode, MachineState,
+    MachineValidatingState, ManagedHostState, MeasuringState, RetryInfo, SpdmMeasuringState,
+    StateMachineArea, ValidationState,
 };
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{HealthReportEntry, InsertMachineHealthReportRequest, TpmCaCert, TpmCaCertId};
@@ -712,6 +714,114 @@ async fn test_nvme_clean_failed_state_host(pool: sqlx::PgPool) {
         host.current_state(),
         ManagedHostState::WaitingForCleanup { .. }
     ));
+}
+
+#[crate::sqlx_test]
+async fn test_repeated_initial_discovery_cleanup_failure_preserves_host_init_source(
+    pool: sqlx::PgPool,
+) {
+    fn cleanup_failed_request(machine_id: MachineId) -> Request<rpc::MachineCleanupInfo> {
+        Request::new(rpc::MachineCleanupInfo {
+            machine_id: machine_id.into(),
+            nvme: Some(
+                rpc::protos::forge::machine_cleanup_info::CleanupStepResult {
+                    result: rpc::protos::forge::machine_cleanup_info::CleanupResult::Error as i32,
+                    message: "test nvme failure".to_string(),
+                },
+            ),
+            ..Default::default()
+        })
+    }
+
+    let env = create_test_env(pool).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+    let waiting_for_initial_discovery_cleanup = ManagedHostState::WaitingForCleanup {
+        cleanup_state: CleanupState::HostCleanup {
+            boss_controller_id: None,
+        },
+        cleanup_context: CleanupContext::InitialDiscovery,
+    };
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    db::machine::advance(
+        &host,
+        &mut txn,
+        &waiting_for_initial_discovery_cleanup,
+        None,
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.api
+        .cleanup_machine_completed(cleanup_failed_request(mh.id))
+        .await
+        .unwrap();
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    assert!(matches!(
+        host.current_state(),
+        ManagedHostState::Failed {
+            details: FailureDetails {
+                cause: FailureCause::NVMECleanFailed { .. },
+                source: FailureSource::StateMachineArea(StateMachineArea::HostInit),
+                ..
+            },
+            ..
+        }
+    ));
+    assert!(matches!(
+        host.failure_details.source,
+        FailureSource::StateMachineArea(StateMachineArea::HostInit)
+    ));
+    txn.commit().await.unwrap();
+
+    env.api
+        .cleanup_machine_completed(cleanup_failed_request(mh.id))
+        .await
+        .unwrap();
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    assert!(matches!(
+        host.failure_details.source,
+        FailureSource::StateMachineArea(StateMachineArea::HostInit)
+    ));
+    txn.commit().await.unwrap();
+
+    env.api
+        .cleanup_machine_completed(Request::new(rpc::MachineCleanupInfo {
+            machine_id: mh.id.into(),
+            ..Default::default()
+        }))
+        .await
+        .unwrap();
+
+    // Make the recovery timestamp unambiguously newer than the failed state version and failed_at.
+    let mut txn = env.db_txn().await;
+    sqlx::query(
+        "UPDATE machines SET last_cleanup_time = NOW() + INTERVAL '1 second' WHERE id = $1",
+    )
+    .bind(mh.id)
+    .execute(txn.as_mut())
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    assert!(matches!(
+        host.current_state(),
+        ManagedHostState::HostInit {
+            machine_state: MachineState::WaitingForDiscovery
+        }
+    ));
+    txn.commit().await.unwrap();
 }
 
 #[crate::sqlx_test]
@@ -1815,6 +1925,61 @@ async fn test_measurement_host_init_failed_to_waiting_for_measurements_to_pendin
         ManagedHostState::Ready,
     )
     .await;
+}
+
+#[crate::sqlx_test]
+async fn test_forge_agent_control_host_reprovision_scout_upgrade_does_not_reset_without_cleanup_timestamp(
+    pool: sqlx::PgPool,
+) {
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+    let upgrade_task_id = uuid::Uuid::new_v4().to_string();
+    let task_json = serde_json::json!({
+        "upgrade_task_id": &upgrade_task_id,
+        "component_type": "bmc",
+        "target_version": "1.2.3",
+        "script": {
+            "url": "http://pxe/scripts/upgrade.sh",
+            "sha256": "script-sha",
+        },
+        "execution_timeout_seconds": 30,
+        "artifact_download_timeout_seconds": 10,
+        "file_artifacts": [{
+            "url": "http://pxe/firmware.bin",
+            "sha256": "firmware-sha",
+        }],
+    })
+    .to_string();
+
+    let state = ManagedHostState::HostReprovision {
+        reprovision_state: HostReprovisionState::WaitingForScoutUpgrade {
+            upgrade_task_id,
+            firmware_type: FirmwareComponentType::Bmc,
+            final_version: "1.2.3".to_string(),
+            power_drains_needed: None,
+            started_at: chrono::Utc::now(),
+            deadline: chrono::Utc::now() + chrono::TimeDelta::minutes(60),
+            task_json,
+            result: None,
+        },
+        retry_count: 0,
+    };
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    db::machine::advance(&host, &mut txn, &state, None)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE machines SET last_cleanup_time = NULL WHERE id = $1")
+        .bind(mh.host().id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    let response = mh.host().forge_agent_control().await;
+    assert!(matches!(response.action, Some(Action::FirmwareUpgrade(_))));
+    assert_eq!(response.legacy_action, LegacyAction::FirmwareUpgrade as i32);
 }
 
 #[crate::sqlx_test]

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -777,7 +777,10 @@ async fn test_repeated_initial_discovery_cleanup_failure_preserves_host_init_sou
         host.failure_details.source,
         FailureSource::StateMachineArea(StateMachineArea::HostInit)
     ));
+    let first_failed_at = host.failure_details.failed_at;
     txn.commit().await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 
     env.api
         .cleanup_machine_completed(cleanup_failed_request(mh.id))
@@ -790,6 +793,10 @@ async fn test_repeated_initial_discovery_cleanup_failure_preserves_host_init_sou
         host.failure_details.source,
         FailureSource::StateMachineArea(StateMachineArea::HostInit)
     ));
+    assert!(
+        host.failure_details.failed_at > first_failed_at,
+        "repeated cleanup failure should refresh failure details"
+    );
     txn.commit().await.unwrap();
 
     env.api
@@ -802,13 +809,9 @@ async fn test_repeated_initial_discovery_cleanup_failure_preserves_host_init_sou
 
     // Make the recovery timestamp unambiguously newer than the failed state version and failed_at.
     let mut txn = env.db_txn().await;
-    sqlx::query(
-        "UPDATE machines SET last_cleanup_time = NOW() + INTERVAL '1 second' WHERE id = $1",
-    )
-    .bind(mh.id)
-    .execute(txn.as_mut())
-    .await
-    .unwrap();
+    db::machine::set_cleanup_time(&mh.id, chrono::Utc::now() + Duration::seconds(1), &mut txn)
+        .await
+        .unwrap();
     txn.commit().await.unwrap();
 
     env.run_machine_state_controller_iteration().await;
@@ -1970,9 +1973,7 @@ async fn test_forge_agent_control_host_reprovision_scout_upgrade_does_not_reset_
     db::machine::advance(&host, &mut txn, &state, None)
         .await
         .unwrap();
-    sqlx::query("UPDATE machines SET last_cleanup_time = NULL WHERE id = $1")
-        .bind(mh.host().id)
-        .execute(txn.as_mut())
+    db::machine::clear_cleanup_time(&mh.host().id, &mut txn)
         .await
         .unwrap();
     txn.commit().await.unwrap();
@@ -1999,9 +2000,7 @@ async fn test_forge_agent_control_assigned_discovery_boot_does_not_reset_without
     db::machine::advance(&host, &mut txn, &state, None)
         .await
         .unwrap();
-    sqlx::query("UPDATE machines SET last_cleanup_time = NULL WHERE id = $1")
-        .bind(mh.host().id)
-        .execute(txn.as_mut())
+    db::machine::clear_cleanup_time(&mh.host().id, &mut txn)
         .await
         .unwrap();
     txn.commit().await.unwrap();

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -303,7 +303,7 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
         (r#"{state="hostnotready",substate="discovered"}"#, 1),
         (
             r#"{state="hostnotready",substate="waitingfordiscovery"}"#,
-            1,
+            2,
         ),
         (r#"{state="hostnotready",substate="pollingbiossetup"}"#, 1),
         (
@@ -345,7 +345,7 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
         ("{state=\"hostnotready\",substate=\"discovered\"}", 1),
         (
             "{state=\"hostnotready\",substate=\"waitingfordiscovery\"}",
-            1,
+            2,
         ),
         ("{state=\"hostnotready\",substate=\"pollingbiossetup\"}", 1),
         (

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -45,9 +45,9 @@ use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::hardware_info::TpmEkCertificate;
 use model::machine::health_override::HARDWARE_HEALTH_OVERRIDE_PREFIX;
 use model::machine::{
-    DpuInitState, DpuReprovisionStates, FailureCause, FailureDetails, FailureSource, InstanceState,
-    LockdownMode, MachineState, MachineValidatingState, ManagedHostState, MeasuringState,
-    SpdmMeasuringState, ValidationState,
+    CleanupContext, CleanupState, DpuInitState, DpuReprovisionStates, FailureCause, FailureDetails,
+    FailureSource, InstanceState, LockdownMode, MachineState, MachineValidatingState,
+    ManagedHostState, MeasuringState, RetryInfo, SpdmMeasuringState, ValidationState,
 };
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{HealthReportEntry, InsertMachineHealthReportRequest, TpmCaCert, TpmCaCertId};
@@ -1712,6 +1712,43 @@ async fn test_measurement_host_init_failed_to_waiting_for_measurements_to_pendin
         .expect("Failed to add hardware health report to newly created machine");
 
     let response = mh.host().forge_agent_control().await;
+    assert!(matches!(response.action, Some(Action::Retry(_))));
+    assert_eq!(response.legacy_action, LegacyAction::Retry as i32);
+
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &host_machine_id,
+        3,
+        ManagedHostState::WaitingForCleanup {
+            cleanup_state: CleanupState::HostCleanup {
+                boss_controller_id: None,
+            },
+            cleanup_context: CleanupContext::InitialDiscovery,
+        },
+    )
+    .await;
+
+    let response = mh.host().forge_agent_control().await;
+    assert!(matches!(response.action, Some(Action::Reset(_))));
+    assert_eq!(response.legacy_action, LegacyAction::Reset as i32);
+
+    env.api
+        .cleanup_machine_completed(Request::new(rpc::MachineCleanupInfo {
+            machine_id: mh.id.into(),
+            ..Default::default()
+        }))
+        .await
+        .unwrap();
+
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &host_machine_id,
+        3,
+        ManagedHostState::HostInit {
+            machine_state: MachineState::WaitingForDiscovery,
+        },
+    )
+    .await;
+
+    let response = mh.host().forge_agent_control().await;
     assert!(matches!(response.action, Some(Action::Discovery(_))));
     assert_eq!(response.legacy_action, LegacyAction::Discovery as i32);
 
@@ -1778,6 +1815,40 @@ async fn test_measurement_host_init_failed_to_waiting_for_measurements_to_pendin
         ManagedHostState::Ready,
     )
     .await;
+}
+
+#[crate::sqlx_test]
+async fn test_forge_agent_control_assigned_discovery_boot_does_not_reset_without_cleanup_timestamp(
+    pool: sqlx::PgPool,
+) {
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+    let state = ManagedHostState::Assigned {
+        instance_state: InstanceState::BootingWithDiscoveryImage {
+            retry: RetryInfo { count: 0 },
+        },
+    };
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    db::machine::advance(&host, &mut txn, &state, None)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE machines SET last_cleanup_time = NULL WHERE id = $1")
+        .bind(mh.host().id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    assert!(host.last_cleanup_time.is_none());
+    txn.commit().await.unwrap();
+
+    let response = mh.host().forge_agent_control().await;
+    assert!(matches!(response.action, Some(Action::Noop(_))));
+    assert_eq!(response.legacy_action, LegacyAction::Noop as i32);
 }
 
 #[crate::sqlx_test]

--- a/crates/api/src/tests/resource_pool.rs
+++ b/crates/api/src/tests/resource_pool.rs
@@ -17,6 +17,7 @@
 
 use std::collections::HashSet;
 use std::net::Ipv4Addr;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use common::api_fixtures::create_test_env;
@@ -26,7 +27,7 @@ use model::resource_pool::{
 };
 use rpc::Metadata;
 use rpc::forge::forge_server::Forge;
-use sqlx::migrate::MigrateDatabase;
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 
 use crate::tests;
 use crate::tests::common;
@@ -575,12 +576,18 @@ async fn test_parallel() -> Result<(), eyre::Report> {
     // ResourcePool.name is varchar(32), so keep the DB name short.
     let short_id = &uuid::Uuid::new_v4().simple().to_string()[..8];
     let db_name = format!("test_par_{short_id}");
-    let db_url = format!("{base_url}/{db_name}");
+    let base_options = PgConnectOptions::from_str(&base_url)?;
 
-    let admin = sqlx::Pool::<sqlx::postgres::Postgres>::connect(&base_url).await?;
+    let admin = PgPoolOptions::new()
+        .connect_with(base_options.clone())
+        .await?;
 
-    sqlx::Postgres::create_database(&db_url).await?;
-    let db_pool = sqlx::Pool::<sqlx::postgres::Postgres>::connect(&db_url).await?;
+    sqlx::query(&format!("CREATE DATABASE \"{db_name}\""))
+        .execute(&admin)
+        .await?;
+    let db_pool = PgPoolOptions::new()
+        .connect_with(base_options.database(&db_name))
+        .await?;
     tests::MIGRATOR.run(&db_pool).await?;
 
     let mut txn = db_pool.begin().await?;

--- a/crates/scout/src/deprovision/scrabbing.rs
+++ b/crates/scout/src/deprovision/scrabbing.rs
@@ -1047,26 +1047,10 @@ pub async fn run_no_api(tpm_path: &str) -> Result<(), CarbideClientError> {
         return Ok(());
     }
     tracing::info!("no_api deprovision starts.");
-    let stdin_link = match fs::read_link("/proc/self/fd/0") {
-        Ok(o) => o.to_string_lossy().to_string(),
-        Err(_) => "None".to_string(),
-    };
-    tracing::info!("stdin is {}", stdin_link);
 
     crate::tpm::clear_tpm(tpm_path)?;
 
-    if stdin_link == "/dev/null" {
-        match all_nvme_cleanup().await {
-            Ok(_) => tracing::debug!("nvme cleanup OK"),
-            Err(e) => tracing::error!("nvme cleanup error: {}", e),
-        }
-        match all_hdd_cleanup().await {
-            Ok(_) => tracing::debug!("hdd cleanup OK"),
-            Err(e) => tracing::error!("hdd cleanup error: {}", e),
-        }
-    } else {
-        tracing::info!("stdin == {}. Skip nvme and HDD cleanup.", stdin_link);
-    }
+    tracing::info!("Skipping NVMe and HDD/SAS cleanup in no-api path; RESET owns storage cleanup.");
 
     // P1 errors are propagated (fail startup), P2 errors are handled internally in reset_ib_devices()
     reset_ib_devices().await?;

--- a/crates/scout/src/main.rs
+++ b/crates/scout/src/main.rs
@@ -318,7 +318,8 @@ async fn handle_action(
 ) -> Result<(), CarbideClientError> {
     match action {
         fac::Action::Discovery(_) => {
-            // This is temporary. All cleanup must be done when API call Reset.
+            // Discovery prep must not scrub storage. NVMe/HDD cleanup is owned by RESET so
+            // cleanup status is reported to the API and retried through the cleanup state.
             deprovision::run_no_api(&config.tpm_path).await?;
             let retry = registration::DiscoveryRetry {
                 secs: config.discovery_retry_secs,


### PR DESCRIPTION
## Summary

- Stop Scout's discovery/no-API path from performing hidden NVMe/HDD/SAS cleanup;
  discovery now leaves destructive storage cleanup to the API-directed reset path
- Add cleanup context to `WaitingForCleanup` so the state machine can distinguish
  initial discovery cleanup from deprovision cleanup and route recovery correctly
- Drive initial discovery through `WaitingForCleanup { InitialDiscovery }` before
  returning Scout `Action::Discovery`
- Preserve HostInit cleanup context across repeated `NVMECleanFailed` retries so a
  successful retry returns to `HostInit/WaitingForDiscovery`, not the deprovision flow
- Add regressions covering firmware-upgrade Scout boots, assigned discovery-image
  boots, and repeated HostInit cleanup failures

## Recovery context note

`NVMECleanFailed` recovery currently uses `FailureSource::StateMachineArea(HostInit)`
to remember that the failure happened during initial discovery cleanup. That keeps
this fix scoped and avoids changing serialized `FailureCause` shape in this PR.
A follow-up should consider storing cleanup context directly on the storage-cleanup
failure cause instead of inferring it from `FailureSource`.

## Dev environment validation

- [x] Deployed the local Carbide build into local-dev control-plane
      environment and verified the updated pods rolled out
- [x] Normal delete path: provisioned a host, deleted it, observed API cleanup
      state, Scout `RESET`, NVMe cleanup, successful `cleanup_machine_completed`,
      and no destructive cleanup during the later `DISCOVERY`
- [x] Force-delete/re-ingest path: force-deleted the host, observed the predicted
      host move through `WaitingForCleanup { InitialDiscovery }`, the actual host
      receive `RESET`, cleanup complete successfully, then `DISCOVERY` log the
      no-API cleanup skip message
- [x] Injected an NVMe cleanup failure in Scout for the delete path and verified
      the machine moved to `NVMECleanFailed`
- [x] Restored the non-failing Scout artifact, rebooted the host, and verified the
      machine recovered from `NVMECleanFailed`
- [x] Repeated the injected NVMe cleanup failure and recovery validation for the
      force-delete/re-ingest path
- [x] Verified API state transitions and Scout cleanup behavior in Loki logs

## Test plan

- [x] `cargo +1.90.0 fmt --all`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced context-aware cleanup flow that distinguishes between initial discovery and deprovision cleanup paths for improved failure recovery.

* **Bug Fixes**
  * Enhanced failure handling to preserve initial-discovery cleanup path during recovery, preventing incorrect state transitions.
  * Clarified storage cleanup responsibility, ensuring NVMe and HDD cleanup is properly delegated to the reset workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/infra-controller-core/pull/1748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->