### PR TITLE
feat: add nvos_ip_address static reservation support to ExpectedSwitch

### DIFF
--- a/crates/admin-cli/src/expected_switch/add/args.rs
+++ b/crates/admin-cli/src/expected_switch/add/args.rs
@@ -84,6 +84,13 @@ pub struct Args {
     pub bmc_ip_address: Option<IpAddr>,
 
     #[clap(
+        long = "nvos-ip-address",
+        value_name = "NVOS_IP_ADDRESS",
+        help = "Static IP for the single wired NVOS port. Requires exactly one --nvos-mac-address"
+    )]
+    pub nvos_ip_address: Option<IpAddr>,
+
+    #[clap(
         long = "bmc-retain-credentials",
         value_name = "BMC_RETAIN_CREDENTIALS",
         help = "When true, site-explorer skips BMC password rotation and stores factory-default credentials in Vault as-is"
@@ -118,6 +125,7 @@ impl From<Args> for rpc::forge::ExpectedSwitch {
                 .bmc_ip_address
                 .map(|ip| ip.to_string())
                 .unwrap_or_default(),
+            nvos_ip_address: value.nvos_ip_address.map(|ip| ip.to_string()),
             bmc_retain_credentials: value.bmc_retain_credentials,
         }
     }

--- a/crates/admin-cli/src/expected_switch/common.rs
+++ b/crates/admin-cli/src/expected_switch/common.rs
@@ -36,5 +36,7 @@ pub struct ExpectedSwitchJson {
     pub rack_id: Option<RackId>,
     pub bmc_ip_address: Option<IpAddr>,
     #[serde(default)]
+    pub nvos_ip_address: Option<IpAddr>,
+    #[serde(default)]
     pub bmc_retain_credentials: Option<bool>,
 }

--- a/crates/admin-cli/src/expected_switch/update/args.rs
+++ b/crates/admin-cli/src/expected_switch/update/args.rs
@@ -115,6 +115,13 @@ pub struct Args {
     pub bmc_ip_address: Option<IpAddr>,
 
     #[clap(
+        long = "nvos-ip-address",
+        value_name = "NVOS_IP_ADDRESS",
+        help = "Static IP for the single wired NVOS port. Requires exactly one --nvos-mac-address"
+    )]
+    pub nvos_ip_address: Option<IpAddr>,
+
+    #[clap(
         long = "bmc-retain-credentials",
         value_name = "BMC_RETAIN_CREDENTIALS",
         help = "When true, site-explorer skips BMC password rotation and stores factory-default credentials in Vault as-is"
