### PR TITLE
chore(docs):  Adding requested network isolation docs

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -121,6 +121,12 @@ navigation:
 
     - section: Operations
       contents:
+        - page: Network Isolation
+          path: manuals/network_isolation.md
+        - page: Network Security Groups
+          path: manuals/networking/network_security_groups.md
+        - page: InfiniBand Partitioning
+          path: manuals/networking/infiniband_partitioning.md
         - page: nicocli Reference
           path: manuals/nicocli-reference.md
         - page: NVLink Partitioning

--- a/docs/manuals/network_isolation.md
+++ b/docs/manuals/network_isolation.md
@@ -1,0 +1,166 @@
+# Network Isolation
+
+NICo enforces tenant network isolation across three independent fabrics. Each
+fabric uses a different mechanism, is configured through a different operator
+API, and is verified separately. This page summarises the model so an operator
+can choose the right guide; it is not a replacement for the per-fabric
+configuration guides linked below.
+
+| Fabric | Operator-facing primitive | Isolation enforced by |
+|---|---|---|
+| Ethernet | VPC + VpcPrefix (+ optional Network Security Group) | DPU VRF per VPC (HBN / NVUE) over a pure type-5 EVPN overlay |
+| InfiniBand | InfiniBand partition | UFM P_Key partition membership; `IbFabricMonitor` reconciler |
+| NVLink | NVLink logical partition | NMX-M / NMX-C partition lifecycle; `NvlPartitionMonitor` reconciler |
+
+---
+
+## Who configures what, and how
+
+Network operations split across two roles. The per-fabric guides tag every
+operation with its role and interface using the model below; read this once,
+then use the operations matrix in each guide.
+
+**Operator** (site administrator)
+
+- Day-0 site setup is **TOML** in the API server configuration. After Day 0,
+  TOML changes are rare.
+- For Day-1+ operations, prefer the **REST API**, or **`nicocli`** (its CLI
+  wrapper).
+- Use **`nico-admin-cli`** (which speaks the gRPC API directly) only for
+  operations the REST API does not expose — for example, NMX-C endpoint
+  registration, the NVLink GPU-mapping populate step, or break-glass fabric
+  cleanup.
+
+**Tenant**
+
+- Never edits TOML.
+- Uses the **REST API** or **`nicocli`** exclusively.
+- If neither exposes a required operation, that is a gap: **file a bug**
+  against the REST API / `nicocli` rather than reaching for `nico-admin-cli`.
+
+REST paths in the matrices are shown against the `/v2/org/{org}/nico/...`
+placeholder; `nicocli` commands follow the `nicocli <resource> <verb>` form.
+See the **REST API Reference** tab and the
+[nicocli Reference](nicocli-reference.md) for exact request bodies and flags.
+
+---
+
+## Ethernet
+
+**Operations**
+
+| Task | Role | Interface |
+|---|---|---|
+| IP / VNI / ASN pools, `datacenter_asn`, routing profiles, `deny_prefixes`, admin network | Operator | **TOML** — Day 0 / rare. See the VPC manuals below. |
+| Create / update / delete a VPC | Tenant | **REST** `…/nico/vpc` · `nicocli vpc create` |
+| Create / update / delete a VpcPrefix | Tenant | **REST** `…/nico/vpc-prefix` · `nicocli vpc-prefix create` |
+| Establish VPC peering | Tenant | **REST** `…/nico/vpc-peering` · `nicocli vpc-peering create` |
+| Attach a Network Security Group to a VPC or instance | Tenant | **REST** (`update-vpc` / `update-instance`) · `nicocli` |
+
+See [Who configures what, and how](#who-configures-what-and-how) for the role
+and interface model.
+
+A tenant's instance reaches a VPC by drawing addresses from one of the
+**VpcPrefixes** attached to that VPC. NICo carves a /31 link-net per
+interface from the prefix — one address to the instance, one to the
+DPU's SVI in the VPC's VRF. An instance may participate in several VPCs
+at once by having interfaces drawing from prefixes in different VPCs.
+On the DPU of the managed host backing the instance, each related VPC
+materialises as a Linux VRF; every host interface drawing from a prefix
+in that VPC lives in that VRF. The tenant overlay is a pure type-5 EVPN
+(IP-prefix) overlay — NICo does not stretch any tenant L2 segment across
+the fabric.
+
+Ethernet isolation has three independent layers:
+
+- **Routing isolation (VPC / VRF).** VRFs are isolated by default. A route
+  advertised in one VPC does not appear in another VPC's VRF. Cross-VPC
+  reachability is opt-in via VPC peering or controlled route leaking on the
+  VPC's routing profile.
+- **Default isolation (admin overlay).** A managed host never carries tenant
+  traffic unless a tenant configuration places it in a VPC. Between tenants,
+  during provisioning / termination, or when its configuration is unknown,
+  the DPU is held on the admin overlay (fail-closed).
+- **L3 / L4 filtering (Network Security Groups).** Stateful or stateless
+  rule-based filtering within or across VPCs, attached at VPC or instance
+  scope.
+
+The Ethernet configuration model is documented in the VPC manuals; this
+overview does not duplicate them:
+
+- [VPC Network Virtualization](vpc/vpc_network_virtualization.md) — the full
+  VXLAN / EVPN, VRF, BGP, routing-profile, and DPU-config reference, including
+  [Default Isolation: The Admin Overlay](vpc/vpc_network_virtualization.md#default-isolation-the-admin-overlay)
+- [VPC Routing Profiles](vpc/vpc_routing_profiles.md) — route-target imports /
+  exports and controlled route leaking
+- [VPC Peering](vpc/vpc_peering_management.md) — opt-in cross-VPC reachability
+- [Network Security Groups](networking/network_security_groups.md) — L3 / L4
+  rule filtering and site-wide operator overrides
+
+---
+
+## InfiniBand
+
+Each tenant InfiniBand partition maps to a UFM P_Key. Membership is enforced
+by the subnet manager at the fabric level: hosts that are not members of a
+P_Key cannot exchange traffic with other members of that P_Key, regardless
+of physical connectivity. NICo reconciles desired partition membership against
+UFM via the `IbFabricMonitor` background task and surfaces the synchronisation
+status to operators and to tenants.
+
+See [Configuring InfiniBand Partitions](networking/infiniband_partitioning.md)
+for the operator configuration guide, and the
+[InfiniBand Setup Runbook](../playbooks/ib_runbook.md) for the prerequisite
+UFM / OpenSM hardening.
+
+---
+
+## NVLink
+
+NVLink logical partitions group GPUs across hosts into a single isolated
+NVLink domain. NICo drives partition lifecycle against the NMX-M REST API and
+the NMX-C gRPC API and reconciles desired partitions periodically. Each tenant
+instance that requests NVLink connectivity is placed into the partition
+corresponding to its allocation; a host whose GPUs are not in a partition
+cannot reach any other host's GPUs over NVLink.
+
+See [NVLink Partitioning](nvlink_partitioning.md) for the operator
+configuration guide.
+
+---
+
+## Cross-cutting behaviour
+
+The following invariants apply to every fabric.
+
+- **Per-fabric synchronisation status.** Each instance's `InstanceStatus`
+  exposes a per-fabric `configs_synced` field that is `true` only when the
+  observed fabric state matches the desired configuration. The aggregate
+  `configs_synced` field is the logical AND of all per-fabric fields and gates
+  the instance's `Ready` state.
+- **Provisioning blocks on isolation convergence.** During initial
+  provisioning, the instance state machine waits until every requested fabric
+  has applied the desired configuration before the instance is marked `Ready`.
+  Tenants observe this as the `Configuring` tenant state, and the machine
+  remains in `WaitingForNetworkConfig` until the DPU reports back.
+- **Termination blocks on isolation convergence.** During termination, the
+  state machine waits until every fabric reports that the host has been
+  removed from all tenant partitions before the instance is reported as
+  deleted. This guarantees a terminated instance cannot continue to exchange
+  traffic on any fabric.
+- **Force-delete still tears down fabric state.** Force-deleting a managed
+  host explicitly detaches it from every fabric through the same external
+  APIs the normal lifecycle uses, so external fabric managers do not retain
+  stale tenant references.
+- **External fabric reachability is monitored.** Each external fabric service
+  (UFM, NMX-M, NMX-C) is monitored from NICo with request-success and latency
+  metrics so that fabric-side outages can be distinguished from NICo-side
+  configuration errors.
+
+For the architectural rationale and the patterns shared across all three
+fabrics, see
+[Networking Integrations](../architecture/networking_integrations.md).
+
+For the Day 0 IP, DHCP, DNS, and admin-network configuration that every
+isolation guarantee on this page rests on, see
+[Day 0 IP and Network Configuration](../getting-started/installation-options/day0-ip-network-config.md).

--- a/docs/manuals/networking/infiniband_partitioning.md
+++ b/docs/manuals/networking/infiniband_partitioning.md
@@ -1,0 +1,396 @@
+# Configuring InfiniBand Partitions
+
+This page is the Day-1 configuration guide for InfiniBand partitions in
+NICo. It describes how an operator points NICo at UFM, how partitions are
+allocated and assigned to tenant instances, and how to verify that a host
+has ended up in the partitions it should. Tenant isolation is a property
+of how partitions are assigned — for the cross-fabric isolation picture,
+see [Network Isolation](../network_isolation.md).
+
+The InfiniBand fabric itself — UFM installation, `gv.cfg` / `opensm.conf`
+tuning, M_Key and SA_Key configuration, and static topology files — is
+covered separately in the [InfiniBand Setup
+runbook](../../playbooks/ib_runbook.md). That runbook is a prerequisite for
+this page: NICo's partition guarantees rest on a properly hardened UFM and
+subnet manager.
+
+**Related pages**
+
+- [Network Isolation](../network_isolation.md) — cross-fabric isolation
+  overview; explains how IB partitions fit alongside Ethernet and NVLink
+- [InfiniBand Setup Runbook](../../playbooks/ib_runbook.md) — UFM and OpenSM
+  hardening (prerequisite)
+- [InfiniBand NIC and Port Selection](../../architecture/infiniband/nic_selection.md)
+  — how NICo picks which host NICs / ports are managed
+- [Networking Integrations](../../architecture/networking_integrations.md) —
+  shared architectural patterns across all three fabrics
+
+---
+
+## The Partition Model
+
+InfiniBand partitioning in NICo is built on the InfiniBand-native P_Key
+mechanism enforced by the subnet manager. The operator-facing chain is:
+
+```
+Instance ──► IB Interface ──► IbPartition (NICo) ──► P_Key (UFM)
+```
+
+Read it top to bottom:
+
+1. A **tenant instance** has one or more **IB interfaces**, one per
+   InfiniBand port on the host the instance is allocated to.
+2. Each IB interface references exactly one **`IbPartition`** by ID — this
+   is the NICo object the tenant manipulates.
+3. The `IbPartition` corresponds to a single **P_Key** on UFM. NICo either
+   allocates the P_Key value from a configured range or honours an
+   explicit P_Key the operator supplied.
+4. Enforcement happens at the **subnet manager**. A host port that is not
+   a member of a P_Key cannot exchange InfiniBand traffic with any other
+   member of that P_Key, regardless of physical connectivity. This is
+   fabric-side, not host-side: a misconfigured host cannot bypass it.
+
+Two instances in different P_Keys cannot send any IB traffic to each other;
+two instances in the same P_Key can. There is no operator-visible "peering"
+concept for InfiniBand the way there is for Ethernet VPCs — sharing requires
+placing both instances' interfaces in the same partition.
+
+---
+
+## What Lives Where
+
+| Concern | Location |
+|---|---|
+| Subnet manager, M_Key / SA_Key hardening, static topology | UFM host (see the IB runbook) |
+| UFM endpoint URL(s) and managed P_Key ranges | NICo API server TOML, under `[ib_fabrics.<name>]` |
+| Fabric-wide toggles (enable, MTU, rate limit, service level, monitor cadence) | NICo API server TOML, under `[ib_config]` |
+| UFM API credentials | Vault (or the configured secrets backend), not the TOML file |
+| `IbPartition` objects (tenant-owned) | NICo database, managed by tenants via the REST API / `nicocli` |
+| Per-interface partition assignment | `InstanceInfinibandConfig` on the instance, set via an instance update |
+| Reconciliation between desired and actual UFM state | `IbFabricMonitor`, a background task inside the API server |
+
+NICo treats UFM as the authoritative source for **observed** fabric state.
+It does not cache UFM partition membership separately from what the monitor
+last read. This means that direct out-of-band changes to UFM (an operator
+editing partitions in the UFM UI, for example) will be detected on the next
+monitor iteration and reconciled back to NICo's intended state.
+
+---
+
+## Operations: Who Does What
+
+InfiniBand splits cleanly between operator site setup and tenant partition
+management. See
+[Network Isolation → Who configures what, and how](../network_isolation.md#who-configures-what-and-how)
+for the role and interface model.
+
+| Task | Role | Interface |
+|---|---|---|
+| UFM endpoint(s), P_Key ranges, fabric toggles | Operator | **TOML** (`[ib_fabrics.<name>]`, `[ib_config]`) — Day 0 / rare |
+| UFM API credentials | Operator | Secrets backend (Vault) |
+| Create / update / delete an InfiniBand partition | Tenant | **REST** `…/nico/infiniband-partition` · `nicocli infiniband-partition create` |
+| Assign an instance's IB interface to a partition | Tenant | **REST** `…/nico/instance` (update) · `nicocli instance update` |
+| List partitions and check sync state for triage | Operator | `nicocli infiniband-partition list` → `nico-admin-cli ib_partition show` for deeper internal state |
+| Break-glass: unbind a host from UFM out of band | Operator | **`nico-admin-cli`** (gRPC) — not exposed via REST |
+
+The UFM-facing setup (the first two rows) is the operator's responsibility and
+is described in [Configuring NICo to Talk to UFM](#configuring-nico-to-talk-to-ufm).
+Everything a tenant does — creating partitions and attaching interfaces — goes
+through the REST API or `nicocli`; the gRPC `nico-admin-cli` rows are operator
+triage and break-glass paths that the REST API does not expose.
+
+---
+
+## Configuring NICo to Talk to UFM
+
+Two TOML blocks are involved. Both live in the API server's config file.
+
+### `[ib_fabrics.<name>]` — Endpoints and P_Key Pool
+
+Each named entry defines one InfiniBand fabric that NICo manages.
+
+```toml
+[ib_fabrics.fabric_a]
+endpoints = ["https://ufm-a.example.internal:443"]
+
+  [[ib_fabrics.fabric_a.pkeys]]
+  start = "0x100"
+  end   = "0x1ff"
+
+  [[ib_fabrics.fabric_a.pkeys]]
+  start = "0x300"
+  end   = "0x3ff"
+```
+
+Fields:
+
+| Field | Purpose |
+|---|---|
+| `endpoints` | UFM server URLs. At the time of writing only the first endpoint is consulted; multi-endpoint support exists in the schema for forward compatibility |
+| `pkeys` | One or more inclusive P_Key ranges, hex-encoded. These define the pool that NICo's auto-allocator draws from when a tenant creates an `IbPartition` without specifying a P_Key |
+
+P_Key ranges may be **extended in future restarts but never shrunk**:
+removing or narrowing a range under live tenants would orphan allocated
+partitions. Plan the pool with headroom.
+
+### `[ib_config]` — Fabric Toggles
+
+```toml
+[ib_config]
+enabled = true
+allow_insecure = false
+mtu = 4096
+rate_limit = 200
+service_level = 0
+fabric_monitor_run_interval = "60s"
+```
+
+| Field | Purpose |
+|---|---|
+| `enabled` | Master switch. With `false`, NICo will not call UFM and will not run the monitor |
+| `allow_insecure` | Permit TLS to UFM without certificate verification. Intended for development only |
+| `mtu`, `rate_limit`, `service_level` | Defaults applied to NICo-managed partitions when not overridden per partition |
+| `fabric_monitor_run_interval` | Steady-state cadence for `IbFabricMonitor`. Defaults to 60 seconds |
+
+### UFM credentials
+
+UFM API credentials are not stored in TOML. They are read from the
+configured secrets backend (Vault under standard deployments) by the UFM
+client during initialisation. Rotate them at the secrets backend; NICo
+picks up the new value on its next client re-initialisation.
+
+---
+
+## P_Key Allocation
+
+When a tenant creates an InfiniBand partition (REST
+`POST …/nico/infiniband-partition`, or `nicocli infiniband-partition create`),
+the request may include or omit a desired P_Key:
+
+- **`pkey` omitted.** NICo allocates a free P_Key from the configured
+  pool ranges and returns it on the response. This is the normal tenant
+  flow.
+- **`pkey` specified** (hex, for example `"0x76b"`). NICo accepts the
+  request only if the requested value falls inside a pool range that is
+  **not** marked as auto-assigned, and is otherwise free. Otherwise the
+  request is rejected.
+
+The model's `IbPartition` object retains the allocated P_Key for the
+lifetime of the partition. There is no "renumber" operation; to change a
+P_Key, delete the partition and create a new one (which the tenant flow
+handles via instance reconfiguration).
+
+Updating a partition (`nicocli infiniband-partition update`) is restricted to
+fields other than P_Key (name, MTU, rate limit, and so on). Deleting one
+(`nicocli infiniband-partition delete`) requires that no instance still
+references the partition.
+
+---
+
+## Membership: Full vs Limited
+
+UFM distinguishes **full** and **limited** P_Key membership. Full members
+can communicate with both full and limited members of the same P_Key;
+limited members can only talk to full members.
+
+NICo's posture:
+
+- The `IbPortMembership` enum is **read-only** from NICo's perspective.
+  The monitor records whatever UFM reports for each port-in-partition
+  binding.
+- NICo does **not** expose a config option to choose full or limited
+  membership when creating a partition. Whatever UFM is configured to use
+  (typically full members, with the default partition restricted by the
+  `default_membership = limited` hardening in the IB runbook) is what
+  appears on a NICo-managed binding.
+- The monitor flags a security alert if the default partition shows full
+  membership on a NICo-managed port; that is an indication the UFM
+  hardening described in the runbook has not been applied.
+
+---
+
+## The `IbFabricMonitor`
+
+`IbFabricMonitor` is the background reconciler inside the API server.
+Every iteration it:
+
+1. Reads UFM state: port information (state, GUID, LID), partition
+   membership lists, fabric version, M_Key / SM_Key / SA_Key configuration,
+   and default-partition membership.
+2. Compares observed UFM state to the desired state implied by each
+   instance's `InstanceInfinibandConfig`.
+3. For each IB interface in an instance config, if the host GUID is not
+   already a member of the expected P_Key, calls `bind_ib_ports()` to add
+   it.
+4. For any GUID found in a NICo-managed P_Key that no longer matches a
+   live instance config, calls `unbind_ib_ports()` to remove it.
+5. Updates per-machine InfiniBand status observations in the NICo
+   database, which is what feeds the `configs_synced.infiniband` field on
+   `InstanceStatus`.
+
+Cadence is set by `fabric_monitor_run_interval` (default 60 seconds). After
+applying any UFM changes, the monitor accelerates the next iteration to
+~1 second so that convergence shows up quickly in observed state. Once a
+steady iteration completes with no changes, the monitor returns to the
+configured interval.
+
+The monitor exposes metrics under the `nico_ib_monitor_*` namespace:
+
+| Metric | Use |
+|---|---|
+| `nico_ib_monitor_iteration_latency` | Time per reconcile pass; a sudden rise indicates UFM slowness |
+| `nico_ib_monitor_ufm_changes_applied` | Counter of bind/unbind operations issued; nonzero in steady state is an anomaly |
+| `nico_ib_monitor_machines_by_port_state_count` | Port-state histogram; helps spot hosts stuck `Initialize` or `Down` |
+| `nico_ib_monitor_machines_with_missing_pkeys_count` | Hosts that should be in a partition but are not — investigate |
+| `nico_ib_monitor_machines_with_unexpected_pkeys_count` | Hosts that are in partitions they should not be — investigate immediately |
+| `nico_ib_monitor_ufm_partitions_count` | Partition count UFM reports; sanity check against NICo's view |
+| UFM-error counters | Connection / authentication failures; the schema for these is acknowledged as incomplete in the current code |
+
+---
+
+## How a Tenant Ends Up in a Partition
+
+For a tenant instance with an IB interface attached to a partition:
+
+1. The tenant updates the instance (REST `PATCH …/nico/instance`, or
+   `nicocli instance update`) with an InfiniBand interface configuration
+   that references the desired partition ID for each IB port.
+2. NICo validates the config (every referenced partition exists,
+   ownership matches the tenant) and stores it in the database.
+3. The next `IbFabricMonitor` iteration observes the new desired state
+   and issues `bind_ib_ports()` for each host GUID that is not already a
+   member of the expected P_Key.
+4. UFM updates partition membership. On the following iteration the
+   monitor reads back the new membership and updates the machine's IB
+   status observation.
+5. `InstanceStatus::infiniband::configs_synced` flips to `true` once
+   observed UFM state matches desired state. The aggregate
+   `configs_synced` and therefore the instance's `Ready` state follow.
+
+Tenants observe the in-flight state as `Configuring` and the
+`InstanceStatus` machine remains in `WaitingForNetworkConfig` until the
+monitor reports convergence.
+
+---
+
+## Force-Delete and Cleanup
+
+When an instance is released or its host is force-deleted, NICo clears
+the IB interfaces from the instance config. The reconciler then sees host
+GUIDs in NICo-managed P_Keys that no longer correspond to any live
+instance and removes them via `unbind_ib_ports()`.
+
+NICo tracks the cleanup with an `IbCleanupPending` health alert on the
+machine. The alert is set when cleanup is required and cleared once the
+monitor confirms that every GUID has been removed from UFM-side
+partitions. A machine with an outstanding `IbCleanupPending` alert is
+ineligible for reuse by another tenant: this is the IB equivalent of the
+Ethernet termination guard described in
+[Default Isolation](../vpc/vpc_network_virtualization.md#default-isolation-the-admin-overlay).
+
+There is no dedicated "force-delete IB partition" operation. Partitions
+persist in the NICo database independent of instance churn; their membership
+is what is reconciled against UFM. To remove a partition entirely, every
+instance referencing it must release first, then the tenant's
+`nicocli infiniband-partition delete` (REST `DELETE …/nico/infiniband-partition/{id}`)
+will succeed.
+
+---
+
+## Configuration Workflow
+
+### Operator (per site)
+
+1. Stand up UFM per the [InfiniBand Setup runbook](../../playbooks/ib_runbook.md).
+   Confirm `default_membership = limited`, M_Key / SA_Key hardening, and
+   any required static topology configuration.
+2. Provision a UFM API user with permission to read ports / partitions
+   and to create / update / delete partitions. Store its credentials in
+   the secrets backend.
+3. In the NICo API server config:
+   - Set `[ib_config].enabled = true` and any fabric-wide MTU / rate /
+     service-level defaults.
+   - For each fabric, define `[ib_fabrics.<name>]` with the UFM
+     endpoint(s) and one or more `pkeys` ranges. Size the ranges with
+     room for future growth.
+4. Restart the API server. The `IbFabricMonitor` begins its periodic
+   reconciliation on the next tick.
+
+### Tenant (per partition)
+
+All tenant steps use the REST API or `nicocli`; none require TOML or
+`nico-admin-cli`.
+
+1. `nicocli infiniband-partition create` (REST `POST …/nico/infiniband-partition`)
+   for each isolation domain the tenant needs (typically one per workload).
+2. `nicocli instance update` (REST `PATCH …/nico/instance`) to attach each
+   IB interface to the appropriate partition.
+3. Wait for `configs_synced.infiniband = true` to converge.
+
+---
+
+## Verification
+
+NICo does not ship a single "is IB healthy" command. Verification is a
+short, repeatable checklist.
+
+1. **UFM is reachable.** Check the API server log for "Failed to create
+   UFM client" or similar startup errors. Confirm
+   `nico_ib_monitor_iteration_latency` is being recorded (the monitor
+   is running) and that UFM error counters are flat.
+2. **Configured partitions exist and have converged.** List partitions with
+   `nicocli infiniband-partition list` (REST `GET …/nico/infiniband-partition`)
+   and confirm each is in a converged state. For deeper internal state during
+   triage — the state-machine outcome field that surfaces UFM sync failures —
+   an operator can use `nico-admin-cli ib_partition show` (`--id`,
+   `--tenant-org-id`, or `--name`), which the REST API does not expose.
+3. **Host is a member of the expected partitions.** Inspect the
+   machine's `infiniband_status_observation` via the machine debug
+   tooling and confirm each managed port reports membership in the
+   intended P_Key. Cross-check with the live UFM partition table for
+   the same partition.
+4. **No anomalies in the monitor metrics.**
+   `nico_ib_monitor_machines_with_missing_pkeys_count` and
+   `nico_ib_monitor_machines_with_unexpected_pkeys_count` should both
+   be `0` in steady state. Either being non-zero is a divergence between
+   intent and UFM state and warrants investigation.
+5. **No outstanding cleanup.** Confirm no managed machine has an
+   `IbCleanupPending` alert.
+
+---
+
+## Limitations Worth Knowing
+
+The IB integration is in production but with the following gaps:
+
+- **Single-endpoint UFM today.** Only the first entry in `endpoints` is
+  used at runtime. UFM HA is handled by UFM itself (virtual IP / HA
+  pair); the multi-endpoint config field exists for forward
+  compatibility.
+- **P_Key ranges are append-only in practice.** Restarting with a
+  narrowed range under live partitions is unsafe; ranges should only
+  grow.
+- **No tenant-facing UFM-reachability probe.** Operators rely on
+  metrics and log lines rather than a `ping`-style health command.
+- **SHARP, index-0, and default-membership knobs are not yet wired.**
+  The model has fields reserved for these but they are not honoured by
+  the integration.
+- **UFM error taxonomy is incomplete.** Some UFM failure modes surface
+  as a generic error in the API server log. Distinguishing transient
+  network issues from misconfiguration may require correlating against
+  UFM-side logs.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Instance never leaves `Configuring`; `configs_synced.infiniband = false` | UFM unreachable, host port `Down` or `Initialize`, or PKey allocation pending |
+| `infiniband-partition create` fails with PKey-allocation error | `[ib_fabrics.<name>].pkeys` pool exhausted; operator extends the ranges |
+| `infiniband-partition create` with an explicit `pkey` rejected | Requested PKey falls in an auto-allocate range or is already in use |
+| `nico_ib_monitor_machines_with_unexpected_pkeys_count > 0` | Host is in a partition no instance config asks for; out-of-band UFM edit or a stale binding the monitor will clean up |
+| `nico_ib_monitor_machines_with_missing_pkeys_count > 0` | Desired binding has not (yet) been applied to UFM; check UFM error counters and monitor latency |
+| `IbCleanupPending` alert does not clear | Monitor cannot remove a GUID from a partition (UFM error, or the binding sits outside any NICo-managed range); inspect UFM-side state directly |
+| `infiniband-partition delete` fails | At least one instance still references the partition |
+| Default partition reports full membership on managed ports | UFM hardening incomplete; revisit `default_membership = limited` in the IB runbook |

--- a/docs/manuals/networking/network_security_groups.md
+++ b/docs/manuals/networking/network_security_groups.md
@@ -1,0 +1,423 @@
+# Network Security Groups
+
+Network Security Groups (NSGs) are tenant-owned, rule-based filters that sit
+on top of the VPC / VRF model. They provide stateful or stateless L3 / L4
+filtering for traffic into and out of tenant instances, complementing the
+routing isolation that the VPC itself provides.
+
+This page describes the NSG object model, how rules are attached to traffic,
+how the operator enables and constrains the feature, and how to verify and
+troubleshoot rule enforcement.
+
+**Related pages**
+
+- [Network Isolation Overview](../network_isolation.md)
+- [VPC Network Virtualization](../vpc/vpc_network_virtualization.md) — the
+  VPC, VRF, and DPU configuration layer that NSGs sit on top of
+
+---
+
+## Where NSGs Sit in the Stack
+
+A tenant's traffic on a NICo-managed host passes through three independent
+isolation layers in order:
+
+1. **VPC / VRF.** The DPU places each interface into the VRF of the VPC
+   whose VpcPrefix the interface draws its /31 from. Routes do not leak
+   between VRFs unless an operator opts in via routing-profile flags or
+   VPC peering.
+2. **`deny_prefixes` site ACL.** The site-wide `deny_prefixes` list,
+   configured under the API server's networking config, blocks tenant
+   traffic to a fixed set of prefixes (typically management plane and
+   infrastructure). This applies to every VRF on every DPU and cannot be
+   overridden by a tenant.
+3. **Network Security Groups.** Per-VPC and per-instance rule sets, set by
+   the tenant, with optional site-wide operator overrides inserted ahead of
+   tenant rules.
+
+NSGs are the right tool for filtering East-West traffic *inside* a VPC, for
+restricting which underlay-leaked prefixes a tenant is permitted to reach,
+and for enforcing site-wide baselines (operator overrides) that no tenant
+can disable. They are not a substitute for VPC routing isolation: an NSG
+cannot make two VPCs reachable that the routing profile keeps apart.
+
+---
+
+## Operations: Who Does What
+
+NSGs are almost entirely a tenant operation. The only operator-owned pieces
+are the site-level limits and overrides (TOML) and a break-glass path for
+incident response. See
+[Network Isolation → Who configures what, and how](../network_isolation.md#who-configures-what-and-how)
+for the role and interface model.
+
+| Task | Role | Interface |
+|---|---|---|
+| Site limits and overrides (`max_network_security_group_size`, `stateful_acls_enabled`, `policy_overrides`) | Operator | **TOML** (`[network_security_group]`) — Day 0 / rare; API restart |
+| Create / update / delete an NSG | Tenant | **REST** `…/nico/network-security-group` · `nicocli network-security-group create` |
+| Attach an NSG to a VPC | Tenant | **REST** (`update-vpc`) · `nicocli vpc update` |
+| Attach an NSG to an instance | Tenant | **REST** (`update-instance`) · `nicocli instance update` |
+| Inspect an NSG's rules, version, and status | Tenant | **REST** `GET …/nico/network-security-group/{id}` · `nicocli network-security-group get` |
+| Check where an NSG is attached and its rollout state | Tenant | **REST** `GET …/nico/vpc/{id}` or `…/nico/instance/{id}` (`networkSecurityGroupPropagationDetails`) |
+| Break-glass: modify a tenant's NSG during an incident | Operator | **`nico-admin-cli`** (gRPC) — emergency only |
+
+---
+
+## The Rule Model
+
+An NSG is a tenant-owned object with the following shape:
+
+| Field | Purpose |
+|---|---|
+| `id` | NSG identifier, returned at creation |
+| `tenant_organization_id` | The owning tenant |
+| `stateful_egress` | When `true`, return traffic for egress flows is permitted automatically. Requires the site-level `stateful_acls_enabled` flag (see below) |
+| `rules` | Ordered list of `NetworkSecurityGroupRule` entries, evaluated by priority |
+| `version` | Optimistic-concurrency token; required when updating the NSG |
+
+Each rule has:
+
+| Field | Allowed values |
+|---|---|
+| `direction` | `Ingress` or `Egress` |
+| `ipv6` | `true` for IPv6 rules, `false` for IPv4 (split into two policies on the DPU) |
+| `protocol` | `Any`, `Icmp`, `Icmp6`, `Udp`, `Tcp` |
+| `src_net` / `dst_net` | A CIDR prefix (the wire model is `NetworkSecurityGroupRuleNet::Prefix(IpNetwork)`) |
+| `src_port_start` / `src_port_end` | Optional inclusive source port range |
+| `dst_port_start` / `dst_port_end` | Optional inclusive destination port range |
+| `action` | `Permit` or `Deny` |
+| `priority` | Integer; lower numbers evaluated first inside a policy |
+
+Rules are evaluated in priority order. The first matching `Permit` or
+`Deny` decides the packet; there is no implicit fall-through behaviour
+between rules of the same NSG.
+
+---
+
+## Attaching an NSG
+
+NSGs attach at exactly two scopes:
+
+- **VPC scope.** Set `network_security_group_id` on the VPC by updating it
+  (REST `PATCH …/nico/vpc`, or `nicocli vpc update`). Every instance that has
+  interfaces in this VPC inherits the NSG's rules.
+- **Instance scope.** Set `network_security_group_id` on the instance by
+  updating it (REST `PATCH …/nico/instance`, or `nicocli instance update`).
+  The instance NSG **replaces** the VPC NSG for that instance. Instance-scope
+  NSGs are not merged with VPC-scope NSGs; the instance-scope NSG wins
+  outright.
+
+An NSG can be referenced by multiple VPCs and multiple instances
+concurrently. The NSG object itself does not list its references — the
+attachment lives on the referencing side, as `networkSecurityGroupId` on
+each VPC or instance. To find what an NSG is attached to, inspect the VPCs
+and instances (their `networkSecurityGroupPropagationDetails` also report
+rollout state — see [How NSG Changes Propagate](#how-nsg-changes-propagate)).
+
+### Deletion
+
+`nicocli network-security-group delete` (REST `DELETE …/nico/network-security-group/{id}`)
+succeeds only when the NSG is not referenced by any VPC or instance. The
+expected workflow is:
+
+1. Detach the NSG from any VPCs (`nicocli vpc update` with the field cleared).
+2. Detach the NSG from any instances (`nicocli instance update`).
+3. Wait for the NSG's propagation status to clear for those objects (see
+   [How NSG Changes Propagate](#how-nsg-changes-propagate)).
+4. Delete the NSG.
+
+---
+
+## How NSG Changes Propagate
+
+NSG propagation is tracked **differently** from the other network fabrics.
+For VRF / segment / routing changes, convergence is reflected in the
+instance's `configs_synced.ethernet` field, which gates the instance's
+`Ready` state. **NSGs do not work that way.** Read this section before
+relying on any readiness signal to confirm an NSG change has taken effect.
+
+### Attaching or detaching an NSG
+
+There are two attachment scopes, and they interact with the instance config
+version differently:
+
+- **Instance scope.** `network_security_group_id` is part of the instance's
+  versioned configuration, so attaching or detaching an NSG directly on an
+  instance **bumps that instance's `config_version`**.
+- **VPC scope.** The instance inherits the VPC's NSG (the instance reports
+  `networkSecurityGroupInherited = true`) without the NSG id appearing in
+  the instance's own config. A VPC-scope attach or detach therefore does
+  **not** change the inheriting instances' `config_version`.
+
+In neither case does NSG attachment feed `configs_synced.ethernet` or the
+instance's `Ready` state. Even at instance scope — where the config version
+does bump — the actual application of the rules on the DPU is reported
+through the NSG's own propagation status, not through the config-sync
+machinery.
+
+### Updating an NSG's rules
+
+Editing the rules of an NSG that is already attached bumps only the **NSG's
+own `version`**. It does **not** bump any instance's `config_version` and
+does **not** change any instance's `configs_synced`. The only place the
+rollout is visible is the **NSG propagation status**: each attached DPU
+observes that the NSG version applied on its interfaces is older than the
+NSG version now on the VPC / instance, and that mismatch is what the
+propagation status reflects until the new rules are applied.
+
+### Where propagation status lives
+
+Propagation is exposed per attached object on the VPC and Instance
+resources as `networkSecurityGroupPropagationDetails`, with:
+
+- `status` — `Synchronizing`, `Synchronized`, or `Error`.
+- `detailedStatus` — `None`, `Partial`, `Full`, `Unknown`, or `Error`
+  (how many of the expected interfaces have applied the current NSG version).
+- `unpropagatedInstanceIds` — instances that have not yet applied the
+  current version; the set to watch during a rollout.
+
+NICo computes this on read by comparing the NSG id and version on the
+VPC / instance against what each DPU reports observing on its interfaces.
+There is no separate "NSG synced" flag on the instance; the propagation
+detail is the authoritative signal.
+
+---
+
+## DPU Enforcement
+
+NSG rules are resolved on the API server and pushed to the DPU as part of
+the per-interface configuration response, alongside the VRF, segment, and
+routing-profile data described in
+[VPC Network Virtualization](../vpc/vpc_network_virtualization.md). The DPU
+agent materialises them into NVUE ACLs.
+
+The DPU receives, per interface:
+
+- The resolved rule set (already expanded across port and prefix ranges).
+- A `source` tag (`NSG_SOURCE_NONE`, `NSG_SOURCE_VPC`, or
+  `NSG_SOURCE_INSTANCE`) indicating which scope produced the rules.
+- The `stateful_egress` flag.
+- The NSG `id` and `version`, used by the propagation-status reporting.
+
+The agent renders IPv4 and IPv6 rules into separate NVUE policies and
+combines ingress and egress rules into the appropriate direction. Site-wide
+operator overrides (see below) are rendered into a **separate policy** that
+the DPU evaluates **before** any tenant policy.
+
+---
+
+## Site-Level Operator Configuration
+
+The operator controls three site-wide knobs that affect NSG behaviour.
+These live in the API server configuration file under
+`[network_security_group]`:
+
+```toml
+[network_security_group]
+# Hard cap on the number of expanded rules per NSG.
+# Expansion = src port range × dst port range × src prefix list × dst prefix list.
+max_network_security_group_size = 200
+
+# Master switch for stateful (reflexive) ACL support.
+# Leave disabled until every DPU in the site is running HBN 2.3 or later.
+stateful_acls_enabled = false
+
+# Site-wide override rules. Inserted into a separate policy on the DPU
+# that is evaluated AFTER deny_prefixes but BEFORE any tenant NSG rules.
+# A tenant cannot disable or contradict these.
+policy_overrides = []
+```
+
+### `max_network_security_group_size`
+
+NICo expands rule entries before pushing them to the DPU (the cartesian
+product of source ports × destination ports × source prefixes × destination
+prefixes). This cap is the operator's protection against a tenant
+accidentally requesting a vast rule set. The DPU agent also enforces its
+own ceiling, on the order of 10,000 expanded rules, as a final safeguard.
+
+A tenant whose NSG would expand beyond this limit receives an error when
+creating or updating the NSG. Tune this
+value if tenants legitimately need larger rule sets; do not raise it
+unilaterally without coordinating with whatever ceiling is configured on
+the DPU side.
+
+### `stateful_acls_enabled`
+
+Toggling this flag controls whether NICo will configure the DPU's default
+stateful-ACL options in the NVUE config it pushes. Stateful NSG behaviour
+also requires the tenant to set `stateful_egress = true` on the NSG;
+without the site-level switch, the DPU treats every rule as stateless
+regardless of the per-NSG flag.
+
+Leave `stateful_acls_enabled = false` until every DPU in the site is
+running HBN 2.3 or later. Earlier HBN versions implement reflexive ACLs in
+a way that lets a single rule permit traffic in both directions, which is
+operationally unsafe.
+
+### `policy_overrides`
+
+`policy_overrides` is a list of `NetworkSecurityGroupRule` entries (same
+shape as tenant rules) that the operator wishes to enforce site-wide.
+
+These rules are inserted into a **separate policy** on the DPU, evaluated:
+
+1. **After** `deny_prefixes` (the absolute site denylist).
+2. **Before** any tenant-defined NSG rules.
+
+This ordering gives the operator a reliable place to:
+
+- Force-permit infrastructure flows (for example, package mirrors,
+  telemetry collectors, time servers) that every tenant must be able to
+  reach, without depending on each tenant putting them in their own NSG.
+- Force-deny baselines that every tenant must obey, regardless of what
+  their own NSGs say. A tenant cannot write a `Permit` rule that
+  contradicts an operator override, because the override is evaluated
+  first and decides the packet.
+
+Each entry follows the same JSON / TOML structure as a tenant rule. A
+worked example:
+
+```toml
+[network_security_group]
+stateful_acls_enabled = false
+max_network_security_group_size = 200
+
+  [[network_security_group.policy_overrides]]
+  direction = "Egress"
+  ipv6 = false
+  protocol = "Udp"
+  dst_net = "10.0.5.0/24"          # site-controller VIPs
+  dst_port_start = 123
+  dst_port_end = 123
+  action = "Permit"
+  priority = 10
+
+  [[network_security_group.policy_overrides]]
+  direction = "Egress"
+  ipv6 = false
+  protocol = "Tcp"
+  dst_net = "0.0.0.0/0"
+  dst_port_start = 22
+  dst_port_end = 22
+  action = "Deny"
+  priority = 20
+```
+
+Changing `policy_overrides` requires restarting the API server (it is a
+static configuration field, not a runtime-mutable RPC). After restart, the
+new override set propagates to every DPU as part of the next
+configuration-poll cycle.
+
+---
+
+## Quarantine and Forced Override
+
+When a managed host is placed into a quarantine lifecycle state, NICo
+substitutes a quarantine-specific override policy in place of
+`policy_overrides`. The intent is to give an operator a way to constrain
+traffic from a host that is under investigation without having to detach
+it from its tenant VPCs first. This is internal behaviour and is not
+operator-configurable; quarantine is driven by the machine lifecycle and
+health-alert subsystem.
+
+---
+
+## Current Limitations
+
+The NSG feature is in production use, but the following limitations are
+worth knowing before designing rule sets:
+
+- **Rule `src_net` / `dst_net` accept CIDR prefixes only.** The model has
+  a structural extension point for VPC references (so that a tenant could
+  say "permit from any instance in VPC X"), but VPC-reference resolution
+  is not yet implemented. Use explicit CIDRs.
+- **IPv4 and IPv6 are separate rules.** A rule has an `ipv6` boolean and
+  applies only to one address family; if a tenant needs both, two rules
+  are required.
+- **`stateful_egress` requires the site flag.** A tenant may set
+  `stateful_egress = true` on the NSG, but it has no effect until the
+  site-level `stateful_acls_enabled = true`.
+- **Updates require version-token agreement.** An NSG update takes the
+  NSG's `version` and fails if it has been concurrently modified. This is
+  the standard NICo optimistic-concurrency pattern.
+
+---
+
+## Configuration Workflow
+
+The site operator's NSG configuration is normally done once and rarely
+changed; the tenant flow is what runs day-to-day.
+
+### Operator (once per site)
+
+1. Confirm the HBN version on every DPU in the site. If any DPU is on a
+   version earlier than HBN 2.3, leave `stateful_acls_enabled = false`.
+2. Decide the rule-size budget per NSG and set
+   `max_network_security_group_size` accordingly.
+3. Decide what baseline traffic must be permitted (telemetry, NTP, package
+   mirrors) and what baseline must be denied (operator-defined denylist
+   that goes beyond `deny_prefixes`). Encode these as
+   `policy_overrides`.
+4. Restart the API server.
+
+### Tenant (per NSG)
+
+All tenant steps use the REST API or `nicocli`; none require TOML or
+`nico-admin-cli`.
+
+1. `nicocli network-security-group create` (REST `POST …/nico/network-security-group`)
+   with the desired rule set. The response includes the NSG `id` and `version`.
+2. Attach the NSG at VPC scope (`nicocli vpc update`) or instance scope
+   (`nicocli instance update`).
+3. Wait for the NSG **propagation status** on the VPC / instance to reach
+   `Synchronized` (`detailedStatus: Full`). Do **not** wait on
+   `configs_synced.ethernet` — NSG rollout is not reported there. See
+   [How NSG Changes Propagate](#how-nsg-changes-propagate).
+
+Updates use `nicocli network-security-group update` with the current `version`
+token. Deletion uses `nicocli network-security-group delete` after detaching
+every reference.
+
+---
+
+## Verification
+
+For a given tenant configuration, confirm:
+
+1. **NSG exists and is the expected version.**
+   `nicocli network-security-group get <id>` (REST
+   `GET …/nico/network-security-group/{id}`) shows the rules,
+   `stateful_egress`, and current `version`.
+2. **The NSG is attached where intended.** Check the
+   `networkSecurityGroupPropagationDetails` on each VPC and instance
+   (`nicocli vpc get <id>` / `nicocli instance get <id>`); each lists the
+   attached `networkSecurityGroupId` and, for instances, whether it is
+   inherited from the VPC (`networkSecurityGroupInherited`).
+3. **Propagation has converged.** On those same objects,
+   `networkSecurityGroupPropagationDetails.status` reads `Synchronized` with
+   `detailedStatus: Full`, and `unpropagatedInstanceIds` is empty. While the
+   rollout is in flight the status is `Synchronizing`. Note this is a
+   **separate** signal from `configs_synced.ethernet`, which NSG changes do
+   not affect.
+4. **Operator overrides are present site-wide.** On any active DPU,
+   inspect the running NVUE ACL configuration; the override policy is
+   distinct from the tenant policy and contains the rules listed in the
+   API server's `policy_overrides`. A discrepancy means the API server
+   was not restarted after the configuration change.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `network-security-group create` fails with size-limit error | Expanded rule count exceeds `max_network_security_group_size` |
+| Stateful return traffic is being dropped | `stateful_acls_enabled = false` site-wide, or `stateful_egress = false` on the NSG, or DPU on HBN earlier than 2.3 |
+| Tenant rule that "should permit" a flow has no effect | An operator `policy_overrides` rule denies the same flow at higher (earlier-evaluated) priority |
+| Two instances in the same VPC cannot reach each other on a permitted port | NSG attached only to one side, or the NSG attached at instance scope overrides the VPC-scope NSG |
+| `network-security-group delete` fails | At least one VPC or instance still sets this NSG as its `networkSecurityGroupId`; detach on those objects first |
+| Site-wide override change does not take effect | API server was not restarted after editing `policy_overrides` |
+| NSG rule change made, but `configs_synced.ethernet` / instance `Ready` never reacted | Expected: NSG changes do not feed `configs_synced`. Track rollout via `networkSecurityGroupPropagationDetails` instead |
+| NSG propagation status stuck `Synchronizing` (`unpropagatedInstanceIds` non-empty) | DPUs on the listed instances have not yet applied the current NSG version; check DPU health and the per-interface config push |
+| NSG propagation status `Error` | A DPU rejected the rule set (for example, expanded size over the DPU ceiling); inspect the propagation `details` string |

--- a/docs/manuals/nvlink_partitioning.md
+++ b/docs/manuals/nvlink_partitioning.md
@@ -13,6 +13,30 @@ NICo extends the concept of an *NVLink Partition* with the *NVLink Logical Parti
 
 > **Note**: NVLink Partitioning is only supported for GB200 compute nodes.
 
+## Operations: Who Does What
+
+NVLink splits between operator site setup against NMX-M / NMX-C and tenant
+partition management. Notably, several operator steps (NMX-C endpoint
+registration, the GPU-mapping populate step) are **not exposed via the REST
+API** and are therefore driven through `nico-admin-cli` over gRPC. See
+[Network Isolation → Who configures what, and how](network_isolation.md#who-configures-what-and-how)
+for the role and interface model.
+
+| Task | Role | Interface |
+|---|---|---|
+| Enable NVLink; NMX-M / NMX-C connection and TLS settings | Operator | **TOML** (`[nvlink_config]`) — Day 0 / rare |
+| NMX-M credentials | Operator | `nico-admin-cli credential add-nmx-m` (gRPC) — not in REST |
+| NMX-C endpoints (per chassis serial) | Operator | `nico-admin-cli nvlink-nmxc-endpoints …` (gRPC) — not in REST |
+| Populate the machine → NMX-M GPU mapping | Operator | `nico-admin-cli nvlink-info populate` (gRPC) — not in REST |
+| Create / update / delete an NVLink Logical Partition | Tenant | **REST** `…/nico/nvlink-logical-partition` · `nicocli nvlink-logical-partition create` |
+| Assign or change an instance's GPUs' partition | Tenant | **REST** `…/nico/instance` (`nvLinkInterfaces`) · `nicocli instance update` |
+| Inspect a machine's GPU domain placement (triage) | Operator | `nico-admin-cli machine nvlink-info` (gRPC) |
+
+The operator NMX setup (the first four rows) is detailed under
+[Enabling NMX-C-based NVLink Partitioning](#enabling-nmx-c-based-nvlink-partitioning)
+and [Enabling NMX-M-based NVLink Partitioning](#enabling-nmx-m-based-nvlink-partitioning).
+The tenant rows are the REST / `nicocli` flow described next.
+
 ### Creating a NVLink Logical Partition
 
 NICo users can create NVLink Logical Partitions and plan GPU assignments using NVLink Interfaces for Instances (as described in steps **1-2**). NICo can also automatically generate NVLink Interfaces and assign them to Instances (as described in step **3**).
@@ -84,6 +108,115 @@ If you want finer control, leave `nvLinkLogicalPartitionId` unset on the VPC and
 | VPC doesn't have `nvLinkLogicalPartitionId` set, Instance specifies `nvLinkInterfaces` | Per-GPU NVLink Logical Partition assignments are used |
 | Same `nvLinkLogicalPartitionId` on multiple VPCs | Allowed — no implicit exclusivity |
 
+### How NICo Reconciles NVLink State
+
+NICo runs a periodic reconciler against NMX-M and NMX-C to keep the actual
+NVLink partition topology aligned with the desired state implied by tenant
+instance configurations. The behaviour matters whenever an operator is
+diagnosing latency between an API call and an instance becoming `Ready`.
+
+Each reconciliation pass does the following:
+
+1. Loads every NVLink Logical Partition and every NVLink Physical Partition
+   from the NICo database.
+2. Queries each configured NMX-M and / or NMX-C endpoint for the current
+   partition list and GPU membership on that endpoint's chassis or domain.
+3. Compares observed state against desired state.
+4. Issues create / update / remove operations to the fabric-management
+   service to converge it onto desired state.
+5. Updates per-machine GPU status observations in the NICo database. The
+   per-instance `configs_synced.nvlink` field is derived from these
+   observations and is what gates the instance's `Ready` state.
+
+Cadence is set by `nvlink_config.monitor_run_interval` (default `60s`).
+
+The reconciler exposes metrics under the
+`nico_nvlink_partition_monitor_*` namespace. Useful ones:
+
+| Metric | Use |
+|---|---|
+| `nico_nvlink_partition_monitor_iteration_latency` | Time per reconcile pass |
+| `nico_nvlink_partition_monitor_nmxc_op_latency` | Per-operation latency against NMX-C |
+| `nico_nvlink_partition_monitor_nmxc_changes_applied` | Counter of changes issued; nonzero in steady state is an anomaly |
+| `nico_nvlink_partition_monitor_nmxc_connect_error_count` | Connection failures to any NMX-C endpoint |
+| `nico_nvlink_partition_monitor_nmxm_connect_error_count` | Connection failures to NMX-M |
+| `nico_nvlink_partition_monitor_num_logical_partitions` | Logical-partition count NICo is tracking |
+| `nico_nvlink_partition_monitor_num_physical_partitions` | Physical-partition count NICo is tracking |
+| `nico_nvlink_partition_monitor_nmxc_partition_count` | Partition count NMX-C reports |
+| `nico_nvlink_partition_monitor_nmxc_gpu_count` | GPU count NMX-C reports across managed partitions |
+
+### Instance Release and Logical Partition Deletion
+
+When an instance is released (via `ReleaseInstance`):
+
+1. The instance's NVLink configuration is cleared from the database.
+2. The reconciler observes that GPUs previously assigned to the instance
+   are no longer requested in any live partition.
+3. The reconciler removes those GPUs from their NMX-M / NMX-C partitions.
+4. Once all NVLink state is removed, the machine's GPU status observation
+   reflects an empty domain assignment and the host becomes eligible for
+   reuse.
+
+When a Logical Partition is deleted, every underlying NVLink Physical
+Partition on each NMX-M / NMX-C endpoint backing it is also deleted. The
+deletion is rejected if any instance still references the Logical
+Partition.
+
+When a host is force-deleted, the instance running on it is implicitly
+released and the above cleanup path runs. Operators do not need to detach
+NVLink configuration manually before force-deleting.
+
+### Enabling NMX-C-based NVLink Partitioning
+
+NMX-C is the gRPC control path for NVLink partition management and is the
+current default for new deployments. NMX-M remains supported and is
+covered in the next section; the two are not mutually exclusive and a
+single site may use both.
+
+The TOML toggles live alongside the NMX-M ones under `[nvlink_config]`:
+
+```toml
+[nvlink_config]
+enabled = true
+monitor_run_interval = "60s"
+
+# Optional TLS material for NMX-C. Leave unset to use the system trust
+# store and present no client certificate.
+nmx_c_tls_ca_cert_path     = "/etc/nico/nmxc/ca.pem"
+nmx_c_tls_client_cert_path = "/etc/nico/nmxc/client.crt"
+nmx_c_tls_client_key_path  = "/etc/nico/nmxc/client.key"
+nmx_c_tls_authority        = "nmxc.example.internal"
+
+allow_insecure = false
+```
+
+| Field | Purpose |
+|---|---|
+| `nmx_c_tls_ca_cert_path` | Optional PEM containing additional CAs for verifying the NMX-C endpoint's certificate |
+| `nmx_c_tls_client_cert_path` | Optional client certificate for mTLS to NMX-C |
+| `nmx_c_tls_client_key_path` | Optional client key matching the certificate above |
+| `nmx_c_tls_authority` | Optional override for the expected server name during certificate verification (SNI / hostname check) |
+| `allow_insecure` | When `true`, disables TLS verification entirely. Intended for development |
+
+Unlike NMX-M, where a single endpoint URL is set in TOML, NMX-C endpoints
+are **per-chassis** and stored in the NICo database. Register them with
+`nico-admin-cli`, keyed by the chassis serial:
+
+```bash
+nico-admin-cli nvlink-nmxc-endpoints create \
+    --chassis-serial <serial> \
+    --endpoint https://nmxc-host:443
+
+nico-admin-cli nvlink-nmxc-endpoints show
+```
+
+`update` and `delete` subcommands follow the same pattern. The reconciler
+picks up new endpoints on the next iteration; no restart is required.
+
+The TLS material in TOML applies uniformly to every NMX-C endpoint NICo
+talks to. Per-endpoint credential overrides are not currently supported;
+deploy a uniform trust posture across the site's NMX-C control plane.
+
 ### Enabling NMX-M-based NVLink Partitioning
 
 This section describes how to enable NVLink support via the [NMX-M platform](https://docs.nvidia.com/networking/display/nmxmv8513000).
@@ -133,3 +266,42 @@ This section describes how to enable NVLink support via the [NMX-M platform](htt
     * nico-core logs should not show "Failed to create NMXM client".
     * Logs should not show failures getting NMX-M partitions or GPU list.
     * Metrics show that `nico_nvlink_partition_monitor_nmxm_connect_error_count` is `0`.
+
+### Verifying a Tenant's NVLink Placement
+
+After an instance has been created and the reconciler has had at least one
+opportunity to run, an operator can confirm correct placement with the
+following checks. There is no single all-in-one health command; the steps
+below should be repeatable as a checklist.
+
+1. **Reconciler is running.**
+   `nico_nvlink_partition_monitor_iteration_latency` is being recorded
+   and both `nico_nvlink_partition_monitor_nmxc_connect_error_count`
+   and `nico_nvlink_partition_monitor_nmxm_connect_error_count` are
+   flat.
+2. **Logical-partition count matches expectation.**
+   `nico_nvlink_partition_monitor_num_logical_partitions` reflects
+   the partitions a site planner expects to exist. A sudden change is
+   worth correlating with recent tenant API activity.
+3. **Per-instance configuration has converged.** The instance's
+   `InstanceStatus` reports `configs_synced.nvlink = true` and the
+   `nvLinkInterfaces` list on the instance shows the expected
+   `nvLinkLogicalPartitionId` and `nvLinkDomainId` for each GPU.
+4. **Per-machine GPU placement.**
+
+    ```
+    nicocli machine nvlink-info --machine-id <machine-id>
+    ```
+
+    Returns the machine's NVLink GPU status observations, including the
+    Domain each GPU is currently assigned to. Use this to confirm that
+    two instances expected to share an NVLink Logical Partition have
+    actually landed in the same NVLink Domain — instances in different
+    Domains cannot share GPU memory regardless of having the same
+    Logical Partition ID.
+5. **Cleanup after release.** After releasing an instance, the same
+   `machine nvlink-info` output should show an empty Domain assignment
+   on the affected GPUs within one or two reconcile intervals. Failure
+   to clear indicates the reconciler could not remove the GPU from its
+   NMX-M / NMX-C partition; investigate the corresponding connect-error
+   and op-latency metrics.

--- a/docs/manuals/vpc/vpc_network_virtualization.md
+++ b/docs/manuals/vpc/vpc_network_virtualization.md
@@ -130,6 +130,58 @@ the instance as ready only after the DPU confirms the configuration has been app
 
 ---
 
+## Default Isolation: The Admin Overlay
+
+NICo guarantees that a managed host never carries tenant traffic unless an explicit tenant
+configuration places it into a VPC. A "default VPC" in the cloud-provider sense — a system-created
+VPC that every tenant inherits — does not exist. Tenants get the VPCs an operator (or the tenant
+API) creates for them; absent any such VPC, an instance has no place to send tenant traffic.
+
+The guarantee is upheld by an **admin overlay** that is separate from every tenant VPC, and by a
+fail-closed default when no configuration is available at all.
+
+### The admin VPC and admin segments
+
+During site initialisation NICo creates an admin VPC together with a set of admin network
+segments. These are not tenant-visible and exist only to give the DPU somewhere safe to attach a
+host before, between, and after tenant allocations. The admin VPC follows the same VPC / VRF
+mechanics as any tenant VPC — it has its own VRF on each DPU, its own VNI, and its own routing
+profile — but it is reserved for NICo's own use.
+
+### `use_admin_network`
+
+When the API server assembles `ManagedHostNetworkConfig` for a DPU, it sets
+`use_admin_network = true` whenever any of the following hold:
+
+- The host has no instance allocated.
+- The instance has no interfaces configured for this DPU.
+- The host is in a transient lifecycle state (provisioning, repair, termination) in which tenant
+  traffic must not flow.
+
+With `use_admin_network = true` the DPU agent places every host interface into the admin VRF
+instead of any tenant VPC's VRF. From the wire's perspective, the host is on the admin overlay
+and cannot exchange traffic with any tenant instance.
+
+### Isolated mode (fail-closed)
+
+A DPU that cannot retrieve its configuration at all — for example, because the host is unknown to
+NICo and `GetManagedHostNetworkConfig` returns `NOT_FOUND` — places itself into **isolated
+mode**: every host interface is detached from any overlay until NICo issues an explicit
+configuration. This is the fail-closed default. Nothing in the data path silently falls back to a
+tenant network.
+
+### Termination guard
+
+The instance state machine blocks the termination flow until the DPU confirms that all tenant
+interfaces have been moved off tenant VPCs and onto the admin overlay (or that the machine has
+been tagged with a health alert preventing reuse). This is what guarantees that a tenant whose
+instance has been released cannot remain on the wire as a "ghost instance" pending disk wipe.
+
+For the per-fabric isolation story across Ethernet, InfiniBand, and NVLink, see
+[Network Isolation](../network_isolation.md).
+
+---
+
 ## Intra-VPC Connectivity
 
 Instances in the same VPC communicate via the VPC VRF on each DPU. No operator configuration


### PR DESCRIPTION
## Description
Introduces requested docs related to network-isolation along with IB partition and security group management.

I tried to lightly highlight where the split is between tenant operations and admin operations.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

