### PR TITLE
undo rename of forge in charts

### DIFF
--- a/bluefield/charts/nico-dpu-agent/templates/daemonset.yaml
+++ b/bluefield/charts/nico-dpu-agent/templates/daemonset.yaml
@@ -73,7 +73,7 @@ spec:
             - name: proc-mem-info
               mountPath: /host-mem-info
             - name: nico-certs
-              mountPath: /opt/nico
+              mountPath: /opt/forge
             - name: host-resolv-conf
               mountPath: /host-resolv.conf
               readOnly: true
@@ -135,14 +135,14 @@ spec:
                   key: {{ .Values.hbn.nvue_password_key }}
           volumeMounts:
             - name: nico-certs
-              mountPath: /opt/nico
+              mountPath: /opt/forge
             - name: hw-cache
               mountPath: /data
               readOnly: true
       volumes:
         - name: nico-certs
           hostPath:
-            path: /opt/nico
+            path: /opt/forge
             type: DirectoryOrCreate
         - name: hw-cache
           emptyDir: {}

--- a/bluefield/charts/nico-fmds/templates/daemonset.yaml
+++ b/bluefield/charts/nico-fmds/templates/daemonset.yaml
@@ -51,14 +51,14 @@ spec:
             - /busybox/sh
             - -c
             - |
-              echo "Waiting for nico certificates in /opt/nico ..."
-              while [ ! -f /opt/nico/nico_root.pem ] || [ ! -f /opt/nico/machine_cert.pem ] || [ ! -f /opt/nico/machine_cert.key ]; do
+              echo "Waiting for nico certificates in /opt/forge ..."
+              while [ ! -f /opt/forge/forge_root.pem ] || [ ! -f /opt/forge/machine_cert.pem ] || [ ! -f /opt/forge/machine_cert.key ]; do
                 sleep 5
               done
               echo "Certificates found, starting nico-fmds."
           volumeMounts:
             - name: nico-certs
-              mountPath: /opt/nico
+              mountPath: /opt/forge
               readOnly: true
       containers:
         - name: nico-fmds
@@ -67,9 +67,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           args:
             - "--grpc-address=$(POD_IP):50052"
-            - "--root-ca=/opt/nico/nico_root.pem"
-            - "--client-cert=/opt/nico/machine_cert.pem"
-            - "--client-key=/opt/nico/machine_cert.key"
+            - "--root-ca=/opt/forge/forge_root.pem"
+            - "--client-cert=/opt/forge/machine_cert.pem"
+            - "--client-key=/opt/forge/machine_cert.key"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with toYaml .Values.serviceDaemonSet.resources }}
           resources:
@@ -103,12 +103,12 @@ spec:
                   fieldPath: metadata.namespace
           volumeMounts:
             - name: nico-certs
-              mountPath: /opt/nico
+              mountPath: /opt/forge
               readOnly: true
       volumes:
         - name: nico-certs
           hostPath:
-            path: /opt/nico
+            path: /opt/forge
             type: DirectoryOrCreate
       {{- with .Values.tolerations }}
       tolerations:

--- a/bluefield/charts/nico-otelcol/files/otel_config.yaml
+++ b/bluefield/charts/nico-otelcol/files/otel_config.yaml
@@ -363,9 +363,9 @@ exporters:
   otlp/site:
     endpoint: otel-receiver.nico:443
     tls:
-      ca_file: /opt/nico/nico_root.pem
-      cert_file: /opt/nico/machine_cert.pem
-      key_file: /opt/nico/machine_cert.key
+      ca_file: /opt/forge/forge_root.pem
+      cert_file: /opt/forge/machine_cert.pem
+      key_file: /opt/forge/machine_cert.key
       reload_interval: 1h
     retry_on_failure:
       enabled: true

--- a/bluefield/charts/nico-otelcol/templates/daemonset.yaml
+++ b/bluefield/charts/nico-otelcol/templates/daemonset.yaml
@@ -91,7 +91,7 @@ spec:
               mountPath: /var/log/auth.log
               readOnly: true
             - name: nico-certs
-              mountPath: /opt/nico
+              mountPath: /opt/forge
               readOnly: true
             - name: machine-id
               mountPath: /run/otelcol-contrib
@@ -118,7 +118,7 @@ spec:
             type: FileOrCreate
         - name: nico-certs
           hostPath:
-            path: /opt/nico
+            path: /opt/forge
             type: DirectoryOrCreate
         - name: machine-id
           hostPath:


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
undes the rename of /opt/forge and forge_root.pem

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

