### PR TITLE
chore: Align Flow internal RBAC SPIFFE ID with carbide-flow

### DIFF
--- a/crates/api/src/auth/internal_rbac_rules.rs
+++ b/crates/api/src/auth/internal_rbac_rules.rs
@@ -944,7 +944,7 @@ impl RuleInfo {
                         Principal::SpiffeServiceIdentifier("carbide-hardware-health".to_string())
                     }
                     RulePrincipal::Flow => {
-                        Principal::SpiffeServiceIdentifier("carbide-rla".to_string())
+                        Principal::SpiffeServiceIdentifier("carbide-flow".to_string())
                     }
                     RulePrincipal::MaintenanceJobs => {
                         Principal::SpiffeServiceIdentifier("carbide-maintenance-jobs".to_string())
@@ -1116,25 +1116,25 @@ mod rbac_rule_tests {
         assert!(InternalRBACRules::allowed_from_static(
             "SetMaintenance",
             &[Principal::SpiffeServiceIdentifier(
-                "carbide-rla".to_string()
+                "carbide-flow".to_string()
             )]
         ));
         assert!(InternalRBACRules::allowed_from_static(
             "InsertMachineHealthReport",
             &[Principal::SpiffeServiceIdentifier(
-                "carbide-rla".to_string()
+                "carbide-flow".to_string()
             )]
         ));
         assert!(InternalRBACRules::allowed_from_static(
             "RemoveMachineHealthReport",
             &[Principal::SpiffeServiceIdentifier(
-                "carbide-rla".to_string()
+                "carbide-flow".to_string()
             )]
         ));
         assert!(InternalRBACRules::allowed_from_static(
             "MachineSetAutoUpdate",
             &[Principal::SpiffeServiceIdentifier(
-                "carbide-rla".to_string()
+                "carbide-flow".to_string()
             )]
         ));
         for method in ["FindMacAddressByBmcIp", "GetBmcCredentials"] {


### PR DESCRIPTION


## Description
Forged Flow certificates use spiffe://forge.local/forge-system/sa/carbide-flow. Internal RBAC still mapped RulePrincipal::Flow to carbide-rla, causing HTTP 403 on inventory-sync and other Flow→Core gRPC calls after the RLA rename.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

