### PR TITLE
fix(api,agent): Add config for additional routes on the DPU for the secondary overlay

### DIFF
--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -566,26 +566,17 @@ pub async fn update_traffic_intercept_bridging(
     nc: &rpc::ManagedHostNetworkConfigResponse,
     skip_post: bool,
 ) -> eyre::Result<bool> {
-    let (bridge_config, secondary_overlay_vtep_ip) = match nc
-        .traffic_intercept_config
-        .as_ref()
-        .map(|vc| (vc.bridging.as_ref(), vc.additional_overlay_vtep_ip.as_ref()))
-    {
-        Some((b, s)) => (
-            match b {
-                Some(b) => b,
-                _ => eyre::bail!("traffic_intercept bridging config not provided"),
-            },
-            match s {
-                Some(s) => s.to_owned(),
-                _ => eyre::bail!(
-                    "secondary_overlay_vtep_ip required by traffic_intercept bridging not found"
-                ),
-            },
-        ),
-        _ => {
-            eyre::bail!("traffic_intercept config not provided")
-        }
+    // Read the traffic-intercept inputs supplied by the controller.
+    let Some(traffic_intercept_config) = nc.traffic_intercept_config.as_ref() else {
+        eyre::bail!("traffic_intercept config not provided");
+    };
+    let Some(bridge_config) = traffic_intercept_config.bridging.as_ref() else {
+        eyre::bail!("traffic_intercept bridging config not provided");
+    };
+    let Some(secondary_overlay_vtep_ip) =
+        traffic_intercept_config.additional_overlay_vtep_ip.as_ref()
+    else {
+        eyre::bail!("secondary_overlay_vtep_ip required by traffic_intercept bridging not found");
     };
 
     // IPv4 only for now. Internal HBN bridge plumbing uses 169.254.x.x
@@ -605,7 +596,10 @@ pub async fn update_traffic_intercept_bridging(
     };
 
     let conf = traffic_intercept_bridging::TrafficInterceptBridgingConfig {
-        secondary_overlay_vtep_ip,
+        secondary_overlay_vtep_ip: secondary_overlay_vtep_ip.to_owned(),
+        secondary_vtep_aggregate_prefixes: traffic_intercept_config
+            .secondary_vtep_aggregate_prefixes
+            .clone(),
         vf_intercept_bridge_ip: vf_intercept_bridge_ip.to_string(),
         intercept_bridge_prefix_len: bridge_prefix.prefix_len(),
         // We use the bridge name here because the OVS will create a link/dev on the
@@ -2648,6 +2642,7 @@ mod tests {
                 }),
                 additional_overlay_vtep_ip: Some("10.255.254.253".to_string()),
                 public_prefixes: vec!["7.6.5.0/24".to_string()],
+                secondary_vtep_aggregate_prefixes: vec!["10.255.254.0/24".to_string()],
             }),
 
             tenant_interfaces,

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -90,6 +90,7 @@ async fn test_traffic_intercept_bridging() -> eyre::Result<()> {
     let bridging = traffic_intercept_bridging::build(
         traffic_intercept_bridging::TrafficInterceptBridgingConfig {
             secondary_overlay_vtep_ip: "1.1.1.1".to_string(),
+            secondary_vtep_aggregate_prefixes: vec!["1.1.1.0/24".to_string()],
             vf_intercept_bridge_ip: "10.10.10.2".to_string(),
             vf_intercept_bridge_name: "pfdpu000br-dpu".to_string(),
             intercept_bridge_prefix_len: 29,
@@ -865,6 +866,7 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
             }),
             additional_overlay_vtep_ip: Some("10.2.2.1".to_string()),
             public_prefixes: vec!["7.8.0.0/16".to_string()],
+            secondary_vtep_aggregate_prefixes: vec!["10.2.2.0/24".to_string()],
         }),
 
         dhcp_servers: vec!["127.0.0.1".to_string()],

