### PR TITLE
fix: skip host boot-order remediation for DGXH100s during HostPlatformConfiguration

### DIFF
--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -316,6 +316,12 @@ impl HardwareInfo {
             .as_ref()
             .is_some_and(|dmi| dmi.product_name.contains("GB200")) // TODO: for now just do GB200
     }
+
+    pub fn is_dgx_h100(&self) -> bool {
+        self.dmi_data
+            .as_ref()
+            .is_some_and(|dmi| dmi.sys_vendor == "NVIDIA" && dmi.product_name == "DGXH100")
+    }
 }
 
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -9709,7 +9709,24 @@ async fn handle_instance_host_platform_config(
 
             log_host_config(redfish_client.as_ref(), mh_snapshot).await;
 
-            let configure_host_boot_order = if redfish_client
+            let is_viking = mh_snapshot
+                .host_snapshot
+                .hardware_info
+                .as_ref()
+                .and_then(|hw| hw.dmi_data.as_ref())
+                .is_some_and(|dmi| dmi.sys_vendor == "NVIDIA" && dmi.product_name == "DGXH100");
+
+            let configure_host_boot_order = if is_viking {
+                // Viking BMC FW has known issues with the boot-order remediation path.
+                // Skip the unreliable Redfish read/PATCH sequence and apply the host's
+                // lockdown policy before continuing.
+                tracing::info!(
+                    machine_id = %mh_snapshot.host_snapshot.id,
+                    bmc_vendor = %vendor,
+                    "Skipping boot order remediation on Viking (known FW/BMC issue)"
+                );
+                false
+            } else if redfish_client
                 .is_boot_order_setup(&boot_interface_mac.to_string())
                 .await
                 .map_err(|e| redfish_error("is_boot_order_setup", e))?
@@ -9737,7 +9754,9 @@ async fn handle_instance_host_platform_config(
                     },
                 }
             } else {
-                InstanceState::WaitingForDpusToUp
+                InstanceState::HostPlatformConfiguration {
+                    platform_config_state: HostPlatformConfigurationState::LockHost,
+                }
             }
         }
         HostPlatformConfigurationState::ConfigureBios {

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -9713,8 +9713,7 @@ async fn handle_instance_host_platform_config(
                 .host_snapshot
                 .hardware_info
                 .as_ref()
-                .and_then(|hw| hw.dmi_data.as_ref())
-                .is_some_and(|dmi| dmi.sys_vendor == "NVIDIA" && dmi.product_name == "DGXH100");
+                .is_some_and(|hw| hw.is_dgx_h100());
 
             let configure_host_boot_order = if is_viking {
                 // Viking BMC FW has known issues with the boot-order remediation path.


### PR DESCRIPTION
## Description

Viking BMCs currently report inconsistent boot-order state: the actual host has the DPU first, but the current redfish boot order continues to report a different first device even after retries, NVRAM clear, firmware update, and power cycling. This causes NICo to loop in `SetBootOrder` / `CheckBootOrder` and blocks instance termination/reprovision flows.

This change skips the unreliable boot-order read/patch remediation path until newer DGXH100 BMC FW fixes this. 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
NVBug-5967790
NVBug-6020642

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

