### PR TITLE
chore: skip empty health reports for health overrides in hw-health

### DIFF
--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -84,6 +84,7 @@ client_cert = "/var/run/secrets/spiffe.io/tls.crt"
 client_key = "/var/run/secrets/spiffe.io/tls.key"
 api_url = "https://carbide-api.forge-system.svc.cluster.local:1079"
 workers = 8
+skip_empty_reports = true
 
 [sinks.rack_health_report]
 root_ca = "/var/run/secrets/spiffe.io/ca.crt"
@@ -91,6 +92,7 @@ client_cert = "/var/run/secrets/spiffe.io/tls.crt"
 client_key = "/var/run/secrets/spiffe.io/tls.key"
 api_url = "https://carbide-api.forge-system.svc.cluster.local:1079"
 workers = 2
+skip_empty_reports = true
 
 [sinks.switch_health_report]
 root_ca = "/var/run/secrets/spiffe.io/ca.crt"
@@ -98,6 +100,7 @@ client_cert = "/var/run/secrets/spiffe.io/tls.crt"
 client_key = "/var/run/secrets/spiffe.io/tls.key"
 api_url = "https://carbide-api.forge-system.svc.cluster.local:1079"
 workers = 2
+skip_empty_reports = true
 
 [sinks.power_shelf_health_report]
 root_ca = "/var/run/secrets/spiffe.io/ca.crt"
@@ -105,6 +108,7 @@ client_cert = "/var/run/secrets/spiffe.io/tls.crt"
 client_key = "/var/run/secrets/spiffe.io/tls.key"
 api_url = "https://carbide-api.forge-system.svc.cluster.local:1079"
 workers = 2
+skip_empty_reports = true
 
 # ==============================================================================
 # Rate Limiting

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -313,6 +313,9 @@ pub struct HealthReportSinkConfig {
 
     /// Number of concurrent workers submitting reports to Carbide API.
     pub workers: usize,
+
+    /// Drop reports that contain no successes and no alerts before submitting them.
+    pub skip_empty_reports: bool,
 }
 
 impl Default for HealthReportSinkConfig {
@@ -320,6 +323,7 @@ impl Default for HealthReportSinkConfig {
         Self {
             connection: CarbideApiConnectionConfig::default(),
             workers: 4,
+            skip_empty_reports: true,
         }
     }
 }
@@ -332,6 +336,9 @@ pub struct RackHealthReportSinkConfig {
 
     /// Number of concurrent workers submitting rack-level reports to Carbide API.
     pub workers: usize,
+
+    /// Drop reports that contain no successes and no alerts before submitting them.
+    pub skip_empty_reports: bool,
 }
 
 impl Default for RackHealthReportSinkConfig {
@@ -339,6 +346,7 @@ impl Default for RackHealthReportSinkConfig {
         Self {
             connection: CarbideApiConnectionConfig::default(),
             workers: 2,
+            skip_empty_reports: true,
         }
     }
 }
@@ -351,6 +359,9 @@ pub struct SwitchHealthReportSinkConfig {
 
     /// Number of concurrent workers submitting switch-level reports to Carbide API.
     pub workers: usize,
+
+    /// Drop reports that contain no successes and no alerts before submitting them.
+    pub skip_empty_reports: bool,
 }
 
 impl Default for SwitchHealthReportSinkConfig {
@@ -358,6 +369,7 @@ impl Default for SwitchHealthReportSinkConfig {
         Self {
             connection: CarbideApiConnectionConfig::default(),
             workers: 2,
+            skip_empty_reports: true,
         }
     }
 }
@@ -370,6 +382,9 @@ pub struct PowerShelfHealthReportSinkConfig {
 
     /// Number of concurrent workers submitting power-shelf-level reports to Carbide API.
     pub workers: usize,
+
+    /// Drop reports that contain no successes and no alerts before submitting them.
+    pub skip_empty_reports: bool,
 }
 
 impl Default for PowerShelfHealthReportSinkConfig {
@@ -377,6 +392,7 @@ impl Default for PowerShelfHealthReportSinkConfig {
         Self {
             connection: CarbideApiConnectionConfig::default(),
             workers: 2,
+            skip_empty_reports: true,
         }
     }
 }
