### PR TITLE
fix(api): abort switch/machine reprovisioning when parent rack is in …

### DIFF
--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -6839,6 +6839,68 @@ impl std::fmt::Debug for HostUpgradeState {
     }
 }
 
+/// If the machine's parent rack is in `RackState::Error`, clear
+/// `host_reprovisioning_requested` and short-circuit back to the machine's
+/// pre-reprovisioning steady state (`Ready`, or `Assigned { instance_state:
+/// Ready }` if currently assigned). The rack will never advance the
+/// remaining `HostReprovision` sub-states once it has bailed out.
+///
+/// Only applies to rack-level reprovisioning requests; non-rack-initiated
+/// reprovisions are independent of the rack's lifecycle.
+async fn rack_failed_abort_host_reprovision_outcome(
+    state: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    machine_id: &MachineId,
+) -> Result<Option<StateHandlerOutcome<ManagedHostState>>, StateHandlerError> {
+    if !is_rack_level_reprovisioning(state) {
+        return Ok(None);
+    }
+
+    let Some(rack_id) = state.host_snapshot.rack_id.as_ref() else {
+        return Ok(None);
+    };
+
+    let mut conn = ctx.services.db_pool.acquire().await?;
+    let racks = db::rack::find_by(
+        conn.as_mut(),
+        db::ObjectColumnFilter::One(db::rack::IdColumn, rack_id),
+    )
+    .await?;
+    drop(conn);
+    let Some(rack) = racks.into_iter().next() else {
+        return Ok(None);
+    };
+    if !matches!(
+        rack.controller_state.value,
+        model::rack::RackState::Error { .. }
+    ) {
+        return Ok(None);
+    }
+
+    let target_state = match &state.managed_state {
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::HostReprovision { .. },
+        } => ManagedHostState::Assigned {
+            instance_state: InstanceState::Ready,
+        },
+        _ => ManagedHostState::Ready,
+    };
+
+    tracing::info!(
+        machine_id = %machine_id,
+        rack_id = %rack_id,
+        from = ?state.managed_state,
+        to = ?target_state,
+        "Rack is in Error; aborting machine HostReprovision and returning to Ready",
+    );
+
+    let mut txn = ctx.services.db_pool.begin().await?;
+    db::host_machine_update::clear_host_reprovisioning_request(txn.as_mut(), machine_id).await?;
+    Ok(Some(
+        StateHandlerOutcome::transition(target_state).with_txn(txn),
+    ))
+}
+
 impl HostUpgradeState {
     // Handles when in HostReprovisioning or when entering it
     async fn handle_host_reprovision(
@@ -6848,6 +6910,12 @@ impl HostUpgradeState {
         machine_id: &MachineId,
         scenario: HostFirmwareScenario,
     ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+        if let Some(outcome) =
+            rack_failed_abort_host_reprovision_outcome(state, ctx, machine_id).await?
+        {
+            return Ok(outcome);
+        }
+
         // Treat Ready (but flagged to do updates) the same as HostReprovisionState/CheckingFirmware
         let original_state = &state.managed_state.clone();
         let (mut host_reprovision_state, retry_count) = match &state.managed_state {

--- a/crates/switch-controller/src/reprovisioning.rs
+++ b/crates/switch-controller/src/reprovisioning.rs
@@ -18,13 +18,70 @@
 //! Handler for SwitchControllerState::ReProvisioning.
 
 use carbide_uuid::switch::SwitchId;
-use db::switch as db_switch;
+use db::db_read::PgPoolReader;
+use db::{ObjectColumnFilter, rack as db_rack, switch as db_switch};
+use model::rack::RackState;
 use model::switch::{ReProvisioningState, Switch, SwitchControllerState};
 use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
 
 use crate::context::SwitchStateHandlerContextObjects;
+
+/// Returns true if the switch reprovisioning request was initiated by a
+/// rack-level service (i.e. the rack firmware upgrade flow).
+fn is_rack_level_reprovisioning(state: &Switch) -> bool {
+    state
+        .switch_reprovisioning_requested
+        .as_ref()
+        .is_some_and(|req| req.initiator.starts_with("rack-"))
+}
+
+/// If the parent rack is in `RackState::Error`, clear
+/// `switch_reprovisioning_requested` and short-circuit to `Ready`. The
+/// rack will never advance the remaining `ReProvisioning` sub-states once
+/// it has bailed out, so waiting on them would leave the switch stuck.
+///
+/// Only applies to rack-level reprovisioning requests; non-rack-initiated
+/// reprovisions are independent of the rack's lifecycle.
+async fn rack_failed_abort_outcome(
+    switch_id: &SwitchId,
+    state: &Switch,
+    ctx: &mut StateHandlerContext<'_, SwitchStateHandlerContextObjects>,
+) -> Result<Option<StateHandlerOutcome<SwitchControllerState>>, StateHandlerError> {
+    if !is_rack_level_reprovisioning(state) {
+        return Ok(None);
+    }
+
+    let Some(rack_id) = state.rack_id.as_ref() else {
+        return Ok(None);
+    };
+
+    let mut reader: PgPoolReader = ctx.services.db_pool.clone().into();
+    let racks = db_rack::find_by(
+        reader.as_mut(),
+        ObjectColumnFilter::One(db_rack::IdColumn, rack_id),
+    )
+    .await?;
+    let Some(rack) = racks.into_iter().next() else {
+        return Ok(None);
+    };
+    if !matches!(rack.controller_state.value, RackState::Error { .. }) {
+        return Ok(None);
+    }
+
+    tracing::info!(
+        switch_id = %switch_id,
+        rack_id = %rack_id,
+        "Rack is in Error; aborting switch ReProvisioning and returning to Ready",
+    );
+
+    let mut txn = ctx.services.db_pool.begin().await?;
+    db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id).await?;
+    Ok(Some(
+        StateHandlerOutcome::transition(SwitchControllerState::Ready).with_txn(txn),
+    ))
+}
 
 /// Handles the ReProvisioning state for a switch.
 pub async fn handle_reprovisioning(
@@ -38,6 +95,10 @@ pub async fn handle_reprovisioning(
         } => reprovisioning_state,
         _ => unreachable!("handle_reprovisioning called with non-ReProvisioning state"),
     };
+
+    if let Some(outcome) = rack_failed_abort_outcome(switch_id, state, ctx).await? {
+        return Ok(outcome);
+    }
 
     match reprovisioning_state {
         ReProvisioningState::WaitingForRackFirmwareUpgrade => {


### PR DESCRIPTION
…Error

When the rack maintenance flow bails out into RackState::Error, switches in SwitchControllerState::ReProvisioning and machines in HostReprovision were staying stuck waiting for sub-states (firmware upgrade, NVOS update, NMX-C configure) the rack would never advance.

Add an early-exit at the start of each reprovisioning handler: look up the parent rack and, if it is in Error, clear the rack-driven reprovisioning request bit (switch_reprovisioning_requested / host_reprovisioning_requested) and transition the object back to its pre-reprovisioning Ready state.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

