### PR TITLE
refactor(rack-controller): prepare RMS controllers for extraction

### DIFF
--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -54,6 +54,7 @@ use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::state_controller::config::IterationConfig;
+use crate::state_controller::rack::config::{RackValidationConfig, RmsConfig};
 
 static BF2_NIC: &str = "24.47.2682";
 static BF2_BMC: &str = "BF-25.10-20";
@@ -1740,30 +1741,6 @@ fn default_max_database_connections() -> u32 {
     1000
 }
 
-fn default_rms_enforce_tls() -> bool {
-    true
-}
-
-/// Rack Manager Service (RMS) configuration for API connectivity and mTLS.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct RmsConfig {
-    /// URL of the RMS API for rack-level firmware upgrades and power sequencing.
-    pub api_url: Option<String>,
-
-    /// Path to the root CA certificate for TLS verification when connecting to RMS.
-    pub root_ca_path: Option<String>,
-
-    /// Path to the client certificate PEM for mTLS with RMS.
-    pub client_cert: Option<String>,
-
-    /// Path to the client private key PEM for mTLS with RMS.
-    pub client_key: Option<String>,
-
-    /// Enforce TLS when connecting to RMS. Defaults to true.
-    #[serde(default = "default_rms_enforce_tls")]
-    pub enforce_tls: bool,
-}
-
 /// DpuConfig related internal configuration
 #[derive(Clone, Debug, Serialize)]
 pub struct DpuConfig {
@@ -2334,35 +2311,6 @@ pub struct MachineValidationTestConfig {
 }
 
 impl MachineValidationConfig {
-    const fn default_run_interval() -> std::time::Duration {
-        std::time::Duration::from_secs(60)
-    }
-}
-
-/// Configuration for rack-level validation (partition-based
-/// multi-node tests run after firmware upgrade / maintenance).
-///
-/// Example:
-/// ```toml
-/// [rack_validation_config]
-/// enabled = true
-/// run_interval = "60s"
-/// ```
-#[derive(Default, Clone, Debug, Deserialize, Serialize)]
-pub struct RackValidationConfig {
-    /// Enables rack validation testing.
-    #[serde(default)]
-    pub enabled: bool,
-
-    #[serde(
-        default = "RackValidationConfig::default_run_interval",
-        deserialize_with = "deserialize_duration",
-        serialize_with = "as_std_duration"
-    )]
-    pub run_interval: std::time::Duration,
-}
-
-impl RackValidationConfig {
     const fn default_run_interval() -> std::time::Duration {
         std::time::Duration::from_secs(60)
     }

--- a/crates/api/src/rack/mod.rs
+++ b/crates/api/src/rack/mod.rs
@@ -15,6 +15,24 @@
  * limitations under the License.
  */
 
+use librms::RackManagerError;
+
+use crate::state_controller::state_handler::{ExternalServiceError, StateHandlerError};
+
 pub mod bms_client;
 pub mod firmware_update;
 pub mod rms_client;
+
+pub(crate) fn rack_manager_error(
+    operation: &'static str,
+    error: RackManagerError,
+) -> StateHandlerError {
+    ExternalServiceError::with_source(
+        "rack_manager",
+        operation,
+        error.to_string(),
+        "rack_manager_error",
+        error,
+    )
+    .into()
+}

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -90,8 +90,11 @@ use crate::state_controller::ib_partition::handler::IBPartitionStateHandler;
 use crate::state_controller::ib_partition::io::IBPartitionStateControllerIO;
 use crate::state_controller::machine::handler::MachineStateHandlerBuilder;
 use crate::state_controller::machine::io::MachineStateControllerIO;
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerServices;
 use crate::state_controller::power_shelf::handler::PowerShelfStateHandler;
 use crate::state_controller::power_shelf::io::PowerShelfStateControllerIO;
+use crate::state_controller::rack::config::RackConfig;
+use crate::state_controller::rack::context::RackStateHandlerServices;
 use crate::state_controller::rack::handler::RackStateHandler;
 use crate::state_controller::rack::io::RackStateControllerIO;
 use crate::state_controller::state_change_emitter::StateChangeEmitterBuilder;
@@ -1200,7 +1203,14 @@ pub async fn initialize_and_start_controllers<'a>(
         .database(db_pool.clone(), work_lock_manager_handle.clone())
         .meter("carbide_power_shelves", meter.clone())
         .processor_id(state_controller_id.clone())
-        .services(handler_services.clone())
+        .services(
+            PowerShelfStateHandlerServices {
+                db_pool: handler_services.db_pool.clone(),
+                rms_client: handler_services.rms_client.clone(),
+                credential_manager: handler_services.credential_manager.clone(),
+            }
+            .into(),
+        )
         .iteration_config((&carbide_config.power_shelf_state_controller.controller).into())
         .state_handler(Arc::new(PowerShelfStateHandler::default()))
         .build_and_spawn(join_set, cancel_token.clone())
@@ -1210,7 +1220,26 @@ pub async fn initialize_and_start_controllers<'a>(
         .database(db_pool.clone(), work_lock_manager_handle.clone())
         .meter("carbide_racks", meter.clone())
         .processor_id(state_controller_id.clone())
-        .services(handler_services.clone())
+        .services(
+            RackStateHandlerServices {
+                db_pool: handler_services.db_pool.clone(),
+                rms_client: handler_services.rms_client.clone(),
+                site_config: RackConfig {
+                    rms: handler_services.site_config.rms.clone(),
+                    rack_validation_config: handler_services
+                        .site_config
+                        .rack_validation_config
+                        .clone(),
+                    rack_profiles: handler_services.site_config.rack_profiles.clone(),
+                }
+                .into(),
+                switch_system_image_rms_client: handler_services
+                    .switch_system_image_rms_client
+                    .clone(),
+                credential_manager: handler_services.credential_manager.clone(),
+            }
+            .into(),
+        )
         .state_handler(Arc::new(RackStateHandler::default()))
         .build_and_spawn(join_set, cancel_token.clone())
         .expect("Unable to build RackStateController");

--- a/crates/api/src/state_controller/external_service_error.rs
+++ b/crates/api/src/state_controller/external_service_error.rs
@@ -16,23 +16,8 @@
  */
 
 use carbide_dpf::DpfError;
-use librms::RackManagerError;
 
 use crate::state_controller::state_handler::{ExternalServiceError, StateHandlerError};
-
-pub(crate) fn rack_manager_error(
-    operation: &'static str,
-    error: RackManagerError,
-) -> StateHandlerError {
-    ExternalServiceError::with_source(
-        "rack_manager",
-        operation,
-        error.to_string(),
-        "rack_manager_error",
-        error,
-    )
-    .into()
-}
 
 pub(crate) fn dpf_error(error: DpfError) -> StateHandlerError {
     ExternalServiceError::with_source("dpf", "", error.to_string(), "dpf_error", error).into()

--- a/crates/api/src/state_controller/power_shelf/configuring.rs
+++ b/crates/api/src/state_controller/power_shelf/configuring.rs
@@ -19,11 +19,11 @@
 
 use carbide_uuid::power_shelf::PowerShelfId;
 use model::power_shelf::{PowerShelf, PowerShelfControllerState};
-
-use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
-use crate::state_controller::state_handler::{
+use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
 
 /// Handles the Configuring state for a power shelf.
 ///

--- a/crates/api/src/state_controller/power_shelf/context.rs
+++ b/crates/api/src/state_controller/power_shelf/context.rs
@@ -15,13 +15,26 @@
  * limitations under the License.
  */
 
-use crate::state_controller::common_services::CommonStateHandlerServices;
+use std::sync::Arc;
+
+use forge_secrets::credentials::CredentialManager;
+use librms::RmsApi;
+use sqlx::PgPool;
+use state_controller::state_handler::StateHandlerContextObjects;
+
 use crate::state_controller::power_shelf::metrics::PowerShelfMetrics;
-use crate::state_controller::state_handler::StateHandlerContextObjects;
 
 pub struct PowerShelfStateHandlerContextObjects {}
 
+#[derive(Clone)]
+pub struct PowerShelfStateHandlerServices {
+    pub db_pool: PgPool,
+    /// Rack Manager Service client
+    pub rms_client: Option<Arc<dyn RmsApi>>,
+    pub credential_manager: Arc<dyn CredentialManager>,
+}
+
 impl StateHandlerContextObjects for PowerShelfStateHandlerContextObjects {
     type ObjectMetrics = PowerShelfMetrics;
-    type Services = CommonStateHandlerServices;
+    type Services = PowerShelfStateHandlerServices;
 }

--- a/crates/api/src/state_controller/power_shelf/deleting.rs
+++ b/crates/api/src/state_controller/power_shelf/deleting.rs
@@ -20,11 +20,11 @@
 use carbide_uuid::power_shelf::PowerShelfId;
 use db::power_shelf as db_power_shelf;
 use model::power_shelf::{PowerShelf, PowerShelfControllerState};
-
-use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
-use crate::state_controller::state_handler::{
+use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
 
 /// Handles the Deleting state for a power shelf.
 ///

--- a/crates/api/src/state_controller/power_shelf/error_state.rs
+++ b/crates/api/src/state_controller/power_shelf/error_state.rs
@@ -19,11 +19,11 @@
 
 use carbide_uuid::power_shelf::PowerShelfId;
 use model::power_shelf::{PowerShelf, PowerShelfControllerState};
-
-use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
-use crate::state_controller::state_handler::{
+use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
 
 /// Handles the Error state for a power shelf.
 ///

--- a/crates/api/src/state_controller/power_shelf/fetching_data.rs
+++ b/crates/api/src/state_controller/power_shelf/fetching_data.rs
@@ -19,11 +19,11 @@
 
 use carbide_uuid::power_shelf::PowerShelfId;
 use model::power_shelf::{PowerShelf, PowerShelfControllerState};
-
-use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
-use crate::state_controller::state_handler::{
+use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
 
 /// Handles the FetchingData state for a power shelf.
 ///

--- a/crates/api/src/state_controller/power_shelf/handler.rs
+++ b/crates/api/src/state_controller/power_shelf/handler.rs
@@ -21,6 +21,9 @@ use carbide_uuid::power_shelf::PowerShelfId;
 use model::power_shelf::{
     PowerShelf, PowerShelfControllerState, derive_power_shelf_aggregate_health,
 };
+use state_controller::state_handler::{
+    StateHandler, StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
 use tracing::instrument;
 
 use crate::state_controller::power_shelf::configuring::handle_configuring;
@@ -31,9 +34,6 @@ use crate::state_controller::power_shelf::fetching_data::handle_fetching_data;
 use crate::state_controller::power_shelf::initializing::handle_initializing;
 use crate::state_controller::power_shelf::maintenance::handle_maintenance;
 use crate::state_controller::power_shelf::ready::handle_ready;
-use crate::state_controller::state_handler::{
-    StateHandler, StateHandlerContext, StateHandlerError, StateHandlerOutcome,
-};
 
 /// The actual PowerShelf State handler (structure mirrors SwitchStateHandler).
 #[derive(Debug, Default, Clone)]

--- a/crates/api/src/state_controller/power_shelf/initializing.rs
+++ b/crates/api/src/state_controller/power_shelf/initializing.rs
@@ -19,11 +19,11 @@
 
 use carbide_uuid::power_shelf::PowerShelfId;
 use model::power_shelf::{PowerShelf, PowerShelfControllerState};
-
-use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
-use crate::state_controller::state_handler::{
+use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
 
 /// Handles the Initializing state for a power shelf.
 ///

--- a/crates/api/src/state_controller/power_shelf/io.rs
+++ b/crates/api/src/state_controller/power_shelf/io.rs
@@ -26,8 +26,8 @@ use model::power_shelf::{
 };
 use model::{DeletedFilter, StateSla};
 use sqlx::PgConnection;
+use state_controller::io::StateControllerIO;
 
-use crate::state_controller::io::StateControllerIO;
 use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
 use crate::state_controller::power_shelf::metrics::PowerShelfMetricsEmitter;
 

--- a/crates/api/src/state_controller/power_shelf/maintenance.rs
+++ b/crates/api/src/state_controller/power_shelf/maintenance.rs
@@ -26,12 +26,12 @@ use librms::protos::rack_manager as rms;
 use mac_address::MacAddress;
 use model::power_shelf::{PowerShelf, PowerShelfControllerState, PowerShelfMaintenanceOperation};
 use sqlx::PgPool;
-
-use crate::state_controller::external_service_error::rack_manager_error;
-use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
-use crate::state_controller::state_handler::{
+use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+use crate::rack::rack_manager_error;
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
 
 /// Default BMC HTTPS port used when populating `rms::BmcEndpoint` for power
 /// shelves. Mirrors the value used by `crate::rack::firmware_update`.

--- a/crates/api/src/state_controller/power_shelf/metrics.rs
+++ b/crates/api/src/state_controller/power_shelf/metrics.rs
@@ -18,8 +18,7 @@
 use carbide_health_metrics::{HealthIterationMetrics, HealthObjectMetrics, register_health_gauges};
 use carbide_utils::metrics::SharedMetricsHolder;
 use opentelemetry::metrics::Meter;
-
-use crate::state_controller::metrics::MetricsEmitter;
+use state_controller::metrics::MetricsEmitter;
 
 #[derive(Debug, Default)]
 pub struct PowerShelfMetrics {

--- a/crates/api/src/state_controller/power_shelf/ready.rs
+++ b/crates/api/src/state_controller/power_shelf/ready.rs
@@ -19,11 +19,11 @@
 
 use carbide_uuid::power_shelf::PowerShelfId;
 use model::power_shelf::{PowerShelf, PowerShelfControllerState};
-
-use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
-use crate::state_controller::state_handler::{
+use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
 
 /// Handles the Ready state for a power shelf.
 ///

--- a/crates/api/src/state_controller/rack/config.rs
+++ b/crates/api/src/state_controller/rack/config.rs
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_utils::config::as_std_duration;
+use duration_str::deserialize_duration;
+use model::rack_type::RackProfileConfig;
+use serde::{Deserialize, Serialize};
+
+pub struct RackConfig {
+    pub rms: RmsConfig,
+    pub rack_validation_config: RackValidationConfig,
+    pub rack_profiles: RackProfileConfig,
+}
+
+/// Configuration for rack-level validation (partition-based
+/// multi-node tests run after firmware upgrade / maintenance).
+///
+/// Example:
+/// ```toml
+/// [rack_validation_config]
+/// enabled = true
+/// run_interval = "60s"
+/// ```
+#[derive(Default, Clone, Debug, Deserialize, Serialize)]
+pub struct RackValidationConfig {
+    /// Enables rack validation testing.
+    #[serde(default)]
+    pub enabled: bool,
+
+    #[serde(
+        default = "RackValidationConfig::default_run_interval",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub run_interval: std::time::Duration,
+}
+
+impl RackValidationConfig {
+    const fn default_run_interval() -> std::time::Duration {
+        std::time::Duration::from_secs(60)
+    }
+}
+
+/// Rack Manager Service (RMS) configuration for API connectivity and mTLS.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct RmsConfig {
+    /// URL of the RMS API for rack-level firmware upgrades and power sequencing.
+    pub api_url: Option<String>,
+
+    /// Path to the root CA certificate for TLS verification when connecting to RMS.
+    pub root_ca_path: Option<String>,
+
+    /// Path to the client certificate PEM for mTLS with RMS.
+    pub client_cert: Option<String>,
+
+    /// Path to the client private key PEM for mTLS with RMS.
+    pub client_key: Option<String>,
+
+    /// Enforce TLS when connecting to RMS. Defaults to true.
+    #[serde(default = "default_rms_enforce_tls")]
+    pub enforce_tls: bool,
+}
+
+fn default_rms_enforce_tls() -> bool {
+    true
+}

--- a/crates/api/src/state_controller/rack/context.rs
+++ b/crates/api/src/state_controller/rack/context.rs
@@ -15,13 +15,36 @@
  * limitations under the License.
  */
 
-use crate::state_controller::common_services::CommonStateHandlerServices;
-use crate::state_controller::rack::metrics::RackMetrics;
-use crate::state_controller::state_handler::StateHandlerContextObjects;
+use std::sync::Arc;
+
+use carbide_rack::rms_client::SwitchSystemImageRmsClient;
+use carbide_rack_controller::config::RackConfig;
+use carbide_rack_controller::metrics::RackMetrics;
+use forge_secrets::credentials::CredentialManager;
+use librms::RmsApi;
+use sqlx::PgPool;
+use state_controller::state_handler::StateHandlerContextObjects;
+
+use crate::rack as carbide_rack;
+use crate::state_controller::rack as carbide_rack_controller;
 
 pub struct RackStateHandlerContextObjects {}
+#[derive(Clone)]
+pub struct RackStateHandlerServices {
+    pub db_pool: PgPool,
+    /// Rack Manager Service client
+    pub rms_client: Option<Arc<dyn RmsApi>>,
+    // TODO: probably this is not the best place for config. But this
+    // field is introduced during refactoring. In original code it was
+    // full CarbideConfig.
+    pub site_config: Arc<RackConfig>,
+    /// Shared client for switch system image RPCs that are not yet exposed through
+    /// librms::RmsApi.
+    pub switch_system_image_rms_client: Option<Arc<dyn SwitchSystemImageRmsClient>>,
+    pub credential_manager: Arc<dyn CredentialManager>,
+}
 
 impl StateHandlerContextObjects for RackStateHandlerContextObjects {
     type ObjectMetrics = RackMetrics;
-    type Services = CommonStateHandlerServices;
+    type Services = RackStateHandlerServices;
 }

--- a/crates/api/src/state_controller/rack/created.rs
+++ b/crates/api/src/state_controller/rack/created.rs
@@ -22,15 +22,16 @@
 //! column) match the actual device counts (machines, switches,
 //! power shelves with `rack_id` FK).
 
+use carbide_rack_controller::context::RackStateHandlerContextObjects;
 use carbide_uuid::rack::{RackId, RackProfileId};
 use db::{machine as db_machine, power_shelf as db_power_shelf, switch as db_switch};
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::rack::RackState;
-
-use crate::state_controller::rack::context::RackStateHandlerContextObjects;
-use crate::state_controller::state_handler::{
+use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+use crate::state_controller::rack as carbide_rack_controller;
 
 pub async fn handle_created(
     id: &RackId,

--- a/crates/api/src/state_controller/rack/deleting.rs
+++ b/crates/api/src/state_controller/rack/deleting.rs
@@ -18,8 +18,7 @@
 //! Handler for RackState::Deleting.
 
 use model::rack::RackState;
-
-use crate::state_controller::state_handler::{StateHandlerError, StateHandlerOutcome};
+use state_controller::state_handler::{StateHandlerError, StateHandlerOutcome};
 
 pub async fn handle_deleting() -> Result<StateHandlerOutcome<RackState>, StateHandlerError> {
     Ok(StateHandlerOutcome::wait("rack is being deleted".into()))

--- a/crates/api/src/state_controller/rack/discovering.rs
+++ b/crates/api/src/state_controller/rack/discovering.rs
@@ -22,15 +22,17 @@
 //! state. Once all devices are ready, reprovisioning is triggered and the
 //! rack transitions to Maintenance.
 
+use carbide_rack_controller::context::RackStateHandlerContextObjects;
 use carbide_uuid::rack::{RackId, RackProfileId};
 use db::{machine as db_machine, power_shelf as db_power_shelf, switch as db_switch};
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::rack::{FirmwareUpgradeState, RackMaintenanceState, RackState};
-
-use crate::state_controller::rack::context::RackStateHandlerContextObjects;
-use crate::state_controller::state_handler::{
+use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+use crate::state_controller::rack as carbide_rack_controller;
+
 pub async fn handle_discovering(
     id: &RackId,
     rack_profile_id: Option<&RackProfileId>,

--- a/crates/api/src/state_controller/rack/error_state.rs
+++ b/crates/api/src/state_controller/rack/error_state.rs
@@ -17,15 +17,16 @@
 
 //! Handler for RackState::Error.
 
+use carbide_rack_controller::context::RackStateHandlerContextObjects;
+use carbide_rack_controller::maintenance::first_maintenance_state;
+use carbide_rack_controller::ready::all_components_ready;
 use carbide_uuid::rack::RackId;
 use model::rack::{Rack, RackConfig, RackState};
-
-use crate::state_controller::rack::context::RackStateHandlerContextObjects;
-use crate::state_controller::rack::maintenance::first_maintenance_state;
-use crate::state_controller::rack::ready::all_components_ready;
-use crate::state_controller::state_handler::{
+use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+use crate::state_controller::rack as carbide_rack_controller;
 
 pub async fn handle_error(
     id: &RackId,

--- a/crates/api/src/state_controller/rack/fabric_manager.rs
+++ b/crates/api/src/state_controller/rack/fabric_manager.rs
@@ -17,6 +17,8 @@
 
 use std::collections::{HashMap, HashSet};
 
+use carbide_rack::firmware_update::build_new_node_info;
+use carbide_rack_controller::config::RmsConfig;
 use carbide_uuid::rack::RackId;
 use carbide_uuid::switch::SwitchId;
 use db::switch as db_switch;
@@ -26,7 +28,8 @@ use model::switch::{FabricManagerState, FabricManagerStatus};
 use serde::Deserialize;
 use sqlx::PgConnection;
 
-use crate::rack::firmware_update::build_new_node_info;
+use crate::rack as carbide_rack;
+use crate::state_controller::rack as carbide_rack_controller;
 
 pub(super) fn validate_switch_inventory_for_nmx_cluster(
     switches: &[FirmwareUpgradeDeviceInfo],
@@ -68,7 +71,7 @@ fn build_scale_up_fabric_services_status_request(
 }
 
 pub(super) async fn get_scale_up_fabric_services_status(
-    rms_config: &crate::cfg::file::RmsConfig,
+    rms_config: &RmsConfig,
     rack_id: &RackId,
     switches: &[FirmwareUpgradeDeviceInfo],
 ) -> Result<rms::GetScaleUpFabricServicesStatusResponse, String> {

--- a/crates/api/src/state_controller/rack/handler.rs
+++ b/crates/api/src/state_controller/rack/handler.rs
@@ -17,20 +17,21 @@
 
 //! State Handler implementation for Racks.
 
+use carbide_rack_controller::context::RackStateHandlerContextObjects;
+use carbide_rack_controller::created::handle_created;
+use carbide_rack_controller::deleting::handle_deleting;
+use carbide_rack_controller::discovering::handle_discovering;
+use carbide_rack_controller::error_state::handle_error;
+use carbide_rack_controller::maintenance::handle_maintenance;
+use carbide_rack_controller::ready::handle_ready;
+use carbide_rack_controller::validating::handle_validating;
 use carbide_uuid::rack::RackId;
 use model::rack::{Rack, RackState, derive_rack_aggregate_health};
-
-use crate::state_controller::rack::context::RackStateHandlerContextObjects;
-use crate::state_controller::rack::created::handle_created;
-use crate::state_controller::rack::deleting::handle_deleting;
-use crate::state_controller::rack::discovering::handle_discovering;
-use crate::state_controller::rack::error_state::handle_error;
-use crate::state_controller::rack::maintenance::handle_maintenance;
-use crate::state_controller::rack::ready::handle_ready;
-use crate::state_controller::rack::validating::handle_validating;
-use crate::state_controller::state_handler::{
+use state_controller::state_handler::{
     StateHandler, StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+use crate::state_controller::rack as carbide_rack_controller;
 
 //------------------------------------------------------------------------------
 

--- a/crates/api/src/state_controller/rack/io.rs
+++ b/crates/api/src/state_controller/rack/io.rs
@@ -17,6 +17,8 @@
 
 //! State Controller IO implementation for Racks
 
+use carbide_rack_controller::context::RackStateHandlerContextObjects;
+use carbide_rack_controller::metrics::RackMetricsEmitter;
 use carbide_uuid::rack::RackId;
 use config_version::{ConfigVersion, Versioned};
 use db::rack::IdColumn;
@@ -27,10 +29,9 @@ use model::rack::{
     Rack, RackMaintenanceState, RackSearchFilter, RackState, RackValidationState, state_sla,
 };
 use sqlx::PgConnection;
+use state_controller::io::StateControllerIO;
 
-use crate::state_controller::io::StateControllerIO;
-use crate::state_controller::rack::context::RackStateHandlerContextObjects;
-use crate::state_controller::rack::metrics::RackMetricsEmitter;
+use crate::state_controller::rack as carbide_rack_controller;
 
 /// State Controller IO implementation for Racks
 #[derive(Default, Debug)]

--- a/crates/api/src/state_controller/rack/maintenance.rs
+++ b/crates/api/src/state_controller/rack/maintenance.rs
@@ -17,6 +17,19 @@
 
 //! Handler for RackState::Maintenance.
 
+use carbide_rack::firmware_update::{
+    RackFirmwareInventory, RackSwitchFirmwareInventory, build_firmware_update_batches,
+    build_new_node_info, firmware_type_for_profile, load_rack_firmware_inventory,
+    load_rack_switch_firmware_inventory, submit_firmware_update_batches,
+};
+use carbide_rack::rack_manager_error;
+use carbide_rack::rms_client::SwitchSystemImageRmsClient;
+use carbide_rack_controller::context::RackStateHandlerContextObjects;
+use carbide_rack_controller::fabric_manager::{
+    get_scale_up_fabric_services_status, persist_fabric_manager_statuses, persist_primary_switch,
+    select_primary_switch, validate_switch_inventory_for_nmx_cluster,
+};
+use carbide_rack_controller::validating::strip_rv_labels;
 use carbide_uuid::rack::{RackId, RackProfileId};
 use db::{
     host_machine_update as db_host_machine_update, machine as db_machine,
@@ -33,23 +46,12 @@ use model::rack::{
 };
 use model::rack_firmware::{RackFirmware, RackFirmwareSearchFilter};
 use model::rack_type::RackHardwareType;
-
-use crate::rack::firmware_update::{
-    RackFirmwareInventory, RackSwitchFirmwareInventory, build_firmware_update_batches,
-    build_new_node_info, firmware_type_for_profile, load_rack_firmware_inventory,
-    load_rack_switch_firmware_inventory, submit_firmware_update_batches,
-};
-use crate::rack::rms_client::SwitchSystemImageRmsClient;
-use crate::state_controller::external_service_error::rack_manager_error;
-use crate::state_controller::rack::context::RackStateHandlerContextObjects;
-use crate::state_controller::rack::fabric_manager::{
-    get_scale_up_fabric_services_status, persist_fabric_manager_statuses, persist_primary_switch,
-    select_primary_switch, validate_switch_inventory_for_nmx_cluster,
-};
-use crate::state_controller::rack::validating::strip_rv_labels;
-use crate::state_controller::state_handler::{
+use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+use crate::rack as carbide_rack;
+use crate::state_controller::rack as carbide_rack_controller;
 
 /// Strips all `rv.*` metadata labels from every machine in the rack.
 ///
@@ -552,7 +554,7 @@ fn build_switch_device_info_request(
 async fn rms_start_firmware_upgrade(
     rms_client: &dyn librms::RmsApi,
     firmware_id: &str,
-    batches: Vec<crate::rack::firmware_update::FirmwareUpdateBatchRequest>,
+    batches: Vec<carbide_rack::firmware_update::FirmwareUpdateBatchRequest>,
 ) -> model::rack::FirmwareUpgradeJob {
     let started_at = chrono::Utc::now();
     let submissions = submit_firmware_update_batches(rms_client, batches).await;
@@ -1993,6 +1995,7 @@ pub async fn handle_maintenance(
 
 #[cfg(test)]
 mod tests {
+    use carbide_rack::firmware_update::RackFirmwareInventory;
     use model::rack::{
         ConfigureNmxClusterState, FirmwareUpgradeDeviceInfo, FirmwareUpgradeState,
         MaintenanceActivity, MaintenanceScope, NvosUpdateState, RackMaintenanceState,
@@ -2003,7 +2006,7 @@ mod tests {
         filter_inventory_by_scope, first_maintenance_state, implicit_nvos_update_requested,
         next_state_after_configure, next_state_after_firmware, next_state_after_nvos,
     };
-    use crate::rack::firmware_update::RackFirmwareInventory;
+    use crate::rack as carbide_rack;
 
     fn test_machine_id(byte: u8) -> carbide_uuid::machine::MachineId {
         use carbide_uuid::machine::{MachineIdSource, MachineType};

--- a/crates/api/src/state_controller/rack/metrics.rs
+++ b/crates/api/src/state_controller/rack/metrics.rs
@@ -18,8 +18,7 @@
 use carbide_health_metrics::{HealthIterationMetrics, HealthObjectMetrics, register_health_gauges};
 use carbide_utils::metrics::SharedMetricsHolder;
 use opentelemetry::metrics::Meter;
-
-use crate::state_controller::metrics::MetricsEmitter;
+use state_controller::metrics::MetricsEmitter;
 
 #[derive(Debug, Default)]
 pub struct RackMetrics {

--- a/crates/api/src/state_controller/rack/mod.rs
+++ b/crates/api/src/state_controller/rack/mod.rs
@@ -17,6 +17,7 @@
 
 //! State Controller implementation for Racks.
 
+use carbide_rack_controller::context::RackStateHandlerContextObjects;
 use carbide_uuid::rack::{RackId, RackProfileId};
 use db::machine;
 use model::machine::Machine;
@@ -24,10 +25,11 @@ use model::machine::machine_search_config::MachineSearchConfig;
 use model::rack::Rack;
 use model::rack_type::{RackCapabilitiesSet, RackProfile};
 use sqlx::PgConnection;
+use state_controller::state_handler::{StateHandlerContext, StateHandlerError};
 
-use crate::state_controller::rack::context::RackStateHandlerContextObjects;
-use crate::state_controller::state_handler::{StateHandlerContext, StateHandlerError};
+use crate::state_controller::rack as carbide_rack_controller;
 
+pub mod config;
 pub mod context;
 pub mod created;
 pub mod deleting;

--- a/crates/api/src/state_controller/rack/ready.rs
+++ b/crates/api/src/state_controller/rack/ready.rs
@@ -17,6 +17,8 @@
 
 //! Handler for RackState::Ready.
 
+use carbide_rack_controller::context::RackStateHandlerContextObjects;
+use carbide_rack_controller::maintenance::first_maintenance_state;
 use carbide_uuid::rack::RackId;
 use db::{
     machine as db_machine, power_shelf as db_power_shelf, rack as db_rack, switch as db_switch,
@@ -26,12 +28,11 @@ use model::machine::machine_search_config::MachineSearchConfig;
 use model::power_shelf::PowerShelfSearchFilter;
 use model::rack::{FirmwareUpgradeState, Rack, RackConfig, RackMaintenanceState, RackState};
 use model::switch::SwitchSearchFilter;
-
-use crate::state_controller::rack::context::RackStateHandlerContextObjects;
-use crate::state_controller::rack::maintenance::first_maintenance_state;
-use crate::state_controller::state_handler::{
+use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+use crate::state_controller::rack as carbide_rack_controller;
 
 const COMPONENT_ERROR_STATE: &str = "error";
 const MACHINE_FAILED_STATE: &str = "failed";

--- a/crates/api/src/state_controller/rack/validating.rs
+++ b/crates/api/src/state_controller/rack/validating.rs
@@ -19,15 +19,16 @@
 
 use std::collections::HashMap;
 
+use carbide_rack_controller::context::RackStateHandlerContextObjects;
 use carbide_uuid::rack::RackId;
 use model::machine::Machine;
 use model::metadata::Metadata;
 use model::rack::{MachineRvLabels, Rack, RackState, RackValidationState};
-
-use crate::state_controller::rack::context::RackStateHandlerContextObjects;
-use crate::state_controller::state_handler::{
+use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+use crate::state_controller::rack as carbide_rack_controller;
 
 //------------------------------------------------------------------------------
 // Helper types

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -127,8 +127,11 @@ use crate::state_controller::machine::handler::{
     MachineStateHandler, MachineStateHandlerBuilder, PowerOptionConfig, ReachabilityParams,
 };
 use crate::state_controller::machine::io::MachineStateControllerIO;
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerServices;
 use crate::state_controller::power_shelf::handler::PowerShelfStateHandler;
 use crate::state_controller::power_shelf::io::PowerShelfStateControllerIO;
+use crate::state_controller::rack::config::{RackConfig, RackValidationConfig, RmsConfig};
+use crate::state_controller::rack::context::RackStateHandlerServices;
 use crate::state_controller::rack::handler::RackStateHandler;
 use crate::state_controller::rack::io::RackStateControllerIO;
 use crate::state_controller::state_handler::{
@@ -413,6 +416,23 @@ impl TestEnv {
             ipmi_tool: self.ipmi_tool.clone(),
             site_config: self.config.clone(),
             dpa_info: None,
+            rms_client: self.rms_sim.as_rms_client(),
+            switch_system_image_rms_client: self.rms_sim.as_switch_system_image_rms_client(),
+            credential_manager: self.test_credential_manager.clone(),
+        }
+    }
+
+    /// Creates an instance of CommonStateHandlerServices that are suitable for this
+    /// test environment
+    pub fn rack_state_handler_services(&self) -> RackStateHandlerServices {
+        RackStateHandlerServices {
+            db_pool: self.pool.clone(),
+            site_config: RackConfig {
+                rms: self.config.rms.clone(),
+                rack_validation_config: self.config.rack_validation_config.clone(),
+                rack_profiles: self.config.rack_profiles.clone(),
+            }
+            .into(),
             rms_client: self.rms_sim.as_rms_client(),
             switch_system_image_rms_client: self.rms_sim.as_switch_system_image_rms_client(),
             credential_manager: self.test_credential_manager.clone(),
@@ -1130,7 +1150,7 @@ pub fn get_config() -> CarbideConfig {
         default_tenant_routing_profile_type: "EXTERNAL".to_string(),
         web_ui_sidebar_tools: vec![],
         bgp_leaf_session_password: None,
-        rack_validation_config: crate::cfg::file::RackValidationConfig {
+        rack_validation_config: RackValidationConfig {
             enabled: true,
             ..Default::default()
         },
@@ -1286,7 +1306,7 @@ pub fn get_config() -> CarbideConfig {
         }),
         mlxconfig_profiles: None,
         rack_management_enabled: false,
-        rms: crate::cfg::file::RmsConfig {
+        rms: RmsConfig {
             api_url: Some(
                 SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080).to_string(),
             ),
@@ -1767,7 +1787,14 @@ pub async fn create_test_env_with_overrides(
         .database(db_pool.clone(), work_lock_manager_handle.clone())
         .meter("carbide_power_shelves", test_meter.meter())
         .processor_id(state_controller_id.clone())
-        .services(handler_services.clone())
+        .services(
+            PowerShelfStateHandlerServices {
+                db_pool: handler_services.db_pool.clone(),
+                rms_client: handler_services.rms_client.clone(),
+                credential_manager: handler_services.credential_manager.clone(),
+            }
+            .into(),
+        )
         .state_handler(Arc::new(PowerShelfStateHandler::default()))
         .build_for_manual_iterations(cancel_token.clone())
         .expect("Unable to build PowerShelfStateController");
@@ -1785,7 +1812,26 @@ pub async fn create_test_env_with_overrides(
         .database(db_pool.clone(), work_lock_manager_handle.clone())
         .meter("carbide_racks", test_meter.meter())
         .processor_id(state_controller_id.clone())
-        .services(handler_services.clone())
+        .services(
+            RackStateHandlerServices {
+                db_pool: handler_services.db_pool.clone(),
+                rms_client: handler_services.rms_client.clone(),
+                site_config: RackConfig {
+                    rms: handler_services.site_config.rms.clone(),
+                    rack_validation_config: handler_services
+                        .site_config
+                        .rack_validation_config
+                        .clone(),
+                    rack_profiles: handler_services.site_config.rack_profiles.clone(),
+                }
+                .into(),
+                switch_system_image_rms_client: handler_services
+                    .switch_system_image_rms_client
+                    .clone(),
+                credential_manager: handler_services.credential_manager.clone(),
+            }
+            .into(),
+        )
         .state_handler(Arc::new(RackStateHandler::default()))
         .build_for_manual_iterations(cancel_token.clone())
         .expect("Unable to build RackStateController");

--- a/crates/api/src/tests/power_shelf_state_controller/error_state.rs
+++ b/crates/api/src/tests/power_shelf_state_controller/error_state.rs
@@ -25,9 +25,10 @@ use forge_secrets::credentials::TestCredentialManager;
 use model::power_shelf::{PowerShelf, PowerShelfControllerState, PowerShelfMaintenanceOperation};
 use sqlx::PgConnection;
 
-use crate::state_controller::common_services::CommonStateHandlerServices;
 use crate::state_controller::db_write_batch::DbWriteBatch;
-use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
+use crate::state_controller::power_shelf::context::{
+    PowerShelfStateHandlerContextObjects, PowerShelfStateHandlerServices,
+};
 use crate::state_controller::power_shelf::handler::PowerShelfStateHandler;
 use crate::state_controller::power_shelf::metrics::PowerShelfMetrics;
 use crate::state_controller::state_handler::{
@@ -41,10 +42,13 @@ use crate::tests::power_shelf_state_controller::fixtures::power_shelf::{
 
 const TEST_ERROR_CAUSE: &str = "test error";
 
-fn services(env: &crate::tests::common::api_fixtures::TestEnv) -> CommonStateHandlerServices {
-    let mut services = env.state_handler_services();
-    services.credential_manager = Arc::new(TestCredentialManager::default());
-    services
+fn services(env: &crate::tests::common::api_fixtures::TestEnv) -> PowerShelfStateHandlerServices {
+    let services = env.state_handler_services();
+    PowerShelfStateHandlerServices {
+        db_pool: services.db_pool.clone(),
+        rms_client: services.rms_client.clone(),
+        credential_manager: Arc::new(TestCredentialManager::default()),
+    }
 }
 
 async fn load_power_shelf(pool: &sqlx::PgPool, id: &PowerShelfId) -> PowerShelf {
@@ -68,7 +72,7 @@ async fn park_in_error(txn: &mut PgConnection, power_shelf_id: &PowerShelfId) {
 }
 
 async fn run_handler(
-    services: &mut CommonStateHandlerServices,
+    services: &mut PowerShelfStateHandlerServices,
     state: &mut PowerShelf,
 ) -> StateHandlerOutcome<PowerShelfControllerState> {
     let handler = PowerShelfStateHandler::default();

--- a/crates/api/src/tests/power_shelf_state_controller/maintenance.rs
+++ b/crates/api/src/tests/power_shelf_state_controller/maintenance.rs
@@ -48,9 +48,10 @@ use model::metadata::Metadata;
 use model::power_shelf::{PowerShelf, PowerShelfControllerState, PowerShelfMaintenanceOperation};
 use sqlx::PgConnection;
 
-use crate::state_controller::common_services::CommonStateHandlerServices;
 use crate::state_controller::db_write_batch::DbWriteBatch;
-use crate::state_controller::power_shelf::context::PowerShelfStateHandlerContextObjects;
+use crate::state_controller::power_shelf::context::{
+    PowerShelfStateHandlerContextObjects, PowerShelfStateHandlerServices,
+};
 use crate::state_controller::power_shelf::handler::PowerShelfStateHandler;
 use crate::state_controller::power_shelf::metrics::PowerShelfMetrics;
 use crate::state_controller::state_handler::{
@@ -69,18 +70,18 @@ const TEST_BMC_PASSWORD: &str = "password";
 fn services_with_rms_client(
     env: &TestEnv,
     rms_client: Option<Arc<dyn librms::RmsApi>>,
-) -> CommonStateHandlerServices {
-    let mut services = env.state_handler_services();
-    services.rms_client = rms_client;
-    // Force a credential manager that always resolves BMC creds via the
-    // site-wide fallback. This avoids relying on whatever the test-env
-    // happens to be seeded with for BMC creds.
-    services.credential_manager =
-        Arc::new(TestCredentialManager::new(Credentials::UsernamePassword {
+) -> PowerShelfStateHandlerServices {
+    PowerShelfStateHandlerServices {
+        db_pool: env.state_handler_services().db_pool,
+        rms_client,
+        // Force a credential manager that always resolves BMC creds via the
+        // site-wide fallback. This avoids relying on whatever the test-env
+        // happens to be seeded with for BMC creds.
+        credential_manager: Arc::new(TestCredentialManager::new(Credentials::UsernamePassword {
             username: TEST_BMC_USER.into(),
             password: TEST_BMC_PASSWORD.into(),
-        }));
-    services
+        })),
+    }
 }
 
 /// Drive a power shelf into `Maintenance { operation }` with a maintenance
@@ -158,7 +159,7 @@ async fn load_power_shelf(pool: &sqlx::PgPool, id: &PowerShelfId) -> PowerShelf 
 
 /// Run one iteration of the state handler against the supplied power shelf.
 async fn run_handler(
-    services: &mut CommonStateHandlerServices,
+    services: &mut PowerShelfStateHandlerServices,
     state: &mut PowerShelf,
 ) -> StateHandlerOutcome<PowerShelfControllerState> {
     let handler = PowerShelfStateHandler::default();

--- a/crates/api/src/tests/power_shelf_state_controller/mod.rs
+++ b/crates/api/src/tests/power_shelf_state_controller/mod.rs
@@ -25,6 +25,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::state_controller::config::IterationConfig;
 use crate::state_controller::controller::StateController;
+use crate::state_controller::power_shelf::context::PowerShelfStateHandlerServices;
 use crate::state_controller::power_shelf::handler::PowerShelfStateHandler;
 use crate::state_controller::power_shelf::io::PowerShelfStateControllerIO;
 use crate::tests::common;
@@ -137,7 +138,14 @@ async fn test_power_shelf_deletion_with_state_controller(
         })
         .database(pool.clone(), env.api.work_lock_manager_handle.clone())
         .processor_id(uuid::Uuid::new_v4().to_string())
-        .services(handler_services.clone())
+        .services(
+            PowerShelfStateHandlerServices {
+                db_pool: handler_services.db_pool.clone(),
+                rms_client: handler_services.rms_client.clone(),
+                credential_manager: handler_services.credential_manager.clone(),
+            }
+            .into(),
+        )
         .state_handler(power_shelf_handler.clone())
         .build_for_manual_iterations(cancel_token.clone())
         .unwrap();

--- a/crates/api/src/tests/rack_state_controller/handler.rs
+++ b/crates/api/src/tests/rack_state_controller/handler.rs
@@ -620,7 +620,7 @@ async fn test_expected_no_definition_stays_parked(
     let mut rack = get_db_rack(txn.as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -760,7 +760,7 @@ async fn test_expected_incomplete_device_counts_stays(
     .await?;
 
     let handler = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -818,7 +818,7 @@ async fn test_expected_counts_match_but_not_linked_stays(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -887,7 +887,7 @@ async fn test_expected_zero_topology_transitions_to_discovering(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -956,7 +956,7 @@ async fn test_expected_more_discovered_than_expected_transitions(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -1020,7 +1020,7 @@ async fn test_discovering_waits_for_compute_ready(
     .await?;
 
     let handler = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -1075,7 +1075,7 @@ async fn test_discovering_empty_rack_transitions_to_maintenance(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -1126,7 +1126,7 @@ async fn test_error_state_does_nothing(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -1172,7 +1172,7 @@ async fn test_maintenance_completed_transitions_to_validation(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -1232,7 +1232,7 @@ async fn test_ready_with_no_labels_stays_ready(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -1278,7 +1278,7 @@ async fn test_firmware_upgrade_start_without_default_advances_to_nvos_update(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -1362,7 +1362,7 @@ async fn test_firmware_upgrade_start_with_unavailable_default_advances_to_nvos_u
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -1473,7 +1473,7 @@ async fn test_firmware_upgrade_start_transitions_to_wait_for_complete(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -1605,7 +1605,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_while_jobs_running(
     });
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -1694,7 +1694,7 @@ async fn test_firmware_upgrade_wait_for_complete_transitions_to_error_on_job_fai
     });
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -1818,7 +1818,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_termi
     });
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -1972,7 +1972,7 @@ async fn test_firmware_upgrade_wait_for_complete_retries_when_job_lookup_fails(
     });
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -2051,7 +2051,7 @@ async fn test_firmware_upgrade_wait_for_complete_retries_on_transient_poll_error
     });
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -2145,7 +2145,7 @@ async fn test_nvos_update_start_transitions_to_wait_for_complete(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -2228,7 +2228,7 @@ async fn test_configure_nmx_cluster_transitions_to_completed(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -2296,7 +2296,7 @@ async fn test_ready_topology_changed_transitions_to_discovering(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -2354,7 +2354,7 @@ async fn test_ready_reprovision_requested_transitions_to_maintenance(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -2406,7 +2406,7 @@ async fn test_validation_failed_transitions_to_error(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler_instance = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -2505,7 +2505,7 @@ async fn test_ready_with_failed_switch_transitions_to_error(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -2580,7 +2580,7 @@ async fn test_ready_with_failed_power_shelf_transitions_to_error(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -2631,7 +2631,7 @@ async fn test_ready_with_all_healthy_components_waits(
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
     let handler = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -2683,7 +2683,7 @@ async fn test_error_recovers_to_ready_when_all_components_ready(
     let error_state = rack.controller_state.value.clone();
 
     let handler = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
@@ -2742,7 +2742,7 @@ async fn test_error_stays_in_error_when_components_not_all_ready(
     let error_state = rack.controller_state.value.clone();
 
     let handler = RackStateHandler::default();
-    let mut services = env.state_handler_services();
+    let mut services = env.rack_state_handler_services();
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
     let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {

--- a/crates/api/src/tests/rack_state_controller/mod.rs
+++ b/crates/api/src/tests/rack_state_controller/mod.rs
@@ -219,7 +219,7 @@ async fn test_can_retrieve_rack_state_history_with_real_handler(
 
     // Run the real handler through the controller.
     let rack_handler = Arc::new(RackStateHandler::default());
-    let handler_services = Arc::new(env.state_handler_services());
+    let handler_services = Arc::new(env.rack_state_handler_services());
     let cancel_token = CancellationToken::new();
     let mut controller = StateController::<RackStateControllerIO>::builder()
         .iteration_config(IterationConfig {
@@ -462,7 +462,7 @@ async fn test_error_state_does_nothing_with_controller(
     .await?;
 
     let rack_handler = Arc::new(RackStateHandler::default());
-    let handler_services = Arc::new(env.state_handler_services());
+    let handler_services = Arc::new(env.rack_state_handler_services());
     let cancel_token = CancellationToken::new();
     let mut controller = StateController::<RackStateControllerIO>::builder()
         .iteration_config(IterationConfig {
@@ -506,7 +506,7 @@ async fn test_rack_deletion_with_state_controller(
     let rack_handler = Arc::new(TestRackStateHandler::default());
     const ITERATION_TIME: Duration = Duration::from_millis(50);
 
-    let handler_services = Arc::new(env.state_handler_services());
+    let handler_services = Arc::new(env.rack_state_handler_services());
 
     let cancel_token = CancellationToken::new();
     let mut controller = StateController::<RackStateControllerIO>::builder()


### PR DESCRIPTION
## Description

Introduce controller-specific service/config boundaries for rack and power shelf controllers, and update imports to use the future crate names. This is an intermediate step in decomposing `carbide-api` while minimizing disruption and merge conflicts for ongoing development.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

