### PR TITLE
feat(api): add site-level dpu_mode default

### DIFF
--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -58,28 +58,38 @@ impl DpuMode {
         matches!(self, DpuMode::DpuMode)
     }
 
-    /// Resolve a host's effective DPU mode from its (optional) per-host
-    /// `ExpectedMachine.dpu_mode` value and the site-wide
-    /// `force_dpu_nic_mode` "fallback" flag, which is deprecated more
-    /// than a fallback, but for now I'm treating it as a fallback.
+    /// Resolve a host's effective DPU mode from three inputs, in precedence:
+    /// 1. The (optional) per-host `ExpectedMachine.dpu_mode` value.
+    /// 2. The (optional) site-wide `dpu_mode` default (new top-level
+    ///    setting on `CarbideConfig` that lets an operator flip an entire
+    ///    site to e.g. `NicMode` without per-host overrides).
+    /// 3. The deprecated site-wide `force_dpu_nic_mode` flag, kept as a
+    ///    final fallback. This isn't used by any of our deployments,
+    ///    and will be cleaned up in a subsequent PR.
     ///
     /// Notes!
     /// - An explicit per-host `NicMode` or `NoDpu` always wins.
-    /// - `DpuMode` (the default) or no `ExpectedMachine` at all means
-    ///   back back to the site flag, where `force_dpu_nic_mode=true` means
-    ///   `NicMode`, otherwise `DpuMode`.
-    ///
-    /// This keeps backwards compatibility with deployments that still rely
-    /// on the `force_dpu_nic_mode` site-level flag; once all hosts have explicit
-    /// modes configured (or we're happy with the `None` default), the flag can
-    /// be retired.
-    pub fn resolve(expected_mode: Option<DpuMode>, site_force_nic_mode: bool) -> DpuMode {
+    /// - Per-host `DpuMode` (the default variant) or no `ExpectedMachine`
+    ///   at all == defer to the site-level default.
+    /// - Site-level `NicMode` or `NoDpu` then wins over the legacy flag.
+    /// - Site-level `DpuMode` or missing == let `force_dpu_nic_mode` decide
+    ///   (`true` -> `NicMode`, `false` -> `DpuMode`).
+    pub fn resolve(
+        expected_mode: Option<DpuMode>,
+        site_default_mode: Option<DpuMode>,
+        site_force_nic_mode: bool,
+    ) -> DpuMode {
         match expected_mode {
             Some(DpuMode::NicMode) => DpuMode::NicMode,
             Some(DpuMode::NoDpu) => DpuMode::NoDpu,
-            // `DpuMode` (default) or missing == let the site flag decide.
-            _ if site_force_nic_mode => DpuMode::NicMode,
-            _ => DpuMode::DpuMode,
+            // `DpuMode` (default) or missing == defer to site-level default.
+            _ => match site_default_mode {
+                Some(DpuMode::NicMode) => DpuMode::NicMode,
+                Some(DpuMode::NoDpu) => DpuMode::NoDpu,
+                // Site-level `DpuMode` or missing == let the legacy flag decide.
+                _ if site_force_nic_mode => DpuMode::NicMode,
+                _ => DpuMode::DpuMode,
+            },
         }
     }
 }
