### PR TITLE
feat(configurenmxc): harden nmxc  fabric state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6297,7 +6297,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.3#02f9c19148f4aa4c6b7c9e5efe8f40361c9a3167"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.4#dd2152ac5642c5256b893e396647e159003d0071"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -456,13 +456,16 @@ impl Display for RackMaintenanceState {
 
 /// Sub-states of `RackMaintenanceState::ConfigureNmxCluster`.
 ///
-/// `Start` selects a primary switch and asks RMS to configure the
-/// NMX cluster. `WaitForFabricStatus` polls
-/// `GetScaleUpFabricServicesStatus` and persists the per-switch
-/// `fabric_manager_status` before advancing.
+/// `Start` selects and persists the primary switch. `DisableScaleUpFabricState`
+/// disables ScaleUpFabric state on all scoped switches before
+/// `ConfigureScaleUpFabricManager` configures only the primary switch.
+/// `WaitForFabricStatus` polls `GetScaleUpFabricServicesStatus` and persists
+/// the per-switch `fabric_manager_status` before advancing.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ConfigureNmxClusterState {
     Start,
+    DisableScaleUpFabricState,
+    ConfigureScaleUpFabricManager,
     WaitForFabricStatus,
 }
 
@@ -470,6 +473,12 @@ impl Display for ConfigureNmxClusterState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ConfigureNmxClusterState::Start => write!(f, "Start"),
+            ConfigureNmxClusterState::DisableScaleUpFabricState => {
+                write!(f, "DisableScaleUpFabricState")
+            }
+            ConfigureNmxClusterState::ConfigureScaleUpFabricManager => {
+                write!(f, "ConfigureScaleUpFabricManager")
+            }
             ConfigureNmxClusterState::WaitForFabricStatus => write!(f, "WaitForFabricStatus"),
         }
     }

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -456,11 +456,12 @@ impl Display for RackMaintenanceState {
 
 /// Sub-states of `RackMaintenanceState::ConfigureNmxCluster`.
 ///
-/// `Start` selects and persists the primary switch. `DisableScaleUpFabricState`
+/// `Start` advances into the NMX cluster sequence. `DisableScaleUpFabricState`
 /// disables ScaleUpFabric state on all scoped switches before
-/// `ConfigureScaleUpFabricManager` configures only the primary switch.
-/// `WaitForFabricStatus` polls `GetScaleUpFabricServicesStatus` and persists
-/// the per-switch `fabric_manager_status` before advancing.
+/// `ConfigureScaleUpFabricManager` selects, persists, and configures only the
+/// primary switch. `WaitForFabricStatus` polls
+/// `GetScaleUpFabricServicesStatus` and persists the per-switch
+/// `fabric_manager_status` before advancing.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ConfigureNmxClusterState {
     Start,

--- a/crates/api-test-helper/src/mock_rms.rs
+++ b/crates/api-test-helper/src/mock_rms.rs
@@ -1068,54 +1068,6 @@ impl RmsApi for MockRmsApi {
         self.get_firmware_job_status_calls.lock().await.push(cmd);
         pop_or_err(&mut self.get_firmware_job_status_responses.lock().await)
     }
-    async fn add_firmware_object(
-        &self,
-        _cmd: rms::AddFirmwareObjectRequest,
-    ) -> Result<rms::FirmwareObject, RackManagerError> {
-        Ok(rms::FirmwareObject::default())
-    }
-    async fn get_firmware_object(
-        &self,
-        _cmd: rms::GetFirmwareObjectRequest,
-    ) -> Result<rms::FirmwareObject, RackManagerError> {
-        Ok(rms::FirmwareObject::default())
-    }
-    async fn list_firmware_objects(
-        &self,
-        _cmd: rms::ListFirmwareObjectsRequest,
-    ) -> Result<rms::ListFirmwareObjectsResponse, RackManagerError> {
-        Ok(rms::ListFirmwareObjectsResponse::default())
-    }
-    async fn delete_firmware_object(
-        &self,
-        _cmd: rms::DeleteFirmwareObjectRequest,
-    ) -> Result<rms::OperationResponse, RackManagerError> {
-        Ok(rms::OperationResponse::default())
-    }
-    async fn set_default_firmware_object(
-        &self,
-        _cmd: rms::SetDefaultFirmwareObjectRequest,
-    ) -> Result<rms::FirmwareObject, RackManagerError> {
-        Ok(rms::FirmwareObject::default())
-    }
-    async fn apply_firmware_object(
-        &self,
-        _cmd: rms::ApplyFirmwareObjectRequest,
-    ) -> Result<rms::ApplyFirmwareObjectResponse, RackManagerError> {
-        Ok(rms::ApplyFirmwareObjectResponse::default())
-    }
-    async fn apply_switch_system_image(
-        &self,
-        _cmd: rms::ApplySwitchSystemImageRequest,
-    ) -> Result<rms::ApplySwitchSystemImageResponse, RackManagerError> {
-        Ok(rms::ApplySwitchSystemImageResponse::default())
-    }
-    async fn get_firmware_object_history(
-        &self,
-        _cmd: rms::GetFirmwareObjectHistoryRequest,
-    ) -> Result<rms::GetFirmwareObjectHistoryResponse, RackManagerError> {
-        Ok(rms::GetFirmwareObjectHistoryResponse::default())
-    }
     async fn list_firmware_on_switch(
         &self,
         cmd: rms::ListFirmwareOnSwitchCommand,

--- a/crates/api-test-helper/src/mock_rms.rs
+++ b/crates/api-test-helper/src/mock_rms.rs
@@ -1068,6 +1068,54 @@ impl RmsApi for MockRmsApi {
         self.get_firmware_job_status_calls.lock().await.push(cmd);
         pop_or_err(&mut self.get_firmware_job_status_responses.lock().await)
     }
+    async fn add_firmware_object(
+        &self,
+        _cmd: rms::AddFirmwareObjectRequest,
+    ) -> Result<rms::FirmwareObject, RackManagerError> {
+        Ok(rms::FirmwareObject::default())
+    }
+    async fn get_firmware_object(
+        &self,
+        _cmd: rms::GetFirmwareObjectRequest,
+    ) -> Result<rms::FirmwareObject, RackManagerError> {
+        Ok(rms::FirmwareObject::default())
+    }
+    async fn list_firmware_objects(
+        &self,
+        _cmd: rms::ListFirmwareObjectsRequest,
+    ) -> Result<rms::ListFirmwareObjectsResponse, RackManagerError> {
+        Ok(rms::ListFirmwareObjectsResponse::default())
+    }
+    async fn delete_firmware_object(
+        &self,
+        _cmd: rms::DeleteFirmwareObjectRequest,
+    ) -> Result<rms::OperationResponse, RackManagerError> {
+        Ok(rms::OperationResponse::default())
+    }
+    async fn set_default_firmware_object(
+        &self,
+        _cmd: rms::SetDefaultFirmwareObjectRequest,
+    ) -> Result<rms::FirmwareObject, RackManagerError> {
+        Ok(rms::FirmwareObject::default())
+    }
+    async fn apply_firmware_object(
+        &self,
+        _cmd: rms::ApplyFirmwareObjectRequest,
+    ) -> Result<rms::ApplyFirmwareObjectResponse, RackManagerError> {
+        Ok(rms::ApplyFirmwareObjectResponse::default())
+    }
+    async fn apply_switch_system_image(
+        &self,
+        _cmd: rms::ApplySwitchSystemImageRequest,
+    ) -> Result<rms::ApplySwitchSystemImageResponse, RackManagerError> {
+        Ok(rms::ApplySwitchSystemImageResponse::default())
+    }
+    async fn get_firmware_object_history(
+        &self,
+        _cmd: rms::GetFirmwareObjectHistoryRequest,
+    ) -> Result<rms::GetFirmwareObjectHistoryResponse, RackManagerError> {
+        Ok(rms::GetFirmwareObjectHistoryResponse::default())
+    }
     async fn list_firmware_on_switch(
         &self,
         cmd: rms::ListFirmwareOnSwitchCommand,

--- a/crates/api/src/rack/rms_client.rs
+++ b/crates/api/src/rack/rms_client.rs
@@ -850,6 +850,12 @@ pub mod test_support {
                 .pop_front()
                 .unwrap_or(Ok(rms::SetScaleUpFabricStateResponse::default()))
         }
+        async fn set_scale_up_fabric_state(
+            &self,
+            _cmd: rms::SetScaleUpFabricStateRequest,
+        ) -> Result<rms::SetScaleUpFabricStateResponse, RackManagerError> {
+            Ok(rms::SetScaleUpFabricStateResponse::default())
+        }
         async fn fetch_switch_system_image(
             &self,
             _cmd: rms::FetchSwitchSystemImageRequest,

--- a/crates/api/src/rack/rms_client.rs
+++ b/crates/api/src/rack/rms_client.rs
@@ -82,6 +82,19 @@ pub mod test_support {
         switch_system_image_job_statuses:
             Arc<Mutex<HashMap<String, rms::GetSwitchSystemImageJobStatusResponse>>>,
         switch_system_image_job_errors: Arc<Mutex<HashMap<String, String>>>,
+        submitted_get_device_info_by_device_list_requests:
+            Arc<Mutex<Vec<rms::GetDeviceInfoByDeviceListRequest>>>,
+        queued_get_device_info_by_device_list_responses:
+            Arc<Mutex<VecDeque<Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError>>>>,
+        submitted_configure_scale_up_fabric_manager_requests:
+            Arc<Mutex<Vec<rms::ConfigureScaleUpFabricManagerRequest>>>,
+        queued_configure_scale_up_fabric_manager_responses: Arc<
+            Mutex<VecDeque<Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError>>>,
+        >,
+        submitted_set_scale_up_fabric_state_requests:
+            Arc<Mutex<Vec<rms::SetScaleUpFabricStateRequest>>>,
+        queued_set_scale_up_fabric_state_responses:
+            Arc<Mutex<VecDeque<Result<rms::SetScaleUpFabricStateResponse, RackManagerError>>>>,
         submitted_set_power_state_by_device_list_requests:
             Arc<Mutex<Vec<rms::SetPowerStateByDeviceListRequest>>>,
         queued_set_power_state_by_device_list_responses:
@@ -111,6 +124,18 @@ pub mod test_support {
                 queued_apply_switch_system_image_responses: Arc::new(Mutex::new(VecDeque::new())),
                 switch_system_image_job_statuses: Arc::new(Mutex::new(HashMap::new())),
                 switch_system_image_job_errors: Arc::new(Mutex::new(HashMap::new())),
+                submitted_get_device_info_by_device_list_requests: Arc::new(Mutex::new(Vec::new())),
+                queued_get_device_info_by_device_list_responses: Arc::new(Mutex::new(
+                    VecDeque::new(),
+                )),
+                submitted_configure_scale_up_fabric_manager_requests: Arc::new(Mutex::new(
+                    Vec::new(),
+                )),
+                queued_configure_scale_up_fabric_manager_responses: Arc::new(Mutex::new(
+                    VecDeque::new(),
+                )),
+                submitted_set_scale_up_fabric_state_requests: Arc::new(Mutex::new(Vec::new())),
+                queued_set_scale_up_fabric_state_responses: Arc::new(Mutex::new(VecDeque::new())),
                 submitted_set_power_state_by_device_list_requests: Arc::new(Mutex::new(Vec::new())),
                 queued_set_power_state_by_device_list_responses: Arc::new(Mutex::new(
                     VecDeque::new(),
@@ -161,6 +186,24 @@ pub mod test_support {
                     .clone(),
                 switch_system_image_job_statuses: self.switch_system_image_job_statuses.clone(),
                 switch_system_image_job_errors: self.switch_system_image_job_errors.clone(),
+                submitted_get_device_info_by_device_list_requests: self
+                    .submitted_get_device_info_by_device_list_requests
+                    .clone(),
+                queued_get_device_info_by_device_list_responses: self
+                    .queued_get_device_info_by_device_list_responses
+                    .clone(),
+                submitted_configure_scale_up_fabric_manager_requests: self
+                    .submitted_configure_scale_up_fabric_manager_requests
+                    .clone(),
+                queued_configure_scale_up_fabric_manager_responses: self
+                    .queued_configure_scale_up_fabric_manager_responses
+                    .clone(),
+                submitted_set_scale_up_fabric_state_requests: self
+                    .submitted_set_scale_up_fabric_state_requests
+                    .clone(),
+                queued_set_scale_up_fabric_state_responses: self
+                    .queued_set_scale_up_fabric_state_responses
+                    .clone(),
                 submitted_set_power_state_by_device_list_requests: self
                     .submitted_set_power_state_by_device_list_requests
                     .clone(),
@@ -302,6 +345,63 @@ pub mod test_support {
                 .clone()
         }
 
+        pub async fn queue_get_device_info_by_device_list_response(
+            &self,
+            response: Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError>,
+        ) {
+            self.queued_get_device_info_by_device_list_responses
+                .lock()
+                .await
+                .push_back(response);
+        }
+
+        pub async fn submitted_get_device_info_by_device_list_requests(
+            &self,
+        ) -> Vec<rms::GetDeviceInfoByDeviceListRequest> {
+            self.submitted_get_device_info_by_device_list_requests
+                .lock()
+                .await
+                .clone()
+        }
+
+        pub async fn queue_configure_scale_up_fabric_manager_response(
+            &self,
+            response: Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError>,
+        ) {
+            self.queued_configure_scale_up_fabric_manager_responses
+                .lock()
+                .await
+                .push_back(response);
+        }
+
+        pub async fn submitted_configure_scale_up_fabric_manager_requests(
+            &self,
+        ) -> Vec<rms::ConfigureScaleUpFabricManagerRequest> {
+            self.submitted_configure_scale_up_fabric_manager_requests
+                .lock()
+                .await
+                .clone()
+        }
+
+        pub async fn queue_set_scale_up_fabric_state_response(
+            &self,
+            response: Result<rms::SetScaleUpFabricStateResponse, RackManagerError>,
+        ) {
+            self.queued_set_scale_up_fabric_state_responses
+                .lock()
+                .await
+                .push_back(response);
+        }
+
+        pub async fn submitted_set_scale_up_fabric_state_requests(
+            &self,
+        ) -> Vec<rms::SetScaleUpFabricStateRequest> {
+            self.submitted_set_scale_up_fabric_state_requests
+                .lock()
+                .await
+                .clone()
+        }
+
         /// Queue a `Result` to be returned on the next call to
         /// `set_power_state_by_device_list`. Used by power-shelf maintenance
         /// tests to drive both the success and failure paths of the
@@ -352,6 +452,19 @@ pub mod test_support {
         switch_system_image_job_statuses:
             Arc<Mutex<HashMap<String, rms::GetSwitchSystemImageJobStatusResponse>>>,
         switch_system_image_job_errors: Arc<Mutex<HashMap<String, String>>>,
+        submitted_get_device_info_by_device_list_requests:
+            Arc<Mutex<Vec<rms::GetDeviceInfoByDeviceListRequest>>>,
+        queued_get_device_info_by_device_list_responses:
+            Arc<Mutex<VecDeque<Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError>>>>,
+        submitted_configure_scale_up_fabric_manager_requests:
+            Arc<Mutex<Vec<rms::ConfigureScaleUpFabricManagerRequest>>>,
+        queued_configure_scale_up_fabric_manager_responses: Arc<
+            Mutex<VecDeque<Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError>>>,
+        >,
+        submitted_set_scale_up_fabric_state_requests:
+            Arc<Mutex<Vec<rms::SetScaleUpFabricStateRequest>>>,
+        queued_set_scale_up_fabric_state_responses:
+            Arc<Mutex<VecDeque<Result<rms::SetScaleUpFabricStateResponse, RackManagerError>>>>,
         submitted_set_power_state_by_device_list_requests:
             Arc<Mutex<Vec<rms::SetPowerStateByDeviceListRequest>>>,
         queued_set_power_state_by_device_list_responses:
@@ -362,9 +475,17 @@ pub mod test_support {
     impl RmsApi for MockRmsClient {
         async fn get_device_info_by_device_list(
             &self,
-            _cmd: rms::GetDeviceInfoByDeviceListRequest,
+            cmd: rms::GetDeviceInfoByDeviceListRequest,
         ) -> Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError> {
-            Ok(rms::GetDeviceInfoByDeviceListResponse::default())
+            self.submitted_get_device_info_by_device_list_requests
+                .lock()
+                .await
+                .push(cmd);
+            self.queued_get_device_info_by_device_list_responses
+                .lock()
+                .await
+                .pop_front()
+                .unwrap_or(Ok(rms::GetDeviceInfoByDeviceListResponse::default()))
         }
         async fn get_node_device_info(
             &self,
@@ -703,15 +824,31 @@ pub mod test_support {
         }
         async fn configure_scale_up_fabric_manager(
             &self,
-            _cmd: rms::ConfigureScaleUpFabricManagerRequest,
+            cmd: rms::ConfigureScaleUpFabricManagerRequest,
         ) -> Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError> {
-            Ok(rms::ConfigureScaleUpFabricManagerResponse::default())
+            self.submitted_configure_scale_up_fabric_manager_requests
+                .lock()
+                .await
+                .push(cmd);
+            self.queued_configure_scale_up_fabric_manager_responses
+                .lock()
+                .await
+                .pop_front()
+                .unwrap_or(Ok(rms::ConfigureScaleUpFabricManagerResponse::default()))
         }
         async fn set_scale_up_fabric_state(
             &self,
-            _cmd: rms::SetScaleUpFabricStateRequest,
+            cmd: rms::SetScaleUpFabricStateRequest,
         ) -> Result<rms::SetScaleUpFabricStateResponse, RackManagerError> {
-            Ok(rms::SetScaleUpFabricStateResponse::default())
+            self.submitted_set_scale_up_fabric_state_requests
+                .lock()
+                .await
+                .push(cmd);
+            self.queued_set_scale_up_fabric_state_responses
+                .lock()
+                .await
+                .pop_front()
+                .unwrap_or(Ok(rms::SetScaleUpFabricStateResponse::default()))
         }
         async fn fetch_switch_system_image(
             &self,

--- a/crates/api/src/rack/rms_client.rs
+++ b/crates/api/src/rack/rms_client.rs
@@ -850,12 +850,6 @@ pub mod test_support {
                 .pop_front()
                 .unwrap_or(Ok(rms::SetScaleUpFabricStateResponse::default()))
         }
-        async fn set_scale_up_fabric_state(
-            &self,
-            _cmd: rms::SetScaleUpFabricStateRequest,
-        ) -> Result<rms::SetScaleUpFabricStateResponse, RackManagerError> {
-            Ok(rms::SetScaleUpFabricStateResponse::default())
-        }
         async fn fetch_switch_system_image(
             &self,
             _cmd: rms::FetchSwitchSystemImageRequest,

--- a/crates/api/src/state_controller/rack/maintenance.rs
+++ b/crates/api/src/state_controller/rack/maintenance.rs
@@ -2021,6 +2021,10 @@ pub async fn handle_maintenance(
                     },
                 }))
             }
+            ConfigureNmxClusterState::DisableScaleUpFabricState
+            | ConfigureNmxClusterState::ConfigureScaleUpFabricManager => Ok(
+                StateHandlerOutcome::wait("ConfigureNmxCluster sub-state is not wired yet".into()),
+            ),
             ConfigureNmxClusterState::WaitForFabricStatus => {
                 let switch_inventory = load_rack_switch_firmware_inventory(
                     &ctx.services.db_pool,

--- a/crates/api/src/state_controller/rack/maintenance.rs
+++ b/crates/api/src/state_controller/rack/maintenance.rs
@@ -1892,6 +1892,10 @@ pub async fn handle_maintenance(
                     },
                 }))
             }
+            ConfigureNmxClusterState::DisableScaleUpFabricState
+            | ConfigureNmxClusterState::ConfigureScaleUpFabricManager => Ok(
+                StateHandlerOutcome::wait("ConfigureNmxCluster sub-state is not wired yet".into()),
+            ),
             ConfigureNmxClusterState::WaitForFabricStatus => {
                 let switch_inventory = load_rack_switch_firmware_inventory(
                     &ctx.services.db_pool,

--- a/crates/api/src/state_controller/rack/maintenance.rs
+++ b/crates/api/src/state_controller/rack/maintenance.rs
@@ -26,6 +26,7 @@ use carbide_rack::firmware_update::{
 };
 use carbide_rack::rack_manager_error;
 use carbide_rack::rms_client::SwitchSystemImageRmsClient;
+use carbide_rack_controller::config::RmsConfig;
 use carbide_rack_controller::context::RackStateHandlerContextObjects;
 use carbide_rack_controller::fabric_manager::{
     get_scale_up_fabric_services_status, persist_fabric_manager_statuses, persist_primary_switch,
@@ -448,6 +449,31 @@ fn build_switch_device_info_request(
         }),
         ..Default::default()
     }
+}
+
+#[cfg(not(test))]
+const NMX_CONFIGURE_RMS_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+#[cfg(not(test))]
+fn build_nmx_configure_rms_client(rms_config: &RmsConfig) -> Option<librms::RackManagerApi> {
+    let url = rms_config
+        .api_url
+        .as_deref()
+        .filter(|url| !url.is_empty())?;
+    let mut rms_client_config = librms::client_config::RmsClientConfig::new(
+        rms_config.root_ca_path.clone(),
+        rms_config.client_cert.clone(),
+        rms_config.client_key.clone(),
+        rms_config.enforce_tls,
+    );
+    rms_client_config.connect_timeout = Some(NMX_CONFIGURE_RMS_CONNECT_TIMEOUT);
+    let rms_api_config = librms::client::RmsApiConfig::new(url, &rms_client_config);
+    Some(librms::RackManagerApi::new(&rms_api_config))
+}
+
+#[cfg(test)]
+fn build_nmx_configure_rms_client(_rms_config: &RmsConfig) -> Option<librms::RackManagerApi> {
+    None
 }
 
 fn rms_component_filters_from_components(
@@ -1732,10 +1758,23 @@ pub async fn handle_maintenance(
                 }))
             }
             ConfigureNmxClusterState::DisableScaleUpFabricState => {
-                let Some(rms_client) = ctx.services.rms_client.as_ref() else {
-                    return transition_to_rack_error(id, state, "RMS client not configured", ctx)
-                        .await;
-                };
+                let nmx_configure_rms_client =
+                    build_nmx_configure_rms_client(&ctx.services.site_config.rms);
+                let rms_client: &dyn librms::RmsApi =
+                    if let Some(rms_client) = nmx_configure_rms_client.as_ref() {
+                        rms_client
+                    } else {
+                        let Some(rms_client) = ctx.services.rms_client.as_ref() else {
+                            return transition_to_rack_error(
+                                id,
+                                state,
+                                "RMS client not configured",
+                                ctx,
+                            )
+                            .await;
+                        };
+                        rms_client.as_ref()
+                    };
                 let switch_inventory = load_rack_switch_firmware_inventory(
                     &ctx.services.db_pool,
                     ctx.services.credential_manager.as_ref(),
@@ -1850,10 +1889,23 @@ pub async fn handle_maintenance(
                 }))
             }
             ConfigureNmxClusterState::ConfigureScaleUpFabricManager => {
-                let Some(rms_client) = ctx.services.rms_client.as_ref() else {
-                    return transition_to_rack_error(id, state, "RMS client not configured", ctx)
-                        .await;
-                };
+                let nmx_configure_rms_client =
+                    build_nmx_configure_rms_client(&ctx.services.site_config.rms);
+                let rms_client: &dyn librms::RmsApi =
+                    if let Some(rms_client) = nmx_configure_rms_client.as_ref() {
+                        rms_client
+                    } else {
+                        let Some(rms_client) = ctx.services.rms_client.as_ref() else {
+                            return transition_to_rack_error(
+                                id,
+                                state,
+                                "RMS client not configured",
+                                ctx,
+                            )
+                            .await;
+                        };
+                        rms_client.as_ref()
+                    };
                 let switch_inventory = load_rack_switch_firmware_inventory(
                     &ctx.services.db_pool,
                     ctx.services.credential_manager.as_ref(),
@@ -2021,10 +2073,6 @@ pub async fn handle_maintenance(
                     },
                 }))
             }
-            ConfigureNmxClusterState::DisableScaleUpFabricState
-            | ConfigureNmxClusterState::ConfigureScaleUpFabricManager => Ok(
-                StateHandlerOutcome::wait("ConfigureNmxCluster sub-state is not wired yet".into()),
-            ),
             ConfigureNmxClusterState::WaitForFabricStatus => {
                 let switch_inventory = load_rack_switch_firmware_inventory(
                     &ctx.services.db_pool,

--- a/crates/api/src/state_controller/rack/maintenance.rs
+++ b/crates/api/src/state_controller/rack/maintenance.rs
@@ -452,7 +452,7 @@ fn build_switch_device_info_request(
 }
 
 #[cfg(not(test))]
-const NMX_CONFIGURE_RMS_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+const NMX_CONFIGURE_RMS_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 #[cfg(not(test))]
 fn build_nmx_configure_rms_client(rms_config: &RmsConfig) -> Option<librms::RackManagerApi> {

--- a/crates/api/src/state_controller/rack/maintenance.rs
+++ b/crates/api/src/state_controller/rack/maintenance.rs
@@ -1721,6 +1721,17 @@ pub async fn handle_maintenance(
             configure_nmx_cluster,
         } => match configure_nmx_cluster {
             ConfigureNmxClusterState::Start => {
+                tracing::info!(
+                    rack_id = %id,
+                    "Starting ConfigureNmxCluster; advancing to DisableScaleUpFabricState"
+                );
+                Ok(StateHandlerOutcome::transition(RackState::Maintenance {
+                    maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+                        configure_nmx_cluster: ConfigureNmxClusterState::DisableScaleUpFabricState,
+                    },
+                }))
+            }
+            ConfigureNmxClusterState::DisableScaleUpFabricState => {
                 let Some(rms_client) = ctx.services.rms_client.as_ref() else {
                     return transition_to_rack_error(id, state, "RMS client not configured", ctx)
                         .await;
@@ -1733,7 +1744,125 @@ pub async fn handle_maintenance(
                 .await
                 .map_err(|error| {
                     StateHandlerError::GenericError(eyre::eyre!(
-                        "failed to load rack switch firmware inventory for ConfigureNmxCluster: {}",
+                        "failed to load rack switch firmware inventory for DisableScaleUpFabricState: {}",
+                        error
+                    ))
+                })?;
+                let switch_inventory = filter_switch_inventory_by_scope(switch_inventory, scope);
+
+                if switch_inventory.switches.is_empty() {
+                    return Ok(skip_configure_nmx_cluster_outcome(
+                        id,
+                        "rack has no switches in inventory",
+                        scope,
+                    ));
+                }
+
+                if let Err(cause) =
+                    validate_switch_inventory_for_nmx_cluster(&switch_inventory.switches)
+                {
+                    return transition_to_rack_error(id, state, cause, ctx).await;
+                }
+
+                tracing::info!(
+                    rack_id = %id,
+                    switch_count = switch_inventory.switches.len(),
+                    "Disabling ScaleUpFabric state before selecting ConfigureNmxCluster primary switch"
+                );
+                let response = match rms_client
+                    .set_scale_up_fabric_state(rms::SetScaleUpFabricStateRequest {
+                        nodes: Some(rms::NodeSet {
+                            devices: switch_inventory
+                                .switches
+                                .iter()
+                                .map(|switch| {
+                                    build_new_node_info(id, switch, rms::NodeType::Switch)
+                                })
+                                .collect(),
+                        }),
+                        enabled: Some(false),
+                        verify_ssl: false,
+                        ..Default::default()
+                    })
+                    .await
+                {
+                    Ok(response) => response,
+                    Err(error) => {
+                        let error = rack_manager_error("set_scale_up_fabric_state", error);
+                        return transition_to_rack_error(id, state, error.to_string(), ctx).await;
+                    }
+                };
+
+                let batch = response.response.unwrap_or_default();
+                if batch.status != rms::ReturnCode::Success as i32 || batch.failed_nodes > 0 {
+                    let node_error = batch
+                        .node_results
+                        .iter()
+                        .find(|result| {
+                            result.status != rms::ReturnCode::Success as i32
+                                || !result.error_message.is_empty()
+                        })
+                        .map(|result| {
+                            if result.error_message.is_empty() {
+                                format!("status={}", result.status)
+                            } else {
+                                result.error_message.clone()
+                            }
+                        });
+                    let summary = if !batch.message.trim().is_empty() {
+                        batch.message
+                    } else if let Some(error) = node_error {
+                        error
+                    } else {
+                        format!(
+                            "batch status {}, failed_nodes {}",
+                            batch.status, batch.failed_nodes,
+                        )
+                    };
+                    tracing::error!(
+                        rack_id = %id,
+                        batch_status = batch.status,
+                        successful_nodes = batch.successful_nodes,
+                        failed_nodes = batch.failed_nodes,
+                        summary = %summary,
+                        "RMS SetScaleUpFabricState failed",
+                    );
+                    return transition_to_rack_error(
+                        id,
+                        state,
+                        format!("RMS SetScaleUpFabricState failed: {}", summary),
+                        ctx,
+                    )
+                    .await;
+                }
+
+                tracing::info!(
+                    rack_id = %id,
+                    successful_nodes = batch.successful_nodes,
+                    switch_count = switch_inventory.switches.len(),
+                    "ScaleUpFabric state disabled; advancing to ConfigureScaleUpFabricManager"
+                );
+                Ok(StateHandlerOutcome::transition(RackState::Maintenance {
+                    maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+                        configure_nmx_cluster:
+                            ConfigureNmxClusterState::ConfigureScaleUpFabricManager,
+                    },
+                }))
+            }
+            ConfigureNmxClusterState::ConfigureScaleUpFabricManager => {
+                let Some(rms_client) = ctx.services.rms_client.as_ref() else {
+                    return transition_to_rack_error(id, state, "RMS client not configured", ctx)
+                        .await;
+                };
+                let switch_inventory = load_rack_switch_firmware_inventory(
+                    &ctx.services.db_pool,
+                    ctx.services.credential_manager.as_ref(),
+                    id,
+                )
+                .await
+                .map_err(|error| {
+                    StateHandlerError::GenericError(eyre::eyre!(
+                        "failed to load rack switch firmware inventory for ConfigureScaleUpFabricManager: {}",
                         error
                     ))
                 })?;
@@ -1892,10 +2021,6 @@ pub async fn handle_maintenance(
                     },
                 }))
             }
-            ConfigureNmxClusterState::DisableScaleUpFabricState
-            | ConfigureNmxClusterState::ConfigureScaleUpFabricManager => Ok(
-                StateHandlerOutcome::wait("ConfigureNmxCluster sub-state is not wired yet".into()),
-            ),
             ConfigureNmxClusterState::WaitForFabricStatus => {
                 let switch_inventory = load_rack_switch_firmware_inventory(
                     &ctx.services.db_pool,

--- a/crates/api/src/tests/rack_state_controller/handler.rs
+++ b/crates/api/src/tests/rack_state_controller/handler.rs
@@ -37,7 +37,6 @@ use model::rack_type::{
     RackHardwareClass, RackHardwareTopology, RackHardwareType, RackProfile, RackProfileConfig,
 };
 use model::switch::{NewSwitch, SwitchConfig};
-use serde_json::json;
 use tonic::Request;
 
 use crate::state_controller::db_write_batch::DbWriteBatch;
@@ -170,58 +169,6 @@ fn config_with_nmx_cluster_profile() -> crate::cfg::file::CarbideConfig {
         },
     );
     config
-}
-
-fn default_lookup_table_json() -> serde_json::Value {
-    json!({
-        "devices": {
-            "Compute Node": {
-                "HMC_prod": {
-                    "filename": "hmc-prod.bin",
-                    "target": "/redfish/v1/Chassis/HGX_Chassis_0",
-                    "component": "HMC",
-                    "bundle": "bundle-hmc",
-                    "firmware_type": "prod",
-                    "version": "1.0.0"
-                },
-                "BMC_prod": {
-                    "filename": "bmc-prod.bin",
-                    "target": "FW_BMC_0",
-                    "component": "BMC",
-                    "bundle": "bundle-bmc",
-                    "firmware_type": "prod",
-                    "version": "1.0.0"
-                }
-            }
-        }
-    })
-}
-
-async fn insert_default_rack_firmware(
-    pool: &sqlx::PgPool,
-    firmware_id: &str,
-    rack_hardware_type: RackHardwareType,
-    available: bool,
-) {
-    let mut txn = pool.begin().await.unwrap();
-    db::rack_firmware::create(
-        &mut txn,
-        firmware_id,
-        rack_hardware_type,
-        json!({ "Id": firmware_id }),
-        Some(default_lookup_table_json()),
-    )
-    .await
-    .unwrap();
-    if available {
-        db::rack_firmware::set_available(&mut txn, firmware_id, true)
-            .await
-            .unwrap();
-    }
-    db::rack_firmware::set_default(&mut txn, firmware_id)
-        .await
-        .unwrap();
-    txn.commit().await.unwrap();
 }
 
 async fn create_single_compute_rack(

--- a/crates/api/src/tests/rack_state_controller/handler.rs
+++ b/crates/api/src/tests/rack_state_controller/handler.rs
@@ -2526,6 +2526,268 @@ async fn test_configure_nmx_cluster_configure_selects_persists_and_configures_pr
 }
 
 #[crate::sqlx_test]
+async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fabric_status(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides {
+            config: Some(config_with_nmx_cluster_profile()),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let rack_id = new_rack_id();
+    let mut txn = pool.acquire().await?;
+    db_rack::create(
+        &mut txn,
+        &rack_id,
+        Some(&RackProfileId::new("NmxCluster")),
+        &RackConfig::default(),
+        None,
+    )
+    .await?;
+    drop(txn);
+
+    let switch_ids = attach_switches_with_nvos_credentials(&env, &rack_id, 2).await?;
+    let secondary_switch_id = switch_ids[0].clone();
+    let primary_switch_id = switch_ids[1].clone();
+    let topology_type = RackHardwareTopology::Gb200Nvl72r1C2g4Topology.to_string();
+
+    env.rms_sim
+        .queue_set_scale_up_fabric_state_response(Ok(rms::SetScaleUpFabricStateResponse {
+            response: Some(rms::NodeBatchResponse {
+                status: rms::ReturnCode::Success as i32,
+                successful_nodes: switch_ids.len() as i32,
+                failed_nodes: 0,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+        .await;
+    env.rms_sim
+        .queue_get_device_info_by_device_list_response(Ok(rms::GetDeviceInfoByDeviceListResponse {
+            status: rms::ReturnCode::Success as i32,
+            node_device_info: vec![
+                rms::NodeDeviceInfo {
+                    node_id: secondary_switch_id.to_string(),
+                    tray_index: Some(2),
+                    slot_number: Some(2),
+                    ..Default::default()
+                },
+                rms::NodeDeviceInfo {
+                    node_id: primary_switch_id.to_string(),
+                    tray_index: Some(1),
+                    slot_number: Some(1),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }))
+        .await;
+    env.rms_sim
+        .queue_configure_scale_up_fabric_manager_response(Ok(
+            rms::ConfigureScaleUpFabricManagerResponse {
+                status: rms::ReturnCode::Success as i32,
+                topology_used: topology_type.clone(),
+                scale_up_fabric_state_enabled: false,
+                grpc_enabled: true,
+                ..Default::default()
+            },
+        ))
+        .await;
+
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+
+    let handler_instance = RackStateHandler::default();
+    let mut services = env.state_handler_services();
+    let mut metrics = RackMetrics::default();
+    let mut db_writes = DbWriteBatch::default();
+    let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut db_writes,
+    };
+
+    let start_state = RackState::Maintenance {
+        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+            configure_nmx_cluster: ConfigureNmxClusterState::Start,
+        },
+    };
+    let outcome = handler_instance
+        .handle_object_state(&rack_id, &mut rack, &start_state, &mut ctx)
+        .await?;
+    let disable_state = match outcome {
+        StateHandlerOutcome::Transition { next_state, .. } => {
+            assert!(
+                matches!(
+                    next_state,
+                    RackState::Maintenance {
+                        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+                            configure_nmx_cluster:
+                                ConfigureNmxClusterState::DisableScaleUpFabricState,
+                        },
+                    }
+                ),
+                "ConfigureNmxCluster(Start) should transition to DisableScaleUpFabricState, got {:?}",
+                next_state
+            );
+            next_state
+        }
+        other => panic!(
+            "Expected Transition, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    };
+
+    assert!(
+        env.rms_sim
+            .submitted_set_scale_up_fabric_state_requests()
+            .await
+            .is_empty()
+    );
+    assert!(
+        env.rms_sim
+            .submitted_get_device_info_by_device_list_requests()
+            .await
+            .is_empty()
+    );
+    assert!(
+        env.rms_sim
+            .submitted_configure_scale_up_fabric_manager_requests()
+            .await
+            .is_empty()
+    );
+
+    let outcome = handler_instance
+        .handle_object_state(&rack_id, &mut rack, &disable_state, &mut ctx)
+        .await?;
+    let configure_state = match outcome {
+        StateHandlerOutcome::Transition { next_state, .. } => {
+            assert!(
+                matches!(
+                    next_state,
+                    RackState::Maintenance {
+                        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+                            configure_nmx_cluster:
+                                ConfigureNmxClusterState::ConfigureScaleUpFabricManager,
+                        },
+                    }
+                ),
+                "DisableScaleUpFabricState should transition to ConfigureScaleUpFabricManager, got {:?}",
+                next_state
+            );
+            next_state
+        }
+        other => panic!(
+            "Expected Transition, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    };
+
+    let disable_requests = env
+        .rms_sim
+        .submitted_set_scale_up_fabric_state_requests()
+        .await;
+    assert_eq!(disable_requests.len(), 1);
+    let disable_request = &disable_requests[0];
+    assert_eq!(disable_request.enabled, Some(false));
+    let disable_devices = disable_request
+        .nodes
+        .as_ref()
+        .expect("disable request should include nodes")
+        .devices
+        .as_slice();
+    assert_eq!(disable_devices.len(), switch_ids.len());
+    let disabled_node_ids = disable_devices
+        .iter()
+        .map(|device| device.node_id.clone())
+        .collect::<std::collections::HashSet<_>>();
+    for switch_id in &switch_ids {
+        assert!(disabled_node_ids.contains(&switch_id.to_string()));
+    }
+    assert!(
+        env.rms_sim
+            .submitted_get_device_info_by_device_list_requests()
+            .await
+            .is_empty()
+    );
+    assert!(
+        env.rms_sim
+            .submitted_configure_scale_up_fabric_manager_requests()
+            .await
+            .is_empty()
+    );
+
+    let outcome = handler_instance
+        .handle_object_state(&rack_id, &mut rack, &configure_state, &mut ctx)
+        .await?;
+
+    match outcome {
+        StateHandlerOutcome::Transition { next_state, .. } => {
+            assert!(
+                matches!(
+                    next_state,
+                    RackState::Maintenance {
+                        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+                            configure_nmx_cluster: ConfigureNmxClusterState::WaitForFabricStatus,
+                        },
+                    }
+                ),
+                "ConfigureScaleUpFabricManager should transition to WaitForFabricStatus, got {:?}",
+                next_state
+            );
+        }
+        other => panic!(
+            "Expected Transition, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+
+    let device_info_requests = env
+        .rms_sim
+        .submitted_get_device_info_by_device_list_requests()
+        .await;
+    assert_eq!(device_info_requests.len(), 1);
+    let device_info_devices = device_info_requests[0]
+        .nodes
+        .as_ref()
+        .expect("device-info request should include nodes")
+        .devices
+        .as_slice();
+    assert_eq!(device_info_devices.len(), switch_ids.len());
+
+    let configure_requests = env
+        .rms_sim
+        .submitted_configure_scale_up_fabric_manager_requests()
+        .await;
+    assert_eq!(configure_requests.len(), 1);
+    let configure_request = &configure_requests[0];
+    assert_eq!(configure_request.topology_type, topology_type);
+    assert_eq!(
+        configure_request
+            .device
+            .as_ref()
+            .expect("configure request should include a primary switch")
+            .node_id,
+        primary_switch_id.to_string()
+    );
+
+    let mut txn = pool.acquire().await?;
+    let primary_switch = db_switch::find_by_id(&mut txn, &primary_switch_id)
+        .await?
+        .expect("primary switch should exist");
+    let secondary_switch = db_switch::find_by_id(&mut txn, &secondary_switch_id)
+        .await?
+        .expect("secondary switch should exist");
+    assert!(primary_switch.is_primary);
+    assert!(!secondary_switch.is_primary);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_failure_stops_flow(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/api/src/tests/rack_state_controller/handler.rs
+++ b/crates/api/src/tests/rack_state_controller/handler.rs
@@ -321,13 +321,13 @@ async fn attach_switches_with_nvos_credentials(
         )?;
 
         let new_switch = NewSwitch {
-            id: switch_id.clone(),
+            id: switch_id,
             config: SwitchConfig {
                 name: expected_switch.metadata.name.clone(),
                 enable_nmxc: false,
                 fabric_manager_config: None,
             },
-            bmc_mac_address: Some(expected_switch.bmc_mac_address.clone()),
+            bmc_mac_address: Some(expected_switch.bmc_mac_address),
             metadata: None,
             rack_id: Some(rack_id.clone()),
             slot_number: Some(index as i32),
@@ -344,7 +344,7 @@ async fn attach_switches_with_nvos_credentials(
             .set_credentials(
                 &CredentialKey::BmcCredentials {
                     credential_type: BmcCredentialType::BmcRoot {
-                        bmc_mac_address: expected_switch.bmc_mac_address.clone(),
+                        bmc_mac_address: expected_switch.bmc_mac_address,
                     },
                 },
                 &Credentials::UsernamePassword {
@@ -2288,7 +2288,6 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_runs_on_all_sw
                 failed_nodes: 0,
                 ..Default::default()
             }),
-            ..Default::default()
         }))
         .await;
 
@@ -2398,8 +2397,8 @@ async fn test_configure_nmx_cluster_configure_selects_persists_and_configures_pr
     drop(txn);
 
     let switch_ids = attach_switches_with_nvos_credentials(&env, &rack_id, 2).await?;
-    let secondary_switch_id = switch_ids[0].clone();
-    let primary_switch_id = switch_ids[1].clone();
+    let secondary_switch_id = switch_ids[0];
+    let primary_switch_id = switch_ids[1];
     let topology_type = RackHardwareTopology::Gb200Nvl72r1C2g4Topology.to_string();
 
     env.rms_sim
@@ -2551,8 +2550,8 @@ async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fab
     drop(txn);
 
     let switch_ids = attach_switches_with_nvos_credentials(&env, &rack_id, 2).await?;
-    let secondary_switch_id = switch_ids[0].clone();
-    let primary_switch_id = switch_ids[1].clone();
+    let secondary_switch_id = switch_ids[0];
+    let primary_switch_id = switch_ids[1];
     let topology_type = RackHardwareTopology::Gb200Nvl72r1C2g4Topology.to_string();
 
     env.rms_sim
@@ -2563,7 +2562,6 @@ async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fab
                 failed_nodes: 0,
                 ..Default::default()
             }),
-            ..Default::default()
         }))
         .await;
     env.rms_sim
@@ -2815,7 +2813,6 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_failure_stops_
                 message: "disable rejected".to_string(),
                 ..Default::default()
             }),
-            ..Default::default()
         }))
         .await;
 
@@ -3015,7 +3012,7 @@ async fn test_configure_nmx_cluster_configure_failure_advances_to_wait_for_fabri
     drop(txn);
 
     let switch_ids = attach_switches_with_nvos_credentials(&env, &rack_id, 2).await?;
-    let primary_switch_id = switch_ids[0].clone();
+    let primary_switch_id = switch_ids[0];
     let topology_type = RackHardwareTopology::Gb200Nvl72r1C2g4Topology.to_string();
 
     env.rms_sim

--- a/crates/api/src/tests/rack_state_controller/handler.rs
+++ b/crates/api/src/tests/rack_state_controller/handler.rs
@@ -27,9 +27,10 @@ use librms::protos::rack_manager as rms;
 use model::expected_machine::ExpectedMachineData;
 use model::expected_rack::ExpectedRack;
 use model::rack::{
-    FirmwareUpgradeDeviceStatus, FirmwareUpgradeJob, FirmwareUpgradeState, MaintenanceActivity,
-    MaintenanceScope, NvosUpdateState, NvosUpdateSwitchStatus, Rack, RackConfig,
-    RackFirmwareUpgradeState, RackMaintenanceState, RackPowerState, RackState, RackValidationState,
+    ConfigureNmxClusterState, FirmwareUpgradeDeviceStatus, FirmwareUpgradeJob,
+    FirmwareUpgradeState, MaintenanceActivity, MaintenanceScope, NvosUpdateState,
+    NvosUpdateSwitchStatus, Rack, RackConfig, RackFirmwareUpgradeState, RackMaintenanceState,
+    RackPowerState, RackState, RackValidationState,
 };
 use model::rack_type::{
     RackCapabilitiesSet, RackCapabilityCompute, RackCapabilityPowerShelf, RackCapabilitySwitch,
@@ -229,71 +230,91 @@ async fn create_two_compute_rack(
     Ok((rack_id, host_a, host_b))
 }
 
+async fn attach_switches_with_nvos_credentials(
+    env: &TestEnv,
+    rack_id: &RackId,
+    count: usize,
+) -> Result<Vec<SwitchId>, Box<dyn std::error::Error>> {
+    let mut txn = env.pool.begin().await?;
+    let expected_switches = create_expected_switches(txn.as_mut()).await;
+    let selected_switches = expected_switches
+        .into_iter()
+        .take(count)
+        .collect::<Vec<_>>();
+    if selected_switches.len() != count {
+        return Err(eyre::eyre!("expected at least {} switch fixtures", count).into());
+    }
+
+    let mut switch_ids = Vec::with_capacity(selected_switches.len());
+    for (index, expected_switch) in selected_switches.iter().enumerate() {
+        let switch_id = model::switch::switch_id::from_hardware_info(
+            &expected_switch.serial_number,
+            "NVIDIA",
+            "Switch",
+            carbide_uuid::switch::SwitchIdSource::ProductBoardChassisSerial,
+            carbide_uuid::switch::SwitchType::NvLink,
+        )?;
+
+        let new_switch = NewSwitch {
+            id: switch_id.clone(),
+            config: SwitchConfig {
+                name: expected_switch.metadata.name.clone(),
+                enable_nmxc: false,
+                fabric_manager_config: None,
+            },
+            bmc_mac_address: Some(expected_switch.bmc_mac_address.clone()),
+            metadata: None,
+            rack_id: Some(rack_id.clone()),
+            slot_number: Some(index as i32),
+            tray_index: Some(0),
+        };
+        db_switch::create(txn.as_mut(), &new_switch).await?;
+        switch_ids.push(switch_id);
+    }
+    txn.commit().await?;
+
+    for expected_switch in selected_switches {
+        env.api
+            .credential_manager
+            .set_credentials(
+                &CredentialKey::BmcCredentials {
+                    credential_type: BmcCredentialType::BmcRoot {
+                        bmc_mac_address: expected_switch.bmc_mac_address.clone(),
+                    },
+                },
+                &Credentials::UsernamePassword {
+                    username: "root".to_string(),
+                    password: "notforprod".to_string(),
+                },
+            )
+            .await
+            .map_err(|error| eyre::eyre!("failed to set switch BMC credentials: {}", error))?;
+        env.api
+            .credential_manager
+            .set_credentials(
+                &CredentialKey::SwitchNvosAdmin {
+                    bmc_mac_address: expected_switch.bmc_mac_address,
+                },
+                &Credentials::UsernamePassword {
+                    username: "nvos-admin".to_string(),
+                    password: "nvos-pass".to_string(),
+                },
+            )
+            .await
+            .map_err(|error| eyre::eyre!("failed to set switch NVOS credentials: {}", error))?;
+    }
+
+    Ok(switch_ids)
+}
+
 async fn attach_switch_with_nvos_credentials(
     env: &TestEnv,
     rack_id: &RackId,
 ) -> Result<SwitchId, Box<dyn std::error::Error>> {
-    let mut txn = env.pool.begin().await?;
-    let expected_switch = create_expected_switches(txn.as_mut())
-        .await
-        .into_iter()
-        .next()
-        .ok_or("expected at least one switch fixture")?;
-
-    let switch_id = model::switch::switch_id::from_hardware_info(
-        &expected_switch.serial_number,
-        "NVIDIA",
-        "Switch",
-        carbide_uuid::switch::SwitchIdSource::ProductBoardChassisSerial,
-        carbide_uuid::switch::SwitchType::NvLink,
-    )?;
-
-    let new_switch = NewSwitch {
-        id: switch_id,
-        config: SwitchConfig {
-            name: expected_switch.metadata.name.clone(),
-            enable_nmxc: false,
-            fabric_manager_config: None,
-        },
-        bmc_mac_address: Some(expected_switch.bmc_mac_address),
-        metadata: None,
-        rack_id: Some(rack_id.clone()),
-        slot_number: Some(0),
-        tray_index: Some(0),
-    };
-    db_switch::create(txn.as_mut(), &new_switch).await?;
-    txn.commit().await?;
-
-    env.api
-        .credential_manager
-        .set_credentials(
-            &CredentialKey::BmcCredentials {
-                credential_type: BmcCredentialType::BmcRoot {
-                    bmc_mac_address: expected_switch.bmc_mac_address,
-                },
-            },
-            &Credentials::UsernamePassword {
-                username: "root".to_string(),
-                password: "notforprod".to_string(),
-            },
-        )
-        .await
-        .map_err(|error| eyre::eyre!("failed to set switch BMC credentials: {}", error))?;
-    env.api
-        .credential_manager
-        .set_credentials(
-            &CredentialKey::SwitchNvosAdmin {
-                bmc_mac_address: expected_switch.bmc_mac_address,
-            },
-            &Credentials::UsernamePassword {
-                username: "nvos-admin".to_string(),
-                password: "nvos-pass".to_string(),
-            },
-        )
-        .await
-        .map_err(|error| eyre::eyre!("failed to set switch NVOS credentials: {}", error))?;
-
-    Ok(switch_id)
+    let mut switch_ids = attach_switches_with_nvos_credentials(env, rack_id, 1).await?;
+    switch_ids
+        .pop()
+        .ok_or_else(|| eyre::eyre!("expected one switch fixture").into())
 }
 
 pub(crate) fn new_rack_id() -> RackId {
@@ -2089,6 +2110,199 @@ async fn test_nvos_update_start_transitions_to_wait_for_complete(
             std::mem::discriminant(&other)
         ),
     }
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_configure_nmx_cluster_start_advances_to_disable_scale_up_fabric_state(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(pool.clone(), TestEnvOverrides::default()).await;
+
+    let rack_id = new_rack_id();
+    let mut txn = pool.acquire().await?;
+    db_rack::create(
+        &mut txn,
+        &rack_id,
+        Some(&RackProfileId::new("Empty")),
+        &RackConfig::default(),
+        None,
+    )
+    .await?;
+
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+
+    let handler_instance = RackStateHandler::default();
+    let mut services = env.state_handler_services();
+    let mut metrics = RackMetrics::default();
+    let mut db_writes = DbWriteBatch::default();
+    let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut db_writes,
+    };
+
+    let nmx_state = RackState::Maintenance {
+        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+            configure_nmx_cluster: ConfigureNmxClusterState::Start,
+        },
+    };
+    let outcome = handler_instance
+        .handle_object_state(&rack_id, &mut rack, &nmx_state, &mut ctx)
+        .await?;
+
+    match outcome {
+        StateHandlerOutcome::Transition { next_state, .. } => {
+            assert!(
+                matches!(
+                    next_state,
+                    RackState::Maintenance {
+                        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+                            configure_nmx_cluster:
+                                ConfigureNmxClusterState::DisableScaleUpFabricState,
+                        },
+                    }
+                ),
+                "ConfigureNmxCluster(Start) should transition to DisableScaleUpFabricState, got {:?}",
+                next_state
+            );
+        }
+        other => panic!(
+            "Expected Transition, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+
+    assert!(
+        env.rms_sim
+            .submitted_set_scale_up_fabric_state_requests()
+            .await
+            .is_empty()
+    );
+    assert!(
+        env.rms_sim
+            .submitted_get_device_info_by_device_list_requests()
+            .await
+            .is_empty()
+    );
+    assert!(
+        env.rms_sim
+            .submitted_configure_scale_up_fabric_manager_requests()
+            .await
+            .is_empty()
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_runs_on_all_switches(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(pool.clone(), TestEnvOverrides::default()).await;
+
+    let rack_id = new_rack_id();
+    let mut txn = pool.acquire().await?;
+    db_rack::create(
+        &mut txn,
+        &rack_id,
+        Some(&RackProfileId::new("Empty")),
+        &RackConfig::default(),
+        None,
+    )
+    .await?;
+    drop(txn);
+
+    let switch_ids = attach_switches_with_nvos_credentials(&env, &rack_id, 2).await?;
+    env.rms_sim
+        .queue_set_scale_up_fabric_state_response(Ok(rms::SetScaleUpFabricStateResponse {
+            response: Some(rms::NodeBatchResponse {
+                status: rms::ReturnCode::Success as i32,
+                successful_nodes: switch_ids.len() as i32,
+                failed_nodes: 0,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+        .await;
+
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+
+    let handler_instance = RackStateHandler::default();
+    let mut services = env.state_handler_services();
+    let mut metrics = RackMetrics::default();
+    let mut db_writes = DbWriteBatch::default();
+    let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut db_writes,
+    };
+
+    let nmx_state = RackState::Maintenance {
+        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+            configure_nmx_cluster: ConfigureNmxClusterState::DisableScaleUpFabricState,
+        },
+    };
+    let outcome = handler_instance
+        .handle_object_state(&rack_id, &mut rack, &nmx_state, &mut ctx)
+        .await?;
+
+    match outcome {
+        StateHandlerOutcome::Transition { next_state, .. } => {
+            assert!(
+                matches!(
+                    next_state,
+                    RackState::Maintenance {
+                        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+                            configure_nmx_cluster:
+                                ConfigureNmxClusterState::ConfigureScaleUpFabricManager,
+                        },
+                    }
+                ),
+                "DisableScaleUpFabricState should transition to ConfigureScaleUpFabricManager, got {:?}",
+                next_state
+            );
+        }
+        other => panic!(
+            "Expected Transition, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+
+    let requests = env
+        .rms_sim
+        .submitted_set_scale_up_fabric_state_requests()
+        .await;
+    assert_eq!(requests.len(), 1);
+    let request = &requests[0];
+    assert_eq!(request.enabled, Some(false));
+    let devices = request
+        .nodes
+        .as_ref()
+        .expect("disable request should include nodes")
+        .devices
+        .as_slice();
+    assert_eq!(devices.len(), switch_ids.len());
+    let node_ids = devices
+        .iter()
+        .map(|device| device.node_id.clone())
+        .collect::<std::collections::HashSet<_>>();
+    for switch_id in &switch_ids {
+        assert!(node_ids.contains(&switch_id.to_string()));
+    }
+    assert!(
+        env.rms_sim
+            .submitted_get_device_info_by_device_list_requests()
+            .await
+            .is_empty()
+    );
+    assert!(
+        env.rms_sim
+            .submitted_configure_scale_up_fabric_manager_requests()
+            .await
+            .is_empty()
+    );
 
     Ok(())
 }

--- a/crates/api/src/tests/rack_state_controller/handler.rs
+++ b/crates/api/src/tests/rack_state_controller/handler.rs
@@ -2199,7 +2199,7 @@ async fn test_configure_nmx_cluster_start_advances_to_disable_scale_up_fabric_st
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -2294,7 +2294,7 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_runs_on_all_sw
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -2436,7 +2436,7 @@ async fn test_configure_nmx_cluster_configure_selects_persists_and_configures_pr
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -2599,7 +2599,7 @@ async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fab
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -2819,7 +2819,7 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_failure_stops_
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -2924,7 +2924,7 @@ async fn test_configure_nmx_cluster_configure_selection_failure_stops_before_con
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -3048,7 +3048,7 @@ async fn test_configure_nmx_cluster_configure_failure_advances_to_wait_for_fabri
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {

--- a/crates/api/src/tests/rack_state_controller/handler.rs
+++ b/crates/api/src/tests/rack_state_controller/handler.rs
@@ -34,9 +34,10 @@ use model::rack::{
 };
 use model::rack_type::{
     RackCapabilitiesSet, RackCapabilityCompute, RackCapabilityPowerShelf, RackCapabilitySwitch,
-    RackHardwareClass, RackHardwareType, RackProfile, RackProfileConfig,
+    RackHardwareClass, RackHardwareTopology, RackHardwareType, RackProfile, RackProfileConfig,
 };
 use model::switch::{NewSwitch, SwitchConfig};
+use serde_json::json;
 use tonic::Request;
 
 use crate::state_controller::db_write_batch::DbWriteBatch;
@@ -157,6 +158,70 @@ pub(crate) fn config_with_rack_profiles() -> crate::cfg::file::CarbideConfig {
         .collect(),
     };
     config
+}
+
+fn config_with_nmx_cluster_profile() -> crate::cfg::file::CarbideConfig {
+    let mut config = config_with_rack_profiles();
+    config.rack_profiles.rack_profiles.insert(
+        "NmxCluster".to_string(),
+        RackProfile {
+            rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
+            ..Default::default()
+        },
+    );
+    config
+}
+
+fn default_lookup_table_json() -> serde_json::Value {
+    json!({
+        "devices": {
+            "Compute Node": {
+                "HMC_prod": {
+                    "filename": "hmc-prod.bin",
+                    "target": "/redfish/v1/Chassis/HGX_Chassis_0",
+                    "component": "HMC",
+                    "bundle": "bundle-hmc",
+                    "firmware_type": "prod",
+                    "version": "1.0.0"
+                },
+                "BMC_prod": {
+                    "filename": "bmc-prod.bin",
+                    "target": "FW_BMC_0",
+                    "component": "BMC",
+                    "bundle": "bundle-bmc",
+                    "firmware_type": "prod",
+                    "version": "1.0.0"
+                }
+            }
+        }
+    })
+}
+
+async fn insert_default_rack_firmware(
+    pool: &sqlx::PgPool,
+    firmware_id: &str,
+    rack_hardware_type: RackHardwareType,
+    available: bool,
+) {
+    let mut txn = pool.begin().await.unwrap();
+    db::rack_firmware::create(
+        &mut txn,
+        firmware_id,
+        rack_hardware_type,
+        json!({ "Id": firmware_id }),
+        Some(default_lookup_table_json()),
+    )
+    .await
+    .unwrap();
+    if available {
+        db::rack_firmware::set_available(&mut txn, firmware_id, true)
+            .await
+            .unwrap();
+    }
+    db::rack_firmware::set_default(&mut txn, firmware_id)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
 }
 
 async fn create_single_compute_rack(
@@ -2303,6 +2368,159 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_runs_on_all_sw
             .await
             .is_empty()
     );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_configure_nmx_cluster_configure_selects_persists_and_configures_primary_switch(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides {
+            config: Some(config_with_nmx_cluster_profile()),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let rack_id = new_rack_id();
+    let mut txn = pool.acquire().await?;
+    db_rack::create(
+        &mut txn,
+        &rack_id,
+        Some(&RackProfileId::new("NmxCluster")),
+        &RackConfig::default(),
+        None,
+    )
+    .await?;
+    drop(txn);
+
+    let switch_ids = attach_switches_with_nvos_credentials(&env, &rack_id, 2).await?;
+    let secondary_switch_id = switch_ids[0].clone();
+    let primary_switch_id = switch_ids[1].clone();
+    let topology_type = RackHardwareTopology::Gb200Nvl72r1C2g4Topology.to_string();
+
+    env.rms_sim
+        .queue_get_device_info_by_device_list_response(Ok(rms::GetDeviceInfoByDeviceListResponse {
+            status: rms::ReturnCode::Success as i32,
+            node_device_info: vec![
+                rms::NodeDeviceInfo {
+                    node_id: secondary_switch_id.to_string(),
+                    tray_index: Some(2),
+                    slot_number: Some(2),
+                    ..Default::default()
+                },
+                rms::NodeDeviceInfo {
+                    node_id: primary_switch_id.to_string(),
+                    tray_index: Some(1),
+                    slot_number: Some(1),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }))
+        .await;
+    env.rms_sim
+        .queue_configure_scale_up_fabric_manager_response(Ok(
+            rms::ConfigureScaleUpFabricManagerResponse {
+                status: rms::ReturnCode::Success as i32,
+                topology_used: topology_type.clone(),
+                scale_up_fabric_state_enabled: false,
+                grpc_enabled: true,
+                ..Default::default()
+            },
+        ))
+        .await;
+
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+
+    let handler_instance = RackStateHandler::default();
+    let mut services = env.state_handler_services();
+    let mut metrics = RackMetrics::default();
+    let mut db_writes = DbWriteBatch::default();
+    let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut db_writes,
+    };
+
+    let nmx_state = RackState::Maintenance {
+        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+            configure_nmx_cluster: ConfigureNmxClusterState::ConfigureScaleUpFabricManager,
+        },
+    };
+    let outcome = handler_instance
+        .handle_object_state(&rack_id, &mut rack, &nmx_state, &mut ctx)
+        .await?;
+
+    match outcome {
+        StateHandlerOutcome::Transition { next_state, .. } => {
+            assert!(
+                matches!(
+                    next_state,
+                    RackState::Maintenance {
+                        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+                            configure_nmx_cluster: ConfigureNmxClusterState::WaitForFabricStatus,
+                        },
+                    }
+                ),
+                "ConfigureScaleUpFabricManager should transition to WaitForFabricStatus, got {:?}",
+                next_state
+            );
+        }
+        other => panic!(
+            "Expected Transition, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+
+    assert!(
+        env.rms_sim
+            .submitted_set_scale_up_fabric_state_requests()
+            .await
+            .is_empty()
+    );
+
+    let device_info_requests = env
+        .rms_sim
+        .submitted_get_device_info_by_device_list_requests()
+        .await;
+    assert_eq!(device_info_requests.len(), 1);
+    let device_info_nodes = device_info_requests[0]
+        .nodes
+        .as_ref()
+        .expect("device-info request should include nodes")
+        .devices
+        .as_slice();
+    assert_eq!(device_info_nodes.len(), switch_ids.len());
+
+    let configure_requests = env
+        .rms_sim
+        .submitted_configure_scale_up_fabric_manager_requests()
+        .await;
+    assert_eq!(configure_requests.len(), 1);
+    let configure_request = &configure_requests[0];
+    assert_eq!(configure_request.topology_type, topology_type);
+    assert_eq!(
+        configure_request
+            .device
+            .as_ref()
+            .expect("configure request should include a primary switch")
+            .node_id,
+        primary_switch_id.to_string()
+    );
+
+    let mut txn = pool.acquire().await?;
+    let primary_switch = db_switch::find_by_id(&mut txn, &primary_switch_id)
+        .await?
+        .expect("primary switch should exist");
+    let secondary_switch = db_switch::find_by_id(&mut txn, &secondary_switch_id)
+        .await?
+        .expect("secondary switch should exist");
+    assert!(primary_switch.is_primary);
+    assert!(!secondary_switch.is_primary);
 
     Ok(())
 }

--- a/crates/api/src/tests/rack_state_controller/handler.rs
+++ b/crates/api/src/tests/rack_state_controller/handler.rs
@@ -2525,6 +2525,346 @@ async fn test_configure_nmx_cluster_configure_selects_persists_and_configures_pr
     Ok(())
 }
 
+#[crate::sqlx_test]
+async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_failure_stops_flow(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(pool.clone(), TestEnvOverrides::default()).await;
+
+    let rack_id = new_rack_id();
+    let mut txn = pool.acquire().await?;
+    db_rack::create(
+        &mut txn,
+        &rack_id,
+        Some(&RackProfileId::new("Empty")),
+        &RackConfig::default(),
+        None,
+    )
+    .await?;
+    drop(txn);
+
+    attach_switches_with_nvos_credentials(&env, &rack_id, 2).await?;
+    env.rms_sim
+        .queue_set_scale_up_fabric_state_response(Ok(rms::SetScaleUpFabricStateResponse {
+            response: Some(rms::NodeBatchResponse {
+                status: rms::ReturnCode::Failure as i32,
+                successful_nodes: 1,
+                failed_nodes: 1,
+                message: "disable rejected".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+        .await;
+
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+
+    let handler_instance = RackStateHandler::default();
+    let mut services = env.state_handler_services();
+    let mut metrics = RackMetrics::default();
+    let mut db_writes = DbWriteBatch::default();
+    let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut db_writes,
+    };
+
+    let nmx_state = RackState::Maintenance {
+        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+            configure_nmx_cluster: ConfigureNmxClusterState::DisableScaleUpFabricState,
+        },
+    };
+    let outcome = handler_instance
+        .handle_object_state(&rack_id, &mut rack, &nmx_state, &mut ctx)
+        .await?;
+
+    match outcome {
+        StateHandlerOutcome::Transition { next_state, .. } => match next_state {
+            RackState::Error { cause } => {
+                assert!(cause.contains("RMS SetScaleUpFabricState failed"));
+                assert!(cause.contains("disable rejected"));
+            }
+            other => panic!("Expected Error state, got {:?}", other),
+        },
+        other => panic!(
+            "Expected Transition, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+
+    assert_eq!(
+        env.rms_sim
+            .submitted_set_scale_up_fabric_state_requests()
+            .await
+            .len(),
+        1
+    );
+    assert!(
+        env.rms_sim
+            .submitted_get_device_info_by_device_list_requests()
+            .await
+            .is_empty()
+    );
+    assert!(
+        env.rms_sim
+            .submitted_configure_scale_up_fabric_manager_requests()
+            .await
+            .is_empty()
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_configure_nmx_cluster_configure_selection_failure_stops_before_configure(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides {
+            config: Some(config_with_nmx_cluster_profile()),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let rack_id = new_rack_id();
+    let mut txn = pool.acquire().await?;
+    db_rack::create(
+        &mut txn,
+        &rack_id,
+        Some(&RackProfileId::new("NmxCluster")),
+        &RackConfig::default(),
+        None,
+    )
+    .await?;
+    drop(txn);
+
+    let switch_ids = attach_switches_with_nvos_credentials(&env, &rack_id, 2).await?;
+    env.rms_sim
+        .queue_get_device_info_by_device_list_response(Ok(rms::GetDeviceInfoByDeviceListResponse {
+            status: rms::ReturnCode::Success as i32,
+            node_device_info: vec![
+                rms::NodeDeviceInfo {
+                    node_id: switch_ids[0].to_string(),
+                    tray_index: Some(1),
+                    slot_number: Some(1),
+                    ..Default::default()
+                },
+                rms::NodeDeviceInfo {
+                    node_id: switch_ids[1].to_string(),
+                    tray_index: Some(1),
+                    slot_number: Some(2),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }))
+        .await;
+
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+
+    let handler_instance = RackStateHandler::default();
+    let mut services = env.state_handler_services();
+    let mut metrics = RackMetrics::default();
+    let mut db_writes = DbWriteBatch::default();
+    let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut db_writes,
+    };
+
+    let nmx_state = RackState::Maintenance {
+        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+            configure_nmx_cluster: ConfigureNmxClusterState::ConfigureScaleUpFabricManager,
+        },
+    };
+    let outcome = handler_instance
+        .handle_object_state(&rack_id, &mut rack, &nmx_state, &mut ctx)
+        .await?;
+
+    match outcome {
+        StateHandlerOutcome::Transition { next_state, .. } => match next_state {
+            RackState::Error { cause } => {
+                assert!(cause.contains("duplicate tray_index 1"));
+            }
+            other => panic!("Expected Error state, got {:?}", other),
+        },
+        other => panic!(
+            "Expected Transition, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+
+    assert!(
+        env.rms_sim
+            .submitted_set_scale_up_fabric_state_requests()
+            .await
+            .is_empty()
+    );
+    assert_eq!(
+        env.rms_sim
+            .submitted_get_device_info_by_device_list_requests()
+            .await
+            .len(),
+        1
+    );
+    assert!(
+        env.rms_sim
+            .submitted_configure_scale_up_fabric_manager_requests()
+            .await
+            .is_empty()
+    );
+
+    let mut txn = pool.acquire().await?;
+    for switch_id in switch_ids {
+        let switch = db_switch::find_by_id(&mut txn, &switch_id)
+            .await?
+            .expect("switch should exist");
+        assert!(!switch.is_primary);
+    }
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_configure_nmx_cluster_configure_failure_advances_to_wait_for_fabric_status(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides {
+            config: Some(config_with_nmx_cluster_profile()),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let rack_id = new_rack_id();
+    let mut txn = pool.acquire().await?;
+    db_rack::create(
+        &mut txn,
+        &rack_id,
+        Some(&RackProfileId::new("NmxCluster")),
+        &RackConfig::default(),
+        None,
+    )
+    .await?;
+    drop(txn);
+
+    let switch_ids = attach_switches_with_nvos_credentials(&env, &rack_id, 2).await?;
+    let primary_switch_id = switch_ids[0].clone();
+    let topology_type = RackHardwareTopology::Gb200Nvl72r1C2g4Topology.to_string();
+
+    env.rms_sim
+        .queue_get_device_info_by_device_list_response(Ok(rms::GetDeviceInfoByDeviceListResponse {
+            status: rms::ReturnCode::Success as i32,
+            node_device_info: vec![
+                rms::NodeDeviceInfo {
+                    node_id: primary_switch_id.to_string(),
+                    tray_index: Some(1),
+                    slot_number: Some(1),
+                    ..Default::default()
+                },
+                rms::NodeDeviceInfo {
+                    node_id: switch_ids[1].to_string(),
+                    tray_index: Some(2),
+                    slot_number: Some(2),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }))
+        .await;
+    env.rms_sim
+        .queue_configure_scale_up_fabric_manager_response(Ok(
+            rms::ConfigureScaleUpFabricManagerResponse {
+                status: rms::ReturnCode::Failure as i32,
+                message: "configure rejected".to_string(),
+                ..Default::default()
+            },
+        ))
+        .await;
+
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+
+    let handler_instance = RackStateHandler::default();
+    let mut services = env.state_handler_services();
+    let mut metrics = RackMetrics::default();
+    let mut db_writes = DbWriteBatch::default();
+    let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut db_writes,
+    };
+
+    let nmx_state = RackState::Maintenance {
+        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+            configure_nmx_cluster: ConfigureNmxClusterState::ConfigureScaleUpFabricManager,
+        },
+    };
+    let outcome = handler_instance
+        .handle_object_state(&rack_id, &mut rack, &nmx_state, &mut ctx)
+        .await?;
+
+    match outcome {
+        StateHandlerOutcome::Transition { next_state, .. } => {
+            assert!(
+                matches!(
+                    next_state,
+                    RackState::Maintenance {
+                        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+                            configure_nmx_cluster: ConfigureNmxClusterState::WaitForFabricStatus,
+                        },
+                    }
+                ),
+                "ConfigureScaleUpFabricManager failure should transition to WaitForFabricStatus, got {:?}",
+                next_state
+            );
+        }
+        other => panic!(
+            "Expected Transition, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+
+    assert!(
+        env.rms_sim
+            .submitted_set_scale_up_fabric_state_requests()
+            .await
+            .is_empty()
+    );
+    assert_eq!(
+        env.rms_sim
+            .submitted_get_device_info_by_device_list_requests()
+            .await
+            .len(),
+        1
+    );
+    let configure_requests = env
+        .rms_sim
+        .submitted_configure_scale_up_fabric_manager_requests()
+        .await;
+    assert_eq!(configure_requests.len(), 1);
+    assert_eq!(configure_requests[0].topology_type, topology_type);
+    assert_eq!(
+        configure_requests[0]
+            .device
+            .as_ref()
+            .expect("configure request should include a primary switch")
+            .node_id,
+        primary_switch_id.to_string()
+    );
+
+    let mut txn = pool.acquire().await?;
+    let primary_switch = db_switch::find_by_id(&mut txn, &primary_switch_id)
+        .await?
+        .expect("primary switch should exist");
+    assert!(primary_switch.is_primary);
+
+    Ok(())
+}
+
 /// test_configure_nmx_cluster_transitions_to_completed verifies that
 /// Maintenance::ConfigureNmxCluster transitions to Maintenance::Completed.
 #[crate::sqlx_test]

--- a/crates/api/src/tests/rack_state_controller/mod.rs
+++ b/crates/api/src/tests/rack_state_controller/mod.rs
@@ -266,12 +266,14 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
 
     //--------------------------------------------------------------------------
 
-    // Iterations 3-5: FirmwareUpgrade -> Completed.
+    // Iterations 3-6: FirmwareUpgrade -> Completed.
     //
     // The default maintenance sequence is:
-    // FirmwareUpgrade -> ConfigureNmxCluster -> PowerSequence -> Completed.
-    controller.run_single_iteration().await; // FirmwareUpgrade(Start) -> ConfigureNmxCluster
-    controller.run_single_iteration().await; // ConfigureNmxCluster -> PowerSequence
+    // FirmwareUpgrade -> ConfigureNmxCluster(Start)
+    // -> ConfigureNmxCluster(DisableScaleUpFabricState) -> PowerSequence -> Completed.
+    controller.run_single_iteration().await; // FirmwareUpgrade(Start) -> ConfigureNmxCluster(Start)
+    controller.run_single_iteration().await; // ConfigureNmxCluster(Start) -> DisableScaleUpFabricState
+    controller.run_single_iteration().await; // DisableScaleUpFabricState -> PowerSequence
     controller.run_single_iteration().await; // PowerSequence -> Completed
 
     let rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
@@ -286,7 +288,7 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
         rack.controller_state.value
     );
 
-    // Iteration 6: Maintenance(Completed) -> Validating(Pending).
+    // Iteration 7: Maintenance(Completed) -> Validating(Pending).
     // The handler clears rv.* labels (none present yet) and transitions.
     controller.run_single_iteration().await;
 
@@ -304,7 +306,7 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
 
     //--------------------------------------------------------------------------
 
-    // --- Setup for iterations 7-10: Validation states ---
+    // --- Setup for iterations 8-11: Validation states ---
     //
     // Set rv.* labels on both compute trays so the real handler can drive the
     // validation sub-state machine. Both machines are assigned to the same
@@ -334,7 +336,7 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
         txn.commit().await?;
     }
 
-    // Iteration 7: Validating(Pending) -> Validating(InProgress).
+    // Iteration 8: Validating(Pending) -> Validating(InProgress).
     // The handler finds rv.run-id on a machine and promotes to InProgress.
     controller.run_single_iteration().await;
 
@@ -352,7 +354,7 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
 
     //--------------------------------------------------------------------------
 
-    // Iteration 8: Validating(InProgress) -> Validating(Partial).
+    // Iteration 9: Validating(InProgress) -> Validating(Partial).
     // Partition p0 has validated > 0 (both nodes pass), so InProgress -> Partial.
     controller.run_single_iteration().await;
 
@@ -370,7 +372,7 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
 
     //--------------------------------------------------------------------------
 
-    // Iteration 9: Validating(Partial) -> Validating(Validated).
+    // Iteration 10: Validating(Partial) -> Validating(Validated).
     // validated(1) == total_partitions(1) -> Validated.
     controller.run_single_iteration().await;
 
@@ -388,7 +390,7 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
 
     //--------------------------------------------------------------------------
 
-    // Iteration 10: Validating(Validated) -> Ready.
+    // Iteration 11: Validating(Validated) -> Ready.
     controller.run_single_iteration().await;
 
     let rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
@@ -418,6 +420,7 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
         "{\"state\": \"discovering\"}",
         "{\"state\": \"maintenance\", \"maintenance_state\": {\"FirmwareUpgrade\": {\"rack_firmware_upgrade\": \"Start\"}}}",
         "{\"state\": \"maintenance\", \"maintenance_state\": {\"ConfigureNmxCluster\": {\"configure_nmx_cluster\": \"Start\"}}}",
+        "{\"state\": \"maintenance\", \"maintenance_state\": {\"ConfigureNmxCluster\": {\"configure_nmx_cluster\": \"DisableScaleUpFabricState\"}}}",
         "{\"state\": \"maintenance\", \"maintenance_state\": {\"PowerSequence\": {\"rack_power\": \"PoweringOn\"}}}",
         "{\"state\": \"maintenance\", \"maintenance_state\": \"Completed\"}",
         "{\"state\": \"validating\", \"validating_state\": \"Pending\"}",


### PR DESCRIPTION
## Description
-  add new substate to nmx-configure to disable cluster on all switches.
-  selectively configure nmxc on primary switch

## Type of Change
- [ ] **Add** - New feature or capability

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

