### PR TITLE
fix: do a hello to nmx-c server before issuing any browse operation

### DIFF
--- a/crates/api/src/handlers/nmxc_browse.rs
+++ b/crates/api/src/handlers/nmxc_browse.rs
@@ -129,6 +129,10 @@ pub(crate) async fn nmxc_browse(
             .await
             .map_err(CarbideError::from)?;
 
+        nmxc.hello(NMX_C_GATEWAY_ID)
+            .await
+            .map_err(|e| CarbideError::internal(format!("Failed to call NMX-C hello: {e}")))?;
+
         let result = match op {
             rpc::NmxcBrowseOperation::Unspecified => Err(CarbideError::InvalidArgument(
                 "operation must be set to a supported NmxcBrowseOperation".to_string(),


### PR DESCRIPTION
## Description
nmxc-browse could be the first client path issuing an operation to nmx-c server. So, make sure that nmxc browser always issues a Hello before requesting any browse operation.
## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

