### PR TITLE
refactor(measured-boot): move grpc conversions into rpc crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,7 +2172,6 @@ dependencies = [
 name = "carbide-measured-boot"
 version = "0.0.0"
 dependencies = [
- "carbide-rpc",
  "carbide-uuid",
  "chrono",
  "clap",
@@ -2356,6 +2355,7 @@ dependencies = [
  "carbide-health-report",
  "carbide-http-connector",
  "carbide-libmlx-model",
+ "carbide-measured-boot",
  "carbide-network",
  "carbide-secrets",
  "carbide-tls",

--- a/crates/admin-cli/src/attestation/measured_boot/bundle/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/bundle/cmds.rs
@@ -20,13 +20,13 @@
 
 use std::str::FromStr;
 
-use ::rpc::admin_cli::ToTable;
+use ::rpc::measured_boot::FromGrpcOpt;
 use ::rpc::protos::measured_boot::{
     ListMeasurementBundleMachinesRequest, RenameMeasurementBundleRequest,
     ShowMeasurementBundleRequest, UpdateMeasurementBundleRequest,
 };
 use carbide_uuid::machine::MachineId;
-use measured_boot::FromGrpcOpt;
+use measured_boot::ToTable;
 use measured_boot::bundle::MeasurementBundle;
 use measured_boot::records::MeasurementBundleRecord;
 use serde::Serialize;

--- a/crates/admin-cli/src/attestation/measured_boot/journal/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/journal/cmds.rs
@@ -17,12 +17,12 @@
 
 //!
 //! `measurement journal` subcommand dispatcher + backing functions.
-use ::rpc::admin_cli::{ToTable, just_print_summary};
+use ::rpc::measured_boot::{FromGrpc, FromGrpcOpt};
 use ::rpc::protos::measured_boot::ShowMeasurementJournalRequest;
 use measured_boot::bundle::MeasurementBundle;
 use measured_boot::journal::MeasurementJournal;
 use measured_boot::records::MeasurementJournalRecord;
-use measured_boot::{FromGrpc, FromGrpcOpt};
+use measured_boot::{ToTable, just_print_summary};
 use serde::Serialize;
 
 use crate::attestation::measured_boot::global;

--- a/crates/admin-cli/src/attestation/measured_boot/machine/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/machine/cmds.rs
@@ -18,9 +18,9 @@
 //!
 //! `measurement mock-machine` subcommand dispatcher + backing functions.
 
-use ::rpc::admin_cli::ToTable;
+use ::rpc::measured_boot::FromGrpcOpt;
 use ::rpc::protos::measured_boot::ShowCandidateMachineRequest;
-use measured_boot::FromGrpcOpt;
+use measured_boot::ToTable;
 use measured_boot::machine::CandidateMachine;
 use measured_boot::records::CandidateMachineSummary;
 use measured_boot::report::MeasurementReport;

--- a/crates/admin-cli/src/attestation/measured_boot/mod.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/mod.rs
@@ -27,8 +27,8 @@ pub mod profile;
 pub mod report;
 pub mod site;
 
-use ::rpc::admin_cli::{ToTable, set_summary};
 use carbide_uuid::machine::MachineId;
+use measured_boot::{ToTable, set_summary};
 use serde::Serialize;
 
 use crate::cfg::dispatch::Dispatch;

--- a/crates/admin-cli/src/attestation/measured_boot/profile/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/profile/cmds.rs
@@ -20,7 +20,7 @@
 
 use std::str::FromStr;
 
-use ::rpc::admin_cli::ToTable;
+use ::rpc::measured_boot::FromGrpcOpt;
 use ::rpc::protos::measured_boot::{
     DeleteMeasurementSystemProfileRequest, ListMeasurementSystemProfileBundlesRequest,
     ListMeasurementSystemProfileMachinesRequest, RenameMeasurementSystemProfileRequest,
@@ -28,7 +28,7 @@ use ::rpc::protos::measured_boot::{
 };
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::measured_boot::MeasurementBundleId;
-use measured_boot::FromGrpcOpt;
+use measured_boot::ToTable;
 use measured_boot::profile::MeasurementSystemProfile;
 use measured_boot::records::MeasurementSystemProfileRecord;
 use serde::Serialize;

--- a/crates/admin-cli/src/attestation/measured_boot/report/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/report/cmds.rs
@@ -18,9 +18,9 @@
 //!
 //! `measurement report` subcommand dispatcher + backing functions.
 
-use ::rpc::admin_cli::ToTable;
+use ::rpc::measured_boot::FromGrpcOpt;
 use ::rpc::protos::measured_boot::ListMeasurementReportRequest;
-use measured_boot::FromGrpcOpt;
+use measured_boot::ToTable;
 use measured_boot::bundle::MeasurementBundle;
 use measured_boot::records::MeasurementReportRecord;
 use measured_boot::report::MeasurementReport;

--- a/crates/admin-cli/src/attestation/measured_boot/site/cmds.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/site/cmds.rs
@@ -21,11 +21,11 @@
 use std::fs::File;
 use std::io::BufReader;
 
-use ::rpc::admin_cli::{ToTable, set_summary};
+use ::rpc::measured_boot::FromGrpcOpt;
 use ::rpc::protos::measured_boot::ImportSiteMeasurementsRequest;
-use measured_boot::FromGrpcOpt;
 use measured_boot::records::{MeasurementApprovedMachineRecord, MeasurementApprovedProfileRecord};
 use measured_boot::site::{ImportResult, SiteModel};
+use measured_boot::{ToTable, set_summary};
 use serde::Serialize;
 
 use crate::attestation::measured_boot::global;

--- a/crates/admin-cli/src/main.rs
+++ b/crates/admin-cli/src/main.rs
@@ -21,7 +21,7 @@
 use std::fs::File;
 use std::io::Write;
 
-use ::rpc::admin_cli::{OutputFormat, ToTable};
+use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge_api_client::ForgeApiClient;
 use ::rpc::forge_tls_client::{ApiConfig, ForgeClientConfig};
 use cfg::cli_options::{CliCommand, CliOptions};
@@ -32,6 +32,7 @@ use forge_tls::client_config::{
     get_carbide_api_url, get_client_cert_info, get_config_from_file, get_forge_root_ca_path,
     get_proxy_info,
 };
+use measured_boot::ToTable;
 use serde::Serialize;
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use tracing_subscriber::fmt;

--- a/crates/api/src/handlers/attestation.rs
+++ b/crates/api/src/handlers/attestation.rs
@@ -360,15 +360,14 @@ pub(crate) async fn attest_quote(
     // In this case, we're not doing anything with
     // the resulting report (at least not yet), so just
     // throw it away.
-    let report =
-        db::measured_boot::report::new(&mut txn, machine_id, pcr_values.into_inner().as_slice())
-            .await
-            .map_err(|e| CarbideError::Internal {
-                message: format!(
-                    "Failed storing measurement report: (machine_id: {}, err: {})",
-                    &machine_id, e
-                ),
-            })?;
+    let report = db::measured_boot::report::new(&mut txn, machine_id, &pcr_values.0)
+        .await
+        .map_err(|e| CarbideError::Internal {
+            message: format!(
+                "Failed storing measurement report: (machine_id: {}, err: {})",
+                &machine_id, e
+            ),
+        })?;
 
     // if the attestation was successful and enabled, we can now vend the certs
     // - get attestation result

--- a/crates/api/src/measured_boot/rpc/bundle.rs
+++ b/crates/api/src/measured_boot/rpc/bundle.rs
@@ -23,7 +23,6 @@ use db::measured_boot::bundle;
 use db::measured_boot::interface::bundle::{
     get_machines_for_bundle_id, get_machines_for_bundle_name, get_measurement_bundle_records,
 };
-use measured_boot::pcr::PcrRegisterValue;
 use measured_boot::records::MeasurementBundleState;
 use rpc::protos::measured_boot::{
     CreateMeasurementBundleRequest, CreateMeasurementBundleResponse,
@@ -41,6 +40,7 @@ use tonic::Status;
 
 use crate::api::Api;
 use crate::errors::CarbideError;
+use crate::measured_boot::convert_vec;
 
 /// handle_create_measurement_bundle handles the CreateMeasurementBundle
 /// API endpoint.
@@ -55,7 +55,7 @@ pub async fn handle_create_measurement_bundle(
         req.profile_id
             .ok_or(CarbideError::MissingArgument("profile_id"))?,
         req.name,
-        &PcrRegisterValue::from_pb_vec(req.pcr_values),
+        &convert_vec(req.pcr_values),
         Some(MeasurementBundleState::from(state)),
     )
     .await

--- a/crates/api/src/measured_boot/rpc/machine.rs
+++ b/crates/api/src/measured_boot/rpc/machine.rs
@@ -24,7 +24,6 @@ use std::str::FromStr;
 use ::rpc::errors::RpcDataConversionError;
 use carbide_uuid::machine::MachineId;
 use db::measured_boot::interface::machine::get_candidate_machine_records;
-use measured_boot::pcr::PcrRegisterValue;
 use rpc::protos::measured_boot::{
     AttestCandidateMachineRequest, AttestCandidateMachineResponse, ListCandidateMachinesRequest,
     ListCandidateMachinesResponse, ShowCandidateMachineRequest, ShowCandidateMachineResponse,
@@ -34,6 +33,7 @@ use tonic::Status;
 
 use crate::CarbideError;
 use crate::api::Api;
+use crate::measured_boot::convert_vec;
 
 /// handle_attest_candidate_machine handles the AttestCandidateMachine API endpoint.
 pub async fn handle_attest_candidate_machine(
@@ -46,7 +46,7 @@ pub async fn handle_attest_candidate_machine(
         MachineId::from_str(&req.machine_id).map_err(|_| {
             CarbideError::from(RpcDataConversionError::InvalidMachineId(req.machine_id))
         })?,
-        &PcrRegisterValue::from_pb_vec(req.pcr_values),
+        &convert_vec(req.pcr_values),
     )
     .await
     .map_err(|e| CarbideError::Internal {

--- a/crates/api/src/measured_boot/rpc/report.rs
+++ b/crates/api/src/measured_boot/rpc/report.rs
@@ -27,7 +27,7 @@ use db::measured_boot::interface::report::{
     get_all_measurement_report_records, get_measurement_report_records_for_machine_id,
     match_latest_reports,
 };
-use measured_boot::pcr::{PcrRegisterValue, PcrSet, parse_pcr_index_input};
+use measured_boot::pcr::{PcrSet, parse_pcr_index_input};
 use rpc::protos::measured_boot::{
     CreateMeasurementReportRequest, CreateMeasurementReportResponse,
     DeleteMeasurementReportRequest, DeleteMeasurementReportResponse, ListMeasurementReportRequest,
@@ -42,6 +42,7 @@ use tonic::Status;
 
 use crate::CarbideError;
 use crate::api::Api;
+use crate::measured_boot::convert_vec;
 
 /// handle_create_measurement_report handles the CreateMeasurementReport
 /// API endpoint.
@@ -55,7 +56,7 @@ pub async fn handle_create_measurement_report(
         MachineId::from_str(&req.machine_id).map_err(|_| {
             CarbideError::from(RpcDataConversionError::InvalidMachineId(req.machine_id))
         })?,
-        &PcrRegisterValue::from_pb_vec(req.pcr_values),
+        &convert_vec(req.pcr_values),
     )
     .await
     .map_err(|e| CarbideError::Internal {
@@ -274,7 +275,7 @@ pub async fn handle_match_measurement_report(
     api: &Api,
     req: MatchMeasurementReportRequest,
 ) -> Result<MatchMeasurementReportResponse, Status> {
-    let pcr_register = PcrRegisterValue::from_pb_vec(req.pcr_values);
+    let pcr_register = convert_vec(req.pcr_values);
     let mut reports = match_latest_reports(&api.database_connection, &pcr_register)
         .await
         .map_err(|e| CarbideError::Internal {

--- a/crates/api/src/measured_boot/tests/rpc.rs
+++ b/crates/api/src/measured_boot/tests/rpc.rs
@@ -23,14 +23,15 @@
 mod tests {
     use std::str::FromStr;
 
+    use ::rpc::measured_boot::{FromGrpc, FromGrpcOpt};
     use carbide_uuid::machine::MachineId;
     use carbide_uuid::measured_boot::TrustedMachineId;
     use measured_boot::pcr::PcrRegisterValue;
     use measured_boot::records::MeasurementApprovedMachineRecord;
-    use measured_boot::{FromGrpc, FromGrpcOpt};
     use model::machine::{CURRENT_STATE_MODEL_VERSION, ManagedHostState};
     use rpc::protos::measured_boot as mbrpc;
 
+    use crate::measured_boot::convert_vec;
     use crate::measured_boot::rpc::{bundle, journal, machine, profile, report, site};
     use crate::measured_boot::tests::common::{create_test_machine, load_topology_json};
     use crate::tests::common::api_fixtures::create_test_env;
@@ -299,7 +300,7 @@ mod tests {
         ];
         let req = mbrpc::AttestCandidateMachineRequest {
             machine_id: princess_network.machine_id.to_string(),
-            pcr_values: PcrRegisterValue::to_pb_vec(&pcr_values),
+            pcr_values: convert_vec(pcr_values),
         };
 
         // And that attestation resulted in..
@@ -382,7 +383,7 @@ mod tests {
         // Make the report.
         let req = mbrpc::CreateMeasurementReportRequest {
             machine_id: princess_network.machine_id.to_string(),
-            pcr_values: PcrRegisterValue::to_pb_vec(&pcr_values),
+            pcr_values: convert_vec(pcr_values),
         };
         let result = report::handle_create_measurement_report(api, req).await;
         assert!(result.is_ok());
@@ -552,7 +553,7 @@ mod tests {
 
         let req = mbrpc::CreateMeasurementReportRequest {
             machine_id: princess_network.machine_id.to_string(),
-            pcr_values: PcrRegisterValue::to_pb_vec(&pcr_values),
+            pcr_values: convert_vec(pcr_values),
         };
         let result = report::handle_create_measurement_report(api, req).await;
         assert!(result.is_ok());
@@ -652,7 +653,7 @@ mod tests {
         let req = mbrpc::CreateMeasurementBundleRequest {
             name: Some(String::from("test-bundle")),
             profile_id: profile.profile_id,
-            pcr_values: PcrRegisterValue::to_pb_vec(&pcr_values),
+            pcr_values: convert_vec(pcr_values.clone()),
             state: mbrpc::MeasurementBundleStatePb::Active.into(),
         };
         let resp = bundle::handle_create_measurement_bundle(api, req).await?;
@@ -857,7 +858,7 @@ mod tests {
         // Make the report.
         let req = mbrpc::CreateMeasurementReportRequest {
             machine_id: princess_network.machine_id.to_string(),
-            pcr_values: PcrRegisterValue::to_pb_vec(&report_pcr_values()),
+            pcr_values: convert_vec(report_pcr_values()),
         };
         let result = report::handle_create_measurement_report(api, req).await;
         assert!(result.is_ok());
@@ -904,7 +905,7 @@ mod tests {
         let req = mbrpc::CreateMeasurementBundleRequest {
             name: Some(String::from("3-elem_3m")),
             profile_id: profile.profile_id,
-            pcr_values: PcrRegisterValue::to_pb_vec(&pcr_values),
+            pcr_values: convert_vec(pcr_values.clone()),
             state: mbrpc::MeasurementBundleStatePb::Active.into(),
         };
         let resp = bundle::handle_create_measurement_bundle(api, req).await?;
@@ -942,7 +943,7 @@ mod tests {
         let req = mbrpc::CreateMeasurementBundleRequest {
             name: Some(String::from("5-elem_2m")),
             profile_id: profile.profile_id,
-            pcr_values: PcrRegisterValue::to_pb_vec(&pcr_values),
+            pcr_values: convert_vec(pcr_values.clone()),
             state: mbrpc::MeasurementBundleStatePb::Active.into(),
         };
         let resp = bundle::handle_create_measurement_bundle(api, req).await?;
@@ -978,7 +979,7 @@ mod tests {
         let req = mbrpc::CreateMeasurementBundleRequest {
             name: Some(String::from("5-elem_0m")),
             profile_id: profile.profile_id,
-            pcr_values: PcrRegisterValue::to_pb_vec(&pcr_values),
+            pcr_values: convert_vec(pcr_values.clone()),
             state: mbrpc::MeasurementBundleStatePb::Active.into(),
         };
         let resp = bundle::handle_create_measurement_bundle(api, req).await?;
@@ -1013,7 +1014,7 @@ mod tests {
         let req = mbrpc::CreateMeasurementBundleRequest {
             name: Some(String::from("4-elem_3m")),
             profile_id: profile.profile_id,
-            pcr_values: PcrRegisterValue::to_pb_vec(&pcr_values),
+            pcr_values: convert_vec(pcr_values.clone()),
             state: mbrpc::MeasurementBundleStatePb::Active.into(),
         };
         let resp = bundle::handle_create_measurement_bundle(api, req).await?;
@@ -1042,7 +1043,7 @@ mod tests {
         let req = mbrpc::CreateMeasurementBundleRequest {
             name: Some(String::from("3-elem_1m")),
             profile_id: profile.profile_id,
-            pcr_values: PcrRegisterValue::to_pb_vec(&pcr_values),
+            pcr_values: convert_vec(pcr_values.clone()),
             state: mbrpc::MeasurementBundleStatePb::Active.into(),
         };
         let resp = bundle::handle_create_measurement_bundle(api, req).await?;
@@ -1182,7 +1183,7 @@ mod tests {
         // Make the report.
         let req = mbrpc::CreateMeasurementReportRequest {
             machine_id: princess_network.machine_id.to_string(),
-            pcr_values: PcrRegisterValue::to_pb_vec(&report_pcr_values()),
+            pcr_values: convert_vec(report_pcr_values()),
         };
         let result = report::handle_create_measurement_report(api, req).await;
         assert!(result.is_ok());
@@ -1226,7 +1227,7 @@ mod tests {
         // Make the report for another machine
         let req = mbrpc::CreateMeasurementReportRequest {
             machine_id: beer_louisiana.machine_id.to_string(),
-            pcr_values: PcrRegisterValue::to_pb_vec(&three_elem_3matching_pcr_values()),
+            pcr_values: convert_vec(three_elem_3matching_pcr_values()),
         };
         let result = report::handle_create_measurement_report(api, req).await;
         assert!(result.is_ok());
@@ -1256,7 +1257,7 @@ mod tests {
         let req = mbrpc::CreateMeasurementBundleRequest {
             name: Some(String::from("3-elem_3m")),
             profile_id: beer_louisiana_profile_id,
-            pcr_values: PcrRegisterValue::to_pb_vec(&three_elem_3matching_pcr_values()),
+            pcr_values: convert_vec(three_elem_3matching_pcr_values()),
             state: mbrpc::MeasurementBundleStatePb::Active.into(),
         };
         let resp = bundle::handle_create_measurement_bundle(api, req).await?;
@@ -1369,7 +1370,7 @@ mod tests {
         let req = mbrpc::CreateMeasurementBundleRequest {
             name: Some(String::from("test-bundle")),
             profile_id: profile1.profile_id,
-            pcr_values: PcrRegisterValue::to_pb_vec(&pcr_values1),
+            pcr_values: convert_vec(pcr_values1.clone()),
             state: mbrpc::MeasurementBundleStatePb::Active.into(),
         };
         let resp = bundle::handle_create_measurement_bundle(api, req).await?;
@@ -1382,7 +1383,7 @@ mod tests {
         let req = mbrpc::CreateMeasurementBundleRequest {
             name: Some(String::from("test-bundle-2")),
             profile_id: profile2.profile_id,
-            pcr_values: PcrRegisterValue::to_pb_vec(&pcr_values2),
+            pcr_values: convert_vec(pcr_values2.clone()),
             state: mbrpc::MeasurementBundleStatePb::Active.into(),
         };
         let resp = bundle::handle_create_measurement_bundle(api, req).await?;
@@ -1462,7 +1463,7 @@ mod tests {
 
         let req = mbrpc::CreateMeasurementReportRequest {
             machine_id: princess_network.machine_id.to_string(),
-            pcr_values: PcrRegisterValue::to_pb_vec(&pcr_values),
+            pcr_values: convert_vec(pcr_values),
         };
         let result = report::handle_create_measurement_report(api, req).await;
         assert!(result.is_ok());
@@ -1571,7 +1572,7 @@ mod tests {
 
         let req = mbrpc::CreateMeasurementReportRequest {
             machine_id: princess_network.machine_id.to_string(),
-            pcr_values: PcrRegisterValue::to_pb_vec(&pcr_values),
+            pcr_values: convert_vec(pcr_values),
         };
         let result = report::handle_create_measurement_report(api, req).await;
         assert!(result.is_ok());
@@ -1778,7 +1779,7 @@ mod tests {
 
         let req = mbrpc::CreateMeasurementReportRequest {
             machine_id: princess_network.machine_id.to_string(),
-            pcr_values: PcrRegisterValue::to_pb_vec(&princess_values),
+            pcr_values: convert_vec(princess_values),
         };
         let result = report::handle_create_measurement_report(api, req).await;
         assert!(result.is_ok());
@@ -1836,7 +1837,7 @@ mod tests {
 
         let req = mbrpc::CreateMeasurementReportRequest {
             machine_id: beer_louisiana.machine_id.to_string(),
-            pcr_values: PcrRegisterValue::to_pb_vec(&beer_values),
+            pcr_values: convert_vec(beer_values),
         };
         let result = report::handle_create_measurement_report(api, req).await;
         assert!(result.is_ok());
@@ -1894,7 +1895,7 @@ mod tests {
 
         let req = mbrpc::CreateMeasurementReportRequest {
             machine_id: lime_coconut.machine_id.to_string(),
-            pcr_values: PcrRegisterValue::to_pb_vec(&lime_values),
+            pcr_values: convert_vec(lime_values),
         };
         let result = report::handle_create_measurement_report(api, req).await;
         assert!(result.is_ok());

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -110,6 +110,7 @@ use crate::dpf::DpfOperations;
 use crate::ethernet_virtualization::{EthVirtData, SiteFabricPrefixList};
 use crate::logging::level_filter::ActiveLevel;
 use crate::logging::log_limiter::LogLimiter;
+use crate::measured_boot::convert_vec;
 use crate::rack::rms_client::test_support::RmsSim;
 use crate::scout_stream;
 use crate::state_controller::common_services::CommonStateHandlerServices;
@@ -2753,7 +2754,7 @@ pub async fn inject_machine_measurements(
         .attest_candidate_machine(Request::new(
             rpc::protos::measured_boot::AttestCandidateMachineRequest {
                 machine_id: machine_id.to_string(),
-                pcr_values: PcrRegisterValue::to_pb_vec(&pcr_values),
+                pcr_values: convert_vec(pcr_values),
             },
         ))
         .await

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
+use ::rpc::measured_boot::FromGrpc;
 use base64::prelude::*;
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::machine_validation::MachineValidationId;
@@ -37,7 +38,6 @@ use common::api_fixtures::{
 };
 use health_report::HealthReport;
 use ipnetwork::IpNetwork;
-use measured_boot::FromGrpc;
 use measured_boot::bundle::MeasurementBundle;
 use measured_boot::pcr::PcrRegisterValue;
 use measured_boot::records::MeasurementBundleState;
@@ -60,6 +60,7 @@ use rpc::{DiscoveryData, DiscoveryInfo};
 use tonic::{Code, Request};
 
 use crate::handlers::measured_boot::rpc_forge::MachineDiscoveryInfo;
+use crate::measured_boot::convert_vec;
 use crate::state_controller::db_write_batch::DbWriteBatch;
 use crate::state_controller::machine::context::MachineStateHandlerContextObjects;
 use crate::state_controller::machine::handler::{
@@ -1740,7 +1741,7 @@ async fn test_measurement_host_init_failed_to_waiting_for_measurements_to_pendin
         .attest_candidate_machine(Request::new(
             rpc::protos::measured_boot::AttestCandidateMachineRequest {
                 machine_id: host_machine_id.to_string(),
-                pcr_values: PcrRegisterValue::to_pb_vec(&pcr_values),
+                pcr_values: convert_vec(pcr_values),
             },
         ))
         .await

--- a/crates/api/src/web/attestation.rs
+++ b/crates/api/src/web/attestation.rs
@@ -18,6 +18,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use ::rpc::measured_boot::FromGrpc;
 use askama::Template;
 use axum::extract::{Path as AxumPath, Query as AxumQuery, State as AxumState};
 use axum::response::{Html, IntoResponse};
@@ -25,7 +26,7 @@ use carbide_uuid::measured_boot::MeasurementReportId;
 use hyper::http::StatusCode;
 use measured_boot::site::{MachineAttestationSummary, MachineAttestationSummaryList};
 use measured_boot::{
-    FromGrpc, bundle as mbbundle, journal as mbjournal, profile as mbprofile, report as mbreport,
+    bundle as mbbundle, journal as mbjournal, profile as mbprofile, report as mbreport,
 };
 use rpc::forge::forge_server::Forge;
 use rpc::protos::measured_boot as mbprotos;

--- a/crates/measured-boot/Cargo.toml
+++ b/crates/measured-boot/Cargo.toml
@@ -26,12 +26,11 @@ name = "measured_boot"
 
 [features]
 sqlx = ["dep:sqlx", "carbide-uuid/sqlx"]
-cli = ["dep:prettytable-rs", "dep:eyre", "dep:clap", "carbide-rpc/cli"]
+cli = ["dep:prettytable-rs", "dep:eyre", "dep:clap"]
 
 [dependencies]
 # workspace dependencies
 carbide-uuid = { path = "../uuid" }
-carbide-rpc = { path = "../rpc" }
 
 thiserror = { workspace = true }
 sqlx = { workspace = true, optional = true }

--- a/crates/measured-boot/src/bundle.rs
+++ b/crates/measured-boot/src/bundle.rs
@@ -21,15 +21,12 @@
  */
 
 use carbide_uuid::measured_boot::{MeasurementBundleId, MeasurementSystemProfileId};
-#[cfg(feature = "cli")]
-use rpc::admin_cli::ToTable;
-use rpc::errors::RpcDataConversionError;
-use rpc::protos::measured_boot::{MeasurementBundlePb, MeasurementBundleStatePb};
 use serde::Serialize;
 
 use super::pcr::PcrRegisterValue;
 use super::records::{MeasurementBundleState, MeasurementBundleValueRecord};
-use crate::{FromGrpc, FromGrpcOpt};
+#[cfg(feature = "cli")]
+use crate::ToTable;
 
 /// MeasurementBundle is a composition of a MeasurementBundleRecord,
 /// whose attributes are essentially copied directly it, as well as
@@ -66,24 +63,6 @@ pub struct MeasurementBundle {
     pub ts: chrono::DateTime<chrono::Utc>,
 }
 
-impl From<MeasurementBundle> for MeasurementBundlePb {
-    fn from(val: MeasurementBundle) -> Self {
-        let pb_state: MeasurementBundleStatePb = val.state.into();
-        Self {
-            bundle_id: Some(val.bundle_id),
-            profile_id: Some(val.profile_id),
-            name: val.name,
-            state: pb_state.into(),
-            values: val
-                .values
-                .iter()
-                .map(|value| value.clone().into())
-                .collect(),
-            ts: Some(val.ts.into()),
-        }
-    }
-}
-
 impl MeasurementBundle {
     pub fn pcr_values(&self) -> Vec<PcrRegisterValue> {
         let borrowed = &self.values;
@@ -94,43 +73,6 @@ impl MeasurementBundle {
 impl crate::DisplayName for MeasurementBundle {
     fn display_name() -> &'static str {
         "bundle"
-    }
-}
-
-impl FromGrpc<MeasurementBundlePb> for MeasurementBundle {}
-
-impl FromGrpcOpt<MeasurementBundlePb> for MeasurementBundle {}
-
-impl TryFrom<MeasurementBundlePb> for MeasurementBundle {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(msg: MeasurementBundlePb) -> Result<Self, Box<dyn std::error::Error>> {
-        let state = msg.state();
-        let values: super::Result<Vec<MeasurementBundleValueRecord>> = msg
-            .values
-            .iter()
-            .map(
-                |attr| match MeasurementBundleValueRecord::try_from(attr.clone()) {
-                    Ok(worked) => Ok(worked),
-                    Err(failed) => Err(super::Error::RpcConversion(format!(
-                        "attr conversion failed: {failed}"
-                    ))),
-                },
-            )
-            .collect();
-
-        Ok(Self {
-            bundle_id: msg
-                .bundle_id
-                .ok_or(RpcDataConversionError::MissingArgument("bundle_id"))?,
-            profile_id: msg
-                .profile_id
-                .ok_or(RpcDataConversionError::MissingArgument("profile_id"))?,
-            name: msg.name.clone(),
-            state: MeasurementBundleState::from(state),
-            values: values?,
-            ts: chrono::DateTime::<chrono::Utc>::try_from(msg.ts.unwrap())?,
-        })
     }
 }
 

--- a/crates/measured-boot/src/journal.rs
+++ b/crates/measured-boot/src/journal.rs
@@ -20,25 +20,19 @@
  *  tables in the database, leveraging the journal-specific record types.
  */
 
-use std::str::FromStr;
-
-use carbide_uuid::UuidEmptyStringError;
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::measured_boot::{
     MeasurementBundleId, MeasurementJournalId, MeasurementReportId, MeasurementSystemProfileId,
 };
 use chrono::Utc;
-use rpc::errors::RpcDataConversionError;
-use rpc::protos::measured_boot::{MeasurementJournalPb, MeasurementMachineStatePb};
 use serde::Serialize;
 #[cfg(feature = "cli")]
 use {
-    rpc::admin_cli::ToTable,
-    rpc::admin_cli::{just_print_summary, serde_just_print_summary},
+    crate::ToTable,
+    crate::{just_print_summary, serde_just_print_summary},
 };
 
 use super::records::MeasurementMachineState;
-use crate::{FromGrpc, FromGrpcOpt};
 
 /// MeasurementJournal is a composition of a MeasurementJournalRecord,
 /// whose attributes are essentially copied directly it, as well as
@@ -92,50 +86,6 @@ impl MeasurementJournal {
 impl crate::DisplayName for MeasurementJournal {
     fn display_name() -> &'static str {
         "journal"
-    }
-}
-
-impl FromGrpc<MeasurementJournalPb> for MeasurementJournal {}
-
-impl FromGrpcOpt<MeasurementJournalPb> for MeasurementJournal {}
-
-impl From<MeasurementJournal> for MeasurementJournalPb {
-    fn from(val: MeasurementJournal) -> Self {
-        let pb_state: MeasurementMachineStatePb = val.state.into();
-        Self {
-            journal_id: Some(val.journal_id),
-            machine_id: val.machine_id.to_string(),
-            report_id: Some(val.report_id),
-            profile_id: val.profile_id,
-            bundle_id: val.bundle_id,
-            state: pb_state.into(),
-            ts: Some(val.ts.into()),
-        }
-    }
-}
-
-impl TryFrom<MeasurementJournalPb> for MeasurementJournal {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(msg: MeasurementJournalPb) -> Result<Self, Box<dyn std::error::Error>> {
-        if msg.machine_id.is_empty() {
-            return Err(UuidEmptyStringError {}.into());
-        }
-        let state = msg.state();
-
-        Ok(Self {
-            journal_id: msg
-                .journal_id
-                .ok_or(RpcDataConversionError::MissingArgument("journal_id"))?,
-            machine_id: MachineId::from_str(&msg.machine_id)?,
-            report_id: msg
-                .report_id
-                .ok_or(RpcDataConversionError::MissingArgument("report_id"))?,
-            profile_id: msg.profile_id,
-            bundle_id: msg.bundle_id,
-            state: MeasurementMachineState::from(state),
-            ts: chrono::DateTime::<chrono::Utc>::try_from(msg.ts.unwrap())?,
-        })
     }
 }
 

--- a/crates/measured-boot/src/lib.rs
+++ b/crates/measured-boot/src/lib.rs
@@ -14,6 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#[cfg(feature = "cli")]
+use std::sync::atomic::{AtomicBool, Ordering};
+
 pub mod bundle;
 pub mod journal;
 pub mod machine;
@@ -37,36 +41,36 @@ pub trait DisplayName {
     fn display_name() -> &'static str;
 }
 
-pub trait FromGrpc<M>: TryFrom<M> + DisplayName
-where
-    <Self as std::convert::TryFrom<M>>::Error: std::fmt::Display,
-{
-    fn from_grpc(msg: M) -> Result<Self> {
-        Self::try_from(msg).map_err(|e| {
-            Error::RpcConversion(format!("bad message: {}: {e}", Self::display_name()))
-        })
-    }
+/// SUMMARY is a global variable that is being used by a few structs which
+/// implement serde::Serialize with skip_serialization_if.
+///
+/// I had wanted the ability to have summarized or extended versions of
+/// serialized output, and decided I could use skip_serialization_if along with
+/// a function that looks at a global variable.
+///
+/// You set --extended on the CLI, which controls whether or not to summarized
+/// (default is summarized).
+#[cfg(feature = "cli")]
+static SUMMARY: AtomicBool = AtomicBool::new(false);
+
+#[cfg(feature = "cli")]
+pub fn serde_just_print_summary<T>(_: &T) -> bool {
+    SUMMARY.load(Ordering::SeqCst)
 }
 
-pub trait FromGrpcOpt<M>: FromGrpc<M>
-where
-    <Self as std::convert::TryFrom<M>>::Error: std::fmt::Display,
-{
-    fn from_grpc_opt(msg: Option<M>) -> Result<Self> {
-        msg.ok_or_else(|| {
-            Error::RpcConversion(format!("{} is unexpectedly empty", Self::display_name()))
-        })
-        .and_then(Self::from_grpc)
-    }
+#[cfg(feature = "cli")]
+pub fn just_print_summary() -> bool {
+    SUMMARY.load(Ordering::SeqCst)
 }
 
-pub trait FromPbVec<M: Clone>: FromGrpc<M>
-where
-    <Self as std::convert::TryFrom<M>>::Error: std::fmt::Display,
-{
-    fn from_pb_vec(pbs: &[M]) -> Result<Vec<Self>> {
-        pbs.iter()
-            .map(|record| Self::from_grpc(record.clone()))
-            .collect()
-    }
+#[cfg(feature = "cli")]
+pub fn set_summary(val: bool) {
+    SUMMARY.store(val, Ordering::SeqCst);
+}
+
+/// ToTable is a trait which is used alongside the cli_output command
+/// and being able to prettytable print results.
+#[cfg(feature = "cli")]
+pub trait ToTable {
+    fn into_table(self) -> eyre::Result<String>;
 }

--- a/crates/measured-boot/src/machine.rs
+++ b/crates/measured-boot/src/machine.rs
@@ -21,19 +21,15 @@
  */
 
 use std::collections::HashMap;
-use std::str::FromStr;
 
-use carbide_uuid::UuidEmptyStringError;
 use carbide_uuid::machine::MachineId;
 use chrono::Utc;
-#[cfg(feature = "cli")]
-use rpc::admin_cli::ToTable;
-use rpc::protos::measured_boot::{CandidateMachinePb, MeasurementMachineStatePb};
 use serde::Serialize;
 
 use super::journal::MeasurementJournal;
 use super::records::MeasurementMachineState;
-use crate::{FromGrpc, FromGrpcOpt};
+#[cfg(feature = "cli")]
+use crate::ToTable;
 
 /// CandidateMachine describes a machine that is a candidate for attestation,
 /// and is derived from machine information in the machine_toplogies table.
@@ -50,47 +46,6 @@ pub struct CandidateMachine {
 impl crate::DisplayName for CandidateMachine {
     fn display_name() -> &'static str {
         "machine"
-    }
-}
-
-impl FromGrpc<CandidateMachinePb> for CandidateMachine {}
-
-impl FromGrpcOpt<CandidateMachinePb> for CandidateMachine {}
-
-impl From<CandidateMachine> for CandidateMachinePb {
-    fn from(val: CandidateMachine) -> Self {
-        let pb_state: MeasurementMachineStatePb = val.state.into();
-        Self {
-            machine_id: val.machine_id.to_string(),
-            state: pb_state.into(),
-            journal: val.journal.map(|journal| journal.into()),
-            attrs: val.attrs,
-            created_ts: Some(val.created_ts.into()),
-            updated_ts: Some(val.updated_ts.into()),
-        }
-    }
-}
-
-impl TryFrom<CandidateMachinePb> for CandidateMachine {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(msg: CandidateMachinePb) -> Result<Self, Box<dyn std::error::Error>> {
-        if msg.machine_id.is_empty() {
-            return Err(UuidEmptyStringError {}.into());
-        }
-        let state = msg.state();
-
-        Ok(Self {
-            machine_id: MachineId::from_str(&msg.machine_id)?,
-            state: MeasurementMachineState::from(state),
-            journal: match msg.journal {
-                Some(journal_pb) => Some(MeasurementJournal::try_from(journal_pb)?),
-                None => None,
-            },
-            attrs: msg.attrs,
-            created_ts: chrono::DateTime::<chrono::Utc>::try_from(msg.created_ts.unwrap())?,
-            updated_ts: chrono::DateTime::<chrono::Utc>::try_from(msg.updated_ts.unwrap())?,
-        })
     }
 }
 

--- a/crates/measured-boot/src/pcr.rs
+++ b/crates/measured-boot/src/pcr.rs
@@ -21,12 +21,12 @@
  */
 
 use std::collections::HashSet;
-use std::convert::{From, Into};
+use std::convert::From;
 use std::fmt;
 use std::hash::Hash;
 use std::vec::Vec;
 
-use rpc::protos::measured_boot::PcrRegisterValuePb;
+use crate::records::{MeasurementBundleValueRecord, MeasurementReportValueRecord};
 
 // PcrRange is a small struct used when parsing
 // --pcr-register values from the CLI as part of
@@ -170,38 +170,22 @@ pub struct PcrRegisterValue {
     pub sha_any: String,
 }
 
-pub struct PcrRegisterValueVec(Vec<PcrRegisterValue>);
+pub struct PcrRegisterValueVec(pub Vec<PcrRegisterValue>);
 
-impl PcrRegisterValueVec {
-    pub fn into_inner(self) -> Vec<PcrRegisterValue> {
-        self.0
-    }
-}
-
-impl PcrRegisterValue {
-    pub fn from_pb_vec(pbs: Vec<PcrRegisterValuePb>) -> Vec<Self> {
-        pbs.into_iter().map(|value| value.into()).collect()
-    }
-
-    pub fn to_pb_vec(values: &[Self]) -> Vec<PcrRegisterValuePb> {
-        values.iter().map(|value| value.clone().into()).collect()
-    }
-}
-
-impl From<PcrRegisterValue> for PcrRegisterValuePb {
-    fn from(val: PcrRegisterValue) -> Self {
-        Self {
-            pcr_register: val.pcr_register as i32,
+impl From<MeasurementBundleValueRecord> for PcrRegisterValue {
+    fn from(val: MeasurementBundleValueRecord) -> Self {
+        PcrRegisterValue {
+            pcr_register: val.pcr_register,
             sha_any: val.sha_any,
         }
     }
 }
 
-impl From<PcrRegisterValuePb> for PcrRegisterValue {
-    fn from(msg: PcrRegisterValuePb) -> Self {
+impl From<MeasurementReportValueRecord> for PcrRegisterValue {
+    fn from(val: MeasurementReportValueRecord) -> Self {
         Self {
-            pcr_register: msg.pcr_register as i16,
-            sha_any: msg.sha_any,
+            pcr_register: val.pcr_register,
+            sha_any: val.sha_any,
         }
     }
 }

--- a/crates/measured-boot/src/profile.rs
+++ b/crates/measured-boot/src/profile.rs
@@ -20,17 +20,13 @@
  *  tables in the database, leveraging the profile-specific record types.
  */
 
-use std::convert::{Into, TryFrom};
-
 use carbide_uuid::measured_boot::MeasurementSystemProfileId;
 use chrono::{DateTime, Utc};
-#[cfg(feature = "cli")]
-use rpc::admin_cli::ToTable;
-use rpc::protos::measured_boot::MeasurementSystemProfilePb;
 use serde::Serialize;
 
 use super::records::MeasurementSystemProfileAttrRecord;
-use crate::{FromGrpc, FromGrpcOpt};
+#[cfg(feature = "cli")]
+use crate::ToTable;
 
 /// MeasurementSystemProfile is a composition of a MeasurementSystemProfileRecord,
 /// whose attributes are essentially copied directly it, as well as
@@ -43,57 +39,13 @@ use crate::{FromGrpc, FromGrpcOpt};
 pub struct MeasurementSystemProfile {
     pub profile_id: MeasurementSystemProfileId,
     pub name: String,
-    pub ts: chrono::DateTime<Utc>,
+    pub ts: DateTime<Utc>,
     pub attrs: Vec<MeasurementSystemProfileAttrRecord>,
 }
 
 impl crate::DisplayName for MeasurementSystemProfile {
     fn display_name() -> &'static str {
         "profile"
-    }
-}
-
-impl FromGrpc<MeasurementSystemProfilePb> for MeasurementSystemProfile {}
-
-impl FromGrpcOpt<MeasurementSystemProfilePb> for MeasurementSystemProfile {}
-
-impl From<MeasurementSystemProfile> for MeasurementSystemProfilePb {
-    fn from(val: MeasurementSystemProfile) -> Self {
-        Self {
-            profile_id: Some(val.profile_id),
-            name: val.name,
-            ts: Some(val.ts.into()),
-            attrs: val.attrs.iter().map(|attr| attr.clone().into()).collect(),
-        }
-    }
-}
-
-impl TryFrom<MeasurementSystemProfilePb> for MeasurementSystemProfile {
-    type Error = super::Error;
-
-    fn try_from(msg: MeasurementSystemProfilePb) -> super::Result<Self> {
-        let attrs: super::Result<Vec<MeasurementSystemProfileAttrRecord>> = msg
-            .attrs
-            .iter()
-            .map(
-                |attr| match MeasurementSystemProfileAttrRecord::try_from(attr.clone()) {
-                    Ok(worked) => Ok(worked),
-                    Err(failed) => Err(super::Error::RpcConversion(format!(
-                        "attr conversion failed: {failed}"
-                    ))),
-                },
-            )
-            .collect();
-
-        Ok(Self {
-            profile_id: msg.profile_id.ok_or(super::Error::RpcConversion(
-                "missing profile_id".to_string(),
-            ))?,
-            name: msg.name.clone(),
-            attrs: attrs?,
-            ts: DateTime::<Utc>::try_from(msg.ts.unwrap())
-                .map_err(|e| super::Error::RpcConversion(e.to_string()))?,
-        })
     }
 }
 

--- a/crates/measured-boot/src/records.rs
+++ b/crates/measured-boot/src/records.rs
@@ -27,29 +27,18 @@
  *  what type of key is being passed around. A bunch of uuid::Uuid is meh.
  */
 
-use std::convert::Into;
 use std::error::Error;
 use std::fmt;
 use std::str::FromStr;
 
+use carbide_uuid::DbTable;
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::measured_boot::{
     MeasurementApprovedMachineId, MeasurementApprovedProfileId, MeasurementBundleId,
     MeasurementBundleValueId, MeasurementJournalId, MeasurementReportId, MeasurementReportValueId,
     MeasurementSystemProfileAttrId, MeasurementSystemProfileId, TrustedMachineId,
 };
-use carbide_uuid::{DbTable, UuidEmptyStringError};
 use chrono::{DateTime, Utc};
-#[cfg(feature = "cli")]
-use rpc::admin_cli::{ToTable, serde_just_print_summary};
-use rpc::errors::RpcDataConversionError;
-use rpc::protos::measured_boot::{
-    CandidateMachineSummaryPb, MeasurementApprovedMachineRecordPb,
-    MeasurementApprovedProfileRecordPb, MeasurementApprovedTypePb, MeasurementBundleRecordPb,
-    MeasurementBundleStatePb, MeasurementBundleValueRecordPb, MeasurementJournalRecordPb,
-    MeasurementMachineStatePb, MeasurementReportRecordPb, MeasurementReportValueRecordPb,
-    MeasurementSystemProfileAttrRecordPb, MeasurementSystemProfileRecordPb,
-};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "sqlx")]
 use sqlx::{
@@ -57,8 +46,9 @@ use sqlx::{
     {FromRow, Row},
 };
 
-use super::pcr::PcrRegisterValue;
-use crate::{DisplayName, FromGrpc, FromGrpcOpt, FromPbVec};
+use crate::DisplayName;
+#[cfg(feature = "cli")]
+use crate::{ToTable, serde_just_print_summary};
 
 /// StringToEnumError is used for taking an input string and converting
 /// it to an enum of a given type. It is leveraged by MeasurementBundleState,
@@ -94,7 +84,7 @@ pub struct MeasurementSystemProfileRecord {
     pub name: String,
 
     // ts is the timestamp the profile was created.
-    pub ts: chrono::DateTime<Utc>,
+    pub ts: DateTime<Utc>,
 }
 
 impl DbTable for MeasurementSystemProfileRecord {
@@ -106,34 +96,6 @@ impl DbTable for MeasurementSystemProfileRecord {
 impl DisplayName for MeasurementSystemProfileRecord {
     fn display_name() -> &'static str {
         "system profile record"
-    }
-}
-
-impl FromGrpc<MeasurementSystemProfileRecordPb> for MeasurementSystemProfileRecord {}
-
-impl FromPbVec<MeasurementSystemProfileRecordPb> for MeasurementSystemProfileRecord {}
-
-impl From<MeasurementSystemProfileRecord> for MeasurementSystemProfileRecordPb {
-    fn from(val: MeasurementSystemProfileRecord) -> Self {
-        Self {
-            profile_id: Some(val.profile_id),
-            name: val.name,
-            ts: Some(val.ts.into()),
-        }
-    }
-}
-
-impl TryFrom<MeasurementSystemProfileRecordPb> for MeasurementSystemProfileRecord {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(msg: MeasurementSystemProfileRecordPb) -> Result<Self, Box<dyn std::error::Error>> {
-        Ok(Self {
-            profile_id: msg
-                .profile_id
-                .ok_or(RpcDataConversionError::MissingArgument("profile_id"))?,
-            name: msg.name.clone(),
-            ts: DateTime::<Utc>::try_from(msg.ts.unwrap())?,
-        })
     }
 }
 
@@ -186,42 +148,6 @@ impl DbTable for MeasurementSystemProfileAttrRecord {
 impl DisplayName for MeasurementSystemProfileAttrRecord {
     fn display_name() -> &'static str {
         "system profile attr record"
-    }
-}
-
-impl FromGrpc<MeasurementSystemProfileAttrRecordPb> for MeasurementSystemProfileAttrRecord {}
-
-impl FromPbVec<MeasurementSystemProfileAttrRecordPb> for MeasurementSystemProfileAttrRecord {}
-
-impl From<MeasurementSystemProfileAttrRecord> for MeasurementSystemProfileAttrRecordPb {
-    fn from(val: MeasurementSystemProfileAttrRecord) -> Self {
-        Self {
-            attribute_id: Some(val.attribute_id),
-            profile_id: Some(val.profile_id),
-            key: val.key,
-            value: val.value,
-            ts: Some(val.ts.into()),
-        }
-    }
-}
-
-impl TryFrom<MeasurementSystemProfileAttrRecordPb> for MeasurementSystemProfileAttrRecord {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(
-        msg: MeasurementSystemProfileAttrRecordPb,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        Ok(Self {
-            attribute_id: msg
-                .attribute_id
-                .ok_or(RpcDataConversionError::MissingArgument("attribute_id"))?,
-            profile_id: msg
-                .profile_id
-                .ok_or(RpcDataConversionError::MissingArgument("profile_id"))?,
-            key: msg.key.clone(),
-            value: msg.value.clone(),
-            ts: DateTime::<Utc>::try_from(msg.ts.unwrap())?,
-        })
     }
 }
 
@@ -293,30 +219,6 @@ impl fmt::Display for MeasurementBundleState {
     }
 }
 
-impl From<MeasurementBundleState> for MeasurementBundleStatePb {
-    fn from(val: MeasurementBundleState) -> Self {
-        match val {
-            MeasurementBundleState::Pending => Self::Pending,
-            MeasurementBundleState::Active => Self::Active,
-            MeasurementBundleState::Obsolete => Self::Obsolete,
-            MeasurementBundleState::Retired => Self::Retired,
-            MeasurementBundleState::Revoked => Self::Revoked,
-        }
-    }
-}
-
-impl From<MeasurementBundleStatePb> for MeasurementBundleState {
-    fn from(msg: MeasurementBundleStatePb) -> Self {
-        match msg {
-            MeasurementBundleStatePb::Pending => Self::Pending,
-            MeasurementBundleStatePb::Active => Self::Active,
-            MeasurementBundleStatePb::Obsolete => Self::Obsolete,
-            MeasurementBundleStatePb::Retired => Self::Retired,
-            MeasurementBundleStatePb::Revoked => Self::Revoked,
-        }
-    }
-}
-
 /// MeasurementBundleStateRecord exists so we can do an sqlx::query_as and
 /// *just* select the state (and bind it to a struct). It doesn't really need
 /// to be much other than this for now.
@@ -371,43 +273,6 @@ impl DisplayName for MeasurementBundleRecord {
     }
 }
 
-impl FromGrpc<MeasurementBundleRecordPb> for MeasurementBundleRecord {}
-
-impl FromPbVec<MeasurementBundleRecordPb> for MeasurementBundleRecord {}
-
-impl From<MeasurementBundleRecord> for MeasurementBundleRecordPb {
-    fn from(val: MeasurementBundleRecord) -> Self {
-        let pb_state: MeasurementBundleStatePb = val.state.into();
-        Self {
-            bundle_id: Some(val.bundle_id),
-            name: val.name,
-            profile_id: Some(val.profile_id),
-            state: pb_state.into(),
-            ts: Some(val.ts.into()),
-        }
-    }
-}
-
-impl TryFrom<MeasurementBundleRecordPb> for MeasurementBundleRecord {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(msg: MeasurementBundleRecordPb) -> Result<Self, Box<dyn std::error::Error>> {
-        let state = msg.state();
-
-        Ok(Self {
-            bundle_id: msg
-                .bundle_id
-                .ok_or(RpcDataConversionError::MissingArgument("bundle_id"))?,
-            profile_id: msg
-                .profile_id
-                .ok_or(RpcDataConversionError::MissingArgument("profile_id"))?,
-            name: msg.name.clone(),
-            state: MeasurementBundleState::from(state),
-            ts: DateTime::<Utc>::try_from(msg.ts.unwrap())?,
-        })
-    }
-}
-
 /// MeasurementBundleValueRecord defines a single row
 /// from the measurement_bundles_values table.
 ///
@@ -457,49 +322,6 @@ impl DisplayName for MeasurementBundleValueRecord {
     }
 }
 
-impl FromGrpc<MeasurementBundleValueRecordPb> for MeasurementBundleValueRecord {}
-
-impl FromPbVec<MeasurementBundleValueRecordPb> for MeasurementBundleValueRecord {}
-
-impl From<MeasurementBundleValueRecord> for PcrRegisterValue {
-    fn from(val: MeasurementBundleValueRecord) -> Self {
-        PcrRegisterValue {
-            pcr_register: val.pcr_register,
-            sha_any: val.sha_any,
-        }
-    }
-}
-
-impl From<MeasurementBundleValueRecord> for MeasurementBundleValueRecordPb {
-    fn from(val: MeasurementBundleValueRecord) -> Self {
-        Self {
-            value_id: Some(val.value_id),
-            bundle_id: Some(val.bundle_id),
-            pcr_register: val.pcr_register as i32,
-            sha_any: val.sha_any,
-            ts: Some(val.ts.into()),
-        }
-    }
-}
-
-impl TryFrom<MeasurementBundleValueRecordPb> for MeasurementBundleValueRecord {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(msg: MeasurementBundleValueRecordPb) -> Result<Self, Box<dyn std::error::Error>> {
-        Ok(Self {
-            value_id: msg
-                .value_id
-                .ok_or(RpcDataConversionError::MissingArgument("value_id"))?,
-            bundle_id: msg
-                .bundle_id
-                .ok_or(RpcDataConversionError::MissingArgument("bundle_id"))?,
-            pcr_register: msg.pcr_register as i16,
-            sha_any: msg.sha_any.clone(),
-            ts: DateTime::<Utc>::try_from(msg.ts.unwrap())?,
-        })
-    }
-}
-
 /// MeasurementReportRecord defines a single row from
 /// the measurement_reports table.
 ///
@@ -527,36 +349,6 @@ impl DbTable for MeasurementReportRecord {
 impl DisplayName for MeasurementReportRecord {
     fn display_name() -> &'static str {
         "report record"
-    }
-}
-
-impl FromGrpc<MeasurementReportRecordPb> for MeasurementReportRecord {}
-
-impl From<MeasurementReportRecord> for MeasurementReportRecordPb {
-    fn from(val: MeasurementReportRecord) -> Self {
-        Self {
-            report_id: Some(val.report_id),
-            machine_id: val.machine_id.to_string(),
-            ts: Some(val.ts.into()),
-        }
-    }
-}
-
-impl TryFrom<MeasurementReportRecordPb> for MeasurementReportRecord {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(msg: MeasurementReportRecordPb) -> Result<Self, Box<dyn std::error::Error>> {
-        if msg.machine_id.is_empty() {
-            return Err(UuidEmptyStringError {}.into());
-        };
-
-        Ok(Self {
-            report_id: msg
-                .report_id
-                .ok_or(RpcDataConversionError::MissingArgument("report_id"))?,
-            machine_id: MachineId::from_str(&msg.machine_id)?,
-            ts: DateTime::<Utc>::try_from(msg.ts.unwrap())?,
-        })
     }
 }
 
@@ -608,47 +400,6 @@ impl DbTable for MeasurementReportValueRecord {
 impl DisplayName for MeasurementReportValueRecord {
     fn display_name() -> &'static str {
         "report value record"
-    }
-}
-
-impl FromGrpc<MeasurementReportValueRecordPb> for MeasurementReportValueRecord {}
-
-impl From<MeasurementReportValueRecord> for PcrRegisterValue {
-    fn from(val: MeasurementReportValueRecord) -> Self {
-        Self {
-            pcr_register: val.pcr_register,
-            sha_any: val.sha_any,
-        }
-    }
-}
-
-impl From<MeasurementReportValueRecord> for MeasurementReportValueRecordPb {
-    fn from(val: MeasurementReportValueRecord) -> Self {
-        Self {
-            value_id: Some(val.value_id),
-            report_id: Some(val.report_id),
-            pcr_register: val.pcr_register as i32,
-            sha_any: val.sha_any,
-            ts: Some(val.ts.into()),
-        }
-    }
-}
-
-impl TryFrom<MeasurementReportValueRecordPb> for MeasurementReportValueRecord {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(msg: MeasurementReportValueRecordPb) -> Result<Self, Box<dyn std::error::Error>> {
-        Ok(Self {
-            value_id: msg
-                .value_id
-                .ok_or(RpcDataConversionError::MissingArgument("value_id"))?,
-            report_id: msg
-                .report_id
-                .ok_or(RpcDataConversionError::MissingArgument("report_id"))?,
-            pcr_register: msg.pcr_register as i16,
-            sha_any: msg.sha_any.clone(),
-            ts: DateTime::<Utc>::try_from(msg.ts.unwrap())?,
-        })
     }
 }
 
@@ -714,49 +465,6 @@ impl DisplayName for MeasurementJournalRecord {
     }
 }
 
-impl FromGrpc<MeasurementJournalRecordPb> for MeasurementJournalRecord {}
-
-impl From<MeasurementJournalRecord> for MeasurementJournalRecordPb {
-    fn from(val: MeasurementJournalRecord) -> Self {
-        let pb_state: MeasurementMachineStatePb = val.state.into();
-
-        Self {
-            journal_id: Some(val.journal_id),
-            machine_id: val.machine_id.to_string(),
-            report_id: Some(val.report_id),
-            profile_id: val.profile_id,
-            bundle_id: val.bundle_id,
-            state: pb_state.into(),
-            ts: Some(val.ts.into()),
-        }
-    }
-}
-
-impl TryFrom<MeasurementJournalRecordPb> for MeasurementJournalRecord {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(msg: MeasurementJournalRecordPb) -> Result<Self, Box<dyn std::error::Error>> {
-        if msg.machine_id.is_empty() {
-            return Err(UuidEmptyStringError {}.into());
-        }
-        let state = msg.state();
-
-        Ok(Self {
-            journal_id: msg
-                .journal_id
-                .ok_or(RpcDataConversionError::MissingArgument("journal_id"))?,
-            machine_id: MachineId::from_str(&msg.machine_id)?,
-            report_id: msg
-                .report_id
-                .ok_or(RpcDataConversionError::MissingArgument("report_id"))?,
-            profile_id: msg.profile_id,
-            bundle_id: msg.bundle_id,
-            state: MeasurementMachineState::from(state),
-            ts: DateTime::<Utc>::try_from(msg.ts.unwrap())?,
-        })
-    }
-}
-
 /// MeasurementMachineState is an enum in the database, and
 /// is used for tracking the state of a machine.
 ///
@@ -795,28 +503,6 @@ impl fmt::Display for MeasurementMachineState {
     }
 }
 
-impl From<MeasurementMachineState> for MeasurementMachineStatePb {
-    fn from(val: MeasurementMachineState) -> Self {
-        match val {
-            MeasurementMachineState::Discovered => Self::Discovered,
-            MeasurementMachineState::PendingBundle => Self::PendingBundle,
-            MeasurementMachineState::Measured => Self::Measured,
-            MeasurementMachineState::MeasuringFailed => Self::MeasuringFailed,
-        }
-    }
-}
-
-impl From<MeasurementMachineStatePb> for MeasurementMachineState {
-    fn from(msg: MeasurementMachineStatePb) -> Self {
-        match msg {
-            MeasurementMachineStatePb::Discovered => Self::Discovered,
-            MeasurementMachineStatePb::PendingBundle => Self::PendingBundle,
-            MeasurementMachineStatePb::Measured => Self::Measured,
-            MeasurementMachineStatePb::MeasuringFailed => Self::MeasuringFailed,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize)]
 pub struct CandidateMachineSummary {
     // machine_id is the ID of the machine, e.g. fm100hxxxxx.
@@ -829,32 +515,6 @@ pub struct CandidateMachineSummary {
 impl DisplayName for CandidateMachineSummary {
     fn display_name() -> &'static str {
         "candidate machine record"
-    }
-}
-
-impl FromGrpc<CandidateMachineSummaryPb> for CandidateMachineSummary {}
-
-impl From<CandidateMachineSummary> for CandidateMachineSummaryPb {
-    fn from(val: CandidateMachineSummary) -> Self {
-        Self {
-            machine_id: val.machine_id.to_string(),
-            ts: Some(val.ts.into()),
-        }
-    }
-}
-
-impl TryFrom<CandidateMachineSummaryPb> for CandidateMachineSummary {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(msg: CandidateMachineSummaryPb) -> Result<Self, Box<dyn std::error::Error>> {
-        if msg.machine_id.is_empty() {
-            return Err(UuidEmptyStringError {}.into());
-        }
-
-        Ok(Self {
-            machine_id: MachineId::from_str(&msg.machine_id)?,
-            ts: DateTime::<Utc>::try_from(msg.ts.unwrap())?,
-        })
     }
 }
 
@@ -900,24 +560,6 @@ impl FromStr for MeasurementApprovedType {
 impl fmt::Display for MeasurementApprovedType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{self:?}")
-    }
-}
-
-impl From<MeasurementApprovedType> for MeasurementApprovedTypePb {
-    fn from(val: MeasurementApprovedType) -> Self {
-        match val {
-            MeasurementApprovedType::Oneshot => Self::Oneshot,
-            MeasurementApprovedType::Persist => Self::Persist,
-        }
-    }
-}
-
-impl From<MeasurementApprovedTypePb> for MeasurementApprovedType {
-    fn from(val: MeasurementApprovedTypePb) -> Self {
-        match val {
-            MeasurementApprovedTypePb::Oneshot => Self::Oneshot,
-            MeasurementApprovedTypePb::Persist => Self::Persist,
-        }
     }
 }
 
@@ -976,58 +618,9 @@ impl DisplayName for MeasurementApprovedMachineRecord {
     }
 }
 
-impl FromGrpc<MeasurementApprovedMachineRecordPb> for MeasurementApprovedMachineRecord {}
-
-impl FromGrpcOpt<MeasurementApprovedMachineRecordPb> for MeasurementApprovedMachineRecord {}
-
 impl DbTable for MeasurementApprovedMachineRecord {
     fn db_table_name() -> &'static str {
         "measurement_approved_machines"
-    }
-}
-
-impl From<MeasurementApprovedMachineRecord> for MeasurementApprovedMachineRecordPb {
-    fn from(val: MeasurementApprovedMachineRecord) -> Self {
-        let approval_type: MeasurementApprovedTypePb = val.approval_type.into();
-
-        Self {
-            approval_id: Some(val.approval_id),
-            machine_id: val.machine_id.to_string(),
-            approval_type: approval_type.into(),
-            pcr_registers: val.pcr_registers.unwrap_or("".to_string()),
-            comments: val.comments.unwrap_or("".to_string()),
-            ts: Some(val.ts.into()),
-        }
-    }
-}
-
-impl TryFrom<MeasurementApprovedMachineRecordPb> for MeasurementApprovedMachineRecord {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(
-        msg: MeasurementApprovedMachineRecordPb,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        if msg.machine_id.is_empty() {
-            return Err(UuidEmptyStringError {}.into());
-        }
-        let approval_type = msg.approval_type();
-
-        Ok(Self {
-            approval_id: msg
-                .approval_id
-                .ok_or(RpcDataConversionError::MissingArgument("approval_id"))?,
-            machine_id: TrustedMachineId::from_str(&msg.machine_id)?,
-            approval_type: MeasurementApprovedType::from(approval_type),
-            pcr_registers: match !msg.pcr_registers.is_empty() {
-                true => Some(msg.pcr_registers.clone()),
-                false => None,
-            },
-            comments: match !msg.comments.is_empty() {
-                true => Some(msg.comments.clone()),
-                false => None,
-            },
-            ts: DateTime::<Utc>::try_from(msg.ts.unwrap())?,
-        })
     }
 }
 
@@ -1084,62 +677,15 @@ pub struct MeasurementApprovedProfileRecord {
     pub ts: chrono::DateTime<Utc>,
 }
 
-impl DisplayName for MeasurementApprovedProfileRecord {
-    fn display_name() -> &'static str {
-        "record"
-    }
-}
-
-impl FromGrpc<MeasurementApprovedProfileRecordPb> for MeasurementApprovedProfileRecord {}
-
-impl FromGrpcOpt<MeasurementApprovedProfileRecordPb> for MeasurementApprovedProfileRecord {}
-
 impl DbTable for MeasurementApprovedProfileRecord {
     fn db_table_name() -> &'static str {
         "measurement_approved_profiles"
     }
 }
 
-impl From<MeasurementApprovedProfileRecord> for MeasurementApprovedProfileRecordPb {
-    fn from(val: MeasurementApprovedProfileRecord) -> Self {
-        let approval_type: MeasurementApprovedTypePb = val.approval_type.into();
-
-        Self {
-            approval_id: Some(val.approval_id),
-            profile_id: Some(val.profile_id),
-            approval_type: approval_type.into(),
-            pcr_registers: val.pcr_registers.unwrap_or("".to_string()),
-            comments: val.comments.unwrap_or("".to_string()),
-            ts: Some(val.ts.into()),
-        }
-    }
-}
-
-impl TryFrom<MeasurementApprovedProfileRecordPb> for MeasurementApprovedProfileRecord {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(
-        msg: MeasurementApprovedProfileRecordPb,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        let approval_type = msg.approval_type();
-        Ok(Self {
-            approval_id: msg
-                .approval_id
-                .ok_or(RpcDataConversionError::MissingArgument("approval_id"))?,
-            profile_id: msg
-                .profile_id
-                .ok_or(RpcDataConversionError::MissingArgument("profile_id"))?,
-            approval_type: MeasurementApprovedType::from(approval_type),
-            pcr_registers: match !msg.pcr_registers.is_empty() {
-                true => Some(msg.pcr_registers.clone()),
-                false => None,
-            },
-            comments: match !msg.comments.is_empty() {
-                true => Some(msg.comments.clone()),
-                false => None,
-            },
-            ts: DateTime::<Utc>::try_from(msg.ts.unwrap())?,
-        })
+impl DisplayName for MeasurementApprovedProfileRecord {
+    fn display_name() -> &'static str {
+        "record"
     }
 }
 

--- a/crates/measured-boot/src/report.rs
+++ b/crates/measured-boot/src/report.rs
@@ -20,21 +20,15 @@
  *  tables in the database, leveraging the report-specific record types.
  */
 
-use std::str::FromStr;
-
-use carbide_uuid::UuidEmptyStringError;
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::measured_boot::MeasurementReportId;
 use chrono::Utc;
-#[cfg(feature = "cli")]
-use rpc::admin_cli::ToTable;
-use rpc::errors::RpcDataConversionError;
-use rpc::protos::measured_boot::MeasurementReportPb;
 use serde::Serialize;
 
 use super::pcr::PcrRegisterValue;
 use super::records::MeasurementReportValueRecord;
-use crate::{FromGrpc, FromGrpcOpt};
+#[cfg(feature = "cli")]
+use crate::ToTable;
 
 /// MeasurementReport is a composition of a MeasurementReportRecord,
 /// whose attributes are essentially copied directly it, as well as
@@ -58,56 +52,6 @@ impl MeasurementReport {
 impl crate::DisplayName for MeasurementReport {
     fn display_name() -> &'static str {
         "report"
-    }
-}
-
-impl FromGrpc<MeasurementReportPb> for MeasurementReport {}
-
-impl FromGrpcOpt<MeasurementReportPb> for MeasurementReport {}
-
-impl From<MeasurementReport> for MeasurementReportPb {
-    fn from(val: MeasurementReport) -> Self {
-        Self {
-            report_id: Some(val.report_id),
-            machine_id: val.machine_id.to_string(),
-            values: val
-                .values
-                .iter()
-                .map(|value| value.clone().into())
-                .collect(),
-            ts: Some(val.ts.into()),
-        }
-    }
-}
-
-impl TryFrom<MeasurementReportPb> for MeasurementReport {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(msg: MeasurementReportPb) -> Result<Self, Box<dyn std::error::Error>> {
-        if msg.machine_id.is_empty() {
-            return Err(UuidEmptyStringError {}.into());
-        }
-        let values: super::Result<Vec<MeasurementReportValueRecord>> = msg
-            .values
-            .iter()
-            .map(
-                |value| match MeasurementReportValueRecord::try_from(value.clone()) {
-                    Ok(worked) => Ok(worked),
-                    Err(failed) => Err(super::Error::RpcConversion(format!(
-                        "attr conversion failed: {failed}"
-                    ))),
-                },
-            )
-            .collect();
-
-        Ok(Self {
-            report_id: msg
-                .report_id
-                .ok_or(RpcDataConversionError::MissingArgument("report_id"))?,
-            machine_id: MachineId::from_str(&msg.machine_id)?,
-            values: values?,
-            ts: chrono::DateTime::<chrono::Utc>::try_from(msg.ts.unwrap())?,
-        })
     }
 }
 

--- a/crates/measured-boot/src/site.rs
+++ b/crates/measured-boot/src/site.rs
@@ -22,19 +22,11 @@
  * This also provides code for importing/exporting (and working with) SiteModels.
  */
 
-use std::convert::{From, Into};
-use std::str::FromStr;
 use std::vec::Vec;
 
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::measured_boot::MeasurementBundleId;
 use chrono::Utc;
-#[cfg(feature = "cli")]
-use rpc::admin_cli::ToTable;
-use rpc::protos::measured_boot::{
-    ImportSiteMeasurementsResponse, ListAttestationSummaryResponse, MachineAttestationSummaryPb,
-    SiteModelPb,
-};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "sqlx")]
 use sqlx::FromRow;
@@ -43,19 +35,12 @@ use super::records::{
     MeasurementBundleRecord, MeasurementBundleValueRecord, MeasurementSystemProfileAttrRecord,
     MeasurementSystemProfileRecord,
 };
-use crate::{FromGrpc, FromGrpcOpt, FromPbVec};
+#[cfg(feature = "cli")]
+use crate::ToTable;
 
 #[derive(Serialize)]
 pub struct ImportResult {
     pub status: String,
-}
-
-impl From<&ImportSiteMeasurementsResponse> for ImportResult {
-    fn from(msg: &ImportSiteMeasurementsResponse) -> Self {
-        Self {
-            status: msg.result().as_str_name().to_string(),
-        }
-    }
 }
 
 #[cfg(feature = "cli")]
@@ -90,64 +75,6 @@ impl crate::DisplayName for SiteModel {
     }
 }
 
-impl FromGrpc<SiteModelPb> for SiteModel {}
-
-impl FromGrpcOpt<SiteModelPb> for SiteModel {}
-
-impl TryFrom<SiteModelPb> for SiteModel {
-    type Error = super::Error;
-
-    fn try_from(model: SiteModelPb) -> Result<Self, Self::Error> {
-        Ok(Self {
-            measurement_system_profiles: MeasurementSystemProfileRecord::from_pb_vec(
-                &model.measurement_system_profiles,
-            )?,
-            measurement_system_profiles_attrs: MeasurementSystemProfileAttrRecord::from_pb_vec(
-                &model.measurement_system_profiles_attrs,
-            )?,
-            measurement_bundles: MeasurementBundleRecord::from_pb_vec(&model.measurement_bundles)?,
-            measurement_bundles_values: MeasurementBundleValueRecord::from_pb_vec(
-                &model.measurement_bundles_values,
-            )?,
-        })
-    }
-}
-
-impl From<SiteModel> for SiteModelPb {
-    fn from(model: SiteModel) -> Self {
-        let measurement_system_profiles = model
-            .measurement_system_profiles
-            .into_iter()
-            .map(|record| record.into())
-            .collect();
-
-        let measurement_system_profiles_attrs = model
-            .measurement_system_profiles_attrs
-            .into_iter()
-            .map(|record| record.into())
-            .collect();
-
-        let measurement_bundles = model
-            .measurement_bundles
-            .into_iter()
-            .map(|record| record.into())
-            .collect();
-
-        let measurement_bundles_values = model
-            .measurement_bundles_values
-            .into_iter()
-            .map(|record| record.into())
-            .collect();
-
-        Self {
-            measurement_system_profiles,
-            measurement_system_profiles_attrs,
-            measurement_bundles,
-            measurement_bundles_values,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "sqlx", derive(FromRow))]
 pub struct MachineAttestationSummary {
@@ -159,50 +86,3 @@ pub struct MachineAttestationSummary {
 }
 
 pub struct MachineAttestationSummaryList(pub Vec<MachineAttestationSummary>);
-
-// we need methods to convert this to gRPC messages and back
-impl From<MachineAttestationSummaryList> for ListAttestationSummaryResponse {
-    fn from(val: MachineAttestationSummaryList) -> Self {
-        Self {
-            attestation_outcomes: val
-                .0
-                .into_iter()
-                .map(|e| MachineAttestationSummaryPb {
-                    machine_id: e.machine_id.to_string(),
-                    bundle_id: e.bundle_id,
-                    profile_name: e.profile_name,
-                    ts: Some(e.ts.into()),
-                })
-                .collect(),
-        }
-    }
-}
-
-impl TryFrom<ListAttestationSummaryResponse> for MachineAttestationSummaryList {
-    type Error = super::Error;
-    fn try_from(val: ListAttestationSummaryResponse) -> Result<Self, Self::Error> {
-        let mut attestation_summary_list = Vec::<MachineAttestationSummary>::new();
-
-        for pb in val.attestation_outcomes {
-            attestation_summary_list.push(MachineAttestationSummary {
-                machine_id: MachineId::from_str(&pb.machine_id).map_err(|err| {
-                    super::Error::RpcConversion(format!(
-                        "Could not deserialize ListAttestationSummaryResponse(machine_id): {err}"
-                    ))
-                })?,
-                bundle_id: pb.bundle_id,
-                profile_name: pb.profile_name,
-                ts: match pb.ts {
-                    Some(ts) => chrono::DateTime::<Utc>::try_from(ts).map_err(|err| {
-                        super::Error::RpcConversion(format!(
-                            "Could not deserialize ListAttestationSummaryResponse(timestamp): {err}"
-                        ))
-                    })?,
-                    None => chrono::DateTime::<Utc>::default(),
-                },
-            });
-        }
-
-        Ok(Self(attestation_summary_list))
-    }
-}

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -35,6 +35,7 @@ carbide-http-connector = { path = "../http-connector" }
 carbide-tls = { path = "../tls" }
 carbide-health-report = { path = "../health-report" }
 carbide-libmlx-model = { path = "../libmlx-model" }
+carbide-measured-boot = { path = "../measured-boot", default-features = false }
 carbide-secrets = { path = "../secrets" }
 carbide-network = { path = "../network" }
 carbide-utils = { path = "../utils" }

--- a/crates/rpc/src/admin_cli.rs
+++ b/crates/rpc/src/admin_cli.rs
@@ -23,38 +23,7 @@
 
 */
 
-use std::sync::atomic::{AtomicBool, Ordering};
-
 pub use output::OutputFormat;
-
-/// SUMMARY is a global variable that is being used by a few structs which
-/// implement serde::Serialize with skip_serialization_if.
-///
-/// I had wanted the ability to have summarized or extended versions of
-/// serialized output, and decided I could use skip_serialization_if along with
-/// a function that looks at a global variable.
-///
-/// You set --extended on the CLI, which controls whether or not to summarized
-/// (default is summarized).
-static SUMMARY: AtomicBool = AtomicBool::new(false);
-
-pub fn serde_just_print_summary<T>(_: &T) -> bool {
-    SUMMARY.load(Ordering::SeqCst)
-}
-
-pub fn just_print_summary() -> bool {
-    SUMMARY.load(Ordering::SeqCst)
-}
-
-pub fn set_summary(val: bool) {
-    SUMMARY.store(val, Ordering::SeqCst);
-}
-
-/// ToTable is a trait which is used alongside the cli_output command
-/// and being able to prettytable print results.
-pub trait ToTable {
-    fn into_table(self) -> eyre::Result<String>;
-}
 
 pub mod output {
     use std::fmt;

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -63,6 +63,7 @@ pub use crate::protos::{fmds, health, site_explorer};
 pub mod errors;
 pub mod forge_tls_client;
 pub mod libmlx;
+pub mod measured_boot;
 pub mod network;
 pub mod protos;
 pub mod secrets;

--- a/crates/rpc/src/measured_boot/bundle.rs
+++ b/crates/rpc/src/measured_boot/bundle.rs
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ *  Code for working the measurement_bundles and measurement_bundles_values
+ *  tables in the database, leveraging the bundle-specific record types.
+ */
+
+use measured_boot::bundle::MeasurementBundle;
+use measured_boot::records::{MeasurementBundleState, MeasurementBundleValueRecord};
+
+use crate::errors::RpcDataConversionError;
+use crate::measured_boot::{FromGrpc, FromGrpcOpt, conv_timestamp_opt};
+use crate::protos::measured_boot::{MeasurementBundlePb, MeasurementBundleStatePb};
+
+impl From<MeasurementBundle> for MeasurementBundlePb {
+    fn from(val: MeasurementBundle) -> Self {
+        let pb_state: MeasurementBundleStatePb = val.state.into();
+        Self {
+            bundle_id: Some(val.bundle_id),
+            profile_id: Some(val.profile_id),
+            name: val.name,
+            state: pb_state.into(),
+            values: val
+                .values
+                .iter()
+                .map(|value| value.clone().into())
+                .collect(),
+            ts: Some(val.ts.into()),
+        }
+    }
+}
+
+impl FromGrpc<MeasurementBundlePb> for MeasurementBundle {}
+
+impl FromGrpcOpt<MeasurementBundlePb> for MeasurementBundle {}
+
+impl TryFrom<MeasurementBundlePb> for MeasurementBundle {
+    type Error = RpcDataConversionError;
+
+    fn try_from(msg: MeasurementBundlePb) -> Result<Self, Self::Error> {
+        let state = msg.state();
+        let values = msg
+            .values
+            .iter()
+            .map(
+                |attr| match MeasurementBundleValueRecord::try_from(attr.clone()) {
+                    Ok(worked) => Ok(worked),
+                    Err(failed) => Err(RpcDataConversionError::InvalidArgument(format!(
+                        "attr conversion failed: {failed}"
+                    ))),
+                },
+            )
+            .collect::<Result<Vec<_>, _>>();
+
+        Ok(Self {
+            bundle_id: msg
+                .bundle_id
+                .ok_or(RpcDataConversionError::MissingArgument("bundle_id"))?,
+            profile_id: msg
+                .profile_id
+                .ok_or(RpcDataConversionError::MissingArgument("profile_id"))?,
+            name: msg.name.clone(),
+            state: MeasurementBundleState::from(state),
+            values: values?,
+            ts: conv_timestamp_opt(msg.ts, "ts")?,
+        })
+    }
+}

--- a/crates/rpc/src/measured_boot/journal.rs
+++ b/crates/rpc/src/measured_boot/journal.rs
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ *  Code for working the measuremment_journal and measurement_journal_values
+ *  tables in the database, leveraging the journal-specific record types.
+ */
+
+use measured_boot::journal::MeasurementJournal;
+use measured_boot::records::MeasurementMachineState;
+
+use crate::errors::RpcDataConversionError;
+use crate::measured_boot::{FromGrpc, FromGrpcOpt, conv_machine_id, conv_timestamp_opt};
+use crate::protos::measured_boot::{MeasurementJournalPb, MeasurementMachineStatePb};
+
+impl FromGrpc<MeasurementJournalPb> for MeasurementJournal {}
+
+impl FromGrpcOpt<MeasurementJournalPb> for MeasurementJournal {}
+
+impl From<MeasurementJournal> for MeasurementJournalPb {
+    fn from(val: MeasurementJournal) -> Self {
+        let pb_state: MeasurementMachineStatePb = val.state.into();
+        Self {
+            journal_id: Some(val.journal_id),
+            machine_id: val.machine_id.to_string(),
+            report_id: Some(val.report_id),
+            profile_id: val.profile_id,
+            bundle_id: val.bundle_id,
+            state: pb_state.into(),
+            ts: Some(val.ts.into()),
+        }
+    }
+}
+
+impl TryFrom<MeasurementJournalPb> for MeasurementJournal {
+    type Error = RpcDataConversionError;
+
+    fn try_from(msg: MeasurementJournalPb) -> Result<Self, Self::Error> {
+        let state = msg.state();
+
+        Ok(Self {
+            journal_id: msg
+                .journal_id
+                .ok_or(RpcDataConversionError::MissingArgument("journal_id"))?,
+            machine_id: conv_machine_id(&msg.machine_id)?,
+            report_id: msg
+                .report_id
+                .ok_or(RpcDataConversionError::MissingArgument("report_id"))?,
+            profile_id: msg.profile_id,
+            bundle_id: msg.bundle_id,
+            state: MeasurementMachineState::from(state),
+            ts: conv_timestamp_opt(msg.ts, "ts")?,
+        })
+    }
+}

--- a/crates/rpc/src/measured_boot/machine.rs
+++ b/crates/rpc/src/measured_boot/machine.rs
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ *  Code for working the machine_topologies table in the
+ *  database to match candidate machines to profiles and bundles.
+ */
+
+use measured_boot::journal::MeasurementJournal;
+use measured_boot::machine::CandidateMachine;
+use measured_boot::records::MeasurementMachineState;
+
+use crate::errors::RpcDataConversionError;
+use crate::measured_boot::{FromGrpc, FromGrpcOpt, conv_machine_id, conv_timestamp_opt};
+use crate::protos::measured_boot::{CandidateMachinePb, MeasurementMachineStatePb};
+
+impl FromGrpc<CandidateMachinePb> for CandidateMachine {}
+
+impl FromGrpcOpt<CandidateMachinePb> for CandidateMachine {}
+
+impl From<CandidateMachine> for CandidateMachinePb {
+    fn from(val: CandidateMachine) -> Self {
+        let pb_state: MeasurementMachineStatePb = val.state.into();
+        Self {
+            machine_id: val.machine_id.to_string(),
+            state: pb_state.into(),
+            journal: val.journal.map(|journal| journal.into()),
+            attrs: val.attrs,
+            created_ts: Some(val.created_ts.into()),
+            updated_ts: Some(val.updated_ts.into()),
+        }
+    }
+}
+
+impl TryFrom<CandidateMachinePb> for CandidateMachine {
+    type Error = RpcDataConversionError;
+
+    fn try_from(msg: CandidateMachinePb) -> Result<Self, Self::Error> {
+        let state = msg.state();
+
+        Ok(Self {
+            machine_id: conv_machine_id(&msg.machine_id)?,
+            state: MeasurementMachineState::from(state),
+            journal: match msg.journal {
+                Some(journal_pb) => Some(MeasurementJournal::try_from(journal_pb)?),
+                None => None,
+            },
+            attrs: msg.attrs,
+            created_ts: conv_timestamp_opt(msg.created_ts, "created_ts")?,
+            updated_ts: conv_timestamp_opt(msg.updated_ts, "updated_ts")?,
+        })
+    }
+}

--- a/crates/rpc/src/measured_boot/mod.rs
+++ b/crates/rpc/src/measured_boot/mod.rs
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::str::FromStr;
+
+use carbide_uuid::machine::MachineId;
+use chrono::{DateTime, Utc};
+use measured_boot::DisplayName;
+
+use crate::errors::RpcDataConversionError;
+
+pub mod bundle;
+pub mod journal;
+pub mod machine;
+pub mod pcr;
+pub mod profile;
+pub mod records;
+pub mod report;
+pub mod site;
+
+pub trait FromGrpc<M>: TryFrom<M, Error = RpcDataConversionError> + DisplayName {
+    fn from_grpc(msg: M) -> Result<Self, RpcDataConversionError> {
+        Self::try_from(msg).map_err(|e| {
+            RpcDataConversionError::InvalidArgument(format!(
+                "bad message: {}: {e}",
+                Self::display_name()
+            ))
+        })
+    }
+}
+
+pub trait FromGrpcOpt<M>: FromGrpc<M> {
+    fn from_grpc_opt(msg: Option<M>) -> Result<Self, RpcDataConversionError> {
+        msg.ok_or_else(|| {
+            RpcDataConversionError::InvalidArgument(format!(
+                "{} is unexpectedly empty",
+                Self::display_name()
+            ))
+        })
+        .and_then(Self::from_grpc)
+    }
+}
+
+pub trait FromPbVec<M: Clone>: FromGrpc<M> {
+    fn from_pb_vec(pbs: &[M]) -> Result<Vec<Self>, RpcDataConversionError> {
+        pbs.iter()
+            .map(|record| Self::from_grpc(record.clone()))
+            .collect()
+    }
+}
+
+fn conv_timestamp_opt(
+    ts: Option<crate::Timestamp>,
+    name: &'static str,
+) -> Result<DateTime<Utc>, RpcDataConversionError> {
+    ts.ok_or(RpcDataConversionError::MissingArgument(name))?
+        .try_into()
+        .map_err(|err| RpcDataConversionError::InvalidArgument(format!("timestamp: {err}")))
+}
+
+fn conv_machine_id(machine_id: &str) -> Result<MachineId, RpcDataConversionError> {
+    MachineId::from_str(machine_id)
+        .map_err(|_| RpcDataConversionError::InvalidMachineId(machine_id.into()))
+}

--- a/crates/rpc/src/measured_boot/pcr.rs
+++ b/crates/rpc/src/measured_boot/pcr.rs
@@ -15,21 +15,31 @@
  * limitations under the License.
  */
 
-//!
-//! Carbide API module specific to measured boot/machine attestation.
+/*!
+ *  gRPC conversions between `PcrRegisterValue` and its protobuf
+ *  representation `PcrRegisterValuePb`.
+ */
 
-pub mod metrics_collector;
-pub mod rpc;
+use std::convert::From;
 
-#[cfg(test)]
-pub mod tests;
+use measured_boot::pcr::PcrRegisterValue;
 
-// So far this helper is only used by measured boot functions. Similar
-// function exist in model: try_convert_vec. Maybe at some point of
-// time we need to unify all these conversions in helpers library.
-pub fn convert_vec<T, R>(source: Vec<T>) -> Vec<R>
-where
-    R: From<T>,
-{
-    source.into_iter().map(R::from).collect()
+use crate::protos::measured_boot::PcrRegisterValuePb;
+
+impl From<PcrRegisterValue> for PcrRegisterValuePb {
+    fn from(val: PcrRegisterValue) -> Self {
+        Self {
+            pcr_register: val.pcr_register as i32,
+            sha_any: val.sha_any,
+        }
+    }
+}
+
+impl From<PcrRegisterValuePb> for PcrRegisterValue {
+    fn from(msg: PcrRegisterValuePb) -> Self {
+        Self {
+            pcr_register: msg.pcr_register as i16,
+            sha_any: msg.sha_any,
+        }
+    }
 }

--- a/crates/rpc/src/measured_boot/profile.rs
+++ b/crates/rpc/src/measured_boot/profile.rs
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ *  Code for working the measurement_system_profiles and measurement_system_profiles_attrs
+ *  tables in the database, leveraging the profile-specific record types.
+ */
+
+use std::convert::{Into, TryFrom};
+
+use measured_boot::profile::MeasurementSystemProfile;
+use measured_boot::records::MeasurementSystemProfileAttrRecord;
+
+use crate::errors::RpcDataConversionError;
+use crate::measured_boot::{FromGrpc, FromGrpcOpt, conv_timestamp_opt};
+use crate::protos::measured_boot::MeasurementSystemProfilePb;
+
+impl FromGrpc<MeasurementSystemProfilePb> for MeasurementSystemProfile {}
+
+impl FromGrpcOpt<MeasurementSystemProfilePb> for MeasurementSystemProfile {}
+
+impl From<MeasurementSystemProfile> for MeasurementSystemProfilePb {
+    fn from(val: MeasurementSystemProfile) -> Self {
+        Self {
+            profile_id: Some(val.profile_id),
+            name: val.name,
+            ts: Some(val.ts.into()),
+            attrs: val.attrs.iter().map(|attr| attr.clone().into()).collect(),
+        }
+    }
+}
+
+impl TryFrom<MeasurementSystemProfilePb> for MeasurementSystemProfile {
+    type Error = RpcDataConversionError;
+
+    fn try_from(msg: MeasurementSystemProfilePb) -> Result<Self, Self::Error> {
+        let attrs = msg
+            .attrs
+            .into_iter()
+            .map(
+                |attr| match MeasurementSystemProfileAttrRecord::try_from(attr) {
+                    Ok(worked) => Ok(worked),
+                    Err(failed) => Err(RpcDataConversionError::InvalidArgument(format!(
+                        "attr conversion failed: {failed}"
+                    ))),
+                },
+            )
+            .collect::<Result<Vec<_>, _>>();
+
+        Ok(Self {
+            profile_id: msg
+                .profile_id
+                .ok_or(RpcDataConversionError::InvalidArgument(
+                    "missing profile_id".to_string(),
+                ))?,
+            name: msg.name.clone(),
+            attrs: attrs?,
+            ts: conv_timestamp_opt(msg.ts, "ts")?,
+        })
+    }
+}

--- a/crates/rpc/src/measured_boot/records.rs
+++ b/crates/rpc/src/measured_boot/records.rs
@@ -1,0 +1,453 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ *  gRPC conversions between measured-boot record/enum types and their
+ *  protobuf counterparts. Implements `From`/`TryFrom` along with the
+ *  `FromGrpc`, `FromGrpcOpt`, and `FromPbVec` traits for the record
+ *  types defined in `measured_boot::records`.
+ */
+
+use std::convert::Into;
+use std::str::FromStr;
+
+use carbide_uuid::measured_boot::TrustedMachineId;
+use measured_boot::records::{
+    CandidateMachineSummary, MeasurementApprovedMachineRecord, MeasurementApprovedProfileRecord,
+    MeasurementApprovedType, MeasurementBundleRecord, MeasurementBundleState,
+    MeasurementBundleValueRecord, MeasurementJournalRecord, MeasurementMachineState,
+    MeasurementReportRecord, MeasurementReportValueRecord, MeasurementSystemProfileAttrRecord,
+    MeasurementSystemProfileRecord,
+};
+
+use crate::errors::RpcDataConversionError;
+use crate::measured_boot::{FromGrpc, FromGrpcOpt, FromPbVec, conv_machine_id, conv_timestamp_opt};
+use crate::protos::measured_boot::{
+    CandidateMachineSummaryPb, MeasurementApprovedMachineRecordPb,
+    MeasurementApprovedProfileRecordPb, MeasurementApprovedTypePb, MeasurementBundleRecordPb,
+    MeasurementBundleStatePb, MeasurementBundleValueRecordPb, MeasurementJournalRecordPb,
+    MeasurementMachineStatePb, MeasurementReportRecordPb, MeasurementReportValueRecordPb,
+    MeasurementSystemProfileAttrRecordPb, MeasurementSystemProfileRecordPb,
+};
+
+impl FromGrpc<MeasurementSystemProfileRecordPb> for MeasurementSystemProfileRecord {}
+
+impl FromPbVec<MeasurementSystemProfileRecordPb> for MeasurementSystemProfileRecord {}
+
+impl From<MeasurementSystemProfileRecord> for MeasurementSystemProfileRecordPb {
+    fn from(val: MeasurementSystemProfileRecord) -> Self {
+        Self {
+            profile_id: Some(val.profile_id),
+            name: val.name,
+            ts: Some(val.ts.into()),
+        }
+    }
+}
+
+impl TryFrom<MeasurementSystemProfileRecordPb> for MeasurementSystemProfileRecord {
+    type Error = RpcDataConversionError;
+
+    fn try_from(msg: MeasurementSystemProfileRecordPb) -> Result<Self, Self::Error> {
+        Ok(Self {
+            profile_id: msg
+                .profile_id
+                .ok_or(RpcDataConversionError::MissingArgument("profile_id"))?,
+            name: msg.name.clone(),
+            ts: conv_timestamp_opt(msg.ts, "ts")?,
+        })
+    }
+}
+
+impl FromGrpc<MeasurementSystemProfileAttrRecordPb> for MeasurementSystemProfileAttrRecord {}
+
+impl FromPbVec<MeasurementSystemProfileAttrRecordPb> for MeasurementSystemProfileAttrRecord {}
+
+impl From<MeasurementSystemProfileAttrRecord> for MeasurementSystemProfileAttrRecordPb {
+    fn from(val: MeasurementSystemProfileAttrRecord) -> Self {
+        Self {
+            attribute_id: Some(val.attribute_id),
+            profile_id: Some(val.profile_id),
+            key: val.key,
+            value: val.value,
+            ts: Some(val.ts.into()),
+        }
+    }
+}
+
+impl TryFrom<MeasurementSystemProfileAttrRecordPb> for MeasurementSystemProfileAttrRecord {
+    type Error = RpcDataConversionError;
+
+    fn try_from(msg: MeasurementSystemProfileAttrRecordPb) -> Result<Self, Self::Error> {
+        Ok(Self {
+            attribute_id: msg
+                .attribute_id
+                .ok_or(RpcDataConversionError::MissingArgument("attribute_id"))?,
+            profile_id: msg
+                .profile_id
+                .ok_or(RpcDataConversionError::MissingArgument("profile_id"))?,
+            key: msg.key.clone(),
+            value: msg.value.clone(),
+            ts: conv_timestamp_opt(msg.ts, "ts")?,
+        })
+    }
+}
+
+impl From<MeasurementBundleState> for MeasurementBundleStatePb {
+    fn from(val: MeasurementBundleState) -> Self {
+        match val {
+            MeasurementBundleState::Pending => Self::Pending,
+            MeasurementBundleState::Active => Self::Active,
+            MeasurementBundleState::Obsolete => Self::Obsolete,
+            MeasurementBundleState::Retired => Self::Retired,
+            MeasurementBundleState::Revoked => Self::Revoked,
+        }
+    }
+}
+
+impl From<MeasurementBundleStatePb> for MeasurementBundleState {
+    fn from(msg: MeasurementBundleStatePb) -> Self {
+        match msg {
+            MeasurementBundleStatePb::Pending => Self::Pending,
+            MeasurementBundleStatePb::Active => Self::Active,
+            MeasurementBundleStatePb::Obsolete => Self::Obsolete,
+            MeasurementBundleStatePb::Retired => Self::Retired,
+            MeasurementBundleStatePb::Revoked => Self::Revoked,
+        }
+    }
+}
+
+impl FromGrpc<MeasurementBundleRecordPb> for MeasurementBundleRecord {}
+
+impl FromPbVec<MeasurementBundleRecordPb> for MeasurementBundleRecord {}
+
+impl From<MeasurementBundleRecord> for MeasurementBundleRecordPb {
+    fn from(val: MeasurementBundleRecord) -> Self {
+        let pb_state: MeasurementBundleStatePb = val.state.into();
+        Self {
+            bundle_id: Some(val.bundle_id),
+            name: val.name,
+            profile_id: Some(val.profile_id),
+            state: pb_state.into(),
+            ts: Some(val.ts.into()),
+        }
+    }
+}
+
+impl TryFrom<MeasurementBundleRecordPb> for MeasurementBundleRecord {
+    type Error = RpcDataConversionError;
+
+    fn try_from(msg: MeasurementBundleRecordPb) -> Result<Self, Self::Error> {
+        let state = msg.state();
+
+        Ok(Self {
+            bundle_id: msg
+                .bundle_id
+                .ok_or(RpcDataConversionError::MissingArgument("bundle_id"))?,
+            profile_id: msg
+                .profile_id
+                .ok_or(RpcDataConversionError::MissingArgument("profile_id"))?,
+            name: msg.name.clone(),
+            state: MeasurementBundleState::from(state),
+            ts: conv_timestamp_opt(msg.ts, "ts")?,
+        })
+    }
+}
+
+impl FromGrpc<MeasurementBundleValueRecordPb> for MeasurementBundleValueRecord {}
+
+impl FromPbVec<MeasurementBundleValueRecordPb> for MeasurementBundleValueRecord {}
+
+impl From<MeasurementBundleValueRecord> for MeasurementBundleValueRecordPb {
+    fn from(val: MeasurementBundleValueRecord) -> Self {
+        Self {
+            value_id: Some(val.value_id),
+            bundle_id: Some(val.bundle_id),
+            pcr_register: val.pcr_register as i32,
+            sha_any: val.sha_any,
+            ts: Some(val.ts.into()),
+        }
+    }
+}
+
+impl TryFrom<MeasurementBundleValueRecordPb> for MeasurementBundleValueRecord {
+    type Error = RpcDataConversionError;
+
+    fn try_from(msg: MeasurementBundleValueRecordPb) -> Result<Self, Self::Error> {
+        Ok(Self {
+            value_id: msg
+                .value_id
+                .ok_or(RpcDataConversionError::MissingArgument("value_id"))?,
+            bundle_id: msg
+                .bundle_id
+                .ok_or(RpcDataConversionError::MissingArgument("bundle_id"))?,
+            pcr_register: msg.pcr_register as i16,
+            sha_any: msg.sha_any.clone(),
+            ts: conv_timestamp_opt(msg.ts, "ts")?,
+        })
+    }
+}
+
+impl FromGrpc<MeasurementReportRecordPb> for MeasurementReportRecord {}
+
+impl From<MeasurementReportRecord> for MeasurementReportRecordPb {
+    fn from(val: MeasurementReportRecord) -> Self {
+        Self {
+            report_id: Some(val.report_id),
+            machine_id: val.machine_id.to_string(),
+            ts: Some(val.ts.into()),
+        }
+    }
+}
+
+impl TryFrom<MeasurementReportRecordPb> for MeasurementReportRecord {
+    type Error = RpcDataConversionError;
+
+    fn try_from(msg: MeasurementReportRecordPb) -> Result<Self, Self::Error> {
+        Ok(Self {
+            report_id: msg
+                .report_id
+                .ok_or(RpcDataConversionError::MissingArgument("report_id"))?,
+            machine_id: conv_machine_id(&msg.machine_id)?,
+            ts: conv_timestamp_opt(msg.ts, "ts")?,
+        })
+    }
+}
+
+impl FromGrpc<MeasurementReportValueRecordPb> for MeasurementReportValueRecord {}
+
+impl From<MeasurementReportValueRecord> for MeasurementReportValueRecordPb {
+    fn from(val: MeasurementReportValueRecord) -> Self {
+        Self {
+            value_id: Some(val.value_id),
+            report_id: Some(val.report_id),
+            pcr_register: val.pcr_register as i32,
+            sha_any: val.sha_any,
+            ts: Some(val.ts.into()),
+        }
+    }
+}
+
+impl TryFrom<MeasurementReportValueRecordPb> for MeasurementReportValueRecord {
+    type Error = RpcDataConversionError;
+
+    fn try_from(msg: MeasurementReportValueRecordPb) -> Result<Self, Self::Error> {
+        Ok(Self {
+            value_id: msg
+                .value_id
+                .ok_or(RpcDataConversionError::MissingArgument("value_id"))?,
+            report_id: msg
+                .report_id
+                .ok_or(RpcDataConversionError::MissingArgument("report_id"))?,
+            pcr_register: msg.pcr_register as i16,
+            sha_any: msg.sha_any.clone(),
+            ts: conv_timestamp_opt(msg.ts, "ts")?,
+        })
+    }
+}
+
+impl FromGrpc<MeasurementJournalRecordPb> for MeasurementJournalRecord {}
+
+impl From<MeasurementJournalRecord> for MeasurementJournalRecordPb {
+    fn from(val: MeasurementJournalRecord) -> Self {
+        let pb_state: MeasurementMachineStatePb = val.state.into();
+
+        Self {
+            journal_id: Some(val.journal_id),
+            machine_id: val.machine_id.to_string(),
+            report_id: Some(val.report_id),
+            profile_id: val.profile_id,
+            bundle_id: val.bundle_id,
+            state: pb_state.into(),
+            ts: Some(val.ts.into()),
+        }
+    }
+}
+
+impl TryFrom<MeasurementJournalRecordPb> for MeasurementJournalRecord {
+    type Error = RpcDataConversionError;
+
+    fn try_from(msg: MeasurementJournalRecordPb) -> Result<Self, Self::Error> {
+        let state = msg.state();
+
+        Ok(Self {
+            journal_id: msg
+                .journal_id
+                .ok_or(RpcDataConversionError::MissingArgument("journal_id"))?,
+            machine_id: conv_machine_id(&msg.machine_id)?,
+            report_id: msg
+                .report_id
+                .ok_or(RpcDataConversionError::MissingArgument("report_id"))?,
+            profile_id: msg.profile_id,
+            bundle_id: msg.bundle_id,
+            state: MeasurementMachineState::from(state),
+            ts: conv_timestamp_opt(msg.ts, "ts")?,
+        })
+    }
+}
+
+impl From<MeasurementMachineState> for MeasurementMachineStatePb {
+    fn from(val: MeasurementMachineState) -> Self {
+        match val {
+            MeasurementMachineState::Discovered => Self::Discovered,
+            MeasurementMachineState::PendingBundle => Self::PendingBundle,
+            MeasurementMachineState::Measured => Self::Measured,
+            MeasurementMachineState::MeasuringFailed => Self::MeasuringFailed,
+        }
+    }
+}
+
+impl From<MeasurementMachineStatePb> for MeasurementMachineState {
+    fn from(msg: MeasurementMachineStatePb) -> Self {
+        match msg {
+            MeasurementMachineStatePb::Discovered => Self::Discovered,
+            MeasurementMachineStatePb::PendingBundle => Self::PendingBundle,
+            MeasurementMachineStatePb::Measured => Self::Measured,
+            MeasurementMachineStatePb::MeasuringFailed => Self::MeasuringFailed,
+        }
+    }
+}
+
+impl FromGrpc<CandidateMachineSummaryPb> for CandidateMachineSummary {}
+
+impl From<CandidateMachineSummary> for CandidateMachineSummaryPb {
+    fn from(val: CandidateMachineSummary) -> Self {
+        Self {
+            machine_id: val.machine_id.to_string(),
+            ts: Some(val.ts.into()),
+        }
+    }
+}
+
+impl TryFrom<CandidateMachineSummaryPb> for CandidateMachineSummary {
+    type Error = RpcDataConversionError;
+
+    fn try_from(msg: CandidateMachineSummaryPb) -> Result<Self, Self::Error> {
+        Ok(Self {
+            machine_id: conv_machine_id(&msg.machine_id)?,
+            ts: conv_timestamp_opt(msg.ts, "ts")?,
+        })
+    }
+}
+
+impl From<MeasurementApprovedType> for MeasurementApprovedTypePb {
+    fn from(val: MeasurementApprovedType) -> Self {
+        match val {
+            MeasurementApprovedType::Oneshot => Self::Oneshot,
+            MeasurementApprovedType::Persist => Self::Persist,
+        }
+    }
+}
+
+impl From<MeasurementApprovedTypePb> for MeasurementApprovedType {
+    fn from(val: MeasurementApprovedTypePb) -> Self {
+        match val {
+            MeasurementApprovedTypePb::Oneshot => Self::Oneshot,
+            MeasurementApprovedTypePb::Persist => Self::Persist,
+        }
+    }
+}
+
+impl FromGrpc<MeasurementApprovedMachineRecordPb> for MeasurementApprovedMachineRecord {}
+
+impl FromGrpcOpt<MeasurementApprovedMachineRecordPb> for MeasurementApprovedMachineRecord {}
+
+impl From<MeasurementApprovedMachineRecord> for MeasurementApprovedMachineRecordPb {
+    fn from(val: MeasurementApprovedMachineRecord) -> Self {
+        let approval_type: MeasurementApprovedTypePb = val.approval_type.into();
+
+        Self {
+            approval_id: Some(val.approval_id),
+            machine_id: val.machine_id.to_string(),
+            approval_type: approval_type.into(),
+            pcr_registers: val.pcr_registers.unwrap_or("".to_string()),
+            comments: val.comments.unwrap_or("".to_string()),
+            ts: Some(val.ts.into()),
+        }
+    }
+}
+
+impl TryFrom<MeasurementApprovedMachineRecordPb> for MeasurementApprovedMachineRecord {
+    type Error = RpcDataConversionError;
+
+    fn try_from(msg: MeasurementApprovedMachineRecordPb) -> Result<Self, Self::Error> {
+        let approval_type = msg.approval_type();
+
+        Ok(Self {
+            approval_id: msg
+                .approval_id
+                .ok_or(RpcDataConversionError::MissingArgument("approval_id"))?,
+            machine_id: TrustedMachineId::from_str(&msg.machine_id).map_err(|err| {
+                RpcDataConversionError::InvalidArgument(format!("trusted machine id: {err}"))
+            })?,
+            approval_type: MeasurementApprovedType::from(approval_type),
+            pcr_registers: match !msg.pcr_registers.is_empty() {
+                true => Some(msg.pcr_registers.clone()),
+                false => None,
+            },
+            comments: match !msg.comments.is_empty() {
+                true => Some(msg.comments.clone()),
+                false => None,
+            },
+            ts: conv_timestamp_opt(msg.ts, "ts")?,
+        })
+    }
+}
+
+impl FromGrpc<MeasurementApprovedProfileRecordPb> for MeasurementApprovedProfileRecord {}
+
+impl FromGrpcOpt<MeasurementApprovedProfileRecordPb> for MeasurementApprovedProfileRecord {}
+
+impl From<MeasurementApprovedProfileRecord> for MeasurementApprovedProfileRecordPb {
+    fn from(val: MeasurementApprovedProfileRecord) -> Self {
+        let approval_type: MeasurementApprovedTypePb = val.approval_type.into();
+
+        Self {
+            approval_id: Some(val.approval_id),
+            profile_id: Some(val.profile_id),
+            approval_type: approval_type.into(),
+            pcr_registers: val.pcr_registers.unwrap_or("".to_string()),
+            comments: val.comments.unwrap_or("".to_string()),
+            ts: Some(val.ts.into()),
+        }
+    }
+}
+
+impl TryFrom<MeasurementApprovedProfileRecordPb> for MeasurementApprovedProfileRecord {
+    type Error = RpcDataConversionError;
+
+    fn try_from(msg: MeasurementApprovedProfileRecordPb) -> Result<Self, Self::Error> {
+        let approval_type = msg.approval_type();
+        Ok(Self {
+            approval_id: msg
+                .approval_id
+                .ok_or(RpcDataConversionError::MissingArgument("approval_id"))?,
+            profile_id: msg
+                .profile_id
+                .ok_or(RpcDataConversionError::MissingArgument("profile_id"))?,
+            approval_type: MeasurementApprovedType::from(approval_type),
+            pcr_registers: match !msg.pcr_registers.is_empty() {
+                true => Some(msg.pcr_registers.clone()),
+                false => None,
+            },
+            comments: match !msg.comments.is_empty() {
+                true => Some(msg.comments.clone()),
+                false => None,
+            },
+            ts: conv_timestamp_opt(msg.ts, "ts")?,
+        })
+    }
+}

--- a/crates/rpc/src/measured_boot/report.rs
+++ b/crates/rpc/src/measured_boot/report.rs
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ *  Code for working the measuremment_reports and measurement_reports_values
+ *  tables in the database, leveraging the report-specific record types.
+ */
+
+use measured_boot::records::MeasurementReportValueRecord;
+use measured_boot::report::MeasurementReport;
+
+use crate::errors::RpcDataConversionError;
+use crate::measured_boot::{FromGrpc, FromGrpcOpt, conv_machine_id, conv_timestamp_opt};
+use crate::protos::measured_boot::MeasurementReportPb;
+
+impl FromGrpc<MeasurementReportPb> for MeasurementReport {}
+
+impl FromGrpcOpt<MeasurementReportPb> for MeasurementReport {}
+
+impl From<MeasurementReport> for MeasurementReportPb {
+    fn from(val: MeasurementReport) -> Self {
+        Self {
+            report_id: Some(val.report_id),
+            machine_id: val.machine_id.to_string(),
+            values: val
+                .values
+                .iter()
+                .map(|value| value.clone().into())
+                .collect(),
+            ts: Some(val.ts.into()),
+        }
+    }
+}
+
+impl TryFrom<MeasurementReportPb> for MeasurementReport {
+    type Error = RpcDataConversionError;
+
+    fn try_from(msg: MeasurementReportPb) -> Result<Self, Self::Error> {
+        let values = msg
+            .values
+            .iter()
+            .map(
+                |value| match MeasurementReportValueRecord::try_from(value.clone()) {
+                    Ok(worked) => Ok(worked),
+                    Err(failed) => Err(RpcDataConversionError::InvalidArgument(format!(
+                        "attr conversion failed: {failed}"
+                    ))),
+                },
+            )
+            .collect::<Result<Vec<_>, _>>();
+
+        Ok(Self {
+            report_id: msg
+                .report_id
+                .ok_or(RpcDataConversionError::MissingArgument("report_id"))?,
+            machine_id: conv_machine_id(&msg.machine_id)?,
+            values: values?,
+            ts: conv_timestamp_opt(msg.ts, "ts")?,
+        })
+    }
+}

--- a/crates/rpc/src/measured_boot/site.rs
+++ b/crates/rpc/src/measured_boot/site.rs
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ *  Code for working the measurement_trusted_machines and measurement_trusted_profiles
+ *  tables in the database, leveraging the site-specific record types.
+ *
+ * This also provides code for importing/exporting (and working with) SiteModels.
+ */
+use std::convert::{From, Into};
+use std::vec::Vec;
+
+use measured_boot::records::{
+    MeasurementBundleRecord, MeasurementBundleValueRecord, MeasurementSystemProfileAttrRecord,
+    MeasurementSystemProfileRecord,
+};
+use measured_boot::site::{
+    ImportResult, MachineAttestationSummary, MachineAttestationSummaryList, SiteModel,
+};
+
+use crate::errors::RpcDataConversionError;
+use crate::measured_boot::{FromGrpc, FromGrpcOpt, FromPbVec, conv_machine_id, conv_timestamp_opt};
+use crate::protos::measured_boot::{
+    ImportSiteMeasurementsResponse, ListAttestationSummaryResponse, MachineAttestationSummaryPb,
+    SiteModelPb,
+};
+
+impl From<&ImportSiteMeasurementsResponse> for ImportResult {
+    fn from(msg: &ImportSiteMeasurementsResponse) -> Self {
+        Self {
+            status: msg.result().as_str_name().to_string(),
+        }
+    }
+}
+
+impl FromGrpc<SiteModelPb> for SiteModel {}
+
+impl FromGrpcOpt<SiteModelPb> for SiteModel {}
+
+impl TryFrom<SiteModelPb> for SiteModel {
+    type Error = RpcDataConversionError;
+
+    fn try_from(model: SiteModelPb) -> Result<Self, Self::Error> {
+        Ok(Self {
+            measurement_system_profiles: MeasurementSystemProfileRecord::from_pb_vec(
+                &model.measurement_system_profiles,
+            )?,
+            measurement_system_profiles_attrs: MeasurementSystemProfileAttrRecord::from_pb_vec(
+                &model.measurement_system_profiles_attrs,
+            )?,
+            measurement_bundles: MeasurementBundleRecord::from_pb_vec(&model.measurement_bundles)?,
+            measurement_bundles_values: MeasurementBundleValueRecord::from_pb_vec(
+                &model.measurement_bundles_values,
+            )?,
+        })
+    }
+}
+
+impl From<SiteModel> for SiteModelPb {
+    fn from(model: SiteModel) -> Self {
+        let measurement_system_profiles = model
+            .measurement_system_profiles
+            .into_iter()
+            .map(|record| record.into())
+            .collect();
+
+        let measurement_system_profiles_attrs = model
+            .measurement_system_profiles_attrs
+            .into_iter()
+            .map(|record| record.into())
+            .collect();
+
+        let measurement_bundles = model
+            .measurement_bundles
+            .into_iter()
+            .map(|record| record.into())
+            .collect();
+
+        let measurement_bundles_values = model
+            .measurement_bundles_values
+            .into_iter()
+            .map(|record| record.into())
+            .collect();
+
+        Self {
+            measurement_system_profiles,
+            measurement_system_profiles_attrs,
+            measurement_bundles,
+            measurement_bundles_values,
+        }
+    }
+}
+
+impl From<MachineAttestationSummaryList> for ListAttestationSummaryResponse {
+    fn from(val: MachineAttestationSummaryList) -> Self {
+        Self {
+            attestation_outcomes: val
+                .0
+                .into_iter()
+                .map(|e| MachineAttestationSummaryPb {
+                    machine_id: e.machine_id.to_string(),
+                    bundle_id: e.bundle_id,
+                    profile_name: e.profile_name,
+                    ts: Some(e.ts.into()),
+                })
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<ListAttestationSummaryResponse> for MachineAttestationSummaryList {
+    type Error = RpcDataConversionError;
+
+    fn try_from(val: ListAttestationSummaryResponse) -> Result<Self, Self::Error> {
+        let mut attestation_summary_list = Vec::<MachineAttestationSummary>::new();
+
+        for pb in val.attestation_outcomes {
+            attestation_summary_list.push(MachineAttestationSummary {
+                machine_id: conv_machine_id(&pb.machine_id)?,
+                bundle_id: pb.bundle_id,
+                profile_name: pb.profile_name,
+                ts: pb
+                    .ts
+                    .map(|ts| conv_timestamp_opt(Some(ts), "ts"))
+                    .transpose()?
+                    .unwrap_or_default(),
+            });
+        }
+
+        Ok(Self(attestation_summary_list))
+    }
+}

--- a/crates/uuid/src/lib.rs
+++ b/crates/uuid/src/lib.rs
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::error::Error;
-use std::fmt;
 
 pub mod compute_allocation;
 pub mod domain;
@@ -39,17 +37,6 @@ pub mod switch;
 pub mod typed_uuids;
 pub mod vpc;
 pub mod vpc_peering;
-
-#[derive(Debug)]
-pub struct UuidEmptyStringError;
-
-impl fmt::Display for UuidEmptyStringError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "input UUID string cannot be empty",)
-    }
-}
-
-impl Error for UuidEmptyStringError {}
 
 /// DbPrimaryUuid is a trait intended for primary keys which
 /// derive the sqlx UUID type. The intent is the db_primary_uuid_name


### PR DESCRIPTION
## Description

Move measured-boot protobuf conversion traits and impls out of the measured-boot crate and into the rpc crate. This removes the transitional measured-boot -> rpc dependency and eliminates a transitive rpc dependency from downstream database/model crates.

This is part of the broader effort to remove direct model -> rpc and db -> rpc dependencies by keeping grpc-specific conversion logic alongside the generated protobuf types.

Also move measured-boot CLI table/summary helpers into the measured-boot crate so admin-cli output formatting no longer depends on rpc for those traits.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
