### PR TITLE
fix(api,agent): Correct mapping of routing-profile to VPC on the DPU

### DIFF
--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -149,6 +149,44 @@ pub enum NvueUpdateFlavor<'a> {
     RestApi { nvue_client: &'a NvueClient },
 }
 
+/// Converts an RPC routing profile into the NVUE renderer model.
+impl From<&rpc::RoutingProfile> for nvue::RoutingProfile {
+    fn from(profile: &rpc::RoutingProfile) -> Self {
+        // Preserve the API-provided routing policy without applying template concerns here.
+        nvue::RoutingProfile {
+            leak_default_route_from_underlay: profile.leak_default_route_from_underlay,
+            leak_tenant_host_routes_to_underlay: profile.leak_tenant_host_routes_to_underlay,
+            tenant_leak_communities_accepted: profile.tenant_leak_communities_accepted,
+            route_target_imports: profile
+                .route_target_imports
+                .iter()
+                .map(|rt| nvue::RouteTargetConfig {
+                    asn: rt.asn,
+                    vni: rt.vni,
+                })
+                .collect(),
+            route_targets_on_exports: profile
+                .route_targets_on_exports
+                .iter()
+                .map(|rt| nvue::RouteTargetConfig {
+                    asn: rt.asn,
+                    vni: rt.vni,
+                })
+                .collect(),
+            accepted_leaks_from_underlay: profile
+                .accepted_leaks_from_underlay
+                .iter()
+                .map(|l| l.prefix.to_owned())
+                .collect(),
+            allowed_anycast_prefixes: profile
+                .allowed_anycast_prefixes
+                .iter()
+                .map(|p| p.prefix.to_owned())
+                .collect(),
+        }
+    }
+}
+
 /// Update the NVUE network config. Returns Ok(true) if the configuration changed, and
 /// Ok(false) if not.
 pub async fn update_nvue(
@@ -257,6 +295,10 @@ pub async fn update_nvue(
                 svi_ip: admin_interface.svi_ip.clone(),
                 tenant_vrf_loopback_ip: admin_interface.tenant_vrf_loopback_ip.clone(),
                 network_security_group_id: None, // NSGs are not applied on the admin network.
+                routing_profile: admin_interface
+                    .routing_profile
+                    .as_ref()
+                    .map(nvue::RoutingProfile::from),
                 is_l2_segment: if nc.network_virtualization_type()
                     == ::rpc::forge::VpcVirtualizationType::Fnn
                 {
@@ -307,6 +349,7 @@ pub async fn update_nvue(
                     .network_security_group
                     .as_ref()
                     .map(|n| n.id.clone()),
+                routing_profile: net.routing_profile.as_ref().map(nvue::RoutingProfile::from),
                 is_l2_segment: net.is_l2_segment,
             });
         }
@@ -318,6 +361,19 @@ pub async fn update_nvue(
     if tenancy_enabled && networks.is_empty() {
         return Err(eyre::eyre!(
             "BUG: network config provided without interfaces"
+        ));
+    }
+
+    // FNN requires a routing profile per rendered port, unless an older
+    // response-level compatibility profile is present.
+    if vpc_virtualization_type == VpcVirtualizationType::Fnn
+        && nc.routing_profile.is_none()
+        && !networks
+            .iter()
+            .all(|network| network.routing_profile.is_some())
+    {
+        return Err(eyre::eyre!(
+            "BUG: FNN config provided without routing-profile"
         ));
     }
 
@@ -437,46 +493,7 @@ pub async fn update_nvue(
         ct_l3_vni: nc.vpc_vni,
         ct_vrf_loopback: "FNN".to_string(),
         l3_domains: vec![],
-        ct_routing_profile: if nc.network_virtualization_type()
-            == ::rpc::forge::VpcVirtualizationType::Fnn
-            && nc.routing_profile.is_none()
-        {
-            return Err(eyre::eyre!(
-                "BUG: FNN config provided without routing-profile"
-            ));
-        } else {
-            nc.routing_profile.as_ref().map(|rp| nvue::RoutingProfile {
-                leak_default_route_from_underlay: rp.leak_default_route_from_underlay,
-                leak_tenant_host_routes_to_underlay: rp.leak_tenant_host_routes_to_underlay,
-                tenant_leak_communities_accepted: rp.tenant_leak_communities_accepted,
-                route_target_imports: rp
-                    .route_target_imports
-                    .iter()
-                    .map(|rt| nvue::RouteTargetConfig {
-                        asn: rt.asn,
-                        vni: rt.vni,
-                    })
-                    .collect(),
-                route_targets_on_exports: rp
-                    .route_targets_on_exports
-                    .iter()
-                    .map(|rt| nvue::RouteTargetConfig {
-                        asn: rt.asn,
-                        vni: rt.vni,
-                    })
-                    .collect(),
-                accepted_leaks_from_underlay: rp
-                    .accepted_leaks_from_underlay
-                    .iter()
-                    .map(|l| l.prefix.to_owned())
-                    .collect(),
-                allowed_anycast_prefixes: rp
-                    .allowed_anycast_prefixes
-                    .iter()
-                    .map(|p| p.prefix.to_owned())
-                    .collect(),
-            })
-        },
+        ct_routing_profile: nc.routing_profile.as_ref().map(nvue::RoutingProfile::from),
         bgp_leaf_session_password: nc.bgp_leaf_session_password.clone(),
     };
 
@@ -2323,6 +2340,7 @@ mod tests {
             internal_uuid: None,
             mtu: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         };
         assert_eq!(admin_interface.svi_ip, None);
 
@@ -2374,6 +2392,33 @@ mod tests {
                 internal_uuid: None,
                 mtu: None,
                 ipv6_interface_config: None,
+                routing_profile: Some(rpc::RoutingProfile {
+                    leak_default_route_from_underlay:
+                        include_network_host_route_and_default_leaking,
+                    leak_tenant_host_routes_to_underlay:
+                        include_network_host_route_and_default_leaking,
+                    tenant_leak_communities_accepted:
+                        include_network_host_route_and_default_leaking,
+                    accepted_leaks_from_underlay: if include_network_host_route_and_default_leaking
+                    {
+                        vec![rpc::PrefixFilterPolicyEntry {
+                            prefix: "10.255.0.0/24".to_string(),
+                        }]
+                    } else {
+                        vec![]
+                    },
+                    allowed_anycast_prefixes: vec![rpc::PrefixFilterPolicyEntry {
+                        prefix: "5.255.254.0/24".to_string(),
+                    }],
+                    route_target_imports: vec![rpc_common::RouteTarget {
+                        asn: 44444,
+                        vni: 55555,
+                    }],
+                    route_targets_on_exports: vec![rpc_common::RouteTarget {
+                        asn: 77415,
+                        vni: 800,
+                    }],
+                }),
             },
             rpc::FlatInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Physical.into(),
@@ -2548,6 +2593,33 @@ mod tests {
                 internal_uuid: None,
                 mtu: None,
                 ipv6_interface_config: None,
+                routing_profile: Some(rpc::RoutingProfile {
+                    leak_default_route_from_underlay:
+                        include_network_host_route_and_default_leaking,
+                    leak_tenant_host_routes_to_underlay:
+                        include_network_host_route_and_default_leaking,
+                    tenant_leak_communities_accepted:
+                        include_network_host_route_and_default_leaking,
+                    accepted_leaks_from_underlay: if include_network_host_route_and_default_leaking
+                    {
+                        vec![rpc::PrefixFilterPolicyEntry {
+                            prefix: "10.255.0.0/24".to_string(),
+                        }]
+                    } else {
+                        vec![]
+                    },
+                    allowed_anycast_prefixes: vec![rpc::PrefixFilterPolicyEntry {
+                        prefix: "5.255.254.0/24".to_string(),
+                    }],
+                    route_target_imports: vec![rpc_common::RouteTarget {
+                        asn: 44444,
+                        vni: 55555,
+                    }],
+                    route_targets_on_exports: vec![rpc_common::RouteTarget {
+                        asn: 77415,
+                        vni: 800,
+                    }],
+                }),
             },
         ];
 
@@ -2584,13 +2656,15 @@ mod tests {
                 asn: 11111,
                 vni: 22222,
             }],
