### PR TITLE
fix(bluefield): make cert directory configurable to match agent code

### DIFF
--- a/bluefield/charts/nico-dpu-agent/templates/daemonset.yaml
+++ b/bluefield/charts/nico-dpu-agent/templates/daemonset.yaml
@@ -73,7 +73,7 @@ spec:
             - name: proc-mem-info
               mountPath: /host-mem-info
             - name: nico-certs
-              mountPath: /opt/nico
+              mountPath: {{ .Values.certsDir | default "/opt/nico" }}
             - name: host-resolv-conf
               mountPath: /host-resolv.conf
               readOnly: true
@@ -135,14 +135,14 @@ spec:
                   key: {{ .Values.hbn.nvue_password_key }}
           volumeMounts:
             - name: nico-certs
-              mountPath: /opt/nico
+              mountPath: {{ .Values.certsDir | default "/opt/nico" }}
             - name: hw-cache
               mountPath: /data
               readOnly: true
       volumes:
         - name: nico-certs
           hostPath:
-            path: /opt/nico
+            path: {{ .Values.certsDir | default "/opt/nico" }}
             type: DirectoryOrCreate
         - name: hw-cache
           emptyDir: {}

--- a/bluefield/charts/nico-dpu-agent/tests/image_layout_test.yaml
+++ b/bluefield/charts/nico-dpu-agent/tests/image_layout_test.yaml
@@ -1,0 +1,86 @@
+suite: cert directory overrides
+templates:
+  - daemonset.yaml
+tests:
+  - it: should mount certs at /opt/forge in init container by default
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: nico-certs
+            mountPath: /opt/forge
+
+  - it: should mount certs at /opt/forge in main container by default
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nico-certs
+            mountPath: /opt/forge
+
+  - it: should hostPath-mount /opt/forge by default
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nico-certs
+            hostPath:
+              path: /opt/forge
+              type: DirectoryOrCreate
+
+  - it: should fall back to /opt/nico when certsDir is cleared
+    set:
+      image:
+        repository: test
+        tag: test
+      certsDir: null
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: nico-certs
+            mountPath: /opt/nico
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nico-certs
+            mountPath: /opt/nico
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nico-certs
+            hostPath:
+              path: /opt/nico
+              type: DirectoryOrCreate
+
+  - it: should accept a custom certsDir value
+    set:
+      image:
+        repository: test
+        tag: test
+      certsDir: /custom/cert/dir
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: nico-certs
+            mountPath: /custom/cert/dir
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nico-certs
+            hostPath:
+              path: /custom/cert/dir
+              type: DirectoryOrCreate

--- a/bluefield/charts/nico-dpu-agent/values.yaml
+++ b/bluefield/charts/nico-dpu-agent/values.yaml
@@ -9,6 +9,9 @@ exposedPorts:
   labels: {}
   ports: {}
 
+### Cert directory on the host (also used as the container mountPath).
+certsDir: /opt/forge
+
 ### Service specific values ###
 image:
   repository: ""

--- a/bluefield/charts/nico-dpu-otel-agent/templates/configmap.yaml
+++ b/bluefield/charts/nico-dpu-otel-agent/templates/configmap.yaml
@@ -6,4 +6,6 @@ metadata:
     {{- include "nico-dpu-otel-agent.labels" . | nindent 4 }}
 data:
   config.toml: |
-    {{- .Files.Get "files/otel-agent-config.toml" | nindent 4 }}
+    {{- /* Swap the embedded /opt/nico/nico_root.pem path to certsDir/rootCaFile. */ -}}
+    {{- $rootCa := printf "%s/%s" (.Values.certsDir | default "/opt/nico") (.Values.rootCaFile | default "nico_root.pem") -}}
+    {{- .Files.Get "files/otel-agent-config.toml" | replace "/opt/nico/nico_root.pem" $rootCa | nindent 4 }}

