### PR TITLE
fix: move static reservations/assignments out of "expected" flows

### DIFF
--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -488,22 +488,17 @@ pub async fn validate_existing_mac_and_create(
                     }
                 }
 
-                // If a fixed IP is specified for this NIC, use static
-                // allocation instead of the pool allocator.
-                let strategy = if let Some(ref expected_nic) = host_nic
-                    && let Some(ref ipaddr) = expected_nic.fixed_ip
-                {
-                    let fixed_addr: IpAddr = ipaddr.parse().map_err(|_| {
-                        DatabaseError::internal(format!(
-                            "invalid fixed_ip '{ipaddr}' for MAC {mac_address}"
-                        ))
-                    })?;
-                    AddressSelectionStrategy::StaticAddress(fixed_addr)
-                } else {
-                    AddressSelectionStrategy::NextAvailableIp
-                };
-
-                let v = create(txn, &network_segments, &mac_address, true, strategy).await?;
+                // Dynamic-pool allocation.
+                // Any AddressSelectionStrategy::StaticIp flows will have happened as part of
+                // preallocate_machine_interface or preallocate_bmc_machine_interface.
+                let v = create(
+                    txn,
+                    &network_segments,
+                    &mac_address,
+                    true,
+                    AddressSelectionStrategy::NextAvailableIp,
+                )
+                .await?;
                 Ok(v)
             } else {
                 Err(DatabaseError::internal(format!(
@@ -539,18 +534,22 @@ pub async fn validate_existing_mac_and_create(
     }
 }
 
-/// Ensure a a `machine_interface` exists for the `mac_address` with its reserved allocation,
-/// either falling into a Carbide-managed segment (when there is a match within a managed
-/// prefix), or into the `static_assignments` segment for IPs that are outside of managed
-/// networks.
+/// Ensure a a `machine_interface` exists for the `mac_address` with its
+/// reserved allocation, either falling into a Carbide-managed segment (when
+/// there is a match within a managed prefix), or into the `static_assignments`
+/// segment for IPs that are outside of managed networks.
+///
+/// Calls are idempotent on the input `(mac_address, static_ip)`, meaning
+/// repeat calls return `Ok(())` if/once the end state matches the request.
 ///
 /// Errors on conflicts that need operator attention, e.g.
 /// - The interface for this MAC exists but carries different addresses, or,
 /// - The IP is already allocated to a different MAC.
 ///
-/// Called from the expected-machine handlers to do config time preallocation, and from
-/// the DHCP `discover()` path to re-allocate if needed (ensuring static DHCP reservations
-/// are maintained). Tbh it could probably just be in the DHCP `discover()` path only.
+/// Called as part of site-explorer iterations (when an ExpectedMachine has a
+/// static assignment/reservation configured), and from the DHCP `discover()`
+/// path (when a client whose configuration expects a static address) to ensure
+/// the fixed-address is returned.
 pub async fn preallocate_machine_interface(
     txn: &mut PgConnection,
     mac_address: MacAddress,
@@ -567,27 +566,48 @@ pub async fn preallocate_bmc_machine_interface(
     preallocate_machine_interface_with_type(txn, mac_address, static_ip, InterfaceType::Bmc).await
 }
 
+/// If a machine interface row already exists for `mac_address`, reconcile it against the
+/// requested (`static_ip`, `interface_type`):
+///   - Returns `Ok(true)` when an existing row carries `static_ip`. Promotes `interface_type`
+///     (and clears `primary_interface` for Bmc) if those don't already match.
+///   - Returns `Ok(false)` when no row exists for `mac_address` — caller should create.
+///   - Returns `Err(InvalidArgument)` when a row exists but carries different addresses.
+async fn reconcile_existing_preallocation(
+    txn: &mut PgConnection,
+    mac_address: MacAddress,
+    static_ip: IpAddr,
+    interface_type: InterfaceType,
+) -> DatabaseResult<bool> {
+    let existing = find_by_mac_address(&mut *txn, mac_address).await?;
+    let Some(iface) = existing.first() else {
+        return Ok(false);
+    };
+    if !iface.addresses.contains(&static_ip) {
+        return Err(DatabaseError::InvalidArgument(format!(
+            "a machine interface already exists for MAC {mac_address} with addresses {:?}; use update to change the IP address",
+            iface.addresses,
+        )));
+    }
+    if iface.interface_type != interface_type {
+        set_interface_type(&iface.id, interface_type, txn).await?;
+    }
+    if interface_type == InterfaceType::Bmc && iface.primary_interface {
+        set_primary_interface(&iface.id, false, txn).await?;
+    }
+    Ok(true)
+}
+
 async fn preallocate_machine_interface_with_type(
     txn: &mut PgConnection,
     mac_address: MacAddress,
     static_ip: IpAddr,
     interface_type: InterfaceType,
 ) -> DatabaseResult<()> {
-    let existing = find_by_mac_address(&mut *txn, mac_address).await?;
-    if let Some(iface) = existing.first() {
-        if iface.addresses.contains(&static_ip) {
-            if iface.interface_type != interface_type {
-                set_interface_type(&iface.id, interface_type, txn).await?;
-            }
-            if interface_type == InterfaceType::Bmc && iface.primary_interface {
-                set_primary_interface(&iface.id, false, txn).await?;
-            }
-            return Ok(());
-        }
-        return Err(DatabaseError::InvalidArgument(format!(
-            "a machine interface already exists for MAC {mac_address} with addresses {:?}; use update to change the IP address",
-            iface.addresses,
-        )));
+    // If there's already a matching record for (ip, mac), just return Ok,
+    // instead of attempting to insert, getting a duplicate error, and then
+    // handling.
+    if reconcile_existing_preallocation(txn, mac_address, static_ip, interface_type).await? {
+        return Ok(());
     }
 
     if let Some(existing_addr) =
@@ -604,7 +624,7 @@ async fn preallocate_machine_interface_with_type(
         None => db_network_segment::static_assignments(&mut *txn).await?,
     };
 
-    create_with_type(
+    match create_with_type(
         txn,
         std::slice::from_ref(&segment),
         &mac_address,
@@ -612,16 +632,33 @@ async fn preallocate_machine_interface_with_type(
         AddressSelectionStrategy::StaticAddress(static_ip),
         interface_type,
     )
-    .await?;
-
-    tracing::info!(
-        %mac_address,
-        %static_ip,
-        segment_id = %segment.id,
-        "Pre-allocated static machine interface"
-    );
-
-    Ok(())
+    .await
+    {
+        Ok(_) => {
+            tracing::info!(
+                %mac_address,
+                %static_ip,
+                segment_id = %segment.id,
+                "Pre-allocated static machine interface"
+            );
+            Ok(())
+        }
+        Err(DatabaseError::NetworkSegmentDuplicateMacAddress(_)) => {
+            // Looks like we might have lost a race with anohter inserter. Try to
+            // uphold our idempotency by re-fetching to reconcile. If the conflicting
+            // row carries our `static_ip`, our work is already done!
+            // Otherwise return an error.
+            if reconcile_existing_preallocation(txn, mac_address, static_ip, interface_type).await?
+            {
+                Ok(())
+            } else {
+                Err(DatabaseError::internal(format!(
+                    "duplicate-MAC error for {mac_address}, but could not reconcile",
+                )))
+            }
+        }
+        Err(e) => Err(e),
+    }
 }
 
 pub async fn create(

--- a/crates/api/src/dhcp/discover.rs
+++ b/crates/api/src/dhcp/discover.rs
@@ -247,24 +247,21 @@ pub async fn discover_dhcp(
                             .await
                             .map_err(CarbideError::from)?
                     {
-                        // If ExpectedHostNics are configured, see if any
-                        // of them are annotated as "primary", or if any of
-                        // them have a fixed_ip DHCP reservation.
+                        // Walk the host_nics list to see if there's a matching NIC (because it
+                        // may have a static reservation need or a primary-interface need)
+                        let mut declared_primary_mac: Option<MacAddress> = None;
                         for nic in &m.data.host_nics {
+                            if nic.primary == Some(true) {
+                                declared_primary_mac = Some(nic.mac_address);
+                            }
                             if nic.mac_address == parsed_mac {
                                 host_nic = Some(nic.clone());
                             }
                         }
-                        if let Some(declared_primary) =
-                            m.data.host_nics.iter().find(|n| n.primary == Some(true))
-                        {
-                            is_primary_nic = Some(declared_primary.mac_address == parsed_mac);
+                        if let Some(pmac) = declared_primary_mac {
+                            is_primary_nic = Some(pmac == parsed_mac);
                         }
-                        if let Some(nic) = m
-                            .data
-                            .host_nics
-                            .iter()
-                            .find(|n| n.mac_address == parsed_mac)
+                        if let Some(ref nic) = host_nic
                             && let Some(fixed_ip_str) = &nic.fixed_ip
                         {
                             let fixed_ip: IpAddr = fixed_ip_str.parse().map_err(|_| {
@@ -275,7 +272,8 @@ pub async fn discover_dhcp(
                             // It looks like there's a DHCP reservation for this address,
                             // so make an idempotent call to ensure we have a preallocated
                             // machine interface (and machine interface address) for it,
-                            // creating one if needed.
+                            // creating one if needed. Races against site-explorer's
+                            // reconciliation pass are handled inside preallocate.
                             db::machine_interface::preallocate_machine_interface(
                                 &mut txn, parsed_mac, fixed_ip,
                             )
@@ -290,8 +288,10 @@ pub async fn discover_dhcp(
                         // In this case it looks like our parsed MAC address is for the BMC
                         // of an expected machine, and it has a static DHCP reservation per
                         // its bmc_ip_address, so again, ensure the machine interface is
-                        // allocated before continuing.
-                        db::machine_interface::preallocate_machine_interface(
+                        // allocated before continuing. BMC variant so the row carries
+                        // InterfaceType::Bmc (and primary=false). Races against
+                        // site-explorer's reconciliation pass are handled inside preallocate.
+                        db::machine_interface::preallocate_bmc_machine_interface(
                             &mut txn, parsed_mac, bmc_ip,
                         )
                         .await?;

--- a/crates/api/src/handlers/expected_machine.rs
+++ b/crates/api/src/handlers/expected_machine.rs
@@ -62,9 +62,7 @@ pub(crate) async fn get(
     Ok(tonic::Response::new(response))
 }
 
-/// Adds an expected machine. When `bmc_ip_address` is present, pre-allocates a `machine_interface`
-/// for that BMC MAC and IP (shared helper with expected switches / power shelves) so discovery can
-/// proceed without waiting on DHCP.
+/// Adds an expected machine.
 pub(crate) async fn add(
     api: &Api,
     request: tonic::Request<rpc::ExpectedMachine>,
@@ -108,9 +106,9 @@ pub(crate) async fn add(
         data: db_data,
     };
 
-    let mut txn = api.txn_begin().await?;
+    validate_expected_machine_for_insert(&machine)?;
 
-    preallocate_interfaces_for(&mut txn, &machine).await?;
+    let mut txn = api.txn_begin().await?;
     db::expected_machine::create(&mut txn, machine).await?;
 
     txn.commit().await?;
@@ -118,32 +116,19 @@ pub(crate) async fn add(
     Ok(tonic::Response::new(()))
 }
 
-/// Validate the ExpectedMachine payload and pre-allocate `machine_interfaces`
-/// (and their addresses) for the BMC and any host NICs with a fixed-address
-/// via `fixed_ip`.
-///
-/// Shared between the `add` gRPC handler and `expected_machines.json`.
-pub(crate) async fn preallocate_interfaces_for(
-    txn: &mut sqlx::PgConnection,
+/// Validate the ExpectedMachine payload prior to insert.
+/// Shared between the `add` gRPC handler and the
+/// `expected_machines.json` import flow.
+pub(crate) fn validate_expected_machine_for_insert(
     machine: &ExpectedMachine,
 ) -> Result<(), CarbideError> {
     validate_at_most_one_primary_host_nic(&machine.data.host_nics)?;
 
-    if let Some(bmc_ip) = machine.data.bmc_ip_address {
-        db::machine_interface::preallocate_bmc_machine_interface(
-            txn,
-            machine.bmc_mac_address,
-            bmc_ip,
-        )
-        .await?;
-    }
-
     for nic in &machine.data.host_nics {
         if let Some(ref ip_str) = nic.fixed_ip {
-            let ip: std::net::IpAddr = ip_str.parse().map_err(|_| {
+            let _: std::net::IpAddr = ip_str.parse().map_err(|_| {
                 CarbideError::InvalidArgument(format!("invalid fixed_ip: {ip_str}"))
             })?;
-            db::machine_interface::preallocate_machine_interface(txn, nic.mac_address, ip).await?;
         }
     }
 
@@ -151,10 +136,10 @@ pub(crate) async fn preallocate_interfaces_for(
 }
 
 /// Create missing expected_machines that aren't already in the database,
-/// calling `preallocate_interfaces_for` for each new entry. This is currently
+/// calling `validate_expected_machine_for_insert` for each new entry. This is currently
 /// purely used by the expected_machines.json import path only, but lives
-/// here so it can re-leverage `preallocate_instances_for` and share the
-/// same allocation codepath as the API handler.
+/// here so it can re-leverage `validate_expected_machine_for_insert` and share the
+/// same validation codepath as the API handler.
 pub(crate) async fn create_missing_from(
     txn: &mut sqlx::PgConnection,
     expected_machines: &[ExpectedMachine],
@@ -174,7 +159,7 @@ pub(crate) async fn create_missing_from(
             );
             continue;
         }
-        preallocate_interfaces_for(&mut *txn, expected_machine).await?;
+        validate_expected_machine_for_insert(expected_machine)?;
         db::expected_machine::create(&mut *txn, expected_machine.clone()).await?;
     }
 
@@ -439,15 +424,7 @@ async fn create_expected_machine(
         data: db_data,
     };
 
-    if let Some(bmc_ip) = expected_machine.data.bmc_ip_address {
-        db::machine_interface::preallocate_bmc_machine_interface(
-            txn,
-            expected_machine.bmc_mac_address,
-            bmc_ip,
-        )
-        .await?;
-    }
-
+    validate_expected_machine_for_insert(&expected_machine)?;
     db::expected_machine::create(txn, expected_machine).await?;
 
     Ok(())

--- a/crates/api/src/handlers/expected_power_shelf.rs
+++ b/crates/api/src/handlers/expected_power_shelf.rs
@@ -45,15 +45,6 @@ pub async fn add_expected_power_shelf(
             message: format!("Database error: {}", e),
         })?;
 
-    if let Some(bmc_ip) = power_shelf.bmc_ip_address {
-        db::machine_interface::preallocate_bmc_machine_interface(
-            &mut txn,
-            power_shelf.bmc_mac_address,
-            bmc_ip,
-        )
-        .await?;
-    }
-
     db_expected_power_shelf::create(&mut txn, power_shelf)
         .await
         .map_err(CarbideError::from)?;

--- a/crates/api/src/handlers/expected_switch.rs
+++ b/crates/api/src/handlers/expected_switch.rs
@@ -45,15 +45,6 @@ pub async fn add_expected_switch(
             message: format!("Database error: {}", e),
         })?;
 
-    if let Some(bmc_ip) = switch.bmc_ip_address {
-        db::machine_interface::preallocate_bmc_machine_interface(
-            &mut txn,
-            switch.bmc_mac_address,
-            bmc_ip,
-        )
-        .await?;
-    }
-
     db_expected_switch::create(&mut txn, switch)
         .await
         .map_err(CarbideError::from)?;

--- a/crates/api/src/tests/expected_machine.rs
+++ b/crates/api/src/tests/expected_machine.rs
@@ -2070,8 +2070,10 @@ async fn test_add_expected_machine_with_invalid_static_ip(pool: sqlx::PgPool) {
     );
 }
 
-/// Adding an expected machine with host_nics[].fixed_ip should
-/// pre-allocate a machine_interface with a static address.
+/// Adding an expected machine with `host_nics[].fixed_ip` should result in a static
+/// `machine_interface` for that NIC. The materialization is deferred: site-explorer's
+/// reconciliation pass (or the DHCP discover hook) is what creates the row. The test
+/// triggers that reconciliation after add to verify the end-to-end flow.
 #[crate::sqlx_test]
 async fn test_add_with_host_nic_fixed_ip_creates_interface(
     pool: sqlx::PgPool,
@@ -2100,7 +2102,17 @@ async fn test_add_with_host_nic_fixed_ip_creates_interface(
         }))
         .await?;
 
-    // Verify a machine_interface was created for the host NIC MAC.
+    // Add doesn't preallocate inline; mimic what site-explorer does on the next iteration --
+    // materialize the host NIC's static fixed_ip.
+    carbide_site_explorer::try_preallocate_one(
+        &env.pool,
+        nic_mac,
+        fixed_ip.parse().unwrap(),
+        model::machine_interface::InterfaceType::Data,
+        "expected_machine host NIC",
+    )
+    .await;
+
     let mut txn = env.pool.begin().await?;
     let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, nic_mac).await?;
     assert_eq!(
@@ -2241,10 +2253,37 @@ async fn test_preallocate_machine_interface_rejects_conflicting_ip(
     Ok(())
 }
 
+/// Symmetric to `test_preallocate_machine_interface_rejects_conflicting_ip`: pre-allocating
+/// an IP that another MAC already owns must error rather than silently reassigning. Covers
+/// the `find_by_address`-branch in `preallocate_machine_interface_with_type`.
+#[crate::sqlx_test]
+async fn test_preallocate_machine_interface_rejects_ip_owned_by_different_mac(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let mac_a: MacAddress = "7A:7B:7C:7D:7E:35".parse().unwrap();
+    let mac_b: MacAddress = "7A:7B:7C:7D:7E:36".parse().unwrap();
+    let ip: std::net::IpAddr = "192.0.2.248".parse().unwrap();
+
+    let mut txn = env.db_txn().await;
+    db::machine_interface::preallocate_machine_interface(txn.as_mut(), mac_a, ip).await?;
+    txn.commit().await?;
+
+    let mut txn = env.db_txn().await;
+    let result =
+        db::machine_interface::preallocate_machine_interface(txn.as_mut(), mac_b, ip).await;
+    assert!(
+        matches!(result, Err(DatabaseError::InvalidArgument(_))),
+        "preallocating an IP owned by a different MAC should be rejected, got {result:?}"
+    );
+
+    Ok(())
+}
+
 /// After a `machine_interface` row gets deleted (e.g. force-delete
 /// --delete-interfaces), a subsequent `preallocate_machine_interface` call
 /// must successfully recreate it with the same static IP. This is the
-/// lazy-allocation flow that we rely on with DHCP discover(...).
+/// deferred-allocation flow that we rely on with DHCP discover(...).
 #[crate::sqlx_test]
 async fn test_preallocate_machine_interface_recreates_after_deletion(
     pool: sqlx::PgPool,
@@ -2278,12 +2317,60 @@ async fn test_preallocate_machine_interface_recreates_after_deletion(
     Ok(())
 }
 
-/// Recovery scenario for the BMC: operator force-deleted a managed machine
-/// and its interfaces, then the BMC re-DHCPs. With DHCP in the allocation
-/// path, discover(...) consults `find_by_bmc_mac_address`, re-preallocates,
-/// and the existing find_or_create path serves the static IP.
+/// When an interface row already exists for the right (MAC, IP) but with the wrong
+/// `interface_type`, a subsequent preallocate call should promote the type rather than
+/// erroring or creating a duplicate. Covers the case where a host NIC initially DHCPs in as
+/// `InterfaceType::Data`, then the operator's expected_machine config later marks the same
+/// MAC as the BMC (or vice versa), and the next reconciliation pass (or discover hook)
+/// reconciles.
 #[crate::sqlx_test]
-async fn test_dhcp_discover_recovers_bmc_after_interface_deletion(
+async fn test_preallocate_machine_interface_promotes_interface_type(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let mac: MacAddress = "7A:7B:7C:7D:7E:34".parse().unwrap();
+    let ip: std::net::IpAddr = "192.0.2.247".parse().unwrap();
+
+    // Initial preallocation lands as InterfaceType::Data.
+    let mut txn = env.db_txn().await;
+    db::machine_interface::preallocate_machine_interface(txn.as_mut(), mac, ip).await?;
+    let before = db::machine_interface::find_by_mac_address(txn.as_mut(), mac).await?;
+    assert_eq!(
+        before[0].interface_type,
+        model::machine_interface::InterfaceType::Data,
+        "Data-variant preallocate should start as InterfaceType::Data"
+    );
+    txn.commit().await?;
+
+    // Re-preallocate the same (MAC, IP) but as the BMC variant. Helper should promote
+    // the existing row's interface_type rather than erroring or creating a duplicate.
+    let mut txn = env.db_txn().await;
+    db::machine_interface::preallocate_bmc_machine_interface(txn.as_mut(), mac, ip).await?;
+    let after = db::machine_interface::find_by_mac_address(txn.as_mut(), mac).await?;
+    txn.commit().await?;
+
+    assert_eq!(after.len(), 1, "no duplicate row should have been created");
+    assert_eq!(
+        after[0].interface_type,
+        model::machine_interface::InterfaceType::Bmc,
+        "Bmc-variant preallocate should promote the existing row to InterfaceType::Bmc"
+    );
+    assert!(
+        after[0].addresses.contains(&ip),
+        "promoted row should still carry the same IP"
+    );
+
+    Ok(())
+}
+
+/// First DHCPDISCOVER for an `expected_machines` BMC: discover() consults
+/// `find_by_bmc_mac_address`, preallocates from `bmc_ip_address`, and the existing
+/// find_or_create path serves that static IP. Add-time doesn't preallocate; row materialization
+/// is deferred until this hook fires (for in-network MACs that DHCPDISCOVER) or until
+/// site-explorer's reconciliation pass runs (for everything, including external
+/// static-assignments IPs).
+#[crate::sqlx_test]
+async fn test_dhcp_discover_preallocates_bmc_ip_for_unknown_mac(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool).await;
@@ -2302,16 +2389,13 @@ async fn test_dhcp_discover_recovers_bmc_after_interface_deletion(
         }))
         .await?;
 
-    // Baseline -- pre-allocation happened during add.
+    // Add no longer preallocates -- the row should be absent until DHCPDISCOVER fires.
     let mut txn = env.db_txn().await;
     let before = db::machine_interface::find_by_mac_address(txn.as_mut(), bmc_mac).await?;
-    assert_eq!(before.len(), 1, "expected_machine add should pre-allocate");
-    assert!(before[0].addresses.contains(&bmc_ip.parse().unwrap()));
-    let interface_id = before[0].id;
-
-    // Simulate `force-delete --delete-interfaces`: the machine_interface row
-    // goes away while the expected_machines entry stays.
-    db::machine_interface::delete(&interface_id, txn.as_mut()).await?;
+    assert!(
+        before.is_empty(),
+        "add does not preallocate inline; the interface should only appear after discover()"
+    );
     txn.commit().await?;
 
     let bmc_mac_str = bmc_mac.to_string();
@@ -2329,26 +2413,30 @@ async fn test_dhcp_discover_recovers_bmc_after_interface_deletion(
 
     assert_eq!(
         response.address, bmc_ip,
-        "BMC re-DHCP should serve the configured bmc_ip_address, not a dynamic-pool allocation"
+        "BMC DHCP should serve the configured bmc_ip_address, not a dynamic-pool allocation"
     );
 
     let mut txn = env.db_txn().await;
     let after = db::machine_interface::find_by_mac_address(txn.as_mut(), bmc_mac).await?;
-    assert_eq!(after.len(), 1, "interface should be re-created");
+    assert_eq!(after.len(), 1, "interface should be created by discover()");
     assert!(
         after[0].addresses.contains(&bmc_ip.parse().unwrap()),
-        "re-created interface should carry the configured static IP"
+        "preallocated interface should carry the configured static IP"
+    );
+    assert_eq!(
+        after[0].interface_type,
+        model::machine_interface::InterfaceType::Bmc,
+        "BMC discover hook should mark the interface as InterfaceType::Bmc, not Data"
     );
 
     Ok(())
 }
 
-/// Same recovery scenario for a host NIC with `fixed_ip`. discover() passes
-/// the matched `ExpectedHostNic` through to `validate_existing_mac_and_create`,
-/// which honors `fixed_ip` via `AddressSelectionStrategy::StaticAddress`.
-/// This test pins that the DHCP discover allocation flow works.
+/// First DHCPDISCOVER for an `ExpectedHostNic.fixed_ip`. discover() passes the matched NIC
+/// through to `validate_existing_mac_and_create`, which honors `fixed_ip` via
+/// `AddressSelectionStrategy::StaticAddress`. Pins the deferred preallocation path for host NICs.
 #[crate::sqlx_test]
-async fn test_dhcp_discover_recovers_host_nic_after_interface_deletion(
+async fn test_dhcp_discover_preallocates_host_nic_fixed_ip_for_unknown_mac(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool).await;
@@ -2377,9 +2465,10 @@ async fn test_dhcp_discover_recovers_host_nic_after_interface_deletion(
 
     let mut txn = env.db_txn().await;
     let before = db::machine_interface::find_by_mac_address(txn.as_mut(), nic_mac).await?;
-    assert_eq!(before.len(), 1);
-    let interface_id = before[0].id;
-    db::machine_interface::delete(&interface_id, txn.as_mut()).await?;
+    assert!(
+        before.is_empty(),
+        "add does not preallocate inline; the interface should only appear after discover()"
+    );
     txn.commit().await?;
 
     let nic_mac_str = nic_mac.to_string();
@@ -2398,6 +2487,15 @@ async fn test_dhcp_discover_recovers_host_nic_after_interface_deletion(
     assert_eq!(
         response.address, fixed_ip,
         "host NIC re-DHCP should serve the configured fixed_ip"
+    );
+
+    let mut txn = env.db_txn().await;
+    let after = db::machine_interface::find_by_mac_address(txn.as_mut(), nic_mac).await?;
+    assert_eq!(after.len(), 1, "interface should be created by discover()");
+    assert_eq!(
+        after[0].interface_type,
+        model::machine_interface::InterfaceType::Data,
+        "host NIC discover hook should mark the interface as InterfaceType::Data, not Bmc"
     );
 
     Ok(())
@@ -2868,8 +2966,25 @@ async fn test_create_missing_from_preallocates_interfaces(
     .await?;
     txn.commit().await?;
 
-    // Both the BMC interface and the host NIC interface should now exist
-    // with their static IPs assigned.
+    // Mimic site-explorer's per-row materialization: one preallocate per static IP on the
+    // entity we just inserted.
+    carbide_site_explorer::try_preallocate_one(
+        &env.pool,
+        bmc_mac,
+        bmc_ip,
+        model::machine_interface::InterfaceType::Bmc,
+        "expected_machine BMC",
+    )
+    .await;
+    carbide_site_explorer::try_preallocate_one(
+        &env.pool,
+        nic_mac,
+        host_ip,
+        model::machine_interface::InterfaceType::Data,
+        "expected_machine host NIC",
+    )
+    .await;
+
     let mut txn = env.pool.begin().await?;
     for (mac, expected_ip) in [(bmc_mac, bmc_ip), (nic_mac, host_ip)] {
         let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, mac).await?;
@@ -2885,7 +3000,7 @@ async fn test_create_missing_from_preallocates_interfaces(
         );
     }
 
-    // Re-running with the same input must be a no-op (i.e. idempotent).
+    // Re-running create_missing_from with the same input must be a no-op (idempotent).
     let mut txn = env.pool.begin().await?;
     crate::handlers::expected_machine::create_missing_from(
         &mut txn,

--- a/crates/api/src/tests/expected_power_shelf.rs
+++ b/crates/api/src/tests/expected_power_shelf.rs
@@ -965,8 +965,17 @@ async fn test_add_with_bmc_ip_creates_static_interface(
         }))
         .await?;
 
-    // Verify a machine_interface was effectiveely pre-created
-    // for the BMC MAC.
+    // Add doesn't preallocate inline; mimic what site-explorer does on the next iteration --
+    // materialize the static BMC interface for this entity.
+    carbide_site_explorer::try_preallocate_one(
+        &env.pool,
+        bmc_mac,
+        bmc_ip.parse().unwrap(),
+        model::machine_interface::InterfaceType::Bmc,
+        "expected_power_shelf BMC",
+    )
+    .await;
+
     let mut txn = env.pool.begin().await?;
     let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac).await?;
     assert_eq!(
@@ -1030,54 +1039,6 @@ async fn test_add_without_bmc_ip_creates_no_interface(
     Ok(())
 }
 
-/// Adding an expected power shelf with bmc_ip_address should fail if
-/// a machine_interface already exists for that MAC (e.g., the device
-/// already DHCP'd).
-#[crate::sqlx_test()]
-async fn test_add_with_bmc_ip_rejects_if_interface_exists(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool).await;
-    let bmc_mac: MacAddress = "6A:6B:6C:6D:6E:80".parse().unwrap();
-    let relay: std::net::IpAddr = common::api_fixtures::FIXTURE_DHCP_RELAY_ADDRESS
-        .parse()
-        .unwrap();
-
-    // Create an interface via DHCP (simulating the device already being on the network).
-    let mut txn = env.pool.begin().await?;
-    db::machine_interface::validate_existing_mac_and_create(
-        &mut txn,
-        bmc_mac,
-        std::slice::from_ref(&relay),
-        None,
-    )
-    .await?;
-    txn.commit().await?;
-
-    // Now try to add an expected power shelf with the same MAC -- should fail.
-    let result = env
-        .api
-        .add_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
-            expected_power_shelf_id: None,
-            bmc_mac_address: bmc_mac.to_string(),
-            bmc_username: "ADMIN".into(),
-            bmc_password: "PASS".into(),
-            shelf_serial_number: "PS-COLLISION-001".into(),
-            bmc_ip_address: "192.0.1.190".into(),
-            metadata: Some(rpc::forge::Metadata::default()),
-            rack_id: None,
-            bmc_retain_credentials: None,
-        }))
-        .await;
-
-    assert!(
-        result.is_err(),
-        "add should fail if interface already exists for this MAC"
-    );
-
-    Ok(())
-}
-
 /// Adding an expected power shelf with an external bmc_ip_address (not
 /// in any managed prefix) should create the interface on the
 /// static-assignments anchor segment.
@@ -1103,6 +1064,17 @@ async fn test_add_with_external_bmc_ip_uses_static_assignments(
         }))
         .await?;
 
+    // Add doesn't preallocate inline; mimic what site-explorer does on the next iteration --
+    // materialize the static BMC interface for this entity.
+    carbide_site_explorer::try_preallocate_one(
+        &env.pool,
+        bmc_mac,
+        external_ip.parse().unwrap(),
+        model::machine_interface::InterfaceType::Bmc,
+        "expected_power_shelf BMC",
+    )
+    .await;
+
     // Verify interface was created on the static-assignments segment
     let mut txn = env.pool.begin().await?;
     let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac).await?;
@@ -1115,54 +1087,6 @@ async fn test_add_with_external_bmc_ip_uses_static_assignments(
     assert_eq!(
         iface.segment_id, static_seg.id,
         "external IP should be on the static-assignments segment"
-    );
-
-    Ok(())
-}
-
-/// Adding an expected power shelf with a bmc_ip_address that is already
-/// allocated to another interface should fail.
-#[crate::sqlx_test()]
-async fn test_add_with_bmc_ip_rejects_if_ip_already_allocated(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool).await;
-    let relay: std::net::IpAddr = common::api_fixtures::FIXTURE_DHCP_RELAY_ADDRESS
-        .parse()
-        .unwrap();
-
-    // Create an interface via DHCP -- it gets an IP from the admin pool.
-    let mut txn = env.pool.begin().await?;
-    let existing = db::machine_interface::validate_existing_mac_and_create(
-        &mut txn,
-        "6A:6B:6C:6D:6E:87".parse().unwrap(),
-        std::slice::from_ref(&relay),
-        None,
-    )
-    .await?;
-    let taken_ip = existing.addresses[0];
-    txn.commit().await?;
-
-    // Try to add an expected power shelf with a DIFFERENT MAC but the
-    // SAME IP -- should fail.
-    let result = env
-        .api
-        .add_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
-            expected_power_shelf_id: None,
-            bmc_mac_address: "6A:6B:6C:6D:6E:88".to_string(),
-            bmc_username: "ADMIN".into(),
-            bmc_password: "PASS".into(),
-            shelf_serial_number: "PS-IP-COLLISION".into(),
-            bmc_ip_address: taken_ip.to_string(),
-            metadata: Some(rpc::forge::Metadata::default()),
-            rack_id: None,
-            bmc_retain_credentials: None,
-        }))
-        .await;
-
-    assert!(
-        result.is_err(),
-        "add should fail if the IP is already allocated to another interface"
     );
 
     Ok(())
@@ -1223,7 +1147,8 @@ async fn test_update_with_different_bmc_ip_leaves_interface_alone(
     let bmc_mac: MacAddress = "6A:6B:6C:6D:6E:82".parse().unwrap();
     let original_ip = "192.0.1.192";
 
-    // Add expected power shelf with bmc_ip_address.
+    // Add expected power shelf with bmc_ip_address, then run the sweep so the static
+    // machine_interface row exists (the sweep is what materializes it).
     env.api
         .add_expected_power_shelf(tonic::Request::new(rpc::forge::ExpectedPowerShelf {
             expected_power_shelf_id: None,
@@ -1237,6 +1162,14 @@ async fn test_update_with_different_bmc_ip_leaves_interface_alone(
             bmc_retain_credentials: None,
         }))
         .await?;
+    carbide_site_explorer::try_preallocate_one(
+        &env.pool,
+        bmc_mac,
+        original_ip.parse().unwrap(),
+        model::machine_interface::InterfaceType::Bmc,
+        "expected_power_shelf BMC",
+    )
+    .await;
 
     // Update with a DIFFERENT bmc_ip_address -- should succeed but
     // not touch the interface (it already has an address).
@@ -1417,6 +1350,14 @@ async fn test_update_without_bmc_ip_does_not_touch_interface(
             bmc_retain_credentials: None,
         }))
         .await?;
+    carbide_site_explorer::try_preallocate_one(
+        &env.pool,
+        bmc_mac,
+        bmc_ip.parse().unwrap(),
+        model::machine_interface::InterfaceType::Bmc,
+        "expected_power_shelf BMC",
+    )
+    .await;
 
     // Update without bmc_ip_address (just changing credentials).
     env.api

--- a/crates/api/src/tests/expected_switch.rs
+++ b/crates/api/src/tests/expected_switch.rs
@@ -943,8 +943,9 @@ async fn test_update_persists_nvos_mac_addresses(pool: sqlx::PgPool) {
     assert_eq!(fetched.nvos_mac_addresses, vec![new_nvos_mac]);
 }
 
-/// When an expected switch is created with a bmc_ip_address, a real
-/// machine_interface with a static address should be created in the DB.
+/// When an expected switch is registered with a bmc_ip_address, the static `machine_interface`
+/// gets materialized lazily by site-explorer's per-iteration sweep (the gRPC `add` handler
+/// doesn't preallocate inline). Verify that flow end-to-end.
 #[crate::sqlx_test()]
 async fn test_add_with_bmc_ip_creates_static_interface(
     pool: sqlx::PgPool,
@@ -969,6 +970,17 @@ async fn test_add_with_bmc_ip_creates_static_interface(
             bmc_retain_credentials: None,
         }))
         .await?;
+
+    // Add doesn't preallocate inline; mimic what site-explorer does on the next iteration --
+    // materialize the static BMC interface for this entity.
+    carbide_site_explorer::try_preallocate_one(
+        &env.pool,
+        bmc_mac,
+        bmc_ip.parse().unwrap(),
+        model::machine_interface::InterfaceType::Bmc,
+        "expected_switch BMC",
+    )
+    .await;
 
     let mut txn = env.pool.begin().await?;
     let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac).await?;

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -5674,3 +5674,316 @@ async fn power_shelf_skips_creation_when_bmc_mac_already_used(
 
     Ok(())
 }
+
+/// Site-explorer reconciles every `expected_*` row's configured static IPs into
+/// `machine_interface` rows by calling `try_preallocate_one` per static IP during
+/// `update_explored_endpoints`. This test drives the same per-row materialization directly,
+/// covering the static-assignments-segment counterpart to the DHCP `discover()` recovery hook:
+/// devices whose IP lives outside any Carbide-managed network never reach `discover()`, so this
+/// per-row preallocation is what gets their rows onto the books.
+#[crate::sqlx_test]
+async fn test_site_explorer_reconcile_creates_missing_preallocations(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+
+    let machine_bmc_mac: MacAddress = "AA:BB:CC:DD:E0:01".parse().unwrap();
+    let machine_bmc_ip: IpAddr = "10.99.0.10".parse().unwrap();
+    let switch_bmc_mac: MacAddress = "AA:BB:CC:DD:E0:02".parse().unwrap();
+    let switch_bmc_ip: IpAddr = "10.99.0.11".parse().unwrap();
+    let power_shelf_bmc_mac: MacAddress = "AA:BB:CC:DD:E0:03".parse().unwrap();
+    let power_shelf_bmc_ip: IpAddr = "10.99.0.12".parse().unwrap();
+
+    // Seed each expected_* row WITHOUT a corresponding machine_interface. The gRPC `add`
+    // handlers don't preallocate inline; site-explorer's reconciliation pass is what
+    // materializes the rows.
+    let mut txn = env.pool.begin().await?;
+    db::expected_machine::create(
+        &mut txn,
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: machine_bmc_mac,
+            data: ExpectedMachineData {
+                serial_number: "reconcile-m-001".to_string(),
+                bmc_ip_address: Some(machine_bmc_ip),
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    db::expected_switch::create(
+        &mut txn,
+        model::expected_switch::ExpectedSwitch {
+            expected_switch_id: None,
+            bmc_mac_address: switch_bmc_mac,
+            nvos_mac_addresses: vec![],
+            bmc_username: "ADMIN".into(),
+            serial_number: "reconcile-sw-001".into(),
+            bmc_password: "PASS".into(),
+            nvos_username: None,
+            nvos_password: None,
+            bmc_ip_address: Some(switch_bmc_ip),
+            metadata: Metadata::default(),
+            rack_id: None,
+            bmc_retain_credentials: None,
+        },
+    )
+    .await?;
+    db::expected_power_shelf::create(
+        &mut txn,
+        model::expected_power_shelf::ExpectedPowerShelf {
+            expected_power_shelf_id: None,
+            bmc_mac_address: power_shelf_bmc_mac,
+            bmc_username: "ADMIN".into(),
+            serial_number: "reconcile-ps-001".into(),
+            bmc_password: "PASS".into(),
+            bmc_ip_address: Some(power_shelf_bmc_ip),
+            metadata: Metadata::default(),
+            rack_id: None,
+            bmc_retain_credentials: None,
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    // Baseline: no interfaces yet.
+    let mut txn = env.pool.begin().await?;
+    for mac in [machine_bmc_mac, switch_bmc_mac, power_shelf_bmc_mac] {
+        let before = db::machine_interface::find_by_mac_address(&mut *txn, mac).await?;
+        assert!(
+            before.is_empty(),
+            "no machine_interface should exist before site-explorer reconciles for {mac}"
+        );
+    }
+    txn.commit().await?;
+
+    for (mac, ip, kind) in [
+        (machine_bmc_mac, machine_bmc_ip, "expected_machine BMC"),
+        (switch_bmc_mac, switch_bmc_ip, "expected_switch BMC"),
+        (
+            power_shelf_bmc_mac,
+            power_shelf_bmc_ip,
+            "expected_power_shelf BMC",
+        ),
+    ] {
+        carbide_site_explorer::try_preallocate_one(
+            &env.pool,
+            mac,
+            ip,
+            model::machine_interface::InterfaceType::Bmc,
+            kind,
+        )
+        .await;
+    }
+
+    let mut txn = env.pool.begin().await?;
+    for (mac, ip) in [
+        (machine_bmc_mac, machine_bmc_ip),
+        (switch_bmc_mac, switch_bmc_ip),
+        (power_shelf_bmc_mac, power_shelf_bmc_ip),
+    ] {
+        let after = db::machine_interface::find_by_mac_address(&mut *txn, mac).await?;
+        assert_eq!(after.len(), 1, "should be preallocated for {mac}");
+        assert!(
+            after[0].addresses.contains(&ip),
+            "preallocated row for {mac} should carry {ip}, got {:?}",
+            after[0].addresses,
+        );
+        assert_eq!(
+            after[0].interface_type,
+            model::machine_interface::InterfaceType::Bmc,
+            "BMC IPs should be preallocated with InterfaceType::Bmc, not Data ({mac})"
+        );
+    }
+
+    Ok(())
+}
+
+/// Site-explorer's reconciliation pass must materialize `ExpectedHostNic.fixed_ip`
+/// reservations too, not just BMC IPs.
+#[crate::sqlx_test]
+async fn test_site_explorer_reconcile_preallocates_host_nic_fixed_ip(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+
+    let bmc_mac: MacAddress = "AA:BB:CC:DD:E1:01".parse().unwrap();
+    let nic_mac: MacAddress = "AA:BB:CC:DD:E1:02".parse().unwrap();
+    let fixed_ip = "10.99.0.20";
+
+    let mut txn = env.pool.begin().await?;
+    db::expected_machine::create(
+        &mut txn,
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: bmc_mac,
+            data: ExpectedMachineData {
+                serial_number: "reconcile-hostnic-001".to_string(),
+                host_nics: vec![model::expected_machine::ExpectedHostNic {
+                    mac_address: nic_mac,
+                    nic_type: Some("onboard".into()),
+                    fixed_ip: Some(fixed_ip.into()),
+                    fixed_mask: None,
+                    fixed_gateway: None,
+                    primary: None,
+                }],
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    let parsed_fixed_ip: IpAddr = fixed_ip.parse().unwrap();
+    carbide_site_explorer::try_preallocate_one(
+        &env.pool,
+        nic_mac,
+        parsed_fixed_ip,
+        model::machine_interface::InterfaceType::Data,
+        "expected_machine host NIC",
+    )
+    .await;
+
+    let mut txn = env.pool.begin().await?;
+    let nic_iface = db::machine_interface::find_by_mac_address(&mut *txn, nic_mac).await?;
+    assert_eq!(
+        nic_iface.len(),
+        1,
+        "host NIC interface should be preallocated"
+    );
+    assert!(
+        nic_iface[0].addresses.contains(&parsed_fixed_ip),
+        "preallocated host NIC interface should carry the fixed_ip"
+    );
+    assert_eq!(
+        nic_iface[0].interface_type,
+        model::machine_interface::InterfaceType::Data,
+        "host NIC preallocation should mark the interface as InterfaceType::Data, not Bmc"
+    );
+
+    Ok(())
+}
+
+/// Running `try_preallocate_one` twice for the same (mac, ip) must be a no-op the second time
+/// -- no new rows, no errors. This is the steady-state behavior since site-explorer iterates
+/// continuously and re-issues the same calls on every pass.
+#[crate::sqlx_test]
+async fn test_site_explorer_reconcile_is_idempotent(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+
+    let bmc_mac: MacAddress = "AA:BB:CC:DD:E2:01".parse().unwrap();
+    let bmc_ip: IpAddr = "10.99.0.30".parse().unwrap();
+
+    let mut txn = env.pool.begin().await?;
+    db::expected_machine::create(
+        &mut txn,
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: bmc_mac,
+            data: ExpectedMachineData {
+                serial_number: "reconcile-idem-001".to_string(),
+                bmc_ip_address: Some(bmc_ip),
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    for _ in 0..2 {
+        carbide_site_explorer::try_preallocate_one(
+            &env.pool,
+            bmc_mac,
+            bmc_ip,
+            model::machine_interface::InterfaceType::Bmc,
+            "expected_machine BMC",
+        )
+        .await;
+    }
+
+    let mut txn = env.pool.begin().await?;
+    let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac).await?;
+    assert_eq!(
+        interfaces.len(),
+        1,
+        "two preallocate calls should not create duplicate machine_interface rows"
+    );
+    assert!(interfaces[0].addresses.contains(&bmc_ip));
+
+    Ok(())
+}
+
+/// A per-entry conflict (e.g., two expected_machines configured with the same static IP -- a
+/// genuine operator misconfiguration) must not abort the whole reconciliation pass. The
+/// conflicting entry gets logged and skipped; the rest of the iteration continues.
+#[crate::sqlx_test]
+async fn test_site_explorer_reconcile_tolerates_per_entry_conflicts(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+
+    let mac_a: MacAddress = "AA:BB:CC:DD:E3:01".parse().unwrap();
+    let mac_b: MacAddress = "AA:BB:CC:DD:E3:02".parse().unwrap();
+    let mac_c: MacAddress = "AA:BB:CC:DD:E3:03".parse().unwrap();
+    let shared_ip: IpAddr = "10.99.0.40".parse().unwrap();
+    let ok_ip: IpAddr = "10.99.0.41".parse().unwrap();
+
+    let mut txn = env.pool.begin().await?;
+    // Two machines configured with the SAME bmc_ip_address -- the second will conflict at
+    // preallocate time. A third has its own valid IP and should still get preallocated.
+    for (mac, ip, sn) in [
+        (mac_a, shared_ip, "reconcile-conflict-a"),
+        (mac_b, shared_ip, "reconcile-conflict-b"),
+        (mac_c, ok_ip, "reconcile-conflict-c"),
+    ] {
+        db::expected_machine::create(
+            &mut txn,
+            ExpectedMachine {
+                id: None,
+                bmc_mac_address: mac,
+                data: ExpectedMachineData {
+                    serial_number: sn.to_string(),
+                    bmc_ip_address: Some(ip),
+                    ..Default::default()
+                },
+            },
+        )
+        .await?;
+    }
+    txn.commit().await?;
+
+    // try_preallocate_one swallows per-entry errors -- the conflict between mac_a and mac_b
+    // gets logged and the third call still succeeds.
+    for (mac, ip) in [(mac_a, shared_ip), (mac_b, shared_ip), (mac_c, ok_ip)] {
+        carbide_site_explorer::try_preallocate_one(
+            &env.pool,
+            mac,
+            ip,
+            model::machine_interface::InterfaceType::Bmc,
+            "expected_machine BMC",
+        )
+        .await;
+    }
+
+    let mut txn = env.pool.begin().await?;
+    // Exactly one of {mac_a, mac_b} won the race for the shared IP.
+    let a = db::machine_interface::find_by_mac_address(&mut *txn, mac_a).await?;
+    let b = db::machine_interface::find_by_mac_address(&mut *txn, mac_b).await?;
+    let winners = a.len() + b.len();
+    assert_eq!(
+        winners, 1,
+        "exactly one of the two conflicting MACs should have a preallocated row"
+    );
+    // The third, non-conflicting entry must still be preallocated.
+    let c = db::machine_interface::find_by_mac_address(&mut *txn, mac_c).await?;
+    assert_eq!(
+        c.len(),
+        1,
+        "non-conflicting expected_machine should still be preallocated despite the upstream conflict"
+    );
+    assert!(c[0].addresses.contains(&ok_ip));
+
+    Ok(())
+}

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -1456,7 +1456,6 @@ impl SiteExplorer {
         let underlay_segments =
             db::network_segment::list_segment_ids(&mut txn, Some(NetworkSegmentType::Underlay))
                 .await?;
-        let interfaces = db::machine_interface::find_all(&mut txn).await?;
         let explored_endpoints = db::explored_endpoints::find_all(txn.as_pgconn()).await?;
         let expected_switches = db::expected_switch::find_all(&mut txn).await?;
         let expected_machines = db::expected_machine::find_all(&mut txn).await?;
@@ -1482,7 +1481,12 @@ impl SiteExplorer {
             .map(|sku| (sku.id, sku.device_type))
             .collect();
 
-        // Record expected machine metrics
+        // Record expected machine metrics and reconcile any configured static-IP reservations
+        // (bmc_ip_address, host_nics[].fixed_ip) into machine_interfaces. Idempotent on the
+        // api-db side -- steady-state runs are no-ops at the row level. This is the canonical
+        // path that materializes static reservations for IPs that don't reach
+        // `discover_dhcp` (devices on the static-assignments segment, devices not yet powered
+        // on, etc.), and a belt-and-suspenders for the in-network case too.
         for expected_machine in &expected_machines {
             let device_type = expected_machine
                 .data
@@ -1494,6 +1498,68 @@ impl SiteExplorer {
                 expected_machine.data.sku_id.as_deref(),
                 device_type,
             );
+
+            if let Some(bmc_ip) = expected_machine.data.bmc_ip_address {
+                try_preallocate_one(
+                    &self.database_connection,
+                    expected_machine.bmc_mac_address,
+                    bmc_ip,
+                    InterfaceType::Bmc,
+                    "expected_machine BMC",
+                )
+                .await;
+            }
+            for nic in &expected_machine.data.host_nics {
+                let Some(ip_str) = nic.fixed_ip.as_deref() else {
+                    continue;
+                };
+                let ip: IpAddr = match ip_str.parse() {
+                    Ok(ip) => ip,
+                    Err(error) => {
+                        tracing::warn!(
+                            %error,
+                            nic_mac = %nic.mac_address,
+                            fixed_ip = %ip_str,
+                            "Site-explorer preallocation: invalid fixed_ip on expected_machine host NIC"
+                        );
+                        continue;
+                    }
+                };
+                try_preallocate_one(
+                    &self.database_connection,
+                    nic.mac_address,
+                    ip,
+                    InterfaceType::Data,
+                    "expected_machine host NIC",
+                )
+                .await;
+            }
+        }
+
+        for expected_switch in &expected_switches {
+            if let Some(bmc_ip) = expected_switch.bmc_ip_address {
+                try_preallocate_one(
+                    &self.database_connection,
+                    expected_switch.bmc_mac_address,
+                    bmc_ip,
+                    InterfaceType::Bmc,
+                    "expected_switch BMC",
+                )
+                .await;
+            }
+        }
+
+        for expected_power_shelf in &expected_power_shelves {
+            if let Some(bmc_ip) = expected_power_shelf.bmc_ip_address {
+                try_preallocate_one(
+                    &self.database_connection,
+                    expected_power_shelf.bmc_mac_address,
+                    bmc_ip,
+                    InterfaceType::Bmc,
+                    "expected_power_shelf BMC",
+                )
+                .await;
+            }
         }
 
         let expected_count = expected_machines.len();
@@ -1507,7 +1573,11 @@ impl SiteExplorer {
         // until the machine is ingested. At that point in time this filter will remove them
         // from the to-be-scanned list.
         // Get all underlay interfaces from the database, which includes interfaces
-        // which have come from both DHCP and/or static assignments.
+        // which have come from both DHCP and/or static assignments. Fetched here, after the
+        // preallocate loops above, so we see any freshly preallocated rows from this iteration.
+        let mut txn = self.txn_begin().await?;
+        let interfaces = db::machine_interface::find_all(&mut txn).await?;
+        txn.commit().await?;
         let underlay_interfaces: Vec<MachineInterfaceSnapshot> = interfaces
             .into_iter()
             .filter(|iface| {
@@ -2647,6 +2717,56 @@ impl SiteExplorer {
                 );
                 Ok(true)
             }
+        }
+    }
+}
+
+/// Reconcile a single static-IP reservation into `machine_interfaces` in its
+/// own transaction.
+///
+/// Called once per configured static IP during the `update_explored_endpoints`
+/// walk over `expected_machine` / `expected_switch` / `expected_power_shelf`.
+/// Idempotent on the api-db side -- steady-state runs are noops. Per-entry
+/// errors are logged as warnings, and doesn't stop the wider iteration.
+///
+/// This is `pub` so tests can drive a single (mac, ip, interface_type)
+/// preallocation directly without needing to create a full `SiteExplorer`.
+pub async fn try_preallocate_one(
+    pool: &PgPool,
+    mac: MacAddress,
+    ip: IpAddr,
+    interface_type: InterfaceType,
+    kind: &'static str,
+) {
+    let mut txn = match db::Transaction::begin(pool).await {
+        Ok(t) => t,
+        Err(error) => {
+            tracing::warn!(
+                %error, %mac, %ip, kind,
+                "Site-explorer preallocation: txn_begin failed"
+            );
+            return;
+        }
+    };
+    let result = match interface_type {
+        InterfaceType::Bmc => {
+            db::machine_interface::preallocate_bmc_machine_interface(txn.as_pgconn(), mac, ip).await
+        }
+        InterfaceType::Data => {
+            db::machine_interface::preallocate_machine_interface(txn.as_pgconn(), mac, ip).await
+        }
+    };
+    match result {
+        Ok(()) => {
+            if let Err(error) = txn.commit().await {
+                tracing::warn!(
+                    %error, %mac, %ip, kind,
+                    "Site-explorer preallocation: commit failed"
+                );
+            }
+        }
+        Err(error) => {
+            tracing::warn!(%error, %mac, %ip, kind, "Site-explorer preallocation skipped");
         }
     }
 }


### PR DESCRIPTION
## Description

This supports https://github.com/NVIDIA/infra-controller/issues/1865 and https://github.com/NVIDIA/infra-controller/issues/790 and https://github.com/NVIDIA/infra-controller/issues/644.

When I first put together the static reservations/assignments, since these were static, and coming from `ExpectedMachine` data, I had this thinking to do preallocation of assignments/reservations at expected insert time (e.g. `expected-machine add ....`).

The problem with that was, since these interfaces are static (and had nothing to do with DHCP at the time), if they got deleted (like force deleting a machine, or deleting a machine interface), there was nothing dynamic happening to re-create them, and the only way to get them back was to re-add or update expected data to force the flow to run again. This happened when someone working on some hardware force deleted their machine, and the static `machine_interfaces` entries didn't come back.

Obviously this is wrong. `ExpectedMachine` data is effectively config that describes expectations, and it shouldn't be configuring anything until the machine we're expecting shows up.

So, static reservation/assignment should happen in two places:
- For static reservations within Carbide-managed networks, we should simply have our `dhcp_discover` handler check to see if the client has a static configuration, and if it does, call the correct allocation flow for it (to *attempt to* allocate the reserved IP -- if it's already in use, we'll fail -- people can't hijack and/or duplicate).
- For static IPs outside of Carbide-managed segments (e.g. BCM), we should leverage `site-explorer` iterations to ensure explored expected machines have their assignments in place.

This led me to consider the fact we really only need the `site-explorer` flow for all of it -- in its iteration, it can take care of ensuring machine interfaces exist for DHCP reservations and static assignments, BUT, if a machine powers up and attempts to DHCP before site-explorer iterates to it (and we don't have integration in the DHCP flow), then DHCP would just happily allocate an address dynamically -- we need DHCP to check for what are effectively `fixed-address` mappings and hand out those IPs.

So this PR:
- Rips out all of the expected-* call site preallocation stuff.
- Wires reservation logic into site-explorer iterations.
- Wires reservation logic into the dhcp_discover flow.

My goal is to have everything flow cleanly into lower-level handlers for interface creation and allocation, where we have:
- `preallocate_machine_interface`
- `preallocate_bmc_machine_interface`

..and that ultimately flows into `create_with_type` (with `::FixedIp` as the type), which gives us `create_static_path`.

Tests added/updated! Also including a high level flow diagram of the allocation flow:

<img width="910" height="831" alt="Screenshot 2026-05-22 at 4 17 27 PM" src="https://github.com/user-attachments/assets/ac33f543-8634-4acc-bafe-db1b6a568671" />

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

