### PR TITLE
chore(db,model): Move NvlinkNmxcEndpoint to model

### DIFF
--- a/crates/api-db/src/nvlink_nmxc_endpoints.rs
+++ b/crates/api-db/src/nvlink_nmxc_endpoints.rs
@@ -15,17 +15,11 @@
  * limitations under the License.
  */
 
+use model::nmxc::NvlinkNmxcEndpoint;
 use sqlx::PgConnection;
 
 use crate::db_read::DbReader;
 use crate::{DatabaseError, DatabaseResult};
-
-/// Row from `nvlink_nmxc_endpoints`: chassis serial and NMX-C gRPC endpoint URL.
-#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
-pub struct NvlinkNmxcEndpoint {
-    pub chassis_serial: String,
-    pub endpoint: String,
-}
 
 pub async fn find_by_chassis_serial(
     txn: impl DbReader<'_>,
@@ -98,13 +92,4 @@ pub async fn update(
         .fetch_optional(txn)
         .await
         .map_err(|e| DatabaseError::new(Q, e))
-}
-
-impl From<NvlinkNmxcEndpoint> for rpc::forge::NvlinkNmxcEndpoint {
-    fn from(row: NvlinkNmxcEndpoint) -> Self {
-        Self {
-            chassis_serial: row.chassis_serial,
-            endpoint: row.endpoint,
-        }
-    }
 }

--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -72,6 +72,7 @@ pub mod network_devices;
 pub mod network_prefix;
 pub mod network_security_group;
 pub mod network_segment;
+pub mod nmxc;
 pub mod nvl_logical_partition;
 pub mod nvl_partition;
 pub mod operating_system_definition;

--- a/crates/api-model/src/nmxc.rs
+++ b/crates/api-model/src/nmxc.rs
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Row from `nvlink_nmxc_endpoints`: chassis serial and NMX-C gRPC endpoint URL.
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub struct NvlinkNmxcEndpoint {
+    pub chassis_serial: String,
+    pub endpoint: String,
+}

--- a/crates/api-model/src/rpc_conv/mod.rs
+++ b/crates/api-model/src/rpc_conv/mod.rs
@@ -45,6 +45,7 @@ pub mod network_devices;
 pub mod network_prefix;
 pub mod network_security_group;
 pub mod network_segment;
+pub mod nmxc;
 pub mod nvl_logical_partition;
 pub mod nvl_partition;
 pub mod operating_system_definition;

--- a/crates/api-model/src/rpc_conv/nmxc.rs
+++ b/crates/api-model/src/rpc_conv/nmxc.rs
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::nmxc::NvlinkNmxcEndpoint;
+
+impl From<NvlinkNmxcEndpoint> for rpc::forge::NvlinkNmxcEndpoint {
+    fn from(row: NvlinkNmxcEndpoint) -> Self {
+        Self {
+            chassis_serial: row.chassis_serial,
+            endpoint: row.endpoint,
+        }
+    }
+}


### PR DESCRIPTION
## Description

Move NvlinkNmxcEndpoint to model crate to remove db -> rpc dependency.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
#1580 

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