--- a/bluefield/charts/nico-dpu-otel-agent/templates/daemonset.yaml
+++ b/bluefield/charts/nico-dpu-otel-agent/templates/daemonset.yaml
@@ -80,7 +80,7 @@ spec:
               subPath: config.toml
               readOnly: true
             - name: nico-certs
-              mountPath: /opt/nico
+              mountPath: {{ .Values.certsDir | default "/opt/nico" }}
               readOnly: true
             - name: ssl-certs
               mountPath: /etc/ssl/certs
@@ -92,7 +92,7 @@ spec:
             name: {{ include "nico-dpu-otel-agent.fullname" . }}-config
         - name: nico-certs
           hostPath:
-            path: /opt/nico
+            path: {{ .Values.certsDir | default "/opt/nico" }}
             type: DirectoryOrCreate
         - name: ssl-certs
           hostPath:

--- a/bluefield/charts/nico-dpu-otel-agent/tests/image_layout_test.yaml
+++ b/bluefield/charts/nico-dpu-otel-agent/tests/image_layout_test.yaml
@@ -1,0 +1,79 @@
+suite: cert directory overrides
+templates:
+  - daemonset.yaml
+  - configmap.yaml
+tests:
+  - it: should mount certs at /opt/forge by default
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nico-certs
+            mountPath: /opt/forge
+            readOnly: true
+
+  - it: should hostPath-mount /opt/forge by default
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nico-certs
+            hostPath:
+              path: /opt/forge
+              type: DirectoryOrCreate
+
+  - it: configmap should embed /opt/forge/forge_root.pem in root-ca by default
+    template: configmap.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'root-ca\s*=\s*"/opt/forge/forge_root\.pem"'
+
+  - it: should fall back to /opt/nico when certsDir is cleared
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+      certsDir: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nico-certs
+            mountPath: /opt/nico
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nico-certs
+            hostPath:
+              path: /opt/nico
+              type: DirectoryOrCreate
+
+  - it: configmap should embed /opt/nico/nico_root.pem when overrides cleared
+    template: configmap.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+      certsDir: null
+      rootCaFile: null
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'root-ca\s*=\s*"/opt/nico/nico_root\.pem"'

--- a/bluefield/charts/nico-dpu-otel-agent/values.yaml
+++ b/bluefield/charts/nico-dpu-otel-agent/values.yaml
@@ -9,6 +9,10 @@ exposedPorts:
   labels: {}
   ports: {}
 
+### Cert directory + root CA filename overrides.
+certsDir: /opt/forge
+rootCaFile: forge_root.pem
+
 ### Service specific values ###
 image:
   repository: ""

--- a/bluefield/charts/nico-fmds/templates/daemonset.yaml
+++ b/bluefield/charts/nico-fmds/templates/daemonset.yaml
@@ -51,14 +51,16 @@ spec:
             - /busybox/sh
             - -c
             - |
-              echo "Waiting for nico certificates in /opt/nico ..."
-              while [ ! -f /opt/nico/nico_root.pem ] || [ ! -f /opt/nico/machine_cert.pem ] || [ ! -f /opt/nico/machine_cert.key ]; do
+              {{- $dir := .Values.certsDir | default "/opt/nico" }}
+              {{- $rootCa := .Values.rootCaFile | default "nico_root.pem" }}
+              echo "Waiting for certificates in {{ $dir }} ..."
+              while [ ! -f {{ $dir }}/{{ $rootCa }} ] || [ ! -f {{ $dir }}/machine_cert.pem ] || [ ! -f {{ $dir }}/machine_cert.key ]; do
                 sleep 5
               done
               echo "Certificates found, starting nico-fmds."
           volumeMounts:
             - name: nico-certs
-              mountPath: /opt/nico
+              mountPath: {{ .Values.certsDir | default "/opt/nico" }}
               readOnly: true
       containers:
         - name: nico-fmds
