### PR TITLE
fix(site-explorer): bail out when Redfish service root vendor is null…

### DIFF
--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -128,6 +128,10 @@ impl RedfishClient {
 
         let service_root = client.get_service_root().await.map_err(map_redfish_error)?;
 
+        if service_root.vendor.is_none() {
+            return Err(EndpointExplorationError::MissingVendor);
+        }
+
         let Some(vendor) = service_root.vendor() else {
             tracing::info!("No vendor found for BMC at {bmc_ip_address}");
             return Err(EndpointExplorationError::MissingVendor);


### PR DESCRIPTION
… so power shelf chassis fallback runs
Some power shelf BMCs (e.g. Lite-On) do not populate the `Vendor`
field in the Redfish service root. Previously, `get_redfish_vendor()`
relied solely on `ServiceRoot::vendor()`, which can derive a vendor
from other hints and mask the missing field. That prevented the
upper-layer fallback in `bmc_endpoint_explorer` from kicking in to
probe the Chassis `Manufacturer` field for power shelves.
Add an explicit check on the raw `service_root.vendor` field and
return `EndpointExplorationError::MissingVendor` early when it is
`None`, so the caller can fall back to chassis-based vendor probing
for power shelf endpoints.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

