### PR TITLE
chore: deprecate InlineIpxe.user_data field

### DIFF
--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -760,7 +760,6 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
                 user_data: Some("".to_string()),
                 variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(rpc::forge::InlineIpxe {
                     ipxe_script: " chain http://10.217.126.4/public/blobs/internal/x86_64/qcow-imager.efi loglevel=7 console=ttyS0,115200 console=tty0 pci=realloc=off image_url=https://pbss.s8k.io/v1/AUTH_team-forge/images.qcow2/carbide-dev-environment/carbide-dev-environment-latest.qcow2".to_string(),
-                    user_data: Some("".to_string()),
                 })),
             }),
             network: Some(rpc::InstanceNetworkConfig {

--- a/crates/api-model/src/rpc_conv/os.rs
+++ b/crates/api-model/src/rpc_conv/os.rs
@@ -36,7 +36,6 @@ impl TryFrom<InlineIpxe> for rpc::forge::InlineIpxe {
     fn try_from(config: InlineIpxe) -> Result<rpc::forge::InlineIpxe, Self::Error> {
         Ok(Self {
             ipxe_script: config.ipxe_script,
-            user_data: None,
         })
     }
 }
@@ -53,10 +52,9 @@ impl TryFrom<rpc::forge::InstanceOperatingSystemConfig> for OperatingSystem {
             .ok_or(RpcDataConversionError::MissingArgument(
                 "InstanceOperatingSystemConfig::variant",
             ))?;
-        let mut ipxe_user_data = None;
+        let ipxe_user_data = None;
         let variant = match variant {
             rpc::forge::instance_operating_system_config::Variant::Ipxe(ipxe) => {
-                ipxe_user_data = ipxe.user_data.clone();
                 OperatingSystemVariant::Ipxe(ipxe.try_into()?)
             }
             rpc::forge::instance_operating_system_config::Variant::OsImageId(id) => {
@@ -87,8 +85,7 @@ impl TryFrom<OperatingSystem> for rpc::forge::InstanceOperatingSystemConfig {
     ) -> Result<rpc::forge::InstanceOperatingSystemConfig, Self::Error> {
         let variant = match config.variant {
             OperatingSystemVariant::Ipxe(ipxe) => {
-                let mut ipxe: rpc::forge::InlineIpxe = ipxe.try_into()?;
-                ipxe.user_data = config.user_data.clone();
+                let ipxe: rpc::forge::InlineIpxe = ipxe.try_into()?;
                 rpc::forge::instance_operating_system_config::Variant::Ipxe(ipxe)
             }
             OperatingSystemVariant::OsImage(id) => {

--- a/crates/api/src/tests/common/api_fixtures/instance.rs
+++ b/crates/api/src/tests/common/api_fixtures/instance.rs
@@ -293,7 +293,6 @@ pub fn default_os_config() -> rpc::forge::InstanceOperatingSystemConfig {
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe".to_string(),
-                user_data: Some("SomeRandomData".to_string()),
             },
         )),
     }

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -3637,7 +3637,6 @@ async fn test_instance_cannot_allocate_requested_ip_with_network_segment(
                         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
                             rpc::forge::InlineIpxe {
                                 ipxe_script: "SomeRandomiPxe1".to_string(),
-                                user_data: Some("SomeRandomData1".to_string()),
                             },
                         )),
                     }),
@@ -3955,7 +3954,6 @@ async fn test_update_instance_config_vpc_prefix_network_update_delete_vf(
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
-                user_data: Some("SomeRandomData1".to_string()),
             },
         )),
     };
@@ -4360,7 +4358,6 @@ async fn test_update_instance_config_vpc_prefix_network_update_state_machine(
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
-                user_data: Some("SomeRandomData1".to_string()),
             },
         )),
     };
@@ -5694,7 +5691,6 @@ async fn test_can_not_update_instance_config_after_deletion(
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
-                user_data: Some("SomeRandomData1".to_string()),
             },
         )),
     };

--- a/crates/api/src/tests/instance_allocate.rs
+++ b/crates/api/src/tests/instance_allocate.rs
@@ -216,7 +216,6 @@ async fn test_zero_dpu_instance_allocation_rejects_explicit_interfaces(
                     variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
-                            user_data: None,
                         },
                     )),
                 }),
@@ -292,7 +291,6 @@ async fn test_zero_dpu_instance_allocation_auto(
                     variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
-                            user_data: None,
                         },
                     )),
                 }),