@@ -66,10 +68,12 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           args:
+            {{- $dir := .Values.certsDir | default "/opt/nico" }}
+            {{- $rootCa := .Values.rootCaFile | default "nico_root.pem" }}
             - "--grpc-address=$(POD_IP):50052"
-            - "--root-ca=/opt/nico/nico_root.pem"
-            - "--client-cert=/opt/nico/machine_cert.pem"
-            - "--client-key=/opt/nico/machine_cert.key"
+            - "--root-ca={{ $dir }}/{{ $rootCa }}"
+            - "--client-cert={{ $dir }}/machine_cert.pem"
+            - "--client-key={{ $dir }}/machine_cert.key"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with toYaml .Values.serviceDaemonSet.resources }}
           resources:
@@ -103,12 +107,12 @@ spec:
                   fieldPath: metadata.namespace
           volumeMounts:
             - name: nico-certs
-              mountPath: /opt/nico
+              mountPath: {{ .Values.certsDir | default "/opt/nico" }}
               readOnly: true
       volumes:
         - name: nico-certs
           hostPath:
-            path: /opt/nico
+            path: {{ .Values.certsDir | default "/opt/nico" }}
             type: DirectoryOrCreate
       {{- with .Values.tolerations }}
       tolerations:

--- a/bluefield/charts/nico-fmds/tests/image_layout_test.yaml
+++ b/bluefield/charts/nico-fmds/tests/image_layout_test.yaml
@@ -1,0 +1,114 @@
+suite: cert directory overrides
+templates:
+  - daemonset.yaml
+tests:
+  - it: should mount certs at /opt/forge by default
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: nico-certs
+            mountPath: /opt/forge
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nico-certs
+            mountPath: /opt/forge
+            readOnly: true
+
+  - it: should hostPath-mount /opt/forge by default
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nico-certs
+            hostPath:
+              path: /opt/forge
+              type: DirectoryOrCreate
+
+  - it: should pass /opt/forge/forge_root.pem to fmds args by default
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --root-ca=/opt/forge/forge_root.pem
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --client-cert=/opt/forge/machine_cert.pem
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --client-key=/opt/forge/machine_cert.key
+
+  - it: wait-for-certs script should poll /opt/forge/forge_root.pem by default
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: 'Waiting for certificates in /opt/forge'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: '/opt/forge/forge_root\.pem'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: '/opt/forge/machine_cert\.pem'
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: '/opt/forge/machine_cert\.key'
+
+  - it: should fall back to /opt/nico and nico_root.pem when overrides cleared
+    set:
+      image:
+        repository: test
+        tag: test
+      certsDir: null
+      rootCaFile: null
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nico-certs
+            hostPath:
+              path: /opt/nico
+              type: DirectoryOrCreate
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --root-ca=/opt/nico/nico_root.pem
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --client-cert=/opt/nico/machine_cert.pem
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: '/opt/nico/nico_root\.pem'
+
+  - it: should accept a custom certsDir + rootCaFile pair
+    set:
+      image:
+        repository: test
+        tag: test
+      certsDir: /custom/dir
+      rootCaFile: custom_root.pem
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --root-ca=/custom/dir/custom_root.pem
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --client-cert=/custom/dir/machine_cert.pem
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: '/custom/dir/custom_root\.pem'

--- a/bluefield/charts/nico-fmds/values.yaml
+++ b/bluefield/charts/nico-fmds/values.yaml
@@ -9,6 +9,10 @@ exposedPorts:
   labels: {}
   ports: {}
 
+### Cert directory + root CA filename overrides.
+certsDir: /opt/forge
+rootCaFile: forge_root.pem
+
 ### Service specific values ###
 # Prometheus /metrics listen port (must match nico-otelcol scrape target).
 metricsPort: 8888

