### PR TITLE
Disable default features for rumqttc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9188,12 +9188,8 @@ dependencies = [
  "flume",
  "futures-util",
  "log",
- "rustls-native-certs",
- "rustls-pemfile",
- "rustls-webpki 0.102.8",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rustls",
  "tokio-stream",
  "tokio-util",
 ]
@@ -9430,7 +9426,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -9480,7 +9476,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -9492,17 +9488,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ resolv-conf = "0.7.0"
 ringbuf = "0.5.0"
 rsa = "0.9.9"
 rtnetlink = "0.21"
-rumqttc = "0.25"
+rumqttc = { default-features = false, version = "0.25" }
 russh = "0.60.2"
 rustc-hash = "2.1.1"
 rustls-pemfile = "2.2.0"


### PR DESCRIPTION
## Description
Including default features gives us an older version of the rustls-webpki crate, which is triggering a dependabot warning. (The upstream crate hasn't updated its rustls version yet.)

We don't end up needing that feature from the crate anyway, so excluding it removes our dependency on the vulnerable rustls version.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://github.com/NVIDIA/infra-controller/security/dependabot/59
https://github.com/NVIDIA/infra-controller/security/dependabot/60
https://github.com/NVIDIA/infra-controller/security/dependabot/39
https://github.com/NVIDIA/infra-controller/security/dependabot/38
https://github.com/NVIDIA/infra-controller/security/dependabot/49
https://github.com/NVIDIA/infra-controller/security/dependabot/48
https://github.com/NVIDIA/infra-controller/security/dependabot/47
https://github.com/NVIDIA/infra-controller/security/dependabot/46


## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes

