### PR TITLE
fix(api): Allow admin vpc VNI updates from config

### DIFF
--- a/crates/api-db/src/vpc.rs
+++ b/crates/api-db/src/vpc.rs
@@ -185,6 +185,21 @@ pub async fn find_by_vni(txn: &mut PgConnection, vni: i32) -> Result<Vec<Vpc>, D
         .map_err(|e| DatabaseError::query(query, e))
 }
 
+/// Updates both persisted VNI locations for a VPC.
+pub async fn set_vni(value: &Vpc, txn: &mut PgConnection, vni: i32) -> DatabaseResult<Vpc> {
+    // Keep the requested VNI column and the actual status VNI in sync.
+    let query = "UPDATE vpcs
+            SET vni=$1, status=jsonb_set(status, '{vni}', to_jsonb($1::integer), true), updated=NOW()
+            WHERE id=$2 AND deleted is null
+            RETURNING *";
+    sqlx::query_as(query)
+        .bind(vni)
+        .bind(value.id)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
 pub async fn find_by_name(txn: impl DbReader<'_>, name: &str) -> Result<Vec<Vpc>, DatabaseError> {
     find_by(txn, ObjectColumnFilter::One(NameColumn, &name)).await
 }

--- a/crates/api/src/db_init.rs
+++ b/crates/api/src/db_init.rs
@@ -260,28 +260,101 @@ pub(crate) async fn create_admin_vpc(
 
     let mut txn = Transaction::begin(db_pool).await?;
 
+    let configured_vni = vpc_vni as i32;
     let admin_segments = db::network_segment::admin(&mut txn).await?;
-    let existing_vpc = db::vpc::find_by_vni(&mut txn, vpc_vni as i32).await?;
+    let attached_admin_vpc_ids = admin_segments
+        .iter()
+        .filter_map(|segment| segment.config.vpc_id)
+        .unique()
+        .collect_vec();
 
-    if let Some(existing_vpc) = existing_vpc.first() {
+    // Admin VPC startup reconciliation has three expected cases:
+    // 1. Fresh install with admin FNN enabled: no admin segments are attached
+    //    and no VPC should already own the configured admin VNI, so create it.
+    // 2. Existing install with admin FNN already seeded: admin segments point
+    //    at one admin VPC, so that attached VPC is authoritative and its VNI
+    //    may be updated from config.
+    // 3. Existing install enabling admin FNN for the first time: admin segments
+    //    are unattached, but tenant VPCs may already exist. In this case we
+    //    must reject if any VPC already owns the configured admin VNI rather
+    //    than adopting that VPC as the admin VPC.
+    let existing_vpc = match attached_admin_vpc_ids.as_slice() {
+        [admin_vpc_id] => {
+            // The attached VPC is the authoritative admin VPC across config changes.
+            let mut vpcs = db::vpc::find_by(
+                &mut txn,
+                ObjectColumnFilter::One(vpc::IdColumn, admin_vpc_id),
+            )
+            .await?;
+            if vpcs.len() != 1 {
+                return Err(CarbideError::internal(format!(
+                    "Admin network segment references missing VPC {admin_vpc_id}."
+                )));
+            }
+            Some(vpcs.remove(0))
+        }
+        [] => {
+            // This is first-time admin VPC seeding. Do not adopt an existing
+            // tenant VPC that happens to use the configured admin VNI.
+            if let Some(conflicting_vpc) =
+                db::vpc::find_by_vni(&mut txn, configured_vni).await?.pop()
+            {
+                return Err(CarbideError::internal(format!(
+                    "Configured admin VPC VNI {configured_vni} is already used by VPC {}, but no admin VPC is attached to admin network segments.",
+                    conflicting_vpc.id
+                )));
+            }
+            None
+        }
+        _ => {
+            return Err(CarbideError::internal(format!(
+                "Admin network segments are attached to multiple VPCs: {}.",
+                attached_admin_vpc_ids.iter().join(", ")
+            )));
+        }
+    };
+
+    if let Some(mut existing_vpc) = existing_vpc {
+        let existing_vni = existing_vpc.status.as_ref().and_then(|status| status.vni);
+        if existing_vni != Some(configured_vni) || existing_vpc.vni != Some(configured_vni) {
+            if let Some(conflicting_vpc) = db::vpc::find_by_vni(&mut txn, configured_vni)
+                .await?
+                .into_iter()
+                .find(|vpc| vpc.id != existing_vpc.id)
+            {
+                return Err(CarbideError::internal(format!(
+                    "Configured admin VPC VNI {configured_vni} is already used by VPC {}, but admin network segments are attached to VPC {}.",
+                    conflicting_vpc.id, existing_vpc.id
+                )));
+            }
+
+            existing_vpc = db::vpc::set_vni(&existing_vpc, &mut txn, configured_vni).await?;
+            tracing::info!(
+                vpc_id = %existing_vpc.id,
+                previous_vni = ?existing_vni,
+                configured_vni,
+                "Updated admin VPC VNI from FNN config"
+            );
+        }
+
         for admin_segment in admin_segments {
-            if let Some(vpc_id) = admin_segment.config.vpc_id {
-                if vpc_id != existing_vpc.id {
+            match admin_segment.config.vpc_id {
+                Some(vpc_id) if vpc_id != existing_vpc.id => {
                     return Err(CarbideError::internal(format!(
                         "Mismatch found in admin vpc id {} and admin network segment's attached vpc id {vpc_id}.",
                         existing_vpc.id
                     )));
                 }
-
-                // All good here. We have valid admin vpc and it is attached to valid segment.
-            } else {
-                // Somehow vni field is not updated in network segment table. do it now.
-                db::network_segment::set_vpc_id_and_can_stretch(
-                    &admin_segment,
-                    &mut txn,
-                    existing_vpc.id,
-                )
-                .await?;
+                Some(_) => {}
+                None => {
+                    // Attach any newly-created admin segment to the existing admin VPC.
+                    db::network_segment::set_vpc_id_and_can_stretch(
+                        &admin_segment,
+                        &mut txn,
+                        existing_vpc.id,
+                    )
+                    .await?;
+                }
             }
         }
 
@@ -293,7 +366,7 @@ pub(crate) async fn create_admin_vpc(
     // Let's create admin vpc.
     let admin_vpc = NewVpc {
         id: uuid::Uuid::new_v4().into(),
-        vni: Some(vpc_vni as i32),
+        vni: Some(configured_vni),
         tenant_organization_id: "carbide_internal".to_string(),
         // For consistency, but admin routing profile is defined in-line in the
         // FNN config.
@@ -310,7 +383,7 @@ pub(crate) async fn create_admin_vpc(
     let vpc = db::vpc::persist(
         admin_vpc,
         VpcStatus {
-            vni: Some(vpc_vni as i32),
+            vni: Some(configured_vni),
         },
         &mut txn,
     )

--- a/crates/api/src/tests/vpc.rs
+++ b/crates/api/src/tests/vpc.rs
@@ -866,6 +866,107 @@ async fn create_admin_vpc(pool: sqlx::PgPool) -> Result<(), eyre::Report> {
 }
 
 #[crate::sqlx_test]
+async fn create_admin_vpc_updates_existing_admin_vpc_vni(
+    pool: sqlx::PgPool,
+) -> Result<(), eyre::Report> {
+    let env = create_test_env(pool).await;
+    let initial_vni = 10000;
+    let updated_vni = 10001;
+
+    // Create the initial admin VPC and verify the admin segments attach to it.
+    db_init::create_admin_vpc(&env.pool, Some(initial_vni)).await?;
+    let mut txn = env.pool.begin().await?;
+    let mut initial_admin_vpcs = db::vpc::find_by_vni(&mut txn, initial_vni as i32).await?;
+    assert_eq!(initial_admin_vpcs.len(), 1);
+    let initial_admin_vpc = initial_admin_vpcs.remove(0);
+    for admin_segment in db::network_segment::admin(&mut txn).await? {
+        assert_eq!(Some(initial_admin_vpc.id), admin_segment.config.vpc_id);
+    }
+    txn.commit().await?;
+
+    // Change the configured VNI and run startup reconciliation again.
+    db_init::create_admin_vpc(&env.pool, Some(updated_vni)).await?;
+
+    // Fetch from the DB to verify the existing admin VPC was updated in place.
+    let mut txn = env.pool.begin().await?;
+    let mut updated_admin_vpcs = db::vpc::find_by_vni(&mut txn, updated_vni as i32).await?;
+    assert_eq!(updated_admin_vpcs.len(), 1);
+    let updated_admin_vpc = updated_admin_vpcs.remove(0);
+    assert_eq!(updated_admin_vpc.id, initial_admin_vpc.id);
+    assert_eq!(updated_admin_vpc.vni, Some(updated_vni as i32));
+    assert_eq!(
+        updated_admin_vpc
+            .status
+            .as_ref()
+            .and_then(|status| status.vni),
+        Some(updated_vni as i32)
+    );
+    assert!(
+        db::vpc::find_by_vni(&mut txn, initial_vni as i32)
+            .await?
+            .is_empty()
+    );
+
+    // Verify reconciliation did not create a duplicate admin VPC row.
+    let admin_vpcs = db::vpc::find_by_name(&env.pool, "admin").await?;
+    assert_eq!(admin_vpcs.len(), 1);
+
+    // Verify every admin segment still points at the same reconciled VPC.
+    for admin_segment in db::network_segment::admin(&mut txn).await? {
+        assert_eq!(Some(updated_admin_vpc.id), admin_segment.config.vpc_id);
+    }
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn create_admin_vpc_rejects_existing_tenant_vpc_vni(
+    pool: sqlx::PgPool,
+) -> Result<(), eyre::Report> {
+    let env = create_test_env(pool).await;
+    let vni = 60001;
+
+    // Create a tenant VPC with the same VNI before the admin VPC is seeded.
+    let tenant_vpc = env
+        .api
+        .create_vpc(
+            VpcCreationRequest::builder("tenant-admin-vni-conflict")
+                .vni(vni)
+                .metadata(rpc::forge::Metadata {
+                    name: "tenant-admin-vni-conflict".to_string(),
+                    ..Default::default()
+                })
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    // Verify the VNI actually persisted before running admin reconciliation.
+    let mut txn = env.pool.begin().await?;
+    let mut tenant_vpcs = db::vpc::find_by_vni(&mut txn, vni as i32).await?;
+    assert_eq!(tenant_vpcs.len(), 1);
+    assert_eq!(tenant_vpcs.remove(0).id, tenant_vpc.id.unwrap());
+    txn.commit().await?;
+
+    // Seeding the admin VPC must fail instead of adopting the tenant VPC.
+    let err = db_init::create_admin_vpc(&env.pool, Some(vni))
+        .await
+        .expect_err("admin VPC seeding should reject an already-used tenant VNI");
+    assert!(
+        err.to_string()
+            .contains("but no admin VPC is attached to admin network segments")
+    );
+
+    // Verify the admin segments remain unattached after the rejected seed.
+    let mut txn = env.pool.begin().await?;
+    for admin_segment in db::network_segment::admin(&mut txn).await? {
+        assert!(admin_segment.config.vpc_id.is_none());
+    }
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn create_update_network_security_group_for_vpc(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Description

Changing the VNI of the admin VPC was resulting in an additional admin VPC and the previous one being orphaned.  The admin VPC is an internal structure that tenants should have to manage beyond the api config.

This PR allows for VNI changes by tracking the "current" VNI through existing admin segments, and then updating to the new VNI defined in config after some checks/validation to prevent accidentally hijacking existing VPCs.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

Satisfies https://github.com/NVIDIA/infra-controller/issues/1880