--- a/bluefield/charts/nico-otelcol/templates/configmap.yaml
+++ b/bluefield/charts/nico-otelcol/templates/configmap.yaml
@@ -6,4 +6,7 @@ metadata:
     {{- include "nico-otelcol.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    {{- .Files.Get "files/otel_config.yaml" | nindent 4 }}
+    {{- /* Swap the embedded /opt/nico cert dir + nico_root.pem filename to match certsDir + rootCaFile. */ -}}
+    {{- $certsDir := .Values.certsDir | default "/opt/nico" -}}
+    {{- $rootCa := .Values.rootCaFile | default "nico_root.pem" -}}
+    {{- .Files.Get "files/otel_config.yaml" | replace "/opt/nico/nico_root.pem" (printf "%s/%s" $certsDir $rootCa) | replace "/opt/nico" $certsDir | nindent 4 }}

--- a/bluefield/charts/nico-otelcol/templates/daemonset.yaml
+++ b/bluefield/charts/nico-otelcol/templates/daemonset.yaml
@@ -91,7 +91,7 @@ spec:
               mountPath: /var/log/auth.log
               readOnly: true
             - name: nico-certs
-              mountPath: /opt/nico
+              mountPath: {{ .Values.certsDir | default "/opt/nico" }}
               readOnly: true
             - name: machine-id
               mountPath: /run/otelcol-contrib
@@ -118,7 +118,7 @@ spec:
             type: FileOrCreate
         - name: nico-certs
           hostPath:
-            path: /opt/nico
+            path: {{ .Values.certsDir | default "/opt/nico" }}
             type: DirectoryOrCreate
         - name: machine-id
           hostPath:

--- a/bluefield/charts/nico-otelcol/tests/image_layout_test.yaml
+++ b/bluefield/charts/nico-otelcol/tests/image_layout_test.yaml
@@ -1,0 +1,91 @@
+suite: cert directory overrides
+templates:
+  - daemonset.yaml
+  - configmap.yaml
+tests:
+  - it: should mount certs at /opt/forge by default
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nico-certs
+            mountPath: /opt/forge
+            readOnly: true
+
+  - it: should hostPath-mount /opt/forge by default
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nico-certs
+            hostPath:
+              path: /opt/forge
+              type: DirectoryOrCreate
+
+  - it: configmap should embed /opt/forge cert paths and forge_root.pem by default
+    template: configmap.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'ca_file:\s*/opt/forge/forge_root\.pem'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'cert_file:\s*/opt/forge/machine_cert\.pem'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'key_file:\s*/opt/forge/machine_cert\.key'
+
+  - it: should fall back to /opt/nico when certsDir is cleared
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+      certsDir: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nico-certs
+            mountPath: /opt/nico
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nico-certs
+            hostPath:
+              path: /opt/nico
+              type: DirectoryOrCreate
+
+  - it: configmap should embed /opt/nico cert paths and nico_root.pem when cleared
+    template: configmap.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+      certsDir: null
+      rootCaFile: null
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'ca_file:\s*/opt/nico/nico_root\.pem'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'cert_file:\s*/opt/nico/machine_cert\.pem'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'key_file:\s*/opt/nico/machine_cert\.key'

--- a/bluefield/charts/nico-otelcol/values.yaml
+++ b/bluefield/charts/nico-otelcol/values.yaml
@@ -9,6 +9,10 @@ exposedPorts:
   labels: {}
   ports: {}
 
+### Cert directory + root CA filename overrides.
+certsDir: /opt/forge
+rootCaFile: forge_root.pem
+
 ### Service specific values ###
 # Prometheus receiver port; must match DPUServiceConfiguration configPorts (dpf_services).
 prometheusPort: 9999


### PR DESCRIPTION
The carbide/forge → NICo rename in PR #1532 updated the helm charts to mount certs at /opt/nico, but the Rust agent code (and bundled otel configs) still read certs from /opt/forge/forge_root.pem. The chart and the binary were pointing at different directories, breaking certificate discovery for nico-fmds, nico-dpu-agent, nico-dpu-otel-agent, and nico-otelcol.

Adds helm-unittest coverage under each chart's tests/ directory verifying both the default (forge) and cleared (nico) render paths.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [X] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

