### PR TITLE
refactor(ib-partition-controller): extract into dedicated crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,6 +1178,7 @@ dependencies = [
  "carbide-health-report",
  "carbide-host-support",
  "carbide-ib-fabric",
+ "carbide-ib-partition-controller",
  "carbide-ipmi",
  "carbide-ipxe-renderer",
  "carbide-libmlx",
@@ -1994,6 +1995,22 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "carbide-ib-partition-controller"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "carbide-api-db",
+ "carbide-api-model",
+ "carbide-ib-fabric",
+ "carbide-uuid",
+ "config-version",
+ "eyre",
+ "sqlx",
+ "state-controller",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -44,6 +44,7 @@ carbide-firmware = { path = "../firmware" }
 carbide-health-report = { path = "../health-report" }
 carbide-health-metrics = { path = "../health-metrics" }
 carbide-ib-fabric = { path = "../ib-fabric" }
+carbide-ib-partition-controller = { path = "../ib-partition-controller" }
 carbide-ipxe-renderer = { path = "../ipxe-renderer" }
 carbide-ipmi = { path = "../ipmi" }
 carbide-redfish = { path = "../redfish" }

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -25,6 +25,9 @@ use arc_swap::ArcSwap;
 use carbide_firmware::FirmwareDownloader;
 use carbide_ib_fabric::IbFabricMonitor;
 use carbide_ib_fabric::ib::{self, IBFabricManager};
+use carbide_ib_partition_controller::context::IBPartitionStateHandlerServices;
+use carbide_ib_partition_controller::handler::IBPartitionStateHandler;
+use carbide_ib_partition_controller::io::IBPartitionStateControllerIO;
 use carbide_ipmi::IPMITool;
 use carbide_network_segment_controller::context::NetworkSegmentStateHandlerServices;
 use carbide_network_segment_controller::handler::NetworkSegmentStateHandler;
@@ -89,8 +92,6 @@ use crate::state_controller::common_services::CommonStateHandlerServices;
 use crate::state_controller::controller::{Enqueuer, StateController};
 use crate::state_controller::dpa_interface::handler::DpaInterfaceStateHandler;
 use crate::state_controller::dpa_interface::io::DpaInterfaceStateControllerIO;
-use crate::state_controller::ib_partition::handler::IBPartitionStateHandler;
-use crate::state_controller::ib_partition::io::IBPartitionStateControllerIO;
 use crate::state_controller::machine::handler::MachineStateHandlerBuilder;
 use crate::state_controller::machine::io::MachineStateControllerIO;
 use crate::state_controller::power_shelf::context::PowerShelfStateHandlerServices;
@@ -1194,7 +1195,14 @@ pub async fn initialize_and_start_controllers<'a>(
         .database(db_pool.clone(), work_lock_manager_handle.clone())
         .meter("carbide_ib_partitions", meter.clone())
         .processor_id(state_controller_id.clone())
-        .services(handler_services.clone())
+        .services(
+            IBPartitionStateHandlerServices {
+                db_pool: handler_services.db_pool.clone(),
+                ib_fabric_manager: handler_services.ib_fabric_manager.clone(),
+                ib_pools: handler_services.ib_pools.clone(),
+            }
+            .into(),
+        )
         .iteration_config((&carbide_config.ib_partition_state_controller.controller).into())
         .state_handler(Arc::new(IBPartitionStateHandler::default()))
         .build_and_spawn(join_set, cancel_token.clone())

--- a/crates/api/src/state_controller/external_service_error.rs
+++ b/crates/api/src/state_controller/external_service_error.rs
@@ -22,7 +22,3 @@ use crate::state_controller::state_handler::{ExternalServiceError, StateHandlerE
 pub(crate) fn dpf_error(error: DpfError) -> StateHandlerError {
     ExternalServiceError::with_source("dpf", "", error.to_string(), "dpf_error", error).into()
 }
-
-pub(crate) fn ufm_error(operation: &'static str, error: eyre::Report) -> StateHandlerError {
-    ExternalServiceError::new("ufm", operation, error.to_string(), "ib_fabric_error").into()
-}

--- a/crates/api/src/state_controller/mod.rs
+++ b/crates/api/src/state_controller/mod.rs
@@ -18,7 +18,6 @@
 pub mod common_services;
 pub mod dpa_interface;
 pub(crate) mod external_service_error;
-pub mod ib_partition;
 pub mod machine;
 pub mod power_shelf;
 pub mod rack;

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -29,6 +29,9 @@ use async_trait::async_trait;
 use carbide_ib_fabric::IbFabricMonitor;
 use carbide_ib_fabric::config::{IBFabricConfig, IbFabricDefinition};
 use carbide_ib_fabric::ib::{self, IBFabricManagerImpl, IBFabricManagerType};
+use carbide_ib_partition_controller::context::IBPartitionStateHandlerServices;
+use carbide_ib_partition_controller::handler::IBPartitionStateHandler;
+use carbide_ib_partition_controller::io::IBPartitionStateControllerIO;
 use carbide_ipmi::IPMITool;
 use carbide_network_segment_controller::context::NetworkSegmentStateHandlerServices;
 use carbide_network_segment_controller::handler::NetworkSegmentStateHandler;
@@ -124,8 +127,6 @@ use crate::rack::rms_client::test_support::RmsSim;
 use crate::scout_stream;
 use crate::state_controller::common_services::CommonStateHandlerServices;
 use crate::state_controller::controller::{Enqueuer, StateController};
-use crate::state_controller::ib_partition::handler::IBPartitionStateHandler;
-use crate::state_controller::ib_partition::io::IBPartitionStateControllerIO;
 use crate::state_controller::machine::handler::{
     MachineStateHandler, MachineStateHandlerBuilder, PowerOptionConfig, ReachabilityParams,
 };
@@ -1755,7 +1756,14 @@ pub async fn create_test_env_with_overrides(
         .database(db_pool.clone(), work_lock_manager_handle.clone())
         .meter("carbide_machines", test_meter.meter())
         .processor_id(state_controller_id.clone())
-        .services(handler_services.clone())
+        .services(
+            IBPartitionStateHandlerServices {
+                db_pool: handler_services.db_pool.clone(),
+                ib_fabric_manager: handler_services.ib_fabric_manager.clone(),
+                ib_pools: handler_services.ib_pools.clone(),
+            }
+            .into(),
+        )
         .state_handler(Arc::new(ib_swap.clone()))
         .build_for_manual_iterations(cancel_token.clone())
         .expect("Unable to build state controller");

--- a/crates/ib-partition-controller/Cargo.toml
+++ b/crates/ib-partition-controller/Cargo.toml
@@ -1,0 +1,38 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[package]
+name = "carbide-ib-partition-controller"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[dependencies]
+carbide-api-db = { path = "../api-db", default-features = false }
+carbide-api-model = { path = "../api-model", default-features = false }
+carbide-ib-fabric = { path = "../ib-fabric" }
+carbide-uuid = { path = "../uuid", default-features = false }
+config-version = { path = "../config-version", default-features = false }
+state-controller = { path = "../state-controller" }
+
+async-trait = { workspace = true }
+eyre = { workspace = true }
+sqlx = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/ib-partition-controller/src/context.rs
+++ b/crates/ib-partition-controller/src/context.rs
@@ -15,12 +15,25 @@
  * limitations under the License.
  */
 
-use crate::state_controller::common_services::CommonStateHandlerServices;
-use crate::state_controller::state_handler::StateHandlerContextObjects;
+use std::sync::Arc;
+
+use carbide_ib_fabric::ib::IBFabricManager;
+use model::resource_pool::common::IbPools;
+use sqlx::PgPool;
+use state_controller::state_handler::StateHandlerContextObjects;
 
 pub struct IBPartitionStateHandlerContextObjects {}
 
+#[derive(Clone)]
+pub struct IBPartitionStateHandlerServices {
+    pub db_pool: PgPool,
+    /// API for interaction with Forge IBFabricManager
+    pub ib_fabric_manager: Arc<dyn IBFabricManager>,
+    /// Resource pools for ib pkey allocation/release.
+    pub ib_pools: IbPools,
+}
+
 impl StateHandlerContextObjects for IBPartitionStateHandlerContextObjects {
-    type Services = CommonStateHandlerServices;
+    type Services = IBPartitionStateHandlerServices;
     type ObjectMetrics = ();
 }

--- a/crates/ib-partition-controller/src/handler.rs
+++ b/crates/ib-partition-controller/src/handler.rs
@@ -19,12 +19,12 @@ use carbide_ib_fabric::ib::{GetPartitionOptions, IBFabricManagerConfig};
 use carbide_uuid::infiniband::IBPartitionId;
 use model::ib::{DEFAULT_IB_FABRIC_NAME, IBQosConf};
 use model::ib_partition::{IBPartition, IBPartitionControllerState, IBPartitionStatus};
-
-use crate::state_controller::external_service_error::ufm_error;
-use crate::state_controller::ib_partition::context::IBPartitionStateHandlerContextObjects;
-use crate::state_controller::state_handler::{
+use state_controller::state_handler::{
     StateHandler, StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+use crate::context::IBPartitionStateHandlerContextObjects;
+use crate::ufm_error;
 
 /// The actual IBPartition State handler
 #[derive(Debug, Default, Clone)]

--- a/crates/ib-partition-controller/src/io.rs
+++ b/crates/ib-partition-controller/src/io.rs
@@ -24,10 +24,10 @@ use model::StateSla;
 use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::ib_partition::{self, IBPartition, IBPartitionControllerState};
 use sqlx::PgConnection;
+use state_controller::io::StateControllerIO;
+use state_controller::metrics::NoopMetricsEmitter;
 
-use crate::state_controller::ib_partition::context::IBPartitionStateHandlerContextObjects;
-use crate::state_controller::io::StateControllerIO;
-use crate::state_controller::metrics::NoopMetricsEmitter;
+use crate::context::IBPartitionStateHandlerContextObjects;
 
 /// State Controller IO implementation for Infiniband Partitions
 #[derive(Default, Debug)]

--- a/crates/ib-partition-controller/src/lib.rs
+++ b/crates/ib-partition-controller/src/lib.rs
@@ -17,6 +17,12 @@
 
 //! State Controller implementation for IB Partitions.
 
+use state_controller::state_handler::{ExternalServiceError, StateHandlerError};
+
 pub mod context;
 pub mod handler;
 pub mod io;
+
+pub(crate) fn ufm_error(operation: &'static str, error: eyre::Report) -> StateHandlerError {
+    ExternalServiceError::new("ufm", operation, error.to_string(), "ib_fabric_error").into()
+}


### PR DESCRIPTION
## Description
Move the IB partition state controller out of `crates/api` into a new `carbide-ib-partition-controller` crate as part of the ongoing controller extraction work.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

