### PR TITLE
Fix devspace deployment after nico rename

### DIFF
--- a/deploy/nico-base/api/deployment.yaml
+++ b/deploy/nico-base/api/deployment.yaml
@@ -161,6 +161,9 @@ spec:
             - name: nico-roots
               mountPath: "/var/run/secrets/forge-roots"
               readOnly: true
+            - name: nico-roots
+              mountPath: "/var/run/secrets/nico-roots"
+              readOnly: true
             - name: firmware
               mountPath: "/opt/carbide/firmware"
               readOnly: true

--- a/dev/deployment/devspace/README.md
+++ b/dev/deployment/devspace/README.md
@@ -1,6 +1,6 @@
 # Local Development with DevSpace
 
-You can use [DevSpace](https://www.devspace.sh) to deploy ncx-infrastructure-core locally using mock hosts.
+You can use [DevSpace](https://www.devspace.sh) to deploy infra-controller core locally using mock hosts.
 
 The process is broken into two steps:
 
@@ -44,8 +44,8 @@ Examples:
 LOCAL_DEV_INSTALL_POSTGRES=0 \
 LOCAL_DEV_POSTGRES_HOST=my-postgres.postgres.svc.cluster.local \
 LOCAL_DEV_POSTGRES_PORT=5432 \
-LOCAL_DEV_POSTGRES_DB=carbide \
-LOCAL_DEV_POSTGRES_USER=carbide \
+LOCAL_DEV_POSTGRES_DB=nico \
+LOCAL_DEV_POSTGRES_USER=nico \
 LOCAL_DEV_POSTGRES_PASSWORD=secret \
 dev/deployment/devspace/bootstrap-prereqs.sh
 ```
@@ -85,52 +85,53 @@ devspace deploy
 
 DevSpace will:
 
-- build the local runtime images from [`Dockerfile.api`](Dockerfile.api) and [`Dockerfile.machine-a-tron`](Dockerfile.machine-a-tron)
+- build the local runtime images from [`Dockerfile.api`](Dockerfile.api), [`Dockerfile.bmc-proxy`](Dockerfile.bmc-proxy), and [`Dockerfile.machine-a-tron`](Dockerfile.machine-a-tron)
 - deploy the Helm chart in [`helm/`](../../../helm)
 - apply the local-only `machine-a-tron` Kubernetes objects from [`machine-a-tron.yaml`](machine-a-tron.yaml) with `kubectl`
 - inject the built image names and DevSpace-generated tags into both deployments at runtime
 
-The image builds are configured in [`devspace.yaml`](../../../devspace.yaml). Both Dockerfiles are multi-stage builds: the builder stage compiles the Rust binary inside Docker from the local `build-container-localdev` image, and the runtime stage copies only the finished binary and required runtime assets. DevSpace first checks whether `build-container-localdev` already exists locally and reuses it if present; otherwise it builds it from [`dev/docker/Dockerfile.build-container-x86_64`](../../../dev/docker/Dockerfile.build-container-x86_64). BuildKit cache mounts are used for Cargo registry, Cargo git checkouts, and Cargo target output so rebuilds stay fast without copying host build artifacts into the image.
+The image builds are configured in [`devspace.yaml`](../../../devspace.yaml). The Dockerfiles are multi-stage builds: the builder stage compiles the Rust binary inside Docker from the local `build-container-localdev` image, and the runtime stage copies only the finished binary and required runtime assets. DevSpace first checks whether `build-container-localdev` already exists locally and reuses it if present; otherwise it builds it from [`dev/docker/Dockerfile.build-container-x86_64`](../../../dev/docker/Dockerfile.build-container-x86_64). BuildKit cache mounts are used for Cargo registry, Cargo git checkouts, and Cargo target output so rebuilds stay fast without copying host build artifacts into the image.
 
-The DevSpace images also use Dockerfile-specific ignore files: [`Dockerfile.api.dockerignore`](Dockerfile.api.dockerignore) and [`Dockerfile.machine-a-tron.dockerignore`](Dockerfile.machine-a-tron.dockerignore). This keeps the top-level [`.dockerignore`](../../../.dockerignore) aligned with the main branch for CI and release builds, while still giving the local DevSpace builds a small Docker context.
+The DevSpace images also use Dockerfile-specific ignore files: [`Dockerfile.api.dockerignore`](Dockerfile.api.dockerignore), [`Dockerfile.bmc-proxy.dockerignore`](Dockerfile.bmc-proxy.dockerignore), and [`Dockerfile.machine-a-tron.dockerignore`](Dockerfile.machine-a-tron.dockerignore). This keeps the top-level [`.dockerignore`](../../../.dockerignore) aligned with the main branch for CI and release builds, while still giving the local DevSpace builds a small Docker context.
 
-DevSpace watches the Rust workspace, toolchain metadata, and the runtime Dockerfile to decide when the image needs rebuilding.
+DevSpace watches the Rust workspace, toolchain metadata, and the runtime Dockerfiles to decide when images need rebuilding.
 
-The production Helm chart is still only responsible for the product services. `machine-a-tron` is deployed separately as plain local-only Kubernetes objects in [`machine-a-tron.yaml`](machine-a-tron.yaml), with DevSpace wiring in the local image tag and certificate issuer from [`devspace.yaml`](../../../devspace.yaml). The local API site config in [`values.base.yaml`](values.base.yaml) points BMC traffic at `machine-a-tron-bmc-mock.forge-system.svc.cluster.local:1266`.
+The production Helm chart is still only responsible for the product services. `machine-a-tron` is deployed separately as plain local-only Kubernetes objects in [`machine-a-tron.yaml`](machine-a-tron.yaml), with DevSpace wiring in the local image tag and certificate issuer from [`devspace.yaml`](../../../devspace.yaml). The local API and BMC proxy configs in [`values.base.yaml`](values.base.yaml) point BMC traffic at `machine-a-tron-bmc-mock.nico-system.svc.cluster.local:1266`.
 
 Common usage:
 
 ```bash
 devspace deploy
-devspace deploy -n forge-system
+devspace deploy -n nico-system
 devspace deploy --force-build
 ```
 
 ## Manual Equivalent
 
-If you want to understand what DevSpace is doing for the app image, the configured build is effectively:
+If you want to understand what DevSpace is doing for the runtime images, the configured build is effectively:
 
 ```bash
 docker image inspect build-container-localdev >/dev/null 2>&1 || docker build --pull=false -t build-container-localdev -f dev/docker/Dockerfile.build-container-x86_64 .
-docker build -t "carbide-api:<devspace-generated-tag>" -f dev/deployment/devspace/Dockerfile.api .
+docker build -t "nico-api:<devspace-generated-tag>" -f dev/deployment/devspace/Dockerfile.api .
+docker build -t "nico-bmc-proxy:<devspace-generated-tag>" -f dev/deployment/devspace/Dockerfile.bmc-proxy .
 docker build -t "machine-a-tron:<devspace-generated-tag>" -f dev/deployment/devspace/Dockerfile.machine-a-tron .
 ```
 
-DevSpace then deploys the Helm chart with the built `carbide-api` image wired into `global.image.repository` and `global.image.tag`, and applies the local-only `machine-a-tron` manifest with its image wired into the `Deployment` spec.
+DevSpace then deploys the Helm chart with the built `nico-api` image wired into `global.image.repository` and `global.image.tag`, the built `nico-bmc-proxy` image wired into the `nico-bmc-proxy` chart values, and applies the local-only `machine-a-tron` manifest with its image wired into the `Deployment` spec.
 
-## Re-initializing  ncx-infra-controller-core to a clean slate
+## Re-initializing ncx-infra-controller-core to a clean slate
 
-Once deployed, the `carbide-api` container will run and initialize its database, and the `machine-a-tron` container will run a set of mock machines, which will be discovered and ingested into the database, and run through the state machine until they reach a Ready state.
+Once deployed, the `nico-api` container will run and initialize its database, and the `machine-a-tron` container will run a set of mock machines, which will be discovered and ingested into the database, and run through the state machine until they reach a Ready state.
 
 You can start over again (purging the resources from k8s) by running:
 
 ```bash
-devspace purge -n forge-system
+devspace purge -n nico-system
 ```
 
-and it will delete the carbide-api and machine-a-tron deployments.
+and it will delete the NICo Helm release and machine-a-tron deployments.
 
-To clear out the carbide database to start from scratch again, run the nuke-postgres.sh helper script:
+To clear out the nico database to start from scratch again, run the nuke-postgres.sh helper script:
 
 ```bash
 dev/deployment/devspace/nuke-postgres.sh
@@ -139,7 +140,7 @@ dev/deployment/devspace/nuke-postgres.sh
 and the postgres database will be reset to an empty state, allowing you to deploy again:
 
 ```bash
-devspace deploy -n forge-system
+devspace deploy -n nico-system
 ```
 
 ## Files

--- a/dev/deployment/devspace/bootstrap-prereqs.sh
+++ b/dev/deployment/devspace/bootstrap-prereqs.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." && pwd)"
 
-NAMESPACE="${LOCAL_DEV_NAMESPACE:-forge-system}"
+NAMESPACE="${LOCAL_DEV_NAMESPACE:-nico-system}"
 CERT_MANAGER_NAMESPACE="${LOCAL_DEV_CERT_MANAGER_NAMESPACE:-cert-manager}"
 VALUES_FILE="${LOCAL_DEV_VALUES_FILE:-${REPO_ROOT}/dev/deployment/devspace/values.generated.yaml}"
 
@@ -31,9 +31,9 @@ INSTALL_VAULT="${LOCAL_DEV_INSTALL_VAULT:-1}"
 POSTGRES_NAMESPACE="${POSTGRES_NAMESPACE:-postgres}"
 POSTGRES_HOST="${LOCAL_DEV_POSTGRES_HOST:-postgres.${POSTGRES_NAMESPACE}.svc.cluster.local}"
 POSTGRES_PORT="${LOCAL_DEV_POSTGRES_PORT:-5432}"
-POSTGRES_DB="${LOCAL_DEV_POSTGRES_DB:-carbide}"
-POSTGRES_USER="${LOCAL_DEV_POSTGRES_USER:-carbide}"
-POSTGRES_PASSWORD="${LOCAL_DEV_POSTGRES_PASSWORD:-carbide}"
+POSTGRES_DB="${LOCAL_DEV_POSTGRES_DB:-nico}"
+POSTGRES_USER="${LOCAL_DEV_POSTGRES_USER:-nico}"
+POSTGRES_PASSWORD="${LOCAL_DEV_POSTGRES_PASSWORD:-nico}"
 POSTGRES_SSL_MODE="${LOCAL_DEV_POSTGRES_SSL_MODE:-disable}"
 
 VAULT_NAMESPACE="${VAULT_NAMESPACE:-vault}"
@@ -41,7 +41,7 @@ VAULT_ADDR="${LOCAL_DEV_VAULT_ADDR:-http://vault.${VAULT_NAMESPACE}.svc.cluster.
 VAULT_TOKEN="${LOCAL_DEV_VAULT_TOKEN:-root}"
 VAULT_KV_MOUNT="${LOCAL_DEV_VAULT_KV_MOUNT:-secrets}"
 VAULT_PKI_MOUNT="${LOCAL_DEV_VAULT_PKI_MOUNT:-certs}"
-VAULT_PKI_ROLE_NAME="${LOCAL_DEV_VAULT_PKI_ROLE_NAME:-forge-cluster}"
+VAULT_PKI_ROLE_NAME="${LOCAL_DEV_VAULT_PKI_ROLE_NAME:-nico-cluster}"
 VAULT_AUTH_MODE="${LOCAL_DEV_VAULT_AUTH_MODE:-root-token}"
 
 CERT_ISSUER_KIND="${LOCAL_DEV_CERT_ISSUER_KIND:-Issuer}"
@@ -87,7 +87,7 @@ metadata:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: forge-system.carbide.forge-pg-cluster.credentials
+  name: nico-system.nico.nico-pg-cluster.credentials
   namespace: ${NAMESPACE}
 type: Opaque
 stringData:
@@ -101,7 +101,7 @@ stringData:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: forge-system-carbide-database-config
+  name: nico-system-nico-database-config
   namespace: ${NAMESPACE}
 data:
   DB_HOST: ${POSTGRES_HOST}
@@ -111,7 +111,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: carbide-vault-token
+  name: nico-vault-token
   namespace: ${NAMESPACE}
 type: Opaque
 stringData:
@@ -120,7 +120,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: carbide-vault-approle-tokens
+  name: nico-vault-approle-tokens
   namespace: ${NAMESPACE}
 type: Opaque
 stringData:
@@ -310,7 +310,7 @@ EOF
       allow_localhost=true \
       require_cn=false \
       max_ttl='72h' \
-      allowed_uri_sans='spiffe://forge.local/*' >/dev/null
+      allowed_uri_sans='spiffe://nico.local/*' >/dev/null
 
     vault kv get '${VAULT_KV_MOUNT}/machines/bmc/site/root' >/dev/null 2>&1 || \
       echo '{\"UsernamePassword\":{\"username\":\"root\",\"password\":\"vault-password\"}}' | \
@@ -343,12 +343,12 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: forge-local-ca
+  name: nico-local-ca
   namespace: ${NAMESPACE}
 spec:
   isCA: true
-  commonName: forge-local-ca
-  secretName: forge-local-ca
+  commonName: nico-local-ca
+  secretName: nico-local-ca
   privateKey:
     algorithm: ECDSA
     size: 384
@@ -364,17 +364,17 @@ metadata:
   namespace: ${NAMESPACE}
 spec:
   ca:
-    secretName: forge-local-ca
+    secretName: nico-local-ca
 EOF
 
-  kubectl wait --for=condition=Ready certificate/forge-local-ca -n "${NAMESPACE}" --timeout=180s >/dev/null
+  kubectl wait --for=condition=Ready certificate/nico-local-ca -n "${NAMESPACE}" --timeout=180s >/dev/null
 }
 
-sync_forge_roots_secret() {
+sync_nico_roots_secret() {
   local ca_b64=""
 
-  if kubectl get secret forge-local-ca -n "${NAMESPACE}" >/dev/null 2>&1; then
-    ca_b64="$(kubectl get secret forge-local-ca -n "${NAMESPACE}" -o jsonpath='{.data.tls\.crt}')"
+  if kubectl get secret nico-local-ca -n "${NAMESPACE}" >/dev/null 2>&1; then
+    ca_b64="$(kubectl get secret nico-local-ca -n "${NAMESPACE}" -o jsonpath='{.data.tls\.crt}')"
   fi
 
   if [[ -z "${ca_b64}" ]]; then
@@ -385,7 +385,7 @@ sync_forge_roots_secret() {
 apiVersion: v1
 kind: Secret
 metadata:
-  name: forge-roots
+  name: nico-roots
   namespace: ${NAMESPACE}
 type: Opaque
 data:
@@ -414,24 +414,24 @@ global:
       name: ${CERT_ISSUER_NAME}
       group: ${CERT_ISSUER_GROUP}
 
-carbide-api:
+nico-api:
   automountServiceAccountToken: ${automount}
   migrationJob:
     enabled: true
     sslMode: ${POSTGRES_SSL_MODE}
   vaultClusterInfo:
     VAULT_SERVICE: ${VAULT_ADDR}
-    FORGE_VAULT_MOUNT: ${VAULT_KV_MOUNT}
-    FORGE_VAULT_PKI_MOUNT: ${VAULT_PKI_MOUNT}
+    NICO_VAULT_MOUNT: ${VAULT_KV_MOUNT}
+    NICO_VAULT_PKI_MOUNT: ${VAULT_PKI_MOUNT}
   databaseConfig: {}
 ${disable_tls_enforcement}
 
-carbide-bmc-proxy:
+nico-bmc-proxy:
   automountServiceAccountToken: ${automount}
   vaultClusterInfo:
     VAULT_SERVICE: ${VAULT_ADDR}
-    FORGE_VAULT_MOUNT: ${VAULT_KV_MOUNT}
-    FORGE_VAULT_PKI_MOUNT: ${VAULT_PKI_MOUNT}
+    NICO_VAULT_MOUNT: ${VAULT_KV_MOUNT}
+    NICO_VAULT_PKI_MOUNT: ${VAULT_PKI_MOUNT}
   databaseConfig: {}
 ${disable_tls_enforcement}
 EOF
@@ -463,7 +463,7 @@ main() {
   apply_local_postgres
   apply_local_vault
   apply_local_issuer
-  sync_forge_roots_secret
+  sync_nico_roots_secret
   write_generated_values
   print_summary
 }

--- a/dev/deployment/devspace/machine-a-tron.yaml
+++ b/dev/deployment/devspace/machine-a-tron.yaml
@@ -9,7 +9,7 @@ metadata:
   name: machine-a-tron-config
 data:
   mat.toml: |
-    carbide_api_url = "https://carbide-api.forge-system.svc.cluster.local:1079"
+    carbide_api_url = "https://nico-api.nico-system.svc.cluster.local:1079"
     interface = "NOTUSED"
     tui_enabled = false
     use_pxe_api = true
@@ -52,10 +52,10 @@ spec:
     name: local-ca-issuer
     group: cert-manager.io
   dnsNames:
-    - machine-a-tron.forge-system.svc.cluster.local
-    - machine-a-tron-bmc-mock.forge-system.svc.cluster.local
+    - machine-a-tron.nico-system.svc.cluster.local
+    - machine-a-tron-bmc-mock.nico-system.svc.cluster.local
   uris:
-    - spiffe://forge.local/forge-system/sa/machine-a-tron
+    - spiffe://nico.local/nico-system/sa/machine-a-tron
 ---
 apiVersion: v1
 kind: Service

--- a/dev/deployment/devspace/nuke-postgres.sh
+++ b/dev/deployment/devspace/nuke-postgres.sh
@@ -15,24 +15,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-###this script is intended to be used by developers against minikube to delete and recreate the forge database.
-###It assumes that the API server is already down, usually accomplished by bringing down skaffold prior to running the script.
+###this script is intended to be used by developers against minikube to delete and recreate the nico database.
+###It assumes that the API server is already down, usually accomplished by purging DevSpace prior to running the script.
+
+POSTGRES_DB="${LOCAL_DEV_POSTGRES_DB:-nico}"
+POSTGRES_USER="${LOCAL_DEV_POSTGRES_USER:-nico}"
 
 MAX_RETRY=10
 i=0
 while [[ $i -lt $MAX_RETRY ]]; do
-  echo "Attempting to delete forge DB."
+  echo "Attempting to delete ${POSTGRES_DB} DB."
 
 
   #something is holding the DB connection -- so murder it, i don't care this is local get out of the way.
   kubectl exec -ti postgres-0 -n postgres -- psql -U postgres -c "SELECT pg_terminate_backend(pg_stat_activity.pid)
 FROM pg_stat_activity
-WHERE datname = 'carbide'
+WHERE datname = '${POSTGRES_DB}'
   AND pid <> pg_backend_pid();"
 
-  kubectl exec -ti postgres-0 -n postgres -- psql -U postgres -c "DROP DATABASE IF EXISTS carbide;"
+  kubectl exec -ti postgres-0 -n postgres -- psql -U postgres -c "DROP DATABASE IF EXISTS \"${POSTGRES_DB}\";"
   if [ $? -eq 0 ]; then
-      echo "carbide DB successfully deleted"
+      echo "${POSTGRES_DB} DB successfully deleted"
       break
   else
       echo "DB still has connections, waiting to retry."
@@ -42,7 +45,5 @@ WHERE datname = 'carbide'
   i=$((i+1))
 done
 
-echo "Recreating carbide db"
-kubectl exec -ti postgres-0 -n postgres -- psql -U postgres -c 'CREATE DATABASE carbide with owner "carbide";'
-
-
+echo "Recreating ${POSTGRES_DB} db"
+kubectl exec -ti postgres-0 -n postgres -- psql -U postgres -c "CREATE DATABASE \"${POSTGRES_DB}\" with owner \"${POSTGRES_USER}\";"

--- a/dev/deployment/devspace/values.base.yaml
+++ b/dev/deployment/devspace/values.base.yaml
@@ -1,4 +1,4 @@
-carbide-api:
+nico-api:
   resources:
     limits:
       cpu: "16"
@@ -8,14 +8,14 @@ carbide-api:
       memory: "1Gi"
   siteConfig:
     enabled: true
-    carbideApiSiteConfig: |
+    nicoApiSiteConfig: |
       bypass_rbac = true
       attestation_enabled = false
       dpu_ipmi_tool_impl = "test"
-      initial_domain_name = "local.forge"
+      initial_domain_name = "local.nico"
       initial_dpu_agent_upgrade_policy = "off"
 
-      # DB transactions in carbide should be quick, pool size should ≈ the
+      # DB transactions in nico should be quick, pool size should ≈ the
       # number of cores. Default postgres configuration is a 100 connection
       # limit, so let's stay safely below that.
       max_database_connections = 64
@@ -65,9 +65,9 @@ carbide-api:
       permissive_mode = true
 
       [auth.trust]
-      spiffe_trust_domain = "forge.local"
-      spiffe_service_base_paths = ["/forge-system/sa/", "/default/sa/"]
-      spiffe_machine_base_path = "/forge-system/machine/"
+      spiffe_trust_domain = "nico.local"
+      spiffe_service_base_paths = ["/nico-system/sa/", "/default/sa/"]
+      spiffe_machine_base_path = "/nico-system/machine/"
       additional_issuer_cns = []
 
       [host_health]
@@ -89,7 +89,7 @@ carbide-api:
       create_machines = true
       allow_changing_bmc_proxy = true
       allow_zero_dpu_hosts = true
-      bmc_proxy = "machine-a-tron-bmc-mock.forge-system.svc.cluster.local:1266"
+      bmc_proxy = "machine-a-tron-bmc-mock.nico-system.svc.cluster.local:1266"
       run_interval = "10s"
       machines_created_per_run = 1000
       explorations_per_run = 1000
@@ -101,17 +101,17 @@ carbide-api:
       run_interval = "10s"
       concurrency_limit = 100
 
-carbide-bmc-proxy:
+nico-bmc-proxy:
   enabled: true
   replicas: 1 # save on local resources
   configFiles:
     enabled: true
-    carbideBmcProxyConfig: |
+    nicoBmcProxyConfig: |
       listen = "[::]:1079"
       metrics_endpoint = "[::]:1080"
       database_url = "postgres://replaced-by-env-var"
       allowed_principals = ["trusted-certificate"]
-      bmc_proxy = "machine-a-tron-bmc-mock.forge-system.svc.cluster.local:1266"
+      bmc_proxy = "machine-a-tron-bmc-mock.nico-system.svc.cluster.local:1266"
 
       [tls]
       identity_pemfile_path = "/var/run/secrets/spiffe.io/tls.crt"
@@ -120,28 +120,34 @@ carbide-bmc-proxy:
       admin_root_cafile_path = "/etc/forge/carbide-bmc-proxy/site/admin_root_cert_pem"
 
       [auth.trust]
-      spiffe_trust_domain = "forge.local"
+      spiffe_trust_domain = "nico.local"
       spiffe_service_base_paths = [
-        "/forge-system/sa/",
+        "/nico-system/sa/",
         "/default/sa/",
       ]
-      spiffe_machine_base_path = "/forge-system/machine/"
+      spiffe_machine_base_path = "/nico-system/machine/"
       additional_issuer_cns = []
 
       [auth.acls]
       "trusted-certificate" = ["/**"]
 
-carbide-dhcp:
+      [carbide_api]
+      api_url = "https://nico-api.nico-system.svc.cluster.local:1079"
+      root_ca = "/var/run/secrets/spiffe.io/ca.crt"
+      client_cert = "/var/run/secrets/spiffe.io/tls.crt"
+      client_key = "/var/run/secrets/spiffe.io/tls.key"
+
+nico-dhcp:
   enabled: false
-carbide-dns:
+nico-dns:
   enabled: false
-carbide-dsx-exchange-consumer:
+nico-dsx-exchange-consumer:
   enabled: false
-carbide-hardware-health:
+nico-hardware-health:
   enabled: false
-carbide-pxe:
+nico-pxe:
   enabled: false
-carbide-ssh-console-rs:
+nico-ssh-console-rs:
   enabled: false
 unbound:
   enabled: false

--- a/dev/deployment/devspace/values.generated.yaml
+++ b/dev/deployment/devspace/values.generated.yaml
@@ -5,26 +5,26 @@ global:
       name: local-ca-issuer
       group: cert-manager.io
 
-carbide-api:
+nico-api:
   automountServiceAccountToken: false
   migrationJob:
     enabled: true
     sslMode: disable
   vaultClusterInfo:
     VAULT_SERVICE: http://vault.vault.svc.cluster.local:8200
-    FORGE_VAULT_MOUNT: secrets
-    FORGE_VAULT_PKI_MOUNT: certs
+    NICO_VAULT_MOUNT: secrets
+    NICO_VAULT_PKI_MOUNT: certs
   databaseConfig: {}
   extraEnv:
     - name: DISABLE_TLS_ENFORCEMENT
       value: "1"
 
-carbide-bmc-proxy:
+nico-bmc-proxy:
   automountServiceAccountToken: false
   vaultClusterInfo:
     VAULT_SERVICE: http://vault.vault.svc.cluster.local:8200
-    FORGE_VAULT_MOUNT: secrets
-    FORGE_VAULT_PKI_MOUNT: certs
+    NICO_VAULT_MOUNT: secrets
+    NICO_VAULT_PKI_MOUNT: certs
   databaseConfig: {}
   extraEnv:
     - name: DISABLE_TLS_ENFORCEMENT

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -4,7 +4,7 @@ name: ncx-infra-controller-core
 vars:
   LOCAL_DEV_NAMESPACE:
     source: env
-    default: forge-system
+    default: nico-system
   LOCAL_DEV_CERT_ISSUER_KIND:
     source: env
     default: Issuer
@@ -16,12 +16,12 @@ vars:
     default: cert-manager.io
 
 images:
-  carbide-api:
-    image: carbide-api
+  nico-api:
+    image: nico-api
     custom:
       command: |-
         docker image inspect build-container-localdev >/dev/null 2>&1 || docker build --pull=false -t build-container-localdev -f dev/docker/Dockerfile.build-container-x86_64 .
-        docker build -t ${runtime.images.carbide-api.image}:${runtime.images.carbide-api.tag} -f dev/deployment/devspace/Dockerfile.api .
+        docker build -t ${runtime.images.nico-api.image}:${runtime.images.nico-api.tag} -f dev/deployment/devspace/Dockerfile.api .
       onChange:
         - .dockerignore
         - Cargo.toml
@@ -34,12 +34,12 @@ images:
         - dev/deployment/devspace/Dockerfile.api
         - pxe/templates
         - pxe/static/blobs/internal/aarch64/secure-boot-pk.pem
-  carbide-bmc-proxy:
-    image: carbide-bmc-proxy
+  nico-bmc-proxy:
+    image: nico-bmc-proxy
     custom:
       command: |-
         docker image inspect build-container-localdev >/dev/null 2>&1 || docker build --pull=false -t build-container-localdev -f dev/docker/Dockerfile.build-container-x86_64 .
-        docker build -t ${runtime.images.carbide-bmc-proxy.image}:${runtime.images.carbide-bmc-proxy.tag} -f dev/deployment/devspace/Dockerfile.bmc-proxy .
+        docker build -t ${runtime.images.nico-bmc-proxy.image}:${runtime.images.nico-bmc-proxy.tag} -f dev/deployment/devspace/Dockerfile.bmc-proxy .
       onChange:
         - .dockerignore
         - Cargo.toml
@@ -76,13 +76,13 @@ deployments:
       values:
         global:
           image:
-            repository: ${runtime.images.carbide-api.image}
-            tag: ${runtime.images.carbide-api.tag}
+            repository: ${runtime.images.nico-api.image}
+            tag: ${runtime.images.nico-api.tag}
             pullPolicy: IfNotPresent
-        carbide-bmc-proxy:
+        nico-bmc-proxy:
           image:
-            repository: ${runtime.images.carbide-bmc-proxy.image}
-            tag: ${runtime.images.carbide-bmc-proxy.tag}
+            repository: ${runtime.images.nico-bmc-proxy.image}
+            tag: ${runtime.images.nico-bmc-proxy.tag}
             pullPolicy: IfNotPresent
       valuesFiles:
         - dev/deployment/devspace/values.base.yaml
@@ -125,8 +125,8 @@ hooks:
         kind-*)
           echo "Loading images into kind cluster..."
           kind load docker-image \
-            "${runtime.images.carbide-api.image}:${runtime.images.carbide-api.tag}" \
-            "${runtime.images.carbide-bmc-proxy.image}:${runtime.images.carbide-bmc-proxy.tag}" \
+            "${runtime.images.nico-api.image}:${runtime.images.nico-api.tag}" \
+            "${runtime.images.nico-bmc-proxy.image}:${runtime.images.nico-bmc-proxy.tag}" \
             "${runtime.images.machine-a-tron.image}:${runtime.images.machine-a-tron.tag}"
           ;;
         # Add new local K8s tools here


### PR DESCRIPTION
## Description
The helm chart was majorly updated but it looks like none of the devspace stuff was touched.

While we're at it, update the deploy/nico-base yaml to add both mounts to the CA roots for compatibility sake, to match the other files which dual-mount to nico-roots and forge-roots.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

