### PR TITLE
fix: Put back the discovery_info field in ManagedHostDisplay

### DIFF
--- a/crates/api/src/tests/web/managed_host.rs
+++ b/crates/api/src/tests/web/managed_host.rs
@@ -63,9 +63,17 @@ async fn test_ok(pool: sqlx::PgPool) {
     let host = hosts.first().unwrap();
     assert_eq!(host.dpus.len(), 1, "Host should have 1 dpu");
     let dpu = host.dpus.first().unwrap();
+    assert!(
+        !host.discovery_info.network_interfaces.is_empty(),
+        "Host discovery info should be populated and non-default"
+    );
     assert_ne!(
         dpu.machine_id, host.machine_id,
         "DPU should not have the same machine ID as the host"
+    );
+    assert!(
+        !dpu.discovery_info.network_interfaces.is_empty(),
+        "DPU discovery info should be populated and non-default"
     );
 }
 

--- a/crates/rpc-utils/src/managed_host_display.rs
+++ b/crates/rpc-utils/src/managed_host_display.rs
@@ -32,7 +32,7 @@ use rpc::forge::{
 };
 use rpc::machine_discovery::MemoryDevice;
 use rpc::site_explorer::{EndpointExplorationReport, ExploredEndpoint};
-use rpc::{DmiData, DynForge, Machine, Timestamp};
+use rpc::{DiscoveryInfo, DmiData, DynForge, Machine, Timestamp};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
@@ -113,6 +113,8 @@ impl ManagedHostMetadata {
 
 #[derive(Default, Serialize, Deserialize, PartialEq)]
 pub struct ManagedHostOutput {
+    // discovery_info is expected to be part of managed-host.json, but is otherwise unused
+    pub discovery_info: DiscoveryInfo,
     pub hostname: Option<String>,
     pub machine_id: Option<String>,
     pub state: String,
@@ -178,7 +180,10 @@ impl From<Machine> for ManagedHostOutput {
             product_serial: _,
             chassis_serial: host_serial_number,
             bios_version: host_bios_version,
-        } = discovery_info.and_then(|di| di.dmi_data).into();
+        } = discovery_info
+            .as_ref()
+            .and_then(|di| di.dmi_data.as_ref())
+            .into();
 
         let health = machine
             .health
@@ -194,6 +199,7 @@ impl From<Machine> for ManagedHostOutput {
             .collect();
 
         ManagedHostOutput {
+            discovery_info: discovery_info.unwrap_or_default(),
             hostname: primary_interface
                 .as_ref()
                 .map(|i| i.hostname.clone())
@@ -215,6 +221,7 @@ impl From<Machine> for ManagedHostOutput {
                         chrono::TimeDelta::try_from(sla).unwrap_or(chrono::TimeDelta::MAX),
                     )
                 }),
+            state_version: machine.state_version,
             state_reason: machine
                 .state_reason
                 .as_ref()
@@ -252,13 +259,16 @@ impl From<Machine> for ManagedHostOutput {
             tray_index: machine.placement_in_rack.and_then(|p| p.tray_index),
             health,
             health_sources,
-            ..Default::default()
+            // dpus and exploration_report are filled in later
+            dpus: Default::default(),
+            exploration_report: Default::default(),
         }
     }
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct ManagedHostAttachedDpu {
+    pub discovery_info: DiscoveryInfo,
     pub machine_id: Option<String>,
     pub state: Option<String>,
     pub serial_number: Option<String>,
@@ -337,9 +347,14 @@ impl ManagedHostAttachedDpu {
             product_serial: serial_number,
             chassis_serial: _,
             bios_version,
-        } = dpu_machine.discovery_info.and_then(|d| d.dmi_data).into();
+        } = dpu_machine
+            .discovery_info
+            .as_ref()
+            .and_then(|d| d.dmi_data.as_ref())
+            .into();
 
         ManagedHostAttachedDpu {
+            discovery_info: dpu_machine.discovery_info.unwrap_or_default(),
             machine_id: dpu_machine.id.map(|i| i.to_string()),
             state: Some(dpu_machine.state),
             serial_number,
@@ -587,13 +602,13 @@ struct DmiDataDisplay {
     bios_version: Option<String>,
 }
 
-impl From<Option<DmiData>> for DmiDataDisplay {
-    fn from(value: Option<DmiData>) -> Self {
+impl From<Option<&DmiData>> for DmiDataDisplay {
+    fn from(value: Option<&DmiData>) -> Self {
         if let Some(dmi_data) = value {
             Self {
-                product_serial: dmi_data.product_serial.if_non_empty(),
-                chassis_serial: dmi_data.chassis_serial.if_non_empty(),
-                bios_version: dmi_data.bios_version.if_non_empty(),
+                product_serial: dmi_data.product_serial.clone().if_non_empty(),
+                chassis_serial: dmi_data.chassis_serial.clone().if_non_empty(),
+                bios_version: dmi_data.bios_version.clone().if_non_empty(),
             }
         } else {
             Self {


### PR DESCRIPTION
## Description
It was removed as part of #756, but I was under the impression the field was only used for the CLI and HTML views, I did not realize it was used as part of the /admin/managed-host.json output, which is informally specified but used by at least one dependent system.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
This will need to be cherry-picked into our recent releases as well.