### PR TITLE
feat(helm): make chart names, SPIFFE identity, and authz overridable

### DIFF
--- a/helm/charts/nico-api/files/carbide-api-config.toml
+++ b/helm/charts/nico-api/files/carbide-api-config.toml
@@ -60,13 +60,13 @@ permissive_mode = false
 casbin_policy_file = "/etc/forge/carbide-api/casbin-policy.csv"
 
 [auth.trust]
-spiffe_trust_domain = "nico.local"
+spiffe_trust_domain = "{{ .Values.global.spiffe.trustDomain }}"
 spiffe_service_base_paths = [
-  "/nico-system/sa/",
+  "/{{ .Values.auth.namespace | default (include "nico-api.namespace" .) }}/sa/",
   "/default/sa/",
   "/elektra-site-agent/sa/",
 ]
-spiffe_machine_base_path = "/nico-system/machine/"
+spiffe_machine_base_path = "/{{ .Values.auth.namespace | default (include "nico-api.namespace" .) }}/machine/"
 additional_issuer_cns = []
 
 [machine_state_controller]

--- a/helm/charts/nico-api/files/casbin-policy.csv
+++ b/helm/charts/nico-api/files/casbin-policy.csv
@@ -19,8 +19,8 @@
 
 # Map the nico-dhcp SPIFFE ID to the nico-dhcp role.
 # FIXME: verify that this is how these SPIFFE service identifiers look in reality.
-g, spiffe-service-id/nico-dhcp, nico-dhcp
-g, spiffe-service-id/nico-dns, nico-dns
+g, spiffe-service-id/{{ .Values.auth.principals.dhcp }}, nico-dhcp
+g, spiffe-service-id/{{ .Values.auth.principals.dns }}, nico-dns
 g, spiffe-machine-id, machine
 
 # Allow the nico-dhcp role to call its methods.

--- a/helm/charts/nico-api/templates/_helpers.tpl
+++ b/helm/charts/nico-api/templates/_helpers.tpl
@@ -26,7 +26,7 @@ Common labels
 helm.sh/chart: {{ include "nico-api.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: site-controller
-app.kubernetes.io/name: nico-api
+app.kubernetes.io/name: {{ include "nico-api.name" . }}
 app.kubernetes.io/component: api
 {{- end }}
 
@@ -34,7 +34,7 @@ app.kubernetes.io/component: api
 Selector labels
 */}}
 {{- define "nico-api.selectorLabels" -}}
-app.kubernetes.io/name: nico-api
+app.kubernetes.io/name: {{ include "nico-api.name" . }}
 app.kubernetes.io/component: api
 {{- end }}
 
@@ -47,24 +47,36 @@ Global image reference
 
 {{/*
 Certificate spec
-Usage: {{ include "nico-api.certificateSpec" (dict "name" "nico-api-certificate" "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-api.namespace" .)) }}
+Usage: {{ include "nico-api.certificateSpec" (dict "name" "{{ include "nico-api.name" . }}-certificate" "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-api.namespace" .)) }}
 */}}
 {{- define "nico-api.certificateSpec" -}}
 duration: {{ .global.certificate.duration }}
 renewBefore: {{ .global.certificate.renewBefore }}
