### PR TITLE
fix: Revert to use the same old service name to avoid a long name to breach 62 chars limit.

### DIFF
--- a/bluefield/charts/nico-dhcp-server/templates/_helpers.tpl
+++ b/bluefield/charts/nico-dhcp-server/templates/_helpers.tpl
@@ -12,12 +12,10 @@ Create a default fully qualified app name.
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
+{{- /* DPF names the helm release <dpu-cluster>-<dpu-service>-<hash>; */}}
+{{- /* use it verbatim so resource names stay short and don't get a   */}}
+{{- /* redundant chart-name suffix appended.                          */}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/bluefield/charts/nico-dpu-agent/templates/_helpers.tpl
+++ b/bluefield/charts/nico-dpu-agent/templates/_helpers.tpl
@@ -12,12 +12,10 @@ Create a default fully qualified app name.
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
+{{- /* DPF names the helm release <dpu-cluster>-<dpu-service>-<hash>; */}}
+{{- /* use it verbatim so resource names stay short and don't get a   */}}
+{{- /* redundant chart-name suffix appended.                          */}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/bluefield/charts/nico-dpu-otel-agent/templates/_helpers.tpl
+++ b/bluefield/charts/nico-dpu-otel-agent/templates/_helpers.tpl
@@ -12,12 +12,10 @@ Create a default fully qualified app name.
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
+{{- /* DPF names the helm release <dpu-cluster>-<dpu-service>-<hash>; */}}
+{{- /* use it verbatim so resource names stay short and don't get a   */}}
+{{- /* redundant chart-name suffix appended.                          */}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/bluefield/charts/nico-fmds/templates/_helpers.tpl
+++ b/bluefield/charts/nico-fmds/templates/_helpers.tpl
@@ -12,12 +12,10 @@ Create a default fully qualified app name.
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
+{{- /* DPF names the helm release <dpu-cluster>-<dpu-service>-<hash>; */}}
+{{- /* use it verbatim so resource names stay short and don't get a   */}}
+{{- /* redundant chart-name suffix appended.                          */}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/bluefield/charts/nico-otelcol/templates/_helpers.tpl
+++ b/bluefield/charts/nico-otelcol/templates/_helpers.tpl
@@ -12,12 +12,10 @@ Create a default fully qualified app name.
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
+{{- /* DPF names the helm release <dpu-cluster>-<dpu-service>-<hash>; */}}
+{{- /* use it verbatim so resource names stay short and don't get a   */}}
+{{- /* redundant chart-name suffix appended.                          */}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Description
Revert to use the same old service name to avoid a long name to breach 62 chars limit.
This is also breaking the current code as expected service name is `carbide-dpf-cluster-carbide-dhcp-server-52h7x.dpf-operator-system.svc.cluster.local` while the recent name change PR is forcing the update the name as `carbide-dpf-cluster-carbide-dhcp-server-52h7x-nico-dhcp-server.dpf-operator-system.svc.cluster.local`

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

