### PR TITLE
ci(rest): disable main publish + fix duplicate SHA in image tag

### DIFF
--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -129,10 +129,12 @@ jobs:
         run: |
           TAGS=""
           PRIMARY_TAG=""
-          ARTIFACT_VERSION="${{ inputs.semantic_version }}-${{ inputs.short_sha }}"
+          # semantic_version comes from `git describe --long` and already ends in `-g<short_sha>`,
+          # so appending short_sha again would produce a duplicated SHA suffix.
+          ARTIFACT_VERSION="${{ inputs.semantic_version }}"
 
           if [ "${{ inputs.is_main_branch }}" == "true" ]; then
-            PRIMARY_TAG="${{ inputs.semantic_version }}-${{ inputs.short_sha }}"
+            PRIMARY_TAG="${{ inputs.semantic_version }}"
             TAGS="${TAGS},${{ inputs.target_registry }}/${{ inputs.service_name }}:${PRIMARY_TAG}"
             TAGS="${TAGS},${{ inputs.target_registry }}/${{ inputs.service_name }}:latest"
           elif [ "${{ inputs.release_tag }}" != "" ]; then
@@ -259,6 +261,6 @@ jobs:
           display-name: ${{ inputs.service_name }}-image
           description: ${{ inputs.service_name }} image
           version: latest
-          path: artifacts/${{ inputs.service_name }}-${{ inputs.semantic_version }}-${{ inputs.short_sha }}.tar.gz
+          path: artifacts/${{ inputs.service_name }}-${{ steps.docker-tags.outputs.artifact_version }}.tar.gz
           ngc-path: ${{ inputs.ngc_path }}
           ngc-key: ${{ secrets.NVCR_TOKEN }}

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -126,7 +126,8 @@ jobs:
       target_registry: ${{ needs.prepare.outputs.target_registry }}
       branch_name: ${{ needs.prepare.outputs.branch_name }}
       is_main_branch: ${{ needs.prepare.outputs.is_main_branch }}
-      push_enabled: ${{ github.event_name != 'workflow_dispatch' && !contains(github.ref, 'pull-request/') }}
+      # TEMP: disabled until REST image tag scheme is verified clean
+      push_enabled: false
       release_tag: ${{ needs.prepare.outputs.release_tag }}
     secrets:
       NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}

--- a/.github/workflows/rest-helm-workflows.yml
+++ b/.github/workflows/rest-helm-workflows.yml
@@ -46,7 +46,8 @@ jobs:
     name: Push Helm Charts
     needs:
       - validate-charts
-    if: ${{ !cancelled() && github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && needs.validate-charts.result == 'success' && !contains(github.ref, 'pull-request/') }}
+    # TEMP: disabled until REST image tag scheme is verified clean
+    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
Temporarily disable REST publish on main/release/tags and fix the duplicate-SHA bug in REST image tags. Core publish is **unchanged**.

## Why disable
Post-merge of #1800, main started pushing REST images to NGC with redundant SHA suffix:

```
nvcr.io/0837451325059433/carbide-dev/nico-rest-api:0.11.0-pr-3-g72855901-72855901
                                                                ^^^^^^^^^^^^^^^^^^
                                                                duplicated SHA
```

`semantic_version` from `git describe --long` already ends in `-g<short_sha>`, so appending `-${short_sha}` produced the duplicate.

## Why fix in same PR
The tag fix is small and self-contained — shipping the disable and fix together means the follow-up PR is just removing the `false` toggles.

## Changes
- `rest-ci.yml`: `push_enabled: false` (was conditional)
- `rest-helm-workflows.yml`: `if: false` on `push-charts` (was conditional)
- `rest-build-push-service.yml`:
  - `PRIMARY_TAG = semantic_version` (main branch) — drop redundant `-short_sha`
  - `ARTIFACT_VERSION = semantic_version` — drop redundant `-short_sha`
  - `latest` tarball upload path now uses `artifact_version` (was hardcoded with duplicate)

## Scope
- REST docker push — **disabled**
- REST helm push — **disabled**
- Core CI publish — **unchanged**
- Promotion workflow — **unchanged**

## Follow-up
Once verified the fix produces clean tags on a non-publish run, open a follow-up to revert the two `false` toggles:

```yaml
# rest-ci.yml
push_enabled: ${{ github.event_name != 'workflow_dispatch' && !contains(github.ref, 'pull-request/') }}

# rest-helm-workflows.yml
if: ${{ !cancelled() && github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && needs.validate-charts.result == 'success' && !contains(github.ref, 'pull-request/') }}
```

## Expected tag after fix + re-enable
```
nvcr.io/0837451325059433/carbide-dev/nico-rest-api:0.11.0-pr-3-g72855901
nvcr.io/0837451325059433/carbide-dev/nico-rest-api:latest
```