### PR TITLE
chore: hw-health reduce default sensor-fetch concurency to 4

### DIFF
--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -511,7 +511,7 @@ impl Default for SensorCollectorConfig {
             rediscover_interval: Duration::from_secs(300),
             state_refresh_interval: Duration::from_secs(9000),
             sensor_fetch_interval: Duration::from_secs(60),
-            sensor_fetch_concurrency: 10,
+            sensor_fetch_concurrency: 4,
             include_sensor_thresholds: true,
         }
     }


### PR DESCRIPTION
## Description
Multiple real life scenarios showed what sensor fetch concurrency of 10 as default proved to be too aggresive. This PR changes it to 4, as it sufficent for most hardware.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