@@ -248,58 +258,126 @@ pub struct UnexpectedMachine {
 mod tests {
     use super::*;
 
-    /// A completely-unset mode (client didn't set the field) should behave
-    /// the same as `DpuMode` (default) for resolution purposes: the site
-    /// flag decides.
+    /// A completely-unset mode (client didn't set the field) with no
+    /// site-level default should behave the same as `DpuMode` (default)
+    /// for resolution purposes: the legacy flag decides.
     #[test]
-    fn resolve_no_expected_mode_with_site_flag_off_returns_dpu_mode() {
-        assert_eq!(DpuMode::resolve(None, false), DpuMode::DpuMode);
+    fn resolve_no_expected_mode_no_site_default_with_flag_off_returns_dpu_mode() {
+        assert_eq!(DpuMode::resolve(None, None, false), DpuMode::DpuMode);
     }
 
     #[test]
-    fn resolve_no_expected_mode_with_site_flag_on_returns_nic_mode() {
-        assert_eq!(DpuMode::resolve(None, true), DpuMode::NicMode);
+    fn resolve_no_expected_mode_no_site_default_with_flag_on_returns_nic_mode() {
+        assert_eq!(DpuMode::resolve(None, None, true), DpuMode::NicMode);
     }
 
     /// Explicit per-host `DpuMode` is indistinguishable from "not set" in
-    /// the storage type (the default). So it also defers to the site flag
-    /// -- existing `force_dpu_nic_mode` deployments keep working.
+    /// the storage type (the default). So it also defers to the site
+    /// default / legacy flag -- existing `force_dpu_nic_mode` usage
+    /// is maintained, even though we're not using it in any of our
+    /// sites, and I don't think it even really does what we'd want
+    /// anyway.
     #[test]
-    fn resolve_explicit_dpu_mode_defers_to_site_flag() {
+    fn resolve_explicit_dpu_mode_defers_to_site_default_and_flag() {
         assert_eq!(
-            DpuMode::resolve(Some(DpuMode::DpuMode), false),
+            DpuMode::resolve(Some(DpuMode::DpuMode), None, false),
             DpuMode::DpuMode
         );
         assert_eq!(
-            DpuMode::resolve(Some(DpuMode::DpuMode), true),
+            DpuMode::resolve(Some(DpuMode::DpuMode), None, true),
             DpuMode::NicMode
         );
     }
 
-    /// An explicit per-host `NicMode` always wins, regardless of the site
-    /// flag. This is the "I want this specific host in NIC mode" override.
+    /// An explicit per-host `NicMode` always wins, regardless of the
+    /// site-level default or the legacy flag. This is the "I want this
+    /// specific host in NIC mode" override.
     #[test]
-    fn resolve_nic_mode_always_wins() {
-        assert_eq!(
-            DpuMode::resolve(Some(DpuMode::NicMode), false),
-            DpuMode::NicMode
-        );
-        assert_eq!(
-            DpuMode::resolve(Some(DpuMode::NicMode), true),
-            DpuMode::NicMode
-        );
+    fn resolve_per_host_nic_mode_always_wins() {
+        for site_default in [None, Some(DpuMode::DpuMode), Some(DpuMode::NoDpu)] {
+            for flag in [false, true] {
+                assert_eq!(
+                    DpuMode::resolve(Some(DpuMode::NicMode), site_default, flag),
+                    DpuMode::NicMode,
+                    "site_default={site_default:?} flag={flag}"
+                );
+            }
+        }
     }
 
     /// An explicit per-host `NoDpu` always wins. Useful for hosts where
     /// the operator knows there's genuinely no DPU hardware (as opposed
     /// to "DPU present but used as NIC", which is `NicMode`).
     #[test]
-    fn resolve_no_dpu_always_wins() {
+    fn resolve_per_host_no_dpu_always_wins() {
+        for site_default in [None, Some(DpuMode::DpuMode), Some(DpuMode::NicMode)] {
+            for flag in [false, true] {
+                assert_eq!(
+                    DpuMode::resolve(Some(DpuMode::NoDpu), site_default, flag),
+                    DpuMode::NoDpu,
+                    "site_default={site_default:?} flag={flag}"
+                );
+            }
+        }
+    }
+
+    /// Site-level `NicMode` becomes the new default for hosts that don't
+    /// declare a per-host mode -- this is the whole point of the new
+    /// site-level setting (flip an entire site without per-host edits).
+    #[test]
+    fn resolve_site_level_nic_mode_applies_when_per_host_is_unset() {
         assert_eq!(
-            DpuMode::resolve(Some(DpuMode::NoDpu), false),
+            DpuMode::resolve(None, Some(DpuMode::NicMode), false),
+            DpuMode::NicMode
+        );
+        assert_eq!(
+            DpuMode::resolve(Some(DpuMode::DpuMode), Some(DpuMode::NicMode), false),
+            DpuMode::NicMode
+        );
+    }
+
+    /// Same as above for `NoDpu`: site-level setting applies when the
+    /// per-host value is unset (or the default `DpuMode` placeholder).
+    #[test]
+    fn resolve_site_level_no_dpu_applies_when_per_host_is_unset() {
+        assert_eq!(
+            DpuMode::resolve(None, Some(DpuMode::NoDpu), false),
             DpuMode::NoDpu
         );
-        assert_eq!(DpuMode::resolve(Some(DpuMode::NoDpu), true), DpuMode::NoDpu);
+        assert_eq!(
+            DpuMode::resolve(Some(DpuMode::DpuMode), Some(DpuMode::NoDpu), false),
+            DpuMode::NoDpu
+        );
+    }
+
+    /// Site-level `NicMode` / `NoDpu` overrides the legacy
+    /// `force_dpu_nic_mode` flag -- explicit beats implicit.
+    #[test]
+    fn resolve_site_level_overrides_legacy_force_flag() {
+        assert_eq!(
+            DpuMode::resolve(None, Some(DpuMode::NoDpu), true),
+            DpuMode::NoDpu
+        );
+        // Site explicitly says NicMode; legacy flag agreeing is moot.
+        assert_eq!(
+            DpuMode::resolve(None, Some(DpuMode::NicMode), true),
+            DpuMode::NicMode
+        );
+    }
+
+    /// Site-level `DpuMode` is indistinguishable from "not set" -- both
+    /// defer to the legacy flag. Symmetric with the per-host `DpuMode`
+    /// behavior.
+    #[test]
+    fn resolve_site_level_dpu_mode_defers_to_legacy_flag() {
+        assert_eq!(
+            DpuMode::resolve(None, Some(DpuMode::DpuMode), false),
+            DpuMode::DpuMode
+        );
+        assert_eq!(
+            DpuMode::resolve(None, Some(DpuMode::DpuMode), true),
+            DpuMode::NicMode
+        );
     }
 
     /// `is_dpu_managed()` returns true only for the default `DpuMode`

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -2794,6 +2794,7 @@ mod tests {
     use figment::providers::{Env, Format, Toml};
     use libmlx::variables::value::MlxValueType;
     use libredfish::model::service_root::RedfishVendor;
+    use model::expected_machine::DpuMode;
     use model::network_segment::NetworkDefinitionSegmentType;
     use model::resource_pool;
 
@@ -3153,6 +3154,7 @@ mod tests {
                 switches_created_per_run: 9,
                 rotate_switch_nvos_credentials: Arc::new(false.into()),
                 force_dpu_nic_mode: Arc::new(false.into()),
+                dpu_mode: None,
                 explore_mode: SiteExplorerExploreMode::LibRedfish,
             }
         );
@@ -3327,6 +3329,7 @@ mod tests {
                 switches_created_per_run: 9,
                 rotate_switch_nvos_credentials: Arc::new(false.into()),
                 force_dpu_nic_mode: Arc::new(false.into()),
+                dpu_mode: None,
                 explore_mode: SiteExplorerExploreMode::LibRedfish,
             }
         );
@@ -3636,6 +3639,7 @@ mod tests {
                 switches_created_per_run: 9,
                 rotate_switch_nvos_credentials: Arc::new(false.into()),
                 force_dpu_nic_mode: Arc::new(false.into()),
+                dpu_mode: None,
                 explore_mode: SiteExplorerExploreMode::LibRedfish,
             }
         );
@@ -3783,6 +3787,38 @@ mod tests {
         let deserialized = serde_json::from_str::<SiteExplorerConfig>("{}")?;
         assert_eq!(deserialized, SiteExplorerConfig::default());
         Ok(())
+    }
+
+    /// Verifies the new `[site_explorer] dpu_mode = ...` setting
+    /// parses correctly for every named variant. When unset (the
+    /// default), `site_explorer.dpu_mode` is `None` and resolution
+    /// falls back to the legacy `force_dpu_nic_mode` flag.
+    #[test]
+    fn site_explorer_dpu_mode_parses_and_defaults_to_none() {
+        let config: CarbideConfig = Figment::new()
+            .merge(Toml::file(format!("{TEST_DATA_DIR}/min_config.toml")))
+            .extract()
+            .unwrap();
+        assert_eq!(config.site_explorer.dpu_mode, None);
+
+        for (toml_value, expected) in [
+            ("dpu_mode", DpuMode::DpuMode),
+            ("nic_mode", DpuMode::NicMode),
+            ("no_dpu", DpuMode::NoDpu),
+        ] {
+            let config: CarbideConfig = Figment::new()
+                .merge(Toml::file(format!("{TEST_DATA_DIR}/min_config.toml")))
+                .merge(Toml::string(&format!(
+                    "[site_explorer]\ndpu_mode = \"{toml_value}\"\n"
+                )))
+                .extract()
+                .unwrap();
+            assert_eq!(
+                config.site_explorer.dpu_mode,
+                Some(expected),
+                "[site_explorer] dpu_mode = {toml_value:?} should parse to {expected:?}",
+            );
+        }
     }
 
     #[test]

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1889,6 +1889,7 @@ pub async fn create_test_env_with_overrides(
             switches_created_per_run: 1,
             rotate_switch_nvos_credentials: Arc::new(false.into()),
             force_dpu_nic_mode: Arc::new(false.into()),
+            dpu_mode: None,
             // Tests use MockEndpointExplorer. So this doesn't affect anything.
             explore_mode: SiteExplorerExploreMode::NvRedfish,
         },

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -1035,6 +1035,7 @@ async fn test_site_explorer_audit_exploration_results(
         switches_created_per_run: 1,
         rotate_switch_nvos_credentials: Arc::new(false.into()),
         force_dpu_nic_mode: Arc::new(false.into()),
+        dpu_mode: None,
         // Tests use MockEndpointExplorer. So this doesn't affect anything.
         explore_mode: SiteExplorerExploreMode::NvRedfish,
     };

--- a/crates/site-explorer/src/config.rs
+++ b/crates/site-explorer/src/config.rs
@@ -26,6 +26,7 @@ use carbide_utils::config::{
 };
 use chrono::Duration;
 use duration_str::{deserialize_duration, deserialize_duration_chrono};
+use model::expected_machine::DpuMode;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// SiteExplorer related configuration for hardware discovery and ingestion.
@@ -185,6 +186,18 @@ pub struct SiteExplorerConfig {
         serialize_with = "serialize_arc_atomic_bool"
     )]
     pub force_dpu_nic_mode: Arc<AtomicBool>,
+    /// Site-wide default DPU operating mode. When set, applies to every
+    /// host that doesn't declare a per-host `ExpectedMachine.dpu_mode`
+    /// override (or that declares the default `DpuMode` variant, which is
+    /// indistinguishable from "unset"). Per-host `NicMode` / `NoDpu`
+    /// always overrides this. `None` means "no site default declared" and
+    /// resolution falls back to the legacy `force_dpu_nic_mode` flag.
+    ///
+    /// This setting is mirrored from the top-level `CarbideConfig.dpu_mode`
+    /// during config parsing so operators can set it once at the site
+    /// level without nesting under `[site_explorer]`.
+    #[serde(default)]
+    pub dpu_mode: Option<DpuMode>,
     /// Controls which Redfish client implementation is used
     /// for hardware discovery (LibRedfish, NvRedfish, or
     /// CompareResult for side-by-side validation).
@@ -216,6 +229,7 @@ impl Default for SiteExplorerConfig {
             switches_created_per_run: Self::default_switches_created_per_run(),
             rotate_switch_nvos_credentials: Self::default_rotate_switch_nvos_credentials(),
             force_dpu_nic_mode: Arc::new(false.into()),
+            dpu_mode: None,
             explore_mode: Self::default_explore_mode(),
         }
     }

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -980,16 +980,18 @@ impl SiteExplorer {
         explored_dpus: HashMap<IpAddr, ExploredEndpoint>,
         explored_hosts: HashMap<IpAddr, ExploredEndpoint>,
     ) -> SiteExplorerResult<Vec<(ExploredManagedHost, EndpointExplorationReport)>> {
-        // Per-host DPU-mode resolution. The old/deprecated/fallback site-wide
-        // `force_dpu_nic_mode` flag is preserved as a fallback when no
-        // per-host override is declared; a per-host `NicMode` or `NoDpu`
-        // always wins.
+        // Per-host DPU-mode resolution. Precedence:
+        //   1. Per-host `ExpectedMachine.dpu_mode` (NicMode / NoDpu wins).
+        //   2. Site-level default `SiteExplorerConfig.dpu_mode`.
+        //   3. Legacy site-wide `force_dpu_nic_mode` flag (deprecated,
+        //      preserved as a fallback for not too much longer).
+        let site_default_mode = self.config.dpu_mode;
         let site_force_nic_mode = self.config.force_dpu_nic_mode.load(Ordering::Relaxed);
         let effective_mode = |host_bmc_ip: &IpAddr| -> DpuMode {
             let declared = expected_explored_endpoint_index
                 .matched_expected_machine(host_bmc_ip)
                 .map(|em| em.data.dpu_mode);
-            DpuMode::resolve(declared, site_force_nic_mode)
+            DpuMode::resolve(declared, site_default_mode, site_force_nic_mode)
         };
         // Match HOST and DPU using SerialNumber.
         // Compare DPU system.serial_number with HOST chassis.network_adapters[].serial_number


### PR DESCRIPTION
## Description

Closes https://github.com/NVIDIA/infra-controller/issues/1866.

Today, flipping a host out of "DPU mode" means setting `dpu_mode = "nic_mode"` (or `"no_dpu"`) on every single `ExpectedMachine` row. For large sites that's a lot of busy work (even if it's automated) when the intent is really just "this whole site is running DPUs as plain NICs" (or "this whole site has no DPUs at all").

This introduces a `dpu_mode` setting on the site TOML (in the `[site_explorer]` section), that becomes the new base default for the whole site -- an operator drops a single line at the top of the site config and it applies everywhere, no more per-machine touch-ups. Per-machine `ExpectedMachine.dpu_mode` settings still win when set, so individual hosts can still be exceptions to the site-wide default.

A few highlights:
- New `dpu_mode` field in the site config. Defaults to unset (equivalent to `DpuMode::DpuMode`), so default is a no-op.
- Per-machine `dpu_mode` always wins over the site-level value.
- The deprecated `force_dpu_nic_mode` flag is preserved as a final fallback; I'm going to clean it up in a separate PR, since there's some more cleanup work in there beyond this.

I'll be doing `force_dpu_nic_mode` and `allow_zero_dpu_hosts` cleanups in separate PRs. I think we can get rid of both (well, `force_dpu_nic_mode` at the very least).

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [x] This PR contains breaking changes

If anyone was using `force_dpu_nic_mode` for some reason (we weren't in any managed envs, and if someone actually was, it wouldn't have worked really well anyway), then this flag will stop working. Migration is to set `dpu_mode: nic_mode` instead.

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

