### PR TITLE
refactor(api): drop force_dpu_nic_mode in favor of dpu_mode

### DIFF
--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -140,7 +140,7 @@ pub struct Args {
         long = "dpu-mode",
         value_name = "DPU_MODE",
         value_enum,
-        help = "Per-host DPU operating mode. `dpu-mode` (default): DPUs are managed by NICo; `nic-mode`: DPU hardware present but treated as a plain NIC; `no-dpu`: no DPU hardware at all. Unset keeps the site default (site-wide `force_dpu_nic_mode` flag still applies when no per-host value is set)."
+        help = "Per-host DPU operating mode. `dpu-mode` (default): DPUs are managed by NICo; `nic-mode`: DPU hardware present but treated as a plain NIC; `no-dpu`: no DPU hardware at all. Unset defers to the site-wide `[site_explorer] dpu_mode` setting (which itself falls back to `dpu-mode` when not set)."
     )]
     pub dpu_mode: Option<DpuMode>,
 

--- a/crates/admin-cli/src/expected_machines/common.rs
+++ b/crates/admin-cli/src/expected_machines/common.rs
@@ -45,8 +45,9 @@ pub struct ExpectedMachineJson {
     pub bmc_ip_address: Option<String>,
     #[serde(default)]
     pub bmc_retain_credentials: Option<bool>,
-    /// Per-host DPU operating mode. None == site default (which
-    /// means to use the site-level `force_dpu_nic_mode` flag).
+    /// Per-host DPU operating mode. None == defer to the site-wide
+    /// `[site_explorer] dpu_mode` setting (falls back to `DpuMode::DpuMode`
+    /// if that's also unset).
     #[serde(default)]
     pub dpu_mode: Option<rpc::forge::DpuMode>,
     /// Per-host lifecycle profile for settings that affect state-machine progression.

--- a/crates/admin-cli/src/expected_machines/tests.rs
+++ b/crates/admin-cli/src/expected_machines/tests.rs
@@ -493,8 +493,9 @@ fn validate_patch_all_fields() {
 }
 
 // parse_add_without_dpu_mode ensures the flag is optional and defaults to
-// unset; downstream, unset is treated as "use site default" (as in, use
-// the site-wide `force_dpu_nic_mode` flag).
+// unset; downstream, unset is treated as "defer to the site-wide
+// `[site_explorer] dpu_mode` setting" (which itself falls back to
+// `DpuMode::DpuMode` when not set).
 #[test]
 fn parse_add_without_dpu_mode() {
     let cmd = Cmd::try_parse_from([

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -28,10 +28,9 @@ use uuid::Uuid;
 use crate::metadata::Metadata;
 
 /// Per-host DPU operating mode declared by a site operator on an
-/// `ExpectedMachine`. This replaces the site-wide `force_dpu_nic_mode`
-/// config flag; the flag is still honored as a fallback when
-/// `DpuMode::default()` is in effect (i.e. the operator didn't set a
-/// per-host value). `force_dpu_nic_mode` will eventually go away.
+/// `ExpectedMachine`. Per-host values win over the site-wide
+/// `[site_explorer] dpu_mode` setting; if neither is set the host
+/// falls back to `DpuMode::DpuMode`.
 ///
 /// Backed by the Postgres enum `dpu_mode_t`.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, sqlx::Type, Serialize, Deserialize)]
@@ -58,36 +57,25 @@ impl DpuMode {
         matches!(self, DpuMode::DpuMode)
     }
 
-    /// Resolve a host's effective DPU mode from three inputs, in precedence:
-    /// 1. The (optional) per-host `ExpectedMachine.dpu_mode` value.
-    /// 2. The (optional) site-wide `dpu_mode` default (new top-level
-    ///    setting on `CarbideConfig` that lets an operator flip an entire
-    ///    site to e.g. `NicMode` without per-host overrides).
-    /// 3. The deprecated site-wide `force_dpu_nic_mode` flag, kept as a
-    ///    final fallback. This isn't used by any of our deployments,
-    ///    and will be cleaned up in a subsequent PR.
+    /// Resolve a host's effective DPU mode from the (optional) per-host
+    /// `ExpectedMachine.dpu_mode` value and the (optional) site-wide
+    /// `[site_explorer] dpu_mode` setting. Notes:
     ///
-    /// Notes!
     /// - An explicit per-host `NicMode` or `NoDpu` always wins.
     /// - Per-host `DpuMode` (the default variant) or no `ExpectedMachine`
-    ///   at all == defer to the site-level default.
-    /// - Site-level `NicMode` or `NoDpu` then wins over the legacy flag.
-    /// - Site-level `DpuMode` or missing == let `force_dpu_nic_mode` decide
-    ///   (`true` -> `NicMode`, `false` -> `DpuMode`).
-    pub fn resolve(
-        expected_mode: Option<DpuMode>,
-        site_default_mode: Option<DpuMode>,
-        site_force_nic_mode: bool,
-    ) -> DpuMode {
+    ///   at all == defer to the site-wide setting.
+    /// - Site-wide `NicMode` or `NoDpu` then wins.
+    /// - Site-wide `DpuMode` or missing == fall back to the absolute
+    ///   default of `DpuMode::DpuMode`.
+    pub fn resolve(expected_mode: Option<DpuMode>, site_dpu_mode: Option<DpuMode>) -> DpuMode {
         match expected_mode {
             Some(DpuMode::NicMode) => DpuMode::NicMode,
             Some(DpuMode::NoDpu) => DpuMode::NoDpu,
-            // `DpuMode` (default) or missing == defer to site-level default.
-            _ => match site_default_mode {
+            // `DpuMode` (default) or missing == defer to site-wide setting.
+            _ => match site_dpu_mode {
                 Some(DpuMode::NicMode) => DpuMode::NicMode,
                 Some(DpuMode::NoDpu) => DpuMode::NoDpu,
-                // Site-level `DpuMode` or missing == let the legacy flag decide.
-                _ if site_force_nic_mode => DpuMode::NicMode,
+                // Site-wide `DpuMode` or missing == absolute default.
                 _ => DpuMode::DpuMode,
             },
         }
@@ -258,50 +246,39 @@ pub struct UnexpectedMachine {
 mod tests {
     use super::*;
 
-    /// A completely-unset mode (client didn't set the field) with no
-    /// site-level default should behave the same as `DpuMode` (default)
-    /// for resolution purposes: the legacy flag decides.
+    /// Nothing set anywhere -- the host falls back to the absolute
+    /// default, `DpuMode::DpuMode`.
     #[test]
-    fn resolve_no_expected_mode_no_site_default_with_flag_off_returns_dpu_mode() {
-        assert_eq!(DpuMode::resolve(None, None, false), DpuMode::DpuMode);
+    fn resolve_no_expected_mode_no_site_setting_returns_dpu_mode() {
+        assert_eq!(DpuMode::resolve(None, None), DpuMode::DpuMode);
     }
 
+    /// Explicit per-host `DpuMode` is indistinguishable from "not set"
+    /// in the storage type (the default variant), so it also defers to
+    /// the site-wide setting.
     #[test]
-    fn resolve_no_expected_mode_no_site_default_with_flag_on_returns_nic_mode() {
-        assert_eq!(DpuMode::resolve(None, None, true), DpuMode::NicMode);
-    }
-
-    /// Explicit per-host `DpuMode` is indistinguishable from "not set" in
-    /// the storage type (the default). So it also defers to the site
-    /// default / legacy flag -- existing `force_dpu_nic_mode` usage
-    /// is maintained, even though we're not using it in any of our
-    /// sites, and I don't think it even really does what we'd want
-    /// anyway.
-    #[test]
-    fn resolve_explicit_dpu_mode_defers_to_site_default_and_flag() {
+    fn resolve_explicit_per_host_dpu_mode_defers_to_site_setting() {
         assert_eq!(
-            DpuMode::resolve(Some(DpuMode::DpuMode), None, false),
+            DpuMode::resolve(Some(DpuMode::DpuMode), None),
             DpuMode::DpuMode
         );
         assert_eq!(
-            DpuMode::resolve(Some(DpuMode::DpuMode), None, true),
+            DpuMode::resolve(Some(DpuMode::DpuMode), Some(DpuMode::NicMode)),
             DpuMode::NicMode
         );
     }
 
     /// An explicit per-host `NicMode` always wins, regardless of the
-    /// site-level default or the legacy flag. This is the "I want this
-    /// specific host in NIC mode" override.
+    /// site-wide setting. This is the "I want this specific host in
+    /// NIC mode" override.
     #[test]
     fn resolve_per_host_nic_mode_always_wins() {
-        for site_default in [None, Some(DpuMode::DpuMode), Some(DpuMode::NoDpu)] {
-            for flag in [false, true] {
-                assert_eq!(
-                    DpuMode::resolve(Some(DpuMode::NicMode), site_default, flag),
-                    DpuMode::NicMode,
-                    "site_default={site_default:?} flag={flag}"
-                );
-            }
+        for site_dpu_mode in [None, Some(DpuMode::DpuMode), Some(DpuMode::NoDpu)] {
+            assert_eq!(
+                DpuMode::resolve(Some(DpuMode::NicMode), site_dpu_mode),
+                DpuMode::NicMode,
+                "site_dpu_mode={site_dpu_mode:?}"
+            );
         }
     }
 
@@ -310,73 +287,49 @@ mod tests {
     /// to "DPU present but used as NIC", which is `NicMode`).
     #[test]
     fn resolve_per_host_no_dpu_always_wins() {
-        for site_default in [None, Some(DpuMode::DpuMode), Some(DpuMode::NicMode)] {
-            for flag in [false, true] {
-                assert_eq!(
-                    DpuMode::resolve(Some(DpuMode::NoDpu), site_default, flag),
-                    DpuMode::NoDpu,
-                    "site_default={site_default:?} flag={flag}"
-                );
-            }
+        for site_dpu_mode in [None, Some(DpuMode::DpuMode), Some(DpuMode::NicMode)] {
+            assert_eq!(
+                DpuMode::resolve(Some(DpuMode::NoDpu), site_dpu_mode),
+                DpuMode::NoDpu,
+                "site_dpu_mode={site_dpu_mode:?}"
+            );
         }
     }
 
-    /// Site-level `NicMode` becomes the new default for hosts that don't
-    /// declare a per-host mode -- this is the whole point of the new
-    /// site-level setting (flip an entire site without per-host edits).
+    /// Site-wide `NicMode` applies to hosts that don't declare a
+    /// per-host mode -- this is the whole point of the site-wide
+    /// setting (flip an entire site without per-host edits).
     #[test]
-    fn resolve_site_level_nic_mode_applies_when_per_host_is_unset() {
+    fn resolve_site_wide_nic_mode_applies_when_per_host_is_unset() {
         assert_eq!(
-            DpuMode::resolve(None, Some(DpuMode::NicMode), false),
+            DpuMode::resolve(None, Some(DpuMode::NicMode)),
             DpuMode::NicMode
         );
         assert_eq!(
-            DpuMode::resolve(Some(DpuMode::DpuMode), Some(DpuMode::NicMode), false),
+            DpuMode::resolve(Some(DpuMode::DpuMode), Some(DpuMode::NicMode)),
             DpuMode::NicMode
         );
     }
 
-    /// Same as above for `NoDpu`: site-level setting applies when the
+    /// Same as above for `NoDpu`: site-wide setting applies when the
     /// per-host value is unset (or the default `DpuMode` placeholder).
     #[test]
-    fn resolve_site_level_no_dpu_applies_when_per_host_is_unset() {
+    fn resolve_site_wide_no_dpu_applies_when_per_host_is_unset() {
+        assert_eq!(DpuMode::resolve(None, Some(DpuMode::NoDpu)), DpuMode::NoDpu);
         assert_eq!(
-            DpuMode::resolve(None, Some(DpuMode::NoDpu), false),
-            DpuMode::NoDpu
-        );
-        assert_eq!(
-            DpuMode::resolve(Some(DpuMode::DpuMode), Some(DpuMode::NoDpu), false),
+            DpuMode::resolve(Some(DpuMode::DpuMode), Some(DpuMode::NoDpu)),
             DpuMode::NoDpu
         );
     }
 
-    /// Site-level `NicMode` / `NoDpu` overrides the legacy
-    /// `force_dpu_nic_mode` flag -- explicit beats implicit.
+    /// Site-wide `DpuMode` is indistinguishable from "not set" -- both
+    /// fall back to the absolute `DpuMode` default. Symmetric with the
+    /// per-host `DpuMode` behavior.
     #[test]
-    fn resolve_site_level_overrides_legacy_force_flag() {
+    fn resolve_site_wide_dpu_mode_resolves_to_dpu_mode() {
         assert_eq!(
-            DpuMode::resolve(None, Some(DpuMode::NoDpu), true),
-            DpuMode::NoDpu
-        );
-        // Site explicitly says NicMode; legacy flag agreeing is moot.
-        assert_eq!(
-            DpuMode::resolve(None, Some(DpuMode::NicMode), true),
-            DpuMode::NicMode
-        );
-    }
-
-    /// Site-level `DpuMode` is indistinguishable from "not set" -- both
-    /// defer to the legacy flag. Symmetric with the per-host `DpuMode`
-    /// behavior.
-    #[test]
-    fn resolve_site_level_dpu_mode_defers_to_legacy_flag() {
-        assert_eq!(
-            DpuMode::resolve(None, Some(DpuMode::DpuMode), false),
+            DpuMode::resolve(None, Some(DpuMode::DpuMode)),
             DpuMode::DpuMode
-        );
-        assert_eq!(
-            DpuMode::resolve(None, Some(DpuMode::DpuMode), true),
-            DpuMode::NicMode
         );
     }
 

--- a/crates/api/src/cfg/README.md
+++ b/crates/api/src/cfg/README.md
@@ -81,7 +81,6 @@ applicable.
 | `vmaas_config` | `Option<VmaasConfig>` | — | VMaaS configuration for VM system integration (see [VmaasConfig](#vmaasconfig)). |
 | `mlxconfig_profiles` | `Option<HashMap<String, MlxConfigProfile>>` | — | Named Mellanox NIC register configuration profiles for superNIC firmware flashing. TOML key: `mlx-config-profiles`. |
 | `rack_management_enabled` | `bool` | `false` | Standalone infrastructure manager mode for GB200/GB300/VR144. See doc comment for full behavioral changes. |
-| `force_dpu_nic_mode` | `bool` | `false` | Treat DPUs as regular NICs (skip managed DPU config). For dev labs with BF DPUs. |
 | `rms` | `RmsConfig` | *(see below)* | Rack Manager Service configuration for API connectivity and mTLS (see [RmsConfig](#rmsconfig)). |
 | `rack_profiles` | `RackProfileConfig` | *(default)* | Rack profile definitions referenced by expected racks. |
 | `spdm` | `SpdmConfig` | *(see below)* | SPDM hardware attestation (see [SpdmConfig](#spdmconfig)). |

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -19,8 +19,6 @@ use std::collections::HashMap;
 use std::fmt;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
-use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 
 use bmc_vendor::BMCVendor;
 use carbide_authn::config::{AllowedCertCriteria, TrustConfig};
@@ -29,9 +27,7 @@ use carbide_ib_fabric::config::{IBFabricConfig, IbFabricDefinition};
 use carbide_nvlink_manager::config::NvLinkConfig;
 use carbide_preingestion_manager::PreingestionManagerConfig;
 use carbide_site_explorer::config::SiteExplorerConfig;
-use carbide_utils::config::{
-    as_duration, as_std_duration, deserialize_arc_atomic_bool, serialize_arc_atomic_bool,
-};
+use carbide_utils::config::{as_duration, as_std_duration};
 use chrono::Duration;
 use duration_str::{deserialize_duration, deserialize_duration_chrono};
 use figment::Figment;
@@ -476,7 +472,7 @@ pub struct CarbideConfig {
     /// (disconnected / air-gapped) infrastructure manager for racks of GB200/GB300/VR144.
     /// Only set this if using NICo site controller with Rack Manager to manage GB200/300/VR144.
     /// It will change site controller behavior significantly in the following ways, etc.:
-    /// 1. skip dpu management and use dpus in nic mode (optional, can set force_dpu_nic_mode=false)
+    /// 1. skip dpu management and use dpus in nic mode (set the site-wide `[site_explorer] dpu_mode = "nic_mode"`, or per-host `ExpectedMachine.dpu_mode`)
     ///    a. no dpu bfb upgrade and host power cycle
     ///    b. no firmware upgrade and host power cycle
     ///    c. no hbn deployment (no ecmp, etc)
@@ -518,16 +514,6 @@ pub struct CarbideConfig {
     /// the ingestion call.
     #[serde(default)]
     pub rack_profiles: model::rack_type::RackProfileConfig,
-
-    /// Treat any dpu found as a regular NIC and skip configuring it as a managed dpu.
-    /// This is specifically for dev labs to allow using GB200/300 and VR compute
-    /// trays with bluefield dpus as NICs.
-    #[serde(
-        default = "SiteExplorerConfig::default_force_dpu_nic_mode",
-        deserialize_with = "deserialize_arc_atomic_bool",
-        serialize_with = "serialize_arc_atomic_bool"
-    )]
-    pub force_dpu_nic_mode: Arc<AtomicBool>,
 
     /// SPDM (Security Protocol and Data Model) configuration for hardware attestation.
     #[serde(default)]
@@ -2785,6 +2771,7 @@ pub fn default_host_intercept_bridge_port() -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use std::sync::atomic::Ordering as AtomicOrdering;
 
     use carbide_authn::config::CertComponent;
@@ -3153,7 +3140,6 @@ mod tests {
                 create_switches: Arc::new(true.into()),
                 switches_created_per_run: 9,
                 rotate_switch_nvos_credentials: Arc::new(false.into()),
-                force_dpu_nic_mode: Arc::new(false.into()),
                 dpu_mode: None,
                 explore_mode: SiteExplorerExploreMode::LibRedfish,
             }
@@ -3328,7 +3314,6 @@ mod tests {
                 create_switches: Arc::new(true.into()),
                 switches_created_per_run: 9,
                 rotate_switch_nvos_credentials: Arc::new(false.into()),
-                force_dpu_nic_mode: Arc::new(false.into()),
                 dpu_mode: None,
                 explore_mode: SiteExplorerExploreMode::LibRedfish,
             }
@@ -3638,7 +3623,6 @@ mod tests {
                 create_switches: Arc::new(true.into()),
                 switches_created_per_run: 9,
                 rotate_switch_nvos_credentials: Arc::new(false.into()),
-                force_dpu_nic_mode: Arc::new(false.into()),
                 dpu_mode: None,
                 explore_mode: SiteExplorerExploreMode::LibRedfish,
             }
@@ -3789,10 +3773,10 @@ mod tests {
         Ok(())
     }
 
-    /// Verifies the new `[site_explorer] dpu_mode = ...` setting
-    /// parses correctly for every named variant. When unset (the
-    /// default), `site_explorer.dpu_mode` is `None` and resolution
-    /// falls back to the legacy `force_dpu_nic_mode` flag.
+    /// Verifies the `[site_explorer] dpu_mode = ...` setting parses
+    /// correctly for every named variant. When unset (the default),
+    /// `site_explorer.dpu_mode` is `None` and hosts resolve to
+    /// `DpuMode::DpuMode`.
     #[test]
     fn site_explorer_dpu_mode_parses_and_defaults_to_none() {
         let config: CarbideConfig = Figment::new()
@@ -3819,6 +3803,24 @@ mod tests {
                 "[site_explorer] dpu_mode = {toml_value:?} should parse to {expected:?}",
             );
         }
+    }
+
+    /// Real-world site TOMLs may still carry the now-removed
+    /// `force_dpu_nic_mode` setting (top-level and/or under
+    /// `[site_explorer]`). serde silently ignores unknown keys, so
+    /// those files should keep parsing cleanly after the rip-out --
+    /// this is the regression guard for that.
+    #[test]
+    fn legacy_force_dpu_nic_mode_in_toml_still_parses() {
+        let _config: CarbideConfig = Figment::new()
+            .merge(Toml::file(format!("{TEST_DATA_DIR}/min_config.toml")))
+            .merge(Toml::string(
+                "force_dpu_nic_mode = false\n\
+                 [site_explorer]\n\
+                 force_dpu_nic_mode = true\n",
+            ))
+            .extract()
+            .expect("legacy force_dpu_nic_mode in TOML must still parse");
     }
 
     #[test]

--- a/crates/api/src/cfg/test_data/full_config.toml
+++ b/crates/api/src/cfg/test_data/full_config.toml
@@ -81,7 +81,6 @@ machines_created_per_run = 2
 override_target_ip = "1.2.3.4"
 override_target_port = 10443
 reset_rate_limit = "2h"
-force_dpu_nic_mode = false
 
 # Unit is mandatory
 [machine_state_controller]

--- a/crates/api/src/cfg/test_data/full_config_post_migration.toml
+++ b/crates/api/src/cfg/test_data/full_config_post_migration.toml
@@ -48,7 +48,6 @@ machines_created_per_run = 2
 override_target_ip = "1.2.3.4"
 override_target_port = 10443
 reset_rate_limit = "2h"
-force_dpu_nic_mode = false
 
 # Unit is mandatory
 [machine_state_controller]

--- a/crates/api/src/cfg/test_data/site_config.toml
+++ b/crates/api/src/cfg/test_data/site_config.toml
@@ -33,7 +33,6 @@ enabled = false
 concurrent_explorations = 10
 explorations_per_run = 12
 create_machines = false
-force_dpu_nic_mode = false
 
 # Unit is mandatory
 [machine_state_controller]

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -21,7 +21,6 @@ use std::collections::{HashMap, HashSet};
 use std::mem::discriminant as enum_discr;
 use std::net::IpAddr;
 use std::str::FromStr;
-use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
 use attestation::{
@@ -731,32 +730,17 @@ impl MachineStateHandler {
                         },
                     ))
                 } else {
+                    // There used to be a `force_dpu_nic_mode` related return
+                    // here that skipped DPU discovery entirely for operator-flagged
+                    // NIC-mode hosts (site or individual), but we dropped it,
+                    // becuse site-explorer doesn't have DPU IDs associated with
+                    // the host in the first place; `associated_dpu_machine_ids`
+                    // is empty, and the outer branch above already transitions
+                    // to HostInit before we ever reach this. What's nice is, this
+                    // also allows NicMode hosts to get actively reconfigured to
+                    // NIC mode via `set_nic_mode` during site-explorer ingestion,
+                    // which is something we do, but `force_dpu_nic_mode` never did.
                     let mut state_handler_outcome = StateHandlerOutcome::do_nothing();
-                    if ctx
-                        .services
-                        .site_config
-                        .force_dpu_nic_mode
-                        .load(Ordering::Relaxed)
-                    {
-                        // skip dpu discovery and init entirely, treat it as a nic
-                        return Ok(StateHandlerOutcome::transition(
-                            ManagedHostState::HostInit {
-                                machine_state: MachineState::WaitingForPlatformConfiguration {
-                                    retry_count: 0,
-                                },
-                            },
-                        ));
-                        /*
-                        // todo: check for machine type before skipping? not sure site explorer is setting this
-                        if let Some(hwinfo) = mh_snapshot.host_snapshot.hardware_info.clone() {
-                            if let Some(dmi_data) = hwinfo.dmi_data {
-                                if dmi_data.product_name.contains("GB200 NVL") {
-
-                                }
-                            }
-                        }
-                         */
-                    }
                     for dpu_snapshot in &mh_snapshot.dpu_snapshots {
                         state_handler_outcome = self
                             .dpu_handler
@@ -5164,14 +5148,13 @@ impl StateHandler for HostMachineStateHandler {
                             ))
                         }
                         LockdownState::TimeWaitForDPUDown => {
-                            if ctx
-                                .services
-                                .site_config
-                                .force_dpu_nic_mode
-                                .load(Ordering::Relaxed)
-                            {
-                                // skip wait for dpu reboot TimeWaitForDPUDown, WaitForDPUUp
-                                // GB200/300, etc with dpu disconnected or in nic mode
+                            if mh_snapshot.is_zero_dpu() {
+                                // No DPU to wait for going down/up -- skip
+                                // straight to BomValidating. Covers
+                                // NicMode/NoDpu hosts and anything else
+                                // with no DPU snapshots; otherwise we'd
+                                // wait `dpu_wait_time` for a DPU that's
+                                // never going to come up.
                                 let next_state = ManagedHostState::BomValidating {
                                     bom_validating_state: BomValidating::MatchingSku(
                                         BomValidatingContext {
@@ -10432,21 +10415,18 @@ async fn set_host_boot_order(
 ) -> Result<SetBootOrderOutcome, StateHandlerError> {
     match set_boot_order_info.set_boot_order_state {
         SetBootOrderState::SetBootOrder => {
-            if mh_snapshot.dpu_snapshots.is_empty() {
-                // MachineState::SetBootOrder is a NO-OP for the Zero-DPU case
-                if ctx
-                    .services
-                    .site_config
-                    .force_dpu_nic_mode
-                    .load(Ordering::Relaxed)
-                {
-                    redfish_client
-                        .boot_first(Boot::UefiHttp)
-                        .await
-                        .map_err(|e| redfish_error("boot_first", e))?;
-                    return Ok(SetBootOrderOutcome::Done);
-                }
-            }
+            // There used to be a `force_dpu_nic_mode`-gated short-circuit
+            // here that, for zero-DPU hosts when the flag was set, called
+            // `boot_first(Boot::UefiHttp)` and returned `Done` to skip
+            // the rest of the SetBootOrder flow. Dropped along with the
+            // flag. We don't extend the `boot_first(UefiHttp)` call to
+            // all zero-DPU hosts because libredfish doesn't implement
+            // `boot_first` for every vendor yet (Dell currently returns
+            // `NotSupported`); zero-DPU hosts fall through to the
+            // `set_boot_order_dpu_first` path below, which downgrades
+            // the resulting `NoDpu` error via `allow_zero_dpu_hosts`
+            // and still hits `CheckBootOrder` for verification.
+            //
             // Resolve the boot NIC MAC the same way `CheckHostConfig` does,
             // supporting hosts with DPU(s) and zero DPUs alike.
             let boot_interface_mac = mh_snapshot.boot_interface_mac().ok_or_else(|| {

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1328,7 +1328,6 @@ pub fn get_config() -> CarbideConfig {
             ..Default::default()
         },
         dsx_exchange_event_bus: None,
-        force_dpu_nic_mode: Arc::new(false.into()),
         dpf: crate::cfg::file::DpfConfig::default(),
         x86_pxe_boot_url_override: None,
         arm_pxe_boot_url_override: None,
@@ -1888,7 +1887,6 @@ pub async fn create_test_env_with_overrides(
             create_switches: Arc::new(true.into()),
             switches_created_per_run: 1,
             rotate_switch_nvos_credentials: Arc::new(false.into()),
-            force_dpu_nic_mode: Arc::new(false.into()),
             dpu_mode: None,
             // Tests use MockEndpointExplorer. So this doesn't affect anything.
             explore_mode: SiteExplorerExploreMode::NvRedfish,

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -823,7 +823,7 @@ impl<'a> MockExploredHost<'a> {
                                         mode: LockdownMode::Enable,
                                     },
                                 },
-                            }
+                            } | ManagedHostState::BomValidating { .. }
                         )
                 },
             )
@@ -833,13 +833,19 @@ impl<'a> MockExploredHost<'a> {
             return self;
         }
 
-        // We use forge_dpu_agent's health reporting as a signal that
-        // DPU has rebooted.
-        super::network_configured(
-            self.test_env,
-            &self.dpu_machine_ids.values().copied().collect(),
-        )
-        .await;
+        // Zero-DPU hosts skip the WaitForDPUUp lockdown state and land
+        // directly in BomValidating (see `is_zero_dpu` short-circuit in
+        // `LockdownState::TimeWaitForDPUDown`). There are no DPUs to
+        // signal as configured, so skip the network_configured handshake.
+        if !self.dpu_machine_ids.is_empty() {
+            // We use carbide-dpu-agent health reporting as a signal that
+            // DPU has rebooted.
+            super::network_configured(
+                self.test_env,
+                &self.dpu_machine_ids.values().copied().collect(),
+            )
+            .await;
+        }
 
         if self.test_env.config.bom_validation.enabled
             && !self

--- a/crates/api/src/tests/machine_creator.rs
+++ b/crates/api/src/tests/machine_creator.rs
@@ -85,7 +85,6 @@ async fn test_site_explorer_reject_zero_dpu_hosts(
         power_shelves_created_per_run: 1,
         create_switches: Arc::new(true.into()),
         switches_created_per_run: 1,
-        force_dpu_nic_mode: Arc::new(false.into()),
         allow_zero_dpu_hosts: false,
         ..Default::default()
     };

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -1034,7 +1034,6 @@ async fn test_site_explorer_audit_exploration_results(
         create_switches: Arc::new(true.into()),
         switches_created_per_run: 1,
         rotate_switch_nvos_credentials: Arc::new(false.into()),
-        force_dpu_nic_mode: Arc::new(false.into()),
         dpu_mode: None,
         // Tests use MockEndpointExplorer. So this doesn't affect anything.
         explore_mode: SiteExplorerExploreMode::NvRedfish,

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -394,7 +394,7 @@ impl Redfish for RedfishSimClient {
         &'a self,
         _target: libredfish::Boot,
     ) -> libredfish::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { todo!() })
+        Box::pin(async move { Ok(()) })
     }
 
     fn set_boot_override<'a>(

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -5550,18 +5550,19 @@ message ExpectedHostNic {
   optional bool primary = 6;
 }
 
-// Per-host DPU operating mode. Ultimately replaces the site-wide
-// `force_dpu_nic_mode` config flag, so site operators can mix DPU-mode,
+// Per-host DPU operating mode. Lets site operators mix DPU-mode,
 // NIC-mode, and no-DPU hosts within a single site.
 //
 // - DPU_MODE: The default. Attached DPUs are managed by NICo (DPU upgrades,
 //   overlay networking, etc).
 // - NIC_MODE: DPUs are present physically but operate as plain NICs. Site
-//   explorer skips DPU ingest; the host is tracked as if it had no DPUs.
+//   explorer reconfigures them to NIC mode if needed; the host is then
+//   tracked as if it had no DPUs.
 // - NO_DPU: no DPU hardware at all -- a plain host NIC on the underlay.
 //
-// Unset and `DPU_MODE_UNSPECIFIED` both mean "use the site default," which
-// is DPU_MODE unless the site-wide `force_dpu_nic_mode` config flag is on.
+// Unset and `DPU_MODE_UNSPECIFIED` both mean "use the site default,"
+// which comes from `[site_explorer] dpu_mode` (and falls back to
+// DPU_MODE when that's unset).
 enum DpuMode {
   DPU_MODE_UNSPECIFIED = 0;
   DPU_MODE = 1;
@@ -5601,9 +5602,9 @@ message ExpectedMachine {
   // When true, site-explorer skips BMC password rotation and stores the
   // factory-default credentials in Vault as-is.
   optional bool bmc_retain_credentials = 15;
-  // Per-host DPU operating mode. See `DpuMode` above. Unset means "site
-  // default" -- the site-wide `force_dpu_nic_mode` config flag still applies
-  // when no per-host override is set, so existing deployments keep working.
+  // Per-host DPU operating mode. See `DpuMode` above. Unset means "use
+  // the site-wide `[site_explorer] dpu_mode` default" (which itself
+  // defaults to DPU_MODE when unset).
   optional DpuMode dpu_mode = 16;
   // Per-host lifecycle profile. When unset in a patch/update request, the
   // existing DB value is preserved via COALESCE.

--- a/crates/site-explorer/src/config.rs
+++ b/crates/site-explorer/src/config.rs
@@ -179,23 +179,13 @@ pub struct SiteExplorerConfig {
     #[serde(default = "SiteExplorerConfig::default_switches_created_per_run")]
     pub switches_created_per_run: u64,
 
-    /// Use onboard NIC for host networking instead of DPU NICs.
-    #[serde(
-        default = "SiteExplorerConfig::default_force_dpu_nic_mode",
-        deserialize_with = "deserialize_arc_atomic_bool",
-        serialize_with = "serialize_arc_atomic_bool"
-    )]
-    pub force_dpu_nic_mode: Arc<AtomicBool>,
-    /// Site-wide default DPU operating mode. When set, applies to every
-    /// host that doesn't declare a per-host `ExpectedMachine.dpu_mode`
-    /// override (or that declares the default `DpuMode` variant, which is
-    /// indistinguishable from "unset"). Per-host `NicMode` / `NoDpu`
-    /// always overrides this. `None` means "no site default declared" and
-    /// resolution falls back to the legacy `force_dpu_nic_mode` flag.
-    ///
-    /// This setting is mirrored from the top-level `CarbideConfig.dpu_mode`
-    /// during config parsing so operators can set it once at the site
-    /// level without nesting under `[site_explorer]`.
+    /// Site-wide DPU operating mode. When set, applies to every host
+    /// that doesn't declare a per-host `ExpectedMachine.dpu_mode`
+    /// override (or that declares the default `DpuMode` variant,
+    /// which is indistinguishable from "unset"). Per-host `NicMode` /
+    /// `NoDpu` always wins. `None` means "site-wide setting unset"
+    /// and hosts fall back to the absolute default of
+    /// `DpuMode::DpuMode`.
     #[serde(default)]
     pub dpu_mode: Option<DpuMode>,
     /// Controls which Redfish client implementation is used
@@ -228,7 +218,6 @@ impl Default for SiteExplorerConfig {
             create_switches: Arc::new(true.into()),
             switches_created_per_run: Self::default_switches_created_per_run(),
             rotate_switch_nvos_credentials: Self::default_rotate_switch_nvos_credentials(),
-            force_dpu_nic_mode: Arc::new(false.into()),
             dpu_mode: None,
             explore_mode: Self::default_explore_mode(),
         }
@@ -303,10 +292,6 @@ impl SiteExplorerConfig {
 
     pub const fn default_switches_created_per_run() -> u64 {
         9
-    }
-
-    pub fn default_force_dpu_nic_mode() -> Arc<AtomicBool> {
-        Arc::new(false.into())
     }
 
     pub const fn default_explore_mode() -> SiteExplorerExploreMode {

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -958,10 +958,6 @@ impl SiteExplorer {
             }
 
             if ep.report.is_dpu() {
-                // Ignore the DPU if we are using the host NIC instead of the DPU NIC.
-                if self.config.force_dpu_nic_mode.load(Ordering::Relaxed) {
-                    continue;
-                }
                 if self.can_ingest_dpu_endpoint(metrics, &ep).await? {
                     explored_dpus.insert(ep.address, ep);
                 }
@@ -982,16 +978,14 @@ impl SiteExplorer {
     ) -> SiteExplorerResult<Vec<(ExploredManagedHost, EndpointExplorationReport)>> {
         // Per-host DPU-mode resolution. Precedence:
         //   1. Per-host `ExpectedMachine.dpu_mode` (NicMode / NoDpu wins).
-        //   2. Site-level default `SiteExplorerConfig.dpu_mode`.
-        //   3. Legacy site-wide `force_dpu_nic_mode` flag (deprecated,
-        //      preserved as a fallback for not too much longer).
-        let site_default_mode = self.config.dpu_mode;
-        let site_force_nic_mode = self.config.force_dpu_nic_mode.load(Ordering::Relaxed);
+        //   2. Site-wide `SiteExplorerConfig.dpu_mode` setting.
+        //   3. Otherwise: `DpuMode::DpuMode` (the absolute default).
+        let site_dpu_mode = self.config.dpu_mode;
         let effective_mode = |host_bmc_ip: &IpAddr| -> DpuMode {
             let declared = expected_explored_endpoint_index
                 .matched_expected_machine(host_bmc_ip)
                 .map(|em| em.data.dpu_mode);
-            DpuMode::resolve(declared, site_default_mode, site_force_nic_mode)
+            DpuMode::resolve(declared, site_dpu_mode)
         };
         // Match HOST and DPU using SerialNumber.
         // Compare DPU system.serial_number with HOST chassis.network_adapters[].serial_number


### PR DESCRIPTION
## Description

This closes https://github.com/NVIDIA/infra-controller/issues/1917.

This rips out the deprecated `force_dpu_nic_mode` config flag now that `dpu_mode` (per-host on `ExpectedMachine`, or side-wide via `[site-explorer]` config) does the same job.

None of our sites are using `force_dpu_nic_mode`, and it wasn't doing what most people would expect anyway -- it was mostly just enough to skip DPU ingestion in a few places, with the rest of the flow having to limp along via `allow_zero_dpu_hosts` to not error out. Even more interesting, as I started ripping it out, it looks like we somehow had two completely separate `force_dpu_nic_mode` flags anyway (one in `CarbideConfig`, and one in `SiteExplorerConfig`), where the state controller looked at one, and `site-explorer` looked at the other.

`dpu_mode: nic_mode` is functionally equivalent to what the flag used to do, but with a bonus! ...when `site-explorer` finds a DPU on a host configured for NIC mode, it now actively reconfigures the DPU via `set_nic_mode` (if needed) rather than just ignoring the endpoint. This was already wired up via `check_and_configure_dpu_mode`; we just had to stop short-circuiting on the flag for it to take effect.

A few high level notes:
- Field removed from both `CarbideConfig` and `SiteExplorerConfig`; `DpuMode::resolve` simplified.
- The state controller `TimeWaitForDPUDown` and `SetBootOrder` now key off `is_zero_dpu()` instead of the flag. `NicMode` hosts behave the same as before, in addition to `NoDpu` hosts getting the same treatment as well (which is what we want -- they should be treated similarly, since neither has a manageable DPU).
- `SetBootOrder` for zero-DPU hosts now actively sets UEFI HTTP boot, then flows through the existing `CheckBootOrder` verification step; we don't lose the existing boot-order safety check.

Any configs floating out there that still have `force_dpu_nic_mode = false` will keep *parsing* fine, but it won't do anything going forward. But again, we don't have any managed sites using this flag at all, and if anyone is using it, I'm not sure if it's doing what they want, especially with the two separate variables in there.

Tests updated!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [x] This PR contains breaking changes

If anyone out there happens to still be using this flag, which I don't think really will do what they want anyway, it will no longer do anything, and they'll need to migrate to using `dpu_mode: nic_mode` in their config TOML instead.

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

