### PR TITLE
refactor(tls): move DummyTlsVerifier from rpc to carbide-tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,7 +1417,6 @@ dependencies = [
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
- "tss-esapi",
  "url",
  "uuid",
  "version-compare 0.2.1",
@@ -1954,8 +1953,8 @@ dependencies = [
  "carbide-api-db",
  "carbide-api-model",
  "carbide-health-report",
- "carbide-rpc",
  "carbide-secrets",
+ "carbide-tls",
  "carbide-utils",
  "carbide-uuid",
  "chrono",
@@ -2664,6 +2663,7 @@ dependencies = [
 name = "carbide-tls"
 version = "0.0.0"
 dependencies = [
+ "rustls",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/api-model/Cargo.toml
+++ b/crates/api-model/Cargo.toml
@@ -76,7 +76,6 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-tss-esapi = { optional = true, workspace = true }
 url = { workspace = true }
 uuid = { features = ["v4", "serde"], workspace = true }
 version-compare = { workspace = true }

--- a/crates/ib-fabric/Cargo.toml
+++ b/crates/ib-fabric/Cargo.toml
@@ -17,8 +17,8 @@ test-support = []
 carbide-api-db = { path = "../api-db" }
 carbide-api-model = { path = "../api-model" }
 carbide-health-report = { path = "../health-report" }
-carbide-rpc = { path = "../rpc" }
 carbide-secrets = { path = "../secrets" }
+carbide-tls = { path = "../tls" }
 carbide-utils = { path = "../utils" }
 carbide-uuid = { path = "../uuid" }
 

--- a/crates/ib-fabric/src/ib/ufmclient/rest.rs
+++ b/crates/ib-fabric/src/ib/ufmclient/rest.rs
@@ -20,6 +20,7 @@ use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 use std::time::Duration;
 
+use forge_tls::dummy_tls_verifier::DummyTlsVerifier;
 use http_body_util::BodyExt;
 use hyper::header::{AUTHORIZATION, CONTENT_TYPE, USER_AGENT};
 use hyper::http::StatusCode;
@@ -29,7 +30,6 @@ use hyper_timeout::TimeoutConnector;
 use hyper_util::client::legacy::Client as HyperClient;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
-use rpc::forge_tls_client::DummyTlsVerifier;
 use rustls::{ClientConfig, ConfigBuilder, RootCertStore, WantsVerifier};
 use thiserror::Error;
 
@@ -267,7 +267,7 @@ impl RestClient {
         } else {
             rustls_client_builder()
                 .dangerous()
-                .with_custom_certificate_verifier(std::sync::Arc::new(DummyTlsVerifier::new()))
+                .with_custom_certificate_verifier(Arc::new(DummyTlsVerifier::new_for_prod()))
                 .with_no_client_auth()
         };
 

--- a/crates/rpc/src/forge_tls_client.rs
+++ b/crates/rpc/src/forge_tls_client.rs
@@ -23,13 +23,13 @@ use eyre::Result;
 use forge_http_connector::connector::ForgeHttpConnector;
 use forge_http_connector::resolver::{ForgeResolver, ForgeResolverOpts};
 use forge_tls::client_config::ClientCert;
+use forge_tls::dummy_tls_verifier::DummyTlsVerifier;
 use hickory_resolver::config::ResolverConfig;
 use hyper::body::Incoming;
 use hyper_util::client::legacy;
 use hyper_util::rt::{TokioExecutor, TokioTimer};
-use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
-use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
-use rustls::{ClientConfig, DigitallySignedStruct, RootCertStore, SignatureScheme};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::{ClientConfig, RootCertStore};
 use tonic::body::Body;
 use tonic::transport::Uri;
 use tower::ServiceExt;
@@ -80,104 +80,9 @@ pub type ForgeClientT = ForgeClient<
     >,
 >;
 
-//this code was copy and pasted from the implementation of the same struct in sqlx::core,
-//and is only necessary for as long as we're optionally validating TLS
-#[derive(Debug)]
-pub struct DummyTlsVerifier {
-    print_warning: bool,
-}
-
-impl Default for DummyTlsVerifier {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl DummyTlsVerifier {
-    #[cfg(not(test))]
-    pub fn new() -> Self {
-        Self {
-            // Warnings are suppressed if this is running in a unit-test
-            print_warning: std::env::var_os("CARGO_MANIFEST_DIR").is_none(),
-        }
-    }
-
-    #[cfg(test)]
-    pub fn new() -> Self {
-        Self {
-            // Warnings are suppressed if this is running in a unit-test
-            print_warning: false,
-        }
-    }
-}
-
 pub const DEFAULT_DOMAIN: &str = "forge.local";
 
 const VRF_NAME: &str = "mgmt";
-
-impl ServerCertVerifier for DummyTlsVerifier {
-    fn verify_server_cert(
-        &self,
-        _end_entity: &CertificateDer<'_>,
-        _intermediates: &[CertificateDer<'_>],
-        _server_name: &ServerName,
-        _ocsp_response: &[u8],
-        _now: UnixTime,
-    ) -> Result<ServerCertVerified, rustls::Error> {
-        if self.print_warning {
-            eprintln!(
-                "IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS."
-            );
-        }
-        Ok(ServerCertVerified::assertion())
-    }
-
-    fn verify_tls12_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        if self.print_warning {
-            eprintln!(
-                "IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS."
-            );
-        }
-        Ok(HandshakeSignatureValid::assertion())
-    }
-
-    fn verify_tls13_signature(
-        &self,
-        _message: &[u8],
-        _cert: &CertificateDer<'_>,
-        _dss: &DigitallySignedStruct,
-    ) -> Result<HandshakeSignatureValid, rustls::Error> {
-        if self.print_warning {
-            eprintln!(
-                "IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS."
-            );
-        }
-        Ok(HandshakeSignatureValid::assertion())
-    }
-
-    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        vec![
-            SignatureScheme::RSA_PKCS1_SHA1,
-            SignatureScheme::ECDSA_SHA1_Legacy,
-            SignatureScheme::RSA_PKCS1_SHA256,
-            SignatureScheme::ECDSA_NISTP256_SHA256,
-            SignatureScheme::RSA_PKCS1_SHA384,
-            SignatureScheme::ECDSA_NISTP384_SHA384,
-            SignatureScheme::RSA_PKCS1_SHA512,
-            SignatureScheme::ECDSA_NISTP521_SHA512,
-            SignatureScheme::RSA_PSS_SHA256,
-            SignatureScheme::RSA_PSS_SHA384,
-            SignatureScheme::RSA_PSS_SHA512,
-            SignatureScheme::ED25519,
-            SignatureScheme::ED448,
-        ]
-    }
-}
 
 #[derive(Clone, Debug, Default)]
 pub struct ForgeClientConfig {
@@ -619,9 +524,9 @@ impl<'a> ForgeTlsClient<'a> {
                 } else {
                     base_config_builder()
                         .dangerous()
-                        .with_custom_certificate_verifier(std::sync::Arc::new(
-                            DummyTlsVerifier::new(),
-                        ))
+                        .with_custom_certificate_verifier(
+                            Arc::new(DummyTlsVerifier::new_for_prod()),
+                        )
                 }
             };
 
@@ -900,7 +805,7 @@ mod tests {
                 .with_safe_default_protocol_versions()
                 .unwrap()
                 .dangerous()
-                .with_custom_certificate_verifier(std::sync::Arc::new(DummyTlsVerifier::new()))
+                .with_custom_certificate_verifier(Arc::new(DummyTlsVerifier::new_for_tests()))
                 .with_no_client_auth();
 
                 hyper_rustls::HttpsConnectorBuilder::new()

--- a/crates/tls/Cargo.toml
+++ b/crates/tls/Cargo.toml
@@ -26,6 +26,7 @@ authors.workspace = true
 name = "forge_tls"
 
 [dependencies]
+rustls = { workspace = true }
 serde = { features = ["derive"], workspace = true }
 serde_json = { workspace = true }
 tonic = { workspace = true }

--- a/crates/tls/src/dummy_tls_verifier.rs
+++ b/crates/tls/src/dummy_tls_verifier.rs
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, SignatureScheme};
+
+//this code was copy and pasted from the implementation of the same struct in sqlx::core,
+//and is only necessary for as long as we're optionally validating TLS
+#[derive(Debug)]
+pub struct DummyTlsVerifier {
+    print_warning: bool,
+}
+
+impl DummyTlsVerifier {
+    pub fn new_for_tests() -> Self {
+        Self {
+            print_warning: false,
+        }
+    }
+
+    pub fn new_for_prod() -> Self {
+        Self {
+            print_warning: true,
+        }
+    }
+}
+
+impl ServerCertVerifier for DummyTlsVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        if self.print_warning {
+            eprintln!(
+                "IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS."
+            );
+        }
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        if self.print_warning {
+            eprintln!(
+                "IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS."
+            );
+        }
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        if self.print_warning {
+            eprintln!(
+                "IGNORING SERVER CERT, Please ensure that I am removed to actually validate TLS."
+            );
+        }
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        vec![
+            SignatureScheme::RSA_PKCS1_SHA1,
+            SignatureScheme::ECDSA_SHA1_Legacy,
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::ECDSA_NISTP521_SHA512,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::ED25519,
+            SignatureScheme::ED448,
+        ]
+    }
+}

--- a/crates/tls/src/lib.rs
+++ b/crates/tls/src/lib.rs
@@ -21,3 +21,4 @@
 
 pub mod client_config;
 pub mod default;
+pub mod dummy_tls_verifier;


### PR DESCRIPTION
## Description

ib-fabric's UFM client needs the dummy verifier but shouldn't depend on carbide-rpc to get it. Relocate the type to carbide-tls and update ib-fabric accordingly. Drive-by: remove unused tss-esapi dep from api-model.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