@@ -922,6 +938,7 @@ mod tests {
                 "/var/run/secrets/spiffe.io/ca.crt"
             );
             assert_eq!(health_report.workers, 8);
+            assert!(health_report.skip_empty_reports);
         } else {
             panic!("health report sink is disabled")
         }
@@ -1150,6 +1167,31 @@ cache_size = 50
         assert!(config.processors.leak_detection.is_enabled());
         assert!(config.collectors.leak_detector.is_enabled());
         assert!(!config.collectors.nvue.is_enabled());
+        if let Configurable::Enabled(ref health_report) = config.sinks.health_report {
+            assert!(health_report.skip_empty_reports);
+        } else {
+            panic!("health report sink should be enabled by default");
+        }
+    }
+
+    #[test]
+    fn test_health_report_sink_can_send_empty_reports_when_configured() {
+        let toml_content = r#"
+[sinks.health_report]
+skip_empty_reports = false
+"#;
+
+        let config: Config = Figment::new()
+            .merge(Serialized::defaults(Config::default()))
+            .merge(Toml::string(toml_content))
+            .extract()
+            .expect("could not parse config toml file");
+
+        if let Configurable::Enabled(ref health_report) = config.sinks.health_report {
+            assert!(!health_report.skip_empty_reports);
+        } else {
+            panic!("health report sink is disabled")
+        }
     }
 
     #[test]

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -202,6 +202,12 @@ pub struct HealthReport {
     pub alerts: Vec<HealthReportAlert>,
 }
 
