### PR TITLE
chore: bump libredfish to v0.44.3 + scaffold BMC HTTP boot URI allowlist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6201,7 +6201,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.2#e2e047cf1fddb4ec8861d7e7f8bdcf7ecbbdb705"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.3#02f9c19148f4aa4c6b7c9e5efe8f40361c9a3167"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.2" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.3" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.12-rc1" }
 ansi-to-html = "0.2.2"
 

--- a/crates/api/src/cfg/README.md
+++ b/crates/api/src/cfg/README.md
@@ -90,6 +90,7 @@ applicable.
 | `dpf` | `DpfConfig` | *(see below)* | DPF (DPU Platform Framework) Kubernetes deployment (see [DpfConfig](#dpfconfig)). |
 | `x86_pxe_boot_url_override` | `Option<String>` | — | Override PXE boot URL for x86 machines. |
 | `arm_pxe_boot_url_override` | `Option<String>` | — | Override PXE boot URL for ARM machines. |
+| `set_http_boot_uri_for_vendors` | `Vec<BMCVendor>` | `[]` | Vendors for which the state controller pins the UEFI HTTP boot URL on the BMC via Redfish `HttpBootUri`. Empty = all machines rely on carbide-dhcp option 67 for the URL. |
 | `compute_allocation_enforcement` | `ComputeAllocationEnforcement` | `WarnOnly` | Controls enforcement of compute allocations on new instance requests. |
 | `supernic_firmware_profiles` | nested `HashMap` | `{}` | SuperNIC firmware profiles keyed by `part_number` then `PSID`. |
 | `component_manager` | `Option<ComponentManagerConfig>` | — | Component manager for NvLink switches and power shelves. |

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -553,6 +553,20 @@ pub struct CarbideConfig {
     #[serde(default)]
     pub arm_pxe_boot_url_override: Option<String>,
 
+    /// Vendors for which the state controller should pin the UEFI HTTP boot
+    /// URL on the BMC (via Redfish `HttpBootUri`) in addition to the existing
+    /// DHCP option 67 path. Machines whose BMC vendor is NOT in this list
+    /// continue to rely on carbide-dhcp's option 67 for the URL.
+    ///
+    /// Empty by default — no machines get the BMC-pinned URL until vendors
+    /// are explicitly added here (typically after per-vendor verification on
+    /// real hardware). Adding a vendor that libredfish doesn't yet implement
+    /// (e.g., `Dell` / `Lenovo` until their libredfish impls land) will
+    /// surface a runtime `NotSupported` error; carbide-dhcp option 67 is the
+    /// fallback URL source.
+    #[serde(default)]
+    pub set_http_boot_uri_for_vendors: Vec<BMCVendor>,
+
     /// Alternate API URL for external hosts that cannot resolve
     /// https://carbide-pxe.forge. This be an IP (e.g., "https://10.0.0.1:1079"),
     /// or an externally resolvable hostname (e.g.,

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1309,6 +1309,7 @@ pub fn get_config() -> CarbideConfig {
         dpf: crate::cfg::file::DpfConfig::default(),
         x86_pxe_boot_url_override: None,
         arm_pxe_boot_url_override: None,
+        set_http_boot_uri_for_vendors: vec![],
         external_api_url: None,
         external_pxe_url: None,
         external_static_pxe_url: None,

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -397,6 +397,13 @@ impl Redfish for RedfishSimClient {
         Box::pin(async move { todo!() })
     }
 
+    fn set_boot_override<'a>(
+        &'a self,
+        _settings: libredfish::BootOverride,
+    ) -> libredfish::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { Ok(None) })
+    }
+
     fn clear_tpm<'a>(&'a self) -> libredfish::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { todo!() })
     }


### PR DESCRIPTION
## Description

This supports https://github.com/NVIDIA/infra-controller/issues/1865.

`libredfish` v0.44.3 adds a new `Redfish::set_boot_override` trait method that exposes the full Redfish Boot override model, including `HttpBootUri`. NICo isn't going to do anything with it yet though, this PR is purely the plumbing required to pull it in.

Includes:
- Bump the `libredfish` version from v0.44.2 to v0.44.3.
- Satisfy the new trait method on `RedfishSimClient` (just do it how we do for `boot_once` and `boot_first`).
- Introduce a new (but unused) `set_http_boot_uri_for_vendors: Vec<BMCVendor>` config field to `crates/api/src/cfg/file.rs`, defaulting to empty via `#[serde(default)]`, meaning all hosts will continue to rely on DHCP option 67 from `carbide-dhcp`.

A follow-up PR will wire the state controller to consult this list and call `set_boot_override` for vendors that are explicitly opted in, allowing us to pin the URL on the BMC (and not rely on DHCP for a URL).

Note that, for now, Dell and Lenovo return `NotSupported` from `libredfish` -- they have a slightly different schema w/ BIOS attribute paths, which I need to take care of in separate `libredfish` PRs before we can support them here. If they get added to `set_http_boot_uri_for_vendor` before they're supported, we'll just log the error w/ a warning and let the existing `carbide-dhcp` based flow (with option 67) do it's thing.

Overarching idea is we'll [eventually] attempt to set the boot URL via Redfish, and if it fails, things will naturally continue to look at Option 67 from `carbide-dhcp` anyway.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

