### PR TITLE
refactor(admin-cli): remove dead rpc CLI output helpers

### DIFF
--- a/crates/admin-cli/src/attestation/measured_boot/bundle/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/bundle/cmds.rs
@@ -49,28 +49,28 @@ pub async fn dispatch(
             cli_output(
                 create_for_id(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
         CmdBundle::Delete(local_args) => {
             cli_output(
                 delete(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
         CmdBundle::Rename(local_args) => {
             cli_output(
                 rename(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
         CmdBundle::SetState(local_args) => {
             cli_output(
                 set_state(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
         CmdBundle::Show(local_args) => {
@@ -78,13 +78,13 @@ pub async fn dispatch(
                 cli_output(
                     show_by_id_or_name(cli.grpc_conn, local_args).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             } else {
                 cli_output(
                     show_all(cli.grpc_conn, local_args).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
         }
@@ -93,7 +93,7 @@ pub async fn dispatch(
                 Some(measurement_bundle) => cli_output(
                     measurement_bundle,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?,
                 None => tracing::info!("No partially matching bundle found"),
             };
@@ -103,14 +103,14 @@ pub async fn dispatch(
                 cli_output(
                     list_machines(cli.grpc_conn, local_args).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
             List::All(_) => {
                 cli_output(
                     list(cli.grpc_conn).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
         },

--- a/crates/admin-cli/src/attestation/measured_boot/journal/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/journal/cmds.rs
@@ -43,7 +43,7 @@ pub async fn dispatch(
             cli_output(
                 delete(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
         CmdJournal::Show(local_args) => {
@@ -51,13 +51,13 @@ pub async fn dispatch(
                 cli_output(
                     show_by_id(cli.grpc_conn, local_args).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             } else {
                 cli_output(
                     show_all(cli.grpc_conn, local_args).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
         }
@@ -65,14 +65,14 @@ pub async fn dispatch(
             cli_output(
                 list(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
         CmdJournal::Promote(local_args) => {
             cli_output(
                 promote(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
     }

--- a/crates/admin-cli/src/attestation/measured_boot/machine/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/machine/cmds.rs
@@ -42,7 +42,7 @@ pub async fn dispatch(
             cli_output(
                 attest(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
         CmdMachine::Show(local_args) => {
@@ -50,13 +50,13 @@ pub async fn dispatch(
                 cli_output(
                     show_by_id(cli.grpc_conn, local_args).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             } else {
                 cli_output(
                     show_all(cli.grpc_conn, local_args).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
         }
@@ -64,7 +64,7 @@ pub async fn dispatch(
             cli_output(
                 list(cli.grpc_conn).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
     }

--- a/crates/admin-cli/src/attestation/measured_boot/profile/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/profile/cmds.rs
@@ -51,21 +51,21 @@ pub async fn dispatch(
             cli_output(
                 create(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
         CmdProfile::Delete(local_args) => {
             cli_output(
                 delete(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
         CmdProfile::Rename(local_args) => {
             cli_output(
                 rename(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
         CmdProfile::Show(local_args) => {
@@ -73,13 +73,13 @@ pub async fn dispatch(
                 cli_output(
                     show_by_id_or_name(cli.grpc_conn, local_args).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             } else {
                 cli_output(
                     show_all(cli.grpc_conn).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
         }
@@ -88,21 +88,21 @@ pub async fn dispatch(
                 cli_output(
                     list_bundles_for_id_or_name(cli.grpc_conn, local_args).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
             List::Machines(local_args) => {
                 cli_output(
                     list_machines_for_id_or_name(cli.grpc_conn, local_args).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
             List::All(_) => {
                 cli_output(
                     list_all(cli.grpc_conn).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
         },

--- a/crates/admin-cli/src/attestation/measured_boot/report/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/report/cmds.rs
@@ -45,28 +45,28 @@ pub async fn dispatch(
             cli_output(
                 create_for_id(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
         CmdReport::Delete(local_args) => {
             cli_output(
                 delete(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
         CmdReport::Promote(local_args) => {
             cli_output(
                 promote(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
         CmdReport::Revoke(local_args) => {
             cli_output(
                 revoke(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
         CmdReport::Show(selector) => match selector {
@@ -74,20 +74,20 @@ pub async fn dispatch(
                 cli_output(
                     show_for_id(cli.grpc_conn, local_args).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
             ShowFor::Machine(local_args) => {
                 cli_output(
                     show_for_machine(cli.grpc_conn, local_args).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
             ShowFor::All => cli_output(
                 show_all(cli.grpc_conn).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?,
         },
         CmdReport::List(selector) => match selector {
@@ -95,14 +95,14 @@ pub async fn dispatch(
                 cli_output(
                     list_machines(cli.grpc_conn, local_args).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
             List::All(_) => {
                 cli_output(
                     list_all(cli.grpc_conn).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
         },
@@ -110,7 +110,7 @@ pub async fn dispatch(
             cli_output(
                 match_values(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
     }

--- a/crates/admin-cli/src/attestation/measured_boot/site/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/site/cmds.rs
@@ -48,13 +48,13 @@ pub async fn dispatch(
             cli_output(
                 import(cli.grpc_conn, local_args).await?,
                 &cli.args.format,
-                ::rpc::admin_cli::Destination::Stdout(),
+                crate::Destination::Stdout(),
             )?;
         }
         CmdSite::Export(local_args) => {
-            let dest: ::rpc::admin_cli::Destination = match &local_args.path {
-                Some(path) => ::rpc::admin_cli::Destination::Path(path.clone()),
-                None => ::rpc::admin_cli::Destination::Stdout(),
+            let dest: crate::Destination = match &local_args.path {
+                Some(path) => crate::Destination::Path(path.clone()),
+                None => crate::Destination::Stdout(),
             };
             cli_output(
                 export(cli.grpc_conn, local_args).await?,
@@ -67,7 +67,7 @@ pub async fn dispatch(
                 cli_output(
                     approve_machine(cli.grpc_conn, local_args).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
             TrustedMachine::Remove(selector) => match selector {
@@ -75,14 +75,14 @@ pub async fn dispatch(
                     cli_output(
                         remove_machine_by_approval_id(cli.grpc_conn, local_args).await?,
                         &cli.args.format,
-                        ::rpc::admin_cli::Destination::Stdout(),
+                        crate::Destination::Stdout(),
                     )?;
                 }
                 RemoveMachine::ByMachineId(local_args) => {
                     cli_output(
                         remove_machine_by_machine_id(cli.grpc_conn, local_args).await?,
                         &cli.args.format,
-                        ::rpc::admin_cli::Destination::Stdout(),
+                        crate::Destination::Stdout(),
                     )?;
                 }
             },
@@ -90,7 +90,7 @@ pub async fn dispatch(
                 cli_output(
                     list_machines(cli.grpc_conn).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
         },
@@ -99,7 +99,7 @@ pub async fn dispatch(
                 cli_output(
                     approve_profile(cli.grpc_conn, local_args).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
             TrustedProfile::Remove(selector) => match selector {
@@ -107,14 +107,14 @@ pub async fn dispatch(
                     cli_output(
                         remove_profile_by_approval_id(cli.grpc_conn, local_args).await?,
                         &cli.args.format,
-                        ::rpc::admin_cli::Destination::Stdout(),
+                        crate::Destination::Stdout(),
                     )?;
                 }
                 RemoveProfile::ByProfileId(local_args) => {
                     cli_output(
                         remove_profile_by_profile_id(cli.grpc_conn, local_args).await?,
                         &cli.args.format,
-                        ::rpc::admin_cli::Destination::Stdout(),
+                        crate::Destination::Stdout(),
                     )?;
                 }
             },
@@ -122,7 +122,7 @@ pub async fn dispatch(
                 cli_output(
                     list_profiles(cli.grpc_conn).await?,
                     &cli.args.format,
-                    ::rpc::admin_cli::Destination::Stdout(),
+                    crate::Destination::Stdout(),
                 )?;
             }
         },

--- a/crates/admin-cli/src/main.rs
+++ b/crates/admin-cli/src/main.rs
@@ -21,7 +21,7 @@
 use std::fs::File;
 use std::io::Write;
 
-use ::rpc::admin_cli::{Destination, OutputFormat, ToTable};
+use ::rpc::admin_cli::{OutputFormat, ToTable};
 use ::rpc::forge_api_client::ForgeApiClient;
 use ::rpc::forge_tls_client::{ApiConfig, ForgeClientConfig};
 use cfg::cli_options::{CliCommand, CliOptions};
@@ -317,6 +317,13 @@ impl<T> IntoOnlyOne<T> for Vec<T> {
         };
         Ok(first)
     }
+}
+
+/// Destination is an enum used to determine whether CLI output is going
+/// to a file path or stdout.
+pub enum Destination {
+    Path(String),
+    Stdout(),
 }
 
 /// cli_output is the generic function implementation used by the OutputResult

--- a/crates/admin-cli/src/vpc_prefix/create/cmd.rs
+++ b/crates/admin-cli/src/vpc_prefix/create/cmd.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::output::{FormattedOutput, OutputFormat};
+use ::rpc::admin_cli::output::OutputFormat;
 
 use super::args::Args;
 use crate::errors::{CarbideCliError, CarbideCliResult};
@@ -34,6 +34,6 @@ pub async fn create(
         .map(ShowOutput::One)?;
 
     output
-        .write_output(output_format, ::rpc::admin_cli::Destination::Stdout())
+        .write_output(output_format, crate::Destination::Stdout())
         .map_err(CarbideCliError::from)
 }

--- a/crates/admin-cli/src/vpc_prefix/show/cmd.rs
+++ b/crates/admin-cli/src/vpc_prefix/show/cmd.rs
@@ -16,12 +16,16 @@
  */
 
 use std::borrow::Cow;
+use std::fs::File;
+use std::io::{Write, stdout};
 
-use ::rpc::admin_cli::output::{FormattedOutput, IntoTable, OutputFormat};
+use ::rpc::admin_cli::output::OutputFormat;
+use prettytable::{Row, Table};
 use rpc::forge::{PrefixMatchType, VpcPrefix};
 use serde::Serialize;
 
 use super::args::Args;
+use crate::Destination;
 use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 use crate::vpc_prefix::common::{VpcPrefixSelector, get_by_ids, match_all, search};
@@ -36,7 +40,7 @@ pub async fn show(
     let output = fetch(api_client, batch_size, show_method).await?;
 
     output
-        .write_output(output_format, ::rpc::admin_cli::Destination::Stdout())
+        .write_output(output_format, crate::Destination::Stdout())
         .map_err(CarbideCliError::from)
 }
 
@@ -97,7 +101,71 @@ async fn fetch(
     }
 }
 
-impl FormattedOutput for ShowOutput {}
+impl ShowOutput {
+    /// Format the output data as bytes (probably UTF-8 text).
+    pub fn format_output(&self, format: OutputFormat) -> Vec<u8> {
+        match format {
+            OutputFormat::Json => {
+                serde_json::to_vec_pretty(self).expect("Could not serialize as JSON")
+            }
+            OutputFormat::Yaml => {
+                let mut out = Vec::new();
+                serde_yaml::to_writer(&mut out, self).expect("Could not serialize as YAML");
+                out
+            }
+            OutputFormat::AsciiTable => self.render_ascii_table(),
+            OutputFormat::Csv => self.render_csv_table(),
+        }
+    }
+
+    /// Format the output data and write it to the specified destination.
+    pub fn write_output(
+        &self,
+        format: OutputFormat,
+        destination: Destination,
+    ) -> std::io::Result<()> {
+        let output = self.format_output(format);
+        match destination {
+            Destination::Stdout() => {
+                let mut stdout_guard = stdout().lock();
+                stdout_guard.write_all(output.as_slice())
+            }
+            Destination::Path(path) => {
+                File::create(path).and_then(|mut file| file.write_all(output.as_slice()))
+            }
+        }
+    }
+
+    fn render_ascii_table(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        let table = self.make_table();
+        table.print(&mut out).expect("Couldn't render ASCII table");
+        out
+    }
+
+    fn render_csv_table(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        let table = self.make_table();
+        table.to_csv(&mut out).expect("Couldn't render CSV table");
+        out
+    }
+
+    // This is not a trait method in order to keep the `prettytable` types
+    // out of the public API.
+    fn make_table(&self) -> Table {
+        let mut table = Table::new();
+        let header = Row::from(self.header());
+        table.set_titles(header);
+        let rows = self.all_rows();
+        rows.iter().for_each(|row| {
+            let values = Self::row_values(row);
+            let row = Row::from(values);
+            table.add_row(row);
+        });
+
+        table
+    }
+}
 
 impl Serialize for ShowOutput {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -111,9 +179,7 @@ impl Serialize for ShowOutput {
     }
 }
 
-impl IntoTable for ShowOutput {
-    type Row = VpcPrefix;
-
+impl ShowOutput {
     fn header(&self) -> &[&str] {
         &[
             "VpcPrefixId",
@@ -125,11 +191,11 @@ impl IntoTable for ShowOutput {
         ]
     }
 
-    fn all_rows(&self) -> &[Self::Row] {
+    fn all_rows(&self) -> &[VpcPrefix] {
         self.as_slice()
     }
 
-    fn row_values(row: &'_ Self::Row) -> Vec<Cow<'_, str>> {
+    fn row_values(row: &'_ VpcPrefix) -> Vec<Cow<'_, str>> {
         let vpc_prefix_id: Cow<str> = row.id.map(|id| id.to_string().into()).unwrap_or("".into());
         let vpc_id: Cow<str> = row
             .vpc_id

--- a/crates/rpc/src/admin_cli.rs
+++ b/crates/rpc/src/admin_cli.rs
@@ -23,12 +23,9 @@
 
 */
 
-use std::env;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-pub use output::{Destination, OutputFormat};
-#[cfg(feature = "sqlx")]
-use sqlx::{Pool, Postgres};
+pub use output::OutputFormat;
 
 /// SUMMARY is a global variable that is being used by a few structs which
 /// implement serde::Serialize with skip_serialization_if.
@@ -53,52 +50,15 @@ pub fn set_summary(val: bool) {
     SUMMARY.store(val, Ordering::SeqCst);
 }
 
-/// get_db_url returns the full DB URL to use for connecting (and resetting,
-/// if requested).
-pub fn get_db_url(db_url: &str, db_name: &str) -> String {
-    // Attempt to grab the DATABASE_URL first.
-    // If it doesn't exist, fall back to args.db_url.
-    let db_base = match env::var("DATABASE_URL") {
-        Ok(val) => val,
-        Err(_) => db_url.to_string(),
-    };
-    db_base + "/" + db_name
-}
-
-#[cfg(feature = "sqlx")]
-/// connect connects to the database for the provided db_url, which probably
-/// comes from get_db_url.
-pub async fn connect(db_url: &str) -> eyre::Result<Pool<Postgres>> {
-    let pool = sqlx::Pool::<sqlx::postgres::Postgres>::connect(db_url).await?;
-    Ok(pool)
-}
-
 /// ToTable is a trait which is used alongside the cli_output command
 /// and being able to prettytable print results.
 pub trait ToTable {
-    fn into_table(self) -> eyre::Result<String>
-    where
-        Self: Sized,
-    {
-        Ok("not implemented".to_string())
-    }
+    fn into_table(self) -> eyre::Result<String>;
 }
 
 pub mod output {
-    use std::fs::File;
-    use std::io::{Write, stdout};
 
     use clap::ValueEnum;
-    use serde::Serialize;
-    pub use table::IntoTable;
-    use table::{render_ascii_table, render_csv_table};
-
-    /// Destination is an enum used to determine whether CLI output is going
-    /// to a file path or stdout.
-    pub enum Destination {
-        Path(String),
-        Stdout(),
-    }
 
     #[derive(Default, PartialEq, Eq, ValueEnum, Clone, Copy, Debug)]
     #[clap(rename_all = "kebab_case")]
@@ -108,115 +68,5 @@ pub mod output {
         Csv,
         Json,
         Yaml,
-    }
-
-    /// The FormattedOutput trait allows you to handle CLI output for a data
-    /// structure. It has no required methods, however you do need to implement
-    /// serde::Serialize and our own IntoTable trait, as this is a supertrait of
-    /// those two.
-    pub trait FormattedOutput: Serialize + IntoTable {
-        /// Format the output data as bytes (probably UTF-8 text).
-        fn format_output(&self, format: OutputFormat) -> Vec<u8> {
-            match format {
-                OutputFormat::Json => {
-                    serde_json::to_vec_pretty(self).expect("Could not serialize as JSON")
-                }
-                OutputFormat::Yaml => {
-                    let mut out = Vec::new();
-                    serde_yaml::to_writer(&mut out, self).expect("Could not serialize as YAML");
-                    out
-                }
-                OutputFormat::AsciiTable => render_ascii_table(self),
-                OutputFormat::Csv => render_csv_table(self),
-            }
-        }
-
-        /// Format the output data and write it to the specified destination.
-        fn write_output(
-            &self,
-            format: OutputFormat,
-            destination: Destination,
-        ) -> std::io::Result<()> {
-            let output = self.format_output(format);
-            match destination {
-                Destination::Stdout() => {
-                    let mut stdout_guard = stdout().lock();
-                    stdout_guard.write_all(output.as_slice())
-                }
-                Destination::Path(path) => {
-                    File::create(path).and_then(|mut file| file.write_all(output.as_slice()))
-                }
-            }
-        }
-    }
-
-    pub mod table {
-        use std::borrow::Cow;
-
-        use prettytable::{Row, Table};
-
-        /// The IntoTable trait is used to help the AsciiTable and CSV
-        /// formatters turn a data structure into tabular data.
-        pub trait IntoTable: Sized {
-            type Row;
-
-            /// Return the header with the titles for each column. These should
-            /// be ordered the same as in the `.row_values()` implementation.
-            fn header(&self) -> &[&str];
-
-            /// Return a slice spanning all of the rows.
-            fn all_rows(&self) -> &[Self::Row];
-
-            /// Return a Vec with the text values for this row, in the same
-            /// order as `.header()`. If the Row's internal fields contain
-            /// values represented as strings, these values can be returned as
-            /// Cow::Borrowed, and if not you will need to string-format them
-            /// and return these as Cow::Owned.
-            fn row_values(row: &'_ Self::Row) -> Vec<Cow<'_, str>>;
-
-            // fn render_text_table(&self) -> String {
-            //     let table = make_table(self);
-            //     format!("{table}")
-            // }
-        }
-
-        // This is not a trait method in order to keep the `prettytable` types
-        // out of the public API.
-        fn make_table<T>(data_source: &T) -> Table
-        where
-            T: IntoTable,
-        {
-            let mut table = Table::new();
-            let header = Row::from(data_source.header());
-            table.set_titles(header);
-            let rows = data_source.all_rows();
-            rows.iter().for_each(|row| {
-                let values = T::row_values(row);
-                let row = Row::from(values);
-                table.add_row(row);
-            });
-
-            table
-        }
-
-        pub fn render_ascii_table<T>(data_source: &T) -> Vec<u8>
-        where
-            T: IntoTable,
-        {
-            let mut out = Vec::new();
-            let table = make_table(data_source);
-            table.print(&mut out).expect("Couldn't render ASCII table");
-            out
-        }
-
-        pub fn render_csv_table<T>(data_source: &T) -> Vec<u8>
-        where
-            T: IntoTable,
-        {
-            let mut out = Vec::new();
-            let table = make_table(data_source);
-            table.to_csv(&mut out).expect("Couldn't render CSV table");
-            out
-        }
     }
 }


### PR DESCRIPTION
## Description

Remove unused common CLI output helpers from the rpc crate, including dead database helpers and generic formatted-output/table traits. Move the remaining destination/output formatting code into admin-cli and keep VPC prefix table rendering local to its only remaining use site.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

