### PR TITLE
fix(agent): Stop enumerating hardware when is-fake-dpu is true

### DIFF
--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 
 use ::rpc::DiscoveryInfo;
 use ::rpc::forge_tls_client::ForgeClientConfig;
-use ::rpc::machine_discovery::DpuData;
+use ::rpc::machine_discovery::{DmiData, DpuData};
 use carbide_host_support::agent_config::AgentConfig;
 use carbide_host_support::hardware_enumeration::{
     enumerate_and_save_hardware, enumerate_hardware, load_hardware_from_cache,
@@ -490,19 +490,17 @@ async fn register(
     agent: &AgentConfig,
     platform_type: &AgentPlatformType,
 ) -> Result<Registration, eyre::Report> {
-    let mut hardware_info = match platform_type {
-        AgentPlatformType::Containerized => {
-            load_hardware_from_cache().wrap_err("load_hardware_from_cache failed")
-        }
-        _ => enumerate_hardware().wrap_err("enumerate_hardware failed"),
-    }?;
-
-    // Pretend to be a bluefield DPU for local dev.
-    // see model/hardware_info.rs::is_dpu
-    if agent.machine.is_fake_dpu {
-        fill_fake_dpu_info(&mut hardware_info);
-        tracing::debug!("Successfully injected fake DPU data");
-    }
+    // Use synthetic hardware in fake-DPU mode so local tests do not depend on host devices.
+    let hardware_info = if agent.machine.is_fake_dpu {
+        fake_dpu_discovery_info()
+    } else {
+        match platform_type {
+            AgentPlatformType::Containerized => {
+                load_hardware_from_cache().wrap_err("load_hardware_from_cache failed")
+            }
+            _ => enumerate_hardware().wrap_err("enumerate_hardware failed"),
+        }?
+    };
 
     let factory_mac_address: MacAddress = match hardware_info.dpu_info.as_ref() {
         Some(dpu_info) => dpu_info.factory_mac_address.parse().map_err(|e| {
@@ -537,6 +535,27 @@ async fn register(
         machine_id,
         factory_mac_address,
     })
+}
+
+/// Builds synthetic DPU discovery information for fake-DPU tests and local development.
+fn fake_dpu_discovery_info() -> DiscoveryInfo {
+    // Start with stable DMI values so registration does not depend on host hardware.
+    let mut hardware_info = DiscoveryInfo {
+        dmi_data: Some(DmiData {
+            board_name: "BlueField SoC".to_string(),
+            product_name: "BlueField SoC".to_string(),
+            product_serial: "Stable Local Dev serial".to_string(),
+            sys_vendor: "Nvidia".to_string(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    // Reuse the existing fake-DPU overlay for DPU identity and architecture fields.
+    fill_fake_dpu_info(&mut hardware_info);
+    tracing::debug!("Successfully built fake DPU discovery data");
+
+    hardware_info
 }
 
 pub fn pretty_cmd(c: &Command) -> String {


### PR DESCRIPTION
## Description

Updated `register` so that fake-DPU registration now uses synthetic DPU discovery data for local tests.

This is to deal with the errors below, which happened in fake-DPU test mode because registration still calls real enumerate_hardware() before injecting fake DPU data:

```
  level=WARN msg="Pretending local host is a DPU. Dev only." location="crates/agent/src/lib.rs:131"
  ...
  level=WARN msg="Could not read TPM EK certificate using tpm2_getekcertificate: SubprocessStatusNotOk(Some(1), \"ERROR:tcti:src/tss2-tcti/tcti-device.c:452:Tss2_Tcti_Device_Init() Failed to open specified TCTI device file /dev/tpmrm0: Permission denied \n... Failed to open specified TCTI device file /dev/tpm0: Permission denied ...\"); probing known NV
  indices" location="crates/host-support/src/hardware_enumeration/tpm.rs:99"
  level=ERROR msg="Failed to start DPU agent: registration error: enumerate_hardware failed: Hardware enumeration error: TPM is present but EK certificate collection failed; refusing serial fallback: Unable to read TPM EK certificate: Subprocess exited with exit code Some(1). Stderr: ERROR:tcti:src/tss2-tcti/tcti-device.c:452:Tss2_Tcti_Device_Init() Failed to
  open specified TCTI device file /dev/tpmrm0: Permission denied
  ...
  ERROR:tcti:src/tss2-tcti/tcti-device.c:452:Tss2_Tcti_Device_Init() Failed to open specified TCTI device file /dev/tpm0: Permission denied
  ...
  ERROR: Could not load tcti, got: \"(null)\"

```

Likely only matters to people testing truly locally.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