+
+            // This should be ignored because we've defined the routing profile on the "flat interface" config.
             routing_profile: Some(rpc::RoutingProfile {
                 leak_default_route_from_underlay: include_network_host_route_and_default_leaking,
                 leak_tenant_host_routes_to_underlay: include_network_host_route_and_default_leaking,
                 tenant_leak_communities_accepted: include_network_host_route_and_default_leaking,
                 accepted_leaks_from_underlay: if include_network_host_route_and_default_leaking {
                     vec![rpc::PrefixFilterPolicyEntry {
-                        prefix: "10.255.0.0/24".to_string(),
+                        prefix: "111.255.0.0/24".to_string(),
                     }]
                 } else {
                     vec![]
@@ -2599,14 +2673,15 @@ mod tests {
                     prefix: "5.255.254.0/24".to_string(),
                 }],
                 route_target_imports: vec![rpc_common::RouteTarget {
-                    asn: 44444,
-                    vni: 55555,
+                    asn: 34444,
+                    vni: 85555,
                 }],
                 route_targets_on_exports: vec![rpc_common::RouteTarget {
-                    asn: 77415,
-                    vni: 800,
+                    asn: 67415,
+                    vni: 8000,
                 }],
             }),
+
             network_security_policy_overrides: vec![rpc::ResolvedNetworkSecurityGroupRule {
                 src_prefixes: vec!["7.7.7.0/24".to_string()],
                 dst_prefixes: vec!["7.7.7.0/24".to_string()],
@@ -2794,6 +2869,7 @@ mod tests {
             vpc_prefixes: vec!["10.217.4.168/29".to_string()],
             vpc_peer_prefixes: vec![],
             vpc_peer_vnis: vec![],
+            routing_profile: None,
             is_l2_segment: true,
             ipv6_port_config: None,
         }];
@@ -2977,6 +3053,7 @@ mod tests {
             internal_uuid: None,
             mtu: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         };
 
         let mut admin_interface_with_mtu = admin_interface.clone();
@@ -3013,6 +3090,7 @@ mod tests {
                 internal_uuid: None,
                 mtu: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::FlatInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Physical.into(),
@@ -3038,6 +3116,7 @@ mod tests {
                 internal_uuid: None,
                 mtu: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
         ];
 

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -119,43 +119,10 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
         })
         .collect();
 
-    // This assumes that the routing profile is expected to be same for
-    // all VPCs of a tenant _and_ for all VPCs that an instance might span.
-    // That should be ok for now, and a smaller MR later that moves
-    // profiles into FlatInterfaceConfig could change that.
-    // For now, we clone later so that we can put this into each TmplVpc
-    // and make a later transition easier.
-    let routing_profile = conf.ct_routing_profile.as_ref().map(|rt| {
-        let (v4leaks, v6leaks) = split_prefixes_by_family(&rt.accepted_leaks_from_underlay, 1);
-        let (v4allowed_anycast, v6allowed_anycast) =
-            split_prefixes_by_family(&rt.allowed_anycast_prefixes, 1);
-
-        TmplRoutingProfile {
-            TenantLeakCommunitiesAccepted: rt.tenant_leak_communities_accepted,
-            LeakDefaultRouteFromUnderlay: rt.leak_default_route_from_underlay,
-            LeakTenantHostRoutesToUnderlay: rt.leak_tenant_host_routes_to_underlay,
-            AcceptedLeaksFromUnderlayIpv4: v4leaks,
-            AcceptedLeaksFromUnderlayIpv6: v6leaks,
-            AllowedAnycastPrefixesIpv4: v4allowed_anycast,
-            AllowedAnycastPrefixesIpv6: v6allowed_anycast,
-            RouteTargetImports: rt
-                .route_target_imports
-                .iter()
-                .map(|rt| TmplRouteTargetConfig {
-                    ASN: rt.asn,
-                    VNI: rt.vni,
-                })
-                .collect(),
-            RouteTargetsOnExports: rt
-                .route_targets_on_exports
-                .iter()
-                .map(|rt| TmplRouteTargetConfig {
-                    ASN: rt.asn,
-                    VNI: rt.vni,
-                })
-                .collect(),
-        }
-    });
+    let deprecated_routing_profile = conf.ct_routing_profile.clone();
+    let deprecated_tenant_routing_profile = deprecated_routing_profile
+        .as_ref()
+        .map(TmplRoutingProfile::from);
 
     // There are two assumptions about pre-FNN...
     // 1 - ManagedHostNetworkConfigResponse only has rules inherited either from VPC or Instance,
@@ -244,11 +211,16 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
         );
     }
 
-    let mut has_any_vpc_tenant_host_leak_to_underlay = false;
     let mut has_any_vpc_vrf_loopback = false;
     let mut fmds_gateway_matched = false;
 
     for (base_i, network) in conf.ct_port_configs.into_iter().enumerate() {
+        let l3_vni = network.l3_vni.unwrap_or_default();
+        let routing_profile = network
+            .routing_profile
+            .as_ref()
+            .or(deprecated_routing_profile.as_ref())
+            .map(TmplRoutingProfile::from);
         let svi_mac = vni_to_svi_mac(network.vni.unwrap_or(0))?.to_string();
         let (vpc_ipv4, vpc_ipv6) =
             split_prefixes_by_family(&network.vpc_prefixes, (base_i + 1) * 10);
@@ -278,7 +250,7 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
                 .flatten()
                 .collect(),
             SviMAC: svi_mac,
-            VrfName: format!("vpc_{}", network.l3_vni.unwrap_or_default()),
+            VrfName: format!("vpc_{l3_vni}"),
             HasVpcPeerPrefixes: !network.vpc_peer_prefixes.is_empty(),
             HasVpcPeerPrefixesIpv6: network
                 .vpc_peer_prefixes
@@ -311,11 +283,6 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
             fmds_gateway_matched = true;
         }
 
