### PR TITLE
fix: Revert the cluster name to again carbide-dpf-cluster instead of nico-dpf-cluster

### DIFF
--- a/bluefield/charts/nico-dhcp-server/templates/daemonset.yaml
+++ b/bluefield/charts/nico-dhcp-server/templates/daemonset.yaml
@@ -80,17 +80,17 @@ spec:
               value: "full"
           volumeMounts:
             - name: dhcp-conf
-              mountPath: /var/support/nico-dhcp/conf
+              mountPath: /var/support/forge-dhcp/conf
             - name: dhcp-logs
-              mountPath: /var/support/nico-dhcp/logs
+              mountPath: /var/support/forge-dhcp/logs
       volumes:
         - name: dhcp-conf
           hostPath:
-            path: /var/lib/hbn/var/support/nico-dhcp/conf
+            path: /var/lib/hbn/var/support/forge-dhcp/conf
             type: DirectoryOrCreate
         - name: dhcp-logs
           hostPath:
-            path: /var/lib/hbn/var/support/nico-dhcp/logs
+            path: /var/lib/hbn/var/support/forge-dhcp/logs
             type: DirectoryOrCreate
       {{- with .Values.tolerations }}
       tolerations:

--- a/bluefield/charts/nico-dpu-agent/templates/daemonset.yaml
+++ b/bluefield/charts/nico-dpu-agent/templates/daemonset.yaml
@@ -86,8 +86,8 @@ spec:
             - run
             - "--hbn-config-mode=nvue-rest"
             - "--agent-platform-type=containerized"
-            - "--dhcp-grpc-server=http://nico-dpf-cluster-{{ .Values.dhcp_server.service_name }}.dpf-operator-system.svc.cluster.local:10079"
-            - "--fmds-grpc-server=http://nico-dpf-cluster-{{ .Values.fmds.service_name }}.dpf-operator-system.svc.cluster.local:50052"
+            - "--dhcp-grpc-server=http://carbide-dpf-cluster-{{ .Values.dhcp_server.service_name }}.dpf-operator-system.svc.cluster.local:10079"
+            - "--fmds-grpc-server=http://carbide-dpf-cluster-{{ .Values.fmds.service_name }}.dpf-operator-system.svc.cluster.local:50052"
             {{- if not (empty .Values.dhcp_server.interface_prepend) }}
             - "--dhcp-server-interface-prepend={{ .Values.dhcp_server.interface_prepend }}"
             {{ end }}
@@ -125,9 +125,9 @@ spec:
             - name: IGNORE_MGMT_VRF
               value: "1"
             - name: NVUE_HTTPS_ADDRESS
-              value: nico-dpf-cluster-{{ .Values.hbn.nvue_https_address }}.dpf-operator-system.svc.cluster.local:8765
+              value: carbide-dpf-cluster-{{ .Values.hbn.nvue_https_address }}.dpf-operator-system.svc.cluster.local:8765
             - name: NVUE_USERNAME
-              value: "nico"
+              value: "carbide"
             - name: NVUE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/bluefield/charts/nico-dpu-otel-agent/files/otel-agent-config.toml
+++ b/bluefield/charts/nico-dpu-otel-agent/files/otel-agent-config.toml
@@ -1,8 +1,8 @@
 [nico-system]
-api-server = "https://nico-api.nico"
-root-ca = "/opt/nico/nico_root.pem"
-client-cert = "/etc/ssl/certs/nico-dpu-otel-agent.pem"
-client-key = "/etc/ssl/private/nico-dpu-otel-agent.key"
+api-server = "https://carbide-api.forge"
+root-ca = "/opt/forge/forge_root.pem"
+client-cert = "/etc/ssl/certs/forge-dpu-otel-agent.pem"
+client-key = "/etc/ssl/private/forge-dpu-otel-agent.key"
 
 [machine]
 is_fake_dpu = false

--- a/bluefield/charts/nico-dpu-otel-agent/templates/daemonset.yaml
+++ b/bluefield/charts/nico-dpu-otel-agent/templates/daemonset.yaml
@@ -52,7 +52,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - "--config-path=/etc/nico-dpu-otel-agent/config.toml"
+            - "--config-path=/etc/forge-dpu-otel-agent/config.toml"
             - "run"
           {{- with toYaml .Values.serviceDaemonSet.resources }}
           resources:
@@ -76,7 +76,7 @@ spec:
                   fieldPath: metadata.namespace
           volumeMounts:
             - name: config
-              mountPath: /etc/nico-dpu-otel-agent/config.toml
+              mountPath: /etc/forge-dpu-otel-agent/config.toml
               subPath: config.toml
               readOnly: true
             - name: nico-certs

--- a/bluefield/charts/nico-otelcol/files/otel_config.yaml
+++ b/bluefield/charts/nico-otelcol/files/otel_config.yaml
@@ -361,11 +361,11 @@ processors:
 
 exporters:
   otlp/site:
-    endpoint: otel-receiver.nico:443
+    endpoint: otel-receiver.forge:443
     tls:
-      ca_file: /opt/nico/nico_root.pem
-      cert_file: /opt/nico/machine_cert.pem
-      key_file: /opt/nico/machine_cert.key
+      ca_file: /opt/forge/forge_root.pem
+      cert_file: /opt/forge/machine_cert.pem
+      key_file: /opt/forge/machine_cert.key
       reload_interval: 1h
     retry_on_failure:
       enabled: true

--- a/bluefield/charts/nico-otelcol/templates/daemonset.yaml
+++ b/bluefield/charts/nico-otelcol/templates/daemonset.yaml
@@ -61,9 +61,9 @@ spec:
           {{- end }}
           env:
             - name: NICO_DPU_AGENT_METRICS_TARGET
-              value: nico-dpf-cluster-{{ .Values.nico_dpu_agent }}.dpf-operator-system.svc.cluster.local:8888
+              value: carbide-dpf-cluster-{{ .Values.nico_dpu_agent }}.dpf-operator-system.svc.cluster.local:8888
             - name: NICO_FMDS_METRICS_TARGET
-              value: nico-dpf-cluster-{{ .Values.nico_fmds }}.dpf-operator-system.svc.cluster.local:8888
+              value: carbide-dpf-cluster-{{ .Values.nico_fmds }}.dpf-operator-system.svc.cluster.local:8888
             - name: NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## Description
fix the cluster name to again carbide-dpf-cluster instead of nico-dpf-cluster + otel config values fix in the similar way.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

