### PR TITLE
fix(api): Create per-vpc-per-instance VRF loopbacks

### DIFF
--- a/crates/api-db/src/vpc_dpu_loopback.rs
+++ b/crates/api-db/src/vpc_dpu_loopback.rs
@@ -93,6 +93,43 @@ pub async fn delete_and_deallocate(
     Ok(())
 }
 
+/// Deletes and deallocates loopbacks for a DPU scoped to specific VPCs.
+pub async fn delete_and_deallocate_for_vpcs(
+    common_pools: &model::resource_pool::common::CommonPools,
+    dpu_id: &MachineId,
+    vpc_ids: &[VpcId],
+    txn: &mut PgConnection,
+) -> Result<(), DatabaseError> {
+    if vpc_ids.is_empty() {
+        return Ok(());
+    }
+
+    // Delete first so pool release only follows rows that existed.
+    let mut query = sqlx::QueryBuilder::new("DELETE FROM vpc_dpu_loopbacks WHERE dpu_id = ");
+    query.push_bind(dpu_id);
+    query.push(" AND vpc_id = ANY(");
+    query.push_bind(vpc_ids);
+    query.push(") RETURNING *");
+
+    let deleted_loopbacks: Vec<VpcDpuLoopback> = query
+        .build_query_as()
+        .fetch_all(&mut *txn)
+        .await
+        .map_err(|e| DatabaseError::query(query.sql(), e))?;
+
+    for value in deleted_loopbacks {
+        // Return each deleted loopback IP to the shared VPC loopback pool.
+        crate::resource_pool::release(
+            &common_pools.ethernet.pool_vpc_dpu_loopback_ip,
+            txn,
+            value.loopback_ip,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
 pub async fn find(
     txn: &mut PgConnection,
     dpu_id: &MachineId,

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -25,6 +25,7 @@ use ::rpc::{common as rpc_common, forge as rpc};
 use carbide_network::virtualization::VpcVirtualizationType;
 use carbide_utils::arch::CpuArchitecture;
 use carbide_uuid::machine::MachineId;
+use db::vpc_prefix::VpcId;
 use db::{
     DatabaseError, ObjectColumnFilter, dpu_agent_upgrade_policy, network_security_group,
     network_segment,
@@ -337,24 +338,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
             ).await?;
 
             let segment_details = segment_details.iter().map(|x|(x.id, x)).collect::<HashMap<_,_>>();
-
-            // TODO: VPC loopbacks are currently blocked from being advertised out on the DPU.
-            // This must become per-interface/per-VPC before VPC loopbacks can be allowed out.
-            let tenant_loopback_ip = if VpcVirtualizationType::Fnn == network_virtualization_type
-                && use_vpc_vrf_loopback
-            {
-                let tenant_loopback_ip = db::vpc_dpu_loopback::get_or_allocate_loopback_ip_for_vpc(
-                    &api.common_pools,
-                    &mut txn,
-                    &dpu_machine_id,
-                    &vpc.id,
-                )
-                .await?;
-
-                Some(tenant_loopback_ip.to_string())
-            } else {
-                None
-            };
+            let mut tenant_loopback_ips: HashMap<VpcId, String> = HashMap::new();
 
             // if there is no device then this is a legacy config and only the primary dpu is allowed.
             // all other DPUs don't get interfaces
@@ -372,6 +356,36 @@ pub(crate) async fn get_managed_host_network_config_inner(
                     return Err(CarbideError::Internal { message: format!(
                         "Tenant segment id {iface_segment} is not found in db. Can not fetch the details."
                     ) }.into());
+                };
+
+                let tenant_loopback_ip = if VpcVirtualizationType::Fnn == network_virtualization_type
+                    && use_vpc_vrf_loopback
+                {
+                    match segment.config.vpc_id {
+                        Some(vpc_id) => {
+                            if let Some(loopback_ip) = tenant_loopback_ips.get(&vpc_id) {
+                                Some(loopback_ip.clone())
+                            } else {
+                                // Resolve loopbacks after the interface segment is known so each VPC
+                                // receives its own DPU loopback allocation.
+                                let loopback_ip =
+                                    db::vpc_dpu_loopback::get_or_allocate_loopback_ip_for_vpc(
+                                        &api.common_pools,
+                                        &mut txn,
+                                        &dpu_machine_id,
+                                        &vpc_id,
+                                    )
+                                    .await?
+                                    .to_string();
+
+                                tenant_loopback_ips.insert(vpc_id, loopback_ip.clone());
+                                Some(loopback_ip)
+                            }
+                        }
+                        None => None,
+                    }
+                } else {
+                    None
                 };
 
                 // Build the FQDN from this interface's segment domain.
@@ -404,9 +418,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
                     instance.id,
                     iface,
                     fqdn,
-                    // DPU agent reads loopback ip only from 0th interface.
-                    // function build in nvue.rs
-                    tenant_loopback_ip.clone(),
+                    tenant_loopback_ip,
                     network_virtualization_type,
                     suppress_tenant_security_groups,
                     network_security_group_details.clone(),

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -32,6 +32,7 @@ use carbide_redfish::libredfish::conv::{
     IntoLibredfish, IntoModel, machine_last_reboot_requested_mode,
 };
 use carbide_uuid::machine::MachineId;
+use carbide_uuid::vpc::VpcId;
 use chrono::{DateTime, Duration, Utc};
 use config_version::{ConfigVersion, Versioned};
 use db::DatabaseError;
@@ -6478,6 +6479,13 @@ async fn handle_instance_network_config_update_request(
                 .collect_vec();
 
             if !resources_to_be_released.is_empty() {
+                // Resolve VPC membership before old VPC-prefix segments are marked deleted.
+                let old_vpc_ids =
+                    vpc_ids_for_interfaces(&update_request.old_config.interfaces, &mut txn).await?;
+                let new_vpc_ids =
+                    vpc_ids_for_interfaces(&update_request.new_config.interfaces, &mut txn).await?;
+                let released_vpc_ids = old_vpc_ids.difference(&new_vpc_ids).copied().collect_vec();
+
                 let addresses = resources_to_be_released
                     .iter()
                     .flat_map(|x| x.ip_addrs.values().copied().collect_vec())
@@ -6491,14 +6499,13 @@ async fn handle_instance_network_config_update_request(
                 db::instance_address::delete_addresses(&mut txn, &addresses).await?;
                 release_network_segments_with_vpc_prefix(&resources_to_be_released, &mut txn)
                     .await?;
-
-                // TODO: This is not the best way, but will work fine. If you delete all loopback IPs
-                // associated with all DPUs, dpu_agent will assign new IPs during next managed_host_network_config
-                // iteration.
-                // The best way would be to find out the VPCs per DPU which are not used in new config
-                // and delete them only. This can be taken care once multi-dpu instance allocation is
-                // completed.
-                release_vpc_dpu_loopback(mh_snapshot, common_pools.as_deref(), &mut txn).await?;
+                release_vpc_dpu_loopback_for_vpcs(
+                    mh_snapshot,
+                    common_pools.as_deref(),
+                    &mut txn,
+                    &released_vpc_ids,
+                )
+                .await?;
             }
             db::instance::delete_update_network_config_request(&instance.id, &mut txn).await?;
             let next_state = ManagedHostState::Assigned {
@@ -6678,6 +6685,67 @@ pub async fn release_vpc_dpu_loopback(
     }
 
     Ok(())
+}
+
+/// Releases VPC DPU loopbacks for selected VPCs on every DPU in the managed host.
+async fn release_vpc_dpu_loopback_for_vpcs(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    common_pools: Option<&CommonPools>,
+    txn: &mut PgConnection,
+    vpc_ids: &[VpcId],
+) -> Result<(), StateHandlerError> {
+    let Some(common_pools) = common_pools else {
+        return Ok(());
+    };
+
+    if vpc_ids.is_empty() {
+        return Ok(());
+    }
+
+    // Release the removed VPC loopbacks from every DPU that may have rendered them.
+    for dpu_snapshot in &mh_snapshot.dpu_snapshots {
+        db::vpc_dpu_loopback::delete_and_deallocate_for_vpcs(
+            common_pools,
+            &dpu_snapshot.id,
+            vpc_ids,
+            txn,
+        )
+        .await
+        .map_err(|e| StateHandlerError::ResourceCleanupError {
+            resource: "VpcLoopbackIp",
+            error: e.to_string(),
+        })?;
+    }
+
+    Ok(())
+}
+
+/// Returns the VPC IDs referenced by the assigned network segments on these interfaces.
+async fn vpc_ids_for_interfaces(
+    interfaces: &[InstanceInterfaceConfig],
+    txn: &mut PgConnection,
+) -> Result<HashSet<VpcId>, StateHandlerError> {
+    let segment_ids = interfaces
+        .iter()
+        .filter_map(|iface| iface.network_segment_id)
+        .collect_vec();
+
+    if segment_ids.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    // Load segment metadata so VPC-prefix and direct segment interfaces share one path.
+    let segments = db::network_segment::find_by(
+        txn,
+        db::ObjectColumnFilter::List(db::network_segment::IdColumn, &segment_ids),
+        model::network_segment::NetworkSegmentSearchConfig::default(),
+    )
+    .await?;
+
+    Ok(segments
+        .into_iter()
+        .filter_map(|segment| segment.config.vpc_id)
+        .collect())
 }
 
 async fn release_network_segments_with_vpc_prefix(

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -4805,6 +4805,268 @@ async fn test_allocate_instance_with_multiple_fnn_vpc_prefixes(
     );
 }
 
+#[crate::sqlx_test]
+async fn test_fnn_vrf_loopbacks_are_per_vpc_and_removed_on_network_update(pool: sqlx::PgPool) {
+    let mut overrides = TestEnvOverrides::default().with_fnn_config(None);
+    overrides.fnn_config.as_mut().unwrap().use_vpc_vrf_loopback = true;
+    let env = create_test_env_with_overrides(pool, overrides).await;
+
+    // Create FNN tenants matching the existing peer-VPC fixture organizations.
+    for (organization_id, name) in [
+        (
+            "2829bbe3-c169-4cd9-8b2a-19a8b1618a93",
+            "fnn loopback tenant 1",
+        ),
+        (
+            "e65a9d69-39d2-4872-a53e-e5cb87c84e75",
+            "fnn loopback tenant 2",
+        ),
+    ] {
+        env.api
+            .create_tenant(Request::new(rpc::forge::CreateTenantRequest {
+                organization_id: organization_id.to_string(),
+                routing_profile_type: Some("INTERNAL".to_string()),
+                metadata: Some(rpc::forge::Metadata {
+                    name: name.to_string(),
+                    ..Default::default()
+                }),
+            }))
+            .await
+            .unwrap();
+    }
+
+    // Create two FNN VPCs and allocate one interface on each VPC.
+    let (first_vpc, _, first_segment_id, second_vpc, _, second_segment_id) = env
+        .create_vpc_and_peer_vpc_with_tenant_segments(
+            rpc::forge::VpcVirtualizationType::Fnn,
+            rpc::forge::VpcVirtualizationType::Fnn,
+        )
+        .await;
+    let first_vpc = first_vpc.expect("first VPC should be present");
+    let second_vpc = second_vpc.expect("second VPC should be present");
+    let mh = create_managed_host_multi_dpu(&env, 2).await;
+    let first_dpu_id = mh.dpu_n(0).id;
+    let second_dpu_id = mh.dpu_n(1).id;
+
+    let mut txn = env.db_txn().await;
+    let host_machine = mh.host().db_machine(&mut txn).await;
+    let device_locators = [first_dpu_id, second_dpu_id]
+        .iter()
+        .map(|dpu_id| host_machine.get_device_locator_for_dpu_id(dpu_id).unwrap())
+        .collect_vec();
+    txn.commit().await.unwrap();
+
+    let instance = mh
+        .instance_builer(&env)
+        .network(interface_network_config_with_devices(
+            &[first_segment_id, second_segment_id],
+            &device_locators,
+        ))
+        .build()
+        .await;
+
+    // Fetch each DPU config so each interface resolves its own VPC loopback.
+    let first_config = env
+        .api
+        .get_managed_host_network_config(Request::new(
+            rpc::forge::ManagedHostNetworkConfigRequest {
+                dpu_machine_id: Some(first_dpu_id),
+            },
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    let second_config = env
+        .api
+        .get_managed_host_network_config(Request::new(
+            rpc::forge::ManagedHostNetworkConfigRequest {
+                dpu_machine_id: Some(second_dpu_id),
+            },
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+
+    // Verify each DPU received a loopback for its interface's VPC.
+    assert_eq!(first_config.tenant_interfaces.len(), 1);
+    assert_eq!(second_config.tenant_interfaces.len(), 1);
+    let first_loopback = first_config.tenant_interfaces[0]
+        .tenant_vrf_loopback_ip
+        .clone()
+        .expect("first VPC loopback should be present");
+    let second_loopback = second_config.tenant_interfaces[0]
+        .tenant_vrf_loopback_ip
+        .clone()
+        .expect("second VPC loopback should be present");
+    assert_ne!(first_loopback, second_loopback);
+
+    // Update the instance to keep only the first VPC interface.
+    env.api
+        .update_instance_config(Request::new(rpc::forge::InstanceConfigUpdateRequest {
+            if_version_match: None,
+            config: Some(rpc::InstanceConfig {
+                tenant: Some(default_tenant_config()),
+                os: Some(default_os_config()),
+                network: Some(interface_network_config_with_devices(
+                    &[first_segment_id],
+                    std::slice::from_ref(&device_locators[0]),
+                )),
+                infiniband: None,
+                nvlink: None,
+                network_security_group_id: None,
+                dpu_extension_services: None,
+            }),
+            instance_id: Some(instance.id),
+            metadata: Some(rpc::Metadata {
+                name: "single-fnn-vpc".to_string(),
+                description: "tests/instance".to_string(),
+                labels: vec![],
+            }),
+        }))
+        .await
+        .unwrap();
+
+    // Move the instance to ready state after the network config update.
+    env.run_machine_state_controller_iteration_network_config_return_to_ready(&mh, false)
+        .await;
+
+    // Verify only the removed VPC loopback was released.
+    let mut txn = env.db_txn().await;
+    let retained_loopback = db::vpc_dpu_loopback::find(txn.as_mut(), &first_dpu_id, &first_vpc)
+        .await
+        .unwrap()
+        .expect("retained VPC loopback should remain");
+    assert_eq!(retained_loopback.loopback_ip.to_string(), first_loopback);
+    assert!(
+        db::vpc_dpu_loopback::find(txn.as_mut(), &second_dpu_id, &second_vpc)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_fnn_vrf_loopbacks_are_per_vpc_for_pf_and_vf_on_one_dpu(pool: sqlx::PgPool) {
+    let mut overrides = TestEnvOverrides::default().with_fnn_config(None);
+    overrides.fnn_config.as_mut().unwrap().use_vpc_vrf_loopback = true;
+    let env = create_test_env_with_overrides(pool, overrides).await;
+
+    // Create FNN tenants matching the existing peer-VPC fixture organizations.
+    for (organization_id, name) in [
+        (
+            "2829bbe3-c169-4cd9-8b2a-19a8b1618a93",
+            "fnn vf loopback tenant 1",
+        ),
+        (
+            "e65a9d69-39d2-4872-a53e-e5cb87c84e75",
+            "fnn vf loopback tenant 2",
+        ),
+    ] {
+        env.api
+            .create_tenant(Request::new(rpc::forge::CreateTenantRequest {
+                organization_id: organization_id.to_string(),
+                routing_profile_type: Some("INTERNAL".to_string()),
+                metadata: Some(rpc::forge::Metadata {
+                    name: name.to_string(),
+                    ..Default::default()
+                }),
+            }))
+            .await
+            .unwrap();
+    }
+
+    // Create two FNN VPCs and allocate PF/VF interfaces on one DPU.
+    let (first_vpc, _, first_segment_id, second_vpc, _, second_segment_id) = env
+        .create_vpc_and_peer_vpc_with_tenant_segments(
+            rpc::forge::VpcVirtualizationType::Fnn,
+            rpc::forge::VpcVirtualizationType::Fnn,
+        )
+        .await;
+    let first_vpc = first_vpc.expect("first VPC should be present");
+    let second_vpc = second_vpc.expect("second VPC should be present");
+    let mh = create_managed_host(&env).await;
+    let dpu_id = mh.dpu().id;
+    let instance = mh
+        .instance_builer(&env)
+        .network(single_interface_network_config_with_vfs(vec![
+            first_segment_id,
+            second_segment_id,
+        ]))
+        .build()
+        .await;
+
+    // Fetch the single DPU config and verify both PF and VF receive loopbacks.
+    let network_config = env
+        .api
+        .get_managed_host_network_config(Request::new(
+            rpc::forge::ManagedHostNetworkConfigRequest {
+                dpu_machine_id: Some(dpu_id),
+            },
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(network_config.tenant_interfaces.len(), 2);
+    assert_eq!(
+        network_config.tenant_interfaces[0].function_type,
+        rpc::InterfaceFunctionType::Physical as i32
+    );
+    assert_eq!(
+        network_config.tenant_interfaces[1].function_type,
+        rpc::InterfaceFunctionType::Virtual as i32
+    );
+    let first_loopback = network_config.tenant_interfaces[0]
+        .tenant_vrf_loopback_ip
+        .clone()
+        .expect("PF VPC loopback should be present");
+    let second_loopback = network_config.tenant_interfaces[1]
+        .tenant_vrf_loopback_ip
+        .clone()
+        .expect("VF VPC loopback should be present");
+    assert_ne!(first_loopback, second_loopback);
+
+    // Update the instance to keep only the PF-backed VPC interface.
+    env.api
+        .update_instance_config(Request::new(rpc::forge::InstanceConfigUpdateRequest {
+            if_version_match: None,
+            config: Some(rpc::InstanceConfig {
+                tenant: Some(default_tenant_config()),
+                os: Some(default_os_config()),
+                network: Some(single_interface_network_config(first_segment_id)),
+                infiniband: None,
+                nvlink: None,
+                network_security_group_id: None,
+                dpu_extension_services: None,
+            }),
+            instance_id: Some(instance.id),
+            metadata: Some(rpc::Metadata {
+                name: "single-fnn-vpc".to_string(),
+                description: "tests/instance".to_string(),
+                labels: vec![],
+            }),
+        }))
+        .await
+        .unwrap();
+
+    // Move the instance to ready state after the network config update.
+    env.run_machine_state_controller_iteration_network_config_return_to_ready(&mh, false)
+        .await;
+
+    // Verify the retained PF VPC loopback remains and the removed VF VPC loopback is gone.
+    let mut txn = env.db_txn().await;
+    let retained_loopback = db::vpc_dpu_loopback::find(txn.as_mut(), &dpu_id, &first_vpc)
+        .await
+        .unwrap()
+        .expect("retained PF VPC loopback should remain");
+    assert_eq!(retained_loopback.loopback_ip.to_string(), first_loopback);
+    assert!(
+        db::vpc_dpu_loopback::find(txn.as_mut(), &dpu_id, &second_vpc)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
 /// Verifies that non-FNN interfaces cannot span direct segments from multiple VPCs.
 #[crate::sqlx_test]
 async fn test_allocate_instance_rejects_multiple_non_fnn_network_segments(


### PR DESCRIPTION
## Description

Fix DPU tenant VRF loopback handling so instances spanning multiple VPCs receive a distinct VPC VRF loopback per VPC.

Network config updates updates now also release only loopbacks for VPCs no longer referenced by the instance, preserving still-active VPC loopbacks across interface changes.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