-commonName: {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
+commonName: {{ printf "%s.%s.svc.cluster.local" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 dnsNames:
-  - {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
-{{- if not (eq (toString (.cert.includeShortDnsName | default true)) "false") }}
-  - {{ printf "%s.%s" .cert.serviceName .namespace }}
+{{- if .cert.dnsNames }}
+{{- range .cert.dnsNames }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+  - {{ printf "%s.%s.svc.cluster.local" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
+{{- if ne (toString .cert.includeShortDnsName) "false" }}
+  - {{ printf "%s.%s" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 {{- end }}
 {{- range .cert.extraDnsNames | default list }}
   - {{ . }}
 {{- end }}
+{{- end }}
 uris:
-  - {{ printf "spiffe://%s/%s/sa/%s" .global.spiffe.trustDomain .namespace .cert.serviceName }}
+{{- if .cert.uris }}
+{{- range .cert.uris }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+  - {{ printf "spiffe://%s/%s/sa/%s" .global.spiffe.trustDomain (.cert.identityNamespace | default .namespace) (.cert.spiffeServiceName | default .cert.serviceName | default .svcName) }}
 {{- range .cert.extraUris | default list }}
   - {{ . }}
+{{- end }}
 {{- end }}
 privateKey:
   algorithm: {{ .global.certificate.privateKey.algorithm }}
@@ -78,7 +90,7 @@ secretName: {{ .name }}
 
 {{/*
 Service monitor spec
-Usage: {{ include "nico-api.serviceMonitorSpec" (dict "name" "nico-api" "port" "http" "monitor" .Values.serviceMonitor "namespace" "nico-system") }}
+Usage: {{ include "nico-api.serviceMonitorSpec" (dict "name" "{{ include "nico-api.name" . }}" "port" "http" "monitor" .Values.serviceMonitor "namespace" "nico-system") }}
 */}}
 {{- define "nico-api.serviceMonitorSpec" -}}
 endpoints:

--- a/helm/charts/nico-api/templates/certificate.yaml
+++ b/helm/charts/nico-api/templates/certificate.yaml
@@ -1,9 +1,9 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: nico-api-certificate
+  name: {{ include "nico-api.name" . }}-certificate
   namespace: {{ include "nico-api.namespace" . }}
   labels:
     {{- include "nico-api.labels" . | nindent 4 }}
 spec:
-  {{- include "nico-api.certificateSpec" (dict "name" "nico-api-certificate" "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-api.namespace" .)) | nindent 2 }}
+  {{- include "nico-api.certificateSpec" (dict "name" (printf "%s-certificate" (include "nico-api.name" .)) "svcName" (include "nico-api.name" .) "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-api.namespace" .)) | nindent 2 }}

--- a/helm/charts/nico-api/templates/configmap.yaml
+++ b/helm/charts/nico-api/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nico-api-config-files
+  name: {{ include "nico-api.name" . }}-config-files
   namespace: {{ include "nico-api.namespace" . }}
   labels:
     {{- include "nico-api.labels" . | nindent 4 }}
@@ -12,26 +12,26 @@ data:
     {{- if .Values.configFiles.nicoApiConfig }}
     {{- .Values.configFiles.nicoApiConfig | nindent 4 }}
     {{- else }}
-    {{- .Files.Get "files/carbide-api-config.toml" | nindent 4 }}
+    {{- tpl (.Files.Get "files/carbide-api-config.toml") . | nindent 4 }}
     {{- end }}
   nico-api-config.toml: |
     {{- if .Values.configFiles.nicoApiConfig }}
     {{- .Values.configFiles.nicoApiConfig | nindent 4 }}
     {{- else }}
-    {{- .Files.Get "files/carbide-api-config.toml" | nindent 4 }}
+    {{- tpl (.Files.Get "files/carbide-api-config.toml") . | nindent 4 }}
     {{- end }}
   casbin-policy.csv: |
     {{- if .Values.configFiles.casbinPolicy }}
     {{- .Values.configFiles.casbinPolicy | nindent 4 }}
     {{- else }}
-    {{- .Files.Get "files/casbin-policy.csv" | nindent 4 }}
+    {{- tpl (.Files.Get "files/casbin-policy.csv") . | nindent 4 }}
     {{- end }}
 {{- if .Values.siteConfig.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nico-api-site-config-files
+  name: {{ include "nico-api.name" . }}-site-config-files
   namespace: {{ include "nico-api.namespace" . }}
   labels:
     {{- include "nico-api.labels" . | nindent 4 }}

--- a/helm/charts/nico-api/templates/deployment.yaml
+++ b/helm/charts/nico-api/templates/deployment.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nico-api
+  name: {{ include "nico-api.name" . }}
   namespace: {{ include "nico-api.namespace" . }}
   labels:
     {{- include "nico-api.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.annotations | nindent 4 }}
+    {{- tpl (toYaml .Values.annotations) . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   strategy:
@@ -19,10 +19,10 @@ spec:
       labels:
         {{- include "nico-api.labels" . | nindent 8 }}
       annotations:
-        kubectl.kubernetes.io/default-container: nico-api
+        kubectl.kubernetes.io/default-container: {{ include "nico-api.name" . }}
     spec:
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
+      serviceAccountName: {{ include "nico-api.name" . }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -51,7 +51,7 @@ spec:
         {{- end }}
       {{- end }}
       containers:
-        - name: nico-api
+        - name: {{ include "nico-api.name" . }}
           image: "{{ include "nico-api.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
           securityContext:
@@ -160,13 +160,13 @@ spec:
             # Mount config + secrets at both legacy /etc/forge,/var/run/secrets/forge-roots,/opt/carbide
             # and renamed /etc/nico,/var/run/secrets/nico-roots,/opt/nico paths so the chart works
             # whether the binary inside the image looks up its files under forge/carbide or nico names.
-            - name: nico-api-config-files
+            - name: {{ include "nico-api.name" . }}-config-files
               mountPath: /etc/forge/carbide-api
-            - name: nico-api-config-files
+            - name: {{ include "nico-api.name" . }}-config-files
               mountPath: /etc/nico/nico-api
-            - name: nico-api-site-config-files
+            - name: {{ include "nico-api.name" . }}-site-config-files
               mountPath: /etc/forge/carbide-api/site
-            - name: nico-api-site-config-files
+            - name: {{ include "nico-api.name" . }}-site-config-files
               mountPath: /etc/nico/nico-api/site
             - name: persistence
               mountPath: /mnt/persistence
@@ -193,17 +193,17 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
-        - name: nico-api-config-files
+        - name: {{ include "nico-api.name" . }}-config-files
           configMap:
-            name: nico-api-config-files
-        - name: nico-api-site-config-files
+            name: {{ include "nico-api.name" . }}-config-files
+        - name: {{ include "nico-api.name" . }}-site-config-files
           configMap:
-            name: nico-api-site-config-files
+            name: {{ include "nico-api.name" . }}-site-config-files
         - name: persistence
           emptyDir: {}
         - name: spiffe
           secret:
-            secretName: nico-api-certificate
+            secretName: {{ include "nico-api.name" . }}-certificate
         - name: nico-roots
           secret:
             secretName: nico-roots

--- a/helm/charts/nico-api/templates/external-service.yaml
+++ b/helm/charts/nico-api/templates/external-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-api-external
+  name: {{ include "nico-api.name" . }}-external
   namespace: {{ include "nico-api.namespace" . }}
   labels:
     {{- include "nico-api.labels" . | nindent 4 }}

--- a/helm/charts/nico-api/templates/metrics-service.yaml
+++ b/helm/charts/nico-api/templates/metrics-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-api-metrics
+  name: {{ include "nico-api.name" . }}-metrics
   namespace: {{ include "nico-api.namespace" . }}
   labels:
     {{- include "nico-api.labels" . | nindent 4 }}
-    app: nico-api
-    app.kubernetes.io/metrics: nico-api
+    app: {{ include "nico-api.name" . }}
+    app.kubernetes.io/metrics: {{ include "nico-api.name" . }}
 spec:
   selector:
     {{- include "nico-api.selectorLabels" . | nindent 4 }}

--- a/helm/charts/nico-api/templates/migration-job.yaml
+++ b/helm/charts/nico-api/templates/migration-job.yaml
@@ -1,11 +1,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: nico-api-migrate
+  name: {{ include "nico-api.name" . }}-migrate
   namespace: {{ include "nico-api.namespace" . }}
   labels:
     {{- include "nico-api.labels" . | nindent 4 }}
-    app: nico-api-migrate
+    app: {{ include "nico-api.name" . }}-migrate
   annotations:
     argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/sync-wave: "-5"
@@ -16,10 +16,10 @@ metadata:
 spec:
   template:
     metadata:
-      name: nico-api-migrate
+      name: {{ include "nico-api.name" . }}-migrate
       labels:
         {{- include "nico-api.labels" . | nindent 8 }}
-        app: nico-api-migrate
+        app: {{ include "nico-api.name" . }}-migrate
     spec:
       restartPolicy: OnFailure
       {{- with .Values.global.imagePullSecrets }}
@@ -27,7 +27,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - name: nico-api-migrate
+        - name: {{ include "nico-api.name" . }}-migrate
           image: "{{ include "nico-api.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
           command:

--- a/helm/charts/nico-api/templates/profiler-service.yaml
+++ b/helm/charts/nico-api/templates/profiler-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-api-profiler
+  name: {{ include "nico-api.name" . }}-profiler
   namespace: {{ include "nico-api.namespace" . }}
   labels:
     {{- include "nico-api.labels" . | nindent 4 }}
-    app: nico-api
-    app.kubernetes.io/metrics: nico-api
+    app: {{ include "nico-api.name" . }}
+    app.kubernetes.io/metrics: {{ include "nico-api.name" . }}
 spec:
   selector:
     {{- include "nico-api.selectorLabels" . | nindent 4 }}

--- a/helm/charts/nico-api/templates/rbac.yaml
+++ b/helm/charts/nico-api/templates/rbac.yaml
@@ -1,7 +1,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nico-api
+  name: {{ include "nico-api.name" . }}
   namespace: {{ include "nico-api.namespace" . }}
   labels:
     {{- include "nico-api.labels" . | nindent 4 }}
@@ -13,15 +13,15 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nico-api
+  name: {{ include "nico-api.name" . }}
   namespace: {{ include "nico-api.namespace" . }}
   labels:
     {{- include "nico-api.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: nico-api
+  name: {{ include "nico-api.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: nico-api
+    name: {{ include "nico-api.name" . }}
     namespace: {{ include "nico-api.namespace" . }}

--- a/helm/charts/nico-api/templates/service-account.yaml
+++ b/helm/charts/nico-api/templates/service-account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nico-api
+  name: {{ include "nico-api.name" . }}
   namespace: {{ include "nico-api.namespace" . }}
   labels:
     {{- include "nico-api.labels" . | nindent 4 }}

--- a/helm/charts/nico-api/templates/service-grpc.yaml
+++ b/helm/charts/nico-api/templates/service-grpc.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-api
+  name: {{ include "nico-api.name" . }}
   namespace: {{ include "nico-api.namespace" . }}
   labels:
     {{- include "nico-api.labels" . | nindent 4 }}
-    app: nico-api
+    app: {{ include "nico-api.name" . }}
 spec:
   selector:
     {{- include "nico-api.selectorLabels" . | nindent 4 }}

--- a/helm/charts/nico-api/templates/service-monitor.yaml
+++ b/helm/charts/nico-api/templates/service-monitor.yaml
@@ -2,12 +2,12 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: nico-api-metrics
+  name: {{ include "nico-api.name" . }}-metrics
   namespace: {{ include "nico-api.namespace" . }}
   labels:
     {{- include "nico-api.labels" . | nindent 4 }}
-    app: nico-api
+    app: {{ include "nico-api.name" . }}
     prometheus: nico-monitoring
 spec:
-  {{- include "nico-api.serviceMonitorSpec" (dict "name" "nico-api" "port" "http" "monitor" .Values.serviceMonitor "namespace" (include "nico-api.namespace" .)) | nindent 2 }}
+  {{- include "nico-api.serviceMonitorSpec" (dict "name" (include "nico-api.name" .) "port" "http" "monitor" .Values.serviceMonitor "namespace" (include "nico-api.namespace" .)) | nindent 2 }}
 {{- end }}

--- a/helm/charts/nico-api/tests/auth_test.yaml
+++ b/helm/charts/nico-api/tests/auth_test.yaml
@@ -1,0 +1,52 @@
+suite: API authorization config (default nico, override carbide/forge)
+templates:
+  - configmap.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: defaults trust domain, SPIFFE base paths, and casbin principals to nico
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: 'spiffe_trust_domain = "nico\.local"'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '"/nico-system/sa/"'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: 'spiffe_machine_base_path = "/nico-system/machine/"'
+      - matchRegex:
+          path: data["casbin-policy.csv"]
+          pattern: 'g, spiffe-service-id/nico-dhcp, nico-dhcp'
+      - matchRegex:
+          path: data["casbin-policy.csv"]
+          pattern: 'g, spiffe-service-id/nico-dns, nico-dns'
+
+  - it: flips trust domain, base-path namespace, and principals to forge/carbide
+    documentIndex: 0
+    set:
+      global:
+        spiffe:
+          trustDomain: forge.local
+      auth:
+        namespace: forge-system
+        principals:
+          dhcp: carbide-dhcp
+          dns: carbide-dns
+    asserts:
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: 'spiffe_trust_domain = "forge\.local"'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '"/forge-system/sa/"'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: 'spiffe_machine_base_path = "/forge-system/machine/"'
+      - matchRegex:
+          path: data["casbin-policy.csv"]
+          pattern: 'g, spiffe-service-id/carbide-dhcp, nico-dhcp'
+      - matchRegex:
+          path: data["casbin-policy.csv"]
+          pattern: 'g, spiffe-service-id/carbide-dns, nico-dns'

--- a/helm/charts/nico-api/tests/certificate_test.yaml
+++ b/helm/charts/nico-api/tests/certificate_test.yaml
@@ -1,0 +1,161 @@
+suite: certificate dnsNames and uris configurability
+templates:
+  - certificate.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: generates dnsNames and uris from serviceName and namespace by default
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: metadata.name
+          value: nico-api-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-api.nico-system.svc.cluster.local
+            - nico-api.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/nico-api
+
+  - it: appends extraDnsNames and extraUris to the generated lists
+    set:
+      certificate:
+        extraDnsNames:
+          - nico-api.example.com
+        extraUris:
+          - spiffe://nico.local/nico-system/sa/extra
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-api.nico-system.svc.cluster.local
+            - nico-api.nico-system
+            - nico-api.example.com
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/nico-api
+            - spiffe://nico.local/nico-system/sa/extra
+
+  - it: fully overrides the generated dnsNames when certificate.dnsNames is set
+    set:
+      certificate:
+        dnsNames:
+          - api.internal.example.com
+          - api.public.example.com
+    asserts:
+      # The generated svc/short names are replaced, not appended.
+      - equal:
+          path: spec.dnsNames
+          value:
+            - api.internal.example.com
+            - api.public.example.com
+      # uris still fall back to the generated SPIFFE URI.
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/nico-api
+
+  - it: fully overrides the generated uris when certificate.uris is set
+    set:
+      certificate:
+        uris:
+          - spiffe://custom.local/nico-system/sa/nico-api
+    asserts:
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://custom.local/nico-system/sa/nico-api
+      # dnsNames still generated.
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-api.nico-system.svc.cluster.local
+            - nico-api.nico-system
+
+  - it: ignores extraDnsNames once dnsNames override is set
+    set:
+      certificate:
+        dnsNames:
+          - only.example.com
+        extraDnsNames:
+          - ignored.example.com
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - only.example.com
+
+  - it: omits the short dnsName when includeShortDnsName is false
+    set:
+      certificate:
+        includeShortDnsName: false
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-api.nico-system.svc.cluster.local
+
+  - it: also accepts the string "false" to omit the short dnsName
+    set:
+      certificate:
+        includeShortDnsName: "false"
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-api.nico-system.svc.cluster.local
+
+  - it: nameOverride flips the certificate resource name, dnsNames, and SPIFFE URI to the override
+    set:
+      nameOverride: carbide-api
+    asserts:
+      - equal:
+          path: metadata.name
+          value: carbide-api-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - carbide-api.nico-system.svc.cluster.local
+            - carbide-api.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/carbide-api
+
+  - it: spiffeServiceName overrides only the SPIFFE /sa/ name; dnsNames unchanged
+    set:
+      certificate:
+        spiffeServiceName: elektra-site-agent
+    asserts:
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/elektra-site-agent
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-api.nico-system.svc.cluster.local
+            - nico-api.nico-system
+
+  - it: identityNamespace overrides the namespace in dnsNames, commonName, and URI
+    set:
+      certificate:
+        identityNamespace: forge-system
+    asserts:
+      - equal:
+          path: spec.commonName
+          value: nico-api.forge-system.svc.cluster.local
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-api.forge-system.svc.cluster.local
+            - nico-api.forge-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/forge-system/sa/nico-api

--- a/helm/charts/nico-api/tests/naming_test.yaml
+++ b/helm/charts/nico-api/tests/naming_test.yaml
@@ -1,0 +1,35 @@
+suite: resource naming (default nico, nameOverride to carbide)
+templates:
+  - deployment.yaml
+  - service-grpc.yaml
+  - service-account.yaml
+tests:
+  - it: defaults every resource name to the chart name (nico-api)
+    asserts:
+      - equal:
+          path: metadata.name
+          value: nico-api
+
+  - it: nameOverride renames every resource to carbide-api
+    set:
+      nameOverride: carbide-api
+    asserts:
+      - equal:
+          path: metadata.name
+          value: carbide-api
+
+  - it: deployment serviceAccountName defaults to nico-api
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: nico-api
+
+  - it: deployment serviceAccountName honors nameOverride
+    template: deployment.yaml
+    set:
+      nameOverride: carbide-api
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: carbide-api

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -33,10 +33,9 @@ global:
 namespaceOverride: ""
 
 replicas: 1
-serviceAccountName: nico-api
 automountServiceAccountToken: true
 annotations:
-  configmap.reloader.stakater.com/reload: "nico-api-config-files,nico-api-site-config-files"
+  configmap.reloader.stakater.com/reload: '{{ include "nico-api.name" . }}-config-files,{{ include "nico-api.name" . }}-site-config-files'
 
 resources:
   limits:
@@ -74,7 +73,14 @@ service:
 
 certificate:
   ## serviceName is used to auto-generate dnsNames and SPIFFE URIs based on global.namespace
-  serviceName: nico-api
+  serviceName: ""
+  spiffeServiceName: ""
+  identityNamespace: ""
+  ## Fully override the auto-generated dnsNames/uris. When empty, dnsNames and
+  ## uris are generated from serviceName + namespace (extraDnsNames/extraUris
+  ## are appended to the generated list).
+  dnsNames: []
+  uris: []
   extraDnsNames: []
   extraUris: []
 
@@ -136,6 +142,15 @@ serviceMonitor:
   enabled: false
   interval: 30s
   scrapeTimeout: 25s
+
+auth:
+  ## Namespace component accepted in service (/<ns>/sa/) and machine
+  ## (/<ns>/machine/) SPIFFE IDs. Empty = deploy namespace; forge-system for legacy.
+  namespace: ""
+  ## SPIFFE service-id principals granted the dhcp / dns roles in the casbin policy.
+  principals:
+    dhcp: nico-dhcp
+    dns: nico-dns
 
 ## Config files -- can be overridden with custom content
 configFiles:

--- a/helm/charts/nico-bmc-proxy/files/carbide-bmc-proxy.toml
+++ b/helm/charts/nico-bmc-proxy/files/carbide-bmc-proxy.toml
@@ -1,7 +1,7 @@
 listen = "[::]:1079"
 metrics_endpoint = "[::]:1080"
 database_url = "postgres://replaced-by-env-var"
-allowed_principals = ["spiffe-service-id/nico-api", "spiffe-service-id/nv-dps"]
+allowed_principals = ["spiffe-service-id/{{ .Values.auth.apiPrincipal }}", "spiffe-service-id/nv-dps"]
 
 [tls]
 identity_pemfile_path = "/var/run/secrets/spiffe.io/tls.crt"
@@ -10,12 +10,12 @@ root_cafile_path = "/var/run/secrets/spiffe.io/ca.crt"
 admin_root_cafile_path = "/etc/forge/carbide-bmc-proxy/site/admin_root_cert_pem"
 
 [auth.trust]
-spiffe_trust_domain = "nico.local"
+spiffe_trust_domain = "{{ .Values.global.spiffe.trustDomain }}"
 spiffe_service_base_paths = [
-  "/nico-system/sa/",
+  "/{{ .Values.auth.namespace | default (include "nico-bmc-proxy.namespace" .) }}/sa/",
   "/default/sa/",
 ]
-spiffe_machine_base_path = "/nico-system/machine/"
+spiffe_machine_base_path = "/{{ .Values.auth.namespace | default (include "nico-bmc-proxy.namespace" .) }}/machine/"
 additional_issuer_cns = []
 
 [auth.acls]
@@ -32,7 +32,7 @@ additional_issuer_cns = []
 # `prefix*` and `*suffix` match one component by prefix or suffix. `**` matches
 # zero or more path components. Replace templated components like `{id}` with
 # `*` when deriving ACLs from endpoint documentation.
-"spiffe-service-id/nico-api" = ["/**"]
+"spiffe-service-id/{{ .Values.auth.apiPrincipal }}" = ["/**"]
 "spiffe-service-id/nv-dps" = [
   "GET /redfish/v1",
   "POST /redfish/v1/SessionService/Sessions",

--- a/helm/charts/nico-bmc-proxy/templates/_helpers.tpl
+++ b/helm/charts/nico-bmc-proxy/templates/_helpers.tpl
@@ -5,13 +5,20 @@ Allow the release namespace to be overridden for multi-namespace deployments.
 {{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Resource name prefix. Defaults to the chart name; override with nameOverride.
+*/}}
+{{- define "nico-bmc-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 {{- define "nico-bmc-proxy.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 What image to use: Use subchart-local image if defined, fall back on global
-image. In devspace deployments, nico-bmc-proxy gets its own image. In other
+image. In devspace deployments, {{ include "nico-bmc-proxy.name" . }} gets its own image. In other
 deployments, the main nico image contains all binaries, so we can use that.
 */}}
 {{- define "nico-bmc-proxy.image" -}}
@@ -26,31 +33,43 @@ deployments, the main nico image contains all binaries, so we can use that.
 helm.sh/chart: {{ include "nico-bmc-proxy.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: site-controller
-app.kubernetes.io/name: nico-bmc-proxy
+app.kubernetes.io/name: {{ include "nico-bmc-proxy.name" . }}
 app.kubernetes.io/component: bmc-proxy
 {{- end }}
 
 {{- define "nico-bmc-proxy.selectorLabels" -}}
-app.kubernetes.io/name: nico-bmc-proxy
+app.kubernetes.io/name: {{ include "nico-bmc-proxy.name" . }}
 app.kubernetes.io/component: bmc-proxy
 {{- end }}
 
 {{- define "nico-bmc-proxy.certificateSpec" -}}
 duration: {{ .global.certificate.duration }}
 renewBefore: {{ .global.certificate.renewBefore }}
-commonName: {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
+commonName: {{ printf "%s.%s.svc.cluster.local" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 dnsNames:
-  - {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
-{{- if not (eq (toString (.cert.includeShortDnsName | default true)) "false") }}
-  - {{ printf "%s.%s" .cert.serviceName .namespace }}
+{{- if .cert.dnsNames }}
+{{- range .cert.dnsNames }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+  - {{ printf "%s.%s.svc.cluster.local" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
+{{- if ne (toString .cert.includeShortDnsName) "false" }}
+  - {{ printf "%s.%s" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 {{- end }}
 {{- range .cert.extraDnsNames | default list }}
   - {{ . }}
 {{- end }}
+{{- end }}
 uris:
-  - {{ printf "spiffe://%s/%s/sa/%s" .global.spiffe.trustDomain .namespace .cert.serviceName }}
+{{- if .cert.uris }}
+{{- range .cert.uris }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+  - {{ printf "spiffe://%s/%s/sa/%s" .global.spiffe.trustDomain (.cert.identityNamespace | default .namespace) (.cert.spiffeServiceName | default .cert.serviceName | default .svcName) }}
 {{- range .cert.extraUris | default list }}
   - {{ . }}
+{{- end }}
 {{- end }}
 privateKey:
   algorithm: {{ .global.certificate.privateKey.algorithm }}

--- a/helm/charts/nico-bmc-proxy/templates/certificate.yaml
+++ b/helm/charts/nico-bmc-proxy/templates/certificate.yaml
@@ -1,9 +1,9 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: nico-bmc-proxy-certificate
+  name: {{ include "nico-bmc-proxy.name" . }}-certificate
   namespace: {{ include "nico-bmc-proxy.namespace" . }}
   labels:
     {{- include "nico-bmc-proxy.labels" . | nindent 4 }}
 spec:
-  {{- include "nico-bmc-proxy.certificateSpec" (dict "name" "nico-bmc-proxy-certificate" "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-bmc-proxy.namespace" .)) | nindent 2 }}
+  {{- include "nico-bmc-proxy.certificateSpec" (dict "name" (printf "%s-certificate" (include "nico-bmc-proxy.name" .)) "svcName" (include "nico-bmc-proxy.name" .) "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-bmc-proxy.namespace" .)) | nindent 2 }}

--- a/helm/charts/nico-bmc-proxy/templates/configmap.yaml
+++ b/helm/charts/nico-bmc-proxy/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nico-bmc-proxy-config-files
+  name: {{ include "nico-bmc-proxy.name" . }}-config-files
   namespace: {{ include "nico-bmc-proxy.namespace" . }}
   labels:
     {{- include "nico-bmc-proxy.labels" . | nindent 4 }}
@@ -11,13 +11,13 @@ data:
     {{- if .Values.configFiles.nicoBmcProxyConfig }}
     {{- .Values.configFiles.nicoBmcProxyConfig | nindent 4 }}
     {{- else }}
-    {{- .Files.Get "files/carbide-bmc-proxy.toml" | nindent 4 }}
+    {{- tpl (.Files.Get "files/carbide-bmc-proxy.toml") . | nindent 4 }}
     {{- end }}
   nico-bmc-proxy.toml: |
     {{- if .Values.configFiles.nicoBmcProxyConfig }}
     {{- .Values.configFiles.nicoBmcProxyConfig | nindent 4 }}
     {{- else }}
-    {{- .Files.Get "files/carbide-bmc-proxy.toml" | nindent 4 }}
+    {{- tpl (.Files.Get "files/carbide-bmc-proxy.toml") . | nindent 4 }}
     {{- end }}
 {{- if .Values.databaseConfig }}
 ---

--- a/helm/charts/nico-bmc-proxy/templates/deployment.yaml
+++ b/helm/charts/nico-bmc-proxy/templates/deployment.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nico-bmc-proxy
+  name: {{ include "nico-bmc-proxy.name" . }}
   namespace: {{ include "nico-bmc-proxy.namespace" . }}
   labels:
     {{- include "nico-bmc-proxy.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.annotations | nindent 4 }}
+    {{- tpl (toYaml .Values.annotations) . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   strategy:
@@ -22,16 +22,16 @@ spec:
       labels:
         {{- include "nico-bmc-proxy.labels" . | nindent 8 }}
       annotations:
-        kubectl.kubernetes.io/default-container: nico-bmc-proxy
+        kubectl.kubernetes.io/default-container: {{ include "nico-bmc-proxy.name" . }}
     spec:
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
-      serviceAccountName: {{ .Values.serviceAccountName }}
+      serviceAccountName: {{ include "nico-bmc-proxy.name" . }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - name: nico-bmc-proxy
+        - name: {{ include "nico-bmc-proxy.name" . }}
           image: "{{ include "nico-bmc-proxy.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
           command:
@@ -117,9 +117,9 @@ spec:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           volumeMounts:
             # Mount at both legacy and renamed paths so chart works with either image variant.
-            - name: nico-bmc-proxy-config-files
+            - name: {{ include "nico-bmc-proxy.name" . }}-config-files
               mountPath: /etc/forge/carbide-bmc-proxy
-            - name: nico-bmc-proxy-config-files
+            - name: {{ include "nico-bmc-proxy.name" . }}-config-files
               mountPath: /etc/nico/nico-bmc-proxy
             - name: spiffe
               mountPath: "/var/run/secrets/spiffe.io"
@@ -133,12 +133,12 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
-        - name: nico-bmc-proxy-config-files
+        - name: {{ include "nico-bmc-proxy.name" . }}-config-files
           configMap:
-            name: nico-bmc-proxy-config-files
+            name: {{ include "nico-bmc-proxy.name" . }}-config-files
         - name: spiffe
           secret:
-            secretName: nico-bmc-proxy-certificate
+            secretName: {{ include "nico-bmc-proxy.name" . }}-certificate
         - name: nico-roots
           secret:
             secretName: nico-roots

--- a/helm/charts/nico-bmc-proxy/templates/external-service.yaml
+++ b/helm/charts/nico-bmc-proxy/templates/external-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-bmc-proxy-external
+  name: {{ include "nico-bmc-proxy.name" . }}-external
   namespace: {{ include "nico-bmc-proxy.namespace" . }}
   labels:
     {{- include "nico-bmc-proxy.labels" . | nindent 4 }}

--- a/helm/charts/nico-bmc-proxy/templates/metrics-service.yaml
+++ b/helm/charts/nico-bmc-proxy/templates/metrics-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-bmc-proxy-metrics
+  name: {{ include "nico-bmc-proxy.name" . }}-metrics
   namespace: {{ include "nico-bmc-proxy.namespace" . }}
   labels:
     {{- include "nico-bmc-proxy.labels" . | nindent 4 }}
-    app: nico-bmc-proxy
-    app.kubernetes.io/metrics: nico-bmc-proxy
+    app: {{ include "nico-bmc-proxy.name" . }}
+    app.kubernetes.io/metrics: {{ include "nico-bmc-proxy.name" . }}
 spec:
   selector:
     {{- include "nico-bmc-proxy.selectorLabels" . | nindent 4 }}

--- a/helm/charts/nico-bmc-proxy/templates/rbac.yaml
+++ b/helm/charts/nico-bmc-proxy/templates/rbac.yaml
@@ -1,7 +1,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nico-bmc-proxy
+  name: {{ include "nico-bmc-proxy.name" . }}
   namespace: {{ include "nico-bmc-proxy.namespace" . }}
   labels:
     {{- include "nico-bmc-proxy.labels" . | nindent 4 }}
@@ -13,15 +13,15 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nico-bmc-proxy
+  name: {{ include "nico-bmc-proxy.name" . }}
   namespace: {{ include "nico-bmc-proxy.namespace" . }}
   labels:
     {{- include "nico-bmc-proxy.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: nico-bmc-proxy
+  name: {{ include "nico-bmc-proxy.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: nico-bmc-proxy
+    name: {{ include "nico-bmc-proxy.name" . }}
     namespace: {{ include "nico-bmc-proxy.namespace" . }}

--- a/helm/charts/nico-bmc-proxy/templates/service-account.yaml
+++ b/helm/charts/nico-bmc-proxy/templates/service-account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nico-bmc-proxy
+  name: {{ include "nico-bmc-proxy.name" . }}
   namespace: {{ include "nico-bmc-proxy.namespace" . }}
   labels:
     {{- include "nico-bmc-proxy.labels" . | nindent 4 }}

--- a/helm/charts/nico-bmc-proxy/templates/service-monitor.yaml
+++ b/helm/charts/nico-bmc-proxy/templates/service-monitor.yaml
@@ -2,11 +2,11 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: nico-bmc-proxy-metrics
+  name: {{ include "nico-bmc-proxy.name" . }}-metrics
   namespace: {{ include "nico-bmc-proxy.namespace" . }}
   labels:
     {{- include "nico-bmc-proxy.labels" . | nindent 4 }}
-    app: nico-bmc-proxy
+    app: {{ include "nico-bmc-proxy.name" . }}
 spec:
-  {{- include "nico-bmc-proxy.serviceMonitorSpec" (dict "name" "nico-bmc-proxy" "port" "http" "monitor" .Values.serviceMonitor "namespace" (include "nico-bmc-proxy.namespace" .)) | nindent 2 }}
+  {{- include "nico-bmc-proxy.serviceMonitorSpec" (dict "name" (include "nico-bmc-proxy.name" .) "port" "http" "monitor" .Values.serviceMonitor "namespace" (include "nico-bmc-proxy.namespace" .)) | nindent 2 }}
 {{- end }}

--- a/helm/charts/nico-bmc-proxy/templates/service.yaml
+++ b/helm/charts/nico-bmc-proxy/templates/service.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-bmc-proxy
+  name: {{ include "nico-bmc-proxy.name" . }}
   namespace: {{ include "nico-bmc-proxy.namespace" . }}
   labels:
     {{- include "nico-bmc-proxy.labels" . | nindent 4 }}
-    app: nico-bmc-proxy
+    app: {{ include "nico-bmc-proxy.name" . }}
 spec:
   selector:
     {{- include "nico-bmc-proxy.selectorLabels" . | nindent 4 }}

--- a/helm/charts/nico-bmc-proxy/tests/auth_test.yaml
+++ b/helm/charts/nico-bmc-proxy/tests/auth_test.yaml
@@ -1,0 +1,44 @@
+suite: proxy authorization config (default nico, override carbide/forge)
+templates:
+  - configmap.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: defaults trust domain, base paths, and the API principal to nico
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: data["nico-bmc-proxy.toml"]
+          pattern: 'spiffe_trust_domain = "nico\.local"'
+      - matchRegex:
+          path: data["nico-bmc-proxy.toml"]
+          pattern: '"/nico-system/sa/"'
+      - matchRegex:
+          path: data["nico-bmc-proxy.toml"]
+          pattern: 'allowed_principals = \["spiffe-service-id/nico-api"'
+      - matchRegex:
+          path: data["nico-bmc-proxy.toml"]
+          pattern: '"spiffe-service-id/nico-api" = \["/\*\*"\]'
+
+  - it: flips trust domain, base-path namespace, and the API principal to forge/carbide
+    documentIndex: 0
+    set:
+      global:
+        spiffe:
+          trustDomain: forge.local
+      auth:
+        namespace: forge-system
+        apiPrincipal: carbide-api
+    asserts:
+      - matchRegex:
+          path: data["nico-bmc-proxy.toml"]
+          pattern: 'spiffe_trust_domain = "forge\.local"'
+      - matchRegex:
+          path: data["nico-bmc-proxy.toml"]
+          pattern: '"/forge-system/sa/"'
+      - matchRegex:
+          path: data["nico-bmc-proxy.toml"]
+          pattern: 'allowed_principals = \["spiffe-service-id/carbide-api"'
+      - matchRegex:
+          path: data["nico-bmc-proxy.toml"]
+          pattern: '"spiffe-service-id/carbide-api" = \["/\*\*"\]'

--- a/helm/charts/nico-bmc-proxy/tests/certificate_test.yaml
+++ b/helm/charts/nico-bmc-proxy/tests/certificate_test.yaml
@@ -1,0 +1,56 @@
+suite: certificate dnsNames and uris configurability
+templates:
+  - certificate.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: generates dnsNames and uris from serviceName and namespace by default
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: metadata.name
+          value: nico-bmc-proxy-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-bmc-proxy.nico-system.svc.cluster.local
+            - nico-bmc-proxy.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/nico-bmc-proxy
+
+  - it: fully overrides the generated dnsNames and uris when set
+    set:
+      certificate:
+        dnsNames:
+          - nico-bmc-proxy.override.example.com
+        uris:
+          - spiffe://override.local/nico-system/sa/nico-bmc-proxy
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-bmc-proxy.override.example.com
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://override.local/nico-system/sa/nico-bmc-proxy
+
+  - it: nameOverride flips the certificate resource name, dnsNames, and SPIFFE URI to the override
+    set:
+      nameOverride: carbide-bmc-proxy
+    asserts:
+      - equal:
+          path: metadata.name
+          value: carbide-bmc-proxy-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - carbide-bmc-proxy.nico-system.svc.cluster.local
+            - carbide-bmc-proxy.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/carbide-bmc-proxy

--- a/helm/charts/nico-bmc-proxy/values.yaml
+++ b/helm/charts/nico-bmc-proxy/values.yaml
@@ -27,10 +27,9 @@ image:
 namespaceOverride: ""
 
 replicas: 2
-serviceAccountName: nico-bmc-proxy
 automountServiceAccountToken: true
 annotations:
-  configmap.reloader.stakater.com/reload: "nico-bmc-proxy-config-files, nico-bmc-proxy-site-config-files"
+  configmap.reloader.stakater.com/reload: '{{ include "nico-bmc-proxy.name" . }}-config-files, {{ include "nico-bmc-proxy.name" . }}-site-config-files'
 
 resources:
   limits:
@@ -47,7 +46,14 @@ service:
     port: 1080
 
 certificate:
-  serviceName: nico-bmc-proxy
+  serviceName: ""
+  spiffeServiceName: ""
+  identityNamespace: ""
+  ## Fully override the auto-generated dnsNames/uris. When empty, dnsNames and
+  ## uris are generated from serviceName + namespace (extraDnsNames/extraUris
+  ## are appended to the generated list).
+  dnsNames: []
+  uris: []
   extraDnsNames: []
   extraUris: []
 
@@ -94,6 +100,12 @@ serviceMonitor:
   enabled: false
   interval: 30s
   scrapeTimeout: 25s
+
+auth:
+  ## Namespace component accepted in SPIFFE service/machine IDs. Empty = deploy ns.
+  namespace: ""
+  ## SPIFFE service-id of the API allowed full access (allowed_principals + ACL).
+  apiPrincipal: nico-api
 
 configFiles:
   nicoBmcProxyConfig: ""

--- a/helm/charts/nico-dhcp/templates/_helpers.tpl
+++ b/helm/charts/nico-dhcp/templates/_helpers.tpl
@@ -26,7 +26,7 @@ Common labels
 helm.sh/chart: {{ include "nico-dhcp.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: site-controller
-app.kubernetes.io/name: nico-dhcp
+app.kubernetes.io/name: {{ include "nico-dhcp.name" . }}
 app.kubernetes.io/component: dhcp
 {{- end }}
 
@@ -34,7 +34,7 @@ app.kubernetes.io/component: dhcp
 Selector labels
 */}}
 {{- define "nico-dhcp.selectorLabels" -}}
-app.kubernetes.io/name: nico-dhcp
+app.kubernetes.io/name: {{ include "nico-dhcp.name" . }}
 app.kubernetes.io/component: dhcp
 {{- end }}
 
@@ -51,19 +51,31 @@ Certificate spec
 {{- define "nico-dhcp.certificateSpec" -}}
 duration: {{ .global.certificate.duration }}
 renewBefore: {{ .global.certificate.renewBefore }}
-commonName: {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
+commonName: {{ printf "%s.%s.svc.cluster.local" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 dnsNames:
-  - {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
-{{- if not (eq (toString (.cert.includeShortDnsName | default true)) "false") }}
-  - {{ printf "%s.%s" .cert.serviceName .namespace }}
+{{- if .cert.dnsNames }}
+{{- range .cert.dnsNames }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+  - {{ printf "%s.%s.svc.cluster.local" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
+{{- if ne (toString .cert.includeShortDnsName) "false" }}
+  - {{ printf "%s.%s" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 {{- end }}
 {{- range .cert.extraDnsNames | default list }}
   - {{ . }}
 {{- end }}
+{{- end }}
 uris:
-  - {{ printf "spiffe://%s/%s/sa/%s" .global.spiffe.trustDomain .namespace .cert.serviceName }}
+{{- if .cert.uris }}
+{{- range .cert.uris }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+  - {{ printf "spiffe://%s/%s/sa/%s" .global.spiffe.trustDomain (.cert.identityNamespace | default .namespace) (.cert.spiffeServiceName | default .cert.serviceName | default .svcName) }}
 {{- range .cert.extraUris | default list }}
   - {{ . }}
+{{- end }}
 {{- end }}
 privateKey:
   algorithm: {{ .global.certificate.privateKey.algorithm }}

--- a/helm/charts/nico-dhcp/templates/certificate.yaml
+++ b/helm/charts/nico-dhcp/templates/certificate.yaml
@@ -1,9 +1,9 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: nico-dhcp-certificate
+  name: {{ include "nico-dhcp.name" . }}-certificate
   namespace: {{ include "nico-dhcp.namespace" . }}
   labels:
     {{- include "nico-dhcp.labels" . | nindent 4 }}
 spec:
-  {{- include "nico-dhcp.certificateSpec" (dict "name" "nico-dhcp-certificate" "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-dhcp.namespace" .)) | nindent 2 }}
+  {{- include "nico-dhcp.certificateSpec" (dict "name" (printf "%s-certificate" (include "nico-dhcp.name" .)) "svcName" (include "nico-dhcp.name" .) "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-dhcp.namespace" .)) | nindent 2 }}

--- a/helm/charts/nico-dhcp/templates/configmap.yaml
+++ b/helm/charts/nico-dhcp/templates/configmap.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nico-dhcp-config
+  name: {{ include "nico-dhcp.name" . }}-config
   namespace: {{ include "nico-dhcp.namespace" . }}
   labels:
     {{- include "nico-dhcp.labels" . | nindent 4 }}
 data:
   kea_config.json: |
     {{- /* Replace __NAMESPACE__ placeholder with actual global.namespace */ -}}
-    {{- .Values.config.keaConfigJson | replace "__NAMESPACE__" (include "nico-dhcp.namespace" .) | nindent 4 }}
+    {{- .Values.config.keaConfigJson | replace "__NAMESPACE__" (include "nico-dhcp.namespace" .) | replace "__API_HOST__" .Values.apiServiceName | nindent 4 }}
 {{- end }}

--- a/helm/charts/nico-dhcp/templates/deployment.yaml
+++ b/helm/charts/nico-dhcp/templates/deployment.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nico-dhcp
+  name: {{ include "nico-dhcp.name" . }}
   namespace: {{ include "nico-dhcp.namespace" . }}
   labels:
     {{- include "nico-dhcp.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.annotations | nindent 4 }}
+    {{- tpl (toYaml .Values.annotations) . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   strategy:
@@ -19,13 +19,13 @@ spec:
       labels:
         {{- include "nico-dhcp.labels" . | nindent 8 }}
     spec:
-      serviceAccountName: nico-dhcp
+      serviceAccountName: {{ include "nico-dhcp.name" . }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - name: nico-dhcp
+        - name: {{ include "nico-dhcp.name" . }}
           image: "{{ include "nico-dhcp.image" . }}"
           command: ['sh', '-c', 'mkdir -vp /var/run/kea /var/lib/kea && /sbin/kea-dhcp4 -c /tmp/kea_config.json']
           env:
@@ -52,8 +52,8 @@ spec:
       volumes:
         - name: spiffe
           secret:
-            secretName: nico-dhcp-certificate
+            secretName: {{ include "nico-dhcp.name" . }}-certificate
         - name: config
           configMap:
             defaultMode: 420
-            name: nico-dhcp-config
+            name: {{ include "nico-dhcp.name" . }}-config

--- a/helm/charts/nico-dhcp/templates/external-service.yaml
+++ b/helm/charts/nico-dhcp/templates/external-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-dhcp-external
+  name: {{ include "nico-dhcp.name" . }}-external
   namespace: {{ include "nico-dhcp.namespace" . }}
   labels:
     {{- include "nico-dhcp.labels" . | nindent 4 }}

--- a/helm/charts/nico-dhcp/templates/metrics-service.yaml
+++ b/helm/charts/nico-dhcp/templates/metrics-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-dhcp-metrics
+  name: {{ include "nico-dhcp.name" . }}-metrics
   namespace: {{ include "nico-dhcp.namespace" . }}
   labels:
     {{- include "nico-dhcp.labels" . | nindent 4 }}
-    app: nico-dhcp
-    app.kubernetes.io/metrics: nico-dhcp
+    app: {{ include "nico-dhcp.name" . }}
+    app.kubernetes.io/metrics: {{ include "nico-dhcp.name" . }}
 spec:
   selector:
     {{- include "nico-dhcp.selectorLabels" . | nindent 4 }}

--- a/helm/charts/nico-dhcp/templates/rbac.yaml
+++ b/helm/charts/nico-dhcp/templates/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nico-dhcp
+  name: {{ include "nico-dhcp.name" . }}
   namespace: {{ include "nico-dhcp.namespace" . }}
   labels:
     {{- include "nico-dhcp.labels" . | nindent 4 }}
@@ -10,7 +10,7 @@ automountServiceAccountToken: true
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nico-dhcp
+  name: {{ include "nico-dhcp.name" . }}
   namespace: {{ include "nico-dhcp.namespace" . }}
   labels:
     {{- include "nico-dhcp.labels" . | nindent 4 }}
@@ -22,15 +22,15 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nico-dhcp
+  name: {{ include "nico-dhcp.name" . }}
   namespace: {{ include "nico-dhcp.namespace" . }}
   labels:
     {{- include "nico-dhcp.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: nico-dhcp
+  name: {{ include "nico-dhcp.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: nico-dhcp
+    name: {{ include "nico-dhcp.name" . }}
     namespace: {{ include "nico-dhcp.namespace" . }}

--- a/helm/charts/nico-dhcp/templates/service-monitor.yaml
+++ b/helm/charts/nico-dhcp/templates/service-monitor.yaml
@@ -2,12 +2,12 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: nico-dhcp-metrics
+  name: {{ include "nico-dhcp.name" . }}-metrics
   namespace: {{ include "nico-dhcp.namespace" . }}
   labels:
     {{- include "nico-dhcp.labels" . | nindent 4 }}
-    app: nico-dhcp
+    app: {{ include "nico-dhcp.name" . }}
     prometheus: nico-monitoring
 spec:
-  {{- include "nico-dhcp.serviceMonitorSpec" (dict "name" "nico-dhcp" "port" "http" "monitor" .Values.serviceMonitor "namespace" "nico-system") | nindent 2 }}
+  {{- include "nico-dhcp.serviceMonitorSpec" (dict "name" (include "nico-dhcp.name" .) "port" "http" "monitor" .Values.serviceMonitor "namespace" "nico-system") | nindent 2 }}
 {{- end }}

--- a/helm/charts/nico-dhcp/templates/service.yaml
+++ b/helm/charts/nico-dhcp/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-dhcp
+  name: {{ include "nico-dhcp.name" . }}
   namespace: {{ include "nico-dhcp.namespace" . }}
   labels:
     {{- include "nico-dhcp.labels" . | nindent 4 }}

--- a/helm/charts/nico-dhcp/tests/apiservice_test.yaml
+++ b/helm/charts/nico-dhcp/tests/apiservice_test.yaml
@@ -1,0 +1,18 @@
+suite: API service host (apiServiceName) default nico, override carbide
+templates:
+  - configmap.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: defaults the Kea hook API URL host to nico-api
+    asserts:
+      - matchRegex:
+          path: data["kea_config.json"]
+          pattern: 'https://nico-api\.nico-system\.svc\.cluster\.local'
+  - it: apiServiceName overrides the Kea hook API URL host to carbide-api
+    set:
+      apiServiceName: carbide-api
+    asserts:
+      - matchRegex:
+          path: data["kea_config.json"]
+          pattern: 'https://carbide-api\.nico-system\.svc\.cluster\.local'

--- a/helm/charts/nico-dhcp/tests/certificate_test.yaml
+++ b/helm/charts/nico-dhcp/tests/certificate_test.yaml
@@ -1,0 +1,56 @@
+suite: certificate dnsNames and uris configurability
+templates:
+  - certificate.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: generates dnsNames and uris from serviceName and namespace by default
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: metadata.name
+          value: nico-dhcp-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-dhcp.nico-system.svc.cluster.local
+            - nico-dhcp.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/nico-dhcp
+
+  - it: fully overrides the generated dnsNames and uris when set
+    set:
+      certificate:
+        dnsNames:
+          - nico-dhcp.override.example.com
+        uris:
+          - spiffe://override.local/nico-system/sa/nico-dhcp
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-dhcp.override.example.com
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://override.local/nico-system/sa/nico-dhcp
+
+  - it: nameOverride flips the certificate resource name, dnsNames, and SPIFFE URI to the override
+    set:
+      nameOverride: carbide-dhcp
+    asserts:
+      - equal:
+          path: metadata.name
+          value: carbide-dhcp-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - carbide-dhcp.nico-system.svc.cluster.local
+            - carbide-dhcp.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/carbide-dhcp

--- a/helm/charts/nico-dhcp/values.yaml
+++ b/helm/charts/nico-dhcp/values.yaml
@@ -27,7 +27,7 @@ namespaceOverride: ""
 
 replicas: 1
 annotations:
-  configmap.reloader.stakater.com/reload: "nico-dhcp-config"
+  configmap.reloader.stakater.com/reload: '{{ include "nico-dhcp.name" . }}-config'
 
 service:
   port: 67
@@ -35,9 +35,18 @@ service:
 metrics:
   port: 1089
 
+apiServiceName: nico-api
+
 certificate:
   ## serviceName is used to auto-generate dnsNames and SPIFFE URIs based on the release namespace
-  serviceName: nico-dhcp
+  serviceName: ""
+  spiffeServiceName: ""
+  identityNamespace: ""
+  ## Fully override the auto-generated dnsNames/uris. When empty, dnsNames and
+  ## uris are generated from serviceName + namespace (extraDnsNames/extraUris
+  ## are appended to the generated list).
+  dnsNames: []
+  uris: []
   extraDnsNames: []
   extraUris: []
 
@@ -78,7 +87,7 @@ config:
           {
             "library": "/usr/lib/x86_64-linux-gnu/kea/hooks/libdhcp.so",
             "parameters": {
-              "nico-api-url": "https://nico-api.__NAMESPACE__.svc.cluster.local:1079",
+              "nico-api-url": "https://__API_HOST__.__NAMESPACE__.svc.cluster.local:1079",
               "nico-metrics-endpoint": "[::]:1089",
               "nico-nameservers": "127.0.0.1",
               "nico-ntpserver": "127.0.0.1",

--- a/helm/charts/nico-dns/templates/_helpers.tpl
+++ b/helm/charts/nico-dns/templates/_helpers.tpl
@@ -26,7 +26,7 @@ Common labels
 helm.sh/chart: {{ include "nico-dns.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: site-controller
-app.kubernetes.io/name: nico-dns
+app.kubernetes.io/name: {{ include "nico-dns.name" . }}
 app.kubernetes.io/component: dns
 {{- end }}
 
@@ -34,7 +34,7 @@ app.kubernetes.io/component: dns
 Selector labels
 */}}
 {{- define "nico-dns.selectorLabels" -}}
-app.kubernetes.io/name: nico-dns
+app.kubernetes.io/name: {{ include "nico-dns.name" . }}
 app.kubernetes.io/component: dns
 {{- end }}
 
@@ -51,19 +51,31 @@ Certificate spec
 {{- define "nico-dns.certificateSpec" -}}
 duration: {{ .global.certificate.duration }}
 renewBefore: {{ .global.certificate.renewBefore }}
-commonName: {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
+commonName: {{ printf "%s.%s.svc.cluster.local" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 dnsNames:
-  - {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
-{{- if not (eq (toString (.cert.includeShortDnsName | default true)) "false") }}
-  - {{ printf "%s.%s" .cert.serviceName .namespace }}
+{{- if .cert.dnsNames }}
+{{- range .cert.dnsNames }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+  - {{ printf "%s.%s.svc.cluster.local" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
+{{- if ne (toString .cert.includeShortDnsName) "false" }}
+  - {{ printf "%s.%s" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 {{- end }}
 {{- range .cert.extraDnsNames | default list }}
   - {{ . }}
 {{- end }}
+{{- end }}
 uris:
-  - {{ printf "spiffe://%s/%s/sa/%s" .global.spiffe.trustDomain .namespace .cert.serviceName }}
+{{- if .cert.uris }}
+{{- range .cert.uris }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+  - {{ printf "spiffe://%s/%s/sa/%s" .global.spiffe.trustDomain (.cert.identityNamespace | default .namespace) (.cert.spiffeServiceName | default .cert.serviceName | default .svcName) }}
 {{- range .cert.extraUris | default list }}
   - {{ . }}
+{{- end }}
 {{- end }}
 privateKey:
   algorithm: {{ .global.certificate.privateKey.algorithm }}

--- a/helm/charts/nico-dns/templates/certificate.yaml
+++ b/helm/charts/nico-dns/templates/certificate.yaml
@@ -1,9 +1,9 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: nico-dns-certificate
+  name: {{ include "nico-dns.name" . }}-certificate
   namespace: {{ include "nico-dns.namespace" . }}
   labels:
     {{- include "nico-dns.labels" . | nindent 4 }}
 spec:
-  {{- include "nico-dns.certificateSpec" (dict "name" "nico-dns-certificate" "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-dns.namespace" .)) | nindent 2 }}
+  {{- include "nico-dns.certificateSpec" (dict "name" (printf "%s-certificate" (include "nico-dns.name" .)) "svcName" (include "nico-dns.name" .) "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-dns.namespace" .)) | nindent 2 }}

--- a/helm/charts/nico-dns/templates/configmap.yaml
+++ b/helm/charts/nico-dns/templates/configmap.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.envFrom.nicoDnsConfig.configMapName }}
+  name: {{ include "nico-dns.name" . }}
   namespace: {{ include "nico-dns.namespace" . }}
   labels:
     {{- include "nico-dns.labels" . | nindent 4 }}
 data:
-  NICO_API: {{ printf "https://nico-api.%s.svc.cluster.local:%s" (include "nico-dns.namespace" .) (.Values.config.nicoApiPort | default "1079") | quote }}
-  NICO_API_HOST: {{ printf "nico-api.%s.svc.cluster.local" (include "nico-dns.namespace" .) | quote }}
+  NICO_API: {{ printf "https://%s.%s.svc.cluster.local:%s" .Values.apiServiceName (include "nico-dns.namespace" .) (.Values.config.nicoApiPort | default "1079") | quote }}
+  NICO_API_HOST: {{ printf "%s.%s.svc.cluster.local" .Values.apiServiceName (include "nico-dns.namespace" .) | quote }}
   NICO_API_PORT: {{ .Values.config.nicoApiPort | default "1079" | quote }}
   {{- range $key, $value := .Values.config.extraData }}
   {{ $key }}: {{ $value | quote }}

--- a/helm/charts/nico-dns/templates/external-service.yaml
+++ b/helm/charts/nico-dns/templates/external-service.yaml
@@ -5,12 +5,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-dns-external-udp-{{ $i }}
+  name: {{ include "nico-dns.name" . }}-external-udp-{{ $i }}
   namespace: {{ include "nico-dns.namespace" $ }}
   labels:
-    app.kubernetes.io/part-of: nico-dns-instance-{{ $i }}
+    app.kubernetes.io/part-of: {{ include "nico-dns.name" . }}-instance-{{ $i }}
   annotations:
-    metallb.universe.tf/allow-shared-ip: "nico-dns-instance-{{ $i }}"
+    metallb.universe.tf/allow-shared-ip: "{{ include "nico-dns.name" . }}-instance-{{ $i }}"
     {{- $annotations := "" }}
     {{- if and $.Values.externalService.perPodAnnotations (gt (len $.Values.externalService.perPodAnnotations) $i) }}
     {{- $annotations = index $.Values.externalService.perPodAnnotations $i }}
@@ -21,8 +21,8 @@ metadata:
 spec:
   type: {{ $.Values.externalService.type | default "LoadBalancer" }}
   selector:
-    app.kubernetes.io/name: nico-dns
-    statefulset.kubernetes.io/pod-name: nico-dns-{{ $i }}
+    app.kubernetes.io/name: {{ include "nico-dns.name" . }}
+    statefulset.kubernetes.io/pod-name: {{ include "nico-dns.name" . }}-{{ $i }}
   ports:
     - port: 53
       targetPort: 53
@@ -32,12 +32,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-dns-external-tcp-{{ $i }}
+  name: {{ include "nico-dns.name" . }}-external-tcp-{{ $i }}
   namespace: {{ include "nico-dns.namespace" $ }}
   labels:
-    app.kubernetes.io/part-of: nico-dns-instance-{{ $i }}
+    app.kubernetes.io/part-of: {{ include "nico-dns.name" . }}-instance-{{ $i }}
   annotations:
-    metallb.universe.tf/allow-shared-ip: "nico-dns-instance-{{ $i }}"
+    metallb.universe.tf/allow-shared-ip: "{{ include "nico-dns.name" . }}-instance-{{ $i }}"
     {{- $annotations := "" }}
     {{- if and $.Values.externalService.perPodAnnotations (gt (len $.Values.externalService.perPodAnnotations) $i) }}
     {{- $annotations = index $.Values.externalService.perPodAnnotations $i }}
@@ -48,8 +48,8 @@ metadata:
 spec:
   type: {{ $.Values.externalService.type | default "LoadBalancer" }}
   selector:
-    app.kubernetes.io/name: nico-dns
-    statefulset.kubernetes.io/pod-name: nico-dns-{{ $i }}
+    app.kubernetes.io/name: {{ include "nico-dns.name" . }}
+    statefulset.kubernetes.io/pod-name: {{ include "nico-dns.name" . }}-{{ $i }}
   ports:
     - port: 53
       targetPort: 53

--- a/helm/charts/nico-dns/templates/rbac.yaml
+++ b/helm/charts/nico-dns/templates/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nico-dns
+  name: {{ include "nico-dns.name" . }}
   namespace: {{ include "nico-dns.namespace" . }}
   labels:
     {{- include "nico-dns.labels" . | nindent 4 }}
@@ -10,7 +10,7 @@ automountServiceAccountToken: true
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nico-dns
+  name: {{ include "nico-dns.name" . }}
   namespace: {{ include "nico-dns.namespace" . }}
   labels:
     {{- include "nico-dns.labels" . | nindent 4 }}
@@ -22,15 +22,15 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nico-dns
+  name: {{ include "nico-dns.name" . }}
   namespace: {{ include "nico-dns.namespace" . }}
   labels:
     {{- include "nico-dns.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: nico-dns
+  name: {{ include "nico-dns.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: nico-dns
+    name: {{ include "nico-dns.name" . }}
     namespace: {{ include "nico-dns.namespace" . }}

--- a/helm/charts/nico-dns/templates/service.yaml
+++ b/helm/charts/nico-dns/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-dns
+  name: {{ include "nico-dns.name" . }}
   namespace: {{ include "nico-dns.namespace" . }}
   labels:
     {{- include "nico-dns.labels" . | nindent 4 }}

--- a/helm/charts/nico-dns/templates/statefulset.yaml
+++ b/helm/charts/nico-dns/templates/statefulset.yaml
@@ -1,14 +1,14 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: nico-dns
+  name: {{ include "nico-dns.name" . }}
   namespace: {{ include "nico-dns.namespace" . }}
   labels:
     {{- include "nico-dns.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.annotations | nindent 4 }}
+    {{- tpl (toYaml .Values.annotations) . | nindent 4 }}
 spec:
-  serviceName: nico-dns
+  serviceName: {{ include "nico-dns.name" . }}
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
@@ -18,15 +18,15 @@ spec:
       labels:
         {{- include "nico-dns.labels" . | nindent 8 }}
     spec:
-      serviceAccountName: nico-dns
+      serviceAccountName: {{ include "nico-dns.name" . }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - name: nico-dns
+        - name: {{ include "nico-dns.name" . }}
           image: "{{ include "nico-dns.image" . }}"
-          # Picks nico-dns (--nico-url) or carbide-dns (--carbide-url) based on which binary is in the image.
+          # Picks {{ include "nico-dns.name" . }} (--nico-url) or carbide-dns (--carbide-url) based on which binary is in the image.
           command:
             - /bin/sh
             - -c
@@ -40,7 +40,7 @@ spec:
             - name: NICO_API
               valueFrom:
                 configMapKeyRef:
-                  name: {{ .Values.envFrom.nicoDnsConfig.configMapName }}
+                  name: {{ include "nico-dns.name" . }}
                   key: NICO_API
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
@@ -65,4 +65,4 @@ spec:
       volumes:
         - name: spiffe
           secret:
-            secretName: nico-dns-certificate
+            secretName: {{ include "nico-dns.name" . }}-certificate

--- a/helm/charts/nico-dns/tests/apiservice_test.yaml
+++ b/helm/charts/nico-dns/tests/apiservice_test.yaml
@@ -1,0 +1,18 @@
+suite: API service host (apiServiceName) default nico, override carbide
+templates:
+  - configmap.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: defaults the API host to nico-api
+    asserts:
+      - equal:
+          path: data.NICO_API_HOST
+          value: nico-api.nico-system.svc.cluster.local
+  - it: apiServiceName overrides the API host to carbide-api
+    set:
+      apiServiceName: carbide-api
+    asserts:
+      - equal:
+          path: data.NICO_API_HOST
+          value: carbide-api.nico-system.svc.cluster.local

--- a/helm/charts/nico-dns/tests/certificate_test.yaml
+++ b/helm/charts/nico-dns/tests/certificate_test.yaml
@@ -1,0 +1,56 @@
+suite: certificate dnsNames and uris configurability
+templates:
+  - certificate.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: generates dnsNames and uris from serviceName and namespace by default
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: metadata.name
+          value: nico-dns-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-dns.nico-system.svc.cluster.local
+            - nico-dns.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/nico-dns
+
+  - it: fully overrides the generated dnsNames and uris when set
+    set:
+      certificate:
+        dnsNames:
+          - nico-dns.override.example.com
+        uris:
+          - spiffe://override.local/nico-system/sa/nico-dns
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-dns.override.example.com
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://override.local/nico-system/sa/nico-dns
+
+  - it: nameOverride flips the certificate resource name, dnsNames, and SPIFFE URI to the override
+    set:
+      nameOverride: carbide-dns
+    asserts:
+      - equal:
+          path: metadata.name
+          value: carbide-dns-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - carbide-dns.nico-system.svc.cluster.local
+            - carbide-dns.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/carbide-dns

--- a/helm/charts/nico-dns/values.yaml
+++ b/helm/charts/nico-dns/values.yaml
@@ -27,7 +27,7 @@ namespaceOverride: ""
 
 replicas: 2
 annotations:
-  configmap.reloader.stakater.com/reload: "nico-dns, nico-dns-config"
+  configmap.reloader.stakater.com/reload: '{{ include "nico-dns.name" . }}, {{ include "nico-dns.name" . }}-config'
 
 ## DNS server bind address. Default keeps the existing dual-stack/IPv6
 ## listener; set to "0.0.0.0:53" for IPv4-only Kubernetes clusters.
@@ -42,9 +42,18 @@ service:
       name: udp
       protocol: UDP
 
+apiServiceName: nico-api
+
 certificate:
   ## serviceName is used to auto-generate dnsNames and SPIFFE URIs based on the release namespace
-  serviceName: nico-dns
+  serviceName: ""
+  spiffeServiceName: ""
+  identityNamespace: ""
+  ## Fully override the auto-generated dnsNames/uris. When empty, dnsNames and
+  ## uris are generated from serviceName + namespace (extraDnsNames/extraUris
+  ## are appended to the generated list).
+  dnsNames: []
+  uris: []
   extraDnsNames: []
   extraUris: []
 

--- a/helm/charts/nico-dsx-exchange-consumer/templates/_helpers.tpl
+++ b/helm/charts/nico-dsx-exchange-consumer/templates/_helpers.tpl
@@ -26,7 +26,7 @@ Common labels
 helm.sh/chart: {{ include "nico-dsx-exchange-consumer.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: site-controller
-app.kubernetes.io/name: nico-dsx-exchange-consumer
+app.kubernetes.io/name: {{ include "nico-dsx-exchange-consumer.name" . }}
 app.kubernetes.io/component: dsx-exchange-consumer
 {{- end }}
 
@@ -34,7 +34,7 @@ app.kubernetes.io/component: dsx-exchange-consumer
 Selector labels
 */}}
 {{- define "nico-dsx-exchange-consumer.selectorLabels" -}}
-app.kubernetes.io/name: nico-dsx-exchange-consumer
+app.kubernetes.io/name: {{ include "nico-dsx-exchange-consumer.name" . }}
 app.kubernetes.io/component: dsx-exchange-consumer
 {{- end }}
 
@@ -51,19 +51,31 @@ Certificate spec
 {{- define "nico-dsx-exchange-consumer.certificateSpec" -}}
 duration: {{ .global.certificate.duration }}
 renewBefore: {{ .global.certificate.renewBefore }}
-commonName: {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
+commonName: {{ printf "%s.%s.svc.cluster.local" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 dnsNames:
-  - {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
-{{- if not (eq (toString (.cert.includeShortDnsName | default true)) "false") }}
-  - {{ printf "%s.%s" .cert.serviceName .namespace }}
+{{- if .cert.dnsNames }}
+{{- range .cert.dnsNames }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+  - {{ printf "%s.%s.svc.cluster.local" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
+{{- if ne (toString .cert.includeShortDnsName) "false" }}
+  - {{ printf "%s.%s" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 {{- end }}
 {{- range .cert.extraDnsNames | default list }}
   - {{ . }}
 {{- end }}
+{{- end }}
 uris:
-  - {{ printf "spiffe://%s/%s/sa/%s" .global.spiffe.trustDomain .namespace .cert.serviceName }}
+{{- if .cert.uris }}
+{{- range .cert.uris }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+  - {{ printf "spiffe://%s/%s/sa/%s" .global.spiffe.trustDomain (.cert.identityNamespace | default .namespace) (.cert.spiffeServiceName | default .cert.serviceName | default .svcName) }}
 {{- range .cert.extraUris | default list }}
   - {{ . }}
+{{- end }}
 {{- end }}
 privateKey:
   algorithm: {{ .global.certificate.privateKey.algorithm }}

--- a/helm/charts/nico-dsx-exchange-consumer/templates/certificate.yaml
+++ b/helm/charts/nico-dsx-exchange-consumer/templates/certificate.yaml
@@ -1,9 +1,9 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: nico-dsx-exchange-consumer-certificate
+  name: {{ include "nico-dsx-exchange-consumer.name" . }}-certificate
   namespace: {{ include "nico-dsx-exchange-consumer.namespace" . }}
   labels:
     {{- include "nico-dsx-exchange-consumer.labels" . | nindent 4 }}
 spec:
-  {{- include "nico-dsx-exchange-consumer.certificateSpec" (dict "name" "nico-dsx-exchange-consumer-certificate" "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-dsx-exchange-consumer.namespace" .)) | nindent 2 }}
+  {{- include "nico-dsx-exchange-consumer.certificateSpec" (dict "name" (printf "%s-certificate" (include "nico-dsx-exchange-consumer.name" .)) "svcName" (include "nico-dsx-exchange-consumer.name" .) "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-dsx-exchange-consumer.namespace" .)) | nindent 2 }}

--- a/helm/charts/nico-dsx-exchange-consumer/templates/deployment.yaml
+++ b/helm/charts/nico-dsx-exchange-consumer/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nico-dsx-exchange-consumer
+  name: {{ include "nico-dsx-exchange-consumer.name" . }}
   namespace: {{ include "nico-dsx-exchange-consumer.namespace" . }}
   labels:
     {{- include "nico-dsx-exchange-consumer.labels" . | nindent 4 }}
@@ -17,13 +17,13 @@ spec:
       labels:
         {{- include "nico-dsx-exchange-consumer.labels" . | nindent 8 }}
     spec:
-      serviceAccountName: nico-dsx-exchange-consumer
+      serviceAccountName: {{ include "nico-dsx-exchange-consumer.name" . }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - name: nico-dsx-exchange-consumer
+        - name: {{ include "nico-dsx-exchange-consumer.name" . }}
           image: "{{ include "nico-dsx-exchange-consumer.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
           securityContext:
@@ -57,4 +57,4 @@ spec:
       volumes:
         - name: spiffe
           secret:
-            secretName: nico-dsx-exchange-consumer-certificate
+            secretName: {{ include "nico-dsx-exchange-consumer.name" . }}-certificate

--- a/helm/charts/nico-dsx-exchange-consumer/templates/rbac.yaml
+++ b/helm/charts/nico-dsx-exchange-consumer/templates/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nico-dsx-exchange-consumer
+  name: {{ include "nico-dsx-exchange-consumer.name" . }}
   namespace: {{ include "nico-dsx-exchange-consumer.namespace" . }}
   labels:
     {{- include "nico-dsx-exchange-consumer.labels" . | nindent 4 }}
@@ -9,7 +9,7 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nico-dsx-exchange-consumer
+  name: {{ include "nico-dsx-exchange-consumer.name" . }}
   namespace: {{ include "nico-dsx-exchange-consumer.namespace" . }}
   labels:
     {{- include "nico-dsx-exchange-consumer.labels" . | nindent 4 }}
@@ -21,15 +21,15 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nico-dsx-exchange-consumer
+  name: {{ include "nico-dsx-exchange-consumer.name" . }}
   namespace: {{ include "nico-dsx-exchange-consumer.namespace" . }}
   labels:
     {{- include "nico-dsx-exchange-consumer.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: nico-dsx-exchange-consumer
+  name: {{ include "nico-dsx-exchange-consumer.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: nico-dsx-exchange-consumer
+    name: {{ include "nico-dsx-exchange-consumer.name" . }}
     namespace: {{ include "nico-dsx-exchange-consumer.namespace" . }}

--- a/helm/charts/nico-dsx-exchange-consumer/templates/service-monitor.yaml
+++ b/helm/charts/nico-dsx-exchange-consumer/templates/service-monitor.yaml
@@ -2,12 +2,12 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: nico-dsx-exchange-consumer-metrics
+  name: {{ include "nico-dsx-exchange-consumer.name" . }}-metrics
   namespace: {{ include "nico-dsx-exchange-consumer.namespace" . }}
   labels:
     {{- include "nico-dsx-exchange-consumer.labels" . | nindent 4 }}
-    app: nico-dsx-exchange-consumer
+    app: {{ include "nico-dsx-exchange-consumer.name" . }}
     prometheus: nico-monitoring
 spec:
-  {{- include "nico-dsx-exchange-consumer.serviceMonitorSpec" (dict "name" "nico-dsx-exchange-consumer" "port" "metrics" "monitor" .Values.serviceMonitor "namespace" (include "nico-dsx-exchange-consumer.namespace" .)) | nindent 2 }}
+  {{- include "nico-dsx-exchange-consumer.serviceMonitorSpec" (dict "name" (include "nico-dsx-exchange-consumer.name" .) "port" "metrics" "monitor" .Values.serviceMonitor "namespace" (include "nico-dsx-exchange-consumer.namespace" .)) | nindent 2 }}
 {{- end }}

--- a/helm/charts/nico-dsx-exchange-consumer/templates/service.yaml
+++ b/helm/charts/nico-dsx-exchange-consumer/templates/service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-dsx-exchange-consumer
+  name: {{ include "nico-dsx-exchange-consumer.name" . }}
   namespace: {{ include "nico-dsx-exchange-consumer.namespace" . }}
   labels:
     {{- include "nico-dsx-exchange-consumer.labels" . | nindent 4 }}
-    app: nico-dsx-exchange-consumer
-    app.kubernetes.io/metrics: nico-dsx-exchange-consumer
+    app: {{ include "nico-dsx-exchange-consumer.name" . }}
+    app.kubernetes.io/metrics: {{ include "nico-dsx-exchange-consumer.name" . }}
 spec:
   selector:
     {{- include "nico-dsx-exchange-consumer.selectorLabels" . | nindent 4 }}

--- a/helm/charts/nico-dsx-exchange-consumer/tests/certificate_test.yaml
+++ b/helm/charts/nico-dsx-exchange-consumer/tests/certificate_test.yaml
@@ -1,0 +1,56 @@
+suite: certificate dnsNames and uris configurability
+templates:
+  - certificate.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: generates dnsNames and uris from serviceName and namespace by default
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: metadata.name
+          value: nico-dsx-exchange-consumer-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-dsx-exchange-consumer.nico-system.svc.cluster.local
+            - nico-dsx-exchange-consumer.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/nico-dsx-exchange-consumer
+
+  - it: fully overrides the generated dnsNames and uris when set
+    set:
+      certificate:
+        dnsNames:
+          - nico-dsx-exchange-consumer.override.example.com
+        uris:
+          - spiffe://override.local/nico-system/sa/nico-dsx-exchange-consumer
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-dsx-exchange-consumer.override.example.com
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://override.local/nico-system/sa/nico-dsx-exchange-consumer
+
+  - it: nameOverride flips the certificate resource name, dnsNames, and SPIFFE URI to the override
+    set:
+      nameOverride: carbide-dsx-exchange-consumer
+    asserts:
+      - equal:
+          path: metadata.name
+          value: carbide-dsx-exchange-consumer-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - carbide-dsx-exchange-consumer.nico-system.svc.cluster.local
+            - carbide-dsx-exchange-consumer.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/carbide-dsx-exchange-consumer

--- a/helm/charts/nico-dsx-exchange-consumer/values.yaml
+++ b/helm/charts/nico-dsx-exchange-consumer/values.yaml
@@ -31,7 +31,14 @@ service:
 
 certificate:
   ## serviceName is used to auto-generate dnsNames and SPIFFE URIs based on the release namespace
-  serviceName: nico-dsx-exchange-consumer
+  serviceName: ""
+  spiffeServiceName: ""
+  identityNamespace: ""
+  ## Fully override the auto-generated dnsNames/uris. When empty, dnsNames and
+  ## uris are generated from serviceName + namespace (extraDnsNames/extraUris
+  ## are appended to the generated list).
+  dnsNames: []
+  uris: []
   extraDnsNames: []
   extraUris: []
 

--- a/helm/charts/nico-hardware-health/templates/_helpers.tpl
+++ b/helm/charts/nico-hardware-health/templates/_helpers.tpl
@@ -26,7 +26,7 @@ Common labels
 helm.sh/chart: {{ include "nico-hardware-health.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: site-controller
-app.kubernetes.io/name: nico-hardware-health
+app.kubernetes.io/name: {{ include "nico-hardware-health.name" . }}
 app.kubernetes.io/component: hardware-health
 {{- end }}
 
@@ -34,7 +34,7 @@ app.kubernetes.io/component: hardware-health
 Selector labels
 */}}
 {{- define "nico-hardware-health.selectorLabels" -}}
-app.kubernetes.io/name: nico-hardware-health
+app.kubernetes.io/name: {{ include "nico-hardware-health.name" . }}
 app.kubernetes.io/component: hardware-health
 {{- end }}
 
@@ -51,19 +51,31 @@ Certificate spec
 {{- define "nico-hardware-health.certificateSpec" -}}
 duration: {{ .global.certificate.duration }}
 renewBefore: {{ .global.certificate.renewBefore }}
-commonName: {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
+commonName: {{ printf "%s.%s.svc.cluster.local" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 dnsNames:
-  - {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
-{{- if not (eq (toString (.cert.includeShortDnsName | default true)) "false") }}
-  - {{ printf "%s.%s" .cert.serviceName .namespace }}
+{{- if .cert.dnsNames }}
+{{- range .cert.dnsNames }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+  - {{ printf "%s.%s.svc.cluster.local" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
+{{- if ne (toString .cert.includeShortDnsName) "false" }}
+  - {{ printf "%s.%s" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 {{- end }}
 {{- range .cert.extraDnsNames | default list }}
   - {{ . }}
 {{- end }}
+{{- end }}
 uris:
-  - {{ printf "spiffe://%s/%s/sa/%s" .global.spiffe.trustDomain .namespace .cert.serviceName }}
+{{- if .cert.uris }}
+{{- range .cert.uris }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+  - {{ printf "spiffe://%s/%s/sa/%s" .global.spiffe.trustDomain (.cert.identityNamespace | default .namespace) (.cert.spiffeServiceName | default .cert.serviceName | default .svcName) }}
 {{- range .cert.extraUris | default list }}
   - {{ . }}
+{{- end }}
 {{- end }}
 privateKey:
   algorithm: {{ .global.certificate.privateKey.algorithm }}

--- a/helm/charts/nico-hardware-health/templates/certificate.yaml
+++ b/helm/charts/nico-hardware-health/templates/certificate.yaml
@@ -1,9 +1,9 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: nico-hardware-health-certificate
+  name: {{ include "nico-hardware-health.name" . }}-certificate
   namespace: {{ include "nico-hardware-health.namespace" . }}
   labels:
     {{- include "nico-hardware-health.labels" . | nindent 4 }}
 spec:
-  {{- include "nico-hardware-health.certificateSpec" (dict "name" "nico-hardware-health-certificate" "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-hardware-health.namespace" .)) | nindent 2 }}
+  {{- include "nico-hardware-health.certificateSpec" (dict "name" (printf "%s-certificate" (include "nico-hardware-health.name" .)) "svcName" (include "nico-hardware-health.name" .) "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-hardware-health.namespace" .)) | nindent 2 }}

--- a/helm/charts/nico-hardware-health/templates/deployment.yaml
+++ b/helm/charts/nico-hardware-health/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nico-hardware-health
+  name: {{ include "nico-hardware-health.name" . }}
   namespace: {{ include "nico-hardware-health.namespace" . }}
   labels:
     {{- include "nico-hardware-health.labels" . | nindent 4 }}
@@ -17,13 +17,13 @@ spec:
       labels:
         {{- include "nico-hardware-health.labels" . | nindent 8 }}
     spec:
-      serviceAccountName: nico-hardware-health
+      serviceAccountName: {{ include "nico-hardware-health.name" . }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - name: nico-hardware-health
+        - name: {{ include "nico-hardware-health.name" . }}
           image: "{{ include "nico-hardware-health.image" . }}"
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
           securityContext:
@@ -57,4 +57,4 @@ spec:
       volumes:
         - name: spiffe
           secret:
-            secretName: nico-hardware-health-certificate
+            secretName: {{ include "nico-hardware-health.name" . }}-certificate

--- a/helm/charts/nico-hardware-health/templates/rbac.yaml
+++ b/helm/charts/nico-hardware-health/templates/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nico-hardware-health
+  name: {{ include "nico-hardware-health.name" . }}
   namespace: {{ include "nico-hardware-health.namespace" . }}
   labels:
     {{- include "nico-hardware-health.labels" . | nindent 4 }}
@@ -9,7 +9,7 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nico-hardware-health
+  name: {{ include "nico-hardware-health.name" . }}
   namespace: {{ include "nico-hardware-health.namespace" . }}
   labels:
     {{- include "nico-hardware-health.labels" . | nindent 4 }}
@@ -21,15 +21,15 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nico-hardware-health
+  name: {{ include "nico-hardware-health.name" . }}
   namespace: {{ include "nico-hardware-health.namespace" . }}
   labels:
     {{- include "nico-hardware-health.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: nico-hardware-health
+  name: {{ include "nico-hardware-health.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: nico-hardware-health
+    name: {{ include "nico-hardware-health.name" . }}
     namespace: {{ include "nico-hardware-health.namespace" . }}

--- a/helm/charts/nico-hardware-health/templates/service-monitor.yaml
+++ b/helm/charts/nico-hardware-health/templates/service-monitor.yaml
@@ -2,12 +2,12 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: nico-hardware-health-metrics
+  name: {{ include "nico-hardware-health.name" . }}-metrics
   namespace: {{ include "nico-hardware-health.namespace" . }}
   labels:
     {{- include "nico-hardware-health.labels" . | nindent 4 }}
-    app: nico-hardware-health
+    app: {{ include "nico-hardware-health.name" . }}
     prometheus: nico-monitoring
 spec:
-  {{- include "nico-hardware-health.serviceMonitorSpec" (dict "name" "nico-hardware-health" "port" "metrics" "monitor" .Values.serviceMonitor "namespace" "nico-system") | nindent 2 }}
+  {{- include "nico-hardware-health.serviceMonitorSpec" (dict "name" (include "nico-hardware-health.name" .) "port" "metrics" "monitor" .Values.serviceMonitor "namespace" "nico-system") | nindent 2 }}
 {{- end }}

--- a/helm/charts/nico-hardware-health/templates/service.yaml
+++ b/helm/charts/nico-hardware-health/templates/service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-hardware-health
+  name: {{ include "nico-hardware-health.name" . }}
   namespace: {{ include "nico-hardware-health.namespace" . }}
   labels:
     {{- include "nico-hardware-health.labels" . | nindent 4 }}
-    app: nico-hardware-health
-    app.kubernetes.io/metrics: nico-hardware-health
+    app: {{ include "nico-hardware-health.name" . }}
+    app.kubernetes.io/metrics: {{ include "nico-hardware-health.name" . }}
 spec:
   selector:
     {{- include "nico-hardware-health.selectorLabels" . | nindent 4 }}

--- a/helm/charts/nico-hardware-health/tests/certificate_test.yaml
+++ b/helm/charts/nico-hardware-health/tests/certificate_test.yaml
@@ -1,0 +1,56 @@
+suite: certificate dnsNames and uris configurability
+templates:
+  - certificate.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: generates dnsNames and uris from serviceName and namespace by default
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: metadata.name
+          value: nico-hardware-health-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-hardware-health.nico-system.svc.cluster.local
+            - nico-hardware-health.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/nico-hardware-health
+
+  - it: fully overrides the generated dnsNames and uris when set
+    set:
+      certificate:
+        dnsNames:
+          - nico-hardware-health.override.example.com
+        uris:
+          - spiffe://override.local/nico-system/sa/nico-hardware-health
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-hardware-health.override.example.com
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://override.local/nico-system/sa/nico-hardware-health
+
+  - it: nameOverride flips the certificate resource name, dnsNames, and SPIFFE URI to the override
+    set:
+      nameOverride: carbide-hardware-health
+    asserts:
+      - equal:
+          path: metadata.name
+          value: carbide-hardware-health-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - carbide-hardware-health.nico-system.svc.cluster.local
+            - carbide-hardware-health.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/carbide-hardware-health

--- a/helm/charts/nico-hardware-health/values.yaml
+++ b/helm/charts/nico-hardware-health/values.yaml
@@ -32,7 +32,14 @@ service:
 
 certificate:
   ## serviceName is used to auto-generate dnsNames and SPIFFE URIs based on the release namespace
-  serviceName: nico-hardware-health
+  serviceName: ""
+  spiffeServiceName: ""
+  identityNamespace: ""
+  ## Fully override the auto-generated dnsNames/uris. When empty, dnsNames and
+  ## uris are generated from serviceName + namespace (extraDnsNames/extraUris
+  ## are appended to the generated list).
+  dnsNames: []
+  uris: []
   extraDnsNames: []
   extraUris: []
 

--- a/helm/charts/nico-pxe/templates/_helpers.tpl
+++ b/helm/charts/nico-pxe/templates/_helpers.tpl
@@ -26,7 +26,7 @@ Common labels
 helm.sh/chart: {{ include "nico-pxe.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: site-controller
-app.kubernetes.io/name: nico-pxe
+app.kubernetes.io/name: {{ include "nico-pxe.name" . }}
 app.kubernetes.io/component: pxe
 {{- end }}
 
@@ -34,7 +34,7 @@ app.kubernetes.io/component: pxe
 Selector labels
 */}}
 {{- define "nico-pxe.selectorLabels" -}}
-app.kubernetes.io/name: nico-pxe
+app.kubernetes.io/name: {{ include "nico-pxe.name" . }}
 app.kubernetes.io/component: pxe
 {{- end }}
 
@@ -51,19 +51,31 @@ Certificate spec
 {{- define "nico-pxe.certificateSpec" -}}
 duration: {{ .global.certificate.duration }}
 renewBefore: {{ .global.certificate.renewBefore }}
-commonName: {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
+commonName: {{ printf "%s.%s.svc.cluster.local" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 dnsNames:
-  - {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
-{{- if not (eq (toString (.cert.includeShortDnsName | default true)) "false") }}
-  - {{ printf "%s.%s" .cert.serviceName .namespace }}
+{{- if .cert.dnsNames }}
+{{- range .cert.dnsNames }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+  - {{ printf "%s.%s.svc.cluster.local" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
+{{- if ne (toString .cert.includeShortDnsName) "false" }}
+  - {{ printf "%s.%s" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 {{- end }}
 {{- range .cert.extraDnsNames | default list }}
   - {{ . }}
 {{- end }}
+{{- end }}
 uris:
-  - {{ printf "spiffe://%s/%s/sa/%s" .global.spiffe.trustDomain .namespace .cert.serviceName }}
+{{- if .cert.uris }}
+{{- range .cert.uris }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+  - {{ printf "spiffe://%s/%s/sa/%s" .global.spiffe.trustDomain (.cert.identityNamespace | default .namespace) (.cert.spiffeServiceName | default .cert.serviceName | default .svcName) }}
 {{- range .cert.extraUris | default list }}
   - {{ . }}
+{{- end }}
 {{- end }}
 privateKey:
   algorithm: {{ .global.certificate.privateKey.algorithm }}

--- a/helm/charts/nico-pxe/templates/certificate.yaml
+++ b/helm/charts/nico-pxe/templates/certificate.yaml
@@ -1,9 +1,9 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: nico-pxe-certificate
+  name: {{ include "nico-pxe.name" . }}-certificate
   namespace: {{ include "nico-pxe.namespace" . }}
   labels:
     {{- include "nico-pxe.labels" . | nindent 4 }}
 spec:
-  {{- include "nico-pxe.certificateSpec" (dict "name" "nico-pxe-certificate" "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-pxe.namespace" .)) | nindent 2 }}
+  {{- include "nico-pxe.certificateSpec" (dict "name" (printf "%s-certificate" (include "nico-pxe.name" .)) "svcName" (include "nico-pxe.name" .) "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-pxe.namespace" .)) | nindent 2 }}

--- a/helm/charts/nico-pxe/templates/configmap.yaml
+++ b/helm/charts/nico-pxe/templates/configmap.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.envFrom.pxeEnvConfig.configMapName }}
+  name: {{ include "nico-pxe.name" . }}-env-config
   namespace: {{ include "nico-pxe.namespace" . }}
   labels:
     {{- include "nico-pxe.labels" . | nindent 4 }}
 data:
-  NICO_API_HOST: {{ printf "nico-api.%s.svc.cluster.local" (include "nico-pxe.namespace" .) | quote }}
+  NICO_API_HOST: {{ printf "%s.%s.svc.cluster.local" .Values.apiServiceName (include "nico-pxe.namespace" .) | quote }}
   NICO_API_PORT: {{ .Values.config.nicoApiPort | default "1079" | quote }}
   {{- range $key, $value := .Values.config.extraEnvData }}
   {{ $key }}: {{ $value | quote }}

--- a/helm/charts/nico-pxe/templates/deployment.yaml
+++ b/helm/charts/nico-pxe/templates/deployment.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nico-pxe
+  name: {{ include "nico-pxe.name" . }}
   namespace: {{ include "nico-pxe.namespace" . }}
   labels:
     {{- include "nico-pxe.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.annotations | nindent 4 }}
+    {{- tpl (toYaml .Values.annotations) . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   strategy:
@@ -19,9 +19,9 @@ spec:
       labels:
         {{- include "nico-pxe.labels" . | nindent 8 }}
       annotations:
-        kubectl.kubernetes.io/default-container: nico-pxe
+        kubectl.kubernetes.io/default-container: {{ include "nico-pxe.name" . }}
     spec:
-      serviceAccountName: nico-pxe
+      serviceAccountName: {{ include "nico-pxe.name" . }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -50,7 +50,7 @@ spec:
         {{- end }}
       {{- end }}
       containers:
-        - name: nico-pxe
+        - name: {{ include "nico-pxe.name" . }}
           image: "{{ include "nico-pxe.image" . }}"
           # Pick whichever binary is in the image (nico-named or carbide-named).
           command:
@@ -67,7 +67,7 @@ spec:
           {{- if .Values.envFrom }}
           envFrom:
             - configMapRef:
-                name: {{ .Values.envFrom.pxeEnvConfig.configMapName }}
+                name: {{ include "nico-pxe.name" . }}-env-config
                 optional: {{ .Values.envFrom.pxeEnvConfig.optional | default true }}
           {{- end }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
@@ -92,7 +92,7 @@ spec:
       volumes:
         - name: spiffe
           secret:
-            secretName: nico-pxe-certificate
+            secretName: {{ include "nico-pxe.name" . }}-certificate
         {{- if .Values.bootArtifactContainers }}
         - name: boot-artifacts
           emptyDir: {}

--- a/helm/charts/nico-pxe/templates/external-service.yaml
+++ b/helm/charts/nico-pxe/templates/external-service.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-pxe-external
+  name: {{ include "nico-pxe.name" . }}-external
   namespace: {{ include "nico-pxe.namespace" . }}
   labels:
     {{- include "nico-pxe.labels" . | nindent 4 }}
-    app.kubernetes.io/part-of: nico-pxe
+    app.kubernetes.io/part-of: {{ include "nico-pxe.name" . }}
   annotations:
-    metallb.universe.tf/allow-shared-ip: "nico-pxe"
+    metallb.universe.tf/allow-shared-ip: "{{ include "nico-pxe.name" . }}"
     {{- with .Values.externalService.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -28,13 +28,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-pxe-external-80
+  name: {{ include "nico-pxe.name" . }}-external-80
   namespace: {{ include "nico-pxe.namespace" . }}
   labels:
     {{- include "nico-pxe.labels" . | nindent 4 }}
-    app.kubernetes.io/part-of: nico-pxe
+    app.kubernetes.io/part-of: {{ include "nico-pxe.name" . }}
   annotations:
-    metallb.universe.tf/allow-shared-ip: "nico-pxe"
+    metallb.universe.tf/allow-shared-ip: "{{ include "nico-pxe.name" . }}"
     {{- with .Values.externalService.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/helm/charts/nico-pxe/templates/metrics-service.yaml
+++ b/helm/charts/nico-pxe/templates/metrics-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-pxe-metrics
+  name: {{ include "nico-pxe.name" . }}-metrics
   namespace: {{ include "nico-pxe.namespace" . }}
   labels:
     {{- include "nico-pxe.labels" . | nindent 4 }}
-    app: nico-pxe
-    app.kubernetes.io/metrics: nico-pxe
+    app: {{ include "nico-pxe.name" . }}
+    app.kubernetes.io/metrics: {{ include "nico-pxe.name" . }}
 spec:
   selector:
     {{- include "nico-pxe.selectorLabels" . | nindent 4 }}

--- a/helm/charts/nico-pxe/templates/rbac.yaml
+++ b/helm/charts/nico-pxe/templates/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nico-pxe
+  name: {{ include "nico-pxe.name" . }}
   namespace: {{ include "nico-pxe.namespace" . }}
   labels:
     {{- include "nico-pxe.labels" . | nindent 4 }}
@@ -10,7 +10,7 @@ automountServiceAccountToken: true
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nico-pxe
+  name: {{ include "nico-pxe.name" . }}
   namespace: {{ include "nico-pxe.namespace" . }}
   labels:
     {{- include "nico-pxe.labels" . | nindent 4 }}
@@ -22,15 +22,15 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nico-pxe
+  name: {{ include "nico-pxe.name" . }}
   namespace: {{ include "nico-pxe.namespace" . }}
   labels:
     {{- include "nico-pxe.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: nico-pxe
+  name: {{ include "nico-pxe.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: nico-pxe
+    name: {{ include "nico-pxe.name" . }}
     namespace: {{ include "nico-pxe.namespace" . }}

--- a/helm/charts/nico-pxe/templates/service-monitor.yaml
+++ b/helm/charts/nico-pxe/templates/service-monitor.yaml
@@ -2,12 +2,12 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: nico-pxe-metrics
+  name: {{ include "nico-pxe.name" . }}-metrics
   namespace: {{ include "nico-pxe.namespace" . }}
   labels:
     {{- include "nico-pxe.labels" . | nindent 4 }}
-    app: nico-pxe
+    app: {{ include "nico-pxe.name" . }}
     prometheus: nico-monitoring
 spec:
-  {{- include "nico-pxe.serviceMonitorSpec" (dict "name" "nico-pxe" "port" "http" "monitor" .Values.serviceMonitor "namespace" "nico-system") | nindent 2 }}
+  {{- include "nico-pxe.serviceMonitorSpec" (dict "name" (include "nico-pxe.name" .) "port" "http" "monitor" .Values.serviceMonitor "namespace" "nico-system") | nindent 2 }}
 {{- end }}

--- a/helm/charts/nico-pxe/templates/service.yaml
+++ b/helm/charts/nico-pxe/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-pxe
+  name: {{ include "nico-pxe.name" . }}
   namespace: {{ include "nico-pxe.namespace" . }}
   labels:
     {{- include "nico-pxe.labels" . | nindent 4 }}

--- a/helm/charts/nico-pxe/tests/apiservice_test.yaml
+++ b/helm/charts/nico-pxe/tests/apiservice_test.yaml
@@ -1,0 +1,18 @@
+suite: API service host (apiServiceName) default nico, override carbide
+templates:
+  - configmap.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: defaults the API host to nico-api
+    asserts:
+      - equal:
+          path: data.NICO_API_HOST
+          value: nico-api.nico-system.svc.cluster.local
+  - it: apiServiceName overrides the API host to carbide-api
+    set:
+      apiServiceName: carbide-api
+    asserts:
+      - equal:
+          path: data.NICO_API_HOST
+          value: carbide-api.nico-system.svc.cluster.local

--- a/helm/charts/nico-pxe/tests/boot_artifacts_test.yaml
+++ b/helm/charts/nico-pxe/tests/boot_artifacts_test.yaml
@@ -73,19 +73,17 @@ tests:
       bootArtifacts:
         servePath: /custom-boot-path
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].args
-          value:
-            - -s
-            - /custom-boot-path
+      # The container runs a shell binary-picker, so the serve path is rendered
+      # into the command script as `-s <path>` rather than into container args.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '-s /custom-boot-path'
 
   - it: should default serve path to /boot-artifacts
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].args
-          value:
-            - -s
-            - /boot-artifacts
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '-s /boot-artifacts'
 
   - it: should merge bootArtifactContainers and initContainers
     set:

--- a/helm/charts/nico-pxe/tests/certificate_test.yaml
+++ b/helm/charts/nico-pxe/tests/certificate_test.yaml
@@ -1,0 +1,56 @@
+suite: certificate dnsNames and uris configurability
+templates:
+  - certificate.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: generates dnsNames and uris from serviceName and namespace by default
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: metadata.name
+          value: nico-pxe-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-pxe.nico-system.svc.cluster.local
+            - nico-pxe.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/nico-pxe
+
+  - it: fully overrides the generated dnsNames and uris when set
+    set:
+      certificate:
+        dnsNames:
+          - nico-pxe.override.example.com
+        uris:
+          - spiffe://override.local/nico-system/sa/nico-pxe
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-pxe.override.example.com
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://override.local/nico-system/sa/nico-pxe
+
+  - it: nameOverride flips the certificate resource name, dnsNames, and SPIFFE URI to the override
+    set:
+      nameOverride: carbide-pxe
+    asserts:
+      - equal:
+          path: metadata.name
+          value: carbide-pxe-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - carbide-pxe.nico-system.svc.cluster.local
+            - carbide-pxe.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/carbide-pxe

--- a/helm/charts/nico-pxe/values.yaml
+++ b/helm/charts/nico-pxe/values.yaml
@@ -50,14 +50,23 @@ bootArtifacts:
   servePath: /boot-artifacts
 
 annotations:
-  configmap.reloader.stakater.com/reload: "nico-pxe-env-config"
+  configmap.reloader.stakater.com/reload: '{{ include "nico-pxe.name" . }}-env-config'
 
 service:
   port: 8080
 
+apiServiceName: nico-api
+
 certificate:
   ## serviceName is used to auto-generate dnsNames and SPIFFE URIs based on the release namespace
-  serviceName: nico-pxe
+  serviceName: ""
+  spiffeServiceName: ""
+  identityNamespace: ""
+  ## Fully override the auto-generated dnsNames/uris. When empty, dnsNames and
+  ## uris are generated from serviceName + namespace (extraDnsNames/extraUris
+  ## are appended to the generated list).
+  dnsNames: []
+  uris: []
   extraDnsNames: []
   extraUris: []
 

--- a/helm/charts/nico-ssh-console-rs/templates/_helpers.tpl
+++ b/helm/charts/nico-ssh-console-rs/templates/_helpers.tpl
@@ -26,7 +26,7 @@ Common labels
 helm.sh/chart: {{ include "nico-ssh-console-rs.chart" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: site-controller
-app.kubernetes.io/name: nico-ssh-console-rs
+app.kubernetes.io/name: {{ include "nico-ssh-console-rs.name" . }}
 app.kubernetes.io/component: ssh-console-rs
 {{- end }}
 
@@ -34,7 +34,7 @@ app.kubernetes.io/component: ssh-console-rs
 Selector labels
 */}}
 {{- define "nico-ssh-console-rs.selectorLabels" -}}
-app.kubernetes.io/name: nico-ssh-console-rs
+app.kubernetes.io/name: {{ include "nico-ssh-console-rs.name" . }}
 app.kubernetes.io/component: ssh-console-rs
 {{- end }}
 
@@ -51,19 +51,31 @@ Certificate spec
 {{- define "nico-ssh-console-rs.certificateSpec" -}}
 duration: {{ .global.certificate.duration }}
 renewBefore: {{ .global.certificate.renewBefore }}
-commonName: {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
+commonName: {{ printf "%s.%s.svc.cluster.local" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 dnsNames:
-  - {{ printf "%s.%s.svc.cluster.local" .cert.serviceName .namespace }}
-{{- if not (eq (toString (.cert.includeShortDnsName | default true)) "false") }}
-  - {{ printf "%s.%s" .cert.serviceName .namespace }}
+{{- if .cert.dnsNames }}
+{{- range .cert.dnsNames }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+  - {{ printf "%s.%s.svc.cluster.local" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
+{{- if ne (toString .cert.includeShortDnsName) "false" }}
+  - {{ printf "%s.%s" (.cert.serviceName | default .svcName) (.cert.identityNamespace | default .namespace) }}
 {{- end }}
 {{- range .cert.extraDnsNames | default list }}
   - {{ . }}
 {{- end }}
+{{- end }}
 uris:
-  - {{ printf "spiffe://%s/%s/sa/%s" .global.spiffe.trustDomain .namespace .cert.serviceName }}
+{{- if .cert.uris }}
+{{- range .cert.uris }}
+  - {{ . }}
+{{- end }}
+{{- else }}
+  - {{ printf "spiffe://%s/%s/sa/%s" .global.spiffe.trustDomain (.cert.identityNamespace | default .namespace) (.cert.spiffeServiceName | default .cert.serviceName | default .svcName) }}
 {{- range .cert.extraUris | default list }}
   - {{ . }}
+{{- end }}
 {{- end }}
 privateKey:
   algorithm: {{ .global.certificate.privateKey.algorithm }}

--- a/helm/charts/nico-ssh-console-rs/templates/certificate.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/certificate.yaml
@@ -1,9 +1,9 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: nico-ssh-console-rs-certificate
+  name: {{ include "nico-ssh-console-rs.name" . }}-certificate
   namespace: {{ include "nico-ssh-console-rs.namespace" . }}
   labels:
     {{- include "nico-ssh-console-rs.labels" . | nindent 4 }}
 spec:
-  {{- include "nico-ssh-console-rs.certificateSpec" (dict "name" "nico-ssh-console-rs-certificate" "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-ssh-console-rs.namespace" .)) | nindent 2 }}
+  {{- include "nico-ssh-console-rs.certificateSpec" (dict "name" (printf "%s-certificate" (include "nico-ssh-console-rs.name" .)) "svcName" (include "nico-ssh-console-rs.name" .) "cert" .Values.certificate "global" .Values.global "namespace" (include "nico-ssh-console-rs.namespace" .)) | nindent 2 }}

--- a/helm/charts/nico-ssh-console-rs/templates/configmap.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ssh-console-rs-config-files
+  name: {{ include "nico-ssh-console-rs.name" . }}-config-files
   namespace: {{ include "nico-ssh-console-rs.namespace" . }}
   labels:
     {{- include "nico-ssh-console-rs.labels" . | nindent 4 }}
@@ -11,13 +11,13 @@ data:
     {{- .Values.configFiles.config | nindent 4 }}
     {{- else }}
     {{- /* Replace hardcoded nico-system namespace with actual global.namespace */ -}}
-    {{- .Files.Get "files/ssh-console-rs-config.toml" | replace "nico-system" (include "nico-ssh-console-rs.namespace" .) | nindent 4 }}
+    {{- .Files.Get "files/ssh-console-rs-config.toml" | replace "nico-system" (include "nico-ssh-console-rs.namespace" .) | replace "https://nico-api." (printf "https://%s." .Values.apiServiceName) | nindent 4 }}
     {{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ssh-console-rs-otelcol-config
+  name: {{ include "nico-ssh-console-rs.name" . }}-otelcol-config
   namespace: {{ include "nico-ssh-console-rs.namespace" . }}
   labels:
     {{- include "nico-ssh-console-rs.labels" . | nindent 4 }}

--- a/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nico-ssh-console-rs
+  name: {{ include "nico-ssh-console-rs.name" . }}
   namespace: {{ include "nico-ssh-console-rs.namespace" . }}
   labels:
     {{- include "nico-ssh-console-rs.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.annotations | nindent 4 }}
+    {{- tpl (toYaml .Values.annotations) . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicas }}
   # Bumped from default 600s — on a cold cluster, vault-pki-config hook + cert-manager
@@ -22,7 +22,7 @@ spec:
       labels:
         {{- include "nico-ssh-console-rs.labels" . | nindent 8 }}
     spec:
-      serviceAccountName: nico-ssh-console-rs
+      serviceAccountName: {{ include "nico-ssh-console-rs.name" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -54,9 +54,9 @@ spec:
           resources: {}
           volumeMounts:
             # Mount config at both paths so the binary finds it regardless of nico/carbide image variant.
-            - name: ssh-console-rs-config-files
+            - name: {{ include "nico-ssh-console-rs.name" . }}-config-files
               mountPath: /etc/forge/ssh-console
-            - name: ssh-console-rs-config-files
+            - name: {{ include "nico-ssh-console-rs.name" . }}-config-files
               mountPath: /etc/nico/ssh-console
             - name: spiffe
               mountPath: "/var/run/secrets/spiffe.io"
@@ -86,12 +86,12 @@ spec:
               mountPath: /var/lib/otelcol/filelog-checkpoints
         {{ end }}
       volumes:
-        - name: ssh-console-rs-config-files
+        - name: {{ include "nico-ssh-console-rs.name" . }}-config-files
           configMap:
-            name: ssh-console-rs-config-files
+            name: {{ include "nico-ssh-console-rs.name" . }}-config-files
         - name: spiffe
           secret:
-            secretName: nico-ssh-console-rs-certificate
+            secretName: {{ include "nico-ssh-console-rs.name" . }}-certificate
         - name: ssh-host-key
           secret:
             secretName: ssh-host-key
@@ -107,5 +107,5 @@ spec:
           emptyDir: {}
         - name: otelcol-config
           configMap:
-            name: ssh-console-rs-otelcol-config
+            name: {{ include "nico-ssh-console-rs.name" . }}-otelcol-config
         {{ end }}

--- a/helm/charts/nico-ssh-console-rs/templates/external-service.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/external-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-ssh-console-rs-external
+  name: {{ include "nico-ssh-console-rs.name" . }}-external
   namespace: {{ include "nico-ssh-console-rs.namespace" . }}
   labels:
     {{- include "nico-ssh-console-rs.labels" . | nindent 4 }}

--- a/helm/charts/nico-ssh-console-rs/templates/metrics-service.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/metrics-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-ssh-console-rs-metrics
+  name: {{ include "nico-ssh-console-rs.name" . }}-metrics
   namespace: {{ include "nico-ssh-console-rs.namespace" . }}
   labels:
     {{- include "nico-ssh-console-rs.labels" . | nindent 4 }}
-    app: nico-ssh-console-rs
-    app.kubernetes.io/metrics: nico-ssh-console-rs
+    app: {{ include "nico-ssh-console-rs.name" . }}
+    app.kubernetes.io/metrics: {{ include "nico-ssh-console-rs.name" . }}
 spec:
   selector:
     {{- include "nico-ssh-console-rs.selectorLabels" . | nindent 4 }}

--- a/helm/charts/nico-ssh-console-rs/templates/rbac.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: nico-ssh-console-rs
+  name: {{ include "nico-ssh-console-rs.name" . }}
   namespace: {{ include "nico-ssh-console-rs.namespace" . }}
   labels:
     {{- include "nico-ssh-console-rs.labels" . | nindent 4 }}
@@ -9,7 +9,7 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nico-ssh-console-rs
+  name: {{ include "nico-ssh-console-rs.name" . }}
   namespace: {{ include "nico-ssh-console-rs.namespace" . }}
   labels:
     {{- include "nico-ssh-console-rs.labels" . | nindent 4 }}
@@ -21,15 +21,15 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: nico-ssh-console-rs
+  name: {{ include "nico-ssh-console-rs.name" . }}
   namespace: {{ include "nico-ssh-console-rs.namespace" . }}
   labels:
     {{- include "nico-ssh-console-rs.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: nico-ssh-console-rs
+  name: {{ include "nico-ssh-console-rs.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: nico-ssh-console-rs
+    name: {{ include "nico-ssh-console-rs.name" . }}
     namespace: {{ include "nico-ssh-console-rs.namespace" . }}

--- a/helm/charts/nico-ssh-console-rs/templates/service-monitor.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/service-monitor.yaml
@@ -2,12 +2,12 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: nico-ssh-console-rs-metrics
+  name: {{ include "nico-ssh-console-rs.name" . }}-metrics
   namespace: {{ include "nico-ssh-console-rs.namespace" . }}
   labels:
     {{- include "nico-ssh-console-rs.labels" . | nindent 4 }}
-    app: nico-ssh-console-rs
+    app: {{ include "nico-ssh-console-rs.name" . }}
     prometheus: nico-monitoring
 spec:
-  {{- include "nico-ssh-console-rs.serviceMonitorSpec" (dict "name" "nico-ssh-console-rs" "port" "http" "monitor" .Values.serviceMonitor "namespace" "nico-system") | nindent 2 }}
+  {{- include "nico-ssh-console-rs.serviceMonitorSpec" (dict "name" (include "nico-ssh-console-rs.name" .) "port" "http" "monitor" .Values.serviceMonitor "namespace" "nico-system") | nindent 2 }}
 {{- end }}

--- a/helm/charts/nico-ssh-console-rs/templates/service.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: nico-ssh-console-rs
+  name: {{ include "nico-ssh-console-rs.name" . }}
   namespace: {{ include "nico-ssh-console-rs.namespace" . }}
   labels:
     {{- include "nico-ssh-console-rs.labels" . | nindent 4 }}

--- a/helm/charts/nico-ssh-console-rs/tests/apiservice_test.yaml
+++ b/helm/charts/nico-ssh-console-rs/tests/apiservice_test.yaml
@@ -1,0 +1,20 @@
+suite: API service host (apiServiceName) default nico, override carbide
+templates:
+  - configmap.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: defaults the console API URL host to nico-api
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'https://nico-api\.nico-system\.svc\.cluster\.local'
+  - it: apiServiceName overrides the console API URL host to carbide-api
+    documentIndex: 0
+    set:
+      apiServiceName: carbide-api
+    asserts:
+      - matchRegex:
+          path: data["config.toml"]
+          pattern: 'https://carbide-api\.nico-system\.svc\.cluster\.local'

--- a/helm/charts/nico-ssh-console-rs/tests/certificate_test.yaml
+++ b/helm/charts/nico-ssh-console-rs/tests/certificate_test.yaml
@@ -1,0 +1,56 @@
+suite: certificate dnsNames and uris configurability
+templates:
+  - certificate.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: generates dnsNames and uris from serviceName and namespace by default
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: metadata.name
+          value: nico-ssh-console-rs-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-ssh-console-rs.nico-system.svc.cluster.local
+            - nico-ssh-console-rs.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/nico-ssh-console-rs
+
+  - it: fully overrides the generated dnsNames and uris when set
+    set:
+      certificate:
+        dnsNames:
+          - nico-ssh-console-rs.override.example.com
+        uris:
+          - spiffe://override.local/nico-system/sa/nico-ssh-console-rs
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-ssh-console-rs.override.example.com
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://override.local/nico-system/sa/nico-ssh-console-rs
+
+  - it: nameOverride flips the certificate resource name, dnsNames, and SPIFFE URI to the override
+    set:
+      nameOverride: carbide-ssh-console-rs
+    asserts:
+      - equal:
+          path: metadata.name
+          value: carbide-ssh-console-rs-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - carbide-ssh-console-rs.nico-system.svc.cluster.local
+            - carbide-ssh-console-rs.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/carbide-ssh-console-rs

--- a/helm/charts/nico-ssh-console-rs/values.yaml
+++ b/helm/charts/nico-ssh-console-rs/values.yaml
@@ -27,7 +27,7 @@ namespaceOverride: ""
 
 replicas: 1
 annotations:
-  configmap.reloader.stakater.com/reload: "ssh-console-rs-config-files"
+  configmap.reloader.stakater.com/reload: '{{ include "nico-ssh-console-rs.name" . }}-config-files'
 
 imagePullSecrets: []
 
@@ -37,9 +37,18 @@ service:
 metrics:
   port: 9009
 
+apiServiceName: nico-api
+
 certificate:
   ## serviceName is used to auto-generate dnsNames and SPIFFE URIs based on the release namespace
-  serviceName: nico-ssh-console-rs
+  serviceName: ""
+  spiffeServiceName: ""
+  identityNamespace: ""
+  ## Fully override the auto-generated dnsNames/uris. When empty, dnsNames and
+  ## uris are generated from serviceName + namespace (extraDnsNames/extraUris
+  ## are appended to the generated list).
+  dnsNames: []
+  uris: []
   extraDnsNames: []
   extraUris: []
 

--- a/helm/charts/unbound/templates/configmap.yaml
+++ b/helm/charts/unbound/templates/configmap.yaml
@@ -32,3 +32,14 @@ data:
 {{ index .Values.localConfig "nico_local_unknowndomain.conf" | indent 4 }}
   forwarders.conf: |
 {{ index .Values.localConfig "forwarders.conf" | indent 4 }}
+  {{- if .Values.localData }}
+  local_data.conf: |
+    server:
+    {{- range .Values.localData }}
+    {{- $name := .name }}
+    {{- $ttl := .ttl | default 300 }}
+    {{- range .addresses }}
+        local-data: "{{ $name }} {{ $ttl }} IN A {{ . }}"
+    {{- end }}
+    {{- end }}
+  {{- end }}

--- a/helm/charts/unbound/tests/local_data_test.yaml
+++ b/helm/charts/unbound/tests/local_data_test.yaml
@@ -1,0 +1,53 @@
+suite: unbound local DNS A records (localData)
+templates:
+  - configmap.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: omits the local_data.conf key when localData is empty (default)
+    documentIndex: 1
+    asserts:
+      - notExists:
+          path: data["local_data.conf"]
+
+  - it: renders an A record with the default TTL of 300
+    documentIndex: 1
+    set:
+      localData:
+        - name: nico-api.nico
+          addresses: ["10.0.0.1"]
+    asserts:
+      - matchRegex:
+          path: data["local_data.conf"]
+          pattern: 'local-data: "nico-api\.nico 300 IN A 10\.0\.0\.1"'
+
+  - it: honors a custom ttl and emits one line per address
+    documentIndex: 1
+    set:
+      localData:
+        - name: nico-ntp.nico
+          ttl: 60
+          addresses: ["10.0.0.2", "10.0.0.3", "10.0.0.4"]
+    asserts:
+      - matchRegex:
+          path: data["local_data.conf"]
+          pattern: 'local-data: "nico-ntp\.nico 60 IN A 10\.0\.0\.2"'
+      - matchRegex:
+          path: data["local_data.conf"]
+          pattern: 'local-data: "nico-ntp\.nico 60 IN A 10\.0\.0\.4"'
+
+  - it: supports a legacy alias resolving to the same address
+    documentIndex: 1
+    set:
+      localData:
+        - name: nico-api.nico
+          addresses: ["10.0.0.1"]
+        - name: carbide-api.forge
+          addresses: ["10.0.0.1"]
+    asserts:
+      - matchRegex:
+          path: data["local_data.conf"]
+          pattern: 'local-data: "nico-api\.nico 300 IN A 10\.0\.0\.1"'
+      - matchRegex:
+          path: data["local_data.conf"]
+          pattern: 'local-data: "carbide-api\.forge 300 IN A 10\.0\.0\.1"'

--- a/helm/charts/unbound/values.yaml
+++ b/helm/charts/unbound/values.yaml
@@ -31,6 +31,18 @@ env:
   BROKEN_DNSSEC: "1"
   UNBOUND_CONTROL_DIR: /etc/unbound/keys
 
+# Local DNS A records served to managed hosts and DPUs. Rendered into a
+# local_data.conf file that unbound includes from local.conf.d. Names and IPs
+# are environment-specific, so this is empty by default — populate per site.
+localData: []
+# localData:
+#   - name: nico-api.nico
+#     addresses: ["10.0.0.1"]
+#   - name: carbide-api.forge        # legacy alias → same address
+#     addresses: ["10.0.0.1"]
+#   - name: nico-ntp.nico            # multiple addresses are supported
+#     addresses: ["10.0.0.2", "10.0.0.3", "10.0.0.4"]
+
 # Local config files for unbound
 localConfig:
   access_control.conf: |

--- a/helm/examples/carbide-legacy.yaml
+++ b/helm/examples/carbide-legacy.yaml
@@ -1,0 +1,69 @@
+## =============================================================================
+## Legacy carbide/forge overrides — NICo Bare Metal Manager
+## =============================================================================
+## The charts default to nico names and the nico.local trust domain. This file
+## flips every subchart back to the legacy carbide/forge world (resource names,
+## certificate identity, client cross-references, and API/proxy authorization),
+## for clusters not yet migrated off the pre-#1532 carbide/forge identities.
+##
+## Layer it on top of your environment values:
+##   helm upgrade --install nico ./helm -n nico-system -f values-full.yaml -f carbide-legacy.yaml
+## =============================================================================
+
+## global propagates to every subchart (drives cert SANs + the API/proxy auth
+## trust domain).
+global:
+  spiffe:
+    trustDomain: forge.local
+
+nico-api:
+  nameOverride: carbide-api
+  certificate:
+    identityNamespace: forge-system
+  auth:
+    namespace: forge-system          # accepted /<ns>/sa/ and /<ns>/machine/ paths
+    principals:
+      dhcp: carbide-dhcp
+      dns: carbide-dns
+
+nico-bmc-proxy:
+  nameOverride: carbide-bmc-proxy
+  certificate:
+    identityNamespace: forge-system
+  auth:
+    namespace: forge-system
+    apiPrincipal: carbide-api         # API SPIFFE id allowed to call the proxy
+
+nico-dhcp:
+  nameOverride: carbide-dhcp
+  apiServiceName: carbide-api         # client -> API host
+  certificate:
+    identityNamespace: forge-system
+
+nico-dns:
+  nameOverride: carbide-dns
+  apiServiceName: carbide-api
+  certificate:
+    identityNamespace: forge-system
+
+nico-dsx-exchange-consumer:
+  nameOverride: carbide-dsx-exchange-consumer
+  certificate:
+    identityNamespace: forge-system
+
+nico-hardware-health:
+  nameOverride: carbide-hardware-health
+  certificate:
+    identityNamespace: forge-system
+
+nico-pxe:
+  nameOverride: carbide-pxe
+  apiServiceName: carbide-api
+  certificate:
+    identityNamespace: forge-system
+
+nico-ssh-console-rs:
+  nameOverride: carbide-ssh-console-rs
+  apiServiceName: carbide-api
+  certificate:
+    identityNamespace: forge-system

--- a/helm/tests/carbide_legacy_test.yaml
+++ b/helm/tests/carbide_legacy_test.yaml
@@ -1,0 +1,90 @@
+suite: identity & authz — nico default and carbide/forge override
+# One suite, both modes. The "[nico]" cases run against chart defaults; the
+# "[carbide]" cases load examples/carbide-legacy.yaml via per-test `values:` so
+# the same suite validates both the default render and the legacy override from
+# the one shipped example file.
+release:
+  namespace: nico-system
+templates:
+  - charts/nico-api/templates/certificate.yaml
+  - charts/nico-api/templates/configmap.yaml
+  - charts/nico-dns/templates/configmap.yaml
+tests:
+  # ---------------------------------------------------------------- nico default
+  - it: "[nico] nico-api certificate uses nico names and nico.local"
+    template: charts/nico-api/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: nico-api-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-api.nico-system.svc.cluster.local
+            - nico-api.nico-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/nico-api
+
+  - it: "[nico] nico-api auth config + casbin use nico defaults"
+    template: charts/nico-api/templates/configmap.yaml
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: 'spiffe_trust_domain = "nico\.local"'
+      - matchRegex:
+          path: data["casbin-policy.csv"]
+          pattern: 'g, spiffe-service-id/nico-dhcp, nico-dhcp'
+
+  - it: "[nico] nico-dns points clients at the nico-api host"
+    template: charts/nico-dns/templates/configmap.yaml
+    asserts:
+      - equal:
+          path: data.NICO_API_HOST
+          value: nico-api.nico-system.svc.cluster.local
+
+  # ----------------------------------------------- carbide/forge (carbide-legacy)
+  - it: "[carbide] nico-api certificate flips to carbide/forge"
+    template: charts/nico-api/templates/certificate.yaml
+    values:
+      - ../examples/carbide-legacy.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: carbide-api-certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - carbide-api.forge-system.svc.cluster.local
+            - carbide-api.forge-system
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://forge.local/forge-system/sa/carbide-api
+
+  - it: "[carbide] nico-api auth config + casbin flip to forge/carbide"
+    template: charts/nico-api/templates/configmap.yaml
+    documentIndex: 0
+    values:
+      - ../examples/carbide-legacy.yaml
+    asserts:
+      - matchRegex:
+          path: data["carbide-api-config.toml"]
+          pattern: 'spiffe_trust_domain = "forge\.local"'
+      - matchRegex:
+          path: data["carbide-api-config.toml"]
+          pattern: '"/forge-system/sa/"'
+      - matchRegex:
+          path: data["casbin-policy.csv"]
+          pattern: 'g, spiffe-service-id/carbide-dhcp, nico-dhcp'
+
+  - it: "[carbide] nico-dns points clients at the carbide-api host"
+    template: charts/nico-dns/templates/configmap.yaml
+    values:
+      - ../examples/carbide-legacy.yaml
+    asserts:
+      - equal:
+          path: data.NICO_API_HOST
+          value: carbide-api.nico-system.svc.cluster.local

--- a/rest-api/helm/charts/nico-rest-site-agent/templates/certificate.yaml
+++ b/rest-api/helm/charts/nico-rest-site-agent/templates/certificate.yaml
@@ -37,9 +37,13 @@ spec:
   usages:
     - client auth
   dnsNames:
+    {{- if .Values.certificate.dnsNames }}
+    {{- toYaml .Values.certificate.dnsNames | nindent 4 }}
+    {{- else }}
     - {{ include "nico-rest-site-agent.name" . }}
     - {{ include "nico-rest-site-agent.name" . }}.{{ include "nico-rest-site-agent.namespace" . }}
     - {{ include "nico-rest-site-agent.name" . }}.{{ include "nico-rest-site-agent.namespace" . }}.svc.cluster.local
+    {{- end }}
   uris:
     {{- if .Values.certificate.uris }}
     {{- toYaml .Values.certificate.uris | nindent 4 }}

--- a/rest-api/helm/charts/nico-rest-site-agent/tests/certificate_test.yaml
+++ b/rest-api/helm/charts/nico-rest-site-agent/tests/certificate_test.yaml
@@ -1,0 +1,52 @@
+suite: certificate dnsNames and uris configurability
+templates:
+  - certificate.yaml
+release:
+  namespace: nico-rest
+tests:
+  - it: generates dnsNames and uris from the chart name and namespace by default
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-rest-site-agent
+            - nico-rest-site-agent.nico-rest
+            - nico-rest-site-agent.nico-rest.svc.cluster.local
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-rest/sa/nico-rest-site-agent
+
+  - it: fully overrides dnsNames while uris falls back to the generated SPIFFE URI
+    set:
+      certificate:
+        dnsNames:
+          - site-agent.override.example.com
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - site-agent.override.example.com
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-rest/sa/nico-rest-site-agent
+
+  - it: fully overrides uris while dnsNames falls back to the generated names
+    set:
+      certificate:
+        uris:
+          - spiffe://nico.local/nico-system/sa/elektra-site-agent
+    asserts:
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-system/sa/elektra-site-agent
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-rest-site-agent
+            - nico-rest-site-agent.nico-rest
+            - nico-rest-site-agent.nico-rest.svc.cluster.local

--- a/rest-api/helm/charts/nico-rest-site-agent/values.yaml
+++ b/rest-api/helm/charts/nico-rest-site-agent/values.yaml
@@ -65,6 +65,9 @@ certificate:
   privateKey:
     algorithm: ECDSA
     size: 384
+  # -- Fully override the certificate dnsNames. When empty, dnsNames are
+  # generated from the chart name and namespace.
+  dnsNames: []
   # -- Override SPIFFE URIs for the certificate. Must match the service identifier
   # expected by nico-api's InternalRBACRules (SiteAgent = "elektra-site-agent").
   # For nico deployments set to: ["spiffe://nico.local/nico-system/sa/elektra-site-agent"]

--- a/rest-api/helm/charts/nico-rest/charts/nico-rest-common/templates/certificate.yaml
+++ b/rest-api/helm/charts/nico-rest/charts/nico-rest-common/templates/certificate.yaml
@@ -36,5 +36,9 @@ spec:
     - client auth
   dnsNames:
     {{- toYaml .Values.certificate.temporalClientCloud.dnsNames | nindent 4 }}
+  {{- if .Values.certificate.temporalClientCloud.uris }}
+  uris:
+    {{- toYaml .Values.certificate.temporalClientCloud.uris | nindent 4 }}
+  {{- end }}
   issuerRef:
     {{- toYaml .Values.global.certificate.issuerRef | nindent 4 }}

--- a/rest-api/helm/charts/nico-rest/charts/nico-rest-common/tests/certificate_test.yaml
+++ b/rest-api/helm/charts/nico-rest/charts/nico-rest-common/tests/certificate_test.yaml
@@ -1,0 +1,47 @@
+suite: temporal-client-cloud-cert dnsNames and uris configurability
+templates:
+  - certificate.yaml
+set:
+  # Provided by the nico-rest parent chart at render time; set here so the
+  # subchart's certificate template renders standalone under helm-unittest.
+  global.certificate.issuerRef.name: nico-rest-ca-issuer
+  global.certificate.issuerRef.kind: ClusterIssuer
+  global.certificate.issuerRef.group: cert-manager.io
+tests:
+  - it: keeps the configured dnsNames and emits no uris by default
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - temporal-client
+            - nico-rest-api
+            - cloud-worker
+            - site-worker
+      - notExists:
+          path: spec.uris
+
+  - it: emits uris only when temporalClientCloud.uris is set
+    set:
+      certificate:
+        temporalClientCloud:
+          uris:
+            - spiffe://nico.local/nico-rest/sa/temporal-client
+    asserts:
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-rest/sa/temporal-client
+
+  - it: overrides dnsNames when temporalClientCloud.dnsNames is set
+    set:
+      certificate:
+        temporalClientCloud:
+          dnsNames:
+            - temporal-client.override.example.com
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - temporal-client.override.example.com

--- a/rest-api/helm/charts/nico-rest/charts/nico-rest-common/values.yaml
+++ b/rest-api/helm/charts/nico-rest/charts/nico-rest-common/values.yaml
@@ -44,3 +44,5 @@ certificate:
       - nico-rest-api
       - cloud-worker
       - site-worker
+    # -- SPIFFE/SAN URIs for the certificate. When empty, no uris are set.
+    uris: []

--- a/rest-api/helm/charts/nico-rest/charts/nico-rest-site-manager/templates/certificate.yaml
+++ b/rest-api/helm/charts/nico-rest/charts/nico-rest-site-manager/templates/certificate.yaml
@@ -40,10 +40,18 @@ spec:
     - server auth
     - client auth
   dnsNames:
+    {{- if .Values.certificate.dnsNames }}
+    {{- toYaml .Values.certificate.dnsNames | nindent 4 }}
+    {{- else }}
     - {{ include "nico-rest-site-manager.name" . }}
     - {{ include "nico-rest-site-manager.name" . }}.{{ include "nico-rest-site-manager.namespace" . }}
     - {{ include "nico-rest-site-manager.name" . }}.{{ include "nico-rest-site-manager.namespace" . }}.svc.cluster.local
     - localhost
+    {{- end }}
+  {{- if .Values.certificate.uris }}
+  uris:
+    {{- toYaml .Values.certificate.uris | nindent 4 }}
+  {{- end }}
   issuerRef:
     name: {{ .Values.global.certificate.issuerRef.name }}
     kind: {{ .Values.global.certificate.issuerRef.kind }}

--- a/rest-api/helm/charts/nico-rest/charts/nico-rest-site-manager/tests/certificate_test.yaml
+++ b/rest-api/helm/charts/nico-rest/charts/nico-rest-site-manager/tests/certificate_test.yaml
@@ -1,0 +1,49 @@
+suite: certificate dnsNames and uris configurability
+templates:
+  - certificate.yaml
+release:
+  namespace: nico-rest
+set:
+  # Provided by the nico-rest parent chart at render time; set here so the
+  # subchart's certificate template renders standalone under helm-unittest.
+  global.certificate.issuerRef.name: nico-rest-ca-issuer
+  global.certificate.issuerRef.kind: ClusterIssuer
+  global.certificate.issuerRef.group: cert-manager.io
+tests:
+  - it: generates dnsNames (including localhost) by default and emits no uris
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: spec.dnsNames
+          value:
+            - nico-rest-site-manager
+            - nico-rest-site-manager.nico-rest
+            - nico-rest-site-manager.nico-rest.svc.cluster.local
+            - localhost
+      - notExists:
+          path: spec.uris
+
+  - it: fully overrides the generated dnsNames when certificate.dnsNames is set
+    set:
+      certificate:
+        dnsNames:
+          - site-manager.override.example.com
+          - localhost
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - site-manager.override.example.com
+            - localhost
+
+  - it: emits uris only when certificate.uris is set
+    set:
+      certificate:
+        uris:
+          - spiffe://nico.local/nico-rest/sa/nico-rest-site-manager
+    asserts:
+      - equal:
+          path: spec.uris
+          value:
+            - spiffe://nico.local/nico-rest/sa/nico-rest-site-manager

--- a/rest-api/helm/charts/nico-rest/charts/nico-rest-site-manager/values.yaml
+++ b/rest-api/helm/charts/nico-rest/charts/nico-rest-site-manager/values.yaml
@@ -46,6 +46,11 @@ certificate:
   duration: 2160h
   renewBefore: 360h
   commonName: nico-rest-site-manager
+  # -- Fully override the certificate dnsNames. When empty, dnsNames are
+  # generated from the chart name and namespace (plus localhost).
+  dnsNames: []
+  # -- SPIFFE/SAN URIs for the certificate. When empty, no uris are set.
+  uris: []
   subject:
     # -- List of organizations for the certificate subject
     organizations: []


### PR DESCRIPTION
Every `nico-` string the charts emit is now an overridable value that defaults to nico, so the umbrella chart ships pure nico yet can be flipped to the legacy carbide/forge world.
This is needed because the carbide/forge -> nico rename (#1532) moved the API's SPIFFE validation to nico while machine-cert issuance is still on forge, so a deployment may need to present a carbide/forge identity until that migration completes.

Resource naming:

  - `nameOverride` (per subchart, default = chart name `nico-<svc>`) now drives every emitted resource name, label, selector, serviceAccountName, ConfigMap/Certificate name. Chart directories, `Chart.yaml`  names, and the `nico-<svc>.X` helper identifiers stay nico.

Certificate identity:

  - The `certificateSpec` helper takes a `svcName` arg (the name helper) and `certificate.serviceName` defaults to it, so `nameOverride` alone also flips commonName/dnsNames/SPIFFE-URI; this is backwards compatible since the default still renders nico. Adds `certificate.spiffeServiceName` and `certificate.identityNamespace` to decouple the SPIFFE `/sa/` name and namespace from the k8s service.

Cross-references and authz:

  - Clients reach the API via `apiServiceName` (default `nico-api`) in nico-dns/pxe/dhcp/ssh-console-rs.
  - The API and bmc-proxy auth config files are rendered with `tpl` rather than shipped verbatim, so `spiffe_trust_domain` tracks `global.spiffe.trustDomain`, the SPIFFE base-path namespace comes from `auth.namespace`, the casbin principals from `auth.principals.*`, and the bmc-proxy principal from `auth.apiPrincipal`. Whole-file replacement via `configFiles.*` is unchanged (that branch is not `tpl`-rendered).

Binary-read names (env vars, the Kea `nico-api-url` param, config keys, the `/opt/nico` and `/etc/nico` runtime paths, and the dual `*-config.toml` ConfigMap data keys) are deliberately left intact so the chart keeps working with either the nico or carbide image variant.

Adds helm-unittest coverage asserting both the nico default render and the carbide/forge override for naming, certificate SANs, the `apiServiceName` cross-refs, and the authz config.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