-        has_any_vpc_tenant_host_leak_to_underlay = has_any_vpc_tenant_host_leak_to_underlay
-            || routing_profile
-                .as_ref()
-                .map(|p| p.LeakTenantHostRoutesToUnderlay)
-                .unwrap_or_default();
         let (vpc_peer_ipv4, vpc_peer_ipv6) =
             split_prefixes_by_family(&network.vpc_peer_prefixes, 1);
 
@@ -323,15 +290,27 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
             has_any_vpc_vrf_loopback || network.tenant_vrf_loopback_ip.is_some();
 
         vpc_configs
-            .entry(network.l3_vni.unwrap_or_default())
+            .entry(l3_vni)
             .and_modify(|v| {
+                if let (Some(existing_profile), Some(next_profile)) =
+                    (v.RoutingProfile.as_ref(), routing_profile.as_ref())
+                    && existing_profile != next_profile
+                {
+                    tracing::warn!(
+                        l3_vni,
+                        "found different routing profiles for the same VPC L3 VNI; using the first profile"
+                    );
+                }
+                if v.RoutingProfile.is_none() {
+                    v.RoutingProfile = routing_profile.clone();
+                }
                 v.PortPrefixes.extend_from_slice(&port.VpcPrefixes);
                 v.PortPrefixesIpv6.extend_from_slice(&port.VpcPrefixesIpv6);
                 v.PortConfigs.push(port.clone());
             })
             .or_insert_with(|| TmplVpc {
                 VrfName: port.VrfName.clone(),
-                L3VNI: network.l3_vni.unwrap_or_default(),
+                L3VNI: l3_vni,
                 HasVrfLoopback: network.tenant_vrf_loopback_ip.is_some(),
                 VrfLoopback: network.tenant_vrf_loopback_ip.unwrap_or_default(),
                 // TODO: This is wasteful because it should be specific to a VPC.
@@ -350,31 +329,9 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
                     .iter()
                     .map(|vni| TmplVni { Vni: *vni })
                     .collect(),
-                HasAllowedAnycastPrefixesIpv4: routing_profile
-                    .as_ref()
-                    .map(|p| !p.AllowedAnycastPrefixesIpv4.is_empty())
-                    .unwrap_or_default(),
-                HasAllowedAnycastPrefixesIpv6: routing_profile
-                    .as_ref()
-                    .map(|p| !p.AllowedAnycastPrefixesIpv6.is_empty())
-                    .unwrap_or_default(),
                 RoutingProfile: routing_profile.clone(),
                 PortPrefixes: port.VpcPrefixes.clone(),
                 PortPrefixesIpv6: port.VpcPrefixesIpv6.clone(),
-                HasLeaksFromUnderlayIpv4: routing_profile
-                    .as_ref()
-                    .map(|p| {
-                        p.LeakDefaultRouteFromUnderlay
-                            || !p.AcceptedLeaksFromUnderlayIpv4.is_empty()
-                    })
-                    .unwrap_or_default(),
-                HasLeaksFromUnderlayIpv6: routing_profile
-                    .as_ref()
-                    .map(|p| {
-                        p.LeakDefaultRouteFromUnderlay
-                            || !p.AcceptedLeaksFromUnderlayIpv6.is_empty()
-                    })
-                    .unwrap_or_default(),
             });
 
         port_configs.push(port);
@@ -467,6 +424,11 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
 
     let mut vpcs = vpc_configs.into_values().collect::<Vec<TmplVpc>>();
     vpcs.sort_by_key(|a| a.L3VNI);
+    let has_any_vpc_tenant_host_leak_to_underlay = vpcs.iter().any(|vpc| {
+        vpc.RoutingProfile
+            .as_ref()
+            .is_some_and(|profile| profile.LeakTenantHostRoutesToUnderlay)
+    });
 
     let (traffic_intercept_ipv4, traffic_intercept_ipv6) =
         split_prefixes_by_family(&conf.traffic_intercept_public_prefixes, 1);
@@ -540,7 +502,7 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
         Ipv6EgressNetworkSecurityPolicyOverrideRules: egress_ipv6_override_rules,
         HbnVersion: conf.hbn_version,
         Tenant: TmplComputeTenant {
-            RoutingProfile: routing_profile,
+            RoutingProfile: deprecated_tenant_routing_profile,
             Vpcs: vpcs,
             VrfName: conf.ct_vrf_name,
             L3VNI: conf.ct_l3_vni.unwrap_or_default().to_string(),
@@ -946,10 +908,54 @@ fn vni_to_svi_mac(vni: u32) -> eyre::Result<MacAddress> {
     sanitized_mac(&format!("{vni:012}"))
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug, PartialEq)]
 pub struct RouteTargetConfig {
     pub asn: u32,
     pub vni: u32,
+}
+
+/// Converts an agent routing profile into the template-ready routing profile.
+impl From<&RoutingProfile> for TmplRoutingProfile {
+    fn from(profile: &RoutingProfile) -> Self {
+        // Split mixed-family prefix lists before passing them to the template.
+        let (v4leaks, v6leaks) = split_prefixes_by_family(&profile.accepted_leaks_from_underlay, 1);
+        let (v4allowed_anycast, v6allowed_anycast) =
+            split_prefixes_by_family(&profile.allowed_anycast_prefixes, 1);
+        let has_leaks_from_underlay_ipv4 =
+            profile.leak_default_route_from_underlay || !v4leaks.is_empty();
+        let has_leaks_from_underlay_ipv6 =
+            profile.leak_default_route_from_underlay || !v6leaks.is_empty();
+
+        TmplRoutingProfile {
+            TenantLeakCommunitiesAccepted: profile.tenant_leak_communities_accepted,
+            LeakDefaultRouteFromUnderlay: profile.leak_default_route_from_underlay,
+            LeakTenantHostRoutesToUnderlay: profile.leak_tenant_host_routes_to_underlay,
+            HasLeaksFromUnderlayIpv4: has_leaks_from_underlay_ipv4,
+            HasLeaksFromUnderlayIpv6: has_leaks_from_underlay_ipv6,
+            AcceptedLeaksFromUnderlayIpv4: v4leaks,
+            AcceptedLeaksFromUnderlayIpv6: v6leaks,
+            HasAllowedAnycastPrefixesIpv4: !v4allowed_anycast.is_empty(),
+            HasAllowedAnycastPrefixesIpv6: !v6allowed_anycast.is_empty(),
+            AllowedAnycastPrefixesIpv4: v4allowed_anycast,
+            AllowedAnycastPrefixesIpv6: v6allowed_anycast,
+            RouteTargetImports: profile
+                .route_target_imports
+                .iter()
+                .map(|rt| TmplRouteTargetConfig {
+                    ASN: rt.asn,
+                    VNI: rt.vni,
+                })
+                .collect(),
+            RouteTargetsOnExports: profile
+                .route_targets_on_exports
+                .iter()
+                .map(|rt| TmplRouteTargetConfig {
+                    ASN: rt.asn,
+                    VNI: rt.vni,
+                })
+                .collect(),
+        }
+    }
 }
 
 // What we need to configure NVUE
