### PR TITLE
refactor(measured-boot): move RPC mapping to shared conversion traits

### DIFF
--- a/crates/admin-cli/src/attestation/measured_boot/bundle/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/bundle/cmds.rs
@@ -26,6 +26,7 @@ use ::rpc::protos::measured_boot::{
     ShowMeasurementBundleRequest, UpdateMeasurementBundleRequest,
 };
 use carbide_uuid::machine::MachineId;
+use measured_boot::FromGrpcOpt;
 use measured_boot::bundle::MeasurementBundle;
 use measured_boot::records::MeasurementBundleRecord;
 use serde::Serialize;
@@ -126,7 +127,7 @@ pub async fn create_for_id(
 ) -> CarbideCliResult<MeasurementBundle> {
     let response = grpc_conn.0.create_measurement_bundle(create).await?;
 
-    MeasurementBundle::from_grpc(response.bundle.as_ref())
+    MeasurementBundle::from_grpc_opt(response.bundle)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -134,7 +135,7 @@ pub async fn create_for_id(
 pub async fn delete(grpc_conn: &ApiClient, delete: Delete) -> CarbideCliResult<MeasurementBundle> {
     let response = grpc_conn.0.delete_measurement_bundle(delete).await?;
 
-    MeasurementBundle::from_grpc(response.bundle.as_ref())
+    MeasurementBundle::from_grpc_opt(response.bundle)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -145,7 +146,7 @@ pub async fn rename(grpc_conn: &ApiClient, rename: Rename) -> CarbideCliResult<M
         .rename_measurement_bundle(RenameMeasurementBundleRequest::try_from(rename)?)
         .await?;
 
-    MeasurementBundle::from_grpc(response.bundle.as_ref())
+    MeasurementBundle::from_grpc_opt(response.bundle)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -159,7 +160,7 @@ pub async fn set_state(
         .update_measurement_bundle(UpdateMeasurementBundleRequest::try_from(set_state)?)
         .await?;
 
-    MeasurementBundle::from_grpc(response.bundle.as_ref())
+    MeasurementBundle::from_grpc_opt(response.bundle)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -173,7 +174,7 @@ pub async fn show_by_id_or_name(
         .show_measurement_bundle(ShowMeasurementBundleRequest::try_from(show)?)
         .await?;
 
-    MeasurementBundle::from_grpc(response.bundle.as_ref())
+    MeasurementBundle::from_grpc_opt(response.bundle)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -248,7 +249,7 @@ pub async fn find_closest_match(
     }
 
     Ok(Some(
-        MeasurementBundle::from_grpc(response.bundle.as_ref())
+        MeasurementBundle::from_grpc_opt(response.bundle)
             .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))?,
     ))
 }

--- a/crates/admin-cli/src/attestation/measured_boot/journal/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/journal/cmds.rs
@@ -22,6 +22,7 @@ use ::rpc::protos::measured_boot::ShowMeasurementJournalRequest;
 use measured_boot::bundle::MeasurementBundle;
 use measured_boot::journal::MeasurementJournal;
 use measured_boot::records::MeasurementJournalRecord;
+use measured_boot::{FromGrpc, FromGrpcOpt};
 use serde::Serialize;
 
 use crate::attestation::measured_boot::global;
@@ -85,7 +86,7 @@ pub async fn dispatch(
 pub async fn delete(grpc_conn: &ApiClient, delete: Delete) -> CarbideCliResult<MeasurementJournal> {
     let response = grpc_conn.0.delete_measurement_journal(delete).await?;
 
-    MeasurementJournal::from_grpc(response.journal.as_ref())
+    MeasurementJournal::from_grpc_opt(response.journal)
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -98,7 +99,7 @@ pub async fn show_by_id(grpc_conn: &ApiClient, show: Show) -> CarbideCliResult<M
         .show_measurement_journal(ShowMeasurementJournalRequest::try_from(show)?)
         .await?;
 
-    MeasurementJournal::from_grpc(response.journal.as_ref())
+    MeasurementJournal::from_grpc_opt(response.journal)
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -117,7 +118,7 @@ pub async fn show_all(
             .journals
             .drain(..)
             .map(|journal| {
-                MeasurementJournal::from_grpc(Some(&journal))
+                MeasurementJournal::from_grpc(journal)
                     .map_err(|e| CarbideCliError::GenericError(e.to_string()))
             })
             .collect::<CarbideCliResult<Vec<MeasurementJournal>>>()?,

--- a/crates/admin-cli/src/attestation/measured_boot/machine/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/machine/cmds.rs
@@ -20,6 +20,7 @@
 
 use ::rpc::admin_cli::ToTable;
 use ::rpc::protos::measured_boot::ShowCandidateMachineRequest;
+use measured_boot::FromGrpcOpt;
 use measured_boot::machine::CandidateMachine;
 use measured_boot::records::CandidateMachineSummary;
 use measured_boot::report::MeasurementReport;
@@ -76,7 +77,7 @@ pub async fn dispatch(
 pub async fn attest(grpc_conn: &ApiClient, attest: Attest) -> CarbideCliResult<MeasurementReport> {
     let response = grpc_conn.0.attest_candidate_machine(attest).await?;
 
-    MeasurementReport::from_grpc(response.report.as_ref())
+    MeasurementReport::from_grpc_opt(response.report)
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -87,7 +88,7 @@ pub async fn show_by_id(grpc_conn: &ApiClient, show: Show) -> CarbideCliResult<C
         .show_candidate_machine(ShowCandidateMachineRequest::try_from(show)?)
         .await?;
 
-    CandidateMachine::from_grpc(response.machine.as_ref())
+    CandidateMachine::from_grpc_opt(response.machine)
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))
 }
 

--- a/crates/admin-cli/src/attestation/measured_boot/profile/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/profile/cmds.rs
@@ -28,6 +28,7 @@ use ::rpc::protos::measured_boot::{
 };
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::measured_boot::MeasurementBundleId;
+use measured_boot::FromGrpcOpt;
 use measured_boot::profile::MeasurementSystemProfile;
 use measured_boot::records::MeasurementSystemProfileRecord;
 use serde::Serialize;
@@ -121,7 +122,7 @@ pub async fn create(
         .create_measurement_system_profile(create)
         .await?;
 
-    MeasurementSystemProfile::from_grpc(response.system_profile.as_ref())
+    MeasurementSystemProfile::from_grpc_opt(response.system_profile)
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -136,7 +137,7 @@ pub async fn delete(
         .delete_measurement_system_profile(DeleteMeasurementSystemProfileRequest::try_from(delete)?)
         .await?;
 
-    MeasurementSystemProfile::from_grpc(response.system_profile.as_ref())
+    MeasurementSystemProfile::from_grpc_opt(response.system_profile)
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -150,7 +151,7 @@ pub async fn rename(
         .rename_measurement_system_profile(RenameMeasurementSystemProfileRequest::try_from(rename)?)
         .await?;
 
-    MeasurementSystemProfile::from_grpc(response.profile.as_ref())
+    MeasurementSystemProfile::from_grpc_opt(response.profile)
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -184,7 +185,7 @@ pub async fn show_by_id_or_name(
         .show_measurement_system_profile(ShowMeasurementSystemProfileRequest::try_from(show)?)
         .await?;
 
-    MeasurementSystemProfile::from_grpc(response.system_profile.as_ref())
+    MeasurementSystemProfile::from_grpc_opt(response.system_profile)
         .map_err(|e| CarbideCliError::GenericError(e.to_string()))
 }
 

--- a/crates/admin-cli/src/attestation/measured_boot/report/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/report/cmds.rs
@@ -20,6 +20,7 @@
 
 use ::rpc::admin_cli::ToTable;
 use ::rpc::protos::measured_boot::ListMeasurementReportRequest;
+use measured_boot::FromGrpcOpt;
 use measured_boot::bundle::MeasurementBundle;
 use measured_boot::records::MeasurementReportRecord;
 use measured_boot::report::MeasurementReport;
@@ -124,7 +125,7 @@ pub async fn create_for_id(
 ) -> CarbideCliResult<MeasurementReport> {
     let response = grpc_conn.0.create_measurement_report(create).await?;
 
-    MeasurementReport::from_grpc(response.report.as_ref())
+    MeasurementReport::from_grpc_opt(response.report)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -132,7 +133,7 @@ pub async fn create_for_id(
 pub async fn delete(grpc_conn: &ApiClient, delete: Delete) -> CarbideCliResult<MeasurementReport> {
     let response = grpc_conn.0.delete_measurement_report(delete).await?;
 
-    MeasurementReport::from_grpc(response.report.as_ref())
+    MeasurementReport::from_grpc_opt(response.report)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -145,7 +146,7 @@ pub async fn promote(
 ) -> CarbideCliResult<MeasurementBundle> {
     let response = grpc_conn.0.promote_measurement_report(promote).await?;
 
-    MeasurementBundle::from_grpc(response.bundle.as_ref())
+    MeasurementBundle::from_grpc_opt(response.bundle)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -157,7 +158,7 @@ pub async fn promote(
 pub async fn revoke(grpc_conn: &ApiClient, revoke: Revoke) -> CarbideCliResult<MeasurementBundle> {
     let response = grpc_conn.0.revoke_measurement_report(revoke).await?;
 
-    MeasurementBundle::from_grpc(response.bundle.as_ref())
+    MeasurementBundle::from_grpc_opt(response.bundle)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -171,7 +172,7 @@ pub async fn show_for_id(
         .show_measurement_report_for_id(show_for_id)
         .await?;
 
-    MeasurementReport::from_grpc(response.report.as_ref())
+    MeasurementReport::from_grpc_opt(response.report)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 

--- a/crates/admin-cli/src/attestation/measured_boot/site/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/site/cmds.rs
@@ -23,6 +23,7 @@ use std::io::BufReader;
 
 use ::rpc::admin_cli::{ToTable, set_summary};
 use ::rpc::protos::measured_boot::ImportSiteMeasurementsRequest;
+use measured_boot::FromGrpcOpt;
 use measured_boot::records::{MeasurementApprovedMachineRecord, MeasurementApprovedProfileRecord};
 use measured_boot::site::{ImportResult, SiteModel};
 use serde::Serialize;
@@ -138,10 +139,7 @@ pub async fn import(grpc_conn: &ApiClient, import: Import) -> CarbideCliResult<I
 
     // Request.
     let request = ImportSiteMeasurementsRequest {
-        model: Some(
-            SiteModel::to_pb(&site_model)
-                .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))?,
-        ),
+        model: Some(site_model.into()),
     };
 
     // Response + process and return.
@@ -160,7 +158,7 @@ pub async fn export(grpc_conn: &ApiClient, _export: Export) -> CarbideCliResult<
 
     let response = grpc_conn.0.export_site_measurements().await?;
 
-    SiteModel::from_grpc(response.model.as_ref())
+    SiteModel::from_grpc_opt(response.model)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -171,7 +169,7 @@ pub async fn approve_machine(
 ) -> CarbideCliResult<MeasurementApprovedMachineRecord> {
     let response = grpc_conn.0.add_measurement_trusted_machine(approve).await?;
 
-    MeasurementApprovedMachineRecord::from_grpc(response.approval_record.as_ref())
+    MeasurementApprovedMachineRecord::from_grpc_opt(response.approval_record)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -186,7 +184,7 @@ pub async fn remove_machine_by_approval_id(
         .remove_measurement_trusted_machine(by_approval_id)
         .await?;
 
-    MeasurementApprovedMachineRecord::from_grpc(response.approval_record.as_ref())
+    MeasurementApprovedMachineRecord::from_grpc_opt(response.approval_record)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -201,7 +199,7 @@ pub async fn remove_machine_by_machine_id(
         .remove_measurement_trusted_machine(by_machine_id)
         .await?;
 
-    MeasurementApprovedMachineRecord::from_grpc(response.approval_record.as_ref())
+    MeasurementApprovedMachineRecord::from_grpc_opt(response.approval_record)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -231,7 +229,7 @@ pub async fn approve_profile(
 ) -> CarbideCliResult<MeasurementApprovedProfileRecord> {
     let response = grpc_conn.0.add_measurement_trusted_profile(approve).await?;
 
-    MeasurementApprovedProfileRecord::from_grpc(response.approval_record.as_ref())
+    MeasurementApprovedProfileRecord::from_grpc_opt(response.approval_record)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -246,7 +244,7 @@ pub async fn remove_profile_by_approval_id(
         .remove_measurement_trusted_profile(by_approval_id)
         .await?;
 
-    MeasurementApprovedProfileRecord::from_grpc(response.approval_record.as_ref())
+    MeasurementApprovedProfileRecord::from_grpc_opt(response.approval_record)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 
@@ -261,7 +259,7 @@ pub async fn remove_profile_by_profile_id(
         .remove_measurement_trusted_profile(by_profile_id)
         .await?;
 
-    MeasurementApprovedProfileRecord::from_grpc(response.approval_record.as_ref())
+    MeasurementApprovedProfileRecord::from_grpc_opt(response.approval_record)
         .map_err(|e| crate::CarbideCliError::GenericError(e.to_string()))
 }
 

--- a/crates/api/src/measured_boot/rpc/site.rs
+++ b/crates/api/src/measured_boot/rpc/site.rs
@@ -62,8 +62,8 @@ pub async fn handle_import_site_measurements(
 
     // Convert the site model from the SiteModelPb (and
     // make sure its good).
-    let site_model = match &req.model {
-        Some(site_model_pb) => SiteModel::from_pb(site_model_pb).map_err(|e| {
+    let site_model = match req.model {
+        Some(site_model_pb) => SiteModel::try_from(site_model_pb).map_err(|e| {
             CarbideError::InvalidArgument(format!("input site model failed translation: {e}"))
         })?,
         None => {
@@ -100,11 +100,7 @@ pub async fn handle_export_site_measurements(
         })?;
 
     Ok(ExportSiteMeasurementsResponse {
-        model: Some(
-            SiteModel::to_pb(&site_model).map_err(|e| CarbideError::Internal {
-                message: format!("model to pb failed: {e}"),
-            })?,
-        ),
+        model: Some(site_model.into()),
     })
 }
 
@@ -295,5 +291,7 @@ pub async fn handle_list_attestation_summary(
             message: format!("failed to fetch attestation summary: {e}"),
         })?;
 
-    Ok(MachineAttestationSummaryList::to_grpc(&attestation_summary))
+    Ok(ListAttestationSummaryResponse::from(
+        MachineAttestationSummaryList(attestation_summary),
+    ))
 }

--- a/crates/api/src/measured_boot/tests/rpc.rs
+++ b/crates/api/src/measured_boot/tests/rpc.rs
@@ -27,6 +27,7 @@ mod tests {
     use carbide_uuid::measured_boot::TrustedMachineId;
     use measured_boot::pcr::PcrRegisterValue;
     use measured_boot::records::MeasurementApprovedMachineRecord;
+    use measured_boot::{FromGrpc, FromGrpcOpt};
     use model::machine::{CURRENT_STATE_MODEL_VERSION, ManagedHostState};
     use rpc::protos::measured_boot as mbrpc;
 
@@ -1676,7 +1677,7 @@ mod tests {
         let resp = site::handle_add_measurement_trusted_machine(api, req).await?;
         assert!(resp.approval_record.is_some());
         let machine_approval =
-            MeasurementApprovedMachineRecord::from_grpc(resp.approval_record.as_ref())?;
+            MeasurementApprovedMachineRecord::from_grpc_opt(resp.approval_record)?;
         assert_eq!("*".to_string(), machine_approval.machine_id.to_string());
 
         // And then re-fetch the "*" approval just to make sure
@@ -1686,7 +1687,7 @@ mod tests {
         let resp = site::handle_list_measurement_trusted_machines(api, req).await?;
         assert_eq!(1, resp.approval_records.len());
         let permissive_approval =
-            MeasurementApprovedMachineRecord::from_grpc(Some(&resp.approval_records[0]))?;
+            MeasurementApprovedMachineRecord::from_grpc(resp.approval_records[0].clone())?;
         assert_eq!(
             permissive_approval.machine_id.to_string(),
             String::from("*")

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -37,6 +37,7 @@ use common::api_fixtures::{
 };
 use health_report::HealthReport;
 use ipnetwork::IpNetwork;
+use measured_boot::FromGrpc;
 use measured_boot::bundle::MeasurementBundle;
 use measured_boot::pcr::PcrRegisterValue;
 use measured_boot::records::MeasurementBundleState;
@@ -1398,7 +1399,7 @@ async fn test_measurement_failed_state_transition(pool: sqlx::PgPool) {
         .unwrap()
         .into_inner();
     assert_eq!(1, bundles_response.bundles.len());
-    let bundle = MeasurementBundle::from_grpc(Some(&bundles_response.bundles[0])).unwrap();
+    let bundle = MeasurementBundle::from_grpc(bundles_response.bundles[0].clone()).unwrap();
     assert_eq!(bundle.state, MeasurementBundleState::Active);
     let mut txn = env.db_txn().await;
     let retired_bundle = db::measured_boot::bundle::set_state_for_id(
@@ -1500,7 +1501,7 @@ async fn test_measurement_ready_to_retired_to_ca_fail_to_revoked_to_ready(pool: 
         .unwrap()
         .into_inner();
     assert_eq!(1, bundles_response.bundles.len());
-    let bundle = MeasurementBundle::from_grpc(Some(&bundles_response.bundles[0])).unwrap();
+    let bundle = MeasurementBundle::from_grpc(bundles_response.bundles[0].clone()).unwrap();
     assert_eq!(bundle.state, MeasurementBundleState::Active);
     let mut txn = env.db_txn().await;
     let retired_bundle = db::measured_boot::bundle::set_state_for_id(
@@ -1771,7 +1772,7 @@ async fn test_measurement_host_init_failed_to_waiting_for_measurements_to_pendin
         .unwrap()
         .into_inner();
     assert_eq!(1, reports_response.reports.len());
-    let report = MeasurementReport::from_grpc(Some(&reports_response.reports[0])).unwrap();
+    let report = MeasurementReport::from_grpc(reports_response.reports[0].clone()).unwrap();
 
     let _promotion_response = env
         .api

--- a/crates/api/src/web/attestation.rs
+++ b/crates/api/src/web/attestation.rs
@@ -25,7 +25,7 @@ use carbide_uuid::measured_boot::MeasurementReportId;
 use hyper::http::StatusCode;
 use measured_boot::site::{MachineAttestationSummary, MachineAttestationSummaryList};
 use measured_boot::{
-    bundle as mbbundle, journal as mbjournal, profile as mbprofile, report as mbreport,
+    FromGrpc, bundle as mbbundle, journal as mbjournal, profile as mbprofile, report as mbreport,
 };
 use rpc::forge::forge_server::Forge;
 use rpc::protos::measured_boot as mbprotos;
@@ -107,7 +107,7 @@ pub async fn show_attestation_results(
     });
     let report = match state.show_measurement_report_for_id(request).await {
         Ok(resp) => match resp.into_inner().report {
-            Some(report) => match mbreport::MeasurementReport::from_grpc(Some(&report)) {
+            Some(report) => match mbreport::MeasurementReport::from_grpc(report) {
                 Ok(report) => report,
                 Err(err) => {
                     tracing::error!(%err, "show_attestation_results");
@@ -142,7 +142,7 @@ pub async fn show_attestation_results(
         });
         let bundle = match state.show_measurement_bundle(request).await {
             Ok(resp) => match resp.into_inner().bundle {
-                Some(bundle) => match mbbundle::MeasurementBundle::from_grpc(Some(&bundle)) {
+                Some(bundle) => match mbbundle::MeasurementBundle::from_grpc(bundle) {
                     Ok(bundle) => bundle,
                     Err(err) => {
                         tracing::error!(%err, "show_attestation_results");
@@ -175,7 +175,7 @@ pub async fn show_attestation_results(
         });
         match state.find_closest_bundle_match(request).await {
             Ok(resp) => match resp.into_inner().bundle {
-                Some(bundle) => match mbbundle::MeasurementBundle::from_grpc(Some(&bundle)) {
+                Some(bundle) => match mbbundle::MeasurementBundle::from_grpc(bundle) {
                     Ok(bundle) => Some(bundle),
                     Err(err) => {
                         tracing::error!(%err, "show_attestation_results");
@@ -208,7 +208,7 @@ pub async fn show_attestation_results(
         match state.show_measurement_system_profile(request).await {
             Ok(resp) => match resp.into_inner().system_profile {
                 Some(profile_pb) => {
-                    match mbprofile::MeasurementSystemProfile::from_grpc(Some(&profile_pb)) {
+                    match mbprofile::MeasurementSystemProfile::from_grpc(profile_pb) {
                         Ok(profile) => profile,
                         Err(err) => {
                             tracing::error!(%err, "show_attestation_results");
@@ -321,18 +321,16 @@ async fn get_latest_journal_for_machine_id(
 
     let latest_journal = match state.show_measurement_journal(request).await {
         Ok(response) => match response.into_inner().journal {
-            Some(journal_proto) => {
-                match mbjournal::MeasurementJournal::from_grpc(Some(&journal_proto)) {
-                    Ok(journal) => journal,
-                    Err(err) => {
-                        tracing::error!(%err, "get_latest_journal_for_machine_id");
-                        return Err((
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            Html("Failed parsing MeasurementBundle protobuf".to_string()),
-                        ));
-                    }
+            Some(journal_proto) => match mbjournal::MeasurementJournal::from_grpc(journal_proto) {
+                Ok(journal) => journal,
+                Err(err) => {
+                    tracing::error!(%err, "get_latest_journal_for_machine_id");
+                    return Err((
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Html("Failed parsing MeasurementBundle protobuf".to_string()),
+                    ));
                 }
-            }
+            },
             None => {
                 return Err((
                     StatusCode::BAD_REQUEST,
@@ -357,7 +355,7 @@ pub async fn show_attestation_summary(AxumState(state): AxumState<Arc<Api>>) -> 
 
     let attestation_summary = match state.list_attestation_summary(request).await {
         Ok(response) => AttestationSummary {
-            attestations: match MachineAttestationSummaryList::from_grpc(&response.into_inner()) {
+            attestations: match MachineAttestationSummaryList::try_from(response.into_inner()) {
                 Ok(attestations_list) => attestations_list.0,
                 Err(err) => {
                     tracing::error!(%err, "show_attestation_summary");

--- a/crates/measured-boot/src/bundle.rs
+++ b/crates/measured-boot/src/bundle.rs
@@ -29,6 +29,7 @@ use serde::Serialize;
 
 use super::pcr::PcrRegisterValue;
 use super::records::{MeasurementBundleState, MeasurementBundleValueRecord};
+use crate::{FromGrpc, FromGrpcOpt};
 
 /// MeasurementBundle is a composition of a MeasurementBundleRecord,
 /// whose attributes are essentially copied directly it, as well as
@@ -88,24 +89,17 @@ impl MeasurementBundle {
         let borrowed = &self.values;
         borrowed.iter().map(|rec| rec.clone().into()).collect()
     }
+}
 
-    ////////////////////////////////////////////////////////////
-    /// from_grpc takes an optional protobuf (as populated in a
-    /// proto response from the API) and attempts to convert it
-    /// to the backing model.
-    ////////////////////////////////////////////////////////////
-    pub fn from_grpc(some_pb: Option<&MeasurementBundlePb>) -> super::Result<Self> {
-        some_pb
-            .ok_or(super::Error::RpcConversion(String::from(
-                "bundle is unexpectedly empty",
-            )))
-            .and_then(|pb| {
-                Self::try_from(pb.clone()).map_err(|e| {
-                    super::Error::RpcConversion(format!("bundle failed pb->model conversion: {e}"))
-                })
-            })
+impl crate::DisplayName for MeasurementBundle {
+    fn display_name() -> &'static str {
+        "bundle"
     }
 }
+
+impl FromGrpc<MeasurementBundlePb> for MeasurementBundle {}
+
+impl FromGrpcOpt<MeasurementBundlePb> for MeasurementBundle {}
 
 impl TryFrom<MeasurementBundlePb> for MeasurementBundle {
     type Error = Box<dyn std::error::Error>;

--- a/crates/measured-boot/src/journal.rs
+++ b/crates/measured-boot/src/journal.rs
@@ -38,6 +38,7 @@ use {
 };
 
 use super::records::MeasurementMachineState;
+use crate::{FromGrpc, FromGrpcOpt};
 
 /// MeasurementJournal is a composition of a MeasurementJournalRecord,
 /// whose attributes are essentially copied directly it, as well as
@@ -86,24 +87,17 @@ impl MeasurementJournal {
         ]);
         journal_table
     }
+}
 
-    ////////////////////////////////////////////////////////////
-    /// from_grpc takes an optional protobuf (as populated in a
-    /// proto response from the API) and attempts to convert it
-    /// to the backing model.
-    ////////////////////////////////////////////////////////////
-    pub fn from_grpc(some_pb: Option<&MeasurementJournalPb>) -> super::Result<Self> {
-        some_pb
-            .ok_or(super::Error::RpcConversion(
-                "journal is unexpectedly empty".to_string(),
-            ))
-            .and_then(|pb| {
-                Self::try_from(pb.clone()).map_err(|e| {
-                    super::Error::RpcConversion(format!("journal failed pb->model conversion: {e}"))
-                })
-            })
+impl crate::DisplayName for MeasurementJournal {
+    fn display_name() -> &'static str {
+        "journal"
     }
 }
+
+impl FromGrpc<MeasurementJournalPb> for MeasurementJournal {}
+
+impl FromGrpcOpt<MeasurementJournalPb> for MeasurementJournal {}
 
 impl From<MeasurementJournal> for MeasurementJournalPb {
     fn from(val: MeasurementJournal) -> Self {

--- a/crates/measured-boot/src/lib.rs
+++ b/crates/measured-boot/src/lib.rs
@@ -32,3 +32,41 @@ pub enum Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+pub trait DisplayName {
+    fn display_name() -> &'static str;
+}
+
+pub trait FromGrpc<M>: TryFrom<M> + DisplayName
+where
+    <Self as std::convert::TryFrom<M>>::Error: std::fmt::Display,
+{
+    fn from_grpc(msg: M) -> Result<Self> {
+        Self::try_from(msg).map_err(|e| {
+            Error::RpcConversion(format!("bad message: {}: {e}", Self::display_name()))
+        })
+    }
+}
+
+pub trait FromGrpcOpt<M>: FromGrpc<M>
+where
+    <Self as std::convert::TryFrom<M>>::Error: std::fmt::Display,
+{
+    fn from_grpc_opt(msg: Option<M>) -> Result<Self> {
+        msg.ok_or_else(|| {
+            Error::RpcConversion(format!("{} is unexpectedly empty", Self::display_name()))
+        })
+        .and_then(Self::from_grpc)
+    }
+}
+
+pub trait FromPbVec<M: Clone>: FromGrpc<M>
+where
+    <Self as std::convert::TryFrom<M>>::Error: std::fmt::Display,
+{
+    fn from_pb_vec(pbs: &[M]) -> Result<Vec<Self>> {
+        pbs.iter()
+            .map(|record| Self::from_grpc(record.clone()))
+            .collect()
+    }
+}

--- a/crates/measured-boot/src/machine.rs
+++ b/crates/measured-boot/src/machine.rs
@@ -33,6 +33,7 @@ use serde::Serialize;
 
 use super::journal::MeasurementJournal;
 use super::records::MeasurementMachineState;
+use crate::{FromGrpc, FromGrpcOpt};
 
 /// CandidateMachine describes a machine that is a candidate for attestation,
 /// and is derived from machine information in the machine_toplogies table.
@@ -46,24 +47,15 @@ pub struct CandidateMachine {
     pub updated_ts: chrono::DateTime<Utc>,
 }
 
-impl CandidateMachine {
-    ////////////////////////////////////////////////////////////
-    /// from_grpc takes an optional protobuf (as populated in a
-    /// proto response from the API) and attempts to convert it
-    /// to the backing model.
-    ////////////////////////////////////////////////////////////
-    pub fn from_grpc(some_pb: Option<&CandidateMachinePb>) -> super::Result<Self> {
-        some_pb
-            .ok_or(super::Error::RpcConversion(
-                "machine is unexpectedly empty".to_string(),
-            ))
-            .and_then(|pb| {
-                Self::try_from(pb.clone()).map_err(|e| {
-                    super::Error::RpcConversion(format!("machine failed pb->model conversion: {e}"))
-                })
-            })
+impl crate::DisplayName for CandidateMachine {
+    fn display_name() -> &'static str {
+        "machine"
     }
 }
+
+impl FromGrpc<CandidateMachinePb> for CandidateMachine {}
+
+impl FromGrpcOpt<CandidateMachinePb> for CandidateMachine {}
 
 impl From<CandidateMachine> for CandidateMachinePb {
     fn from(val: CandidateMachine) -> Self {

--- a/crates/measured-boot/src/profile.rs
+++ b/crates/measured-boot/src/profile.rs
@@ -30,6 +30,7 @@ use rpc::protos::measured_boot::MeasurementSystemProfilePb;
 use serde::Serialize;
 
 use super::records::MeasurementSystemProfileAttrRecord;
+use crate::{FromGrpc, FromGrpcOpt};
 
 /// MeasurementSystemProfile is a composition of a MeasurementSystemProfileRecord,
 /// whose attributes are essentially copied directly it, as well as
@@ -46,24 +47,15 @@ pub struct MeasurementSystemProfile {
     pub attrs: Vec<MeasurementSystemProfileAttrRecord>,
 }
 
-impl MeasurementSystemProfile {
-    ////////////////////////////////////////////////////////////
-    /// from_grpc takes an optional protobuf (as populated in a
-    /// proto response from the API) and attempts to convert it
-    /// to the backing model.
-    ////////////////////////////////////////////////////////////
-    pub fn from_grpc(some_pb: Option<&MeasurementSystemProfilePb>) -> super::Result<Self> {
-        some_pb
-            .ok_or(super::Error::RpcConversion(
-                "profile is unexpectedly empty".to_string(),
-            ))
-            .and_then(|pb| {
-                Self::try_from(pb.clone()).map_err(|e| {
-                    super::Error::RpcConversion(format!("profile failed pb->model conversion: {e}"))
-                })
-            })
+impl crate::DisplayName for MeasurementSystemProfile {
+    fn display_name() -> &'static str {
+        "profile"
     }
 }
+
+impl FromGrpc<MeasurementSystemProfilePb> for MeasurementSystemProfile {}
+
+impl FromGrpcOpt<MeasurementSystemProfilePb> for MeasurementSystemProfile {}
 
 impl From<MeasurementSystemProfile> for MeasurementSystemProfilePb {
     fn from(val: MeasurementSystemProfile) -> Self {

--- a/crates/measured-boot/src/records.rs
+++ b/crates/measured-boot/src/records.rs
@@ -58,6 +58,7 @@ use sqlx::{
 };
 
 use super::pcr::PcrRegisterValue;
+use crate::{DisplayName, FromGrpc, FromGrpcOpt, FromPbVec};
 
 /// StringToEnumError is used for taking an input string and converting
 /// it to an enum of a given type. It is leveraged by MeasurementBundleState,
@@ -96,31 +97,21 @@ pub struct MeasurementSystemProfileRecord {
     pub ts: chrono::DateTime<Utc>,
 }
 
-impl MeasurementSystemProfileRecord {
-    pub fn from_grpc(msg: MeasurementSystemProfileRecordPb) -> super::Result<Self> {
-        Self::try_from(msg).map_err(|e| {
-            super::Error::RpcConversion(format!("bad input system profile record: {e}"))
-        })
-    }
-
-    pub fn from_pb_vec(pbs: &[MeasurementSystemProfileRecordPb]) -> super::Result<Vec<Self>> {
-        pbs.iter()
-            .map(|record| {
-                Self::try_from(record.clone()).map_err(|e| {
-                    super::Error::RpcConversion(format!(
-                        "failed system profile record conversion: {e}"
-                    ))
-                })
-            })
-            .collect()
-    }
-}
-
 impl DbTable for MeasurementSystemProfileRecord {
     fn db_table_name() -> &'static str {
         "measurement_system_profiles"
     }
 }
+
+impl DisplayName for MeasurementSystemProfileRecord {
+    fn display_name() -> &'static str {
+        "system profile record"
+    }
+}
+
+impl FromGrpc<MeasurementSystemProfileRecordPb> for MeasurementSystemProfileRecord {}
+
+impl FromPbVec<MeasurementSystemProfileRecordPb> for MeasurementSystemProfileRecord {}
 
 impl From<MeasurementSystemProfileRecord> for MeasurementSystemProfileRecordPb {
     fn from(val: MeasurementSystemProfileRecord) -> Self {
@@ -186,31 +177,21 @@ pub struct MeasurementSystemProfileAttrRecord {
     pub ts: chrono::DateTime<Utc>,
 }
 
-impl MeasurementSystemProfileAttrRecord {
-    pub fn from_grpc(msg: MeasurementSystemProfileAttrRecordPb) -> super::Result<Self> {
-        Self::try_from(msg).map_err(|e| {
-            super::Error::RpcConversion(format!("bad input system profile attr record: {e}"))
-        })
-    }
-
-    pub fn from_pb_vec(pbs: &[MeasurementSystemProfileAttrRecordPb]) -> super::Result<Vec<Self>> {
-        pbs.iter()
-            .map(|record| {
-                Self::try_from(record.clone()).map_err(|e| {
-                    super::Error::RpcConversion(format!(
-                        "failed system profile record attr conversion: {e}"
-                    ))
-                })
-            })
-            .collect()
-    }
-}
-
 impl DbTable for MeasurementSystemProfileAttrRecord {
     fn db_table_name() -> &'static str {
         "measurement_system_profiles_attrs"
     }
 }
+
+impl DisplayName for MeasurementSystemProfileAttrRecord {
+    fn display_name() -> &'static str {
+        "system profile attr record"
+    }
+}
+
+impl FromGrpc<MeasurementSystemProfileAttrRecordPb> for MeasurementSystemProfileAttrRecord {}
+
+impl FromPbVec<MeasurementSystemProfileAttrRecordPb> for MeasurementSystemProfileAttrRecord {}
 
 impl From<MeasurementSystemProfileAttrRecord> for MeasurementSystemProfileAttrRecordPb {
     fn from(val: MeasurementSystemProfileAttrRecord) -> Self {
@@ -378,30 +359,21 @@ pub struct MeasurementBundleRecord {
     pub ts: chrono::DateTime<Utc>,
 }
 
-impl MeasurementBundleRecord {
-    pub fn from_grpc(msg: MeasurementBundleRecordPb) -> super::Result<Self> {
-        Self::try_from(msg)
-            .map_err(|e| super::Error::RpcConversion(format!("bad input bundle record: {e}")))
-    }
-
-    pub fn from_pb_vec(pbs: &[MeasurementBundleRecordPb]) -> super::Result<Vec<Self>> {
-        pbs.iter()
-            .map(|record| {
-                Self::try_from(record.clone()).map_err(|e| {
-                    super::Error::RpcConversion(format!(
-                        "failed bundle record attr conversion: {e}"
-                    ))
-                })
-            })
-            .collect()
-    }
-}
-
 impl DbTable for MeasurementBundleRecord {
     fn db_table_name() -> &'static str {
         "measurement_bundles"
     }
 }
+
+impl DisplayName for MeasurementBundleRecord {
+    fn display_name() -> &'static str {
+        "bundle record"
+    }
+}
+
+impl FromGrpc<MeasurementBundleRecordPb> for MeasurementBundleRecord {}
+
+impl FromPbVec<MeasurementBundleRecordPb> for MeasurementBundleRecord {}
 
 impl From<MeasurementBundleRecord> for MeasurementBundleRecordPb {
     fn from(val: MeasurementBundleRecord) -> Self {
@@ -473,30 +445,21 @@ pub struct MeasurementBundleValueRecord {
     pub ts: chrono::DateTime<Utc>,
 }
 
-impl MeasurementBundleValueRecord {
-    pub fn from_grpc(msg: MeasurementBundleValueRecordPb) -> super::Result<Self> {
-        Self::try_from(msg)
-            .map_err(|e| super::Error::RpcConversion(format!("bad input bundle value record: {e}")))
-    }
-
-    pub fn from_pb_vec(pbs: &[MeasurementBundleValueRecordPb]) -> super::Result<Vec<Self>> {
-        pbs.iter()
-            .map(|record| {
-                Self::try_from(record.clone()).map_err(|e| {
-                    super::Error::RpcConversion(format!(
-                        "failed bundle value record attr conversion: {e}"
-                    ))
-                })
-            })
-            .collect()
-    }
-}
-
 impl DbTable for MeasurementBundleValueRecord {
     fn db_table_name() -> &'static str {
         "measurement_bundles_values"
     }
 }
+
+impl DisplayName for MeasurementBundleValueRecord {
+    fn display_name() -> &'static str {
+        "bundle value record"
+    }
+}
+
+impl FromGrpc<MeasurementBundleValueRecordPb> for MeasurementBundleValueRecord {}
+
+impl FromPbVec<MeasurementBundleValueRecordPb> for MeasurementBundleValueRecord {}
 
 impl From<MeasurementBundleValueRecord> for PcrRegisterValue {
     fn from(val: MeasurementBundleValueRecord) -> Self {
@@ -555,18 +518,19 @@ pub struct MeasurementReportRecord {
     pub ts: chrono::DateTime<Utc>,
 }
 
-impl MeasurementReportRecord {
-    pub fn from_grpc(msg: MeasurementReportRecordPb) -> super::Result<Self> {
-        Self::try_from(msg)
-            .map_err(|e| super::Error::RpcConversion(format!("bad input report record: {e}")))
-    }
-}
-
 impl DbTable for MeasurementReportRecord {
     fn db_table_name() -> &'static str {
         "measurement_reports"
     }
 }
+
+impl DisplayName for MeasurementReportRecord {
+    fn display_name() -> &'static str {
+        "report record"
+    }
+}
+
+impl FromGrpc<MeasurementReportRecordPb> for MeasurementReportRecord {}
 
 impl From<MeasurementReportRecord> for MeasurementReportRecordPb {
     fn from(val: MeasurementReportRecord) -> Self {
@@ -635,18 +599,19 @@ pub struct MeasurementReportValueRecord {
     pub ts: chrono::DateTime<Utc>,
 }
 
-impl MeasurementReportValueRecord {
-    pub fn from_grpc(msg: MeasurementReportValueRecordPb) -> super::Result<Self> {
-        Self::try_from(msg)
-            .map_err(|e| super::Error::RpcConversion(format!("bad input report value record: {e}")))
-    }
-}
-
 impl DbTable for MeasurementReportValueRecord {
     fn db_table_name() -> &'static str {
         "measurement_reports_values"
     }
 }
+
+impl DisplayName for MeasurementReportValueRecord {
+    fn display_name() -> &'static str {
+        "report value record"
+    }
+}
+
+impl FromGrpc<MeasurementReportValueRecordPb> for MeasurementReportValueRecord {}
 
 impl From<MeasurementReportValueRecord> for PcrRegisterValue {
     fn from(val: MeasurementReportValueRecord) -> Self {
@@ -737,18 +702,19 @@ pub struct MeasurementJournalRecord {
     pub ts: chrono::DateTime<Utc>,
 }
 
-impl MeasurementJournalRecord {
-    pub fn from_grpc(msg: MeasurementJournalRecordPb) -> super::Result<Self> {
-        Self::try_from(msg)
-            .map_err(|e| super::Error::RpcConversion(format!("bad input journal record: {e}")))
-    }
-}
-
 impl DbTable for MeasurementJournalRecord {
     fn db_table_name() -> &'static str {
         "measurement_journal"
     }
 }
+
+impl DisplayName for MeasurementJournalRecord {
+    fn display_name() -> &'static str {
+        "journal record"
+    }
+}
+
+impl FromGrpc<MeasurementJournalRecordPb> for MeasurementJournalRecord {}
 
 impl From<MeasurementJournalRecord> for MeasurementJournalRecordPb {
     fn from(val: MeasurementJournalRecord) -> Self {
@@ -860,13 +826,13 @@ pub struct CandidateMachineSummary {
     pub ts: chrono::DateTime<Utc>,
 }
 
-impl CandidateMachineSummary {
-    pub fn from_grpc(msg: CandidateMachineSummaryPb) -> super::Result<Self> {
-        Self::try_from(msg).map_err(|e| {
-            super::Error::RpcConversion(format!("bad input candidate machine record: {e}"))
-        })
+impl DisplayName for CandidateMachineSummary {
+    fn display_name() -> &'static str {
+        "candidate machine record"
     }
 }
+
+impl FromGrpc<CandidateMachineSummaryPb> for CandidateMachineSummary {}
 
 impl From<CandidateMachineSummary> for CandidateMachineSummaryPb {
     fn from(val: CandidateMachineSummary) -> Self {
@@ -1004,20 +970,15 @@ impl<'r> FromRow<'r, PgRow> for MeasurementApprovedMachineRecord {
     }
 }
 
-impl MeasurementApprovedMachineRecord {
-    pub fn from_grpc(msg: Option<&MeasurementApprovedMachineRecordPb>) -> super::Result<Self> {
-        match msg {
-            Some(pb) => Self::try_from(pb.clone()).map_err(|e| {
-                super::Error::RpcConversion(format!(
-                    "bad input trusted machine approval record: {e}"
-                ))
-            }),
-            None => Err(super::Error::RpcConversion(
-                "record unexpectedly empty".into(),
-            )),
-        }
+impl DisplayName for MeasurementApprovedMachineRecord {
+    fn display_name() -> &'static str {
+        "record"
     }
 }
+
+impl FromGrpc<MeasurementApprovedMachineRecordPb> for MeasurementApprovedMachineRecord {}
+
+impl FromGrpcOpt<MeasurementApprovedMachineRecordPb> for MeasurementApprovedMachineRecord {}
 
 impl DbTable for MeasurementApprovedMachineRecord {
     fn db_table_name() -> &'static str {
@@ -1123,20 +1084,15 @@ pub struct MeasurementApprovedProfileRecord {
     pub ts: chrono::DateTime<Utc>,
 }
 
-impl MeasurementApprovedProfileRecord {
-    pub fn from_grpc(msg: Option<&MeasurementApprovedProfileRecordPb>) -> super::Result<Self> {
-        match msg {
-            Some(pb) => Self::try_from(pb.clone()).map_err(|e| {
-                super::Error::RpcConversion(format!(
-                    "bad input trusted profile approval record: {e}"
-                ))
-            }),
-            None => Err(super::Error::RpcConversion(
-                "record unexpectedly empty".into(),
-            )),
-        }
+impl DisplayName for MeasurementApprovedProfileRecord {
+    fn display_name() -> &'static str {
+        "record"
     }
 }
+
+impl FromGrpc<MeasurementApprovedProfileRecordPb> for MeasurementApprovedProfileRecord {}
+
+impl FromGrpcOpt<MeasurementApprovedProfileRecordPb> for MeasurementApprovedProfileRecord {}
 
 impl DbTable for MeasurementApprovedProfileRecord {
     fn db_table_name() -> &'static str {

--- a/crates/measured-boot/src/report.rs
+++ b/crates/measured-boot/src/report.rs
@@ -34,6 +34,7 @@ use serde::Serialize;
 
 use super::pcr::PcrRegisterValue;
 use super::records::MeasurementReportValueRecord;
+use crate::{FromGrpc, FromGrpcOpt};
 
 /// MeasurementReport is a composition of a MeasurementReportRecord,
 /// whose attributes are essentially copied directly it, as well as
@@ -52,24 +53,17 @@ impl MeasurementReport {
         let borrowed = &self.values;
         borrowed.iter().map(|rec| rec.clone().into()).collect()
     }
+}
 
-    ////////////////////////////////////////////////////////////
-    /// from_grpc takes an optional protobuf (as populated in a
-    /// proto response from the API) and attempts to convert it
-    /// to the backing model.
-    ////////////////////////////////////////////////////////////
-    pub fn from_grpc(some_pb: Option<&MeasurementReportPb>) -> super::Result<Self> {
-        some_pb
-            .ok_or(super::Error::RpcConversion(
-                "report is unexpectedly empty".to_string(),
-            ))
-            .and_then(|pb| {
-                Self::try_from(pb.clone()).map_err(|e| {
-                    super::Error::RpcConversion(format!("report failed pb->model conversion: {e}"))
-                })
-            })
+impl crate::DisplayName for MeasurementReport {
+    fn display_name() -> &'static str {
+        "report"
     }
 }
+
+impl FromGrpc<MeasurementReportPb> for MeasurementReport {}
+
+impl FromGrpcOpt<MeasurementReportPb> for MeasurementReport {}
 
 impl From<MeasurementReport> for MeasurementReportPb {
     fn from(val: MeasurementReport) -> Self {

--- a/crates/measured-boot/src/site.rs
+++ b/crates/measured-boot/src/site.rs
@@ -43,6 +43,7 @@ use super::records::{
     MeasurementBundleRecord, MeasurementBundleValueRecord, MeasurementSystemProfileAttrRecord,
     MeasurementSystemProfileRecord,
 };
+use crate::{FromGrpc, FromGrpcOpt, FromPbVec};
 
 #[derive(Serialize)]
 pub struct ImportResult {
@@ -83,27 +84,20 @@ impl ToTable for SiteModel {
     }
 }
 
-impl SiteModel {
-    ////////////////////////////////////////////////////////////
-    /// from_grpc takes an optional protobuf (as populated in a
-    /// proto response from the API) and attempts to convert it
-    /// to the backing model.
-    ////////////////////////////////////////////////////////////
-    pub fn from_grpc(some_pb: Option<&SiteModelPb>) -> super::Result<Self> {
-        some_pb
-            .ok_or(super::Error::RpcConversion(
-                "model is unexpectedly empty".to_string(),
-            ))
-            .and_then(|pb| {
-                Self::from_pb(pb).map_err(|e| {
-                    super::Error::RpcConversion(format!("site failed pb->model conversion: {e}"))
-                })
-            })
+impl crate::DisplayName for SiteModel {
+    fn display_name() -> &'static str {
+        "model"
     }
+}
 
-    /// from_pb takes a SiteModelPb and converts it to a SiteModel,
-    /// generally for the purpose of importing it into the database.
-    pub fn from_pb(model: &SiteModelPb) -> super::Result<Self> {
+impl FromGrpc<SiteModelPb> for SiteModel {}
+
+impl FromGrpcOpt<SiteModelPb> for SiteModel {}
+
+impl TryFrom<SiteModelPb> for SiteModel {
+    type Error = super::Error;
+
+    fn try_from(model: SiteModelPb) -> Result<Self, Self::Error> {
         Ok(Self {
             measurement_system_profiles: MeasurementSystemProfileRecord::from_pb_vec(
                 &model.measurement_system_profiles,
@@ -117,40 +111,40 @@ impl SiteModel {
             )?,
         })
     }
+}
 
-    /// to_pb takes a SiteModel and converts it to a SiteModelPb,
-    /// generally for the purpose of handling a gRPC response.
-    pub fn to_pb(model: &SiteModel) -> super::Result<SiteModelPb> {
+impl From<SiteModel> for SiteModelPb {
+    fn from(model: SiteModel) -> Self {
         let measurement_system_profiles = model
             .measurement_system_profiles
-            .iter()
-            .map(|record| record.clone().into())
+            .into_iter()
+            .map(|record| record.into())
             .collect();
 
         let measurement_system_profiles_attrs = model
             .measurement_system_profiles_attrs
-            .iter()
-            .map(|record| record.clone().into())
+            .into_iter()
+            .map(|record| record.into())
             .collect();
 
         let measurement_bundles = model
             .measurement_bundles
-            .iter()
-            .map(|record| record.clone().into())
+            .into_iter()
+            .map(|record| record.into())
             .collect();
 
         let measurement_bundles_values = model
             .measurement_bundles_values
-            .iter()
-            .map(|record| record.clone().into())
+            .into_iter()
+            .map(|record| record.into())
             .collect();
 
-        Ok(SiteModelPb {
+        Self {
             measurement_system_profiles,
             measurement_system_profiles_attrs,
             measurement_bundles,
             measurement_bundles_values,
-        })
+        }
     }
 }
 
@@ -169,29 +163,27 @@ pub struct MachineAttestationSummaryList(pub Vec<MachineAttestationSummary>);
 // we need methods to convert this to gRPC messages and back
 impl From<MachineAttestationSummaryList> for ListAttestationSummaryResponse {
     fn from(val: MachineAttestationSummaryList) -> Self {
-        MachineAttestationSummaryList::to_grpc(&val.0)
-    }
-}
-
-impl MachineAttestationSummaryList {
-    pub fn to_grpc(val: &[MachineAttestationSummary]) -> ListAttestationSummaryResponse {
-        ListAttestationSummaryResponse {
+        Self {
             attestation_outcomes: val
-                .iter()
+                .0
+                .into_iter()
                 .map(|e| MachineAttestationSummaryPb {
                     machine_id: e.machine_id.to_string(),
                     bundle_id: e.bundle_id,
-                    profile_name: e.profile_name.clone(),
+                    profile_name: e.profile_name,
                     ts: Some(e.ts.into()),
                 })
                 .collect(),
         }
     }
+}
 
-    pub fn from_grpc(val: &ListAttestationSummaryResponse) -> super::Result<Self> {
+impl TryFrom<ListAttestationSummaryResponse> for MachineAttestationSummaryList {
+    type Error = super::Error;
+    fn try_from(val: ListAttestationSummaryResponse) -> Result<Self, Self::Error> {
         let mut attestation_summary_list = Vec::<MachineAttestationSummary>::new();
 
-        for pb in &val.attestation_outcomes {
+        for pb in val.attestation_outcomes {
             attestation_summary_list.push(MachineAttestationSummary {
                 machine_id: MachineId::from_str(&pb.machine_id).map_err(|err| {
                     super::Error::RpcConversion(format!(
@@ -199,7 +191,7 @@ impl MachineAttestationSummaryList {
                     ))
                 })?,
                 bundle_id: pb.bundle_id,
-                profile_name: pb.profile_name.clone(),
+                profile_name: pb.profile_name,
                 ts: match pb.ts {
                     Some(ts) => chrono::DateTime::<Utc>::try_from(ts).map_err(|err| {
                         super::Error::RpcConversion(format!(


### PR DESCRIPTION
## Description

As part of isolating domain models from RPC concerns, replace model-internal protobuf conversion helpers with shared conversion traits.

This changes measured-boot types to define RPC mapping through FromGrpc, FromGrpcOpt, and FromPbVec trait impls instead of bespoke from_grpc/from_pb/to_pb methods on the models themselves.

Also updates API, web, CLI, and tests to use the new trait-based conversion flow for staged and optional protobuf values.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

