### PR TITLE
refactor(admin-cli): move admin cli errors to admin cli crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,6 +1048,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "thiserror 2.0.18",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "tonic",

--- a/crates/admin-cli/Cargo.toml
+++ b/crates/admin-cli/Cargo.toml
@@ -62,6 +62,7 @@ reqwest = { workspace = true, features = ["json"] }
 serde = { features = ["derive"], workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 tonic = { workspace = true }

--- a/crates/admin-cli/DEVELOPMENT.md
+++ b/crates/admin-cli/DEVELOPMENT.md
@@ -78,7 +78,7 @@ handler in `cmd.rs`.
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
+use crate::errors::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
@@ -289,7 +289,7 @@ Create `src/my_command/show/cmd.rs`:
  * ..etc etc.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
+use crate::errors::CarbideCliResult;
 
 use super::args::Args;
 use crate::rpc::ApiClient;
@@ -312,7 +312,7 @@ Create `src/my_command/show/mod.rs`:
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
+use crate::errors::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;

--- a/crates/admin-cli/src/attestation/measured_boot/bundle/args.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/bundle/args.rs
@@ -30,7 +30,6 @@
 
 use std::str::FromStr;
 
-use ::rpc::admin_cli::CarbideCliError;
 use ::rpc::protos::measured_boot::{
     CreateMeasurementBundleRequest, DeleteMeasurementBundleRequest, FindClosestBundleMatchRequest,
     ListMeasurementBundleMachinesRequest, MeasurementBundleStatePb, RenameMeasurementBundleRequest,
@@ -50,6 +49,7 @@ use crate::attestation::measured_boot::global::cmds::{
     IdNameIdentifier, IdentifierType, get_identifier,
 };
 use crate::cfg::measurement::parse_pcr_register_values;
+use crate::errors::CarbideCliError;
 
 /// CmdBundle provides a container for the `bundle` subcommand, which itself
 /// contains other subcommands for working with profiles.

--- a/crates/admin-cli/src/attestation/measured_boot/bundle/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/bundle/cmds.rs
@@ -20,7 +20,7 @@
 
 use std::str::FromStr;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, ToTable, cli_output};
+use ::rpc::admin_cli::ToTable;
 use ::rpc::protos::measured_boot::{
     ListMeasurementBundleMachinesRequest, RenameMeasurementBundleRequest,
     ShowMeasurementBundleRequest, UpdateMeasurementBundleRequest,
@@ -34,6 +34,8 @@ use crate::attestation::measured_boot::bundle::args::{
     CmdBundle, Create, Delete, FindClosestMatch, List, ListMachines, Rename, SetState, Show,
 };
 use crate::attestation::measured_boot::{MachineIdList, global};
+use crate::cli_output;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 /// dispatch matches + dispatches the correct command for

--- a/crates/admin-cli/src/attestation/measured_boot/global/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/global/cmds.rs
@@ -19,9 +19,8 @@
 //! Global commands at the root of the CLI, as well as some helper
 //! functions used by main.
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-
 use crate::cfg::measurement::GlobalOptions;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 /// CliData is a simple struct containing the single database connection

--- a/crates/admin-cli/src/attestation/measured_boot/journal/args.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/journal/args.rs
@@ -25,7 +25,6 @@
  *  - `journal promote`: Promote the report from a journal entry into a bundle.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
 use ::rpc::protos::measured_boot::{
     DeleteMeasurementJournalRequest, ListMeasurementJournalRequest, ShowMeasurementJournalRequest,
     list_measurement_journal_request, show_measurement_journal_request,
@@ -34,6 +33,8 @@ use carbide_uuid::machine::MachineId;
 use carbide_uuid::measured_boot::MeasurementJournalId;
 use clap::Parser;
 use measured_boot::pcr::{PcrSet, parse_pcr_index_input};
+
+use crate::errors::CarbideCliError;
 
 /// CmdJournal provides a container for the `journal` subcommand, which itself
 /// contains other subcommands for working with journals.

--- a/crates/admin-cli/src/attestation/measured_boot/journal/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/journal/cmds.rs
@@ -17,10 +17,7 @@
 
 //!
 //! `measurement journal` subcommand dispatcher + backing functions.
-
-use ::rpc::admin_cli::{
-    CarbideCliError, CarbideCliResult, ToTable, cli_output, just_print_summary,
-};
+use ::rpc::admin_cli::{ToTable, just_print_summary};
 use ::rpc::protos::measured_boot::ShowMeasurementJournalRequest;
 use measured_boot::bundle::MeasurementBundle;
 use measured_boot::journal::MeasurementJournal;
@@ -31,6 +28,8 @@ use crate::attestation::measured_boot::global;
 use crate::attestation::measured_boot::journal::args::{CmdJournal, Delete, List, Promote, Show};
 use crate::attestation::measured_boot::report::args::Promote as ReportPromoteArgs;
 use crate::attestation::measured_boot::report::cmds::promote as report_promote;
+use crate::cli_output;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 /// dispatch matches + dispatches the correct command for

--- a/crates/admin-cli/src/attestation/measured_boot/machine/args.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/machine/args.rs
@@ -26,7 +26,6 @@
  *  - `mock-machine list``: Lists all mock machines.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
 use ::rpc::protos::measured_boot::{
     AttestCandidateMachineRequest, ShowCandidateMachineRequest, show_candidate_machine_request,
 };
@@ -35,6 +34,7 @@ use clap::Parser;
 use measured_boot::pcr::PcrRegisterValue;
 
 use crate::cfg::measurement::parse_pcr_register_values;
+use crate::errors::CarbideCliError;
 
 /// CmdMachine provides a container for the `mock-machine`
 /// subcommand, which itself contains other subcommands

--- a/crates/admin-cli/src/attestation/measured_boot/machine/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/machine/cmds.rs
@@ -18,7 +18,7 @@
 //!
 //! `measurement mock-machine` subcommand dispatcher + backing functions.
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, ToTable, cli_output};
+use ::rpc::admin_cli::ToTable;
 use ::rpc::protos::measured_boot::ShowCandidateMachineRequest;
 use measured_boot::machine::CandidateMachine;
 use measured_boot::records::CandidateMachineSummary;
@@ -27,6 +27,8 @@ use serde::Serialize;
 
 use crate::attestation::measured_boot::global;
 use crate::attestation::measured_boot::machine::args::{Attest, CmdMachine, Show};
+use crate::cli_output;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 /// dispatch matches + dispatches the correct command

--- a/crates/admin-cli/src/attestation/measured_boot/mod.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/mod.rs
@@ -27,13 +27,14 @@ pub mod profile;
 pub mod report;
 pub mod site;
 
-use ::rpc::admin_cli::{CarbideCliResult, ToTable, set_summary};
+use ::rpc::admin_cli::{ToTable, set_summary};
 use carbide_uuid::machine::MachineId;
 use serde::Serialize;
 
 use crate::cfg::dispatch::Dispatch;
 use crate::cfg::measurement::{Cmd, GlobalOptions};
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Dispatch for Cmd {
     async fn dispatch(self, ctx: RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/attestation/measured_boot/profile/args.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/profile/args.rs
@@ -30,7 +30,6 @@
 
 use std::str::FromStr;
 
-use ::rpc::admin_cli::CarbideCliError;
 use ::rpc::protos::measured_boot::{
     CreateMeasurementSystemProfileRequest, DeleteMeasurementSystemProfileRequest, KvPair,
     ListMeasurementSystemProfileBundlesRequest, ListMeasurementSystemProfileMachinesRequest,
@@ -46,6 +45,7 @@ use crate::attestation::measured_boot::global::cmds::{
     IdNameIdentifier, IdentifierType, get_identifier,
 };
 use crate::cfg::measurement::{KvPair as CfgKvPair, parse_colon_pairs};
+use crate::errors::CarbideCliError;
 
 // CmdProfile provides a container for the `profile`
 // subcommand, which itself contains other subcommands

--- a/crates/admin-cli/src/attestation/measured_boot/profile/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/profile/cmds.rs
@@ -20,7 +20,7 @@
 
 use std::str::FromStr;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, ToTable, cli_output};
+use ::rpc::admin_cli::ToTable;
 use ::rpc::protos::measured_boot::{
     DeleteMeasurementSystemProfileRequest, ListMeasurementSystemProfileBundlesRequest,
     ListMeasurementSystemProfileMachinesRequest, RenameMeasurementSystemProfileRequest,
@@ -36,6 +36,8 @@ use crate::attestation::measured_boot::profile::args::{
     CmdProfile, Create, Delete, List, ListBundles, ListMachines, Rename, Show,
 };
 use crate::attestation::measured_boot::{MachineIdList, global};
+use crate::cli_output;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 /// dispatch matches + dispatches the correct command for

--- a/crates/admin-cli/src/attestation/measured_boot/report/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/report/cmds.rs
@@ -18,7 +18,7 @@
 //!
 //! `measurement report` subcommand dispatcher + backing functions.
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, ToTable, cli_output};
+use ::rpc::admin_cli::ToTable;
 use ::rpc::protos::measured_boot::ListMeasurementReportRequest;
 use measured_boot::bundle::MeasurementBundle;
 use measured_boot::records::MeasurementReportRecord;
@@ -30,6 +30,8 @@ use crate::attestation::measured_boot::report::args::{
     CmdReport, Create, Delete, List, ListMachines, Match, Promote, Revoke, ShowFor, ShowForId,
     ShowForMachine,
 };
+use crate::cli_output;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 /// dispatch matches + dispatches the correct command for

--- a/crates/admin-cli/src/attestation/measured_boot/site/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/site/cmds.rs
@@ -21,7 +21,7 @@
 use std::fs::File;
 use std::io::BufReader;
 
-use ::rpc::admin_cli::{CarbideCliResult, ToTable, cli_output, set_summary};
+use ::rpc::admin_cli::{ToTable, set_summary};
 use ::rpc::protos::measured_boot::ImportSiteMeasurementsRequest;
 use measured_boot::records::{MeasurementApprovedMachineRecord, MeasurementApprovedProfileRecord};
 use measured_boot::site::{ImportResult, SiteModel};
@@ -33,6 +33,8 @@ use crate::attestation::measured_boot::site::args::{
     RemoveMachineByApprovalId, RemoveMachineByMachineId, RemoveProfile, RemoveProfileByApprovalId,
     RemoveProfileByProfileId, TrustedMachine, TrustedProfile,
 };
+use crate::cli_output;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 /// dispatch matches + dispatches the correct command

--- a/crates/admin-cli/src/attestation/spdm/cancel/cmd.rs
+++ b/crates/admin-cli/src/attestation/spdm/cancel/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use rpc::admin_cli::CarbideCliResult;
-
 use crate::attestation::spdm::cancel::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn cancel(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/attestation/spdm/cancel/mod.rs
+++ b/crates/admin-cli/src/attestation/spdm/cancel/mod.rs
@@ -19,10 +19,10 @@ pub mod args;
 pub mod cmd;
 
 use args::Args;
-use rpc::admin_cli::CarbideCliResult;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for args::Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/attestation/spdm/find/cmd.rs
+++ b/crates/admin-cli/src/attestation/spdm/find/cmd.rs
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-use rpc::admin_cli::CarbideCliResult;
-
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn find(api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/attestation/spdm/find/mod.rs
+++ b/crates/admin-cli/src/attestation/spdm/find/mod.rs
@@ -18,10 +18,9 @@
 pub mod args;
 pub mod cmd;
 
-use rpc::admin_cli::CarbideCliResult;
-
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for args::Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/attestation/spdm/get/cmd.rs
+++ b/crates/admin-cli/src/attestation/spdm/get/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use rpc::admin_cli::CarbideCliResult;
-
 use crate::attestation::spdm::get::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn get(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/attestation/spdm/get/mod.rs
+++ b/crates/admin-cli/src/attestation/spdm/get/mod.rs
@@ -19,10 +19,10 @@ pub mod args;
 pub mod cmd;
 
 use args::Args;
-use rpc::admin_cli::CarbideCliResult;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for args::Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/attestation/spdm/list/cmd.rs
+++ b/crates/admin-cli/src/attestation/spdm/list/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use rpc::admin_cli::CarbideCliResult;
-
 use crate::attestation::spdm::list::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn list(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/attestation/spdm/list/mod.rs
+++ b/crates/admin-cli/src/attestation/spdm/list/mod.rs
@@ -19,10 +19,10 @@ pub mod args;
 pub mod cmd;
 
 use args::Args;
-use rpc::admin_cli::CarbideCliResult;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for args::Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/attestation/spdm/trigger/cmd.rs
+++ b/crates/admin-cli/src/attestation/spdm/trigger/cmd.rs
@@ -16,9 +16,9 @@
  */
 
 use ::rpc::forge::SpdmMachineAttestationTriggerRequest;
-use rpc::admin_cli::CarbideCliResult;
 
 use crate::attestation::spdm::trigger::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn trigger(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/attestation/spdm/trigger/mod.rs
+++ b/crates/admin-cli/src/attestation/spdm/trigger/mod.rs
@@ -19,10 +19,10 @@ pub mod args;
 pub mod cmd;
 
 use args::Args;
-use rpc::admin_cli::CarbideCliResult;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for args::Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/bmc_machine/admin_power_control/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/admin_power_control/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn admin_power_control(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/bmc_machine/admin_power_control/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/admin_power_control/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/bmc_machine/bmc_reset/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/bmc_reset/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn bmc_reset(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/bmc_machine/bmc_reset/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/bmc_reset/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/bmc_machine/create_bmc_user/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/create_bmc_user/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn create_bmc_user(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/bmc_machine/create_bmc_user/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/create_bmc_user/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/bmc_machine/delete_bmc_user/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/delete_bmc_user/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn delete_bmc_user(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/bmc_machine/delete_bmc_user/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/delete_bmc_user/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/bmc_machine/enable_infinite_boot/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/enable_infinite_boot/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use crate::bmc_machine::common::{AdminPowerControlAction, InfiniteBootArgs};
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn enable_infinite_boot(

--- a/crates/admin-cli/src/bmc_machine/enable_infinite_boot/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/enable_infinite_boot/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn is_infinite_boot_enabled(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/bmc_machine/lockdown/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/lockdown/cmd.rs
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge as forgerpc;
 
 use super::args::Args;
 use crate::bmc_machine::common::AdminPowerControlAction;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn lockdown(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/bmc_machine/lockdown/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/lockdown/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/bmc_machine/lockdown_status/cmd.rs
+++ b/crates/admin-cli/src/bmc_machine/lockdown_status/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn lockdown_status(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/bmc_machine/lockdown_status/mod.rs
+++ b/crates/admin-cli/src/bmc_machine/lockdown_status/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/boot_override/clear/cmd.rs
+++ b/crates/admin-cli/src/boot_override/clear/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn clear(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/boot_override/clear/mod.rs
+++ b/crates/admin-cli/src/boot_override/clear/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/boot_override/get/cmd.rs
+++ b/crates/admin-cli/src/boot_override/get/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn get(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/boot_override/get/mod.rs
+++ b/crates/admin-cli/src/boot_override/get/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/boot_override/set/args.rs
+++ b/crates/admin-cli/src/boot_override/set/args.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::MachineBootOverride;
 use carbide_uuid::machine::MachineInterfaceId;
 use clap::Parser;
+
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {

--- a/crates/admin-cli/src/boot_override/set/cmd.rs
+++ b/crates/admin-cli/src/boot_override/set/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::MachineBootOverride;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn set(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/boot_override/set/mod.rs
+++ b/crates/admin-cli/src/boot_override/set/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/cfg/dispatch.rs
+++ b/crates/admin-cli/src/cfg/dispatch.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 // Dispatch is a trait implemented by all CLI command types.
 // It provides a unified interface for executing commands with
@@ -35,11 +34,10 @@ pub(crate) use carbide_macros::Dispatch;
 
 #[cfg(test)]
 mod tests {
-    use ::rpc::admin_cli::CarbideCliResult;
-
     use super::Dispatch;
     use crate::cfg::run::Run;
     use crate::cfg::runtime::RuntimeContext;
+    use crate::errors::CarbideCliResult;
 
     // Stub leaf command type that implements Run for the purpose
     // of testing our Dispatch + Run trait handling flow.

--- a/crates/admin-cli/src/cfg/run.rs
+++ b/crates/admin-cli/src/cfg/run.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 // Run is a trait implemented by leaf argument structs,
 // allowing them to execute themselves given a RuntimeContext.

--- a/crates/admin-cli/src/component_manager/status/cmd.rs
+++ b/crates/admin-cli/src/component_manager/status/cmd.rs
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use prettytable::{Cell, Row, Table};
 
 use super::args::Args;
 use crate::component_manager::common;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 pub async fn get_status(

--- a/crates/admin-cli/src/component_manager/status/mod.rs
+++ b/crates/admin-cli/src/component_manager/status/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/component_manager/update_firmware/cmd.rs
+++ b/crates/admin-cli/src/component_manager/update_firmware/cmd.rs
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use prettytable::{Cell, Row, Table};
 
 use super::args::Args;
 use crate::component_manager::common;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 pub async fn update_firmware(

--- a/crates/admin-cli/src/component_manager/update_firmware/mod.rs
+++ b/crates/admin-cli/src/component_manager/update_firmware/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/component_manager/versions/cmd.rs
+++ b/crates/admin-cli/src/component_manager/versions/cmd.rs
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::ComputeTrayComponent;
 use prettytable::{Cell, Row, Table};
 
 use super::args::Args;
 use crate::component_manager::common;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 /// Formats a raw proto `ComputeTrayComponent` value for display.

--- a/crates/admin-cli/src/component_manager/versions/mod.rs
+++ b/crates/admin-cli/src/component_manager/versions/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/compute_allocation/common.rs
+++ b/crates/admin-cli/src/compute_allocation/common.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge as forgerpc;
 use prettytable::{Table, row};
+
+use crate::errors::CarbideCliResult;
 
 /// Produces a table for printing a non-JSON representation of a
 /// compute allocation to standard out.

--- a/crates/admin-cli/src/compute_allocation/create/args.rs
+++ b/crates/admin-cli/src/compute_allocation/create/args.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
 use ::rpc::forge::{self as forgerpc, CreateComputeAllocationRequest};
 use carbide_uuid::compute_allocation::ComputeAllocationId;
 use clap::Parser;
+
+use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {

--- a/crates/admin-cli/src/compute_allocation/create/cmd.rs
+++ b/crates/admin-cli/src/compute_allocation/create/cmd.rs
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::CreateComputeAllocationRequest;
 
 use super::args::Args;
 use crate::compute_allocation::common::convert_compute_allocations_to_table;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 /// Create a compute allocation.

--- a/crates/admin-cli/src/compute_allocation/create/mod.rs
+++ b/crates/admin-cli/src/compute_allocation/create/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/compute_allocation/delete/cmd.rs
+++ b/crates/admin-cli/src/compute_allocation/delete/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 /// Delete a compute allocation.

--- a/crates/admin-cli/src/compute_allocation/delete/mod.rs
+++ b/crates/admin-cli/src/compute_allocation/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/compute_allocation/show/cmd.rs
+++ b/crates/admin-cli/src/compute_allocation/show/cmd.rs
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::FindComputeAllocationsByIdsRequest;
 
 use super::args::Args;
 use crate::compute_allocation::common::convert_compute_allocations_to_table;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 /// Show one or more compute allocations.

--- a/crates/admin-cli/src/compute_allocation/show/mod.rs
+++ b/crates/admin-cli/src/compute_allocation/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/compute_allocation/update/cmd.rs
+++ b/crates/admin-cli/src/compute_allocation/update/cmd.rs
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::{FindComputeAllocationsByIdsRequest, UpdateComputeAllocationRequest};
 
 use super::args::Args;
 use crate::compute_allocation::common::convert_compute_allocations_to_table;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 /// Update a compute allocation.

--- a/crates/admin-cli/src/compute_allocation/update/mod.rs
+++ b/crates/admin-cli/src/compute_allocation/update/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/add_bmc/args.rs
+++ b/crates/admin-cli/src/credential/add_bmc/args.rs
@@ -17,10 +17,10 @@
 
 use clap::Parser;
 use mac_address::MacAddress;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use rpc::{CredentialType, forge as forgerpc};
 
 use crate::credential::common::{BmcCredentialType, password_validator};
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {

--- a/crates/admin-cli/src/credential/add_bmc/cmd.rs
+++ b/crates/admin-cli/src/credential/add_bmc/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge as forgerpc;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn add_bmc(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/add_bmc/mod.rs
+++ b/crates/admin-cli/src/credential/add_bmc/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/add_dpu_factory_default/cmd.rs
+++ b/crates/admin-cli/src/credential/add_dpu_factory_default/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn add_dpu_factory_default(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/add_dpu_factory_default/mod.rs
+++ b/crates/admin-cli/src/credential/add_dpu_factory_default/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/add_host_factory_default/cmd.rs
+++ b/crates/admin-cli/src/credential/add_host_factory_default/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn add_host_factory_default(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/add_host_factory_default/mod.rs
+++ b/crates/admin-cli/src/credential/add_host_factory_default/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/add_nmxm/cmd.rs
+++ b/crates/admin-cli/src/credential/add_nmxm/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn add_nmxm(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/add_nmxm/mod.rs
+++ b/crates/admin-cli/src/credential/add_nmxm/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/add_uefi/args.rs
+++ b/crates/admin-cli/src/credential/add_uefi/args.rs
@@ -16,10 +16,10 @@
  */
 
 use clap::Parser;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use rpc::{CredentialType, forge as forgerpc};
 
 use crate::credential::common::{UefiCredentialType, password_validator};
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {

--- a/crates/admin-cli/src/credential/add_uefi/cmd.rs
+++ b/crates/admin-cli/src/credential/add_uefi/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge as forgerpc;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn add_uefi(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/add_uefi/mod.rs
+++ b/crates/admin-cli/src/credential/add_uefi/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/add_ufm/args.rs
+++ b/crates/admin-cli/src/credential/add_ufm/args.rs
@@ -16,10 +16,10 @@
  */
 
 use clap::Parser;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use rpc::{CredentialType, forge as forgerpc};
 
 use crate::credential::common::url_validator;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {

--- a/crates/admin-cli/src/credential/add_ufm/cmd.rs
+++ b/crates/admin-cli/src/credential/add_ufm/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge as forgerpc;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn add_ufm(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/add_ufm/mod.rs
+++ b/crates/admin-cli/src/credential/add_ufm/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/bgp/delete_sitewide/cmd.rs
+++ b/crates/admin-cli/src/credential/bgp/delete_sitewide/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn delete_sitewide(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/bgp/delete_sitewide/mod.rs
+++ b/crates/admin-cli/src/credential/bgp/delete_sitewide/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/bgp/mod.rs
+++ b/crates/admin-cli/src/credential/bgp/mod.rs
@@ -18,12 +18,12 @@
 mod delete_sitewide;
 mod set_sitewide;
 
-use ::rpc::admin_cli::CarbideCliResult;
 use clap::Parser;
 
 use crate::cfg::dispatch::Dispatch;
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 #[derive(Parser, Debug, Clone, Dispatch)]
 #[clap(rename_all = "kebab_case")]

--- a/crates/admin-cli/src/credential/bgp/set_sitewide/args.rs
+++ b/crates/admin-cli/src/credential/bgp/set_sitewide/args.rs
@@ -16,10 +16,10 @@
  */
 
 use clap::Parser;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use rpc::{CredentialType, forge as forgerpc};
 
 use crate::credential::common::password_validator;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {

--- a/crates/admin-cli/src/credential/bgp/set_sitewide/cmd.rs
+++ b/crates/admin-cli/src/credential/bgp/set_sitewide/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge as forgerpc;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn set_sitewide(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/bgp/set_sitewide/mod.rs
+++ b/crates/admin-cli/src/credential/bgp/set_sitewide/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/common.rs
+++ b/crates/admin-cli/src/credential/common.rs
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
 use clap::{Parser, ValueEnum};
+
+use crate::errors::CarbideCliError;
 
 pub const DEFAULT_IB_FABRIC_NAME: &str = "default";
 

--- a/crates/admin-cli/src/credential/delete_bmc/cmd.rs
+++ b/crates/admin-cli/src/credential/delete_bmc/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn delete_bmc(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/delete_bmc/mod.rs
+++ b/crates/admin-cli/src/credential/delete_bmc/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/delete_nmxm/cmd.rs
+++ b/crates/admin-cli/src/credential/delete_nmxm/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn delete_nmxm(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/delete_nmxm/mod.rs
+++ b/crates/admin-cli/src/credential/delete_nmxm/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/delete_ufm/args.rs
+++ b/crates/admin-cli/src/credential/delete_ufm/args.rs
@@ -16,10 +16,10 @@
  */
 
 use clap::Parser;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use rpc::{CredentialType, forge as forgerpc};
 
 use crate::credential::common::url_validator;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {

--- a/crates/admin-cli/src/credential/delete_ufm/cmd.rs
+++ b/crates/admin-cli/src/credential/delete_ufm/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge as forgerpc;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn delete_ufm(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/delete_ufm/mod.rs
+++ b/crates/admin-cli/src/credential/delete_ufm/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/generate_ufm_cert/cmd.rs
+++ b/crates/admin-cli/src/credential/generate_ufm_cert/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn generate_ufm_cert(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/credential/generate_ufm_cert/mod.rs
+++ b/crates/admin-cli/src/credential/generate_ufm_cert/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/debug_bundle/cmds.rs
+++ b/crates/admin-cli/src/debug_bundle/cmds.rs
@@ -27,16 +27,16 @@ use std::fs::File;
 use std::io::Write;
 use std::str::FromStr;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::BmcEndpointRequest;
 use carbide_uuid::machine::MachineId;
 use chrono::{DateTime, Local, NaiveDateTime, NaiveTime, Utc};
-use rpc::admin_cli::CarbideCliError::InvalidDateTimeFromUserInput;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use zip::CompressionMethod;
 use zip::write::{FileOptions, ZipWriter};
 
+use crate::errors::CarbideCliError::InvalidDateTimeFromUserInput;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::managed_host::DebugBundle;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/devenv/config/apply/cmd.rs
+++ b/crates/admin-cli/src/devenv/config/apply/cmd.rs
@@ -14,13 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use carbide_network::ip::prefix::Ipv4Network;
 use carbide_uuid::network::NetworkSegmentId;
 use rpc::forge::{PrefixMatchType, Vpc, VpcPrefixCreationRequest, VpcPrefixSearchQuery};
 use serde::{Deserialize, Serialize};
 
 use super::args::{Args, NetworkChoice};
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/admin-cli/src/devenv/config/apply/mod.rs
+++ b/crates/admin-cli/src/devenv/config/apply/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/devenv/config/mod.rs
+++ b/crates/admin-cli/src/devenv/config/mod.rs
@@ -17,13 +17,13 @@
 
 mod apply;
 
-use ::rpc::admin_cli::CarbideCliResult;
 #[cfg(test)]
 pub use apply::args::NetworkChoice;
 use clap::Parser;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 #[derive(Parser, Debug, Clone)]
 pub enum Cmd {

--- a/crates/admin-cli/src/domain/show/cmd.rs
+++ b/crates/admin-cli/src/domain/show/cmd.rs
@@ -18,12 +18,13 @@
 use std::fmt::Write;
 
 use ::rpc::Timestamp;
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use carbide_uuid::domain::DomainId;
 use prettytable::{Table, row};
 use tracing::warn;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 // timestamp_or_default returns a String representation of

--- a/crates/admin-cli/src/domain/show/mod.rs
+++ b/crates/admin-cli/src/domain/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpa/ensure/cmd.rs
+++ b/crates/admin-cli/src/dpa/ensure/cmd.rs
@@ -17,10 +17,11 @@
 
 use std::fmt::Write;
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::{self as forgerpc};
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 // ensure, similar to persist, is an RPC endpoint meant for

--- a/crates/admin-cli/src/dpa/ensure/mod.rs
+++ b/crates/admin-cli/src/dpa/ensure/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpa/show/cmd.rs
+++ b/crates/admin-cli/src/dpa/show/cmd.rs
@@ -17,12 +17,13 @@
 
 use std::fmt::Write;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::{self as forgerpc};
 use carbide_uuid::dpa_interface::DpaInterfaceId;
 use prettytable::{Table, row};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn show(

--- a/crates/admin-cli/src/dpa/show/mod.rs
+++ b/crates/admin-cli/src/dpa/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpf/common.rs
+++ b/crates/admin-cli/src/dpf/common.rs
@@ -17,7 +17,8 @@
 
 use carbide_uuid::machine::MachineId;
 use clap::Parser;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug)]
 pub struct DpfQuery {

--- a/crates/admin-cli/src/dpf/disable/mod.rs
+++ b/crates/admin-cli/src/dpf/disable/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpf/enable/cmd.rs
+++ b/crates/admin-cli/src/dpf/enable/cmd.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
 use carbide_uuid::machine::MachineId;
+use rpc::admin_cli::OutputFormat;
 
 use crate::dpf::common::DpfQuery;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn modify_dpf_state(

--- a/crates/admin-cli/src/dpf/enable/mod.rs
+++ b/crates/admin-cli/src/dpf/enable/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpf/service_version/cmd.rs
+++ b/crates/admin-cli/src/dpf/service_version/cmd.rs
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use prettytable::row;
 
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn service_version(api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpf/service_version/mod.rs
+++ b/crates/admin-cli/src/dpf/service_version/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpf/show/cmd.rs
+++ b/crates/admin-cli/src/dpf/show/cmd.rs
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use prettytable::row;
-use rpc::admin_cli::CarbideCliError;
 
 use crate::dpf::common::DpfQuery;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn show(

--- a/crates/admin-cli/src/dpf/show/mod.rs
+++ b/crates/admin-cli/src/dpf/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpf/snapshot/cmd.rs
+++ b/crates/admin-cli/src/dpf/snapshot/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use carbide_uuid::machine::MachineType;
 
 use crate::dpf::snapshot::args::SnapshotQuery;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn snapshot(query: &SnapshotQuery, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpf/snapshot/mod.rs
+++ b/crates/admin-cli/src/dpf/snapshot/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpu/agent_upgrade_policy/cmd.rs
+++ b/crates/admin-cli/src/dpu/agent_upgrade_policy/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::{AgentUpgradePolicyChoice, Args};
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn agent_upgrade_policy(api_client: &ApiClient, args: Args) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpu/agent_upgrade_policy/mod.rs
+++ b/crates/admin-cli/src/dpu/agent_upgrade_policy/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpu/health_report/cmd.rs
+++ b/crates/admin-cli/src/dpu/health_report/cmd.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use carbide_uuid::machine::MachineId;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::health_utils;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/dpu/health_report/mod.rs
+++ b/crates/admin-cli/src/dpu/health_report/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpu/network/cmd.rs
+++ b/crates/admin-cli/src/dpu/network/cmd.rs
@@ -17,12 +17,13 @@
 
 use std::collections::HashMap;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::ManagedHostNetworkConfigResponse;
 use carbide_uuid::machine::MachineId;
 use prettytable::{Table, format, row};
 
 use crate::async_write;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::machine::network::Args as NetworkCommand;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/dpu/network/mod.rs
+++ b/crates/admin-cli/src/dpu/network/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpu/reprovision/cmd.rs
+++ b/crates/admin-cli/src/dpu/reprovision/cmd.rs
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::DpuReprovisioningRequest;
 use carbide_uuid::machine::MachineType;
 use prettytable::{Table, row};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::machine::{HealthReportTemplates, get_health_report};
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/dpu/reprovision/mod.rs
+++ b/crates/admin-cli/src/dpu/reprovision/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpu/status/cmd.rs
+++ b/crates/admin-cli/src/dpu/status/cmd.rs
@@ -16,12 +16,13 @@
  */
 
 use ::rpc::Machine;
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::BuildInfo;
 use carbide_uuid::machine::MachineId;
 use prettytable::{Row, Table};
 use serde::Serialize;
 
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::{async_write, async_write_table_as_csv};
 

--- a/crates/admin-cli/src/dpu/status/mod.rs
+++ b/crates/admin-cli/src/dpu/status/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpu/versions/cmd.rs
+++ b/crates/admin-cli/src/dpu/versions/cmd.rs
@@ -18,12 +18,13 @@
 use std::collections::HashMap;
 
 use ::rpc::Machine;
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use carbide_uuid::machine::MachineId;
 use prettytable::{Row, Table};
 use serde::Serialize;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::{async_write, async_write_table_as_csv};
 

--- a/crates/admin-cli/src/dpu/versions/mod.rs
+++ b/crates/admin-cli/src/dpu/versions/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpu_remediation/approve/cmd.rs
+++ b/crates/admin-cli/src/dpu_remediation/approve/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
-
 use super::args::Args;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 pub async fn approve_dpu_remediation(

--- a/crates/admin-cli/src/dpu_remediation/approve/mod.rs
+++ b/crates/admin-cli/src/dpu_remediation/approve/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpu_remediation/create/cmd.rs
+++ b/crates/admin-cli/src/dpu_remediation/create/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
 use rpc::forge::CreateRemediationRequest;
 
 use super::args::Args;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 pub async fn create_dpu_remediation(

--- a/crates/admin-cli/src/dpu_remediation/create/mod.rs
+++ b/crates/admin-cli/src/dpu_remediation/create/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpu_remediation/disable/cmd.rs
+++ b/crates/admin-cli/src/dpu_remediation/disable/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
-
 use super::args::Args;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 pub async fn disable_dpu_remediation(

--- a/crates/admin-cli/src/dpu_remediation/disable/mod.rs
+++ b/crates/admin-cli/src/dpu_remediation/disable/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpu_remediation/enable/cmd.rs
+++ b/crates/admin-cli/src/dpu_remediation/enable/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
-
 use super::args::Args;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 pub async fn enable_dpu_remediation(

--- a/crates/admin-cli/src/dpu_remediation/enable/mod.rs
+++ b/crates/admin-cli/src/dpu_remediation/enable/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpu_remediation/list_applied/cmd.rs
+++ b/crates/admin-cli/src/dpu_remediation/list_applied/cmd.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use carbide_uuid::dpu_remediations::RemediationId;
 use carbide_uuid::machine::MachineId;
 use prettytable::{Table, row};
@@ -25,6 +25,7 @@ use rpc::forge::{
 };
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::{async_write, async_writeln};
 

--- a/crates/admin-cli/src/dpu_remediation/list_applied/mod.rs
+++ b/crates/admin-cli/src/dpu_remediation/list_applied/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpu_remediation/revoke/cmd.rs
+++ b/crates/admin-cli/src/dpu_remediation/revoke/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
-
 use super::args::Args;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 pub async fn revoke_dpu_remediation(

--- a/crates/admin-cli/src/dpu_remediation/revoke/mod.rs
+++ b/crates/admin-cli/src/dpu_remediation/revoke/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/dpu_remediation/show/cmd.rs
+++ b/crates/admin-cli/src/dpu_remediation/show/cmd.rs
@@ -17,12 +17,13 @@
 
 use std::fmt::Write;
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use carbide_uuid::dpu_remediations::RemediationId;
 use prettytable::{Table, row};
 use rpc::forge::{Remediation, RemediationList};
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 use crate::{async_write, async_writeln};
 

--- a/crates/admin-cli/src/dpu_remediation/show/mod.rs
+++ b/crates/admin-cli/src/dpu_remediation/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/errors.rs
+++ b/crates/admin-cli/src/errors.rs
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::dpu_remediations::RemediationId;
+use carbide_uuid::instance::InstanceId;
+use carbide_uuid::machine::{MachineId, MachineIdParseError};
+use rpc::forge::MachineType;
+use rpc::forge_tls_client::ForgeTlsClientError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum CarbideCliError {
+    #[error("Unable to connect to carbide API: {0}")]
+    ApiConnectFailed(#[from] ForgeTlsClientError),
+
+    #[error("The API call to the Forge API server returned {0}")]
+    ApiInvocationError(#[from] tonic::Status),
+
+    #[error("Error while writing into string: {0}")]
+    StringWriteError(#[from] std::fmt::Error),
+
+    #[error("Generic Error: {0}")]
+    GenericError(String),
+
+    #[error("Cannot specify both {0} and {1}. Please provide only one.")]
+    ChooseOneError(&'static str, &'static str),
+
+    #[error("Must specify either {0} or {1}.")]
+    RequireOneError(&'static str, &'static str),
+
+    #[error("Invalid datetime format: {0}. Use 'YYYY-MM-DD HH:MM:SS' or 'HH:MM:SS'")]
+    InvalidDateTimeFromUserInput(String),
+
+    #[error("Segment not found.")]
+    SegmentNotFound,
+
+    #[error("Domain not found.")]
+    DomainNotFound,
+
+    #[error("Uuid not found.")]
+    UuidNotFound,
+
+    #[error("MAC not found.")]
+    MacAddressNotFound,
+
+    #[error("Serial number not found.")]
+    SerialNumberNotFound,
+
+    #[error("Error while handling json: {0}")]
+    JsonError(#[from] serde_json::Error),
+
+    #[error("Error while handling yaml: {0}")]
+    YamlError(#[from] serde_yaml::Error),
+
+    #[error("Error while handling csv: {0}")]
+    CsvError(#[from] csv::Error),
+
+    #[error("Unexpected machine type.  expected {0:?} but found {1:?}")]
+    UnexpectedMachineType(MachineType, MachineType),
+
+    #[error("Host machine with id {0} not found")]
+    MachineNotFound(MachineId),
+
+    #[error("Remediation with id {0} not found")]
+    RemediationNotFound(RemediationId),
+
+    #[error("Instance with id {0} not found")]
+    InstanceNotFound(InstanceId),
+
+    #[error("Tenant with id {0} not found")]
+    TenantNotFound(String),
+
+    #[error("I/O error. Does the file exist? {0}")]
+    IOError(#[from] std::io::Error),
+
+    /// For when you expected some values but the response was empty.
+    /// If empty is acceptable don't use this.
+    #[error("No results returned")]
+    Empty,
+
+    #[error("Not Implemented {0}")]
+    NotImplemented(String),
+
+    #[error("Invalid Machine ID: {0}")]
+    InvalidMachineId(#[from] MachineIdParseError),
+
+    #[error("RPC data conversion error: {0}")]
+    RpcDataConversionError(#[from] ::rpc::errors::RpcDataConversionError),
+
+    #[error("Invalid Routing Profile Type: {0}")]
+    InvalidRoutingProfileType(String),
+
+    #[error(transparent)]
+    EyreReport(eyre::Report),
+}
+
+impl From<eyre::Report> for CarbideCliError {
+    // For commands that are [still] returning an eyre::Report,
+    // and not a CarbideCliError, preserve the full report and
+    // error chain for complete context.
+    fn from(err: eyre::Report) -> Self {
+        CarbideCliError::EyreReport(err)
+    }
+}
+
+pub type CarbideCliResult<T> = Result<T, CarbideCliError>;

--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -21,9 +21,10 @@ use carbide_utils::has_duplicates;
 use carbide_uuid::rack::RackId;
 use clap::Parser;
 use mac_address::MacAddress;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use rpc::forge::{DpuMode, ExpectedHostNic};
 use serde::{Deserialize, Serialize};
+
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 /// `forge-admin-cli expected-machine add` — mirrors expected switch flags; optional
 /// `--bmc-ip-address` forwards to the API static-BMC pre-allocation path.

--- a/crates/admin-cli/src/expected_machines/add/mod.rs
+++ b/crates/admin-cli/src/expected_machines/add/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_machines/delete/args.rs
+++ b/crates/admin-cli/src/expected_machines/delete/args.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
 use clap::Parser;
 use mac_address::MacAddress;
 use uuid::Uuid;
+
+use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug)]
 pub struct Args {

--- a/crates/admin-cli/src/expected_machines/delete/mod.rs
+++ b/crates/admin-cli/src/expected_machines/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_machines/erase/mod.rs
+++ b/crates/admin-cli/src/expected_machines/erase/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_machines/patch/args.rs
+++ b/crates/admin-cli/src/expected_machines/patch/args.rs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
 use carbide_utils::has_duplicates;
 use carbide_uuid::rack::RackId;
 use clap::{ArgGroup, Parser};
@@ -23,6 +22,8 @@ use mac_address::MacAddress;
 use rpc::forge::DpuMode;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+use crate::errors::CarbideCliError;
 
 /// Patch expected machine (partial update, preserves unprovided fields).
 ///

--- a/crates/admin-cli/src/expected_machines/patch/mod.rs
+++ b/crates/admin-cli/src/expected_machines/patch/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 /// `expected-machine patch`: forwards CLI flags to `ApiClient::patch_expected_machine` (partial
 /// update; unset flags keep existing values). `--bmc-ip-address` uses the same server-side

--- a/crates/admin-cli/src/expected_machines/replace_all/mod.rs
+++ b/crates/admin-cli/src/expected_machines/replace_all/mod.rs
@@ -22,12 +22,12 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 use serde::{Deserialize, Serialize};
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 use crate::expected_machines::common::ExpectedMachineJson;
 
 /// `expected-machine replace-all`: reads a JSON list and calls `replace_all_expected_machines`.

--- a/crates/admin-cli/src/expected_machines/show/args.rs
+++ b/crates/admin-cli/src/expected_machines/show/args.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
 use clap::Parser;
 use mac_address::MacAddress;
 use uuid::Uuid;
+
+use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug)]
 pub struct Args {

--- a/crates/admin-cli/src/expected_machines/show/cmd.rs
+++ b/crates/admin-cli/src/expected_machines/show/cmd.rs
@@ -16,7 +16,7 @@
  */
 use std::collections::HashMap;
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use clap::ValueEnum;
 use mac_address::MacAddress;
 use prettytable::{Table, row};
@@ -24,6 +24,7 @@ use rpc::forge::ExpectedMachineRequest;
 
 use super::args::Args;
 use crate::async_write;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn show_expected_machines(

--- a/crates/admin-cli/src/expected_machines/show/mod.rs
+++ b/crates/admin-cli/src/expected_machines/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_machines/update/mod.rs
+++ b/crates/admin-cli/src/expected_machines/update/mod.rs
@@ -20,11 +20,11 @@ pub mod cmd;
 
 use std::path::Path;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 use crate::expected_machines::common::ExpectedMachineJson;
 
 /// `expected-machine update <file>`: deserializes `ExpectedMachineJson` and calls

--- a/crates/admin-cli/src/expected_power_shelf/add/mod.rs
+++ b/crates/admin-cli/src/expected_power_shelf/add/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_power_shelf/delete/args.rs
+++ b/crates/admin-cli/src/expected_power_shelf/delete/args.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
 use clap::Parser;
 use mac_address::MacAddress;
 use uuid::Uuid;
+
+use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug)]
 pub struct Args {

--- a/crates/admin-cli/src/expected_power_shelf/delete/mod.rs
+++ b/crates/admin-cli/src/expected_power_shelf/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_power_shelf/erase/mod.rs
+++ b/crates/admin-cli/src/expected_power_shelf/erase/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_power_shelf/replace_all/mod.rs
+++ b/crates/admin-cli/src/expected_power_shelf/replace_all/mod.rs
@@ -22,12 +22,12 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 pub use args::Args;
 use serde::{Deserialize, Serialize};
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::expected_power_shelf::common::ExpectedPowerShelfJson;
 
 impl Run for Args {

--- a/crates/admin-cli/src/expected_power_shelf/show/args.rs
+++ b/crates/admin-cli/src/expected_power_shelf/show/args.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
 use clap::Parser;
 use mac_address::MacAddress;
 use uuid::Uuid;
+
+use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug)]
 pub struct Args {

--- a/crates/admin-cli/src/expected_power_shelf/show/cmd.rs
+++ b/crates/admin-cli/src/expected_power_shelf/show/cmd.rs
@@ -19,10 +19,11 @@ use std::collections::HashMap;
 
 use mac_address::MacAddress;
 use prettytable::{Table, row};
-use rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use rpc::admin_cli::OutputFormat;
 use rpc::forge::ExpectedPowerShelfRequest;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn show(

--- a/crates/admin-cli/src/expected_power_shelf/show/mod.rs
+++ b/crates/admin-cli/src/expected_power_shelf/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_power_shelf/update/args.rs
+++ b/crates/admin-cli/src/expected_power_shelf/update/args.rs
@@ -17,12 +17,13 @@
 
 use std::net::IpAddr;
 
-use ::rpc::admin_cli::CarbideCliError;
 use carbide_uuid::rack::RackId;
 use clap::{ArgGroup, Parser};
 use mac_address::MacAddress;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug, Serialize, Deserialize)]
 #[clap(group(ArgGroup::new("group").required(true).multiple(true).args(&[

--- a/crates/admin-cli/src/expected_power_shelf/update/mod.rs
+++ b/crates/admin-cli/src/expected_power_shelf/update/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_rack/add/mod.rs
+++ b/crates/admin-cli/src/expected_rack/add/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_rack/delete/mod.rs
+++ b/crates/admin-cli/src/expected_rack/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_rack/erase/mod.rs
+++ b/crates/admin-cli/src/expected_rack/erase/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_rack/replace_all/cmd.rs
+++ b/crates/admin-cli/src/expected_rack/replace_all/cmd.rs
@@ -19,11 +19,11 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge as rpc_forge;
 use serde::{Deserialize, Serialize};
 
 use super::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::expected_rack::common::ExpectedRackJson;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/expected_rack/replace_all/mod.rs
+++ b/crates/admin-cli/src/expected_rack/replace_all/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_rack/show/cmd.rs
+++ b/crates/admin-cli/src/expected_rack/show/cmd.rs
@@ -16,10 +16,11 @@
  */
 
 use prettytable::{Table, row};
-use rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use rpc::admin_cli::OutputFormat;
 use rpc::forge::ExpectedRackRequest;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn show(

--- a/crates/admin-cli/src/expected_rack/show/mod.rs
+++ b/crates/admin-cli/src/expected_rack/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_rack/update/args.rs
+++ b/crates/admin-cli/src/expected_rack/update/args.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
 use carbide_uuid::rack::RackId;
 use clap::Parser;
 use serde::{Deserialize, Serialize};
+
+use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug, Serialize, Deserialize)]
 pub struct Args {

--- a/crates/admin-cli/src/expected_rack/update/mod.rs
+++ b/crates/admin-cli/src/expected_rack/update/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_switch/add/mod.rs
+++ b/crates/admin-cli/src/expected_switch/add/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_switch/delete/args.rs
+++ b/crates/admin-cli/src/expected_switch/delete/args.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
 use clap::Parser;
 use mac_address::MacAddress;
 use uuid::Uuid;
+
+use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug)]
 pub struct Args {

--- a/crates/admin-cli/src/expected_switch/delete/mod.rs
+++ b/crates/admin-cli/src/expected_switch/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_switch/erase/mod.rs
+++ b/crates/admin-cli/src/expected_switch/erase/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_switch/replace_all/mod.rs
+++ b/crates/admin-cli/src/expected_switch/replace_all/mod.rs
@@ -22,12 +22,12 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 pub use args::Args;
 use serde::{Deserialize, Serialize};
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::expected_switch::common::ExpectedSwitchJson;
 
 impl Run for Args {

--- a/crates/admin-cli/src/expected_switch/show/args.rs
+++ b/crates/admin-cli/src/expected_switch/show/args.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
 use clap::Parser;
 use mac_address::MacAddress;
 use uuid::Uuid;
+
+use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug)]
 pub struct Args {

--- a/crates/admin-cli/src/expected_switch/show/cmd.rs
+++ b/crates/admin-cli/src/expected_switch/show/cmd.rs
@@ -19,10 +19,11 @@ use std::collections::HashMap;
 
 use mac_address::MacAddress;
 use prettytable::{Table, row};
-use rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use rpc::admin_cli::OutputFormat;
 use rpc::forge::ExpectedSwitchRequest;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn show(

--- a/crates/admin-cli/src/expected_switch/show/mod.rs
+++ b/crates/admin-cli/src/expected_switch/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/expected_switch/update/args.rs
+++ b/crates/admin-cli/src/expected_switch/update/args.rs
@@ -17,12 +17,13 @@
 
 use std::net::IpAddr;
 
-use ::rpc::admin_cli::CarbideCliError;
 use carbide_uuid::rack::RackId;
 use clap::{ArgGroup, Parser};
 use mac_address::MacAddress;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug, Serialize, Deserialize)]
 #[clap(group(ArgGroup::new("group").required(true).multiple(true).args(&[

--- a/crates/admin-cli/src/expected_switch/update/mod.rs
+++ b/crates/admin-cli/src/expected_switch/update/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/extension_service/create/args.rs
+++ b/crates/admin-cli/src/extension_service/create/args.rs
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::dpu_extension_service_credential::Type;
 use clap::Parser;
 
 use super::super::common::ExtensionServiceType;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {

--- a/crates/admin-cli/src/extension_service/create/cmd.rs
+++ b/crates/admin-cli/src/extension_service/create/cmd.rs
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::admin_cli::output::OutputFormat;
 
 use super::super::show::cmd::convert_extension_services_to_table;
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn handle_create(

--- a/crates/admin-cli/src/extension_service/create/mod.rs
+++ b/crates/admin-cli/src/extension_service/create/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/extension_service/delete/cmd.rs
+++ b/crates/admin-cli/src/extension_service/delete/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::admin_cli::output::OutputFormat;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn handle_delete(

--- a/crates/admin-cli/src/extension_service/delete/mod.rs
+++ b/crates/admin-cli/src/extension_service/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/extension_service/get_version/cmd.rs
+++ b/crates/admin-cli/src/extension_service/get_version/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn handle_get_version(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/extension_service/get_version/mod.rs
+++ b/crates/admin-cli/src/extension_service/get_version/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/extension_service/show/cmd.rs
+++ b/crates/admin-cli/src/extension_service/show/cmd.rs
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::admin_cli::output::OutputFormat;
 use ::rpc::forge::{DpuExtensionService, DpuExtensionServiceType};
 use prettytable::{Table, row};
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn handle_show(

--- a/crates/admin-cli/src/extension_service/show/mod.rs
+++ b/crates/admin-cli/src/extension_service/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/extension_service/show_instances/cmd.rs
+++ b/crates/admin-cli/src/extension_service/show_instances/cmd.rs
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::admin_cli::output::OutputFormat;
 use ::rpc::forge::InstanceDpuExtensionServiceInfo;
 use prettytable::{Table, row};
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn handle_show_instances(

--- a/crates/admin-cli/src/extension_service/show_instances/mod.rs
+++ b/crates/admin-cli/src/extension_service/show_instances/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/extension_service/update/args.rs
+++ b/crates/admin-cli/src/extension_service/update/args.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::dpu_extension_service_credential::Type;
 use clap::Parser;
+
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug)]
 pub struct Args {

--- a/crates/admin-cli/src/extension_service/update/cmd.rs
+++ b/crates/admin-cli/src/extension_service/update/cmd.rs
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::admin_cli::output::OutputFormat;
 
 use super::super::show::cmd::convert_extension_services_to_table;
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn handle_update(

--- a/crates/admin-cli/src/extension_service/update/mod.rs
+++ b/crates/admin-cli/src/extension_service/update/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/firmware/show/cmd.rs
+++ b/crates/admin-cli/src/firmware/show/cmd.rs
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use prettytable::{Table, row};
 
 use super::args::Args;
 use crate::async_write;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn show(

--- a/crates/admin-cli/src/firmware/show/mod.rs
+++ b/crates/admin-cli/src/firmware/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/firmware/start_updates.rs
+++ b/crates/admin-cli/src/firmware/start_updates.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
 use ::rpc::forge as forgerpc;
 use chrono::TimeZone;
 
+use crate::errors::CarbideCliError;
 use crate::managed_host::StartUpdates;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/generate_shell_complete/cmds.rs
+++ b/crates/admin-cli/src/generate_shell_complete/cmds.rs
@@ -18,11 +18,11 @@
 use std::io;
 use std::io::Write;
 
-use ::rpc::admin_cli::CarbideCliResult;
 use clap::CommandFactory;
 
 use super::args::Shell;
 use crate::cfg::cli_options::CliOptions;
+use crate::errors::CarbideCliResult;
 
 pub fn generate(shell: Shell) -> CarbideCliResult<()> {
     let mut cmd = CliOptions::command();

--- a/crates/admin-cli/src/generate_shell_complete/mod.rs
+++ b/crates/admin-cli/src/generate_shell_complete/mod.rs
@@ -21,12 +21,12 @@ pub mod cmds;
 #[cfg(test)]
 mod tests;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Cmd;
 
 use crate::cfg::dispatch::Dispatch;
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Cmd {
     async fn run(self, _ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/health_utils.rs
+++ b/crates/admin-cli/src/health_utils.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::{self as forgerpc};
 use prettytable::{Table, row};
 
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::machine::health_report::cmd::get_empty_template;
 use crate::machine::{HealthReportTemplates, get_health_report};
 

--- a/crates/admin-cli/src/host/clear_uefi_password/cmd.rs
+++ b/crates/admin-cli/src/host/clear_uefi_password/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn clear_uefi_password(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/host/clear_uefi_password/mod.rs
+++ b/crates/admin-cli/src/host/clear_uefi_password/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/host/generate_host_uefi_password/cmd.rs
+++ b/crates/admin-cli/src/host/generate_host_uefi_password/cmd.rs
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use forge_secrets::credentials::Credentials;
+
+use crate::errors::CarbideCliResult;
 
 pub fn generate_uefi_password() -> CarbideCliResult<()> {
     let password = Credentials::generate_password_no_special_char();

--- a/crates/admin-cli/src/host/generate_host_uefi_password/mod.rs
+++ b/crates/admin-cli/src/host/generate_host_uefi_password/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, _ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/host/reprovision/cmd.rs
+++ b/crates/admin-cli/src/host/reprovision/cmd.rs
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::HostReprovisioningRequest;
 use carbide_uuid::machine::MachineId;
 use prettytable::{Table, row};
 
 use super::args::{ReprovisionClear, ReprovisionSet};
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::machine::{HealthReportTemplates, get_health_report};
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/host/reprovision/mod.rs
+++ b/crates/admin-cli/src/host/reprovision/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/host/set_uefi_password/cmd.rs
+++ b/crates/admin-cli/src/host/set_uefi_password/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn set_uefi_password(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/host/set_uefi_password/mod.rs
+++ b/crates/admin-cli/src/host/set_uefi_password/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/ib_partition/show/cmd.rs
+++ b/crates/admin-cli/src/ib_partition/show/cmd.rs
@@ -17,12 +17,13 @@
 
 use std::fmt::Write;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as forgerpc;
 use carbide_uuid::infiniband::IBPartitionId;
 use prettytable::{Table, row};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn show(

--- a/crates/admin-cli/src/ib_partition/show/mod.rs
+++ b/crates/admin-cli/src/ib_partition/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/instance/allocate/cmd.rs
+++ b/crates/admin-cli/src/instance/allocate/cmd.rs
@@ -17,9 +17,8 @@
 
 use std::collections::VecDeque;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::instance::common::GlobalOptions;
 use crate::machine;
 use crate::rpc::ApiClient;

--- a/crates/admin-cli/src/instance/allocate/mod.rs
+++ b/crates/admin-cli/src/instance/allocate/mod.rs
@@ -18,12 +18,12 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use super::common::GlobalOptions;
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/instance/reboot/cmd.rs
+++ b/crates/admin-cli/src/instance/reboot/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::{self as forgerpc, InstancePowerRequest};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn handle_reboot(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/instance/reboot/mod.rs
+++ b/crates/admin-cli/src/instance/reboot/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/instance/release/cmd.rs
+++ b/crates/admin-cli/src/instance/release/cmd.rs
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::InstanceReleaseRequest;
 use carbide_uuid::instance::InstanceId;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::instance::common::GlobalOptions;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/instance/release/mod.rs
+++ b/crates/admin-cli/src/instance/release/mod.rs
@@ -18,12 +18,12 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use super::common::GlobalOptions;
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/instance/show/cmd.rs
+++ b/crates/admin-cli/src/instance/show/cmd.rs
@@ -18,7 +18,7 @@ use std::borrow::Cow;
 use std::fmt::Write;
 use std::str::FromStr;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::{self as forgerpc, Vpc, VpcsByIdsRequest};
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::MachineId;
@@ -28,6 +28,7 @@ use prettytable::{Table, row};
 
 use super::args::Args;
 use crate::cfg::cli_options::SortField;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::{async_write, async_writeln, invalid_machine_id};
 

--- a/crates/admin-cli/src/instance/show/mod.rs
+++ b/crates/admin-cli/src/instance/show/mod.rs
@@ -18,12 +18,12 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use super::common::GlobalOptions;
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/instance/update_ib_config/cmd.rs
+++ b/crates/admin-cli/src/instance/update_ib_config/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::instance::common::GlobalOptions;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/instance/update_ib_config/mod.rs
+++ b/crates/admin-cli/src/instance/update_ib_config/mod.rs
@@ -18,12 +18,12 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use super::common::GlobalOptions;
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/instance/update_nvlink_config/cmd.rs
+++ b/crates/admin-cli/src/instance/update_nvlink_config/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::instance::common::GlobalOptions;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/instance/update_nvlink_config/mod.rs
+++ b/crates/admin-cli/src/instance/update_nvlink_config/mod.rs
@@ -18,12 +18,12 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use super::common::GlobalOptions;
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/instance/update_os/cmd.rs
+++ b/crates/admin-cli/src/instance/update_os/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::instance::common::GlobalOptions;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/instance/update_os/mod.rs
+++ b/crates/admin-cli/src/instance/update_os/mod.rs
@@ -18,12 +18,12 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use super::common::GlobalOptions;
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/instance_type/associate/args.rs
+++ b/crates/admin-cli/src/instance_type/associate/args.rs
@@ -16,8 +16,9 @@
  */
 
 use clap::Parser;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use rpc::forge::AssociateMachinesWithInstanceTypeRequest;
+
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {

--- a/crates/admin-cli/src/instance_type/associate/cmd.rs
+++ b/crates/admin-cli/src/instance_type/associate/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn create_association(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/instance_type/associate/mod.rs
+++ b/crates/admin-cli/src/instance_type/associate/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/instance_type/common.rs
+++ b/crates/admin-cli/src/instance_type/common.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge as forgerpc;
 use prettytable::{Table, row};
+
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 /// Produces a table for printing a non-JSON representation of a
 /// instance type to standard out.

--- a/crates/admin-cli/src/instance_type/create/args.rs
+++ b/crates/admin-cli/src/instance_type/create/args.rs
@@ -16,8 +16,9 @@
  */
 
 use clap::Parser;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use rpc::forge::{self as forgerpc, CreateInstanceTypeRequest, InstanceTypeAttributes};
+
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {

--- a/crates/admin-cli/src/instance_type/create/cmd.rs
+++ b/crates/admin-cli/src/instance_type/create/cmd.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::instance_type::common::convert_itypes_to_table;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/instance_type/create/mod.rs
+++ b/crates/admin-cli/src/instance_type/create/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/instance_type/delete/cmd.rs
+++ b/crates/admin-cli/src/instance_type/delete/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 /// Delete an instance type.

--- a/crates/admin-cli/src/instance_type/delete/mod.rs
+++ b/crates/admin-cli/src/instance_type/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/instance_type/disassociate/cmd.rs
+++ b/crates/admin-cli/src/instance_type/disassociate/cmd.rs
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use rpc::TenantState;
 use rpc::forge::RemoveMachineInstanceTypeAssociationRequest;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn remove_association(

--- a/crates/admin-cli/src/instance_type/disassociate/mod.rs
+++ b/crates/admin-cli/src/instance_type/disassociate/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/instance_type/show/cmd.rs
+++ b/crates/admin-cli/src/instance_type/show/cmd.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::FindInstanceTypesByIdsRequest;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::instance_type::common::convert_itypes_to_table;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/instance_type/show/mod.rs
+++ b/crates/admin-cli/src/instance_type/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/instance_type/update/cmd.rs
+++ b/crates/admin-cli/src/instance_type/update/cmd.rs
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::{
     FindInstanceTypesByIdsRequest, InstanceTypeAttributes, UpdateInstanceTypeRequest,
 };
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::instance_type::common::convert_itypes_to_table;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/instance_type/update/mod.rs
+++ b/crates/admin-cli/src/instance_type/update/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/inventory/cmds.rs
+++ b/crates/admin-cli/src/inventory/cmds.rs
@@ -18,7 +18,6 @@ use std::collections::HashMap;
 use std::collections::hash_map::RandomState;
 use std::fs;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::site_explorer::ExploredManagedHost;
 use ::rpc::{InstanceList, MachineList};
 use carbide_uuid::instance::InstanceId;
@@ -26,6 +25,7 @@ use carbide_uuid::machine::MachineId;
 use serde::{Deserialize, Serialize};
 
 use super::args::Cmd;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 // Expected output

--- a/crates/admin-cli/src/inventory/mod.rs
+++ b/crates/admin-cli/src/inventory/mod.rs
@@ -21,12 +21,12 @@ pub mod cmds;
 #[cfg(test)]
 mod tests;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Cmd;
 
 use crate::cfg::dispatch::Dispatch;
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Cmd {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/ip/find/cmd.rs
+++ b/crates/admin-cli/src/ip/find/cmd.rs
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::IpType;
 use serde::Serialize;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 #[derive(Serialize)]

--- a/crates/admin-cli/src/ip/find/mod.rs
+++ b/crates/admin-cli/src/ip/find/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/ipxe_template/show/cmd.rs
+++ b/crates/admin-cli/src/ipxe_template/show/cmd.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use prettytable::{Cell, Row, Table};
 
 use super::args::Args;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 fn scope_display(scope: i32) -> &'static str {

--- a/crates/admin-cli/src/ipxe_template/show/mod.rs
+++ b/crates/admin-cli/src/ipxe_template/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/jump/cmds.rs
+++ b/crates/admin-cli/src/jump/cmds.rs
@@ -18,7 +18,6 @@
 use std::net::IpAddr;
 use std::str::FromStr;
 
-use ::rpc::admin_cli::CarbideCliError;
 use ::rpc::forge as forgerpc;
 use carbide_uuid::machine::MachineId;
 use dpa::ShowDpa;
@@ -26,6 +25,7 @@ use mac_address::MacAddress;
 
 use super::args::Cmd;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliError;
 use crate::{
     compute_allocation, domain, dpa, instance, machine, machine_interfaces, network_segment,
     resource_pool, site_explorer, vpc,

--- a/crates/admin-cli/src/jump/mod.rs
+++ b/crates/admin-cli/src/jump/mod.rs
@@ -21,18 +21,18 @@ pub mod cmds;
 #[cfg(test)]
 mod tests;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Cmd;
 
 use crate::cfg::dispatch::Dispatch;
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Cmd {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
         cmds::jump(self, ctx)
             .await
-            .map_err(|e| ::rpc::admin_cli::CarbideCliError::GenericError(e.to_string()))
+            .map_err(|e| crate::errors::CarbideCliError::GenericError(e.to_string()))
     }
 }
 

--- a/crates/admin-cli/src/machine/auto_update/cmd.rs
+++ b/crates/admin-cli/src/machine/auto_update/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn autoupdate(cfg: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine/auto_update/mod.rs
+++ b/crates/admin-cli/src/machine/auto_update/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine/force_delete/cmd.rs
+++ b/crates/admin-cli/src/machine/force_delete/cmd.rs
@@ -18,11 +18,11 @@
 use std::str::FromStr;
 use std::time::Duration;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::AdminForceDeleteMachineRequest;
 use carbide_uuid::machine::MachineId;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn force_delete(mut query: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine/force_delete/mod.rs
+++ b/crates/admin-cli/src/machine/force_delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine/hardware_info/cmd.rs
+++ b/crates/admin-cli/src/machine/hardware_info/cmd.rs
@@ -17,11 +17,12 @@
 
 use std::fs;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as forgerpc;
 use carbide_uuid::machine::MachineId;
 
 use super::args::MachineHardwareInfoGpus;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn handle_update_machine_hardware_info_gpus(

--- a/crates/admin-cli/src/machine/hardware_info/mod.rs
+++ b/crates/admin-cli/src/machine/hardware_info/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine/health_report/cmd.rs
+++ b/crates/admin-cli/src/machine/health_report/cmd.rs
@@ -17,13 +17,14 @@
 
 use std::str::FromStr;
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use chrono::Utc;
 use health_report::{
     HealthAlertClassification, HealthProbeAlert, HealthProbeId, HealthProbeSuccess, HealthReport,
 };
 
 use super::args::{Args, HealthReportTemplates};
+use crate::errors::CarbideCliResult;
 use crate::health_utils;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/machine/health_report/mod.rs
+++ b/crates/admin-cli/src/machine/health_report/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine/metadata/cmd.rs
+++ b/crates/admin-cli/src/machine/metadata/cmd.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use carbide_uuid::machine::MachineId;
 use mac_address::MacAddress;
 use rpc::Machine;
@@ -24,6 +24,7 @@ use super::args::{
     Args, MachineMetadataCommandAddLabel, MachineMetadataCommandFromExpectedMachine,
     MachineMetadataCommandRemoveLabels, MachineMetadataCommandSet, MachineMetadataCommandShow,
 };
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn metadata(

--- a/crates/admin-cli/src/machine/metadata/mod.rs
+++ b/crates/admin-cli/src/machine/metadata/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine/network/cmd.rs
+++ b/crates/admin-cli/src/machine/network/cmd.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn network(

--- a/crates/admin-cli/src/machine/network/mod.rs
+++ b/crates/admin-cli/src/machine/network/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine/nvlink_info/cmd.rs
+++ b/crates/admin-cli/src/machine/nvlink_info/cmd.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as forgerpc;
 
 use super::args::{NvlinkInfoArgs, NvlinkInfoPopulateArgs};
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn handle_nvlink_info_show(

--- a/crates/admin-cli/src/machine/nvlink_info/mod.rs
+++ b/crates/admin-cli/src/machine/nvlink_info/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine/positions/cmd.rs
+++ b/crates/admin-cli/src/machine/positions/cmd.rs
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge as forgerpc;
 use prettytable::{Row, Table, row};
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn positions(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine/positions/mod.rs
+++ b/crates/admin-cli/src/machine/positions/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine/reboot/cmd.rs
+++ b/crates/admin-cli/src/machine/reboot/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn reboot(api_client: &ApiClient, args: Args) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine/reboot/mod.rs
+++ b/crates/admin-cli/src/machine/reboot/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine/show/cmd.rs
+++ b/crates/admin-cli/src/machine/show/cmd.rs
@@ -18,7 +18,7 @@
 use std::collections::VecDeque;
 use std::fmt::Write;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as forgerpc;
 use carbide_uuid::machine::MachineId;
 use prettytable::{Table, row};
@@ -26,6 +26,7 @@ use rpc::Machine;
 
 use super::args::Args;
 use crate::cfg::cli_options::SortField;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::{async_write, async_write_table_as_csv, async_writeln};
 

--- a/crates/admin-cli/src/machine/show/mod.rs
+++ b/crates/admin-cli/src/machine/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine_interfaces/assign_address/cmd.rs
+++ b/crates/admin-cli/src/machine_interfaces/assign_address/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge as forgerpc;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn handle_assign_address(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine_interfaces/assign_address/mod.rs
+++ b/crates/admin-cli/src/machine_interfaces/assign_address/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine_interfaces/delete/cmd.rs
+++ b/crates/admin-cli/src/machine_interfaces/delete/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn handle_delete(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine_interfaces/delete/mod.rs
+++ b/crates/admin-cli/src/machine_interfaces/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine_interfaces/remove_address/cmd.rs
+++ b/crates/admin-cli/src/machine_interfaces/remove_address/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge as forgerpc;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn handle_remove_address(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine_interfaces/remove_address/mod.rs
+++ b/crates/admin-cli/src/machine_interfaces/remove_address/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine_interfaces/show/cmd.rs
+++ b/crates/admin-cli/src/machine_interfaces/show/cmd.rs
@@ -18,7 +18,7 @@
 use std::collections::BTreeMap;
 use std::fmt::Write;
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as forgerpc;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use prettytable::{Cell, Row, Table};
@@ -26,6 +26,7 @@ use rpc::forge::InterfaceAssociationType;
 use tracing::warn;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn handle_show(

--- a/crates/admin-cli/src/machine_interfaces/show/mod.rs
+++ b/crates/admin-cli/src/machine_interfaces/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine_interfaces/show_addresses/cmd.rs
+++ b/crates/admin-cli/src/machine_interfaces/show_addresses/cmd.rs
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as forgerpc;
 use prettytable::{Cell, Row, Table};
 use serde::Serialize;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 #[derive(Serialize)]

--- a/crates/admin-cli/src/machine_interfaces/show_addresses/mod.rs
+++ b/crates/admin-cli/src/machine_interfaces/show_addresses/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine_validation/external_config/cmd.rs
+++ b/crates/admin-cli/src/machine_validation/external_config/cmd.rs
@@ -17,10 +17,11 @@
 
 use std::fmt::Write;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as forgerpc;
 use prettytable::{Table, row};
 
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn external_config_show(

--- a/crates/admin-cli/src/machine_validation/external_config/mod.rs
+++ b/crates/admin-cli/src/machine_validation/external_config/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine_validation/on_demand/cmd.rs
+++ b/crates/admin-cli/src/machine_validation/on_demand/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::OnDemandOptions;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn on_demand_machine_validation(

--- a/crates/admin-cli/src/machine_validation/on_demand/mod.rs
+++ b/crates/admin-cli/src/machine_validation/on_demand/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine_validation/results/cmd.rs
+++ b/crates/admin-cli/src/machine_validation/results/cmd.rs
@@ -18,11 +18,12 @@
 use std::borrow::Cow;
 use std::fmt::Write;
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as forgerpc;
 use prettytable::{Table, row};
 
 use super::args::ShowResultsOptions;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn handle_results_show(

--- a/crates/admin-cli/src/machine_validation/results/mod.rs
+++ b/crates/admin-cli/src/machine_validation/results/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine_validation/runs/cmd.rs
+++ b/crates/admin-cli/src/machine_validation/runs/cmd.rs
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as forgerpc;
 use prettytable::{Table, row};
 
 use super::args::ShowRunsOptions;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn handle_runs_show(

--- a/crates/admin-cli/src/machine_validation/runs/mod.rs
+++ b/crates/admin-cli/src/machine_validation/runs/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/machine_validation/tests_cmd/cmd.rs
+++ b/crates/admin-cli/src/machine_validation/tests_cmd/cmd.rs
@@ -17,7 +17,7 @@
 
 use std::fmt::Write;
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::{
     self as forgerpc, MachineValidationTestEnableDisableTestRequest,
     MachineValidationTestUpdateRequest, MachineValidationTestVerfiedRequest,
@@ -27,6 +27,7 @@ use prettytable::{Table, row};
 use super::args::{
     AddTestOptions, EnableDisableTestOptions, ShowTestOptions, UpdateTestOptions, VerifyTestOptions,
 };
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn show_tests(

--- a/crates/admin-cli/src/machine_validation/tests_cmd/mod.rs
+++ b/crates/admin-cli/src/machine_validation/tests_cmd/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/main.rs
+++ b/crates/admin-cli/src/main.rs
@@ -18,22 +18,28 @@
 // CLI enums variants can be rather large, we are ok with that.
 #![allow(clippy::large_enum_variant)]
 
-use ::rpc::admin_cli::CarbideCliError;
+use std::fs::File;
+use std::io::Write;
+
+use ::rpc::admin_cli::{Destination, OutputFormat, ToTable};
 use ::rpc::forge_api_client::ForgeApiClient;
 use ::rpc::forge_tls_client::{ApiConfig, ForgeClientConfig};
 use cfg::cli_options::{CliCommand, CliOptions};
 use clap::CommandFactory;
+use errors::CarbideCliResult;
 use eyre::eyre;
 use forge_tls::client_config::{
     get_carbide_api_url, get_client_cert_info, get_config_from_file, get_forge_root_ca_path,
     get_proxy_info,
 };
+use serde::Serialize;
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use tracing_subscriber::fmt;
 use tracing_subscriber::prelude::*;
 
 use crate::cfg::dispatch::Dispatch;
 use crate::cfg::runtime::{RuntimeConfig, RuntimeContext};
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 mod async_write;
@@ -51,6 +57,7 @@ mod dpa;
 mod dpf;
 mod dpu;
 mod dpu_remediation;
+mod errors;
 mod expected_machines;
 mod expected_power_shelf;
 mod expected_rack;
@@ -310,4 +317,36 @@ impl<T> IntoOnlyOne<T> for Vec<T> {
         };
         Ok(first)
     }
+}
+
+/// cli_output is the generic function implementation used by the OutputResult
+/// trait, allowing callers to pass a Serialize-derived struct and have it
+/// print in either JSON or YAML.
+pub fn cli_output<T: Serialize + ToTable>(
+    input: T,
+    format: &OutputFormat,
+    destination: Destination,
+) -> CarbideCliResult<()> {
+    let output = match format {
+        OutputFormat::Json => serde_json::to_string_pretty(&input)?,
+        OutputFormat::Yaml => serde_yaml::to_string(&input)?,
+        OutputFormat::AsciiTable => input
+            .into_table()
+            .map_err(|e| CarbideCliError::GenericError(e.to_string()))?,
+        OutputFormat::Csv => {
+            return Err(CarbideCliError::GenericError(String::from(
+                "CSV not supported for measurement commands (yet)",
+            )));
+        }
+    };
+
+    match destination {
+        Destination::Path(path) => {
+            let mut file = File::create(path)?;
+            file.write_all(output.as_bytes())?
+        }
+        Destination::Stdout() => println!("{output}"),
+    }
+
+    Ok(())
 }

--- a/crates/admin-cli/src/managed_host/debug_bundle/mod.rs
+++ b/crates/admin-cli/src/managed_host/debug_bundle/mod.rs
@@ -17,11 +17,11 @@
 
 pub mod args;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/managed_host/maintenance/cmd.rs
+++ b/crates/admin-cli/src/managed_host/maintenance/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge as forgerpc;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn maintenance(api_client: &ApiClient, action: Args) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/managed_host/maintenance/mod.rs
+++ b/crates/admin-cli/src/managed_host/maintenance/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/managed_host/power_options/cmd.rs
+++ b/crates/admin-cli/src/managed_host/power_options/cmd.rs
@@ -17,12 +17,13 @@
 
 use std::fmt::Write;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use mac_address::MacAddress;
 use prettytable::{Cell, Row, Table};
 use rpc::forge::{BmcEndpointRequest, PowerOptions};
 
 use super::args::{ShowPowerOptions, UpdatePowerOptions};
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn power_options_show(

--- a/crates/admin-cli/src/managed_host/power_options/mod.rs
+++ b/crates/admin-cli/src/managed_host/power_options/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/managed_host/quarantine/cmd.rs
+++ b/crates/admin-cli/src/managed_host/quarantine/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::{Args, QuarantineOff, QuarantineOn};
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn quarantine_on(api_client: &ApiClient, args: QuarantineOn) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/managed_host/quarantine/mod.rs
+++ b/crates/admin-cli/src/managed_host/quarantine/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/managed_host/reset_host_reprovisioning/cmd.rs
+++ b/crates/admin-cli/src/managed_host/reset_host_reprovisioning/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn reset_host_reprovisioning(api_client: &ApiClient, args: Args) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/managed_host/reset_host_reprovisioning/mod.rs
+++ b/crates/admin-cli/src/managed_host/reset_host_reprovisioning/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/managed_host/set_primary_dpu/cmd.rs
+++ b/crates/admin-cli/src/managed_host/set_primary_dpu/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn set_primary_dpu(api_client: &ApiClient, args: Args) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/managed_host/set_primary_dpu/mod.rs
+++ b/crates/admin-cli/src/managed_host/set_primary_dpu/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/managed_host/show/cmd.rs
+++ b/crates/admin-cli/src/managed_host/show/cmd.rs
@@ -19,7 +19,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 
 use ::rpc::Machine;
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use carbide_uuid::machine::MachineId;
 use health_report::HealthProbeAlert;
 use prettytable::{Cell, Row, Table};
@@ -28,6 +28,7 @@ use tracing::warn;
 
 use super::args::Args;
 use crate::cfg::cli_options::SortField;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::{async_write, async_write_table_as_csv};
 

--- a/crates/admin-cli/src/managed_host/show/mod.rs
+++ b/crates/admin-cli/src/managed_host/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/managed_host/start_updates/mod.rs
+++ b/crates/admin-cli/src/managed_host/start_updates/mod.rs
@@ -17,11 +17,11 @@
 
 pub mod args;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 use crate::firmware;
 
 impl Run for Args {

--- a/crates/admin-cli/src/managed_switch/delete/mod.rs
+++ b/crates/admin-cli/src/managed_switch/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/managed_switch/list/mod.rs
+++ b/crates/admin-cli/src/managed_switch/list/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/managed_switch/show/cmd.rs
+++ b/crates/admin-cli/src/managed_switch/show/cmd.rs
@@ -20,11 +20,12 @@ use std::fmt::Write;
 
 use carbide_uuid::switch::SwitchId;
 use prettytable::{Cell, Row, Table};
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use rpc::admin_cli::OutputFormat;
 use rpc::forge::{LinkedExpectedSwitch, MachineInterface, Switch};
 use serde::Serialize;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::{async_write, async_write_table_as_csv};
 

--- a/crates/admin-cli/src/managed_switch/show/mod.rs
+++ b/crates/admin-cli/src/managed_switch/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/metadata.rs
+++ b/crates/admin-cli/src/metadata.rs
@@ -19,8 +19,9 @@ use std::fmt::Write;
 
 use prettytable::{Row, Table};
 use rpc::Metadata;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use rpc::admin_cli::OutputFormat;
 
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::{async_write, async_writeln};
 
 /// Display metadata (name, description, labels) in the

--- a/crates/admin-cli/src/mlx/config/args.rs
+++ b/crates/admin-cli/src/mlx/config/args.rs
@@ -20,8 +20,9 @@
 
 use carbide_uuid::machine::MachineId;
 use clap::Parser;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use rpc::protos::mlx_device as mlx_device_pb;
+
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 // ConfigCommand are the config subcommands.
 #[derive(Parser, Debug)]

--- a/crates/admin-cli/src/mlx/config/cmds.rs
+++ b/crates/admin-cli/src/mlx/config/cmds.rs
@@ -18,7 +18,6 @@
 use ::rpc::admin_cli::OutputFormat;
 use libmlx::runner::result_types::{ComparisonResult, QueryResult, SyncResult};
 use prettytable::{Cell, Row, Table};
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use rpc::protos::mlx_device as mlx_device_pb;
 
 use super::super::{
@@ -28,6 +27,7 @@ use super::super::{
 use super::args::{
     ConfigCommand, ConfigCompareCommand, ConfigQueryCommand, ConfigSetCommand, ConfigSyncCommand,
 };
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 // dispatch routes config subcommands to its handlers.
 pub async fn dispatch(

--- a/crates/admin-cli/src/mlx/connections/cmds.rs
+++ b/crates/admin-cli/src/mlx/connections/cmds.rs
@@ -22,9 +22,10 @@ use std::borrow::Cow;
 
 use chrono::{DateTime, Utc};
 use prettytable::{Cell, Row, Table};
-use rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use rpc::admin_cli::OutputFormat;
 
 use super::args::{ConnectionsCommand, ConnectionsDisconnectCommand, ConnectionsShowCommand};
+use crate::errors::CarbideCliResult;
 use crate::mlx::CliContext;
 
 // dispatch routes connections subcommands to their handlers.

--- a/crates/admin-cli/src/mlx/info/cmds.rs
+++ b/crates/admin-cli/src/mlx/info/cmds.rs
@@ -21,10 +21,11 @@
 use carbide_libmlx_model::device::info::MlxDeviceInfo;
 use libmlx::device::report::MlxDeviceReport;
 use prettytable::{Cell, Row, Table};
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use rpc::admin_cli::OutputFormat;
 use rpc::protos::mlx_device as mlx_device_pb;
 
 use super::args::{InfoCommand, InfoDeviceCommand, InfoMachineCommand};
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::mlx::{CliContext, wrap_text};
 
 // dispatch routes info subcommands to their handlers.

--- a/crates/admin-cli/src/mlx/lockdown/cmds.rs
+++ b/crates/admin-cli/src/mlx/lockdown/cmds.rs
@@ -19,12 +19,13 @@
 // Command handlers for lockdown operations.
 
 use libmlx::lockdown::lockdown::StatusReport;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use rpc::admin_cli::OutputFormat;
 use rpc::protos::mlx_device as mlx_device_pb;
 
 use super::args::{
     LockdownCommand, LockdownLockCommand, LockdownStatusCommand, LockdownUnlockCommand,
 };
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::mlx::CliContext;
 
 // dispatch routes lockdown subcommands to their handlers.

--- a/crates/admin-cli/src/mlx/mod.rs
+++ b/crates/admin-cli/src/mlx/mod.rs
@@ -15,13 +15,14 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use clap::Parser;
 use libmlx::runner::result_types::{ComparisonResult, SyncResult};
 use prettytable::{Cell, Row, Table};
 
 use crate::cfg::dispatch::Dispatch;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 mod config;

--- a/crates/admin-cli/src/mlx/profile/cmds.rs
+++ b/crates/admin-cli/src/mlx/profile/cmds.rs
@@ -21,13 +21,14 @@
 use libmlx::profile::serialization::SerializableProfile;
 use libmlx::runner::result_types::{ComparisonResult, SyncResult};
 use prettytable::{Cell, Row, Table};
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use rpc::admin_cli::OutputFormat;
 use rpc::protos::mlx_device as mlx_device_pb;
 
 use super::args::{
     ProfileCommand, ProfileCompareCommand, ProfileListCommand, ProfileShowCommand,
     ProfileSyncCommand,
 };
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::mlx::{
     CliContext, print_comparison_result_csv, print_comparison_result_table, print_sync_result_csv,
     print_sync_result_table,

--- a/crates/admin-cli/src/mlx/registry/cmds.rs
+++ b/crates/admin-cli/src/mlx/registry/cmds.rs
@@ -20,10 +20,11 @@
 
 use libmlx::variables::registry::MlxVariableRegistry;
 use prettytable::{Cell, Row, Table};
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use rpc::admin_cli::OutputFormat;
 use rpc::protos::mlx_device as mlx_device_pb;
 
 use super::args::{RegistryCommand, RegistryListCommand, RegistryShowCommand};
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::mlx::{CliContext, wrap_text};
 
 // dispatch routes registry subcommands to their handlers.

--- a/crates/admin-cli/src/network_devices/show/cmd.rs
+++ b/crates/admin-cli/src/network_devices/show/cmd.rs
@@ -17,9 +17,10 @@
 
 use std::fmt::Write;
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn handle_show(

--- a/crates/admin-cli/src/network_devices/show/mod.rs
+++ b/crates/admin-cli/src/network_devices/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/network_security_group/attach/cmd.rs
+++ b/crates/admin-cli/src/network_security_group/attach/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 /// "Attaches" a network security group to an object (VPC/Instance)

--- a/crates/admin-cli/src/network_security_group/attach/mod.rs
+++ b/crates/admin-cli/src/network_security_group/attach/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/network_security_group/common.rs
+++ b/crates/admin-cli/src/network_security_group/common.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::{self as forgerpc};
 use prettytable::{Table, row};
+
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 /// Produces a table for printing a non-JSON representation of a
 /// network security group to standard out.

--- a/crates/admin-cli/src/network_security_group/create/args.rs
+++ b/crates/admin-cli/src/network_security_group/create/args.rs
@@ -16,10 +16,11 @@
  */
 
 use clap::Parser;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use rpc::forge::{
     self as forgerpc, CreateNetworkSecurityGroupRequest, NetworkSecurityGroupAttributes,
 };
+
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {

--- a/crates/admin-cli/src/network_security_group/create/cmd.rs
+++ b/crates/admin-cli/src/network_security_group/create/cmd.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::network_security_group::common::convert_nsgs_to_table;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/network_security_group/create/mod.rs
+++ b/crates/admin-cli/src/network_security_group/create/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/network_security_group/delete/cmd.rs
+++ b/crates/admin-cli/src/network_security_group/delete/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 /// Delete a network security group.

--- a/crates/admin-cli/src/network_security_group/delete/mod.rs
+++ b/crates/admin-cli/src/network_security_group/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/network_security_group/detach/cmd.rs
+++ b/crates/admin-cli/src/network_security_group/detach/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 /// "Detaches" a network security group to an object (VPC/Instance)

--- a/crates/admin-cli/src/network_security_group/detach/mod.rs
+++ b/crates/admin-cli/src/network_security_group/detach/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/network_security_group/show/cmd.rs
+++ b/crates/admin-cli/src/network_security_group/show/cmd.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::network_security_group::common::convert_nsgs_to_table;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/network_security_group/show/mod.rs
+++ b/crates/admin-cli/src/network_security_group/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/network_security_group/show_attachments/cmd.rs
+++ b/crates/admin-cli/src/network_security_group/show_attachments/cmd.rs
@@ -17,11 +17,12 @@
 
 use std::collections::HashSet;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::{self as forgerpc};
 use prettytable::{Table, row};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::network_security_group::common::convert_nsgs_to_table;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/network_security_group/show_attachments/mod.rs
+++ b/crates/admin-cli/src/network_security_group/show_attachments/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/network_security_group/update/cmd.rs
+++ b/crates/admin-cli/src/network_security_group/update/cmd.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::network_security_group::common::convert_nsgs_to_table;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/network_security_group/update/mod.rs
+++ b/crates/admin-cli/src/network_security_group/update/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/network_segment/delete/cmd.rs
+++ b/crates/admin-cli/src/network_segment/delete/cmd.rs
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-
 use super::args::Args;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 pub async fn handle_delete(args: Args, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
     if !ctx.config.cloud_unsafe_op_enabled {

--- a/crates/admin-cli/src/network_segment/delete/mod.rs
+++ b/crates/admin-cli/src/network_segment/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/network_segment/show/cmd.rs
+++ b/crates/admin-cli/src/network_segment/show/cmd.rs
@@ -17,7 +17,7 @@
 use std::fmt::Write;
 use std::str::FromStr as _;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as forgerpc;
 use carbide_uuid::domain::DomainId;
 use carbide_uuid::network::NetworkSegmentId;
@@ -25,6 +25,7 @@ use prettytable::{Table, row};
 use serde::Deserialize;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 #[derive(Deserialize)]

--- a/crates/admin-cli/src/network_segment/show/mod.rs
+++ b/crates/admin-cli/src/network_segment/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/nvl_logical_partition/create/cmd.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/create/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn handle_create(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/nvl_logical_partition/create/mod.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/create/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/nvl_logical_partition/delete/args.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/delete/args.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
 use ::rpc::forge as forgerpc;
 use carbide_uuid::nvlink::NvLinkLogicalPartitionId;
 use clap::Parser;
+
+use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug, Clone)]
 pub struct Args {

--- a/crates/admin-cli/src/nvl_logical_partition/delete/cmd.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/delete/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn handle_delete(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/nvl_logical_partition/delete/mod.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/nvl_logical_partition/show/cmd.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/show/cmd.rs
@@ -17,12 +17,13 @@
 
 use std::fmt::Write;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as forgerpc;
 use carbide_uuid::nvlink::NvLinkLogicalPartitionId;
 use prettytable::{Table, row};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn handle_show(

--- a/crates/admin-cli/src/nvl_logical_partition/show/mod.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/nvl_partition/show/cmd.rs
+++ b/crates/admin-cli/src/nvl_partition/show/cmd.rs
@@ -17,12 +17,13 @@
 
 use std::fmt::Write;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as forgerpc;
 use carbide_uuid::nvlink::NvLinkPartitionId;
 use prettytable::{Table, row};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn handle_show(

--- a/crates/admin-cli/src/nvl_partition/show/mod.rs
+++ b/crates/admin-cli/src/nvl_partition/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/nvlink_nmxc_endpoints/create.rs
+++ b/crates/admin-cli/src/nvlink_nmxc_endpoints/create.rs
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::NvlinkNmxcEndpoint;
 use clap::Parser;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug)]
 pub struct Args {

--- a/crates/admin-cli/src/nvlink_nmxc_endpoints/delete.rs
+++ b/crates/admin-cli/src/nvlink_nmxc_endpoints/delete.rs
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::DeleteNvlinkNmxcEndpointRequest;
 use clap::Parser;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug)]
 pub struct Args {

--- a/crates/admin-cli/src/nvlink_nmxc_endpoints/show.rs
+++ b/crates/admin-cli/src/nvlink_nmxc_endpoints/show.rs
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use clap::Parser;
 use prettytable::{Table, row};
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 #[derive(Parser, Debug)]

--- a/crates/admin-cli/src/nvlink_nmxc_endpoints/update.rs
+++ b/crates/admin-cli/src/nvlink_nmxc_endpoints/update.rs
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::NvlinkNmxcEndpoint;
 use clap::Parser;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug)]
 pub struct Args {

--- a/crates/admin-cli/src/operating_system/common.rs
+++ b/crates/admin-cli/src/operating_system/common.rs
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::{
     self as forgerpc, IpxeTemplateArtifact, IpxeTemplateParameter, OperatingSystem,
 };
 use serde::Serialize;
+
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 pub fn str_to_os_id(
     id: &str,

--- a/crates/admin-cli/src/operating_system/create/cmd.rs
+++ b/crates/admin-cli/src/operating_system/create/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::CreateOperatingSystemRequest;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::operating_system::common::{str_to_ipxe_template_id, str_to_os_id};
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/operating_system/create/mod.rs
+++ b/crates/admin-cli/src/operating_system/create/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/operating_system/delete/cmd.rs
+++ b/crates/admin-cli/src/operating_system/delete/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::DeleteOperatingSystemRequest;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::operating_system::common::str_to_os_id;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/operating_system/delete/mod.rs
+++ b/crates/admin-cli/src/operating_system/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/operating_system/get_artifacts/cmd.rs
+++ b/crates/admin-cli/src/operating_system/get_artifacts/cmd.rs
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::IpxeTemplateArtifactCacheStrategy;
 use prettytable::{Cell, Row, Table};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::operating_system::common::{SerializableArtifact, str_to_os_id};
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/operating_system/get_artifacts/mod.rs
+++ b/crates/admin-cli/src/operating_system/get_artifacts/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/operating_system/set_cached_url/cmd.rs
+++ b/crates/admin-cli/src/operating_system/set_cached_url/cmd.rs
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::IpxeTemplateArtifactCacheStrategy;
 use prettytable::{Cell, Row, Table};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::operating_system::common::{SerializableArtifact, str_to_os_id};
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/operating_system/set_cached_url/mod.rs
+++ b/crates/admin-cli/src/operating_system/set_cached_url/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/operating_system/show/cmd.rs
+++ b/crates/admin-cli/src/operating_system/show/cmd.rs
@@ -15,13 +15,14 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::{
     IpxeTemplateArtifactCacheStrategy, OperatingSystemSearchFilter, OperatingSystemType,
 };
 use prettytable::{Cell, Row, Table};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::operating_system::common::{SerializableOs, str_to_os_id};
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/operating_system/show/mod.rs
+++ b/crates/admin-cli/src/operating_system/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/operating_system/update/cmd.rs
+++ b/crates/admin-cli/src/operating_system/update/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::{IpxeTemplateParameters, UpdateOperatingSystemRequest};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::operating_system::common::{str_to_ipxe_template_id, str_to_os_id};
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/operating_system/update/mod.rs
+++ b/crates/admin-cli/src/operating_system/update/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/os_image/common.rs
+++ b/crates/admin-cli/src/os_image/common.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 pub fn str_to_rpc_uuid(id: &str) -> CarbideCliResult<::rpc::common::Uuid> {
     let id: ::rpc::common::Uuid = uuid::Uuid::parse_str(id)

--- a/crates/admin-cli/src/os_image/create/args.rs
+++ b/crates/admin-cli/src/os_image/create/args.rs
@@ -16,9 +16,9 @@
  */
 
 use clap::Parser;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use rpc::forge as forgerpc;
 
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::os_image::common::str_to_rpc_uuid;
 
 #[derive(Parser, Debug, Clone)]

--- a/crates/admin-cli/src/os_image/create/cmd.rs
+++ b/crates/admin-cli/src/os_image/create/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn create(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/os_image/create/mod.rs
+++ b/crates/admin-cli/src/os_image/create/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/os_image/delete/args.rs
+++ b/crates/admin-cli/src/os_image/delete/args.rs
@@ -16,9 +16,9 @@
  */
 
 use clap::Parser;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use rpc::forge::DeleteOsImageRequest;
 
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::os_image::common::str_to_rpc_uuid;
 
 #[derive(Parser, Debug, Clone)]

--- a/crates/admin-cli/src/os_image/delete/cmd.rs
+++ b/crates/admin-cli/src/os_image/delete/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::DeleteOsImageRequest;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn delete(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/os_image/delete/mod.rs
+++ b/crates/admin-cli/src/os_image/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/os_image/show/args.rs
+++ b/crates/admin-cli/src/os_image/show/args.rs
@@ -16,8 +16,8 @@
  */
 
 use clap::Parser;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::os_image::common::str_to_rpc_uuid;
 
 #[derive(Parser, Debug, Clone)]

--- a/crates/admin-cli/src/os_image/show/cmd.rs
+++ b/crates/admin-cli/src/os_image/show/cmd.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 
 use super::args::{Args, ShowQuery};
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn show(

--- a/crates/admin-cli/src/os_image/show/mod.rs
+++ b/crates/admin-cli/src/os_image/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/os_image/update/args.rs
+++ b/crates/admin-cli/src/os_image/update/args.rs
@@ -16,8 +16,8 @@
  */
 
 use clap::Parser;
-use rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::os_image::common::str_to_rpc_uuid;
 
 #[derive(Parser, Debug, Clone)]

--- a/crates/admin-cli/src/os_image/update/cmd.rs
+++ b/crates/admin-cli/src/os_image/update/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::{Args, UpdateRequest};
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn update(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/os_image/update/mod.rs
+++ b/crates/admin-cli/src/os_image/update/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/ping/mod.rs
+++ b/crates/admin-cli/src/ping/mod.rs
@@ -25,11 +25,11 @@ mod tests;
 // This is different than others that pull in Cmd, since
 // this is just a single top-level command without any
 // subcommands.
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Opts;
 
 use crate::cfg::dispatch::Dispatch;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Dispatch for Opts {
     async fn dispatch(self, ctx: RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/power_shelf/delete/mod.rs
+++ b/crates/admin-cli/src/power_shelf/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/power_shelf/force_delete/mod.rs
+++ b/crates/admin-cli/src/power_shelf/force_delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/power_shelf/health_report/add/cmd.rs
+++ b/crates/admin-cli/src/power_shelf/health_report/add/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::{self as rpc, InsertPowerShelfHealthReportRequest};
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::health_utils;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/power_shelf/health_report/add/mod.rs
+++ b/crates/admin-cli/src/power_shelf/health_report/add/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/power_shelf/health_report/print_empty_template/mod.rs
+++ b/crates/admin-cli/src/power_shelf/health_report/print_empty_template/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, _ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/power_shelf/health_report/remove/cmd.rs
+++ b/crates/admin-cli/src/power_shelf/health_report/remove/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::RemovePowerShelfHealthReportRequest;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn remove(api_client: &ApiClient, args: Args) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/power_shelf/health_report/remove/mod.rs
+++ b/crates/admin-cli/src/power_shelf/health_report/remove/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/power_shelf/health_report/show/cmd.rs
+++ b/crates/admin-cli/src/power_shelf/health_report/show/cmd.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::health_utils;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/power_shelf/health_report/show/mod.rs
+++ b/crates/admin-cli/src/power_shelf/health_report/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/power_shelf/list/mod.rs
+++ b/crates/admin-cli/src/power_shelf/list/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/power_shelf/maintenance/cmd.rs
+++ b/crates/admin-cli/src/power_shelf/maintenance/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn maintenance(api_client: &ApiClient, action: Args) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/power_shelf/maintenance/mod.rs
+++ b/crates/admin-cli/src/power_shelf/maintenance/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/power_shelf/metadata/cmd.rs
+++ b/crates/admin-cli/src/power_shelf/metadata/cmd.rs
@@ -15,13 +15,14 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 
 use super::args::{
     Args, PowerShelfMetadataCommandAddLabel, PowerShelfMetadataCommandFromExpectedPowerShelf,
     PowerShelfMetadataCommandRemoveLabels, PowerShelfMetadataCommandSet,
     PowerShelfMetadataCommandShow,
 };
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn metadata(

--- a/crates/admin-cli/src/power_shelf/metadata/mod.rs
+++ b/crates/admin-cli/src/power_shelf/metadata/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/power_shelf/show/cmd.rs
+++ b/crates/admin-cli/src/power_shelf/show/cmd.rs
@@ -20,11 +20,12 @@ use std::str::FromStr;
 use carbide_uuid::power_shelf::PowerShelfId;
 use color_eyre::Result;
 use prettytable::{Table, row};
-use rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use rpc::admin_cli::OutputFormat;
 use rpc::forge::PowerShelf;
 
 use super::args::Args;
 use crate::cfg::runtime::RuntimeConfig;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub fn show_power_shelves(

--- a/crates/admin-cli/src/power_shelf/show/mod.rs
+++ b/crates/admin-cli/src/power_shelf/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/rack/delete/mod.rs
+++ b/crates/admin-cli/src/rack/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/rack/list/mod.rs
+++ b/crates/admin-cli/src/rack/list/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/rack/maintenance/cmd.rs
+++ b/crates/admin-cli/src/rack/maintenance/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge as rpc;
 
 use super::args::MaintenanceOptions;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn on_demand_rack_maintenance(

--- a/crates/admin-cli/src/rack/maintenance/mod.rs
+++ b/crates/admin-cli/src/rack/maintenance/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/rack/metadata/cmd.rs
+++ b/crates/admin-cli/src/rack/metadata/cmd.rs
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 
 use super::args::{
     Args, RackMetadataCommandAddLabel, RackMetadataCommandFromExpectedRack,
     RackMetadataCommandRemoveLabels, RackMetadataCommandSet, RackMetadataCommandShow,
 };
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn metadata(

--- a/crates/admin-cli/src/rack/metadata/mod.rs
+++ b/crates/admin-cli/src/rack/metadata/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/rack/profile/mod.rs
+++ b/crates/admin-cli/src/rack/profile/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 mod show;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/rack/show/mod.rs
+++ b/crates/admin-cli/src/rack/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/rack_firmware/apply/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/apply/cmd.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use prettytable::{Cell, Row, Table};
 
 use super::args::Args;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 pub async fn apply(

--- a/crates/admin-cli/src/rack_firmware/apply/mod.rs
+++ b/crates/admin-cli/src/rack_firmware/apply/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/rack_firmware/create/args.rs
+++ b/crates/admin-cli/src/rack_firmware/create/args.rs
@@ -17,8 +17,9 @@
 
 use std::path::PathBuf;
 
-use ::rpc::admin_cli::CarbideCliError;
 use clap::Parser;
+
+use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug)]
 pub struct Args {

--- a/crates/admin-cli/src/rack_firmware/create/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/create/cmd.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use prettytable::{Table, row};
 
 use super::args::Args;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 pub async fn create(

--- a/crates/admin-cli/src/rack_firmware/create/mod.rs
+++ b/crates/admin-cli/src/rack_firmware/create/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/rack_firmware/delete/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/delete/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
-
 use super::args::Args;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 pub async fn delete(opts: Args, api_client: &ApiClient) -> Result<(), CarbideCliError> {

--- a/crates/admin-cli/src/rack_firmware/delete/mod.rs
+++ b/crates/admin-cli/src/rack_firmware/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/rack_firmware/get/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/get/cmd.rs
@@ -17,11 +17,12 @@
 
 use std::collections::BTreeMap;
 
-use ::rpc::admin_cli::{CarbideCliError, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use prettytable::{Cell, Row, Table, row};
 use serde::Deserialize;
 
 use super::args::Args;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 #[derive(Debug, Deserialize, Default)]

--- a/crates/admin-cli/src/rack_firmware/get/mod.rs
+++ b/crates/admin-cli/src/rack_firmware/get/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/rack_firmware/history/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/history/cmd.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use prettytable::{Cell, Row, Table};
 
 use super::args::Args;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 pub async fn history(

--- a/crates/admin-cli/src/rack_firmware/history/mod.rs
+++ b/crates/admin-cli/src/rack_firmware/history/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/rack_firmware/list/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/list/cmd.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use prettytable::{Cell, Row, Table};
 
 use super::args::Args;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 pub async fn list(

--- a/crates/admin-cli/src/rack_firmware/list/mod.rs
+++ b/crates/admin-cli/src/rack_firmware/list/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/rack_firmware/set_default/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/set_default/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
-
 use super::args::Args;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 pub async fn set_default(opts: Args, api_client: &ApiClient) -> Result<(), CarbideCliError> {

--- a/crates/admin-cli/src/rack_firmware/set_default/mod.rs
+++ b/crates/admin-cli/src/rack_firmware/set_default/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/rack_firmware/status/cmd.rs
+++ b/crates/admin-cli/src/rack_firmware/status/cmd.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 
 use super::args::Args;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 pub async fn get_job_status(

--- a/crates/admin-cli/src/rack_firmware/status/mod.rs
+++ b/crates/admin-cli/src/rack_firmware/status/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/resource_pool/grow/cmd.rs
+++ b/crates/admin-cli/src/resource_pool/grow/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn grow(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/resource_pool/grow/mod.rs
+++ b/crates/admin-cli/src/resource_pool/grow/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/resource_pool/list/cmd.rs
+++ b/crates/admin-cli/src/resource_pool/list/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use prettytable::{Table, row};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn list(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/resource_pool/list/mod.rs
+++ b/crates/admin-cli/src/resource_pool/list/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/route_server/add/cmd.rs
+++ b/crates/admin-cli/src/route_server/add/cmd.rs
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
+use crate::errors::CarbideCliResult;
 use crate::route_server::common::AddressArgs;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/route_server/add/mod.rs
+++ b/crates/admin-cli/src/route_server/add/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/route_server/get/cmd.rs
+++ b/crates/admin-cli/src/route_server/get/cmd.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as rpc;
 use prettytable::{Cell, Row, Table};
 
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn get(format: OutputFormat, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/route_server/get/mod.rs
+++ b/crates/admin-cli/src/route_server/get/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/route_server/remove/cmd.rs
+++ b/crates/admin-cli/src/route_server/remove/cmd.rs
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
+use crate::errors::CarbideCliResult;
 use crate::route_server::common::AddressArgs;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/route_server/remove/mod.rs
+++ b/crates/admin-cli/src/route_server/remove/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/route_server/replace/cmd.rs
+++ b/crates/admin-cli/src/route_server/replace/cmd.rs
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
+use crate::errors::CarbideCliResult;
 use crate::route_server::common::AddressArgs;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/route_server/replace/mod.rs
+++ b/crates/admin-cli/src/route_server/replace/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -17,7 +17,6 @@
 
 use std::collections::HashMap;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::instance_interface_config::NetworkDetails;
 use ::rpc::forge::{
     self as rpc, BmcEndpointRequest, FindInstanceTypesByIdsRequest,
@@ -46,6 +45,7 @@ use carbide_uuid::vpc::VpcId;
 use mac_address::MacAddress;
 
 use crate::IntoOnlyOne;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::expected_machines::common::ExpectedMachineJson;
 use crate::instance::AllocateInstance;
 use crate::machine::MachineAutoupdate;

--- a/crates/admin-cli/src/scout_stream/mod.rs
+++ b/crates/admin-cli/src/scout_stream/mod.rs
@@ -21,10 +21,11 @@ use carbide_uuid::machine::MachineId;
 use chrono::{DateTime, Utc};
 use clap::Parser;
 use prettytable::{Cell, Row, Table};
-use rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use rpc::admin_cli::OutputFormat;
 
 use crate::cfg::dispatch::Dispatch;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 #[cfg(test)]

--- a/crates/admin-cli/src/set/bmc_proxy/cmd.rs
+++ b/crates/admin-cli/src/set/bmc_proxy/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::ConfigSetting;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn bmc_proxy(opts: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/set/bmc_proxy/mod.rs
+++ b/crates/admin-cli/src/set/bmc_proxy/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/set/create_machines/cmd.rs
+++ b/crates/admin-cli/src/set/create_machines/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::ConfigSetting;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn create_machines(opts: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/set/create_machines/mod.rs
+++ b/crates/admin-cli/src/set/create_machines/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/set/log_filter/cmd.rs
+++ b/crates/admin-cli/src/set/log_filter/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::ConfigSetting;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn log_filter(opts: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/set/log_filter/mod.rs
+++ b/crates/admin-cli/src/set/log_filter/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/set/site_explorer_enabled/cmd.rs
+++ b/crates/admin-cli/src/set/site_explorer_enabled/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::ConfigSetting;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn site_explorer_enabled(opts: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/set/site_explorer_enabled/mod.rs
+++ b/crates/admin-cli/src/set/site_explorer_enabled/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/set/tracing_enabled/cmd.rs
+++ b/crates/admin-cli/src/set/tracing_enabled/cmd.rs
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::ConfigSetting;
 
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn tracing_enabled(value: bool, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/set/tracing_enabled/mod.rs
+++ b/crates/admin-cli/src/set/tracing_enabled/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/site_explorer/clear_error/cmd.rs
+++ b/crates/admin-cli/src/site_explorer/clear_error/cmd.rs
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn clear_error(api_client: &ApiClient, address: String) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/site_explorer/clear_error/mod.rs
+++ b/crates/admin-cli/src/site_explorer/clear_error/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/site_explorer/copy_bfb_to_dpu_rshim/cmd.rs
+++ b/crates/admin-cli/src/site_explorer/copy_bfb_to_dpu_rshim/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::{BmcEndpointRequest, CopyBfbToDpuRshimRequest, SshRequest};
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn copy_bfb_to_dpu_rshim(api_client: &ApiClient, args: Args) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/site_explorer/copy_bfb_to_dpu_rshim/mod.rs
+++ b/crates/admin-cli/src/site_explorer/copy_bfb_to_dpu_rshim/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/site_explorer/delete/cmd.rs
+++ b/crates/admin-cli/src/site_explorer/delete/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn delete_endpoint(api_client: &ApiClient, opts: Args) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/site_explorer/delete/mod.rs
+++ b/crates/admin-cli/src/site_explorer/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/site_explorer/explore/cmd.rs
+++ b/crates/admin-cli/src/site_explorer/explore/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::BmcEndpointRequest;
 use mac_address::MacAddress;
 
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn explore(

--- a/crates/admin-cli/src/site_explorer/explore/mod.rs
+++ b/crates/admin-cli/src/site_explorer/explore/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/site_explorer/get_report/cmd.rs
+++ b/crates/admin-cli/src/site_explorer/get_report/cmd.rs
@@ -17,11 +17,12 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::site_explorer::{ExploredEndpoint, ExploredManagedHost, SiteExplorationReport};
 use prettytable::{Cell, Row, Table, format, row};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::{async_write, async_writeln};
 

--- a/crates/admin-cli/src/site_explorer/get_report/mod.rs
+++ b/crates/admin-cli/src/site_explorer/get_report/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/site_explorer/have_credentials/cmd.rs
+++ b/crates/admin-cli/src/site_explorer/have_credentials/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::BmcEndpointRequest;
 use mac_address::MacAddress;
 
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn have_credentials(

--- a/crates/admin-cli/src/site_explorer/have_credentials/mod.rs
+++ b/crates/admin-cli/src/site_explorer/have_credentials/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/site_explorer/is_bmc_in_managed_host/cmd.rs
+++ b/crates/admin-cli/src/site_explorer/is_bmc_in_managed_host/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::BmcEndpointRequest;
 use mac_address::MacAddress;
 
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn is_bmc_in_managed_host(

--- a/crates/admin-cli/src/site_explorer/is_bmc_in_managed_host/mod.rs
+++ b/crates/admin-cli/src/site_explorer/is_bmc_in_managed_host/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/site_explorer/re_explore/cmd.rs
+++ b/crates/admin-cli/src/site_explorer/re_explore/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::ReExploreEndpointRequest;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn re_explore(api_client: &ApiClient, opts: Args) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/site_explorer/re_explore/mod.rs
+++ b/crates/admin-cli/src/site_explorer/re_explore/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/site_explorer/refresh_endpoint/cmd.rs
+++ b/crates/admin-cli/src/site_explorer/refresh_endpoint/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::RefreshEndpointReportRequest;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn refresh_endpoint(api_client: &ApiClient, opts: Args) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/site_explorer/refresh_endpoint/mod.rs
+++ b/crates/admin-cli/src/site_explorer/refresh_endpoint/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/site_explorer/remediation/cmd.rs
+++ b/crates/admin-cli/src/site_explorer/remediation/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use ::rpc::forge::PauseExploredEndpointRemediationRequest;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn remediation(api_client: &ApiClient, opts: Args) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/site_explorer/remediation/mod.rs
+++ b/crates/admin-cli/src/site_explorer/remediation/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/sku/assign/cmd.rs
+++ b/crates/admin-cli/src/sku/assign/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use carbide_uuid::machine::MachineId;
 use rpc::forge::SkuMachinePair;
 
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn assign(

--- a/crates/admin-cli/src/sku/assign/mod.rs
+++ b/crates/admin-cli/src/sku/assign/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/sku/bulk_update_metadata/cmd.rs
+++ b/crates/admin-cli/src/sku/bulk_update_metadata/cmd.rs
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-
 use super::super::update_metadata;
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn bulk_update_metadata(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/sku/bulk_update_metadata/mod.rs
+++ b/crates/admin-cli/src/sku/bulk_update_metadata/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/sku/create/cmd.rs
+++ b/crates/admin-cli/src/sku/create/cmd.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::SkuList;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::sku::show::cmd::show_skus_table;
 

--- a/crates/admin-cli/src/sku/create/mod.rs
+++ b/crates/admin-cli/src/sku/create/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/sku/delete/cmd.rs
+++ b/crates/admin-cli/src/sku/delete/cmd.rs
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use rpc::forge::SkuIdList;
 
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn delete(sku_id: String, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/sku/delete/mod.rs
+++ b/crates/admin-cli/src/sku/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/sku/generate/cmd.rs
+++ b/crates/admin-cli/src/sku/generate/cmd.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 use crate::sku::show::cmd::show_sku_details;
 

--- a/crates/admin-cli/src/sku/generate/mod.rs
+++ b/crates/admin-cli/src/sku/generate/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/sku/replace/cmd.rs
+++ b/crates/admin-cli/src/sku/replace/cmd.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 
 use super::super::common::CreateSkuOptions;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 use crate::sku::show::cmd::show_skus_table;
 

--- a/crates/admin-cli/src/sku/replace/mod.rs
+++ b/crates/admin-cli/src/sku/replace/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/sku/show/cmd.rs
+++ b/crates/admin-cli/src/sku/show/cmd.rs
@@ -16,12 +16,13 @@
  */
 use std::io::Write;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::SkuList;
 use prettytable::{Row, Table};
 use tokio::io::AsyncWriteExt;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::{async_write_table_as_csv, async_writeln};
 

--- a/crates/admin-cli/src/sku/show/mod.rs
+++ b/crates/admin-cli/src/sku/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/sku/show_machines/cmd.rs
+++ b/crates/admin-cli/src/sku/show_machines/cmd.rs
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::SkuList;
 use prettytable::{Row, Table};
 use tokio::io::AsyncWriteExt;
 
 use super::super::common::ShowSkuOptions;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 async fn show_machine_table(

--- a/crates/admin-cli/src/sku/show_machines/mod.rs
+++ b/crates/admin-cli/src/sku/show_machines/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/sku/unassign/cmd.rs
+++ b/crates/admin-cli/src/sku/unassign/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use rpc::forge::RemoveSkuRequest;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn unassign(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/sku/unassign/mod.rs
+++ b/crates/admin-cli/src/sku/unassign/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/sku/update_metadata/cmd.rs
+++ b/crates/admin-cli/src/sku/update_metadata/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn update_metadata(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/sku/update_metadata/mod.rs
+++ b/crates/admin-cli/src/sku/update_metadata/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/sku/verify/cmd.rs
+++ b/crates/admin-cli/src/sku/verify/cmd.rs
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use carbide_uuid::machine::MachineId;
 
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn verify(machine_id: MachineId, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/sku/verify/mod.rs
+++ b/crates/admin-cli/src/sku/verify/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/ssh/copy_bfb/cmd.rs
+++ b/crates/admin-cli/src/ssh/copy_bfb/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use forge_ssh::ssh::copy_bfb_to_bmc_rshim;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn copy_bfb(api_client: &ApiClient, args: Args) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/ssh/copy_bfb/mod.rs
+++ b/crates/admin-cli/src/ssh/copy_bfb/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/ssh/disable_rshim/cmd.rs
+++ b/crates/admin-cli/src/ssh/disable_rshim/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use forge_ssh::ssh::disable_rshim;
 
 use super::super::common::SshArgs;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 pub async fn disable_rshim_cmd(args: SshArgs) -> CarbideCliResult<()> {
     disable_rshim(

--- a/crates/admin-cli/src/ssh/disable_rshim/mod.rs
+++ b/crates/admin-cli/src/ssh/disable_rshim/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, _ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/ssh/enable_rshim/cmd.rs
+++ b/crates/admin-cli/src/ssh/enable_rshim/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use forge_ssh::ssh::enable_rshim;
 
 use super::super::common::SshArgs;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 pub async fn enable_rshim_cmd(args: SshArgs) -> CarbideCliResult<()> {
     enable_rshim(

--- a/crates/admin-cli/src/ssh/enable_rshim/mod.rs
+++ b/crates/admin-cli/src/ssh/enable_rshim/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, _ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/ssh/get_rshim_status/cmd.rs
+++ b/crates/admin-cli/src/ssh/get_rshim_status/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use forge_ssh::ssh::is_rshim_enabled;
 
 use super::super::common::SshArgs;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 pub async fn get_rshim_status(args: SshArgs) -> CarbideCliResult<()> {
     let is_rshim_enabled = is_rshim_enabled(

--- a/crates/admin-cli/src/ssh/get_rshim_status/mod.rs
+++ b/crates/admin-cli/src/ssh/get_rshim_status/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, _ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/ssh/show_obmc_log/cmd.rs
+++ b/crates/admin-cli/src/ssh/show_obmc_log/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use forge_ssh::ssh::read_obmc_console_log;
 
 use super::super::common::SshArgs;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 
 pub async fn show_obmc_log(args: SshArgs) -> CarbideCliResult<()> {
     let log = read_obmc_console_log(

--- a/crates/admin-cli/src/ssh/show_obmc_log/mod.rs
+++ b/crates/admin-cli/src/ssh/show_obmc_log/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, _ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/switch/force_delete/mod.rs
+++ b/crates/admin-cli/src/switch/force_delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/switch/health_report/add/cmd.rs
+++ b/crates/admin-cli/src/switch/health_report/add/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::{self as rpc, InsertSwitchHealthReportRequest};
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::health_utils;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/switch/health_report/add/mod.rs
+++ b/crates/admin-cli/src/switch/health_report/add/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/switch/health_report/print_empty_template/mod.rs
+++ b/crates/admin-cli/src/switch/health_report/print_empty_template/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, _ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/switch/health_report/remove/cmd.rs
+++ b/crates/admin-cli/src/switch/health_report/remove/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::forge::RemoveSwitchHealthReportRequest;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn remove(api_client: &ApiClient, args: Args) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/switch/health_report/remove/mod.rs
+++ b/crates/admin-cli/src/switch/health_report/remove/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/switch/health_report/show/cmd.rs
+++ b/crates/admin-cli/src/switch/health_report/show/cmd.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::health_utils;
 use crate::rpc::ApiClient;
 

--- a/crates/admin-cli/src/switch/health_report/show/mod.rs
+++ b/crates/admin-cli/src/switch/health_report/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/switch/list/mod.rs
+++ b/crates/admin-cli/src/switch/list/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/switch/metadata/cmd.rs
+++ b/crates/admin-cli/src/switch/metadata/cmd.rs
@@ -15,13 +15,14 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use mac_address::MacAddress;
 
 use super::args::{
     Args, SwitchMetadataCommandAddLabel, SwitchMetadataCommandFromExpectedSwitch,
     SwitchMetadataCommandRemoveLabels, SwitchMetadataCommandSet, SwitchMetadataCommandShow,
 };
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn metadata(

--- a/crates/admin-cli/src/switch/metadata/mod.rs
+++ b/crates/admin-cli/src/switch/metadata/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/switch/show/cmd.rs
+++ b/crates/admin-cli/src/switch/show/cmd.rs
@@ -20,11 +20,12 @@ use std::str::FromStr;
 use carbide_uuid::switch::SwitchId;
 use color_eyre::Result;
 use prettytable::{Table, row};
-use rpc::admin_cli::{CarbideCliResult, OutputFormat};
+use rpc::admin_cli::OutputFormat;
 use rpc::forge::Switch;
 
 use super::args::Args;
 use crate::cfg::runtime::RuntimeConfig;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub fn show_switches(switches: Vec<Switch>, output_format: OutputFormat) -> Result<()> {

--- a/crates/admin-cli/src/switch/show/mod.rs
+++ b/crates/admin-cli/src/switch/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/tenant/show/cmd.rs
+++ b/crates/admin-cli/src/tenant/show/cmd.rs
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as forgerpc;
 use prettytable::{Table, row};
 use rpc::forge::TenantByOrganizationIdsRequest;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 /// Produces a table for printing a non-JSON representation of a

--- a/crates/admin-cli/src/tenant/show/mod.rs
+++ b/crates/admin-cli/src/tenant/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/tenant/update/cmd.rs
+++ b/crates/admin-cli/src/tenant/update/cmd.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use rpc::forge::{FindTenantRequest, UpdateTenantRequest};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::tenant::show::cmd::convert_tenants_to_table;
 

--- a/crates/admin-cli/src/tenant/update/mod.rs
+++ b/crates/admin-cli/src/tenant/update/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/tenant_keyset/show/args.rs
+++ b/crates/admin-cli/src/tenant_keyset/show/args.rs
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliError;
 use ::rpc::forge as forgerpc;
 use clap::Parser;
+
+use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug)]
 pub struct Args {

--- a/crates/admin-cli/src/tenant_keyset/show/cmd.rs
+++ b/crates/admin-cli/src/tenant_keyset/show/cmd.rs
@@ -17,11 +17,12 @@
 
 use std::fmt::Write;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as forgerpc;
 use prettytable::{Table, row};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn show(

--- a/crates/admin-cli/src/tenant_keyset/show/mod.rs
+++ b/crates/admin-cli/src/tenant_keyset/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/tpm_ca/add/cmd.rs
+++ b/crates/admin-cli/src/tpm_ca/add/cmd.rs
@@ -19,12 +19,12 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use x509_parser::certificate::X509Certificate;
 use x509_parser::pem::parse_x509_pem;
 use x509_parser::prelude::FromDer;
 use x509_parser::validate::*;
 
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn add_filename(filename: &str, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/tpm_ca/add/mod.rs
+++ b/crates/admin-cli/src/tpm_ca/add/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/tpm_ca/add_bulk/cmd.rs
+++ b/crates/admin-cli/src/tpm_ca/add_bulk/cmd.rs
@@ -18,9 +18,8 @@
 use std::fs;
 use std::path::Path;
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::super::add::cmd::add_individual;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn add_bulk(dirname: &str, api_client: &ApiClient) -> CarbideCliResult<()> {
@@ -30,7 +29,7 @@ pub async fn add_bulk(dirname: &str, api_client: &ApiClient) -> CarbideCliResult
     // call add individually for each one of them
 
     let dir_entry_iter = fs::read_dir(dirpath)
-        .map_err(::rpc::admin_cli::CarbideCliError::IOError)?
+        .map_err(crate::errors::CarbideCliError::IOError)?
         .flatten();
 
     for dir_entry in dir_entry_iter {

--- a/crates/admin-cli/src/tpm_ca/add_bulk/mod.rs
+++ b/crates/admin-cli/src/tpm_ca/add_bulk/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/tpm_ca/delete/cmd.rs
+++ b/crates/admin-cli/src/tpm_ca/delete/cmd.rs
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn delete(ca_cert_id: i32, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/tpm_ca/delete/mod.rs
+++ b/crates/admin-cli/src/tpm_ca/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/tpm_ca/show/cmd.rs
+++ b/crates/admin-cli/src/tpm_ca/show/cmd.rs
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn show(api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/tpm_ca/show/mod.rs
+++ b/crates/admin-cli/src/tpm_ca/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/tpm_ca/show_unmatched_ek/cmd.rs
+++ b/crates/admin-cli/src/tpm_ca/show_unmatched_ek/cmd.rs
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn show_unmatched_ek(api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/tpm_ca/show_unmatched_ek/mod.rs
+++ b/crates/admin-cli/src/tpm_ca/show_unmatched_ek/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/trim_table/measured_boot/cmd.rs
+++ b/crates/admin-cli/src/trim_table/measured_boot/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn trim_measured_boot(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/trim_table/measured_boot/mod.rs
+++ b/crates/admin-cli/src/trim_table/measured_boot/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/version/cmds.rs
+++ b/crates/admin-cli/src/version/cmds.rs
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use prettytable::{Cell, Row, Table, row};
 
 use super::Opts;
+use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
 macro_rules! r {

--- a/crates/admin-cli/src/version/mod.rs
+++ b/crates/admin-cli/src/version/mod.rs
@@ -25,11 +25,11 @@ mod tests;
 // This is different than others that pull in Cmd, since
 // this is just a single top-level command without any
 // subcommands.
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Opts;
 
 use crate::cfg::dispatch::Dispatch;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Dispatch for Opts {
     async fn dispatch(self, ctx: RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/vpc/set_virtualizer/cmd.rs
+++ b/crates/admin-cli/src/vpc/set_virtualizer/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
-
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 /// set_network_virtualization_type is the CLI handler for wrapping

--- a/crates/admin-cli/src/vpc/set_virtualizer/mod.rs
+++ b/crates/admin-cli/src/vpc/set_virtualizer/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/vpc/show/cmd.rs
+++ b/crates/admin-cli/src/vpc/show/cmd.rs
@@ -17,12 +17,13 @@
 use std::borrow::Cow;
 use std::fmt::Write;
 
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult, OutputFormat};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge::{self as forgerpc};
 use carbide_uuid::vpc::VpcId;
 use prettytable::{Table, row};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn show(

--- a/crates/admin-cli/src/vpc/show/mod.rs
+++ b/crates/admin-cli/src/vpc/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/vpc_peering/create/cmd.rs
+++ b/crates/admin-cli/src/vpc_peering/create/cmd.rs
@@ -16,9 +16,9 @@
  */
 
 use ::rpc::admin_cli::output::OutputFormat;
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::vpc_peering::convert_vpc_peerings_to_table;
 

--- a/crates/admin-cli/src/vpc_peering/create/mod.rs
+++ b/crates/admin-cli/src/vpc_peering/create/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/vpc_peering/delete/cmd.rs
+++ b/crates/admin-cli/src/vpc_peering/delete/cmd.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
 use ::rpc::admin_cli::output::OutputFormat;
 
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn delete(

--- a/crates/admin-cli/src/vpc_peering/delete/mod.rs
+++ b/crates/admin-cli/src/vpc_peering/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/vpc_peering/mod.rs
+++ b/crates/admin-cli/src/vpc_peering/mod.rs
@@ -22,12 +22,12 @@ mod show;
 #[cfg(test)]
 mod tests;
 
-use ::rpc::admin_cli::CarbideCliResult;
 use clap::Parser;
 use prettytable::{Table, row};
 use rpc::forge::VpcPeering;
 
 use crate::cfg::dispatch::Dispatch;
+use crate::errors::CarbideCliResult;
 
 #[derive(Parser, Debug, Dispatch)]
 pub enum Cmd {

--- a/crates/admin-cli/src/vpc_peering/show/cmd.rs
+++ b/crates/admin-cli/src/vpc_peering/show/cmd.rs
@@ -16,10 +16,10 @@
  */
 
 use ::rpc::admin_cli::output::OutputFormat;
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use rpc::forge::{VpcPeeringIdList, VpcPeeringSearchFilter, VpcPeeringsByIdsRequest};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::vpc_peering::convert_vpc_peerings_to_table;
 

--- a/crates/admin-cli/src/vpc_peering/show/mod.rs
+++ b/crates/admin-cli/src/vpc_peering/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/vpc_prefix/common.rs
+++ b/crates/admin-cli/src/vpc_prefix/common.rs
@@ -17,12 +17,12 @@
 
 use std::str::FromStr;
 
-use ::rpc::admin_cli::CarbideCliError;
-use ::rpc::admin_cli::CarbideCliError::GenericError;
 use carbide_uuid::vpc::VpcPrefixId;
 use ipnet::IpNet;
 use rpc::forge::{PrefixMatchType, VpcPrefix, VpcPrefixSearchQuery};
 
+use crate::errors::CarbideCliError;
+use crate::errors::CarbideCliError::GenericError;
 use crate::rpc::ApiClient;
 
 #[derive(Clone, Debug)]

--- a/crates/admin-cli/src/vpc_prefix/create/cmd.rs
+++ b/crates/admin-cli/src/vpc_prefix/create/cmd.rs
@@ -16,9 +16,9 @@
  */
 
 use ::rpc::admin_cli::output::{FormattedOutput, OutputFormat};
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::vpc_prefix::show::cmd::ShowOutput;
 

--- a/crates/admin-cli/src/vpc_prefix/create/mod.rs
+++ b/crates/admin-cli/src/vpc_prefix/create/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/vpc_prefix/delete/cmd.rs
+++ b/crates/admin-cli/src/vpc_prefix/delete/cmd.rs
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::CarbideCliResult;
-
 use super::args::Args;
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn delete(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/vpc_prefix/delete/mod.rs
+++ b/crates/admin-cli/src/vpc_prefix/delete/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/admin-cli/src/vpc_prefix/show/cmd.rs
+++ b/crates/admin-cli/src/vpc_prefix/show/cmd.rs
@@ -18,11 +18,11 @@
 use std::borrow::Cow;
 
 use ::rpc::admin_cli::output::{FormattedOutput, IntoTable, OutputFormat};
-use ::rpc::admin_cli::{CarbideCliError, CarbideCliResult};
 use rpc::forge::{PrefixMatchType, VpcPrefix};
 use serde::Serialize;
 
 use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::vpc_prefix::common::{VpcPrefixSelector, get_by_ids, match_all, search};
 

--- a/crates/admin-cli/src/vpc_prefix/show/mod.rs
+++ b/crates/admin-cli/src/vpc_prefix/show/mod.rs
@@ -18,11 +18,11 @@
 pub mod args;
 pub mod cmd;
 
-use ::rpc::admin_cli::CarbideCliResult;
 pub use args::Args;
 
 use crate::cfg::run::Run;
 use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -101,7 +101,7 @@ fn expand_dispatch(input: DeriveInput) -> syn::Result<TokenStream> {
             async fn dispatch(
                 self,
                 mut ctx: crate::cfg::runtime::RuntimeContext,
-            ) -> ::rpc::admin_cli::CarbideCliResult<()> {
+            ) -> crate::errors::CarbideCliResult<()> {
                 use crate::cfg::run::Run;
                 #dispatch_import
                 match self {

--- a/crates/rpc/src/admin_cli.rs
+++ b/crates/rpc/src/admin_cli.rs
@@ -24,21 +24,11 @@
 */
 
 use std::env;
-use std::fs::File;
-use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use carbide_uuid::dpu_remediations::RemediationId;
-use carbide_uuid::instance::InstanceId;
-use carbide_uuid::machine::{MachineId, MachineIdParseError};
 pub use output::{Destination, OutputFormat};
-use serde::Serialize;
 #[cfg(feature = "sqlx")]
 use sqlx::{Pool, Postgres};
-
-use crate::errors;
-use crate::forge::MachineType;
-use crate::forge_tls_client::ForgeTlsClientError;
 
 /// SUMMARY is a global variable that is being used by a few structs which
 /// implement serde::Serialize with skip_serialization_if.
@@ -83,103 +73,6 @@ pub async fn connect(db_url: &str) -> eyre::Result<Pool<Postgres>> {
     Ok(pool)
 }
 
-#[derive(thiserror::Error, Debug)]
-pub enum CarbideCliError {
-    #[error("Unable to connect to carbide API: {0}")]
-    ApiConnectFailed(#[from] ForgeTlsClientError),
-
-    #[error("The API call to the Forge API server returned {0}")]
-    ApiInvocationError(#[from] tonic::Status),
-
-    #[error("Error while writing into string: {0}")]
-    StringWriteError(#[from] std::fmt::Error),
-
-    #[error("Generic Error: {0}")]
-    GenericError(String),
-
-    #[error("Cannot specify both {0} and {1}. Please provide only one.")]
-    ChooseOneError(&'static str, &'static str),
-
-    #[error("Must specify either {0} or {1}.")]
-    RequireOneError(&'static str, &'static str),
-
-    #[error("Invalid datetime format: {0}. Use 'YYYY-MM-DD HH:MM:SS' or 'HH:MM:SS'")]
-    InvalidDateTimeFromUserInput(String),
-
-    #[error("Segment not found.")]
-    SegmentNotFound,
-
-    #[error("Domain not found.")]
-    DomainNotFound,
-
-    #[error("Uuid not found.")]
-    UuidNotFound,
-
-    #[error("MAC not found.")]
-    MacAddressNotFound,
-
-    #[error("Serial number not found.")]
-    SerialNumberNotFound,
-
-    #[error("Error while handling json: {0}")]
-    JsonError(#[from] serde_json::Error),
-
-    #[error("Error while handling yaml: {0}")]
-    YamlError(#[from] serde_yaml::Error),
-
-    #[error("Error while handling csv: {0}")]
-    CsvError(#[from] csv::Error),
-
-    #[error("Unexpected machine type.  expected {0:?} but found {1:?}")]
-    UnexpectedMachineType(MachineType, MachineType),
-
-    #[error("Host machine with id {0} not found")]
-    MachineNotFound(MachineId),
-
-    #[error("Remediation with id {0} not found")]
-    RemediationNotFound(RemediationId),
-
-    #[error("Instance with id {0} not found")]
-    InstanceNotFound(InstanceId),
-
-    #[error("Tenant with id {0} not found")]
-    TenantNotFound(String),
-
-    #[error("I/O error. Does the file exist? {0}")]
-    IOError(#[from] std::io::Error),
-
-    /// For when you expected some values but the response was empty.
-    /// If empty is acceptable don't use this.
-    #[error("No results returned")]
-    Empty,
-
-    #[error("Not Implemented {0}")]
-    NotImplemented(String),
-
-    #[error("Invalid Machine ID: {0}")]
-    InvalidMachineId(#[from] MachineIdParseError),
-
-    #[error("RPC data conversion error: {0}")]
-    RpcDataConversionError(#[from] errors::RpcDataConversionError),
-
-    #[error("Invalid Routing Profile Type: {0}")]
-    InvalidRoutingProfileType(String),
-
-    #[error(transparent)]
-    EyreReport(eyre::Report),
-}
-
-impl From<eyre::Report> for CarbideCliError {
-    // For commands that are [still] returning an eyre::Report,
-    // and not a CarbideCliError, preserve the full report and
-    // error chain for complete context.
-    fn from(err: eyre::Report) -> Self {
-        CarbideCliError::EyreReport(err)
-    }
-}
-
-pub type CarbideCliResult<T> = Result<T, CarbideCliError>;
-
 /// ToTable is a trait which is used alongside the cli_output command
 /// and being able to prettytable print results.
 pub trait ToTable {
@@ -189,38 +82,6 @@ pub trait ToTable {
     {
         Ok("not implemented".to_string())
     }
-}
-
-/// cli_output is the generic function implementation used by the OutputResult
-/// trait, allowing callers to pass a Serialize-derived struct and have it
-/// print in either JSON or YAML.
-pub fn cli_output<T: Serialize + ToTable>(
-    input: T,
-    format: &OutputFormat,
-    destination: Destination,
-) -> CarbideCliResult<()> {
-    let output = match format {
-        OutputFormat::Json => serde_json::to_string_pretty(&input)?,
-        OutputFormat::Yaml => serde_yaml::to_string(&input)?,
-        OutputFormat::AsciiTable => input
-            .into_table()
-            .map_err(|e| CarbideCliError::GenericError(e.to_string()))?,
-        OutputFormat::Csv => {
-            return Err(CarbideCliError::GenericError(String::from(
-                "CSV not supported for measurement commands (yet)",
-            )));
-        }
-    };
-
-    match destination {
-        Destination::Path(path) => {
-            let mut file = File::create(path)?;
-            file.write_all(output.as_bytes())?
-        }
-        Destination::Stdout() => println!("{output}"),
-    }
-
-    Ok(())
 }
 
 pub mod output {


### PR DESCRIPTION
## Description

Probably this is leftovers from previous refactorings, but nobody needs CarbideCliError / CarbideCliResult beside admin-cli. So, moving them to admin-cli crate.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

