### PR TITLE
Use correct fields when parsing NMX-C response in nvlink-info command

### DIFF
--- a/crates/admin-cli/src/machine/nvlink_info/cmd.rs
+++ b/crates/admin-cli/src/machine/nvlink_info/cmd.rs
@@ -190,11 +190,14 @@ pub async fn handle_nvlink_info_populate(
                     "GPU entry missing gpu_id in NMX-C GPU list response".to_string(),
                 )
             })?;
-        let gpu_device_uid = gpu_json.get("gpu_uid").and_then(|v| v.as_u64()).ok_or_else(|| {
-            CarbideCliError::GenericError(
-                "GPU entry missing gpu_uid in NMX-C GPU list response".to_string(),
-            )
-        })?;
+        let gpu_device_uid = gpu_json
+            .get("gpu_uid")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| {
+                CarbideCliError::GenericError(
+                    "GPU entry missing gpu_uid in NMX-C GPU list response".to_string(),
+                )
+            })?;
         let gpu_slot_id = gpu_json
             .get("loc")
             .and_then(|loc| loc.get("slot_id"))

--- a/crates/admin-cli/src/machine/nvlink_info/cmd.rs
+++ b/crates/admin-cli/src/machine/nvlink_info/cmd.rs
@@ -146,17 +146,20 @@ pub async fn handle_nvlink_info_populate(
         })?;
 
     let domain_uuid = list_json
-        .get("DomainUUID")
+        .get("server_header")
+        .and_then(|h| h.get("domain_uuid"))
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .ok_or_else(|| {
-            CarbideCliError::GenericError(
-                "No non-empty DomainUUID in NMX-C GPU list response".to_string(),
-            )
+            CarbideCliError::GenericError("No domain_uuid in NMX-C server_header".to_string())
+        })?
+        .parse::<uuid::Uuid>()
+        .map_err(|e| {
+            CarbideCliError::GenericError(format!("Failed to parse domain_uuid: {}", e))
         })?;
 
     let gpus_json = list_json
-        .get("Gpus")
+        .get("gpu_info_list")
         .and_then(|v| v.as_array())
         .ok_or_else(|| {
             CarbideCliError::GenericError("No Gpus array in NMX-C GPU list response".to_string())
@@ -165,27 +168,43 @@ pub async fn handle_nvlink_info_populate(
     let mut gpus: Vec<forgerpc::NvLinkGpu> = Vec::new();
     for gpu_json in gpus_json {
         let gpu_tray_index = gpu_json
-            .get("LocationInfo")
-            .and_then(|loc| loc.get("TrayIndex"))
+            .get("loc")
+            .and_then(|loc| loc.get("tray_index"))
             .and_then(|v| v.as_i64())
-            .unwrap_or(0) as i32;
+            .map(|v| v as i32)
+            .ok_or_else(|| {
+                CarbideCliError::GenericError(
+                    "GPU entry missing loc.tray_index in NMX-C GPU list response".to_string(),
+                )
+            })?;
         if gpu_tray_index != tray_index {
             continue;
         }
 
         let gpu_device_id = gpu_json
-            .get("DeviceID")
+            .get("gpu_id")
             .and_then(|v| v.as_i64())
-            .unwrap_or(0) as i32;
-        let gpu_device_uid = gpu_json
-            .get("DeviceUID")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0);
+            .map(|v| v as i32)
+            .ok_or_else(|| {
+                CarbideCliError::GenericError(
+                    "GPU entry missing gpu_id in NMX-C GPU list response".to_string(),
+                )
+            })?;
+        let gpu_device_uid = gpu_json.get("gpu_uid").and_then(|v| v.as_u64()).ok_or_else(|| {
+            CarbideCliError::GenericError(
+                "GPU entry missing gpu_uid in NMX-C GPU list response".to_string(),
+            )
+        })?;
         let gpu_slot_id = gpu_json
-            .get("LocationInfo")
-            .and_then(|loc| loc.get("SlotID"))
+            .get("loc")
+            .and_then(|loc| loc.get("slot_id"))
             .and_then(|v| v.as_i64())
-            .unwrap_or(0) as i32;
+            .map(|v| v as i32)
+            .ok_or_else(|| {
+                CarbideCliError::GenericError(
+                    "GPU entry missing loc.slot_id in NMX-C GPU list response".to_string(),
+                )
+            })?;
 
         gpus.push(forgerpc::NvLinkGpu {
             device_id: gpu_device_id,
@@ -202,16 +221,9 @@ pub async fn handle_nvlink_info_populate(
         )));
     }
 
-    // Parse domain_uuid as UUID
-    let domain_uuid_parsed = uuid::Uuid::parse_str(domain_uuid).map_err(|e| {
-        CarbideCliError::GenericError(format!("Failed to parse domain_uuid: {}", e))
-    })?;
-
     // Build the nvlink_info structure for RPC
     let nvlink_info_rpc = forgerpc::MachineNvLinkInfo {
-        domain_uuid: Some(carbide_uuid::nvlink::NvLinkDomainId::from(
-            domain_uuid_parsed,
-        )),
+        domain_uuid: Some(carbide_uuid::nvlink::NvLinkDomainId::from(domain_uuid)),
         gpus: gpus.clone(),
         chassis_serial: serial_number.clone(),
     };


### PR DESCRIPTION
Use the correct fields when parsing the NMX-C response in the nvlink-info admin-cli command. Also, return an error if any of the fields aren't parsed correctly instead of pushing a default value.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