@@ -176,6 +183,7 @@ impl TryFrom<Args> for rpc::forge::ExpectedSwitch {
                 .bmc_ip_address
                 .map(|ip| ip.to_string())
                 .unwrap_or_default(),
+            nvos_ip_address: args.nvos_ip_address.map(|ip| ip.to_string()),
             bmc_retain_credentials: args.bmc_retain_credentials,
         })
     }

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -823,6 +823,7 @@ impl ApiClient {
                         .bmc_ip_address
                         .map(|ip| ip.to_string())
                         .unwrap_or_default(),
+                    nvos_ip_address: switch.nvos_ip_address.map(|ip| ip.to_string()),
                     metadata: switch.metadata,
                     rack_id: switch.rack_id,
                     bmc_retain_credentials: switch.bmc_retain_credentials,

--- a/crates/api-db/migrations/20260522215431_expected_switches_nvos_ip_address.sql
+++ b/crates/api-db/migrations/20260522215431_expected_switches_nvos_ip_address.sql
@@ -1,0 +1,4 @@
+-- Add nvos_ip_address to expected_switches, mirroring bmc_ip_address.
+-- Only meaningful when nvos_mac_addresses has exactly one entry (the single wired NVOS port).
+ALTER TABLE expected_switches ADD COLUMN nvos_ip_address inet;
+CREATE INDEX idx_expected_switches_nvos_ip_address ON expected_switches(nvos_ip_address);

--- a/crates/api-db/src/expected_switch.rs
+++ b/crates/api-db/src/expected_switch.rs
@@ -39,6 +39,21 @@ pub async fn find_by_bmc_mac_address(
         .map_err(|err| DatabaseError::query(sql, err))
 }
 
+/// Find by an NVOS MAC. `nvos_mac_addresses` is a `macaddr[]` column, so we match
+/// rows where the given MAC is contained in that array. Returns at most one row
+/// because the discover hook expects a 1:1 lookup.
+pub async fn find_by_nvos_mac_address(
+    txn: &mut PgConnection,
+    nvos_mac_address: MacAddress,
+) -> Result<Option<ExpectedSwitch>, DatabaseError> {
+    let sql = "SELECT * FROM expected_switches WHERE $1::macaddr = ANY(nvos_mac_addresses)";
+    sqlx::query_as(sql)
+        .bind(nvos_mac_address)
+        .fetch_optional(txn)
+        .await
+        .map_err(|err| DatabaseError::query(sql, err))
+}
+
 pub async fn find_by_serial_number(
     txn: &mut PgConnection,
     serial_number: &str,
@@ -177,9 +192,9 @@ pub async fn create(
 ) -> DatabaseResult<ExpectedSwitch> {
     let id = switch.expected_switch_id.unwrap_or_else(Uuid::new_v4);
     let query = "INSERT INTO expected_switches
-             (expected_switch_id, bmc_mac_address, bmc_username, bmc_password, serial_number, bmc_ip_address, metadata_name, metadata_description, rack_id, metadata_labels, nvos_username, nvos_password, nvos_mac_addresses, bmc_retain_credentials)
+             (expected_switch_id, bmc_mac_address, bmc_username, bmc_password, serial_number, bmc_ip_address, metadata_name, metadata_description, rack_id, metadata_labels, nvos_username, nvos_password, nvos_mac_addresses, bmc_retain_credentials, nvos_ip_address)
              VALUES
-             ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::inet, $7::varchar, $8::varchar, $9::varchar, $10::jsonb, $11::varchar, $12::varchar, $13::macaddr[], $14) RETURNING *";
+             ($1::uuid, $2::macaddr, $3::varchar, $4::varchar, $5::varchar, $6::inet, $7::varchar, $8::varchar, $9::varchar, $10::jsonb, $11::varchar, $12::varchar, $13::macaddr[], $14, $15::inet) RETURNING *";
 
     sqlx::query_as(query)
         .bind(id)
@@ -196,6 +211,7 @@ pub async fn create(
         .bind(&switch.nvos_password)
         .bind(&switch.nvos_mac_addresses)
         .bind(switch.bmc_retain_credentials.unwrap_or(false))
+        .bind(switch.nvos_ip_address)
         .fetch_one(txn)
         .await
         .map_err(|err: sqlx::Error| match err {
@@ -305,9 +321,9 @@ pub async fn clear(txn: &mut PgConnection) -> Result<(), DatabaseError> {
 /// matches by ID; otherwise matches by bmc_mac_address.
 pub async fn update(txn: &mut PgConnection, switch: &ExpectedSwitch) -> DatabaseResult<()> {
     let (where_clause, target_id) = match switch.expected_switch_id {
-        Some(id) => ("expected_switch_id=$13::uuid", id.to_string()),
+        Some(id) => ("expected_switch_id=$14::uuid", id.to_string()),
         None => (
-            "bmc_mac_address=$13::macaddr",
+            "bmc_mac_address=$14::macaddr",
             switch.bmc_mac_address.to_string(),
         ),
     };
@@ -317,7 +333,8 @@ pub async fn update(txn: &mut PgConnection, switch: &ExpectedSwitch) -> Database
          SET bmc_username=$1, bmc_password=$2, serial_number=$3, bmc_ip_address=$4, \
              metadata_name=$5, metadata_description=$6, metadata_labels=$7, \
              rack_id=$8, nvos_username=$9, nvos_password=$10, nvos_mac_addresses=$11::macaddr[], \
-             bmc_retain_credentials=COALESCE($12, bmc_retain_credentials) \
+             bmc_retain_credentials=COALESCE($12, bmc_retain_credentials), \
+             nvos_ip_address=$13::inet \
          WHERE {where_clause}"
     );
 
@@ -334,6 +351,7 @@ pub async fn update(txn: &mut PgConnection, switch: &ExpectedSwitch) -> Database
         .bind(&switch.nvos_password)
         .bind(&switch.nvos_mac_addresses)
         .bind(switch.bmc_retain_credentials)
+        .bind(switch.nvos_ip_address)
         .bind(&target_id)
         .execute(&mut *txn)
         .await

--- a/crates/api-model/src/expected_switch.rs
+++ b/crates/api-model/src/expected_switch.rs
@@ -43,6 +43,11 @@ pub struct ExpectedSwitch {
     pub nvos_password: Option<String>,
     #[serde(default)]
     pub bmc_ip_address: Option<IpAddr>,
+    /// Static IP reservation for the single wired NVOS port. Only meaningful
+    /// when `nvos_mac_addresses` has exactly one entry; handlers reject this
+    /// being set otherwise so the (mac, ip) pairing stays unambiguous.
+    #[serde(default)]
+    pub nvos_ip_address: Option<IpAddr>,
     #[serde(default = "default_metadata_for_deserializer")]
     pub metadata: Metadata,
     pub rack_id: Option<RackId>,
@@ -74,6 +79,7 @@ impl<'r> FromRow<'r, PgRow> for ExpectedSwitch {
             nvos_username: row.try_get("nvos_username")?,
             nvos_password: row.try_get("nvos_password")?,
             bmc_ip_address: row.try_get("bmc_ip_address").ok(),
+            nvos_ip_address: row.try_get("nvos_ip_address").ok(),
             metadata,
             rack_id: row.try_get("rack_id")?,
             bmc_retain_credentials: row.try_get("bmc_retain_credentials")?,

--- a/crates/api/src/dhcp/discover.rs
+++ b/crates/api/src/dhcp/discover.rs
@@ -272,8 +272,7 @@ pub async fn discover_dhcp(
                             // It looks like there's a DHCP reservation for this address,
                             // so make an idempotent call to ensure we have a preallocated
                             // machine interface (and machine interface address) for it,
-                            // creating one if needed. Races against site-explorer's
-                            // reconciliation pass are handled inside preallocate.
+                            // creating one if needed.
                             db::machine_interface::preallocate_machine_interface(
                                 &mut txn, parsed_mac, fixed_ip,
                             )
@@ -293,6 +292,23 @@ pub async fn discover_dhcp(
                         // site-explorer's reconciliation pass are handled inside preallocate.
                         db::machine_interface::preallocate_bmc_machine_interface(
                             &mut txn, parsed_mac, bmc_ip,
+                        )
+                        .await?;
+                    } else if let Some(s) =
+                        db::expected_switch::find_by_nvos_mac_address(&mut txn, parsed_mac)
+                            .await
+                            .map_err(CarbideError::from)?
+                        && let Some(nvos_ip) = s.nvos_ip_address
+                    {
+                        // The parsed MAC matches the single wired NVOS port of an expected
+                        // switch with a configured static IP. Mirrors the ExpectedHostNic
+                        // fixed_ip path: ensure the (mac, nvos_ip) row exists so the static
+                        // reservation gets served by the find_or_create_machine_interface
+                        // step below. Data variant (NVOS is a data interface, not a BMC).
+                        // Races against site-explorer's reconciliation pass are handled
+                        // inside preallocate.
+                        db::machine_interface::preallocate_machine_interface(
+                            &mut txn, parsed_mac, nvos_ip,
                         )
                         .await?;
                     }

--- a/crates/api/src/handlers/expected_switch.rs
+++ b/crates/api/src/handlers/expected_switch.rs
@@ -25,6 +25,20 @@ use crate::CarbideError;
 use crate::api::Api;
 use crate::handlers::machine_interface_address::update_preallocated_machine_interface;
 
+/// `nvos_ip_address` is paired with the single wired NVOS port. We reject any
+/// caller that sets it alongside zero-or-multiple `nvos_mac_addresses`, so the
+/// (mac, ip) pairing stays unambiguous for the discover hook and the
+/// reconciliation pass.
+fn validate_nvos_ip_pairing(switch: &ExpectedSwitch) -> Result<(), CarbideError> {
+    if switch.nvos_ip_address.is_some() && switch.nvos_mac_addresses.len() != 1 {
+        return Err(CarbideError::InvalidArgument(format!(
+            "nvos_ip_address requires exactly one nvos_mac_addresses entry, got {}",
+            switch.nvos_mac_addresses.len(),
+        )));
+    }
+    Ok(())
+}
+
 pub async fn add_expected_switch(
     api: &Api,
     request: Request<rpc::ExpectedSwitch>,
@@ -36,6 +50,8 @@ pub async fn add_expected_switch(
             .map_err(|e: ::rpc::errors::RpcDataConversionError| {
                 CarbideError::InvalidArgument(e.to_string())
             })?;
+
+    validate_nvos_ip_pairing(&switch)?;
 
     let mut txn = api
         .database_connection
@@ -99,6 +115,8 @@ pub async fn update_expected_switch(
                 CarbideError::InvalidArgument(e.to_string())
             })?;
 
+    validate_nvos_ip_pairing(&switch)?;
+
     let mut txn = api
         .database_connection
         .begin()
@@ -109,6 +127,11 @@ pub async fn update_expected_switch(
 
     if let Some(bmc_ip) = switch.bmc_ip_address {
         update_preallocated_machine_interface(&mut txn, switch.bmc_mac_address, bmc_ip).await?;
+    }
+    if let Some(nvos_ip) = switch.nvos_ip_address {
+        // Pairing already validated above; nvos_mac_addresses has exactly one entry.
+        let nvos_mac = switch.nvos_mac_addresses[0];
+        update_preallocated_machine_interface(&mut txn, nvos_mac, nvos_ip).await?;
     }
 
     db_expected_switch::update(&mut txn, &switch)

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -1932,6 +1932,7 @@ pub async fn create_expected_switches(
                 None
             },
             bmc_ip_address: None,
+            nvos_ip_address: None,
             metadata: Metadata {
                 name: format!("Switch{}", i + 1),
                 description: format!("Test Switch {}", i + 1),

--- a/crates/api/src/tests/expected_switch.rs
+++ b/crates/api/src/tests/expected_switch.rs
@@ -61,6 +61,7 @@ async fn test_duplicate_fail_create(pool: sqlx::PgPool) -> Result<(), Box<dyn st
             metadata: Metadata::default(),
             rack_id: None,
             bmc_retain_credentials: None,
+            nvos_ip_address: None,
             nvos_username: None,
             nvos_password: None,
         },
@@ -163,6 +164,7 @@ async fn test_add_expected_switch(pool: sqlx::PgPool) {
             rack_id: None,
             bmc_ip_address: String::new(),
             bmc_retain_credentials: None,
+            nvos_ip_address: None,
         },
         rpc::forge::ExpectedSwitch {
             expected_switch_id: None,
@@ -177,6 +179,7 @@ async fn test_add_expected_switch(pool: sqlx::PgPool) {
             rack_id: None,
             bmc_ip_address: String::new(),
             bmc_retain_credentials: None,
+            nvos_ip_address: None,
         },
         rpc::forge::ExpectedSwitch {
             expected_switch_id: None,
@@ -204,6 +207,7 @@ async fn test_add_expected_switch(pool: sqlx::PgPool) {
             rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
             bmc_ip_address: String::new(),
             bmc_retain_credentials: None,
+            nvos_ip_address: None,
         },
     ] {
         env.api
@@ -304,6 +308,7 @@ async fn test_update_expected_switch(pool: sqlx::PgPool) {
             rack_id: None,
             bmc_ip_address: String::new(),
             bmc_retain_credentials: None,
+            nvos_ip_address: None,
         },
         rpc::forge::ExpectedSwitch {
             expected_switch_id: None,
@@ -318,6 +323,7 @@ async fn test_update_expected_switch(pool: sqlx::PgPool) {
             rack_id: None,
             bmc_ip_address: String::new(),
             bmc_retain_credentials: None,
+            nvos_ip_address: None,
         },
         rpc::forge::ExpectedSwitch {
             expected_switch_id: None,
@@ -345,6 +351,7 @@ async fn test_update_expected_switch(pool: sqlx::PgPool) {
             rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
             bmc_ip_address: String::new(),
             bmc_retain_credentials: None,
+            nvos_ip_address: None,
         },
     ] {
         env.api
@@ -398,6 +405,7 @@ async fn test_get_expected_switch_by_id(pool: sqlx::PgPool) {
         rack_id: None,
         bmc_ip_address: String::new(),
         bmc_retain_credentials: None,
+        nvos_ip_address: None,
     };
 
     env.api
@@ -440,6 +448,7 @@ async fn test_delete_expected_switch_by_id(pool: sqlx::PgPool) {
         rack_id: None,
         bmc_ip_address: String::new(),
         bmc_retain_credentials: None,
+        nvos_ip_address: None,
     };
 
     env.api
@@ -494,6 +503,7 @@ async fn test_update_expected_switch_by_id(pool: sqlx::PgPool) {
         rack_id: None,
         bmc_ip_address: String::new(),
         bmc_retain_credentials: None,
+        nvos_ip_address: None,
     };
 
     env.api
@@ -523,6 +533,7 @@ async fn test_update_expected_switch_by_id(pool: sqlx::PgPool) {
         rack_id: None,
         bmc_ip_address: String::new(),
         bmc_retain_credentials: None,
+        nvos_ip_address: None,
     };
 
     env.api
@@ -565,6 +576,7 @@ async fn test_create_expected_switch_with_explicit_id(pool: sqlx::PgPool) {
         rack_id: None,
         bmc_ip_address: String::new(),
         bmc_retain_credentials: None,
+        nvos_ip_address: None,
     };
 
     env.api
@@ -608,6 +620,7 @@ async fn test_create_expected_switch_auto_generates_id(pool: sqlx::PgPool) {
         rack_id: None,
         bmc_ip_address: String::new(),
         bmc_retain_credentials: None,
+        nvos_ip_address: None,
     };
 
     env.api
@@ -719,6 +732,7 @@ async fn test_update_expected_switch_error(pool: sqlx::PgPool) {
         rack_id: None,
         bmc_ip_address: String::new(),
         bmc_retain_credentials: None,
+        nvos_ip_address: None,
     };
 
     let err = env
@@ -829,6 +843,7 @@ async fn test_replace_all_expected_switches(pool: sqlx::PgPool) {
         rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
         bmc_ip_address: String::new(),
         bmc_retain_credentials: None,
+        nvos_ip_address: None,
     };
 
     let expected_switch_2 = rpc::forge::ExpectedSwitch {
@@ -844,6 +859,7 @@ async fn test_replace_all_expected_switches(pool: sqlx::PgPool) {
         rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
         bmc_ip_address: String::new(),
         bmc_retain_credentials: None,
+        nvos_ip_address: None,
     };
 
     expected_switch_list
@@ -968,6 +984,7 @@ async fn test_add_with_bmc_ip_creates_static_interface(
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
             bmc_retain_credentials: None,
+            nvos_ip_address: None,
         }))
         .await?;
 
@@ -1033,6 +1050,7 @@ async fn test_add_without_bmc_ip_creates_no_interface(
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
             bmc_retain_credentials: None,
+            nvos_ip_address: None,
         }))
         .await?;
 
@@ -1069,6 +1087,7 @@ async fn test_add_expected_switch_with_bmc_retain_credentials(
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
             bmc_retain_credentials: Some(true),
+            nvos_ip_address: None,
         }))
         .await?;
 
@@ -1114,6 +1133,7 @@ async fn test_update_expected_switch_preserves_bmc_retain_credentials(
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
             bmc_retain_credentials: Some(true),
+            nvos_ip_address: None,
         }))
         .await?;
 
@@ -1132,6 +1152,7 @@ async fn test_update_expected_switch_preserves_bmc_retain_credentials(
             metadata: Some(rpc::forge::Metadata::default()),
             rack_id: None,
             bmc_retain_credentials: None,
+            nvos_ip_address: None,
         }))
         .await?;
 
@@ -1148,6 +1169,251 @@ async fn test_update_expected_switch_preserves_bmc_retain_credentials(
         retrieved.bmc_retain_credentials,
         Some(true),
         "bmc_retain_credentials should be preserved after update with None"
+    );
+
+    Ok(())
+}
+
+/// `nvos_ip_address` is paired with the single wired NVOS port. Setting it without any
+/// `nvos_mac_addresses` would leave the (mac, ip) pairing undefined, so the handler must
+/// reject it with `InvalidArgument`.
+#[crate::sqlx_test]
+async fn test_add_expected_switch_rejects_nvos_ip_without_mac(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "7A:7B:7C:7D:7E:60".parse().unwrap();
+
+    let err = env
+        .api
+        .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
+            expected_switch_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            switch_serial_number: "SW-NVOS-NO-MAC".into(),
+            nvos_mac_addresses: vec![],
+            nvos_username: None,
+            nvos_password: None,
+            bmc_ip_address: String::new(),
+            nvos_ip_address: Some("192.0.2.250".into()),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+            bmc_retain_credentials: None,
+        }))
+        .await
+        .expect_err("add must reject nvos_ip_address with no nvos_mac_addresses");
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+    Ok(())
+}
+
+/// Setting `nvos_ip_address` alongside multiple `nvos_mac_addresses` is ambiguous (which MAC
+/// gets the IP?), so the handler must reject it instead of silently picking one.
+#[crate::sqlx_test]
+async fn test_add_expected_switch_rejects_nvos_ip_with_multiple_macs(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "7A:7B:7C:7D:7E:61".parse().unwrap();
+
+    let err = env
+        .api
+        .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
+            expected_switch_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            switch_serial_number: "SW-NVOS-MULTI-MAC".into(),
+            nvos_mac_addresses: vec![
+                "8A:8B:8C:8D:8E:01".to_string(),
+                "8A:8B:8C:8D:8E:02".to_string(),
+            ],
+            nvos_username: None,
+            nvos_password: None,
+            bmc_ip_address: String::new(),
+            nvos_ip_address: Some("192.0.2.251".into()),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+            bmc_retain_credentials: None,
+        }))
+        .await
+        .expect_err("add must reject nvos_ip_address with multiple nvos_mac_addresses");
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+    Ok(())
+}
+
+/// Happy path: `nvos_ip_address` paired with exactly one `nvos_mac_addresses` entry is
+/// accepted by `add`, and the field round-trips through `get`.
+#[crate::sqlx_test]
+async fn test_add_expected_switch_with_nvos_ip_round_trips(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "7A:7B:7C:7D:7E:62".parse().unwrap();
+    let nvos_mac: MacAddress = "8A:8B:8C:8D:8E:10".parse().unwrap();
+    let nvos_ip = "192.0.2.252";
+
+    env.api
+        .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
+            expected_switch_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            switch_serial_number: "SW-NVOS-OK".into(),
+            nvos_mac_addresses: vec![nvos_mac.to_string()],
+            nvos_username: None,
+            nvos_password: None,
+            bmc_ip_address: String::new(),
+            nvos_ip_address: Some(nvos_ip.into()),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+            bmc_retain_credentials: None,
+        }))
+        .await?;
+
+    let retrieved = env
+        .api
+        .get_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitchRequest {
+            bmc_mac_address: bmc_mac.to_string(),
+            expected_switch_id: None,
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(
+        retrieved.nvos_ip_address.as_deref(),
+        Some(nvos_ip),
+        "nvos_ip_address must survive the add -> get round-trip"
+    );
+
+    Ok(())
+}
+
+/// Symmetric to the add validation: update must also reject `nvos_ip_address` when the
+/// `nvos_mac_addresses` count is not exactly one. Covers the case where an operator
+/// adds a valid switch and then mutates it into an invalid pairing.
+#[crate::sqlx_test]
+async fn test_update_expected_switch_rejects_invalid_nvos_pairing(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "7A:7B:7C:7D:7E:63".parse().unwrap();
+    let nvos_mac: MacAddress = "8A:8B:8C:8D:8E:20".parse().unwrap();
+
+    env.api
+        .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
+            expected_switch_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            switch_serial_number: "SW-NVOS-UPDATE".into(),
+            nvos_mac_addresses: vec![nvos_mac.to_string()],
+            nvos_username: None,
+            nvos_password: None,
+            bmc_ip_address: String::new(),
+            nvos_ip_address: None,
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+            bmc_retain_credentials: None,
+        }))
+        .await?;
+
+    let err = env
+        .api
+        .update_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
+            expected_switch_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            switch_serial_number: "SW-NVOS-UPDATE".into(),
+            // Drop the NVOS MAC but try to keep the IP -- pairing now invalid.
+            nvos_mac_addresses: vec![],
+            nvos_username: None,
+            nvos_password: None,
+            bmc_ip_address: String::new(),
+            nvos_ip_address: Some("192.0.2.253".into()),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+            bmc_retain_credentials: None,
+        }))
+        .await
+        .expect_err("update must reject nvos_ip_address with no nvos_mac_addresses");
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+    Ok(())
+}
+
+/// First DHCPDISCOVER for an `ExpectedSwitch.nvos_ip_address`: discover() consults
+/// `find_by_nvos_mac_address`, preallocates from `nvos_ip_address`, and the existing
+/// find_or_create path serves that static IP. Mirrors the host-NIC fixed_ip flow. Add-time
+/// doesn't preallocate; row materialization is deferred until this hook fires or until
+/// site-explorer's reconciliation pass runs.
+#[crate::sqlx_test]
+async fn test_dhcp_discover_preallocates_nvos_ip_for_unknown_mac(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "7A:7B:7C:7D:7E:64".parse().unwrap();
+    let nvos_mac: MacAddress = "8A:8B:8C:8D:8E:30".parse().unwrap();
+    let nvos_ip = "192.0.2.254";
+
+    env.api
+        .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
+            expected_switch_id: None,
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            switch_serial_number: "SW-NVOS-DHCP".into(),
+            nvos_mac_addresses: vec![nvos_mac.to_string()],
+            nvos_username: None,
+            nvos_password: None,
+            bmc_ip_address: String::new(),
+            nvos_ip_address: Some(nvos_ip.into()),
+            metadata: Some(rpc::forge::Metadata::default()),
+            rack_id: None,
+            bmc_retain_credentials: None,
+        }))
+        .await?;
+
+    let mut txn = env.db_txn().await;
+    let before = db::machine_interface::find_by_mac_address(txn.as_mut(), nvos_mac).await?;
+    assert!(
+        before.is_empty(),
+        "add does not preallocate inline; the interface should only appear after discover()"
+    );
+    txn.commit().await?;
+
+    let nvos_mac_str = nvos_mac.to_string();
+    let response = env
+        .api
+        .discover_dhcp(
+            common::rpc_builder::DhcpDiscovery::builder(
+                &nvos_mac_str,
+                common::api_fixtures::FIXTURE_DHCP_RELAY_ADDRESS,
+            )
+            .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    assert_eq!(
+        response.address, nvos_ip,
+        "NVOS DHCP should serve the configured nvos_ip_address"
+    );
+
+    let mut txn = env.db_txn().await;
+    let after = db::machine_interface::find_by_mac_address(txn.as_mut(), nvos_mac).await?;
+    assert_eq!(after.len(), 1, "interface should be created by discover()");
+    assert_eq!(
+        after[0].interface_type,
+        model::machine_interface::InterfaceType::Data,
+        "NVOS discover hook should mark the interface as InterfaceType::Data, not Bmc"
+    );
+    assert!(
+        after[0].addresses.contains(&nvos_ip.parse().unwrap()),
+        "preallocated row should carry the configured nvos_ip_address"
     );
 
     Ok(())

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -3177,6 +3177,7 @@ async fn test_site_explorer_switch_discovery(
         nvos_username: None,
         nvos_password: None,
         bmc_ip_address: None,
+        nvos_ip_address: None,
         metadata: Metadata {
             name: format!("Test Switch {}", serial_number),
             description: format!("A test switch with serial {}", serial_number),
@@ -5412,6 +5413,7 @@ fn expected_switch_fixture(
         nvos_username: None,
         nvos_password: None,
         bmc_ip_address: None,
+        nvos_ip_address: None,
         metadata: Metadata {
             name: format!("Test Switch {serial}"),
             description: String::new(),
@@ -5723,6 +5725,7 @@ async fn test_site_explorer_reconcile_creates_missing_preallocations(
             nvos_username: None,
             nvos_password: None,
             bmc_ip_address: Some(switch_bmc_ip),
+            nvos_ip_address: None,
             metadata: Metadata::default(),
             rack_id: None,
             bmc_retain_credentials: None,
@@ -5984,6 +5987,82 @@ async fn test_site_explorer_reconcile_tolerates_per_entry_conflicts(
         "non-conflicting expected_machine should still be preallocated despite the upstream conflict"
     );
     assert!(c[0].addresses.contains(&ok_ip));
+
+    Ok(())
+}
+
+/// Site-explorer's reconciliation pass must materialize the (nvos_mac, nvos_ip_address)
+/// pairing for expected switches, mirroring how it handles `bmc_ip_address` and the
+/// host-NIC `fixed_ip` paths. Calls `try_preallocate_one` directly the same way the
+/// expected_switches loop does, and verifies the resulting row carries the configured
+/// IP with `InterfaceType::Data`.
+#[crate::sqlx_test]
+async fn test_site_explorer_reconcile_preallocates_nvos_ip(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+
+    let bmc_mac: MacAddress = "AA:BB:CC:DD:E4:01".parse().unwrap();
+    let nvos_mac: MacAddress = "AA:BB:CC:DD:E4:02".parse().unwrap();
+    let nvos_ip: IpAddr = "10.99.0.50".parse().unwrap();
+
+    let mut txn = env.pool.begin().await?;
+    db::expected_switch::create(
+        &mut txn,
+        model::expected_switch::ExpectedSwitch {
+            expected_switch_id: None,
+            bmc_mac_address: bmc_mac,
+            nvos_mac_addresses: vec![nvos_mac],
+            bmc_username: "ADMIN".into(),
+            serial_number: "reconcile-nvos-001".into(),
+            bmc_password: "PASS".into(),
+            nvos_username: None,
+            nvos_password: None,
+            bmc_ip_address: None,
+            nvos_ip_address: Some(nvos_ip),
+            metadata: Metadata::default(),
+            rack_id: None,
+            bmc_retain_credentials: None,
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    // Baseline: no NVOS interface yet.
+    let mut txn = env.pool.begin().await?;
+    let before = db::machine_interface::find_by_mac_address(&mut *txn, nvos_mac).await?;
+    assert!(
+        before.is_empty(),
+        "no machine_interface should exist before site-explorer reconciles for {nvos_mac}"
+    );
+    txn.commit().await?;
+
+    carbide_site_explorer::try_preallocate_one(
+        &env.pool,
+        nvos_mac,
+        nvos_ip,
+        model::machine_interface::InterfaceType::Data,
+        "expected_switch NVOS",
+    )
+    .await;
+
+    let mut txn = env.pool.begin().await?;
+    let after = db::machine_interface::find_by_mac_address(&mut *txn, nvos_mac).await?;
+    assert_eq!(
+        after.len(),
+        1,
+        "expected_switch NVOS should be preallocated for {nvos_mac}"
+    );
+    assert!(
+        after[0].addresses.contains(&nvos_ip),
+        "preallocated row should carry {nvos_ip}, got {:?}",
+        after[0].addresses,
+    );
+    assert_eq!(
+        after[0].interface_type,
+        model::machine_interface::InterfaceType::Data,
+        "NVOS IPs should be preallocated with InterfaceType::Data, not Bmc"
+    );
 
     Ok(())
 }

--- a/crates/component-manager/src/test_support.rs
+++ b/crates/component-manager/src/test_support.rs
@@ -163,6 +163,7 @@ pub(crate) async fn seed_switch(
             serial_number: label.to_owned(),
             bmc_mac_address: mac,
             bmc_ip_address: None,
+            nvos_ip_address: None,
             bmc_username: "admin".into(),
             bmc_password: "pass".into(),
             nvos_username: None,

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -2228,6 +2228,9 @@ message ExpectedSwitch {
   // When true, site-explorer skips BMC password rotation and stores the
   // factory-default credentials in Vault as-is.
   optional bool bmc_retain_credentials = 12;
+  // Static IP reservation for the single wired NVOS port. Only meaningful
+  // when `nvos_mac_addresses` has exactly one entry.
+  optional string nvos_ip_address = 13;
 }
 
 message ExpectedSwitchRequest {

--- a/crates/rpc/src/model/expected_switch.rs
+++ b/crates/rpc/src/model/expected_switch.rs
@@ -46,6 +46,7 @@ impl From<ExpectedSwitch> for rpc::forge::ExpectedSwitch {
                 .bmc_ip_address
                 .map(|ip| ip.to_string())
                 .unwrap_or_default(),
+            nvos_ip_address: expected_switch.nvos_ip_address.map(|ip| ip.to_string()),
             metadata: Some(expected_switch.metadata.into()),
             rack_id: expected_switch.rack_id,
             bmc_retain_credentials: expected_switch.bmc_retain_credentials.filter(|&v| v),
@@ -80,6 +81,15 @@ impl TryFrom<rpc::forge::ExpectedSwitch> for ExpectedSwitch {
         } else {
             rpc.bmc_ip_address.parse().ok()
         };
+        let nvos_ip_address = rpc
+            .nvos_ip_address
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map(|s| {
+                s.parse()
+                    .map_err(|_| RpcDataConversionError::InvalidArgument(s.to_string()))
+            })
+            .transpose()?;
 
         Ok(ExpectedSwitch {
             expected_switch_id,
@@ -90,6 +100,7 @@ impl TryFrom<rpc::forge::ExpectedSwitch> for ExpectedSwitch {
             nvos_username: rpc.nvos_username,
             nvos_password: rpc.nvos_password,
             bmc_ip_address,
+            nvos_ip_address,
             metadata,
             rack_id: rpc.rack_id,
             nvos_mac_addresses,

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -1547,6 +1547,32 @@ impl SiteExplorer {
                 )
                 .await;
             }
+            // NVOS static IP: handler-side validation pairs `nvos_ip_address` with
+            // exactly one `nvos_mac_addresses` entry (the single wired NVOS port).
+            // ...but re-check here just incase, with the failure case being a
+            // log and skip for this pass.
+            if let Some(nvos_ip) = expected_switch.nvos_ip_address {
+                match expected_switch.nvos_mac_addresses.as_slice() {
+                    [nvos_mac] => {
+                        try_preallocate_one(
+                            &self.database_connection,
+                            *nvos_mac,
+                            nvos_ip,
+                            InterfaceType::Data,
+                            "expected_switch NVOS",
+                        )
+                        .await;
+                    }
+                    macs => {
+                        tracing::warn!(
+                            bmc_mac = %expected_switch.bmc_mac_address,
+                            %nvos_ip,
+                            nvos_mac_count = macs.len(),
+                            "Skipping NVOS preallocation: nvos_ip_address requires exactly one nvos_mac_addresses entry"
+                        );
+                    }
+                }
+            }
         }
 
         for expected_power_shelf in &expected_power_shelves {


### PR DESCRIPTION
## Description

This closes https://github.com/NVIDIA/infra-controller/issues/1365.

Preface this with, NVLink switches have 2 NVOS ports physically, but we only ever wire one of them up in practice (the one expressed via `--nvos-mac-address`), for the time being.

As of today, there's no way to express a static IP for that interface -- `ExpectedSwitch` has `bmc_ip_address` for the BMC side, but the NVOS side is purely dynamic (contrast to machines, which now support a `fixed_ip`). So when the NVOS interface DHCPs in, it just gets whatever the segment pool hands out. This adds the missing `nvos_ip_address` field, so we can pin that interface to a known IP, mirroring the existing `ExpectedHostNic::fixed_ip` flow on hosts.

When a switch's NVOS interface DHCPs, `discover_dhcp` now consults `expected_switch::find_by_nvos_mac_address` and will attempt to allocate/assign from the configured `nvos_ip_address` before falling through to `find_or_create_machine_interface` (the same thing machines do). The `site-explorer` reconciliation pass materializes the same row on its own schedule for switches that haven't DHCP'd yet.

A couple of things worth calling out:
- `nvos_ip_address` is paired with the *single* wired NVOS port, so add and update reject it with `InvalidArgument` unless `nvos_mac_addresses` has exactly one entry. Better than silently picking a MAC.
- The preallocated row lands as `InterfaceType::Data`, not `::Bmc` -- NVOS is a data (e.g. host) interface from the segment's point of view.

Tests added for the new flows.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