@@ -1012,7 +1018,7 @@ pub struct NvueConfig {
     pub ct_routing_profile: Option<RoutingProfile>,
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug, PartialEq)]
 pub struct RoutingProfile {
     pub leak_default_route_from_underlay: bool,
     pub leak_tenant_host_routes_to_underlay: bool,
@@ -1147,6 +1153,8 @@ pub struct PortConfig {
     pub is_l2_segment: bool,
     pub is_phy: bool,
     pub network_security_group_id: Option<String>,
+    #[serde(default)]
+    pub routing_profile: Option<RoutingProfile>,
 }
 
 //
@@ -1270,7 +1278,7 @@ struct TmplNvue {
 }
 
 #[allow(non_snake_case)]
-#[derive(Clone, Gtmpl, Debug)]
+#[derive(Clone, Gtmpl, Debug, PartialEq)]
 struct TmplRouteTargetConfig {
     ASN: u32,
     VNI: u32,
@@ -1302,15 +1310,21 @@ struct TmplNetworkSecurityGroupRule {
 }
 
 #[allow(non_snake_case)]
-#[derive(Clone, Gtmpl, Debug)]
+#[derive(Clone, Gtmpl, Debug, PartialEq)]
 struct TmplRoutingProfile {
     LeakTenantHostRoutesToUnderlay: bool,
     LeakDefaultRouteFromUnderlay: bool,
     RouteTargetImports: Vec<TmplRouteTargetConfig>,
     RouteTargetsOnExports: Vec<TmplRouteTargetConfig>,
     TenantLeakCommunitiesAccepted: bool,
+    /// Whether there are _any_ leaks from the default
+    /// VRF into the tenant VRF being used.
+    HasLeaksFromUnderlayIpv4: bool,
+    HasLeaksFromUnderlayIpv6: bool,
     AcceptedLeaksFromUnderlayIpv4: Vec<Prefix>,
     AcceptedLeaksFromUnderlayIpv6: Vec<Prefix>,
+    HasAllowedAnycastPrefixesIpv4: bool,
+    HasAllowedAnycastPrefixesIpv6: bool,
     AllowedAnycastPrefixesIpv4: Vec<Prefix>,
     AllowedAnycastPrefixesIpv6: Vec<Prefix>,
 }
@@ -1408,11 +1422,6 @@ struct TmplVpc {
     HasVpcPeerPrefixesIpv6: bool,
     VpcPeerPrefixesIpv6: Vec<Prefix>,
 
-    /// Whether there are _any_ leaks from the default
-    /// VRF into the tenant VRF being used.
-    HasLeaksFromUnderlayIpv4: bool,
-    HasLeaksFromUnderlayIpv6: bool,
-
     // The relationship between interface:VPC is 1:1 but VPC:interface is 1:M.
     // So, a single VPC could have multiple, per-port, VpcPrefixes.  We can
     // accumulate these and pass them into the template for ease-of-use.
@@ -1422,9 +1431,6 @@ struct TmplVpc {
 
     HasVpcPeerVnis: bool,
     VpcPeerVnis: Vec<TmplVni>,
-
-    HasAllowedAnycastPrefixesIpv4: bool,
-    HasAllowedAnycastPrefixesIpv6: bool,
 
     RoutingProfile: Option<TmplRoutingProfile>,
 }
@@ -1505,7 +1511,7 @@ struct TmplConfigPort {
 }
 
 #[allow(non_snake_case)]
-#[derive(Clone, Gtmpl, Debug)]
+#[derive(Clone, Gtmpl, Debug, PartialEq)]
 struct Prefix {
     Index: String,
     Prefix: String,
@@ -1707,6 +1713,7 @@ mod tests {
             is_l2_segment: true,
             is_phy: false,
             network_security_group_id: None,
+            routing_profile: None,
             ipv6_port_config: None,
         }];
         conf.ct_access_vlans = vec![VlanConfig {
@@ -1752,6 +1759,7 @@ mod tests {
             is_l2_segment: false,
             is_phy: false,
             network_security_group_id: None,
+            routing_profile: None,
             ipv6_port_config: None,
         }];
         conf.ct_access_vlans = vec![VlanConfig {
@@ -1786,6 +1794,7 @@ mod tests {
             is_l2_segment: true,
             is_phy: false,
             network_security_group_id: None,
+            routing_profile: None,
             ipv6_port_config: None,
         }];
         conf.ct_access_vlans = vec![VlanConfig {
@@ -1834,6 +1843,7 @@ mod tests {
             is_l2_segment: false,
             is_phy: false,
             network_security_group_id: None,
+            routing_profile: None,
             ipv6_port_config: None,
         }];
         conf.ct_access_vlans = vec![VlanConfig {
@@ -1873,6 +1883,7 @@ mod tests {
             is_l2_segment: true,
             is_phy: false,
             network_security_group_id: None,
+            routing_profile: None,
             ipv6_port_config: None,
         }];
         conf.ct_access_vlans = vec![VlanConfig {
@@ -1920,6 +1931,7 @@ mod tests {
                 is_l2_segment: false,
                 is_phy: false,
                 network_security_group_id: None,
+                routing_profile: None,
                 ipv6_port_config: None,
             },
             PortConfig {
@@ -1936,6 +1948,7 @@ mod tests {
                 is_l2_segment: false,
                 is_phy: false,
                 network_security_group_id: None,
+                routing_profile: None,
                 ipv6_port_config: None,
             },
         ];
@@ -1995,6 +2008,7 @@ mod tests {
             is_l2_segment: false,
             is_phy: false,
             network_security_group_id: None,
+            routing_profile: None,
         }];
         conf.ct_access_vlans = vec![VlanConfig {
             vlan_id: 100,
@@ -2064,6 +2078,7 @@ mod tests {
             is_l2_segment: true,
             is_phy: true,
             network_security_group_id: None,
+            routing_profile: None,
             ipv6_port_config: None,
         }
     }

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -461,6 +461,7 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
         internal_uuid: None,
         mtu: None,
         ipv6_interface_config: None,
+        routing_profile: None,
     };
     assert_eq!(admin_interface.svi_ip, None);
 
@@ -630,6 +631,7 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
         internal_uuid: None,
         mtu: None,
         ipv6_interface_config: None,
+        routing_profile: None,
     };
 
     let network_security_policy_overrides = vec![

--- a/crates/agent/templates/nvue_startup_fnn.conf
+++ b/crates/agent/templates/nvue_startup_fnn.conf
@@ -232,7 +232,7 @@
           {{- range $vpc := $tenant.Vpcs }}
           DPU_FROM_INSTANCE_PREFIX_LIST_{{ $vpc.VrfName }}:
             rule:
-            {{- if eq (len $vpc.RoutingProfile.AllowedAnycastPrefixesIpv4) 0 }}{{/* This can be removed after a version or two to allow a grace/deprecation period. */}}
+            {{- if not $vpc.RoutingProfile.HasAllowedAnycastPrefixesIpv4 }}{{/* This can be removed after a version or two to allow a grace/deprecation period. */}}
               {{- range $nvueConfig.AnycastSitePrefixes }}
               '{{ .Index }}':
                 action: permit
@@ -312,7 +312,7 @@
                 match:
                   any: {}
           {{- range $vpc := $tenant.Vpcs }}
-              {{- if $vpc.HasLeaksFromUnderlayIpv4 }}
+              {{- if $vpc.RoutingProfile.HasLeaksFromUnderlayIpv4 }}
           FROM_DEFAULT_VRF_TO_{{ $vpc.VrfName }}_PREFIX_LIST:
             rule:
                 {{- range $leak := $vpc.RoutingProfile.AcceptedLeaksFromUnderlayIpv4 }}
@@ -331,7 +331,7 @@
               {{- end }}
           {{- end }}
           {{- range $vpc := $tenant.Vpcs }}
-              {{- if $vpc.HasLeaksFromUnderlayIpv6 }}
+              {{- if $vpc.RoutingProfile.HasLeaksFromUnderlayIpv6 }}
           FROM_DEFAULT_VRF_TO_{{ $vpc.VrfName }}_PREFIX_LIST_IPV6:
             type: ipv6
             rule:
@@ -578,7 +578,7 @@
                 action:
                   deny: {}
           {{- range $vpc := $tenant.Vpcs }}
-            {{- if $vpc.HasLeaksFromUnderlayIpv4 }}
+            {{- if $vpc.RoutingProfile.HasLeaksFromUnderlayIpv4 }}
           FROM_DEFAULT_VRF_TO_{{ $vpc.VrfName }}_MAP:
             rule:
               '10':
@@ -590,7 +590,7 @@
             {{- end }}
           {{- end }}
           {{- range $vpc := $tenant.Vpcs }}
-            {{- if $vpc.HasLeaksFromUnderlayIpv6 }}
+            {{- if $vpc.RoutingProfile.HasLeaksFromUnderlayIpv6 }}
           FROM_DEFAULT_VRF_TO_{{ $vpc.VrfName }}_MAP_V6:
             rule:
               '10':
@@ -809,7 +809,7 @@
                 route-export:
                   to-evpn:
                     enable: on
-                {{- if $vpc.HasLeaksFromUnderlayIpv4 }}
+                {{- if $vpc.RoutingProfile.HasLeaksFromUnderlayIpv4 }}
                 route-import:
                   from-vrf:
                     route-map: FROM_DEFAULT_VRF_TO_{{ $vpc.VrfName }}_MAP
@@ -825,7 +825,7 @@
                 route-export:
                   to-evpn:
                     enable: on
-                {{- if $vpc.HasLeaksFromUnderlayIpv6 }}
+                {{- if $vpc.RoutingProfile.HasLeaksFromUnderlayIpv6 }}
                 route-import:
                   from-vrf:
                     route-map: FROM_DEFAULT_VRF_TO_{{ $vpc.VrfName }}_MAP_V6

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -1035,6 +1035,46 @@ pub struct FnnRoutingProfileConfig {
     pub access_tier: u32,
 }
 
+impl From<&FnnRoutingProfileConfig> for rpc::forge::RoutingProfile {
+    fn from(profile: &FnnRoutingProfileConfig) -> Self {
+        Self {
+            tenant_leak_communities_accepted: profile.tenant_leak_communities_accepted,
+            leak_default_route_from_underlay: profile.leak_default_route_from_underlay,
+            leak_tenant_host_routes_to_underlay: profile.leak_tenant_host_routes_to_underlay,
+            accepted_leaks_from_underlay: profile
+                .accepted_leaks_from_underlay
+                .iter()
+                .map(|entry| rpc::forge::PrefixFilterPolicyEntry {
+                    prefix: entry.prefix.to_string(),
+                })
+                .collect(),
+            allowed_anycast_prefixes: profile
+                .allowed_anycast_prefixes
+                .iter()
+                .map(|entry| rpc::forge::PrefixFilterPolicyEntry {
+                    prefix: entry.prefix.to_string(),
+                })
+                .collect(),
+            route_target_imports: profile
+                .route_target_imports
+                .iter()
+                .map(|route_target| rpc::common::RouteTarget {
+                    asn: route_target.asn,
+                    vni: route_target.vni,
+                })
+                .collect(),
+            route_targets_on_exports: profile
+                .route_targets_on_exports
+                .iter()
+                .map(|route_target| rpc::common::RouteTarget {
+                    asn: route_target.asn,
+                    vni: route_target.vni,
+                })
+                .collect(),
+        }
+    }
+}
+
 /// Entries used for prefix-list policies on the DPUS.
 /// Default behavior is max-len lte 32
 /// We can change that with additional fields on this struct

--- a/crates/api/src/ethernet_virtualization.rs
+++ b/crates/api/src/ethernet_virtualization.rs
@@ -36,7 +36,7 @@ use model::resource_pool::common::CommonPools;
 use sqlx::PgConnection;
 
 use crate::CarbideError;
-use crate::cfg::file::VpcPeeringPolicy;
+use crate::cfg::file::{FnnConfig, FnnRoutingProfileConfig, VpcPeeringPolicy};
 
 #[derive(Default, Clone)]
 pub struct EthVirtData {
@@ -44,6 +44,14 @@ pub struct EthVirtData {
     pub dhcp_servers: Vec<String>,
     pub deny_prefixes: Vec<Ipv4Network>,
     pub site_fabric_prefixes: Option<SiteFabricPrefixList>,
+}
+
+pub struct AdminNetworkOptions<'a> {
+    pub fnn_enabled: bool,
+    pub common_pools: &'a CommonPools,
+    pub booturl: &'a Option<String>,
+    pub use_vpc_vrf_loopback: bool,
+    pub routing_profile: Option<&'a FnnRoutingProfileConfig>,
 }
 
 #[derive(Clone)]
@@ -202,11 +210,16 @@ pub async fn admin_network(
     txn: &mut PgConnection,
     snapshot: &ManagedHostStateSnapshot,
     dpu_machine_id: &MachineId,
-    fnn_enabled_on_admin: bool,
-    common_pools: &CommonPools,
-    booturl: &Option<String>,
-    use_vpc_vrf_loopback: bool,
+    options: AdminNetworkOptions<'_>,
 ) -> Result<(rpc::FlatInterfaceConfig, MachineInterfaceId), tonic::Status> {
+    let AdminNetworkOptions {
+        fnn_enabled: fnn_enabled_on_admin,
+        common_pools,
+        booturl,
+        use_vpc_vrf_loopback,
+        routing_profile: admin_vpc_routing_profile,
+    } = options;
+
     let admin_segments = db::network_segment::admin(txn).await?;
     let admin_segment_ids = admin_segments
         .iter()
@@ -401,6 +414,7 @@ pub async fn admin_network(
         internal_uuid: None,
         mtu: u32::try_from(admin_segment.config.mtu).ok(),
         ipv6_interface_config: None,
+        routing_profile: admin_vpc_routing_profile.map(rpc::RoutingProfile::from),
     };
     Ok((cfg, interface.id))
 }
@@ -418,6 +432,7 @@ pub async fn tenant_network(
     segment: &NetworkSegment,
     vpc_peering_policy_on_existing: Option<VpcPeeringPolicy>,
     booturl: &Option<String>,
+    fnn_config: Option<&FnnConfig>,
 ) -> Result<rpc::FlatInterfaceConfig, tonic::Status> {
     // Any stretchable segment is treated as L2 segment by FNN.
     let is_l2_segment = segment.status.can_stretch.unwrap_or(true);
@@ -530,6 +545,27 @@ pub async fn tenant_network(
         .and_then(|v| v.status.as_ref().and_then(|vs| vs.vni))
         .unwrap_or_default() as u32;
 
+    // Resolve the routing profile from the VPC attached to this interface.
+    let routing_profile = match (vpc.as_ref(), fnn_config) {
+        (Some(vpc), Some(fnn)) if vpc.network_virtualization_type == VpcVirtualizationType::Fnn => {
+            let profile_type =
+                vpc.routing_profile_type
+                    .as_ref()
+                    .ok_or_else(|| CarbideError::Internal {
+                        message: "tenant routing profile type not found in VPC record".to_string(),
+                    })?;
+            let profile = fnn.routing_profiles.get(profile_type).ok_or_else(|| {
+                CarbideError::NotFoundError {
+                    kind: "routing_profile_type",
+                    id: profile_type.to_string(),
+                }
+            })?;
+
+            Some(rpc::RoutingProfile::from(profile))
+        }
+        _ => None,
+    };
+
     let rpc_ft: rpc::InterfaceFunctionType = iface.function_id.function_type().into();
     let (svi_ip, svi_ip_v6) = ds.svi_ips(network_virtualization_type, is_l2_segment)?;
 
@@ -640,6 +676,7 @@ pub async fn tenant_network(
                 .unwrap_or_default(),
             svi_ip: svi_ip_v6,
         }),
+        routing_profile,
     })
 }
 

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -198,14 +198,24 @@ pub(crate) async fn get_managed_host_network_config_inner(
         api.runtime_config.arm_pxe_boot_url_override.clone()
     };
 
+    let admin_vpc_routing_profile = api
+        .runtime_config
+        .fnn
+        .as_ref()
+        .and_then(|f| f.admin_vpc.as_ref())
+        .map(|v| &v.routing_profile);
+
     let (admin_interface_rpc, host_interface_id) = ethernet_virtualization::admin_network(
         &mut txn,
         &snapshot,
         &dpu_snapshot.id,
-        use_fnn_over_admin_nw,
-        &api.common_pools,
-        &booturl_override,
-        use_vpc_vrf_loopback,
+        ethernet_virtualization::AdminNetworkOptions {
+            fnn_enabled: use_fnn_over_admin_nw,
+            common_pools: &api.common_pools,
+            booturl: &booturl_override,
+            use_vpc_vrf_loopback,
+            routing_profile: admin_vpc_routing_profile,
+        },
     )
     .await?;
 
@@ -216,21 +226,12 @@ pub(crate) async fn get_managed_host_network_config_inner(
         None
     };
 
-    let admin_vpc_routing_profile = api
-        .runtime_config
-        .fnn
-        .as_ref()
-        .and_then(|f| f.admin_vpc.as_ref())
-        .map(|v| &v.routing_profile);
-
-    let (routing_profile, tenant_interfaces) = match &snapshot.instance {
-        None => (admin_vpc_routing_profile, vec![]),
+    let tenant_interfaces = match &snapshot.instance {
+        None => vec![],
         // We don't support secondary DPU yet.
         // If admin network is to be used for this managedhost, why to send old tenant data, which
         // is just to be deleted.
-        Some(_instance) if use_admin_network => {
-            (admin_vpc_routing_profile, vec![])
-        }
+        Some(_instance) if use_admin_network => vec![],
         Some(_instance)
             // If instance is waiting for network segment to come up in READY state, stay on admin
             // network.
@@ -243,7 +244,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
         {
             // Should/Can we still query and return the NSG of the VPC so that
             // policies can be configured on the DPU while interfaces are still coming up?
-            (admin_vpc_routing_profile, vec![])
+            vec![]
         }
         Some(instance) => {
             let interfaces = &instance.config.network.interfaces;
@@ -254,35 +255,6 @@ pub(crate) async fn get_managed_host_network_config_inner(
             };
             let vpc = db::vpc::find_by_segment(&mut txn, network_segment_id)
                 .await?;
-
-            // We probably shouldn't allow multiple interfaces that are in different VPCs with
-            // different routing-profiles.  Even in the case of something like a GW instance,
-            // We should probably require that all tenants/vpcs being serviced have a routing profile
-            // that matches the GW instance.
-            // However, if we decide to allow total mixing-and-matching, then this would need to move into
-            // tenant_network() and the profile details would have to move into the flattened interface details.
-            let routing_profile =  if vpc.network_virtualization_type == VpcVirtualizationType::Fnn {
-                api
-                    .runtime_config
-                    .fnn
-                    .as_ref()
-                    .map(|f| {
-                        let Some(profile_type) = vpc.routing_profile_type else {
-                            return Err(CarbideError::Internal{ message: "tenant routing profile type not found in tenant record".to_string()});
-                        };
-
-                        let Some(profile) = f.routing_profiles.get(&profile_type) else {
-                            return Err(CarbideError::NotFoundError {
-                                kind: "routing profile type found in tenant record is not defined",
-                                id: profile_type,
-                            });
-                        };
-                    Ok(profile)
-                })
-                .transpose()?
-            } else {
-                None
-            };
 
             network_virtualization_type = vpc.network_virtualization_type;
 
@@ -426,32 +398,42 @@ pub(crate) async fn get_managed_host_network_config_inner(
                     format!("{dashed_ip}.{domain}")
                 };
 
-                let tenant_interface =
-                    ethernet_virtualization::tenant_network(
-                        &mut txn,
-                        instance.id,
-                        iface,
-                        fqdn,
-                        // DPU agent reads loopback ip only from 0th interface.
-                        // function build in nvue.rs
-                        tenant_loopback_ip.clone(),
-                        network_virtualization_type,
-                        suppress_tenant_security_groups,
-                        network_security_group_details.clone(),
-                        segment,
-                        match api.runtime_config.vpc_peering_policy_on_existing {
-                            None => api.runtime_config.vpc_peering_policy,
-                            Some(vpc_peering_policy) => Some(vpc_peering_policy)
-                        },
-                        &booturl_override,
+                let tenant_interface = ethernet_virtualization::tenant_network(
+                    &mut txn,
+                    instance.id,
+                    iface,
+                    fqdn,
+                    // DPU agent reads loopback ip only from 0th interface.
+                    // function build in nvue.rs
+                    tenant_loopback_ip.clone(),
+                    network_virtualization_type,
+                    suppress_tenant_security_groups,
+                    network_security_group_details.clone(),
+                    segment,
+                    match api.runtime_config.vpc_peering_policy_on_existing {
+                        None => api.runtime_config.vpc_peering_policy,
+                        Some(vpc_peering_policy) => Some(vpc_peering_policy),
+                    },
+                    &booturl_override,
+                    api.runtime_config.fnn.as_ref(),
                 )
                 .await?;
 
                 tenant_interfaces.push(tenant_interface);
             }
 
-            (routing_profile, tenant_interfaces)
+            tenant_interfaces
         }
+    };
+
+    // Deprecated compatibility field for DPU agents that do not yet read
+    // FlatInterfaceConfig.routing_profile.
+    let deprecated_routing_profile = if tenant_interfaces.is_empty() {
+        admin_vpc_routing_profile.map(rpc::RoutingProfile::from)
+    } else {
+        tenant_interfaces
+            .first()
+            .and_then(|interface| interface.routing_profile.clone())
     };
 
     let network_config = build_consolidated_network_config(
@@ -671,41 +653,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
                     vni: rt.vni,
                 })
         }),
-        routing_profile: routing_profile.map(|p| rpc::RoutingProfile {
-            tenant_leak_communities_accepted: p.tenant_leak_communities_accepted,
-            leak_default_route_from_underlay: p.leak_default_route_from_underlay,
-            leak_tenant_host_routes_to_underlay: p.leak_tenant_host_routes_to_underlay,
-            accepted_leaks_from_underlay: p
-                .accepted_leaks_from_underlay
-                .iter()
-                .map(|l| rpc::PrefixFilterPolicyEntry {
-                    prefix: l.prefix.to_string(),
-                })
-                .collect(),
-            allowed_anycast_prefixes: p
-                .allowed_anycast_prefixes
-                .iter()
-                .map(|l| rpc::PrefixFilterPolicyEntry {
-                    prefix: l.prefix.to_string(),
-                })
-                .collect(),
-            route_target_imports: p
-                .route_target_imports
-                .iter()
-                .map(|rt| rpc_common::RouteTarget {
-                    asn: rt.asn,
-                    vni: rt.vni,
-                })
-                .collect(),
-            route_targets_on_exports: p
-                .route_targets_on_exports
-                .iter()
-                .map(|rt| rpc_common::RouteTarget {
-                    asn: rt.asn,
-                    vni: rt.vni,
-                })
-                .collect(),
-        }),
+        routing_profile: deprecated_routing_profile,
         traffic_intercept_config: api.runtime_config.vmaas_config.as_ref().map(|c| {
             rpc::TrafficInterceptConfig {
                 bridging: c.bridging.as_ref().map(|b| rpc::TrafficInterceptBridging {

--- a/crates/api/src/tests/machine_network.rs
+++ b/crates/api/src/tests/machine_network.rs
@@ -23,7 +23,9 @@ use ::rpc::forge::{
     InstanceDpuExtensionServiceConfig, InstanceDpuExtensionServicesConfig,
     ManagedHostNetworkConfigRequest, ManagedHostNetworkStatusRequest,
 };
-use common::api_fixtures::network_segment::create_network_segment;
+use common::api_fixtures::network_segment::{
+    FIXTURE_TENANT_NETWORK_SEGMENT_GATEWAYS, create_network_segment, create_tenant_network_segment,
+};
 use common::api_fixtures::{self, create_managed_host, dpu, network_configured_with_health};
 use forge_secrets::credentials::{BgpCredentialType, CredentialKey, Credentials};
 use mac_address::MacAddress;
@@ -36,7 +38,7 @@ use rpc::Metadata;
 use rpc::forge::forge_server::Forge;
 
 use crate::cfg::file::{
-    AdminFnnConfig, FnnConfig, FnnRoutingProfileConfig, PrefixFilterPolicyEntry,
+    AdminFnnConfig, FnnConfig, FnnRoutingProfileConfig, PrefixFilterPolicyEntry, RouteTargetConfig,
 };
 use crate::tests::common;
 use crate::tests::common::api_fixtures::TestEnvOverrides;
@@ -186,7 +188,7 @@ async fn test_managed_host_network_config_includes_routing_profile_prefix_lists(
         .build()
         .await;
 
-    // Fetch the DPU network config and extract its routing profile.
+    // Fetch the DPU network config and extract its per-interface routing profile.
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
@@ -195,7 +197,10 @@ async fn test_managed_host_network_config_includes_routing_profile_prefix_lists(
         .await
         .unwrap()
         .into_inner();
-    let routing_profile = response.routing_profile.unwrap();
+    let routing_profile = response.tenant_interfaces[0]
+        .routing_profile
+        .clone()
+        .unwrap();
 
     // Verify the configured leak prefixes are preserved in the gRPC response.
     let actual_leaks: Vec<_> = routing_profile
@@ -214,6 +219,192 @@ async fn test_managed_host_network_config_includes_routing_profile_prefix_lists(
     assert_eq!(
         actual_allowed_anycast_prefixes,
         expected_allowed_anycast_prefixes
+    );
+
+    // Verify the deprecated top-level field is still populated for rollout compatibility.
+    assert!(response.routing_profile.is_some());
+}
+
+#[crate::sqlx_test]
+async fn test_managed_host_network_config_includes_per_vpc_routing_profiles(pool: sqlx::PgPool) {
+    let internal_import = RouteTargetConfig {
+        asn: 65001,
+        vni: 111,
+    };
+    let external_export = RouteTargetConfig {
+        asn: 65002,
+        vni: 222,
+    };
+
+    // Configure two distinguishable FNN routing profiles.
+    let env = api_fixtures::create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::default().with_fnn_config(Some(FnnConfig {
+            admin_vpc: None,
+            common_internal_route_target: None,
+            additional_route_target_imports: vec![],
+            routing_profiles: HashMap::from([
+                (
+                    "INTERNAL".to_string(),
+                    FnnRoutingProfileConfig {
+                        internal: true,
+                        access_tier: 1,
+                        leak_default_route_from_underlay: true,
+                        route_target_imports: vec![internal_import.clone()],
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "EXTERNAL".to_string(),
+                    FnnRoutingProfileConfig {
+                        internal: false,
+                        access_tier: 2,
+                        leak_tenant_host_routes_to_underlay: true,
+                        route_targets_on_exports: vec![external_export.clone()],
+                        ..Default::default()
+                    },
+                ),
+            ]),
+            use_vpc_vrf_loopback: false,
+        })),
+    )
+    .await;
+
+    // Create a tenant that can use both routing profiles.
+    let tenant = env
+        .api
+        .create_tenant(tonic::Request::new(rpc::forge::CreateTenantRequest {
+            organization_id: "per-vpc-routing-profile".to_string(),
+            routing_profile_type: Some("INTERNAL".to_string()),
+            metadata: Some(rpc::forge::Metadata {
+                name: "per-vpc-routing-profile".to_string(),
+                description: "".to_string(),
+                labels: vec![],
+            }),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .tenant
+        .unwrap();
+
+    // Create two FNN VPCs with different routing profiles.
+    let internal_vpc = env
+        .api
+        .create_vpc(tonic::Request::new(
+            VpcCreationRequest::builder(tenant.organization_id.as_str())
+                .metadata(Metadata {
+                    name: "internal profile vpc".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .routing_profile_type("INTERNAL".to_string())
+                .rpc(),
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    let internal_segment_id = create_tenant_network_segment(
+        &env.api,
+        internal_vpc.id,
+        FIXTURE_TENANT_NETWORK_SEGMENT_GATEWAYS[0],
+        "TENANT_INTERNAL",
+        true,
+    )
+    .await;
+    env.run_network_segment_controller_iteration().await;
+    env.run_network_segment_controller_iteration().await;
+
+    let external_vpc = env
+        .api
+        .create_vpc(tonic::Request::new(
+            VpcCreationRequest::builder(tenant.organization_id.as_str())
+                .metadata(Metadata {
+                    name: "external profile vpc".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .routing_profile_type("EXTERNAL".to_string())
+                .rpc(),
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    let external_segment_id = create_tenant_network_segment(
+        &env.api,
+        external_vpc.id,
+        FIXTURE_TENANT_NETWORK_SEGMENT_GATEWAYS[1],
+        "TENANT_EXTERNAL",
+        true,
+    )
+    .await;
+    env.run_network_segment_controller_iteration().await;
+    env.run_network_segment_controller_iteration().await;
+
+    // Allocate an instance spanning both VPCs so each interface carries its own profile.
+    let mh = create_managed_host(&env).await;
+    mh.instance_builer(&env)
+        .tenant_org(tenant.organization_id)
+        .network(
+            api_fixtures::instance::single_interface_network_config_with_vfs(vec![
+                internal_segment_id,
+                external_segment_id,
+            ]),
+        )
+        .build()
+        .await;
+
+    // Fetch the DPU config and index profiles by the interface's actual VPC VNI.
+    let response = env
+        .api
+        .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
+            dpu_machine_id: Some(mh.dpu().id),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    let mut txn = env.db_txn().await;
+    let internal_vpc = db::vpc::find_by_segment(txn.as_mut(), internal_segment_id)
+        .await
+        .unwrap();
+    let external_vpc = db::vpc::find_by_segment(txn.as_mut(), external_segment_id)
+        .await
+        .unwrap();
+    let internal_vni = internal_vpc.status.unwrap().vni.unwrap() as u32;
+    let external_vni = external_vpc.status.unwrap().vni.unwrap() as u32;
+    let profiles_by_vni = response
+        .tenant_interfaces
+        .into_iter()
+        .map(|interface| {
+            (
+                interface.vpc_vni,
+                interface
+                    .routing_profile
+                    .expect("FNN interface should include a routing profile"),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    assert_eq!(profiles_by_vni.len(), 2);
+
+    // Verify each VPC receives the profile resolved from that VPC, not the first VPC.
+    let internal_profile = profiles_by_vni.get(&internal_vni).unwrap();
+    assert!(internal_profile.leak_default_route_from_underlay);
+    assert_eq!(
+        internal_profile.route_target_imports,
+        vec![rpc::common::RouteTarget {
+            asn: internal_import.asn,
+            vni: internal_import.vni,
+        }]
+    );
+
+    let external_profile = profiles_by_vni.get(&external_vni).unwrap();
+    assert!(external_profile.leak_tenant_host_routes_to_underlay);
+    assert_eq!(
+        external_profile.route_targets_on_exports,
+        vec![rpc::common::RouteTarget {
+            asn: external_export.asn,
+            vni: external_export.vni,
+        }]
     );
 }
 
@@ -375,7 +566,14 @@ async fn test_managed_host_network_config_omits_admin_fnn_vrf_loopback_by_defaul
     overrides.fnn_config.as_mut().unwrap().admin_vpc = Some(AdminFnnConfig {
         enabled: true,
         vpc_vni: Some(10000),
-        routing_profile: FnnRoutingProfileConfig::default(),
+        routing_profile: FnnRoutingProfileConfig {
+            leak_default_route_from_underlay: true,
+            route_target_imports: vec![RouteTargetConfig {
+                asn: 64512,
+                vni: 10000,
+            }],
+            ..Default::default()
+        },
     });
 
     let env = api_fixtures::create_test_env_with_overrides(pool, overrides).await;
@@ -409,6 +607,16 @@ async fn test_managed_host_network_config_omits_admin_fnn_vrf_loopback_by_defaul
     assert!(response.use_admin_network);
     assert_eq!(admin_interface.vpc_vni, 10000);
     assert!(admin_interface.tenant_vrf_loopback_ip.is_none());
+    assert!(response.routing_profile.is_some());
+
+    let routing_profile = admin_interface
+        .routing_profile
+        .as_ref()
+        .expect("admin interface should include per-interface routing profile");
+    assert!(routing_profile.leak_default_route_from_underlay);
+    assert_eq!(routing_profile.route_target_imports.len(), 1);
+    assert_eq!(routing_profile.route_target_imports[0].asn, 64512);
+    assert_eq!(routing_profile.route_target_imports[0].vni, 10000);
 
     // Verify the admin VPC also did not allocate a VPC/DPU loopback row.
     let mut txn = env.db_txn().await;

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -3971,6 +3971,7 @@ message ManagedHostNetworkConfigResponse {
 
   // Route imports and tagging details for exports
   // used by FNN configs.
+  // Deprecated: use FlatInterfaceConfig.routing_profile for per-VPC routing.
   // NOTE: This will replace internet_l3_vni and common_internal_route_target but could allow
   //       common_internal_route_target to be renamed/repurposed as a site-level RT.
   //       to become a site-level common route target.
@@ -4188,6 +4189,10 @@ message FlatInterfaceConfig {
 
   // IPv6 configuration for dual-stack FNN interfaces.
   optional FlatInterfaceIpv6Config ipv6_interface_config = 19;
+
+  // Route imports and tagging details for exports used by FNN configs.
+  // This is scoped to the VPC that owns this interface.
+  optional RoutingProfile routing_profile = 20;
 
   // The details of the network security group associated with
   // either the instance or its parent VPC.


### PR DESCRIPTION
## Description

Up to now, there was an assumption that all VPCs associated with an instance would use the same routing-profile, but that 1) wasn't explicitly enforce (only de facto), and 2) the assumption prevents things like having a single instance span two VPCs using profiles that differ only by their allowed anycast announcements.

This PR moves the FNN routing-profile handling from a single instance-level/VPC value to the actual per-VPC interface data sent to DPUs.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

