### PR TITLE
fix(helm-prereqs): default KV entries in vault

### DIFF
--- a/helm-prereqs/templates/vault-config-job.yaml
+++ b/helm-prereqs/templates/vault-config-job.yaml
@@ -13,6 +13,7 @@
 ##     - Enable Kubernetes auth, bind cert-manager SA
 ##     - Create cert-manager-nico-policy + nico-vault-policy
 ##     - Enable KV v2 at secrets/
+##     - Seed factory-default KV entries (machines/all_dpus/...)
 ##     - Enable AppRole, create nico role
 ##
 ## Token read from vaultroottoken K8s secret (written by unseal_vault.sh).
@@ -250,6 +251,9 @@ spec:
               path "{{ .Values.vault.kvMount }}/data/nmxm/*" {
                 capabilities = ["create", "read", "patch", "list", "update", "delete"]
               }
+              path "{{ .Values.vault.kvMount }}/data/bgp/*" {
+                capabilities = ["create", "read", "patch", "list", "update", "delete"]
+              }
               POLICY
 
               # ---- K8s auth role for cert-manager ----
@@ -277,6 +281,13 @@ spec:
               # ---- KV v2 + AppRole ----
               echo "Enabling KV v2 at {{ .Values.vault.kvMount }}/..."
               vault secrets enable -path={{ .Values.vault.kvMount }} kv-v2 2>/dev/null || true
+
+              {{- range .Values.vault.kvSeeds }}
+              echo "Seeding {{ $.Values.vault.kvMount }}/{{ .path }}..."
+              vault kv put {{ $.Values.vault.kvMount }}/{{ .path }} @- <<'KVSEED'
+              {{ .data | toJson }}
+              KVSEED
+              {{- end }}
 
               echo "Enabling AppRole auth..."
               vault auth enable approle 2>/dev/null || true

--- a/helm-prereqs/values.yaml
+++ b/helm-prereqs/values.yaml
@@ -58,6 +58,21 @@ vault:
     serviceAccountName: "nico-api"
     tokenTTL: "1h"
   kvMount: "secrets"
+  ## Seed KV-v2 entries written after the KV mount is enabled. Mirrors the
+  ## publicly-documented DPU factory defaults that the Terraform path
+  ## (forged/terraform/v2/modules/vault) writes via vault_kv_secret_v2.
+  ## Set kvSeeds: [] to disable seeding.
+  kvSeeds:
+    - path: "machines/all_dpus/factory_default/bmc-metadata-items/root"
+      data:
+        UsernamePassword:
+          username: "root"
+          password: "0penBmc"
+    - path: "machines/all_dpus/factory_default/uefi-metadata-items/auth"
+      data:
+        UsernamePassword:
+          username: ""
+          password: "bluefield"
 
 certManager:
   siteRoot:


### PR DESCRIPTION
Adding default KV store entries.
Adding vault policy /data/bgp/*

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

