### PR TITLE
fix(agent): Allow VPC VRF loopback into the overlay

### DIFF
--- a/crates/agent/templates/nvue_startup_fnn.conf
+++ b/crates/agent/templates/nvue_startup_fnn.conf
@@ -295,18 +295,6 @@
                   any: {}
           DPU_TO_EVPN_DROP_PREFIX_LIST:
             rule:
-              {{- if not (eq (len $tenant.Vpcs) 0) }}
-                {{- if $nvueConfig.HasAnyVpcVrfLoopback }}
-              '10':
-                action: permit{{/* This means 'match', not 'allow' */}}
-                match:
-                  {{- range $vpc := $tenant.Vpcs }}
-                      {{- if $vpc.VrfLoopback }}
-                  {{ $vpc.VrfLoopback }}/32: {}{{/* Still not clear we really even need a loopback on the VRF for our use-case, and we allow duplication between sites, so keep the type-5 route for it out of the overlay. */}}
-                      {{- end}}
-                  {{- end }}
-                {{- end }}
-              {{- end }}
               '65535':
                 action: deny
                 match:
@@ -777,7 +765,7 @@
         loopback:
           ip:
             address:
-              {{ $vpc.VrfLoopback }}/32: {} {{/* Every VRF on each DPU requires a unique loopback address */}}
+              {{ $vpc.VrfLoopback }}/32: {}
         {{- end }}
         router:
         {{- if $nvueConfig.UseAdminNetwork }}

--- a/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
+++ b/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
@@ -133,10 +133,6 @@
                   any: {}
           DPU_TO_EVPN_DROP_PREFIX_LIST:
             rule:
-              '10':
-                action: permit
-                match:
-                  10.1.1.1/32: {}
               '65535':
                 action: deny
                 match:
@@ -447,7 +443,7 @@
         loopback:
           ip:
             address:
-              10.1.1.1/32: {} 
+              10.1.1.1/32: {}
         router:
           static:
             192.168.0.12/32:

--- a/crates/agent/templates/tests/nvue_build_fnn_dual_stack.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_dual_stack.yaml.expected
@@ -102,10 +102,6 @@
                   any: {}
           DPU_TO_EVPN_DROP_PREFIX_LIST:
             rule:
-              '10':
-                action: permit
-                match:
-                  10.0.0.2/32: {}
               '65535':
                 action: deny
                 match:
@@ -402,7 +398,7 @@
         loopback:
           ip:
             address:
-              10.0.0.2/32: {} 
+              10.0.0.2/32: {}
         router:
           bgp:
             path-selection:

--- a/crates/agent/templates/tests/nvue_build_fnn_ipv6_acls.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_ipv6_acls.yaml.expected
@@ -113,10 +113,6 @@
                   any: {}
           DPU_TO_EVPN_DROP_PREFIX_LIST:
             rule:
-              '10':
-                action: permit
-                match:
-                  10.0.0.2/32: {}
               '65535':
                 action: deny
                 match:
@@ -413,7 +409,7 @@
         loopback:
           ip:
             address:
-              10.0.0.2/32: {} 
+              10.0.0.2/32: {}
         router:
           bgp:
             path-selection:

--- a/crates/agent/templates/tests/nvue_build_fnn_ipv6_only_vpc.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_ipv6_only_vpc.yaml.expected
@@ -103,10 +103,6 @@
                   any: {}
           DPU_TO_EVPN_DROP_PREFIX_LIST:
             rule:
-              '10':
-                action: permit
-                match:
-                  10.0.0.2/32: {}
               '65535':
                 action: deny
                 match:
@@ -403,7 +399,7 @@
         loopback:
           ip:
             address:
-              10.0.0.2/32: {} 
+              10.0.0.2/32: {}
         router:
           bgp:
             path-selection:

--- a/crates/agent/templates/tests/nvue_build_fnn_multi_port_ipv6.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_multi_port_ipv6.yaml.expected
@@ -112,10 +112,6 @@
                   any: {}
           DPU_TO_EVPN_DROP_PREFIX_LIST:
             rule:
-              '10':
-                action: permit
-                match:
-                  10.0.0.2/32: {}
               '65535':
                 action: deny
                 match:
@@ -412,7 +408,7 @@
         loopback:
           ip:
             address:
-              10.0.0.2/32: {} 
+              10.0.0.2/32: {}
         router:
           bgp:
             path-selection:


### PR DESCRIPTION
## Description

VPC VRF loopbacks were previously restricted from being advertised into the tenant overlay via network policy on the DPU.

This was because they were being treated as required by FNN, but some deployments were adding nonsensical values to the `vpc-dpu-lo` resource pool simply to satisfy the requirement.

VPC VRF loopbacks serve only as a debugging tool, and we now gate them via site config options, which default to false, allowing opt-_in_ by deployments that want them and are willing to allocate valid IPs for them.

Now that we 1) correctly allocate a loopback for each VPC of an instance, and 2) have config (that defaults to false/off) to control their advertisement, we can remove the blanket policy from the network config.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

