### PR TITLE
feat(api): auto-transition rack between Ready and Error on component …

### DIFF
--- a/crates/api/src/state_controller/rack/error_state.rs
+++ b/crates/api/src/state_controller/rack/error_state.rs
@@ -22,6 +22,7 @@ use model::rack::{Rack, RackConfig, RackState};
 
 use crate::state_controller::rack::context::RackStateHandlerContextObjects;
 use crate::state_controller::rack::maintenance::first_maintenance_state;
+use crate::state_controller::rack::ready::all_components_ready;
 use crate::state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
@@ -65,6 +66,15 @@ pub async fn handle_error(
             maintenance_state: first_maintenance_state(scope),
         })
         .with_txn(txn));
+    }
+
+    if all_components_ready(id, ctx).await? {
+        tracing::info!(
+            "Rack {} components all Ready, transitioning from Error back to Ready",
+            id
+        );
+        let txn = ctx.services.db_pool.begin().await?;
+        return Ok(StateHandlerOutcome::transition(RackState::Ready).with_txn(txn));
     }
 
     tracing::error!("Rack {} is in error state: {}", id, cause);

--- a/crates/api/src/state_controller/rack/ready.rs
+++ b/crates/api/src/state_controller/rack/ready.rs
@@ -18,14 +18,24 @@
 //! Handler for RackState::Ready.
 
 use carbide_uuid::rack::RackId;
-use db::rack as db_rack;
+use db::{
+    machine as db_machine, power_shelf as db_power_shelf, rack as db_rack, switch as db_switch,
+};
+use model::DeletedFilter;
+use model::machine::machine_search_config::MachineSearchConfig;
+use model::power_shelf::PowerShelfSearchFilter;
 use model::rack::{FirmwareUpgradeState, Rack, RackConfig, RackMaintenanceState, RackState};
+use model::switch::SwitchSearchFilter;
 
 use crate::state_controller::rack::context::RackStateHandlerContextObjects;
 use crate::state_controller::rack::maintenance::first_maintenance_state;
 use crate::state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+const COMPONENT_ERROR_STATE: &str = "error";
+const MACHINE_FAILED_STATE: &str = "failed";
+const COMPONENT_READY_STATE: &str = "ready";
 
 pub async fn handle_ready(
     id: &RackId,
@@ -97,7 +107,197 @@ pub async fn handle_ready(
         .with_txn(txn));
     }
 
+    if let Some(cause) = detect_component_failure(id, ctx).await? {
+        tracing::warn!("Rack {} transitioning from Ready to Error: {}", id, cause);
+        let txn = ctx.services.db_pool.begin().await?;
+        return Ok(StateHandlerOutcome::transition(RackState::Error { cause }).with_txn(txn));
+    }
+
     Ok(StateHandlerOutcome::wait(
         "rack is ready, no maintenance requested".into(),
     ))
