### PR TITLE
fix: Remove RDS modules from scout/qcow

### DIFF
--- a/pxe/mkosi.profiles/qcow-imager-aarch64/mkosi.extra/etc/modprobe.d/disable-mods.conf
+++ b/pxe/mkosi.profiles/qcow-imager-aarch64/mkosi.extra/etc/modprobe.d/disable-mods.conf
@@ -2,3 +2,5 @@ install algif_aead /bin/false
 install esp4 /bin/false
 install esp6 /bin/false
 install rxrpc /bin/false
+install rds /bin/false
+install rds_tcp /bin/false

--- a/pxe/mkosi.profiles/qcow-imager/mkosi.extra/etc/modprobe.d/disable-mods.conf
+++ b/pxe/mkosi.profiles/qcow-imager/mkosi.extra/etc/modprobe.d/disable-mods.conf
@@ -2,3 +2,5 @@ install algif_aead /bin/false
 install esp4 /bin/false
 install esp6 /bin/false
 install rxrpc /bin/false
+install rds /bin/false
+install rds_tcp /bin/false

--- a/pxe/mkosi.profiles/scout-loader-aarch64/mkosi.extra/etc/modprobe.d/disable-mods.conf
+++ b/pxe/mkosi.profiles/scout-loader-aarch64/mkosi.extra/etc/modprobe.d/disable-mods.conf
@@ -2,3 +2,5 @@ install algif_aead /bin/false
 install esp4 /bin/false
 install esp6 /bin/false
 install rxrpc /bin/false
+install rds /bin/false
+install rds_tcp /bin/false

--- a/pxe/mkosi.profiles/scout-loader-x86_64/mkosi.extra/etc/modprobe.d/disable-mods.conf
+++ b/pxe/mkosi.profiles/scout-loader-x86_64/mkosi.extra/etc/modprobe.d/disable-mods.conf
@@ -2,3 +2,5 @@ install algif_aead /bin/false
 install esp4 /bin/false
 install esp6 /bin/false
 install rxrpc /bin/false
+install rds /bin/false
+install rds_tcp /bin/false

--- a/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.extra/etc/modprobe.d/disable-mods.conf
+++ b/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.extra/etc/modprobe.d/disable-mods.conf
@@ -2,3 +2,5 @@ install algif_aead /bin/false
 install esp4 /bin/false
 install esp6 /bin/false
 install rxrpc /bin/false
+install rds /bin/false
+install rds_tcp /bin/false

--- a/pxe/mkosi.profiles/scout-oss-x86_64/mkosi.extra/etc/modprobe.d/disable-mods.conf
+++ b/pxe/mkosi.profiles/scout-oss-x86_64/mkosi.extra/etc/modprobe.d/disable-mods.conf
@@ -2,3 +2,5 @@ install algif_aead /bin/false
 install esp4 /bin/false
 install esp6 /bin/false
 install rxrpc /bin/false
+install rds /bin/false
+install rds_tcp /bin/false


### PR DESCRIPTION
## Description
Disables the modules listed in https://github.com/v12-security/pocs/tree/09e835b587bf71249775654061ae4c79e92cf430/pintheft

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://github.com/NVIDIA/infra-controller/issues/1822

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

