### PR TITLE
fix(helm): make nico-dns listen address configurable

### DIFF
--- a/helm/charts/nico-dns/templates/statefulset.yaml
+++ b/helm/charts/nico-dns/templates/statefulset.yaml
@@ -32,9 +32,9 @@ spec:
             - -c
             - |
               if [ -x /opt/nico/nico-dns ]; then
-                exec /opt/nico/nico-dns run --nico-url="${NICO_API}" --listen="[::]:53"
+                exec /opt/nico/nico-dns run --nico-url="${NICO_API}" --listen={{ .Values.listenAddress | default "[::]:53" | quote }}
               else
-                exec /opt/carbide/carbide-dns run --carbide-url="${NICO_API}" --listen="[::]:53"
+                exec /opt/carbide/carbide-dns run --carbide-url="${NICO_API}" --listen={{ .Values.listenAddress | default "[::]:53" | quote }}
               fi
           env:
             - name: NICO_API

--- a/helm/charts/nico-dns/values.yaml
+++ b/helm/charts/nico-dns/values.yaml
@@ -29,6 +29,10 @@ replicas: 2
 annotations:
   configmap.reloader.stakater.com/reload: "nico-dns, nico-dns-config"
 
+## DNS server bind address. Default keeps the existing dual-stack/IPv6
+## listener; set to "0.0.0.0:53" for IPv4-only Kubernetes clusters.
+listenAddress: "[::]:53"
+
 service:
   ports:
     - port: 53


### PR DESCRIPTION
Summary:
- Add nico-dns.listenAddress with default [::]:53 to preserve current behavior.
- Use the value for both nico-dns and carbide-dns fallback command paths so IPv4-only clusters can set 0.0.0.0:53.

Validation:
- git diff --check
- helm lint helm/charts/nico-dns
- helm template nico-dns helm/charts/nico-dns --show-only templates/statefulset.yaml
- helm template nico-dns helm/charts/nico-dns --set listenAddress=0.0.0.0:53 --show-only templates/statefulset.yaml
- helm template nico helm --set global.image.repository=example/nico --set global.image.tag=test --set nico-dns.listenAddress=0.0.0.0:53 --show-only charts/nico-dns/templates/statefulset.yaml