### PR TITLE
chore(admin-cli): Implement detailed switch show

### DIFF
--- a/crates/admin-cli/src/async_write.rs
+++ b/crates/admin-cli/src/async_write.rs
@@ -69,7 +69,7 @@ macro_rules! async_write_table_as_csv {
         let mut output = Vec::default();
         $table
             .to_csv(&mut output)
-            .map_err(|e| CarbideCliError::GenericError(e.to_string()))?;
+            .map_err(|e| crate::errors::CarbideCliError::GenericError(e.to_string()))?;
         let mut result = $writer.write_all(output.as_slice()).await;
         if result.is_ok() {
             let flush_result = $writer.flush().await;

--- a/crates/admin-cli/src/async_write.rs
+++ b/crates/admin-cli/src/async_write.rs
@@ -69,7 +69,7 @@ macro_rules! async_write_table_as_csv {
         let mut output = Vec::default();
         $table
             .to_csv(&mut output)
-            .map_err(|e| crate::errors::CarbideCliError::GenericError(e.to_string()))?;
+            .map_err(|e| $crate::errors::CarbideCliError::GenericError(e.to_string()))?;
         let mut result = $writer.write_all(output.as_slice()).await;
         if result.is_ok() {
             let flush_result = $writer.flush().await;

--- a/crates/admin-cli/src/dpu/status/cmd.rs
+++ b/crates/admin-cli/src/dpu/status/cmd.rs
@@ -22,7 +22,7 @@ use carbide_uuid::machine::MachineId;
 use prettytable::{Row, Table};
 use serde::Serialize;
 
-use crate::errors::{CarbideCliError, CarbideCliResult};
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 use crate::{async_write, async_write_table_as_csv};
 

--- a/crates/admin-cli/src/dpu/versions/cmd.rs
+++ b/crates/admin-cli/src/dpu/versions/cmd.rs
@@ -24,7 +24,7 @@ use prettytable::{Row, Table};
 use serde::Serialize;
 
 use super::args::Args;
-use crate::errors::{CarbideCliError, CarbideCliResult};
+use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 use crate::{async_write, async_write_table_as_csv};
 

--- a/crates/admin-cli/src/errors.rs
+++ b/crates/admin-cli/src/errors.rs
@@ -18,6 +18,7 @@
 use carbide_uuid::dpu_remediations::RemediationId;
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::{MachineId, MachineIdParseError};
+use carbide_uuid::switch::{SwitchId, SwitchIdParseError};
 use rpc::forge::MachineType;
 use rpc::forge_tls_client::ForgeTlsClientError;
 
@@ -68,11 +69,14 @@ pub enum CarbideCliError {
     #[error("Error while handling csv: {0}")]
     CsvError(#[from] csv::Error),
 
-    #[error("Unexpected machine type.  expected {0:?} but found {1:?}")]
+    #[error("Unexpected machine type. Expected {0:?} but found {1:?}")]
     UnexpectedMachineType(MachineType, MachineType),
 
-    #[error("Host machine with id {0} not found")]
+    #[error("Machine with id {0} not found")]
     MachineNotFound(MachineId),
+
+    #[error("Switch with id {0} not found")]
+    SwitchNotFound(SwitchId),
 
     #[error("Remediation with id {0} not found")]
     RemediationNotFound(RemediationId),
@@ -94,8 +98,11 @@ pub enum CarbideCliError {
     #[error("Not Implemented {0}")]
     NotImplemented(String),
 
-    #[error("Invalid Machine ID: {0}")]
+    #[error("Invalid Machine id: {0}")]
     InvalidMachineId(#[from] MachineIdParseError),
+
+    #[error("Invalid Switch id: {0}")]
+    InvalidSwitchId(#[from] SwitchIdParseError),
 
     #[error("RPC data conversion error: {0}")]
     RpcDataConversionError(#[from] ::rpc::errors::RpcDataConversionError),

--- a/crates/admin-cli/src/machine/show/args.rs
+++ b/crates/admin-cli/src/machine/show/args.rs
@@ -65,7 +65,7 @@ pub struct Args {
 
     #[clap(
         default_value(None),
-        help = "The machine to query, leave empty for all (default)"
+        help = "The machine ID to query. Omit to show all machines."
     )]
     pub machine: Option<MachineId>,
 

--- a/crates/admin-cli/src/machine/show/cmd.rs
+++ b/crates/admin-cli/src/machine/show/cmd.rs
@@ -352,9 +352,7 @@ async fn show_all_machines(
             async_write_table_as_csv!(output_file, table)?;
         }
         OutputFormat::Yaml => {
-            return Err(CarbideCliError::NotImplemented(
-                "YAML formatted output".to_string(),
-            ));
+            return Err(CarbideCliError::NotImplemented(output_format.to_string()));
         }
     }
     Ok(())

--- a/crates/admin-cli/src/managed_host/show/cmd.rs
+++ b/crates/admin-cli/src/managed_host/show/cmd.rs
@@ -320,6 +320,7 @@ fn show_managed_host_details_view(m: carbide_rpc_utils::ManagedHostOutput) -> Ca
             m.host_last_reboot_requested_time_and_mode,
         ),
         ("  Serial Number", m.host_serial_number),
+        ("  Rack ID", m.rack_id),
         ("  BIOS Version", m.host_bios_version),
         ("  GPU Count", Some(m.host_gpu_count.to_string())),
         (

--- a/crates/admin-cli/src/managed_host/show/cmd.rs
+++ b/crates/admin-cli/src/managed_host/show/cmd.rs
@@ -314,11 +314,6 @@ fn show_managed_host_details_view(m: carbide_rpc_utils::ManagedHostOutput) -> Ca
         ("  ID", m.machine_id),
         ("  Slot Number", m.slot_number.map(|n| n.to_string())),
         ("  Tray Index", m.tray_index.map(|n| n.to_string())),
-        ("  Last reboot completed", m.host_last_reboot_time),
-        (
-            "  Last reboot requested",
-            m.host_last_reboot_requested_time_and_mode,
-        ),
         ("  Serial Number", m.host_serial_number),
         ("  Rack ID", m.rack_id),
         ("  BIOS Version", m.host_bios_version),
@@ -330,6 +325,11 @@ fn show_managed_host_details_view(m: carbide_rpc_utils::ManagedHostOutput) -> Ca
         ("  Memory", m.host_memory),
         ("  Admin IP", m.host_admin_ip),
         ("  Admin MAC", m.host_admin_mac),
+        ("  Last reboot completed", m.host_last_reboot_time),
+        (
+            "  Last reboot requested",
+            m.host_last_reboot_requested_time_and_mode,
+        ),
         (
             "  Associated Instance Type",
             Some(m.instance_type_id.unwrap_or("Unassociated".to_string())),

--- a/crates/admin-cli/src/managed_switch/show/cmd.rs
+++ b/crates/admin-cli/src/managed_switch/show/cmd.rs
@@ -359,11 +359,6 @@ fn show_managed_switch_details_view(m: ManagedSwitchOutput) -> CarbideCliResult<
     let mut lines = String::new();
 
     writeln!(&mut lines, "Name        : {}", m.name)?;
-    writeln!(
-        &mut lines,
-        "Switch ID   : {}",
-        m.switch_id.as_deref().unwrap_or(UNKNOWN)
-    )?;
     writeln!(&mut lines, "State       : {}", m.controller_state)?;
     if let Some(ref reason) = m.state_reason {
         writeln!(&mut lines, "    Reason  : {}", reason)?;
@@ -375,6 +370,7 @@ fn show_managed_switch_details_view(m: ManagedSwitchOutput) -> CarbideCliResult<
     )?;
 
     let data = vec![
+        ("  ID", m.switch_id),
         ("  Serial Number", non_empty(m.serial_number)),
         ("  Slot Number", m.slot_number.map(|n| n.to_string())),
         ("  Tray Index", m.tray_index.map(|n| n.to_string())),

--- a/crates/admin-cli/src/managed_switch/show/cmd.rs
+++ b/crates/admin-cli/src/managed_switch/show/cmd.rs
@@ -56,6 +56,8 @@ struct ManagedSwitchOutput {
     serial_number: String,
     bmc_mac: String,
     bmc_ip: Option<String>,
+    bmc_version: Option<String>,
+    bmc_firmware_version: Option<String>,
     nvos_mac_addresses: Vec<String>,
     controller_state: String,
     power_state: Option<String>,
@@ -125,6 +127,12 @@ fn build_managed_switch_outputs(
             serial_number: linked_switch.switch_serial_number.clone(),
             bmc_mac: linked_switch.bmc_mac_address.clone(),
             bmc_ip: linked_switch.explored_endpoint_address.clone(),
+            bmc_version: switch
+                .and_then(|s| s.bmc_info.as_ref())
+                .and_then(|b| b.version.clone()),
+            bmc_firmware_version: switch
+                .and_then(|s| s.bmc_info.as_ref())
+                .and_then(|b| b.firmware_version.clone()),
             nvos_mac_addresses: nvos_macs,
             controller_state: switch
                 .map(|s| s.controller_state.clone())
@@ -185,6 +193,11 @@ fn build_managed_switch_outputs(
                 .and_then(|b| b.mac.clone())
                 .unwrap_or_default(),
             bmc_ip: switch.bmc_info.as_ref().and_then(|b| b.ip.clone()),
+            bmc_version: switch.bmc_info.as_ref().and_then(|b| b.version.clone()),
+            bmc_firmware_version: switch
+                .bmc_info
+                .as_ref()
+                .and_then(|b| b.firmware_version.clone()),
             nvos_mac_addresses: nvos_macs,
             controller_state: switch.controller_state.clone(),
             power_state: switch.status.as_ref().and_then(|st| st.power_state.clone()),
@@ -382,6 +395,8 @@ fn show_managed_switch_details_view(m: ManagedSwitchOutput) -> CarbideCliResult<
             non_empty(m.nvos_mac_addresses.join(", ")),
         ),
         ("  BMC", Some(String::new())),
+        ("    Version", m.bmc_version),
+        ("    Firmware Version", m.bmc_firmware_version),
         ("    IP", m.bmc_ip),
         ("    MAC", non_empty(m.bmc_mac)),
     ];

--- a/crates/admin-cli/src/managed_switch/show/cmd.rs
+++ b/crates/admin-cli/src/managed_switch/show/cmd.rs
@@ -371,9 +371,10 @@ fn show_managed_switch_details_view(m: ManagedSwitchOutput) -> CarbideCliResult<
 
     let data = vec![
         ("  ID", m.switch_id),
-        ("  Serial Number", non_empty(m.serial_number)),
         ("  Slot Number", m.slot_number.map(|n| n.to_string())),
         ("  Tray Index", m.tray_index.map(|n| n.to_string())),
+        ("  Serial Number", non_empty(m.serial_number)),
+        ("  Rack ID", m.rack_id),
         ("  Power State", m.power_state),
         ("  Health", m.health_status),
         (
@@ -383,10 +384,6 @@ fn show_managed_switch_details_view(m: ManagedSwitchOutput) -> CarbideCliResult<
         ("  BMC", Some(String::new())),
         ("    IP", m.bmc_ip),
         ("    MAC", non_empty(m.bmc_mac)),
-        ("  Inventory", Some(String::new())),
-        ("    Expected Switch ID", m.expected_switch_id),
-        ("    Explored Endpoint", m.explored_endpoint),
-        ("    Rack ID", m.rack_id),
     ];
 
     for (key, value) in data {

--- a/crates/admin-cli/src/switch/show/args.rs
+++ b/crates/admin-cli/src/switch/show/args.rs
@@ -15,10 +15,14 @@
  * limitations under the License.
  */
 
+use carbide_uuid::switch::SwitchId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
 pub struct Args {
-    #[clap(help = "Switch ID or name to show (leave empty for all)")]
-    pub identifier: Option<String>,
+    #[clap(
+        default_value(None),
+        help = "The switch ID to query. Omit to show all switches."
+    )]
+    pub switch_id: Option<SwitchId>,
 }

--- a/crates/admin-cli/src/switch/show/cmd.rs
+++ b/crates/admin-cli/src/switch/show/cmd.rs
@@ -15,224 +15,499 @@
  * limitations under the License.
  */
 
-use std::str::FromStr;
+use std::fmt::Write;
 
 use carbide_uuid::switch::SwitchId;
-use color_eyre::Result;
 use prettytable::{Table, row};
 use rpc::admin_cli::OutputFormat;
-use rpc::forge::Switch;
+use rpc::forge::{Switch, SwitchList, SwitchSearchFilter};
 
 use super::args::Args;
-use crate::cfg::runtime::RuntimeConfig;
-use crate::errors::CarbideCliResult;
+use crate::errors::{CarbideCliError, CarbideCliResult};
+use crate::cfg::cli_options::SortField;
 use crate::rpc::ApiClient;
+use crate::{async_write, async_write_table_as_csv};
 
-pub fn show_switches(switches: Vec<Switch>, output_format: OutputFormat) -> Result<()> {
+/// Converts a SwitchList to a Table object.
+fn to_table(switches: &SwitchList) -> Table {
+    let mut table = Table::new();
+
+    table.set_titles(row![
+        "ID",
+        "Name",
+        "Metadata Name",
+        "Slot",
+        "Tray",
+        "Primary",
+        "Power State",
+        "Health",
+        "FabricManager(nmxc)",
+        "State"
+    ]);
+
+    for switch in switches.switches.iter() {
+        let id = switch
+            .id
+            .as_ref()
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| "N/A".to_string());
+
+        let name = switch
+            .config
+            .as_ref()
+            .map(|config| config.name.as_str())
+            .unwrap_or("N/A");
+
+        let metadata_name = switch
+            .metadata
+            .as_ref()
+            .map(|m| m.name.as_str())
+            .unwrap_or("N/A");
+
+        let slot_number = switch
+            .placement_in_rack
+            .as_ref()
+            .and_then(|p| p.slot_number)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "N/A".to_string());
+
+        let tray_index = switch
+            .placement_in_rack
+            .as_ref()
+            .and_then(|p| p.tray_index)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "N/A".to_string());
+
+        let power_state = switch
+            .status
+            .as_ref()
+            .and_then(|status| status.power_state.as_deref())
+            .unwrap_or("N/A");
+
+        let health = switch
+            .status
+            .as_ref()
+            .and_then(|status| status.health_status.as_deref())
+            .unwrap_or("N/A");
+        let is_primary = if switch.is_primary { "Yes" } else { "No" };
+        let fabric_manager_status = switch
+            .status
+            .as_ref()
+            .and_then(|status| status.fabric_manager_status.as_deref())
+            .unwrap_or("N/A");
+
+        table.add_row(row![
+            id,
+            name,
+            metadata_name,
+            slot_number,
+            tray_index,
+            is_primary,
+            power_state,
+            health,
+            fabric_manager_status,
+            switch.controller_state,
+        ]);
+    }
+
+    table
+}
+
+/// Displays a list of switches in a specified output format, optionally sorted by a given
+/// field. Output destination is controlled by the output_file parameter.
+async fn show_switches(
+    output_file: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
+    output_format: &OutputFormat,
+    api_client: &ApiClient,
+    page_size: usize,
+    sort_by: &SortField,
+) -> CarbideCliResult<()> {
+    let filter: SwitchSearchFilter = SwitchSearchFilter::default();
+    let mut switch_list = api_client.get_all_switches(filter, page_size).await?;
+
+    // Sort the switches by the specified field.
+    match sort_by {
+        SortField::PrimaryId => switch_list.switches.sort_by_key(|switch| switch.id),
+        SortField::State => switch_list.switches.sort_by(|s1, s2| {
+            let default_state = "N/A".to_string();
+            let state1 = s1
+                .status
+                .as_ref()
+                .and_then(|status| status.controller_state.as_ref())
+                .unwrap_or(&default_state);
+            let state2 = s2
+                .status
+                .as_ref()
+                .and_then(|status| status.controller_state.as_ref())
+                .unwrap_or(&default_state);
+            state1.cmp(state2)
+        }),
+    }
+
     match output_format {
-        OutputFormat::AsciiTable => {
-            let mut table = Table::new();
-            table.set_titles(row![
-                "ID",
-                "Name",
-                "Metadata Name",
-                "Slot",
-                "Tray",
-                "Primary",
-                "Power State",
-                "Health",
-                "FabricManager(nmxc)",
-                "State"
-            ]);
-
-            for switch in &switches {
-                let id = switch
-                    .id
-                    .as_ref()
-                    .map(|id| id.to_string())
-                    .unwrap_or_else(|| "N/A".to_string());
-
-                let name = switch
-                    .config
-                    .as_ref()
-                    .map(|config| config.name.as_str())
-                    .unwrap_or("N/A");
-
-                let metadata_name = switch
-                    .metadata
-                    .as_ref()
-                    .map(|m| m.name.as_str())
-                    .unwrap_or("N/A");
-
-                let slot_number = switch
-                    .placement_in_rack
-                    .as_ref()
-                    .and_then(|p| p.slot_number)
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "N/A".to_string());
-
-                let tray_index = switch
-                    .placement_in_rack
-                    .as_ref()
-                    .and_then(|p| p.tray_index)
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "N/A".to_string());
-
-                let power_state = switch
-                    .status
-                    .as_ref()
-                    .and_then(|status| status.power_state.as_deref())
-                    .unwrap_or("N/A");
-
-                let health = switch
-                    .status
-                    .as_ref()
-                    .and_then(|status| status.health_status.as_deref())
-                    .unwrap_or("N/A");
-                let is_primary = if switch.is_primary { "Yes" } else { "No" };
-                let fabric_manager_status = switch
-                    .status
-                    .as_ref()
-                    .and_then(|status| status.fabric_manager_status.as_deref())
-                    .unwrap_or("N/A");
-
-                table.add_row(row![
-                    id,
-                    name,
-                    metadata_name,
-                    slot_number,
-                    tray_index,
-                    is_primary,
-                    power_state,
-                    health,
-                    fabric_manager_status,
-                    switch.controller_state,
-                ]);
-            }
-
-            table.printstd();
+        OutputFormat::Json | OutputFormat::Yaml => {
+            return Err(CarbideCliError::NotImplemented(output_format.to_string()));
         }
+        OutputFormat::Csv | OutputFormat::AsciiTable => {
+            let table = to_table(&switch_list);
+
+            // Print table as either as either CSV or ASCII
+            if let OutputFormat::Csv = output_format {
+                async_write_table_as_csv!(output_file, table)?;
+            } else {
+                // ASCII
+                async_write!(output_file, "{}", table)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Displays detailed information about a specific switch in a specified output format
+/// to a specified output destination.
+async fn show_switch_information(
+    switch_id: SwitchId,
+    output_format: &OutputFormat,
+    output_file: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
+    api_client: &ApiClient,
+) -> CarbideCliResult<()> {
+    let switches = api_client.get_one_switch(switch_id).await?.switches;
+    if switches.is_empty() {
+        return Err(CarbideCliError::SwitchNotFound(switch_id));
+    } else if switches.len() > 1 {
+        // This really shouldn't happen in practice.
+        return Err(CarbideCliError::GenericError(format!(
+            "Expected 1 switch, but got {}.",
+            switches.len()
+        )));
+    }
+
+    let switch = &switches[0];
+    match output_format {
         OutputFormat::Json => {
-            println!("JSON output not supported for Switch (protobuf type)");
-            println!("Use ASCII table format instead.");
+            return Err(CarbideCliError::NotImplemented(output_format.to_string()));
+        }
+        OutputFormat::AsciiTable => async_write!(
+            output_file,
+            "{}",
+            switch_details_text(switch).unwrap_or_else(|x| x.to_string())
+        )?,
+        OutputFormat::Csv => {
+            return Err(CarbideCliError::NotImplemented(output_format.to_string()));
         }
         OutputFormat::Yaml => {
-            println!("YAML output not supported for Switch (protobuf type)");
-            println!("Use ASCII table format instead.");
-        }
-        OutputFormat::Csv => {
-            let mut table = Table::new();
-            table.set_titles(row![
-                "ID",
-                "Name",
-                "Metadata Name",
-                "Slot",
-                "Tray",
-                "Primary",
-                "Power State",
-                "Health",
-                "FabricManager(nmxc)",
-                "State"
-            ]);
-
-            for switch in &switches {
-                let id = switch
-                    .id
-                    .as_ref()
-                    .map(|id| id.to_string())
-                    .unwrap_or_else(|| "N/A".to_string());
-
-                let name = switch
-                    .config
-                    .as_ref()
-                    .map(|config| config.name.as_str())
-                    .unwrap_or("N/A");
-
-                let metadata_name = switch
-                    .metadata
-                    .as_ref()
-                    .map(|m| m.name.as_str())
-                    .unwrap_or("N/A");
-
-                let slot_number = switch
-                    .placement_in_rack
-                    .as_ref()
-                    .and_then(|p| p.slot_number)
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "N/A".to_string());
-
-                let tray_index = switch
-                    .placement_in_rack
-                    .as_ref()
-                    .and_then(|p| p.tray_index)
-                    .map(|v| v.to_string())
-                    .unwrap_or_else(|| "N/A".to_string());
-
-                let power_state = switch
-                    .status
-                    .as_ref()
-                    .and_then(|status| status.power_state.as_deref())
-                    .unwrap_or("N/A");
-
-                let health = switch
-                    .status
-                    .as_ref()
-                    .and_then(|status| status.health_status.as_deref())
-                    .unwrap_or("N/A");
-                let is_primary = if switch.is_primary { "Yes" } else { "No" };
-                let fabric_manager_status = switch
-                    .status
-                    .as_ref()
-                    .and_then(|status| status.fabric_manager_status.as_deref())
-                    .unwrap_or("N/A");
-
-                table.add_row(row![
-                    id,
-                    name,
-                    metadata_name,
-                    slot_number,
-                    tray_index,
-                    is_primary,
-                    power_state,
-                    health,
-                    fabric_manager_status,
-                    switch.controller_state,
-                ]);
-            }
-
-            table.to_csv(std::io::stdout()).ok();
+            return Err(CarbideCliError::NotImplemented(output_format.to_string()));
         }
     }
 
     Ok(())
 }
 
+/// Builds and returns a detailed text representation of the Switch for CLI output,
+/// roughly following the structure of the Switch RPC message.
+fn switch_details_text(switch: &Switch) -> CarbideCliResult<String> {
+    let mut lines = String::new();
+
+    let data: Vec<(&str, String)> = vec![
+        (
+            "ID",
+            switch
+                .id
+                .as_ref()
+                .map(|id| id.to_string())
+                .unwrap_or_default(),
+        ),
+        (
+            "Rack ID",
+            switch
+                .rack_id
+                .as_ref()
+                .map(|id| id.to_string())
+                .unwrap_or_default(),
+        ),
+        ("State Version", switch.state_version.clone()),
+        ("Version", switch.version.clone()),
+        (
+            "Primary",
+            if switch.is_primary {
+                "Yes".to_string()
+            } else {
+                "No".to_string()
+            },
+        ),
+        (
+            "Slot Number",
+            switch
+                .placement_in_rack
+                .as_ref()
+                .and_then(|p| p.slot_number)
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "N/A".to_string()),
+        ),
+        (
+            "Tray Index",
+            switch
+                .placement_in_rack
+                .as_ref()
+                .and_then(|p| p.tray_index)
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| "N/A".to_string()),
+        ),
+        (
+            "Deleted At",
+            switch
+                .deleted
+                .as_ref()
+                .map(|ts| ts.to_string())
+                .unwrap_or_else(|| "N/A".to_string()),
+        ),
+    ];
+
+    let width = 1 + data
+        .iter()
+        .fold(0, |accum, (key, _)| std::cmp::max(accum, key.len()));
+
+    for (key, value) in data {
+        writeln!(&mut lines, "{key:<width$}: {value}")?;
+    }
+
+    // Config
+    writeln!(&mut lines, "\nConfig:")?;
+    if let Some(config) = &switch.config {
+        writeln!(&mut lines, "\tName       : {}", config.name)?;
+        writeln!(&mut lines, "\tEnable NMX-C : {}", config.enable_nmxc)?;
+        if let Some(fm_config) = &config.fabric_manager_config
+            && !fm_config.config_map.is_empty()
+        {
+            writeln!(&mut lines, "\tFabric Manager Config:")?;
+            let mut sorted_keys: Vec<&String> = fm_config.config_map.keys().collect();
+            sorted_keys.sort();
+            for k in sorted_keys {
+                writeln!(&mut lines, "\t\t{k}: {}", fm_config.config_map[k])?;
+            }
+        }
+    } else {
+        writeln!(&mut lines, "\tNone")?;
+    }
+
+    // Status
+    writeln!(&mut lines, "\nStatus:")?;
+    if let Some(status) = &switch.status {
+        let status_data: Vec<(&str, String)> = vec![
+            (
+                "Switch Name",
+                status
+                    .switch_name
+                    .clone()
+                    .unwrap_or_else(|| "N/A".to_string()),
+            ),
+            (
+                "Power State",
+                status
+                    .power_state
+                    .clone()
+                    .unwrap_or_else(|| "N/A".to_string()),
+            ),
+            (
+                "Health Status",
+                status
+                    .health_status
+                    .clone()
+                    .unwrap_or_else(|| "N/A".to_string()),
+            ),
+            (
+                "Controller State",
+                status
+                    .controller_state
+                    .clone()
+                    .unwrap_or_else(|| "N/A".to_string()),
+            ),
+            (
+                "Fabric Manager",
+                status
+                    .fabric_manager_status
+                    .clone()
+                    .unwrap_or_else(|| "N/A".to_string()),
+            ),
+        ];
+        let sw = 1 + status_data
+            .iter()
+            .fold(0, |acc, (k, _)| std::cmp::max(acc, k.len()));
+        for (key, value) in status_data {
+            writeln!(&mut lines, "\t{key:<sw$}: {value}")?;
+        }
+
+        // Lifecycle
+        if let Some(lifecycle) = &status.lifecycle {
+            writeln!(&mut lines, "\tLifecycle:")?;
+            writeln!(
+                &mut lines,
+                "\t\tState   : {}",
+                lifecycle.state.to_uppercase()
+            )?;
+            writeln!(&mut lines, "\t\tVersion : {}", lifecycle.version)?;
+            if let Some(reason) = &lifecycle.state_reason {
+                writeln!(
+                    &mut lines,
+                    "\t\tReason  : {}",
+                    reason.outcome_msg.as_deref().unwrap_or("N/A")
+                )?;
+            }
+            if let Some(sla) = &lifecycle.sla {
+                writeln!(
+                    &mut lines,
+                    "\t\tSLA Breached: {}",
+                    sla.time_in_state_above_sla
+                )?;
+            }
+        }
+
+        if let Some(fm_details) = &status.fabric_manager_status_details {
+            writeln!(&mut lines, "\tFabric Manager Status:")?;
+            writeln!(
+                &mut lines,
+                "\t\tState  : {}",
+                fm_details.fabric_manager_state
+            )?;
+            if let Some(info) = &fm_details.addition_info {
+                writeln!(&mut lines, "\t\tInfo   : {info}")?;
+            }
+            if let Some(reason) = &fm_details.reason {
+                writeln!(&mut lines, "\t\tReason : {reason}")?;
+            }
+            if let Some(err) = &fm_details.error_message {
+                writeln!(&mut lines, "\t\tError  : {err}")?;
+            }
+        }
+
+        if !status.health_sources.is_empty() {
+            writeln!(&mut lines, "\tHealth Sources:")?;
+            for hs in &status.health_sources {
+                writeln!(&mut lines, "\t\tmode={} source={}", hs.mode, hs.source)?;
+            }
+        }
+    } else {
+        writeln!(&mut lines, "\tNone")?;
+    }
+
+    // BMC Info
+    writeln!(&mut lines, "\nBMC:")?;
+    if let Some(bmc) = &switch.bmc_info {
+        let bmc_data: Vec<(&str, String)> = vec![
+            ("IP", bmc.ip.clone().unwrap_or_else(|| "N/A".to_string())),
+            ("MAC", bmc.mac.clone().unwrap_or_else(|| "N/A".to_string())),
+            (
+                "Version",
+                bmc.version.clone().unwrap_or_else(|| "N/A".to_string()),
+            ),
+            (
+                "Firmware Version",
+                bmc.firmware_version
+                    .clone()
+                    .unwrap_or_else(|| "N/A".to_string()),
+            ),
+            (
+                "Port",
+                bmc.port
+                    .map(|p| p.to_string())
+                    .unwrap_or_else(|| "N/A".to_string()),
+            ),
+        ];
+        let bw = 1 + bmc_data
+            .iter()
+            .fold(0, |acc, (k, _)| std::cmp::max(acc, k.len()));
+        for (key, value) in bmc_data {
+            writeln!(&mut lines, "\t{key:<bw$}: {value}")?;
+        }
+    } else {
+        writeln!(&mut lines, "\tNone")?;
+    }
+
+    crate::metadata::write_metadata_in_nice_format(&mut lines, width, switch.metadata.as_ref())?;
+
+    Ok(lines)
+}
+
 pub async fn handle_show(
     args: Args,
+    output_format: &OutputFormat,
+    output_file: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
     api_client: &ApiClient,
-    config: &RuntimeConfig,
+    page_size: usize,
+    sort_by: &SortField,
 ) -> CarbideCliResult<()> {
-    let switches = match args.identifier {
-        Some(id) if !id.is_empty() => match SwitchId::from_str(&id) {
-            Ok(switch_id) => api_client.get_one_switch(switch_id).await?.switches,
-            Err(_) => {
-                // Fall back to name-based lookup
-                let query = rpc::forge::SwitchQuery {
-                    name: Some(id),
-                    switch_id: None,
-                };
-                api_client.0.find_switches(query).await?.switches
-            }
-        },
-        _ => {
-            let filter = rpc::forge::SwitchSearchFilter::default();
-            api_client
-                .get_all_switches(filter, config.page_size)
-                .await?
-                .switches
-        }
-    };
+    if let Some(switch_id) = args.switch_id {
+        show_switch_information(switch_id, output_format, output_file, api_client).await
+    } else {
+        show_switches(output_file, output_format, api_client, page_size, sort_by).await
+    }
+}
 
-    show_switches(switches, config.format).ok();
-    Ok(())
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use carbide_uuid::rack::RackId;
+    use carbide_uuid::switch::SwitchId;
+    use rpc::forge::{BmcInfo, Metadata, PlacementInRack, Switch, SwitchConfig, SwitchStatus};
+
+    use super::*;
+
+    // switch_details_text_smoke calls switch_details_text with a representative
+    // Switch (matching the row visible in the ASCII table output) and prints the
+    // formatted result to stdout so it can be inspected manually when running
+    // `cargo test -- --nocapture`.
+    #[tokio::test]
+    async fn switch_details_text_smoke() {
+        let switch = Switch {
+            id: Some(
+                SwitchId::from_str("sw100nsner0op5osl6n85t7772j010jmhafm934n7oej4mlome3okrn9b60")
+                    .unwrap(),
+            ),
+            rack_id: Some(RackId::from_str("ipp6-gb200-36x1").unwrap()),
+            state_version: "V3-T1774905143273055".to_string(),
+            version: "V1-T1778792629596284".to_string(),
+            config: Some(SwitchConfig {
+                name: "MT2519600UD6".to_string(),
+                enable_nmxc: false,
+                fabric_manager_config: None,
+            }),
+            status: Some(SwitchStatus {
+                switch_name: Some(
+                    "sw100nsner0op5osl6n85t7772j010jmhafm934n7oej4mlome3okrn9b60".to_string(),
+                ),
+                power_state: Some("on".to_string()),
+                health_status: Some("ok".to_string()),
+                controller_state: Some("ready".to_string()),
+                fabric_manager_status: Some("not_running".to_string()),
+                ..Default::default()
+            }),
+            placement_in_rack: Some(PlacementInRack {
+                slot_number: Some(13),
+                tray_index: Some(8),
+            }),
+            is_primary: false,
+            controller_state:
+                r#"{"state":"reprovisioning","reprovisioning_state":"WaitingForNVOSUpgrade"}"#
+                    .to_string(),
+            metadata: Some(Metadata {
+                name: "sw100nsner0op5osl6n85t7772j010jmhafm934n7oej4mlome3okrn9b60".to_string(),
+                ..Default::default()
+            }),
+            bmc_info: Some(BmcInfo {
+                ip: Some("10.85.14.106".to_string()),
+                mac: Some("E0:9D:73:F0:45:96".to_string()),
+                version: Some("V1-T1778792629596284".to_string()),
+                firmware_version: Some("1.3.5-GA".to_string()),
+                machine_interface_id: None,
+                port: Some(443),
+            }),
+            ..Default::default()
+        };
+
+        let output = switch_details_text(&switch).expect("switch_details_text should succeed");
+
+        let mut stdout: Box<dyn tokio::io::AsyncWrite + Unpin> = Box::new(tokio::io::stdout());
+        crate::async_write!(stdout, "{}", output).expect("write to stdout should succeed");
+    }
 }

--- a/crates/admin-cli/src/switch/show/cmd.rs
+++ b/crates/admin-cli/src/switch/show/cmd.rs
@@ -23,8 +23,8 @@ use rpc::admin_cli::OutputFormat;
 use rpc::forge::{Switch, SwitchList, SwitchSearchFilter};
 
 use super::args::Args;
-use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::cfg::cli_options::SortField;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::{async_write, async_write_table_as_csv};
 

--- a/crates/admin-cli/src/switch/show/mod.rs
+++ b/crates/admin-cli/src/switch/show/mod.rs
@@ -26,7 +26,15 @@ use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::handle_show(self, &ctx.api_client, &ctx.config).await?;
+        cmd::handle_show(
+            self,
+            &ctx.config.format,
+            &mut ctx.output_file,
+            &ctx.api_client,
+            ctx.config.page_size,
+            &ctx.config.sort_by,
+        )
+        .await?;
         Ok(())
     }
 }

--- a/crates/admin-cli/src/switch/tests.rs
+++ b/crates/admin-cli/src/switch/tests.rs
@@ -23,6 +23,7 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_uuid::switch::SwitchId;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -52,7 +53,7 @@ fn parse_show_no_args() {
 
     match cmd {
         Cmd::Show(args) => {
-            assert!(args.identifier.is_none());
+            assert!(args.switch_id.is_none());
         }
         _ => panic!("expected Show variant"),
     }
@@ -61,12 +62,15 @@ fn parse_show_no_args() {
 // parse_show_with_identifier ensures show parses with identifier.
 #[test]
 fn parse_show_with_identifier() {
-    let cmd = Cmd::try_parse_from(["switch", "show", "switch-123"])
+    use std::str::FromStr;
+    let switch_id = "sw100nsmnq69j4ntqlj162fnnbvg747gfqbicaa6tqgq6spocirfle7rom0";
+    let cmd = Cmd::try_parse_from(["switch", "show", switch_id])
         .expect("should parse show with identifier");
 
     match cmd {
         Cmd::Show(args) => {
-            assert_eq!(args.identifier, Some("switch-123".to_string()));
+            assert!(args.switch_id.is_some());
+            assert_eq!(args.switch_id, Some(SwitchId::from_str(switch_id).unwrap()));
         }
         _ => panic!("expected Show variant"),
     }

--- a/crates/rpc-utils/src/managed_host_display.rs
+++ b/crates/rpc-utils/src/managed_host_display.rs
@@ -145,6 +145,7 @@ pub struct ManagedHostOutput {
     pub instance_type_id: Option<String>,
     pub slot_number: Option<i32>,
     pub tray_index: Option<i32>,
+    pub rack_id: Option<String>,
 }
 
 impl From<Machine> for ManagedHostOutput {
@@ -250,6 +251,7 @@ impl From<Machine> for ManagedHostOutput {
             instance_type_id: machine.instance_type_id.clone(),
             slot_number: machine.placement_in_rack.and_then(|p| p.slot_number),
             tray_index: machine.placement_in_rack.and_then(|p| p.tray_index),
+            rack_id: machine.rack_id.as_ref().map(|id| id.to_string()),
             health,
             health_sources,
             ..Default::default()

--- a/crates/rpc-utils/src/managed_host_display.rs
+++ b/crates/rpc-utils/src/managed_host_display.rs
@@ -194,6 +194,18 @@ impl From<Machine> for ManagedHostOutput {
             .map(|o| o.source)
             .collect();
 
+        // If the rack ID is empty or "Unknown", set it to "N/A"
+        let rack_id = match machine.rack_id.as_ref() {
+            Some(id) => {
+                if id.as_str().is_empty() || id.as_str() == "Unknown" {
+                    Some("N/A".to_string())
+                } else {
+                    Some(id.to_string())
+                }
+            }
+            None => Some("N/A".to_string()),
+        };
+
         ManagedHostOutput {
             hostname: primary_interface
                 .as_ref()
@@ -251,7 +263,7 @@ impl From<Machine> for ManagedHostOutput {
             instance_type_id: machine.instance_type_id.clone(),
             slot_number: machine.placement_in_rack.and_then(|p| p.slot_number),
             tray_index: machine.placement_in_rack.and_then(|p| p.tray_index),
-            rack_id: machine.rack_id.as_ref().map(|id| id.to_string()),
+            rack_id,
             health,
             health_sources,
             ..Default::default()

--- a/crates/rpc/src/admin_cli.rs
+++ b/crates/rpc/src/admin_cli.rs
@@ -57,6 +57,7 @@ pub trait ToTable {
 }
 
 pub mod output {
+    use std::fmt;
 
     use clap::ValueEnum;
 
@@ -68,5 +69,16 @@ pub mod output {
         Csv,
         Json,
         Yaml,
+    }
+
+    impl fmt::Display for OutputFormat {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                OutputFormat::AsciiTable => write!(f, "ASCII table output format"),
+                OutputFormat::Csv => write!(f, "CSV output format"),
+                OutputFormat::Json => write!(f, "JSON output format"),
+                OutputFormat::Yaml => write!(f, "YAML output format"),
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description

This change fully implements both the list view (all switches) and the single-switch detail view, bringing it to parity with the existing `machine show` command.

Additionally: Moves switch ID to Switch details section for `managed-switch show <id>`.

Output format  of `switch show <id>` **before**:

```console
+-------------------------------------------------------------+--------------+-------------------------------------------------------------+------+------+---------+-------------+--------+---------------------+---------------------------------------------------------------------------+
| ID                                                          | Name         | Metadata Name                                               | Slot | Tray | Primary | Power State | Health | FabricManager(nmxc) | State                                                                     |
+=============================================================+==============+=============================================================+======+======+=========+=============+========+=====================+===========================================================================+
| sw100nskfd0k9in3fnt4va16ppqcjnupl6k4cp13io9r0c1l4uhr0045beg | MT2519600UD9 | sw100nskfd0k9in3fnt4va16ppqcjnupl6k4cp13io9r0c1l4uhr0045beg | 10   | 5    | No      | N/A         | N/A    | not_running         | {"state":"reprovisioning","reprovisioning_state":"WaitingForNVOSUpgrade"} |
+-------------------------------------------------------------+--------------+-------------------------------------------------------------+------+------+---------+-------------+--------+---------------------+---------------------------------------------------------------------------+
```

Output format **after**:

```console
ID            : sw100ns3dce61l6ibclidaa3mtd7sp2n9d0afqdb137an3mjg0dpjkn9hd0
Rack ID       : ipp6-gb200-36x1
State Version : V12-T1778873105787903
Version       : V1-T1778792629597329
Primary       : No
Slot Number   : 7
Tray Index    : 2
Deleted At    : N/A

Config:
	Name       : MT2519600UD8
	Enable NMX-C : false

Status:
	Switch Name      : N/A
	Power State      : N/A
	Health Status    : N/A
	Controller State : {"state":"reprovisioning","reprovisioning_state":"WaitingForNVOSUpgrade"}
	Fabric Manager   : not_running
	Lifecycle:
		State   : {"STATE":"REPROVISIONING","REPROVISIONING_STATE":"WAITINGFORNVOSUPGRADE"}
		Version : V12-T1778873105787903
		Reason  : The object is in the state for longer than defined by the SLA. Handler outcome: Wait("waiting for current rack NVOS cycle")
		SLA Breached: true
	Fabric Manager Status:
		State  : 3
	Health Sources:
		mode=0 source=hardware-health.bmc-leak-detectors
		mode=0 source=hardware-health.bmc-sensors

BMC:
	None
METADATA:
	NAME: sw100ns3dce61l6ibclidaa3mtd7sp2n9d0afqdb137an3mjg0dpjkn9hd0
	DESCRIPTION:
	LABELS:
```

This roughly follows the structure of the gRPC `Switch` message - note that rearranging much more than this makes it a maintenance nightmare when the gRPC message undergoes changes.

For context, this is the output format of `machine show <id>`:

```
ID                  : fm100ht5ldjmk2g8d4reoopaqu3ec4gtp6n6ds02tdjvfpt23bbr88loj40
RACK_ID             : ipp6-gb200-36x1
STATE               : READY
STATE_VERSION       : V33-T1779132554336406
MACHINE TYPE        : Host
FAILURE             : None
VERSION             : V1-T1779037261562339
SKU                 :
SKU DEVICE TYPE     :
SLOT NUMBER         : 16
TRAY INDEX          : 6
VENDOR              : NVIDIA
PRODUCT NAME        : GB200 NVL
PRODUCT SERIAL      : 183XXXXXXXXXX
BOARD SERIAL        : 1322325035033
CHASSIS SERIAL      : 1932725000836
BIOS VERSION        : 02.04.14
BOARD VERSION       : AE.1
FIRMWARE AUTOUPDATE : Default
METADATA:
	NAME: fm100ht5ldjmk2g8d4reoopaqu3ec4gtp6n6ds02tdjvfpt23bbr88loj40
	DESCRIPTION:
	LABELS:
...
```

We want to move away from the ALL CAPS key/value representation for the "nice" human-readable text format - no need to scream at the user - but that's outside the scope of this PR.

Changes by file:

`switch/show/args.rs`:
- Replace the untyped `identifier: Option<String>` field with a typed `switch_id: Option<SwitchId>`, matching the machine show pattern and enabling parse-time validation of the switch ID format.

`switch/show/cmd.rs`:
- Add `to_table` to convert a `SwitchList` into a prettytable `Table` (columns: ID, Name, Metadata Name, Slot, Tray, Primary, Power State, Health, FabricManager(nmxc), State).
- Add `show_switches` to fetch all switches with pagination, sort by primary ID or state, and render as ASCII table or CSV.
- Add `show_switch_information` to fetch a single switch by ID and render it in the requested format.
- Add `switch_details_text` to produce a human-readable key-value representation of all Switch RPC fields (config, status/lifecycle, fabric manager details, health sources, BMC info, metadata).
- Rewrite `handle_show` to dispatch to the appropriate function and remove dead commented-out code.
- Add a `switch_details_text_smoke` async unit test that constructs a representative Switch and prints the formatted output to stdout.

`switch/show/mod.rs`:
- Thread `page_size` and `sort_by` through to `handle_show`, matching the signature expected by the new implementation.

`switch/tests.rs`:
- Update `parse_show_no_args` and `parse_show_with_identifier` to reference the new `switch_id` field instead of `identifier`.

`rpc/src/admin_cli.rs`:
- Add `CarbideCliError::SwitchNotFound(SwitchId)` variant.
- Add `OutputFormat::unimplemented_output_format_err()` helper to reduce boilerplate at call sites.

`managed_switch/show/cmd.rs`:
- Move the Switch ID from a standalone header line into the key-value data table so it is formatted consistently with other fields.

`machine/show/cmd.rs`:
- Use `output_format.unimplemented_output_format_err()` for the YAML case instead of an inline `CarbideCliError::NotImplemented`.

`async_write.rs` / `dpu/{status,versions}/cmd.rs`:
- Fix fully-qualified path for `CarbideCliError` in the `async_write_table_as_csv!` macro and remove unused imports.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
Closes #1782 

## Breaking Changes
- [x] This PR contains breaking changes

These changes only affects the CLI. Existing tooling built around expected CLI output formats may break.
1. Users of the `switch show` command will no longer be allowed to input an empty string for the switch ID to display all switches. Instead, they must omit the arg altogether. This arg _must_ be a valid switch ID - it will be immediately parsed and validated into a `SwitchId` so invalid formats will fail.
2. The switch ID in the `managed-switch show` command has been moved into the core `Switch:` body, instead of the header. This is to maintain parity with the output format of `managed-host show`.
3. `switch show <id>` no longer prints an ASCII table row, in the same format as `switch show`. Instead, it prints a more detailed ASCII text output similar to how `machine show <id>` does it.

All other changes are added functionality and do not change existing formats.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

### Manual CLI Tests

Switch ID format is validated - no longer allowing any `String` value:

```console
colossus@forge-rack-manager-ipp6-2:~/cacarlson$ carbide-admin-cli sw show my-switch
error: invalid value 'my-switch' for '[SWITCH_ID]': The Switch ID has an invalid length of 9

colossus@forge-rack-manager-ipp6-2:~/cacarlson$ carbide-admin-cli sw show ""
error: invalid value '' for '[SWITCH_ID]': The Switch ID has an invalid length of 0
```

Omitting `switch_id` positional argument retains same behavior of listing all switches:

```console
colossus@forge-rack-manager-ipp6-2:~/cacarlson$ carbide-admin-cli sw show
+-------------------------------------------------------------+--------------+-------------------------------------------------------------+------+------+---------+-------------+--------+---------------------+---------------------------------------------------------------------------+
| ID                                                          | Name         | Metadata Name                                               | Slot | Tray | Primary | Power State | Health | FabricManager(nmxc) | State                                                                     |
+=============================================================+==============+=============================================================+======+======+=========+=============+========+=====================+===========================================================================+
| sw100ns3dce61l6ibclidaa3mtd7sp2n9d0afqdb137an3mjg0dpjkn9hd0 | MT2519600UD8 | sw100ns3dce61l6ibclidaa3mtd7sp2n9d0afqdb137an3mjg0dpjkn9hd0 | 7    | 2    | No      | N/A         | N/A    | not_running         | {"state":"reprovisioning","reprovisioning_state":"WaitingForNVOSUpgrade"} |
+-------------------------------------------------------------+--------------+-------------------------------------------------------------+------+------+---------+-------------+--------+---------------------+---------------------------------------------------------------------------+
...
```

## Additional Notes

N/A.

