### PR TITLE
refactor(db,model): Add SpdmAttestationStatus model type

### DIFF
--- a/crates/api-db/src/attestation/spdm.rs
+++ b/crates/api-db/src/attestation/spdm.rs
@@ -18,7 +18,7 @@
 use carbide_uuid::machine::MachineId;
 use itertools::Itertools;
 use model::attestation::spdm::{
-    CaCertificate, Evidence, SpdmAttestationState, SpdmDeviceAttestation,
+    CaCertificate, Evidence, SpdmAttestationState, SpdmAttestationStatus, SpdmDeviceAttestation,
     SpdmDeviceAttestationDetails, SpdmMachineDeviceMetadata, SpdmObjectId,
 };
 use model::controller_outcome::PersistentStateHandlerOutcome;
@@ -202,7 +202,7 @@ pub async fn find_machine_ids_for_attestation(
 pub async fn get_attestation_status_for_machine_id(
     txn: &mut PgConnection,
     machine_id: &MachineId,
-) -> Result<rpc::forge::SpdmAttestationStatus, DatabaseError> {
+) -> Result<SpdmAttestationStatus, DatabaseError> {
     // get states for all devices under attestation for a given
     // machine
     let query = r#"
@@ -261,12 +261,12 @@ pub async fn get_attestation_status_for_machine_id(
 
     // some failed and none in progress
     if FAILED_MASK & flags != 0 && INPROGRESS_MASK & flags == 0 {
-        return Ok(rpc::forge::SpdmAttestationStatus::SpdmAttFailed);
+        return Ok(SpdmAttestationStatus::Failed);
     }
     match flags {
-        PASSED_MASK => Ok(rpc::forge::SpdmAttestationStatus::SpdmAttPassed),
-        CANCELLELD_MASK => Ok(rpc::forge::SpdmAttestationStatus::SpdmAttCancelled),
-        _ => Ok(rpc::forge::SpdmAttestationStatus::SpdmAttInProgress),
+        PASSED_MASK => Ok(SpdmAttestationStatus::Passed),
+        CANCELLELD_MASK => Ok(SpdmAttestationStatus::Cancelled),
+        _ => Ok(SpdmAttestationStatus::InProgress),
     }
 }
 

--- a/crates/api-model/src/attestation.rs
+++ b/crates/api-model/src/attestation.rs
@@ -117,7 +117,15 @@ pub mod spdm {
         }
     }
 
-    #[derive(Clone, Debug, thiserror::Error, PartialEq, Eq, Serialize, Deserialize)]
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    pub enum SpdmAttestationStatus {
+        InProgress,
+        Cancelled,
+        Passed,
+        Failed,
+    }
+
+    #[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
     pub enum SpdmHandlerError {
         #[error("Unable to complete measurement trigger: {0}")]
         TriggerMeasurementFail(String),
@@ -139,7 +147,7 @@ pub mod spdm {
         VerificationFailed(String),
     }
 
-    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    #[derive(Clone, Debug, PartialEq, Eq)]
     pub enum AttestationStatus {
         Success,
         NotSupported,

--- a/crates/api-model/src/rpc_conv/attestation.rs
+++ b/crates/api-model/src/rpc_conv/attestation.rs
@@ -18,7 +18,7 @@
 /// Model for SPDM attestation via Redfish
 pub mod spdm {
 
-    use crate::attestation::spdm::SpdmDeviceAttestationDetails;
+    use crate::attestation::spdm::{SpdmAttestationStatus, SpdmDeviceAttestationDetails};
 
     impl From<SpdmDeviceAttestationDetails> for rpc::forge::SpdmAttestationDetails {
         fn from(value: SpdmDeviceAttestationDetails) -> Self {
@@ -29,6 +29,17 @@ pub mod spdm {
                 cancelled_at: value.cancelled_at.map(|x| x.into()),
                 state: format!("{:?}", value.state),
                 device_id: value.device_id,
+            }
+        }
+    }
+
+    impl From<SpdmAttestationStatus> for rpc::forge::SpdmAttestationStatus {
+        fn from(value: SpdmAttestationStatus) -> Self {
+            match value {
+                SpdmAttestationStatus::InProgress => Self::SpdmAttInProgress,
+                SpdmAttestationStatus::Cancelled => Self::SpdmAttCancelled,
+                SpdmAttestationStatus::Passed => Self::SpdmAttPassed,
+                SpdmAttestationStatus::Failed => Self::SpdmAttFailed,
             }
         }
     }

--- a/crates/api/src/handlers/attestation.rs
+++ b/crates/api/src/handlers/attestation.rs
@@ -281,7 +281,7 @@ pub(crate) async fn get_machine_attestations_status(
 
     Ok(Response::new(rpc::SpdmMachineAttestationStatusResponse {
         machine_id: Some(*machine_id),
-        attestation_status: attestation_status.into(),
+        attestation_status: rpc::SpdmAttestationStatus::from(attestation_status).into(),
     }))
 }
 

--- a/crates/api/src/state_controller/machine/handler/attestation.rs
+++ b/crates/api/src/state_controller/machine/handler/attestation.rs
@@ -21,13 +21,12 @@ use carbide_redfish::libredfish::RedfishClientPool;
 use carbide_uuid::machine::MachineId;
 use chrono::Utc;
 use model::attestation::spdm::{
-    SpdmAttestationState, SpdmDeviceAttestationDetails, SpdmHandlerError,
+    SpdmAttestationState, SpdmAttestationStatus, SpdmDeviceAttestationDetails, SpdmHandlerError,
 };
 use model::machine::{
     AttestationMode, FailureCause, FailureDetails, FailureSource, MachineState, ManagedHostState,
     ManagedHostStateSnapshot, SpdmMeasuringState, StateMachineArea,
 };
-use rpc::forge::SpdmAttestationStatus;
 use sqlx::PgPool;
 
 use crate::handlers::attestation as attestation_handlers;
@@ -52,9 +51,9 @@ pub(crate) async fn handle_spdm_attestation_failed_recovery(
         let attestation_status =
             db::attestation::spdm::get_attestation_status_for_machine_id(&mut txn, host_machine_id)
                 .await?;
-        attestation_status == SpdmAttestationStatus::SpdmAttInProgress
-            || attestation_status == SpdmAttestationStatus::SpdmAttCancelled
-            || attestation_status == SpdmAttestationStatus::SpdmAttPassed
+        attestation_status == SpdmAttestationStatus::InProgress
+            || attestation_status == SpdmAttestationStatus::Cancelled
+            || attestation_status == SpdmAttestationStatus::Passed
     };
     if should_resume_attestation {
         match &details.source {
@@ -140,10 +139,10 @@ pub(crate) async fn handle_spdm_poll_state(
     // passed or cancelled -> just move to the next state
     // failed -> get states for all devices and log to the Failed state logging them there
     match attestation_status {
-        SpdmAttestationStatus::SpdmAttPassed | SpdmAttestationStatus::SpdmAttCancelled => {
+        SpdmAttestationStatus::Passed | SpdmAttestationStatus::Cancelled => {
             Ok(StateHandlerOutcome::transition(next_skip_state).with_txn(txn))
         }
-        SpdmAttestationStatus::SpdmAttFailed => {
+        SpdmAttestationStatus::Failed => {
             let attestation_states =
                 db::attestation::spdm::get_attestations_for_machine_id(&mut txn, host_machine_id)
                     .await?;
@@ -171,6 +170,6 @@ pub(crate) async fn handle_spdm_poll_state(
             })
             .with_txn(txn))
         }
-        SpdmAttestationStatus::SpdmAttInProgress => Ok(StateHandlerOutcome::do_nothing()),
+        SpdmAttestationStatus::InProgress => Ok(StateHandlerOutcome::do_nothing()),
     }
 }


### PR DESCRIPTION
## Description

As practice, we don't use RPC types in DB crate. DB crate should use Model types.
SpdmAttestationStatus is rare exception from this rule.

This PR removes this exception.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