+impl HealthReport {
+    pub fn is_empty(&self) -> bool {
+        self.successes.is_empty() && self.alerts.is_empty()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum CollectorEvent {
     MetricCollectionStart,

--- a/crates/health/src/sink/health_report.rs
+++ b/crates/health/src/sink/health_report.rs
@@ -143,6 +143,7 @@ impl DataSink for HealthReportSink {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+
     use super::*;
 
     fn machine_id(value: &str) -> MachineId {

--- a/crates/health/src/sink/health_report.rs
+++ b/crates/health/src/sink/health_report.rs
@@ -35,6 +35,7 @@ struct HealthReportKey {
 
 pub struct HealthReportSink {
     queue: Arc<DedupQueue<HealthReportKey, Arc<HealthReport>>>,
+    skip_empty_reports: bool,
 }
 
 impl HealthReportSink {
@@ -83,13 +84,17 @@ impl HealthReportSink {
             });
         }
 
-        Ok(Self { queue })
+        Ok(Self {
+            queue,
+            skip_empty_reports: config.skip_empty_reports,
+        })
     }
 
     #[cfg(feature = "bench-hooks")]
     pub fn new_for_bench() -> Result<Self, HealthError> {
         Ok(Self {
             queue: Arc::new(DedupQueue::new()),
+            skip_empty_reports: true,
         })
     }
 
@@ -112,6 +117,14 @@ impl DataSink for HealthReportSink {
             return;
         }
 
+        if self.skip_empty_reports && report.is_empty() {
+            tracing::debug!(
+                source = ?report.source,
+                "Skipping empty machine health report"
+            );
+            return;
+        }
+
         if let Some(machine_id) = context.machine_id() {
             let key = HealthReportKey {
                 id: machine_id,
@@ -130,8 +143,11 @@ impl DataSink for HealthReportSink {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::str::FromStr;
 
     use super::*;
+    use crate::endpoint::{BmcAddr, EndpointMetadata, MachineData};
 
     fn machine_id(value: &str) -> MachineId {
         value.parse().expect("valid machine id")
@@ -149,6 +165,71 @@ mod tests {
             successes: Vec::new(),
             alerts: Vec::new(),
         })
+    }
+
+    fn report_with_target(target: HealthReportTarget) -> Arc<HealthReport> {
+        Arc::new(HealthReport {
+            source: ReportSource::BmcSensors,
+            target: Some(target),
+            observed_at: None,
+            successes: Vec::new(),
+            alerts: Vec::new(),
+        })
+    }
+
+    fn machine_context(machine_id: MachineId) -> EventContext {
+        EventContext {
+            endpoint_key: "42:9e:b1:bd:9d:dd".to_string(),
+            addr: BmcAddr {
+                ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                port: Some(443),
+                mac: mac_address::MacAddress::from_str("42:9e:b1:bd:9d:dd").expect("valid mac"),
+            },
+            collector_type: "sensor_collector",
+            metadata: Some(EndpointMetadata::Machine(MachineData {
+                machine_id,
+                machine_serial: None,
+                slot_number: None,
+                tray_index: None,
+                nvlink_domain_uuid: None,
+            })),
+            rack_id: None,
+        }
+    }
+
+    fn sink(skip_empty_reports: bool) -> HealthReportSink {
+        HealthReportSink {
+            queue: Arc::new(DedupQueue::new()),
+            skip_empty_reports,
+        }
+    }
+
+    #[test]
+    fn empty_reports_are_skipped_when_enabled() {
+        let machine_id = machine_id("fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0");
+        let context = machine_context(machine_id);
+        let sink = sink(true);
+
+        sink.handle_event(
+            &context,
+            &CollectorEvent::HealthReport(report_with_target(HealthReportTarget::Machine)),
+        );
+
+        assert!(sink.queue.pop().is_none());
+    }
+
+    #[test]
+    fn empty_reports_can_be_queued_when_skip_is_disabled() {
+        let machine_id = machine_id("fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0");
+        let context = machine_context(machine_id);
+        let sink = sink(false);
+
+        sink.handle_event(
+            &context,
+            &CollectorEvent::HealthReport(report_with_target(HealthReportTarget::Machine)),
+        );
+
+        assert!(sink.queue.pop().is_some());
     }
 
     #[tokio::test]

--- a/crates/health/src/sink/health_report.rs
+++ b/crates/health/src/sink/health_report.rs
@@ -143,11 +143,7 @@ impl DataSink for HealthReportSink {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::net::{IpAddr, Ipv4Addr};
-    use std::str::FromStr;
-
     use super::*;
-    use crate::endpoint::{BmcAddr, EndpointMetadata, MachineData};
 
     fn machine_id(value: &str) -> MachineId {
         value.parse().expect("valid machine id")
@@ -165,71 +161,6 @@ mod tests {
             successes: Vec::new(),
             alerts: Vec::new(),
         })
-    }
-
-    fn report_with_target(target: HealthReportTarget) -> Arc<HealthReport> {
-        Arc::new(HealthReport {
-            source: ReportSource::BmcSensors,
-            target: Some(target),
-            observed_at: None,
-            successes: Vec::new(),
-            alerts: Vec::new(),
-        })
-    }
-
-    fn machine_context(machine_id: MachineId) -> EventContext {
-        EventContext {
-            endpoint_key: "42:9e:b1:bd:9d:dd".to_string(),
-            addr: BmcAddr {
-                ip: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-                port: Some(443),
-                mac: mac_address::MacAddress::from_str("42:9e:b1:bd:9d:dd").expect("valid mac"),
-            },
-            collector_type: "sensor_collector",
-            metadata: Some(EndpointMetadata::Machine(MachineData {
-                machine_id,
-                machine_serial: None,
-                slot_number: None,
-                tray_index: None,
-                nvlink_domain_uuid: None,
-            })),
-            rack_id: None,
-        }
-    }
-
-    fn sink(skip_empty_reports: bool) -> HealthReportSink {
-        HealthReportSink {
-            queue: Arc::new(DedupQueue::new()),
-            skip_empty_reports,
-        }
-    }
-
-    #[test]
-    fn empty_reports_are_skipped_when_enabled() {
-        let machine_id = machine_id("fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0");
-        let context = machine_context(machine_id);
-        let sink = sink(true);
-
-        sink.handle_event(
-            &context,
-            &CollectorEvent::HealthReport(report_with_target(HealthReportTarget::Machine)),
-        );
-
-        assert!(sink.queue.pop().is_none());
-    }
-
-    #[test]
-    fn empty_reports_can_be_queued_when_skip_is_disabled() {
-        let machine_id = machine_id("fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0");
-        let context = machine_context(machine_id);
-        let sink = sink(false);
-
-        sink.handle_event(
-            &context,
-            &CollectorEvent::HealthReport(report_with_target(HealthReportTarget::Machine)),
-        );
-
-        assert!(sink.queue.pop().is_some());
     }
 
     #[tokio::test]

--- a/crates/health/src/sink/power_shelf_health_report.rs
+++ b/crates/health/src/sink/power_shelf_health_report.rs
@@ -35,6 +35,7 @@ struct PowerShelfHealthReportKey {
 
 pub struct PowerShelfHealthReportSink {
     queue: Arc<DedupQueue<PowerShelfHealthReportKey, Arc<HealthReport>>>,
+    skip_empty_reports: bool,
 }
 
 impl PowerShelfHealthReportSink {
@@ -89,7 +90,10 @@ impl PowerShelfHealthReportSink {
             });
         }
 
-        Ok(Self { queue })
+        Ok(Self {
+            queue,
+            skip_empty_reports: config.skip_empty_reports,
+        })
     }
 }
 
@@ -104,6 +108,14 @@ impl DataSink for PowerShelfHealthReportSink {
         };
 
         if report.target != Some(HealthReportTarget::PowerShelf) {
+            return;
+        }
+
+        if self.skip_empty_reports && report.is_empty() {
+            tracing::debug!(
+                source = ?report.source,
+                "Skipping empty power shelf health report"
+            );
             return;
         }
 

--- a/crates/health/src/sink/rack_health_report.rs
+++ b/crates/health/src/sink/rack_health_report.rs
@@ -35,6 +35,7 @@ struct RackHealthReportKey {
 
 pub struct RackHealthReportSink {
     queue: Arc<DedupQueue<RackHealthReportKey, Arc<HealthReport>>>,
+    skip_empty_reports: bool,
 }
 
 impl RackHealthReportSink {
@@ -89,7 +90,10 @@ impl RackHealthReportSink {
             });
         }
 
-        Ok(Self { queue })
+        Ok(Self {
+            queue,
+            skip_empty_reports: config.skip_empty_reports,
+        })
     }
 }
 
@@ -104,6 +108,14 @@ impl DataSink for RackHealthReportSink {
         };
 
         if report.target != Some(HealthReportTarget::Rack) {
+            return;
+        }
+
+        if self.skip_empty_reports && report.is_empty() {
+            tracing::debug!(
+                source = ?report.source,
+                "Skipping empty rack health report"
+            );
             return;
         }
 

--- a/crates/health/src/sink/switch_health_report.rs
+++ b/crates/health/src/sink/switch_health_report.rs
@@ -35,6 +35,7 @@ struct SwitchHealthReportKey {
 
 pub struct SwitchHealthReportSink {
     queue: Arc<DedupQueue<SwitchHealthReportKey, Arc<HealthReport>>>,
+    skip_empty_reports: bool,
 }
 
 impl SwitchHealthReportSink {
@@ -89,7 +90,10 @@ impl SwitchHealthReportSink {
             });
         }
 
-        Ok(Self { queue })
+        Ok(Self {
+            queue,
+            skip_empty_reports: config.skip_empty_reports,
+        })
     }
 }
 
@@ -104,6 +108,14 @@ impl DataSink for SwitchHealthReportSink {
         };
 
         if report.target != Some(HealthReportTarget::Switch) {
+            return;
+        }
+
+        if self.skip_empty_reports && report.is_empty() {
+            tracing::debug!(
+                source = ?report.source,
+                "Skipping empty switch health report"
+            );
             return;
         }
 


### PR DESCRIPTION
## Description
Introduces new flag (enabled by default), which would make HealthOverride sinks in Hardware Health to skip empty health reports.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