@@ -387,7 +385,6 @@ async fn test_zero_dpu_instance_allocation_rejects_missing_auto(
                     variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
-                            user_data: None,
                         },
                     )),
                 }),
@@ -475,7 +472,6 @@ async fn test_zero_dpu_instance_allocation_auto_multi_segment(
                     variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
-                            user_data: None,
                         },
                     )),
                 }),
@@ -621,7 +617,6 @@ async fn test_reject_single_dpu_instance_allocation_no_network_config(
                     variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
-                            user_data: None,
                         },
                     )),
                 }),
@@ -681,7 +676,6 @@ async fn test_reject_single_dpu_instance_allocation_host_inband_network_config(
                     variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
-                            user_data: None,
                         },
                     )),
                 }),
@@ -832,7 +826,6 @@ async fn test_reject_zero_dpu_instance_allocation_multiple_vpcs(
                     variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
-                            user_data: None,
                         },
                     )),
                 }),
@@ -892,7 +885,6 @@ async fn test_single_dpu_instance_allocation(
                     variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
-                            user_data: None,
                         },
                     )),
                 }),
@@ -1038,7 +1030,6 @@ async fn test_reject_zero_dpu_instance_with_tenant_network_segment(
                     variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
-                            user_data: None,
                         },
                     )),
                 }),
@@ -1117,7 +1108,6 @@ async fn test_zero_dpu_instance_surfaces_underlay_ip_in_status(
                     variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
-                            user_data: None,
                         },
                     )),
                 }),
@@ -1245,7 +1235,6 @@ async fn test_reject_zero_dpu_instance_with_extension_services(
                     variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
-                            user_data: None,
                         },
                     )),
                 }),
@@ -1309,7 +1298,6 @@ async fn test_instance_allocation_rejects_auto_with_explicit_interfaces(
                     variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
-                            user_data: None,
                         },
                     )),
                 }),
@@ -1381,7 +1369,6 @@ async fn test_instance_allocation_rejects_auto_on_dpu_host(
                     variant: Some(forge::instance_operating_system_config::Variant::Ipxe(
                         forge::InlineIpxe {
                             ipxe_script: "exit".to_string(),
-                            user_data: None,
                         },
                     )),
                 }),

--- a/crates/api/src/tests/instance_config_update.rs
+++ b/crates/api/src/tests/instance_config_update.rs
@@ -82,7 +82,6 @@ async fn test_update_instance_config(_: PgPoolOptions, options: PgConnectOptions
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
-                user_data: Some("SomeRandomData1".to_string()),
             },
         )),
     };
@@ -131,7 +130,6 @@ async fn test_update_instance_config(_: PgPoolOptions, options: PgConnectOptions
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe2".to_string(),
-                user_data: Some("SomeRandomData2".to_string()),
             },
         )),
     };
@@ -233,7 +231,6 @@ async fn test_update_instance_config(_: PgPoolOptions, options: PgConnectOptions
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe3".to_string(),
-                user_data: Some("SomeRandomData3".to_string()),
             },
         )),
     };
@@ -337,7 +334,6 @@ async fn test_reject_invalid_instance_config_updates(_: PgPoolOptions, options: 
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
-                user_data: Some("SomeRandomData1".to_string()),
             },
         )),
     };
@@ -373,7 +369,6 @@ async fn test_reject_invalid_instance_config_updates(_: PgPoolOptions, options: 
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "".to_string(),
-                user_data: Some("SomeRandomData2".to_string()),
             },
         )),
     };
@@ -603,7 +598,6 @@ async fn test_update_instance_config_vpc_prefix_no_network_update(
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
-                user_data: Some("SomeRandomData1".to_string()),
             },
         )),
     };
@@ -736,7 +730,6 @@ async fn test_update_instance_config_vpc_prefix_network_update(
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
-                user_data: Some("SomeRandomData1".to_string()),
             },
         )),
     };
@@ -940,7 +933,6 @@ async fn test_update_instance_config_vpc_prefix_network_update_post_instance_del
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
-                user_data: Some("SomeRandomData1".to_string()),
             },
         )),
     };
@@ -1094,7 +1086,6 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu(
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
-                user_data: Some("SomeRandomData1".to_string()),
             },
         )),
     };
@@ -1260,7 +1251,6 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu_differen
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
-                user_data: Some("SomeRandomData1".to_string()),
             },
         )),
     };
