### PR TITLE
ci(rest): re-enable main publish after tag scheme fix

### DIFF
--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -129,10 +129,12 @@ jobs:
         run: |
           TAGS=""
           PRIMARY_TAG=""
-          ARTIFACT_VERSION="${{ inputs.semantic_version }}-${{ inputs.short_sha }}"
+          # semantic_version comes from `git describe --long` and already ends in `-g<short_sha>`,
+          # so appending short_sha again would produce a duplicated SHA suffix.
+          ARTIFACT_VERSION="${{ inputs.semantic_version }}"
 
           if [ "${{ inputs.is_main_branch }}" == "true" ]; then
-            PRIMARY_TAG="${{ inputs.semantic_version }}-${{ inputs.short_sha }}"
+            PRIMARY_TAG="${{ inputs.semantic_version }}"
             TAGS="${TAGS},${{ inputs.target_registry }}/${{ inputs.service_name }}:${PRIMARY_TAG}"
             TAGS="${TAGS},${{ inputs.target_registry }}/${{ inputs.service_name }}:latest"
           elif [ "${{ inputs.release_tag }}" != "" ]; then
@@ -259,6 +261,6 @@ jobs:
           display-name: ${{ inputs.service_name }}-image
           description: ${{ inputs.service_name }} image
           version: latest
-          path: artifacts/${{ inputs.service_name }}-${{ inputs.semantic_version }}-${{ inputs.short_sha }}.tar.gz
+          path: artifacts/${{ inputs.service_name }}-${{ steps.docker-tags.outputs.artifact_version }}.tar.gz
           ngc-path: ${{ inputs.ngc_path }}
           ngc-key: ${{ secrets.NVCR_TOKEN }}

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -126,8 +126,7 @@ jobs:
       target_registry: ${{ needs.prepare.outputs.target_registry }}
       branch_name: ${{ needs.prepare.outputs.branch_name }}
       is_main_branch: ${{ needs.prepare.outputs.is_main_branch }}
-      # TEMP: disabled until REST image tag scheme is verified clean
-      push_enabled: false
+      push_enabled: ${{ github.event_name != 'workflow_dispatch' && !contains(github.ref, 'pull-request/') }}
       release_tag: ${{ needs.prepare.outputs.release_tag }}
     secrets:
       NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -126,7 +126,8 @@ jobs:
       target_registry: ${{ needs.prepare.outputs.target_registry }}
       branch_name: ${{ needs.prepare.outputs.branch_name }}
       is_main_branch: ${{ needs.prepare.outputs.is_main_branch }}
-      push_enabled: ${{ github.event_name != 'workflow_dispatch' && !contains(github.ref, 'pull-request/') }}
+      # TEMP: disabled until REST image tag scheme is verified clean
+      push_enabled: false
       release_tag: ${{ needs.prepare.outputs.release_tag }}
     secrets:
       NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}

--- a/.github/workflows/rest-helm-workflows.yml
+++ b/.github/workflows/rest-helm-workflows.yml
@@ -46,8 +46,7 @@ jobs:
     name: Push Helm Charts
     needs:
       - validate-charts
-    # TEMP: disabled until REST image tag scheme is verified clean
-    if: false
+    if: ${{ !cancelled() && github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && needs.validate-charts.result == 'success' && !contains(github.ref, 'pull-request/') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/rest-helm-workflows.yml
+++ b/.github/workflows/rest-helm-workflows.yml
@@ -46,7 +46,8 @@ jobs:
     name: Push Helm Charts
     needs:
       - validate-charts
-    if: ${{ !cancelled() && github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && needs.validate-charts.result == 'success' && !contains(github.ref, 'pull-request/') }}
+    # TEMP: disabled until REST image tag scheme is verified clean
+    if: false
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
Re-enables REST publish (docker + helm) on main / release / tags. Follow-up to #1922.

## Net diff vs main
Just the tag scheme fix from #1922 (`rest-build-push-service.yml`). The disable toggles introduced in #1922 are reverted back to the original conditional gates.

## Merge order
- **If #1922 is merged first**: this PR will show only the revert of the two \`false\` toggles
- **If this PR is merged first**: it effectively combines #1922's fix with re-enabling push (skipping the disable step)

Either order is safe. Closing #1922 in favor of this PR is also fine.

## Expected after merge
Main pushes will produce clean tags:
```
nvcr.io/0837451325059433/carbide-dev/nico-rest-api:0.11.0-pr-3-g72855901
nvcr.io/0837451325059433/carbide-dev/nico-rest-api:latest
```

And helm chart:
```
nico-rest:0.11.0-pr-3.g72855901
```