+}
+
+/// Returns a cause string if any switch, power shelf, or machine in the rack
+/// is in its terminal failure state, or `None` if every component is healthy.
+pub(super) async fn detect_component_failure(
+    rack_id: &RackId,
+    ctx: &mut StateHandlerContext<'_, RackStateHandlerContextObjects>,
+) -> Result<Option<String>, StateHandlerError> {
+    let mut txn = ctx.services.db_pool.begin().await?;
+
+    let failed_switches = db_switch::find_ids(
+        txn.as_mut(),
+        SwitchSearchFilter {
+            rack_id: Some(rack_id.clone()),
+            deleted: DeletedFilter::Exclude,
+            controller_state: Some(COMPONENT_ERROR_STATE.to_string()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let failed_power_shelves = db_power_shelf::find_ids(
+        txn.as_mut(),
+        PowerShelfSearchFilter {
+            rack_id: Some(rack_id.clone()),
+            deleted: DeletedFilter::Exclude,
+            controller_state: Some(COMPONENT_ERROR_STATE.to_string()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let failed_machines = db_machine::find_machine_ids(
+        txn.as_mut(),
+        MachineSearchConfig {
+            rack_id: Some(rack_id.clone()),
+            controller_state: Some(MACHINE_FAILED_STATE.to_string()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    txn.commit().await?;
+
+    if failed_switches.is_empty() && failed_power_shelves.is_empty() && failed_machines.is_empty() {
+        return Ok(None);
+    }
+
+    let mut parts = Vec::new();
+    if !failed_switches.is_empty() {
+        parts.push(format!(
+            "{} switch(es) in Error: [{}]",
+            failed_switches.len(),
+            failed_switches
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", "),
+        ));
+    }
+    if !failed_power_shelves.is_empty() {
+        parts.push(format!(
+            "{} power shelf/shelves in Error: [{}]",
+            failed_power_shelves.len(),
+            failed_power_shelves
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", "),
+        ));
+    }
+    if !failed_machines.is_empty() {
+        parts.push(format!(
+            "{} machine(s) in Failed: [{}]",
+            failed_machines.len(),
+            failed_machines
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", "),
+        ));
+    }
+
+    Ok(Some(format!(
+        "component(s) reported terminal failure: {}",
+        parts.join("; ")
+    )))
+}
+
+/// Returns `true` only when the rack has at least one component registered
+/// and every switch, power shelf, and machine is in its `Ready` state.
+pub(super) async fn all_components_ready(
+    rack_id: &RackId,
+    ctx: &mut StateHandlerContext<'_, RackStateHandlerContextObjects>,
+) -> Result<bool, StateHandlerError> {
+    let mut txn = ctx.services.db_pool.begin().await?;
+
+    let all_switches = db_switch::find_ids(
+        txn.as_mut(),
+        SwitchSearchFilter {
+            rack_id: Some(rack_id.clone()),
+            deleted: DeletedFilter::Exclude,
+            ..Default::default()
+        },
+    )
+    .await?;
+    let ready_switches = db_switch::find_ids(
+        txn.as_mut(),
+        SwitchSearchFilter {
+            rack_id: Some(rack_id.clone()),
+            deleted: DeletedFilter::Exclude,
+            controller_state: Some(COMPONENT_READY_STATE.to_string()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let all_power_shelves = db_power_shelf::find_ids(
+        txn.as_mut(),
+        PowerShelfSearchFilter {
+            rack_id: Some(rack_id.clone()),
+            deleted: DeletedFilter::Exclude,
+            ..Default::default()
+        },
+    )
+    .await?;
+    let ready_power_shelves = db_power_shelf::find_ids(
+        txn.as_mut(),
+        PowerShelfSearchFilter {
+            rack_id: Some(rack_id.clone()),
+            deleted: DeletedFilter::Exclude,
+            controller_state: Some(COMPONENT_READY_STATE.to_string()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let all_machines = db_machine::find_machine_ids(
+        txn.as_mut(),
+        MachineSearchConfig {
+            rack_id: Some(rack_id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+    let ready_machines = db_machine::find_machine_ids(
+        txn.as_mut(),
+        MachineSearchConfig {
+            rack_id: Some(rack_id.clone()),
+            controller_state: Some(COMPONENT_READY_STATE.to_string()),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    txn.commit().await?;
+
+    let total = all_switches.len() + all_power_shelves.len() + all_machines.len();
+    if total == 0 {
+        tracing::debug!(
+            "Rack {} has no components registered; not promoting out of Error",
+            rack_id
+        );
+        return Ok(false);
+    }
+
+    let all_ready = ready_switches.len() == all_switches.len()
+        && ready_power_shelves.len() == all_power_shelves.len()
+        && ready_machines.len() == all_machines.len();
+
+    if !all_ready {
+        tracing::debug!(
+            "Rack {} components not yet all Ready: switches {}/{}, power shelves {}/{}, machines {}/{}",
+            rack_id,
+            ready_switches.len(),
+            all_switches.len(),
+            ready_power_shelves.len(),
+            all_power_shelves.len(),
+            ready_machines.len(),
+            all_machines.len(),
+        );
+    }
+
+    Ok(all_ready)
 }

--- a/crates/api/src/tests/rack_state_controller/handler.rs
+++ b/crates/api/src/tests/rack_state_controller/handler.rs
@@ -2433,6 +2433,337 @@ async fn test_validation_failed_transitions_to_error(
     Ok(())
 }
 
+async fn set_switch_state(
+    txn: &mut sqlx::PgConnection,
+    switch_id: &SwitchId,
+    state: model::switch::SwitchControllerState,
+) {
+    sqlx::query("UPDATE switches SET controller_state = $1 WHERE id = $2")
+        .bind(serde_json::to_value(state).unwrap())
+        .bind(switch_id)
+        .execute(txn)
+        .await
+        .expect("update switch controller_state");
+}
+
+async fn set_power_shelf_state(
+    txn: &mut sqlx::PgConnection,
+    power_shelf_id: &carbide_uuid::power_shelf::PowerShelfId,
+    state: model::power_shelf::PowerShelfControllerState,
+) {
+    sqlx::query("UPDATE power_shelves SET controller_state = $1 WHERE id = $2")
+        .bind(serde_json::to_value(state).unwrap())
+        .bind(power_shelf_id)
+        .execute(txn)
+        .await
+        .expect("update power_shelf controller_state");
+}
+
+async fn create_test_power_shelf(
+    txn: &mut sqlx::PgConnection,
+    rack_id: &RackId,
+    seed: u8,
+) -> carbide_uuid::power_shelf::PowerShelfId {
+    use carbide_uuid::power_shelf::PowerShelfId;
+    let mut bytes = [0u8; 16];
+    bytes[0] = seed;
+    let power_shelf_id = PowerShelfId::from(uuid::Uuid::from_bytes(bytes));
+    let new_power_shelf = model::power_shelf::NewPowerShelf {
+        id: power_shelf_id,
+        config: model::power_shelf::PowerShelfConfig {
+            name: format!("ps-{}", seed),
+            capacity: Some(6000),
+            voltage: Some(480),
+        },
+        bmc_mac_address: None,
+        metadata: None,
+        rack_id: Some(rack_id.clone()),
+    };
+    db::power_shelf::create(txn, &new_power_shelf)
+        .await
+        .expect("create power shelf");
+    power_shelf_id
+}
+
+/// Ready rack moves to Error when one of its switches enters Error.
+#[crate::sqlx_test]
+async fn test_ready_with_failed_switch_transitions_to_error(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(pool.clone(), TestEnvOverrides::default()).await;
+    let (rack_id, switch_id) = create_ready_rack_with_switch(&env, &pool).await?;
+
+    set_switch_state(
+        pool.acquire().await?.as_mut(),
+        &switch_id,
+        model::switch::SwitchControllerState::Error {
+            cause: "synthetic switch failure".to_string(),
+        },
+    )
+    .await;
+
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+
+    let handler = RackStateHandler::default();
+    let mut services = env.state_handler_services();
+    let mut metrics = RackMetrics::default();
+    let mut db_writes = DbWriteBatch::default();
+    let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut db_writes,
+    };
+
+    let outcome = handler
+        .handle_object_state(&rack_id, &mut rack, &RackState::Ready, &mut ctx)
+        .await?;
+
+    match outcome {
+        StateHandlerOutcome::Transition { next_state, .. } => match next_state {
+            RackState::Error { cause } => {
+                assert!(
+                    cause.contains("switch"),
+                    "Error cause should mention failing switch, got: {}",
+                    cause
+                );
+            }
+            other => panic!("Expected Transition to Error, got {:?}", other),
+        },
+        other => panic!(
+            "Expected Transition to Error, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+
+    Ok(())
+}
+
+/// Ready rack moves to Error when an attached power shelf enters Error.
+#[crate::sqlx_test]
+async fn test_ready_with_failed_power_shelf_transitions_to_error(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(pool.clone(), TestEnvOverrides::default()).await;
+
+    let rack_id = new_rack_id();
+    {
+        let mut txn = pool.begin().await?;
+        db_rack::create(
+            txn.as_mut(),
+            &rack_id,
+            Some(&RackProfileId::new("Empty")),
+            &RackConfig::default(),
+            None,
+        )
+        .await?;
+        let power_shelf_id = create_test_power_shelf(txn.as_mut(), &rack_id, 0xa1).await;
+        set_power_shelf_state(
+            txn.as_mut(),
+            &power_shelf_id,
+            model::power_shelf::PowerShelfControllerState::Error {
+                cause: "synthetic power shelf failure".to_string(),
+            },
+        )
+        .await;
+        let rack = get_db_rack(txn.as_mut(), &rack_id).await;
+        db_rack::try_update_controller_state(
+            txn.as_mut(),
+            &rack_id,
+            rack.controller_state.version,
+            rack.controller_state.version.increment(),
+            &RackState::Ready,
+        )
+        .await?;
+        txn.commit().await?;
+    }
+
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+
+    let handler = RackStateHandler::default();
+    let mut services = env.state_handler_services();
+    let mut metrics = RackMetrics::default();
+    let mut db_writes = DbWriteBatch::default();
+    let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut db_writes,
+    };
+
+    let outcome = handler
+        .handle_object_state(&rack_id, &mut rack, &RackState::Ready, &mut ctx)
+        .await?;
+
+    match outcome {
+        StateHandlerOutcome::Transition { next_state, .. } => match next_state {
+            RackState::Error { cause } => {
+                assert!(
+                    cause.contains("power shelf"),
+                    "Error cause should mention failing power shelf, got: {}",
+                    cause
+                );
+            }
+            other => panic!("Expected Transition to Error, got {:?}", other),
+        },
+        other => panic!(
+            "Expected Transition to Error, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+
+    Ok(())
+}
+
+/// Ready rack with all healthy components stays in Ready.
+#[crate::sqlx_test]
+async fn test_ready_with_all_healthy_components_waits(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(pool.clone(), TestEnvOverrides::default()).await;
+    let (rack_id, switch_id) = create_ready_rack_with_switch(&env, &pool).await?;
+
+    set_switch_state(
+        pool.acquire().await?.as_mut(),
+        &switch_id,
+        model::switch::SwitchControllerState::Ready,
+    )
+    .await;
+
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+
+    let handler = RackStateHandler::default();
+    let mut services = env.state_handler_services();
+    let mut metrics = RackMetrics::default();
+    let mut db_writes = DbWriteBatch::default();
+    let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut db_writes,
+    };
+
+    let outcome = handler
+        .handle_object_state(&rack_id, &mut rack, &RackState::Ready, &mut ctx)
+        .await?;
+
+    assert!(
+        matches!(
+            outcome,
+            StateHandlerOutcome::Wait { .. } | StateHandlerOutcome::DoNothing { .. }
+        ),
+        "Ready with healthy components should wait, got {:?}",
+        std::mem::discriminant(&outcome)
+    );
+
+    Ok(())
+}
+
+/// Rack in Error transitions back to Ready once every component is Ready.
+#[crate::sqlx_test]
+async fn test_error_recovers_to_ready_when_all_components_ready(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(pool.clone(), TestEnvOverrides::default()).await;
+    let (rack_id, switch_id) = create_ready_rack_with_switch(&env, &pool).await?;
+
+    set_switch_state(
+        pool.acquire().await?.as_mut(),
+        &switch_id,
+        model::switch::SwitchControllerState::Ready,
+    )
+    .await;
+    crate::tests::rack_state_controller::fixtures::rack::set_rack_controller_state(
+        pool.acquire().await?.as_mut(),
+        &rack_id,
+        RackState::Error {
+            cause: "synthetic prior failure".to_string(),
+        },
+    )
+    .await?;
+
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+    let error_state = rack.controller_state.value.clone();
+
+    let handler = RackStateHandler::default();
+    let mut services = env.state_handler_services();
+    let mut metrics = RackMetrics::default();
+    let mut db_writes = DbWriteBatch::default();
+    let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut db_writes,
+    };
+
+    let outcome = handler
+        .handle_object_state(&rack_id, &mut rack, &error_state, &mut ctx)
+        .await?;
+
+    match outcome {
+        StateHandlerOutcome::Transition { next_state, .. } => {
+            assert!(
+                matches!(next_state, RackState::Ready),
+                "Error with all-Ready components should transition to Ready, got {:?}",
+                next_state
+            );
+        }
+        other => panic!(
+            "Expected Transition to Ready, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+
+    Ok(())
+}
+
+/// Rack in Error does not auto-recover while any component is not yet Ready.
+#[crate::sqlx_test]
+async fn test_error_stays_in_error_when_components_not_all_ready(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(pool.clone(), TestEnvOverrides::default()).await;
+    let (rack_id, switch_id) = create_ready_rack_with_switch(&env, &pool).await?;
+
+    set_switch_state(
+        pool.acquire().await?.as_mut(),
+        &switch_id,
+        model::switch::SwitchControllerState::Initializing {
+            initializing_state: model::switch::InitializingState::WaitForOsMachineInterface,
+        },
+    )
+    .await;
+    crate::tests::rack_state_controller::fixtures::rack::set_rack_controller_state(
+        pool.acquire().await?.as_mut(),
+        &rack_id,
+        RackState::Error {
+            cause: "synthetic prior failure".to_string(),
+        },
+    )
+    .await?;
+
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+    let error_state = rack.controller_state.value.clone();
+
+    let handler = RackStateHandler::default();
+    let mut services = env.state_handler_services();
+    let mut metrics = RackMetrics::default();
+    let mut db_writes = DbWriteBatch::default();
+    let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut db_writes,
+    };
+
+    let outcome = handler
+        .handle_object_state(&rack_id, &mut rack, &error_state, &mut ctx)
+        .await?;
+
+    assert!(
+        matches!(outcome, StateHandlerOutcome::Wait { .. }),
+        "Error with non-Ready components must not auto-recover, got {:?}",
+        std::mem::discriminant(&outcome)
+    );
+
+    Ok(())
+}
+
 async fn get_db_rack<DB>(conn: &mut DB, rack_id: &RackId) -> Rack
 where
     for<'db> &'db mut DB: DbReader<'db>,


### PR DESCRIPTION
…health

The Ready handler now scans the rack's switches, power shelves, and machines for terminal failures and transitions the rack to Error with a descriptive cause when any are detected. Conversely, the Error handler promotes the rack back to Ready once every registered component reports Ready, allowing the rack state to reflect component health without manual intervention.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