@@ -1452,7 +1442,6 @@ async fn test_update_instance_config_vpc_prefix_network_update_different_prefix_
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
-                user_data: Some("SomeRandomData1".to_string()),
             },
         )),
     };

--- a/crates/api/src/tests/instance_os.rs
+++ b/crates/api/src/tests/instance_os.rs
@@ -39,7 +39,6 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe1".to_string(),
-                user_data: Some("SomeRandomData1".to_string()),
             },
         )),
     };
@@ -72,7 +71,6 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe2".to_string(),
-                user_data: Some("SomeRandomData2".to_string()),
             },
         )),
     };
@@ -101,7 +99,6 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "SomeRandomiPxe3".to_string(),
-                user_data: Some("SomeRandomData3".to_string()),
             },
         )),
     };
@@ -178,7 +175,6 @@ async fn test_update_instance_operating_system(_: PgPoolOptions, options: PgConn
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "".to_string(),
-                user_data: None,
             },
         )),
     };
@@ -474,7 +470,6 @@ async fn test_update_instance_os_rejects_inactive_os(_: PgPoolOptions, options: 
         variant: Some(rpc::forge::instance_operating_system_config::Variant::Ipxe(
             rpc::forge::InlineIpxe {
                 ipxe_script: "chain http://example.com".to_string(),
-                user_data: None,
             },
         )),
     };

--- a/crates/api/src/web/instance.rs
+++ b/crates/api/src/web/instance.rs
@@ -350,10 +350,7 @@ impl From<forgerpc::Instance> for InstanceDetail {
                 Some(os_variant) => match os_variant {
                     forgerpc::instance_operating_system_config::Variant::Ipxe(ipxe) => InstanceOs {
                         ipxe_script: ipxe.ipxe_script.clone(),
-                        userdata: os
-                            .user_data
-                            .clone()
-                            .unwrap_or(ipxe.user_data.clone().unwrap_or_default()),
+                        userdata: os.user_data.clone().unwrap_or_default(),
                         run_provisioning_instructions_on_every_boot: os
                             .run_provisioning_instructions_on_every_boot,
                         phone_home_enabled: os.phone_home_enabled,

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -278,7 +278,6 @@ impl ApiClient {
             os: Some(InstanceOperatingSystemConfig {
                 variant: Some(Variant::Ipxe(InlineIpxe {
                     ipxe_script: "Non-existing-ipxe".to_string(),
-                    user_data: None,
                 })),
                 user_data: None,
                 phone_home_enabled: false,

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -2632,8 +2632,7 @@ message InlineIpxe {
   string ipxe_script = 1;
   // Optional user-data that is associated with the iPXE script
   // This can be a cloud-init script
-  // Deprecated, use InstanceOperatingSystemConfig user_data field
-  optional string user_data = 2;
+  reserved 2; // was: optional string user_data, now use InstanceOperatingSystemConfig user_data
 }
 
 // Desired configuration for an instance

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -948,12 +948,11 @@ mod tests {
             user_data: Some("def".to_string()),
             variant: Some(Variant::Ipxe(InlineIpxe {
                 ipxe_script: "abc".to_string(),
-                user_data: Some("def".to_string()),
             })),
         };
 
         assert_eq!(
-            "{\"phone_home_enabled\":true,\"run_provisioning_instructions_on_every_boot\":true,\"user_data\":\"def\",\"variant\":{\"Ipxe\":{\"ipxe_script\":\"abc\",\"user_data\":\"def\"}}}",
+            "{\"phone_home_enabled\":true,\"run_provisioning_instructions_on_every_boot\":true,\"user_data\":\"def\",\"variant\":{\"Ipxe\":{\"ipxe_script\":\"abc\"}}}",
             serde_json::to_string(&os).unwrap()
         );
     }


### PR DESCRIPTION
  * `InlineIpxe.user_data` field is deprecated in favor or using `InstanceOperatingSystemConfig.user_data`.

  * rest component already handles user_data correctly attaching it to `OperatingSystem` and not `InlineIpxe` https://github.com/NVIDIA/infra-controller/blob/main/rest-api/api/pkg/api/handler/instance.go#L107 https://github.com/NVIDIA/infra-controller/blob/main/rest-api/api/pkg/api/handler/instancebatch.go#L103 https://github.com/NVIDIA/infra-controller/blob/main/rest-api/site-workflow/pkg/workflow/instance_test.go#L79 https://github.com/NVIDIA/infra-controller/blob/main/rest-api/site-workflow/pkg/activity/instance_test.go#L86

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [X] Unit tests added/updated
- [X] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