--- a/crates/agent/src/traffic_intercept_bridging.rs
+++ b/crates/agent/src/traffic_intercept_bridging.rs
@@ -27,6 +27,7 @@ const TMPL_BRIDGING: &str = include_str!("../templates/update_intercept_bridging
 // What we need for the commands to configure the bridge.
 pub struct TrafficInterceptBridgingConfig {
     pub secondary_overlay_vtep_ip: String,
+    pub secondary_vtep_aggregate_prefixes: Vec<String>,
     pub vf_intercept_bridge_ip: String,
     pub vf_intercept_bridge_name: String,
     pub intercept_bridge_prefix_len: u8,
@@ -40,6 +41,7 @@ pub struct TrafficInterceptBridgingConfig {
 #[derive(Clone, Gtmpl, Debug)]
 struct TmplTrafficInterceptBridging {
     SecondaryOverlayVtepIP: String,
+    SecondaryVtepAggregatePrefixes: Vec<String>,
     VfInterceptBridgeIP: String,
     VfInterceptBridgeName: String,
     InterceptBridgePrefixLen: u8,
@@ -48,6 +50,7 @@ struct TmplTrafficInterceptBridging {
 pub fn build(conf: TrafficInterceptBridgingConfig) -> eyre::Result<String> {
     let params = TmplTrafficInterceptBridging {
         SecondaryOverlayVtepIP: conf.secondary_overlay_vtep_ip,
+        SecondaryVtepAggregatePrefixes: conf.secondary_vtep_aggregate_prefixes,
         VfInterceptBridgeIP: conf.vf_intercept_bridge_ip,
         VfInterceptBridgeName: conf.vf_intercept_bridge_name,
         InterceptBridgePrefixLen: conf.intercept_bridge_prefix_len,

--- a/crates/agent/templates/tests/update_intercept_bridging.sh.expected
+++ b/crates/agent/templates/tests/update_intercept_bridging.sh.expected
@@ -18,14 +18,41 @@ fi
 
 if ! ip addr show pfdpu000br-dpu | grep 1.1.1.1/32; then
     ip link set pfdpu000br-dpu up
-    ip addr add 1.1.1.1/32 dev pfdpu000br-dpu || exit $?
     # This is how Catalyst learns the current local GENEVE VTEP IP.
     ovs-vsctl set Open_vSwitch . external_ids:ovn-encap-ip=1.1.1.1 || exit $?
+
+    ip addr add 1.1.1.1/32 dev pfdpu000br-dpu || exit $?
 fi
+
+#### Now update the routes
+
+# Get the existing routes point toward the bridge
+VF_BRIDGE_ROUTES=$(ip route | grep -oP '\K[\d.\/]+\svia\s[\d.\/]+(?=\sdev\spfdpu000br-dpu)')
+
+# Get the incoming routes
+INCOMING_ROUTES=( "1.1.1.0/24 via 1.1.1.1" )
+
+# Find only the routes that need to be removed.
+OLD_VF_BRIDGE_ROUTES=$(diff --old-line-format="%L" --unchanged-line-format="" --new-line-format="" \
+    <(printf "%s\n" "${VF_BRIDGE_ROUTES[@]}" | sort) \
+    <(printf "%s\n" "${INCOMING_ROUTES[@]}" | sort))
+
+# Add any new routes
+for r in "${INCOMING_ROUTES[@]}";do
+    if ! ip route | grep "${r}"; then
+        ip route replace ${r} || exit $?
+    fi
+done
+
+
+# Remove old the old routes
+for OLD_ROUTE in "${OLD_VF_BRIDGE_ROUTES[@]}";do
+    ip route del $OLD_ROUTE  &>/dev/null || true
+done;
 
 # Now remove all the old IPs
 # If something went wrong, we'll have exited and won't rip down the old IPs.
 # The next cycle will put things in order if there are no errors.
 for OLD_IP in "${OLD_VF_BRIDGE_IPS[@]}";do
-    ip addr del $OLD_IP dev pfdpu000br-dpu || true
+    ip addr del $OLD_IP dev pfdpu000br-dpu &>/dev/null || true
 done;

--- a/crates/agent/templates/update_intercept_bridging.sh.tmpl
+++ b/crates/agent/templates/update_intercept_bridging.sh.tmpl
@@ -1,4 +1,5 @@
 #!/bin/bash
+{{- $bridgingConfig := . }}
 
 # Get the IPs currently on the bridge used for intercepting VMaaS traffic.
 VF_BRIDGE_IPS=$(ip addr show dev {{ .VfInterceptBridgeName }} | grep -oP 'inet\s\K[\d.\/]+')
@@ -18,14 +19,41 @@ fi
 
 if ! ip addr show {{ .VfInterceptBridgeName }} | grep {{ .SecondaryOverlayVtepIP }}/32; then
     ip link set {{ .VfInterceptBridgeName }} up
-    ip addr add {{ .SecondaryOverlayVtepIP }}/32 dev {{ .VfInterceptBridgeName }} || exit $?
     # This is how Catalyst learns the current local GENEVE VTEP IP.
     ovs-vsctl set Open_vSwitch . external_ids:ovn-encap-ip={{ .SecondaryOverlayVtepIP }} || exit $?
+
+    ip addr add {{ .SecondaryOverlayVtepIP }}/32 dev {{ .VfInterceptBridgeName }} || exit $?
 fi
+
+#### Now update the routes
+
+# Get the existing routes point toward the bridge
+VF_BRIDGE_ROUTES=$(ip route | grep -oP '\K[\d.\/]+\svia\s[\d.\/]+(?=\sdev\s{{ .VfInterceptBridgeName }})')
+
+# Get the incoming routes
+INCOMING_ROUTES=({{ range .SecondaryVtepAggregatePrefixes }} "{{ . }} via {{ $bridgingConfig.SecondaryOverlayVtepIP }}" {{ end }})
+
+# Find only the routes that need to be removed.
+OLD_VF_BRIDGE_ROUTES=$(diff --old-line-format="%L" --unchanged-line-format="" --new-line-format="" \
+    <(printf "%s\n" "${VF_BRIDGE_ROUTES[@]}" | sort) \
+    <(printf "%s\n" "${INCOMING_ROUTES[@]}" | sort))
+
+# Add any new routes
+for r in "${INCOMING_ROUTES[@]}";do
+    if ! ip route | grep "${r}"; then
+        ip route replace ${r} || exit $?
+    fi
+done
+
+
+# Remove old the old routes
+for OLD_ROUTE in "${OLD_VF_BRIDGE_ROUTES[@]}";do
+    ip route del $OLD_ROUTE  &>/dev/null || true
+done;
 
 # Now remove all the old IPs
 # If something went wrong, we'll have exited and won't rip down the old IPs.
 # The next cycle will put things in order if there are no errors.
 for OLD_IP in "${OLD_VF_BRIDGE_IPS[@]}";do
-    ip addr del $OLD_IP dev {{ .VfInterceptBridgeName }} || true
+    ip addr del $OLD_IP dev {{ .VfInterceptBridgeName }} &>/dev/null || true
 done;

--- a/crates/api/src/cfg/README.md
+++ b/crates/api/src/cfg/README.md
@@ -78,7 +78,7 @@ applicable.
 | `power_manager_options` | `PowerManagerOptions` | *(see below)* | Power management timing (see [PowerManagerOptions](#powermanageroptions)). |
 | `sitename` | `Option<String>` | — | Human-readable site name exposed to tenants via FMDS. |
 | `auto_machine_repair_plugin` | `AutoMachineRepairPluginConfig` | *(default)* | Auto-repair configuration for failed machines. |
-| `vmaas_config` | `Option<VmaasConfig>` | — | VMaaS configuration for VM system integration. |
+| `vmaas_config` | `Option<VmaasConfig>` | — | VMaaS configuration for VM system integration (see [VmaasConfig](#vmaasconfig)). |
 | `mlxconfig_profiles` | `Option<HashMap<String, MlxConfigProfile>>` | — | Named Mellanox NIC register configuration profiles for superNIC firmware flashing. TOML key: `mlx-config-profiles`. |
 | `rack_management_enabled` | `bool` | `false` | Standalone infrastructure manager mode for GB200/GB300/VR144. See doc comment for full behavioral changes. |
 | `force_dpu_nic_mode` | `bool` | `false` | Treat DPUs as regular NICs (skip managed DPU config). For dev labs with BF DPUs. |
@@ -234,6 +234,18 @@ Extends `StateControllerConfig` with:
 | `next_try_duration_on_success` | `Duration` | `5m` | Retry interval after successful power operation. |
 | `next_try_duration_on_failure` | `Duration` | `2m` | Retry interval after failed power operation. |
 | `wait_duration_until_host_reboot` | `Duration` | `15m` | Wait after power-down before powering on host. |
+
+### `VmaasConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `allow_instance_vf` | `bool` | `true` | Allow VFs on instance creation. |
+| `hbn_reps` | `Option<String>` | — | HBN representors created by DPUs. |
+| `hbn_sfs` | `Option<String>` | — | HBN SF representors created by DPUs. |
+| `bridging` | `Option<TrafficInterceptBridging>` | — | Advanced traffic-intercept routing and bridging options. |
+| `public_prefixes` | `Vec<Ipv4Network>` | **required** | Publicly routable IPv4 CIDR prefixes used by traffic-intercept users. |
+| `secondary_vtep_aggregate_prefixes` | `Vec<IpNetwork>` | `[]` | IPv4 or IPv6 aggregate prefixes used only for routing and filtering. IP allocation is provided by the secondary VTEP resource pool. |
+| `secondary_overlay_support` | `bool` | `true` | Whether secondary overlay VTEP IPs are expected for DPUs. |
 
 ### `DpuConfig`
 

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -2714,6 +2714,12 @@ pub struct VmaasConfig {
     /// by traffic-intercept users.
     pub public_prefixes: Vec<Ipv4Network>,
 
+    /// Aggregate prefixes associated with secondary VTEPs. These are used only
+    /// for routing and filtering; IP allocation is provided by the secondary
+    /// VTEP resource pool.
+    #[serde(default)]
+    pub secondary_vtep_aggregate_prefixes: Vec<IpNetwork>,
+
     /// Whether a secondary overlay is expected,
     /// which will require secondary VTEP IPs to be allocated
     /// to DPUs

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -710,6 +710,11 @@ pub(crate) async fn get_managed_host_network_config_inner(
                     vf_intercept_bridge_sf: b.vf_intercept_bridge_sf.clone(),
                 }),
                 public_prefixes: c.public_prefixes.iter().map(|p| p.to_string()).collect(),
+                secondary_vtep_aggregate_prefixes: c
+                    .secondary_vtep_aggregate_prefixes
+                    .iter()
+                    .map(|p| p.to_string())
+                    .collect(),
                 additional_overlay_vtep_ip: dpu_snapshot
                     .network_config
                     .secondary_overlay_vtep_ip

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1276,6 +1276,7 @@ pub fn get_config() -> CarbideConfig {
             secondary_overlay_support: true,
             bridging: None,
             public_prefixes: vec![],
+            secondary_vtep_aggregate_prefixes: vec![],
         }),
         mlxconfig_profiles: None,
         rack_management_enabled: false,

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -5789,6 +5789,7 @@ async fn test_instance_with_vf_when_vf_disabled(_: PgPoolOptions, options: PgCon
         hbn_sfs: None,
         bridging: None,
         public_prefixes: vec![],
+        secondary_vtep_aggregate_prefixes: vec![],
         secondary_overlay_support: false,
     });
 
@@ -5829,6 +5830,7 @@ async fn test_instance_without_vf_when_vf_disabled(_: PgPoolOptions, options: Pg
         hbn_sfs: None,
         bridging: None,
         public_prefixes: vec![],
+        secondary_vtep_aggregate_prefixes: vec![],
         secondary_overlay_support: false,
     });
 

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4007,6 +4007,12 @@ message TrafficInterceptConfig {
   // Prefixes expected to be publicly routable and used
   // by VMaaS for internet gateways.
   repeated string public_prefixes            = 3;
+
+  // IPv4 or IPv6 aggregate prefixes associated with secondary
+  // VTEPs. These are used only for routing and filtering, not for
+  // allocating IPs. IP allocation is provided by the secondary VTEP
+  // resource pool.
+  repeated string secondary_vtep_aggregate_prefixes = 4;
 }
 
 


### PR DESCRIPTION
## Description

The existing support/hooks for secondary overlay expect to be driven by a process running in the mgmt vrf.  Before offload kicks in, the first packets will pass through the ARM OS and will need routes to take them into the HBN container as well as trigger the OVS flows to offload after that.

This PR introduces a config option to list the aggregates matching the secondary-vtep-ips resource pool.  I considered pulling the details from the resource pool definition, but it's not clean due to it being a set of arbitrary ranges.

Being explicit about the aggregates isn't a high level of effort and it could always be changed later.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

