### PR TITLE
refactor(api): prepare machine state controller extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,6 +1201,7 @@ dependencies = [
  "carbide-spdm-controller",
  "carbide-sqlx-testing",
  "carbide-ssh",
+ "carbide-state-controller-common",
  "carbide-switch-controller",
  "carbide-tls",
  "carbide-utils",
@@ -2786,6 +2787,16 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "carbide-state-controller-common"
+version = "0.0.0"
+dependencies = [
+ "carbide-utils",
+ "duration-str",
+ "serde",
+ "state-controller",
 ]
 
 [[package]]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -54,6 +54,7 @@ carbide-redfish = { path = "../redfish" }
 carbide-network-segment-controller = { path = "../network-segment-controller" }
 carbide-site-explorer = { path = "../site-explorer" }
 carbide-spdm-controller = { path = "../spdm-controller" }
+carbide-state-controller-common = { path = "../state-controller-common" }
 carbide-switch-controller = { path = "../switch-controller" }
 carbide-preingestion-manager = { path = "../preingestion-manager" }
 carbide-nvlink-manager = { path = "../nvlink-manager" }

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -27,6 +27,7 @@ use carbide_ib_fabric::config::{IBFabricConfig, IbFabricDefinition};
 use carbide_nvlink_manager::config::NvLinkConfig;
 use carbide_preingestion_manager::PreingestionManagerConfig;
 use carbide_site_explorer::config::SiteExplorerConfig;
+use carbide_state_controller_common::config::StateControllerConfig;
 use carbide_utils::config::{as_duration, as_std_duration};
 use chrono::Duration;
 use duration_str::{deserialize_duration, deserialize_duration_chrono};
@@ -49,7 +50,11 @@ use model::tenant::identity_config::SigningAlgorithm;
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::state_controller::config::IterationConfig;
+use crate::state_controller::machine::config::power_manager::default_power_options;
+use crate::state_controller::machine::config::{
+    BomValidationConfig, FirmwareGlobal, MachineStateControllerConfig,
+    MachineStateHandlerSiteConfig, PowerManagerOptions,
+};
 use crate::state_controller::rack::config::{RackValidationConfig, RmsConfig};
 
 static BF2_NIC: &str = "24.47.2682";
@@ -641,6 +646,27 @@ pub struct CarbideConfig {
     pub web_ui_sidebar_tools: Vec<ToolLink>,
 }
 
+impl CarbideConfig {
+    pub fn machine_state_handler_site_config(&self) -> MachineStateHandlerSiteConfig {
+        MachineStateHandlerSiteConfig {
+            firmware_global: self.firmware_global.clone(),
+            machine_state_controller: self.machine_state_controller.clone(),
+            host_health: self.host_health,
+
+            selected_profile: self.selected_profile,
+            bios_profiles: self.bios_profiles.clone(),
+            oem_manager_profiles: self.oem_manager_profiles.clone(),
+
+            dpa_enabled: self.is_dpa_enabled(),
+            dpf_enabled: self.dpf.enabled,
+            spdm_enabled: self.spdm.enabled,
+
+            dpu_enable_secure_boot: self.dpu_config.dpu_enable_secure_boot,
+            allow_zero_dpu_hosts: self.site_explorer.allow_zero_dpu_hosts,
+        }
+    }
+}
+
 /// One external tool link rendered in the admin web UI's "Tools"
 /// sidebar.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -900,43 +926,6 @@ pub struct SpdmConfig {
     /// verification.
     #[serde(default)]
     pub nras_config: Option<nras::Config>,
-}
-
-/// Power management configuration controlling retry
-/// intervals and reboot timing.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct PowerManagerOptions {
-    /// Master switch to enable or disable power
-    /// management.
-    #[serde(default)]
-    pub enabled: bool,
-    /// Interval before retrying power operations after
-    /// a successful attempt.
-    /// Default is 5 minutes.
-    #[serde(
-        default = "default_next_duration_success",
-        deserialize_with = "deserialize_duration_chrono",
-        serialize_with = "as_duration"
-    )]
-    pub next_try_duration_on_success: chrono::TimeDelta,
-    /// Interval before retrying power operations after
-    /// a failed attempt.
-    /// Default is 2 minutes.
-    #[serde(
-        default = "default_next_duration_failure",
-        deserialize_with = "deserialize_duration_chrono",
-        serialize_with = "as_duration"
-    )]
-    pub next_try_duration_on_failure: chrono::TimeDelta,
-    /// Time to wait after power-down before powering on
-    /// the host.
-    /// Default is 15 minutes.
-    #[serde(
-        default = "default_wait_duration_next_reboot",
-        deserialize_with = "deserialize_duration_chrono",
-        serialize_with = "as_duration"
-    )]
-    pub wait_duration_until_host_reboot: chrono::TimeDelta,
 }
 
 /// A BGP route target used in FNN VRF import/export policies.
@@ -1321,98 +1310,6 @@ impl MaxConcurrentUpdates {
     }
 }
 
-/// MachineStateController related config.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct MachineStateControllerConfig {
-    /// Common state controller configs
-    #[serde(default = "StateControllerConfig::default")]
-    pub controller: StateControllerConfig,
-
-    /// How long should we wait before a DPU goes down for sure.
-    #[serde(
-        default = "MachineStateControllerConfig::dpu_wait_time_default",
-        deserialize_with = "deserialize_duration_chrono",
-        serialize_with = "as_duration"
-    )]
-    pub dpu_wait_time: Duration,
-    /// How long to wait for after power down before power on the machine.
-    #[serde(
-        default = "MachineStateControllerConfig::power_down_wait_default",
-        deserialize_with = "deserialize_duration_chrono",
-        serialize_with = "as_duration"
-    )]
-    pub power_down_wait: Duration,
-    /// After how much time, state machine should retrigger reboot if machine does not call back.
-    #[serde(
-        default = "MachineStateControllerConfig::failure_retry_time_default",
-        deserialize_with = "deserialize_duration_chrono",
-        serialize_with = "as_duration"
-    )]
-    pub failure_retry_time: Duration,
-    /// How long to wait for a health report from the DPU before we assume it's down
-    #[serde(
-        default = "MachineStateControllerConfig::dpu_up_threshold_default",
-        deserialize_with = "deserialize_duration_chrono",
-        serialize_with = "as_duration"
-    )]
-    pub dpu_up_threshold: Duration,
-    /// Duration after which a host is considered unhealthy if scout hasn't reported back
-    #[serde(
-        default = "MachineStateControllerConfig::scout_reporting_timeout_default",
-        deserialize_with = "deserialize_duration_chrono",
-        serialize_with = "as_duration"
-    )]
-    pub scout_reporting_timeout: Duration,
-    /// How long to wait for UEFI boot to complete after rebooting a host
-    #[serde(
-        default = "MachineStateControllerConfig::uefi_boot_wait_default",
-        deserialize_with = "deserialize_duration_chrono",
-        serialize_with = "as_duration"
-    )]
-    pub uefi_boot_wait: Duration,
-}
-
-impl MachineStateControllerConfig {
-    pub fn dpu_wait_time_default() -> Duration {
-        Duration::minutes(5)
-    }
-
-    pub fn power_down_wait_default() -> Duration {
-        Duration::minutes(2)
-    }
-
-    pub fn failure_retry_time_default() -> Duration {
-        Duration::minutes(90)
-    }
-
-    pub fn dpu_up_threshold_default() -> Duration {
-        Duration::minutes(5)
-    }
-
-    fn scout_reporting_timeout_default() -> Duration {
-        Duration::minutes(5)
-    }
-
-    pub fn uefi_boot_wait_default() -> Duration {
-        Duration::minutes(5)
-    }
-}
-
-impl Default for MachineStateControllerConfig {
-    fn default() -> Self {
-        Self {
-            controller: StateControllerConfig::default(),
-            dpu_wait_time: MachineStateControllerConfig::dpu_wait_time_default(),
-            power_down_wait: MachineStateControllerConfig::power_down_wait_default(),
-            failure_retry_time: MachineStateControllerConfig::failure_retry_time_default(),
-            dpu_up_threshold: MachineStateControllerConfig::dpu_up_threshold_default(),
-            scout_reporting_timeout: MachineStateControllerConfig::scout_reporting_timeout_default(
-            ),
-            uefi_boot_wait: MachineStateControllerConfig::uefi_boot_wait_default(),
-        }
-    }
-}
-
 /// NetworkSegmentStateController related config.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct NetworkSegmentStateControllerConfig {
@@ -1492,143 +1389,6 @@ pub struct SpdmStateControllerConfig {
     /// Common state controller configs
     #[serde(default = "StateControllerConfig::default")]
     pub controller: StateControllerConfig,
-}
-
-/// Common StateController configurations
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct StateControllerConfig {
-    /// Configures the desired duration for one state controller iteration
-    ///
-    /// Lower iteration times will make the controller react faster to state changes.
-    /// However they will also increase the load on the system
-    #[serde(
-        default = "StateControllerConfig::iteration_time_default",
-        deserialize_with = "deserialize_duration",
-        serialize_with = "as_std_duration"
-    )]
-    pub iteration_time: std::time::Duration,
-
-    /// Configures the maximum time that the state handler will spend on evaluating
-    /// and advancing the state of a single object. If more time elapses during
-    /// state handling than this timeout allows for, state handling will fail with
-    /// a `TimeoutError`.
-    /// How long to wait for after power down before power on the machine.
-    #[serde(
-        default = "StateControllerConfig::max_object_handling_time_default",
-        deserialize_with = "deserialize_duration",
-        serialize_with = "as_std_duration"
-    )]
-    pub max_object_handling_time: std::time::Duration,
-
-    /// Configures the maximum amount of concurrency for the object state controller
-    ///
-    /// The controller will attempt to advance the state of this amount of objects
-    /// in parallel.
-    #[serde(default = "StateControllerConfig::max_concurrency_default")]
-    pub max_concurrency: usize,
-
-    /// Configures the maximum time the state processor will wait when checking
-    /// for and dispatching new tasks.
-    /// This value needs to be lower than `iteration_time` in order to assure that
-    /// tasks are executed more often than generated.
-    /// If the value is set to 0, the processor will dispatch object handling tasks
-    /// immediately once they are enqueued. The downside of 0 (or low) interval is
-    /// however that the state controller will poll the database for new tasks
-    /// with the same low interval.
-    #[serde(
-        default = "StateControllerConfig::processor_dispatch_interval_default",
-        deserialize_with = "deserialize_duration",
-        serialize_with = "as_std_duration"
-    )]
-    pub processor_dispatch_interval: std::time::Duration,
-
-    /// Configures how often the state handling processor will emit log messages
-    #[serde(
-        default = "StateControllerConfig::processor_log_interval_default",
-        deserialize_with = "deserialize_duration",
-        serialize_with = "as_std_duration"
-    )]
-    pub processor_log_interval: std::time::Duration,
-
-    /// Configures how often the state handling processor will reassess metrics and emit them.
-    /// Calculating aggregate metrics is expensive (all object metrics need to be traversed).
-    /// Therefore this should not happen much more frequently than the observabilty system
-    /// will access them.
-    #[serde(
-        default = "StateControllerConfig::metric_emission_interval",
-        deserialize_with = "deserialize_duration",
-        serialize_with = "as_std_duration"
-    )]
-    pub metric_emission_interval: std::time::Duration,
-
-    /// Configures for how long metrics for each object managed by the state controller
-    /// will show up before they get evicted.
-    /// The duration of this needs to be longer than the time between state handler
-    /// invocations for the object
-    #[serde(
-        default = "StateControllerConfig::metric_hold_time",
-        deserialize_with = "deserialize_duration",
-        serialize_with = "as_std_duration"
-    )]
-    pub metric_hold_time: std::time::Duration,
-}
-
-impl StateControllerConfig {
-    pub const fn max_object_handling_time_default() -> std::time::Duration {
-        std::time::Duration::from_secs(3 * 60)
-    }
-
-    pub const fn iteration_time_default() -> std::time::Duration {
-        std::time::Duration::from_secs(30)
-    }
-
-    pub const fn processor_dispatch_interval_default() -> std::time::Duration {
-        std::time::Duration::from_secs(2)
-    }
-
-    pub const fn processor_log_interval_default() -> std::time::Duration {
-        std::time::Duration::from_secs(60)
-    }
-
-    pub const fn metric_emission_interval() -> std::time::Duration {
-        std::time::Duration::from_secs(60)
-    }
-
-    pub const fn metric_hold_time() -> std::time::Duration {
-        std::time::Duration::from_secs(5 * 60)
-    }
-
-    pub const fn max_concurrency_default() -> usize {
-        10
-    }
-}
-
-impl Default for StateControllerConfig {
-    fn default() -> Self {
-        Self {
-            iteration_time: Self::iteration_time_default(),
-            max_object_handling_time: Self::max_object_handling_time_default(),
-            processor_dispatch_interval: Self::processor_dispatch_interval_default(),
-            processor_log_interval: Self::processor_log_interval_default(),
-            max_concurrency: Self::max_concurrency_default(),
-            metric_emission_interval: Self::metric_emission_interval(),
-            metric_hold_time: Self::metric_hold_time(),
-        }
-    }
-}
-
-impl From<&StateControllerConfig> for IterationConfig {
-    fn from(config: &StateControllerConfig) -> Self {
-        IterationConfig {
-            iteration_time: config.iteration_time,
-            max_object_handling_time: config.max_object_handling_time,
-            max_concurrency: config.max_concurrency,
-            processor_dispatch_interval: config.processor_dispatch_interval,
-            processor_log_interval: config.processor_log_interval,
-            metric_emission_interval: config.metric_emission_interval,
-            metric_hold_time: config.metric_hold_time,
-        }
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -1975,104 +1735,6 @@ impl Default for NetworkSecurityGroupConfig {
     }
 }
 
-/// Global firmware management settings controlling
-/// update policies, concurrency, and retry behavior.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
-pub struct FirmwareGlobal {
-    /// Enables automatic host firmware updates via the
-    /// background firmware manager.
-    #[serde(default)]
-    pub autoupdate: bool,
-    /// Host model names to force-enable autoupdate on,
-    /// regardless of the global `autoupdate` setting.
-    #[serde(default)]
-    pub host_enable_autoupdate: Vec<String>,
-    /// Host model names to force-disable autoupdate on,
-    /// regardless of the global `autoupdate` setting.
-    #[serde(default)]
-    pub host_disable_autoupdate: Vec<String>,
-    /// Frequency at which the firmware manager checks for
-    /// and applies updates.
-    /// Default is 30 seconds.
-    #[serde(
-        default = "FirmwareGlobal::run_interval_default",
-        deserialize_with = "deserialize_duration_chrono",
-        serialize_with = "as_duration"
-    )]
-    pub run_interval: Duration,
-    /// Maximum concurrent firmware uploads allowed.
-    /// Default is 4.
-    #[serde(default = "FirmwareGlobal::max_uploads_default")]
-    pub max_uploads: usize,
-    /// Maximum concurrent firmware flashing operations
-    /// across all machines.
-    /// Default is 16.
-    #[serde(default = "FirmwareGlobal::concurrency_limit_default")]
-    pub concurrency_limit: usize,
-    /// Local directory where firmware binaries are stored.
-    /// Default is `/opt/carbide/firmware`.
-    #[serde(default = "FirmwareGlobal::firmware_directory_default")]
-    pub firmware_directory: PathBuf,
-    /// Delay before retrying a failed host firmware
-    /// upgrade.
-    /// Default is 60 minutes.
-    #[serde(
-        default = "FirmwareGlobal::host_firmware_upgrade_retry_interval_default",
-        deserialize_with = "deserialize_duration_chrono",
-        serialize_with = "as_duration"
-    )]
-    pub host_firmware_upgrade_retry_interval: Duration,
-    /// Requires manual tagging of instances before
-    /// firmware updates are applied.
-    #[serde(default = "FirmwareGlobal::instance_updates_manual_tagging_default")]
-    pub instance_updates_manual_tagging: bool,
-    /// Disables retry logic after BMC resets during
-    /// firmware operations.
-    #[serde(default)]
-    pub no_reset_retries: bool,
-    /// Delay after GPU reboot before the HGX BMC can be
-    /// accessed again.
-    /// Default is 30 seconds.
-    #[serde(
-        default = "FirmwareGlobal::hgx_bmc_gpu_reboot_delay_default",
-        deserialize_with = "deserialize_duration_chrono",
-        serialize_with = "as_duration"
-    )]
-    pub hgx_bmc_gpu_reboot_delay: Duration,
-    /// Forces all firmware upgrades to require explicit
-    /// administrator approval.
-    #[serde(default)]
-    pub requires_manual_upgrade: bool,
-    #[serde(default = "FirmwareGlobal::max_concurrent_bfb_copies_default")]
-    pub max_concurrent_bfb_copies: usize,
-}
-
-impl FirmwareGlobal {
-    #[cfg(test)]
-    pub fn test_default() -> Self {
-        FirmwareGlobal {
-            autoupdate: true,
-            host_enable_autoupdate: vec![],
-            host_disable_autoupdate: vec![],
-            max_uploads: 4,
-            run_interval: Duration::seconds(5),
-            concurrency_limit: FirmwareGlobal::concurrency_limit_default(),
-            firmware_directory: PathBuf::default(),
-            host_firmware_upgrade_retry_interval: Self::get_retry_interval(),
-            instance_updates_manual_tagging: false,
-            no_reset_retries: false,
-            hgx_bmc_gpu_reboot_delay: FirmwareGlobal::hgx_bmc_gpu_reboot_delay_default(),
-            requires_manual_upgrade: false,
-            max_concurrent_bfb_copies: FirmwareGlobal::max_concurrent_bfb_copies_default(),
-        }
-    }
-
-    #[cfg(test)]
-    pub fn get_retry_interval() -> Duration {
-        Duration::seconds(1)
-    }
-}
-
 /// Configuration for rolling machine updates and
 /// maintenance windows.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
@@ -2096,54 +1758,6 @@ pub struct TimePeriod {
     pub start: chrono::DateTime<chrono::Utc>,
     /// End of the time window (UTC).
     pub end: chrono::DateTime<chrono::Utc>,
-}
-
-impl FirmwareGlobal {
-    pub fn instance_updates_manual_tagging_default() -> bool {
-        true
-    }
-    pub fn run_interval_default() -> Duration {
-        Duration::seconds(30)
-    }
-    pub fn max_uploads_default() -> usize {
-        4
-    }
-    pub fn concurrency_limit_default() -> usize {
-        16
-    }
-    pub fn firmware_directory_default() -> PathBuf {
-        PathBuf::from("/opt/carbide/firmware")
-    }
-    pub fn host_firmware_upgrade_retry_interval_default() -> Duration {
-        Duration::minutes(60)
-    }
-    pub fn hgx_bmc_gpu_reboot_delay_default() -> Duration {
-        Duration::seconds(30)
-    }
-    pub fn max_concurrent_bfb_copies_default() -> usize {
-        10
-    }
-}
-
-impl Default for FirmwareGlobal {
-    fn default() -> FirmwareGlobal {
-        FirmwareGlobal {
-            autoupdate: false,
-            host_enable_autoupdate: vec![],
-            host_disable_autoupdate: vec![],
-            run_interval: FirmwareGlobal::run_interval_default(),
-            max_uploads: FirmwareGlobal::max_uploads_default(),
-            concurrency_limit: FirmwareGlobal::concurrency_limit_default(),
-            firmware_directory: FirmwareGlobal::firmware_directory_default(),
-            host_firmware_upgrade_retry_interval:
-                FirmwareGlobal::host_firmware_upgrade_retry_interval_default(),
-            instance_updates_manual_tagging: false,
-            no_reset_retries: false,
-            hgx_bmc_gpu_reboot_delay: FirmwareGlobal::hgx_bmc_gpu_reboot_delay_default(),
-            requires_manual_upgrade: false,
-            max_concurrent_bfb_copies: FirmwareGlobal::max_concurrent_bfb_copies_default(),
-        }
-    }
 }
 
 pub fn default_max_find_by_ids() -> u32 {
@@ -2172,27 +1786,6 @@ pub fn default_datacenter_asn() -> u32 {
     // identifier.  It's used in pre-FNN sites and in FNN
     // on DPU routes, but we'll transition away from that.
     11414
-}
-
-pub fn default_next_duration_success() -> Duration {
-    Duration::minutes(5)
-}
-
-pub fn default_next_duration_failure() -> Duration {
-    Duration::minutes(2)
-}
-
-pub fn default_wait_duration_next_reboot() -> Duration {
-    Duration::minutes(15)
-}
-
-pub fn default_power_options() -> PowerManagerOptions {
-    PowerManagerOptions {
-        enabled: false,
-        next_try_duration_on_success: default_next_duration_success(),
-        next_try_duration_on_failure: default_next_duration_failure(),
-        wait_duration_until_host_reboot: default_wait_duration_next_reboot(),
-    }
 }
 
 pub fn default_to_true() -> bool {
@@ -2613,54 +2206,6 @@ impl DsxExchangeEventBusConfig {
 
     pub fn default_topic_prefix() -> String {
         "NICO/v1/machine".to_string()
-    }
-}
-
-/// MachineValidation related configuration
-#[derive(Default, Clone, Copy, Debug, Deserialize, Serialize)]
-pub struct BomValidationConfig {
-    /// Whether BOM Validation is enabled
-    #[serde(default)]
-    pub enabled: bool,
-
-    /// Allow machines that do not have a SKU assigned to bypass SKU validation
-    /// When true, machines in WaitingForSkuAssignment state can proceed without a SKU
-    #[serde(default)]
-    pub ignore_unassigned_machines: bool,
-
-    /// Allow machines to stay in Ready state and remain allocatable even when SKU validation fails
-    /// When false (default): Standard mode - validation failures block allocation (machine enters failed state)
-    /// When true: Allow allocation mode - validation still occurs and health reports are recorded, but machines do not transition
-    /// into failed states (SkuVerificationFailed, SkuMissing, WaitingForSkuAssignment) and can proceed to Ready/MachineValidation
-    #[serde(default)]
-    pub allow_allocation_on_validation_failure: bool,
-
-    /// The interval since the last time the state machine attempted
-    /// to find an existing SKU that matches the machine.
-    #[serde(
-        default = "BomValidationConfig::default_bom_validation_interval",
-        deserialize_with = "deserialize_duration",
-        serialize_with = "as_std_duration"
-    )]
-    pub find_match_interval: std::time::Duration,
-
-    /// When a SKU is assigned to a machine, but doesn't exist
-    /// attempt to create a SKU for the machine.  This only
-    /// applies to SKUs assigned via expected machines.
-    #[serde(default)]
-    pub auto_generate_missing_sku: bool,
-    /// The inteveral between attempting to generate a SKU from amachine
-    #[serde(
-        default = "BomValidationConfig::default_bom_validation_interval",
-        deserialize_with = "deserialize_duration",
-        serialize_with = "as_std_duration"
-    )]
-    pub auto_generate_missing_sku_interval: std::time::Duration,
-}
-
-impl BomValidationConfig {
-    const fn default_bom_validation_interval() -> std::time::Duration {
-        std::time::Duration::from_secs(300)
     }
 }
 
@@ -3905,54 +3450,6 @@ num_of_vfs = 127
                 .to_string()
                 .contains("dpu_config.num_of_vfs must be <= 126"),
             "{error}"
-        );
-    }
-
-    #[test]
-    fn test_power_manager_default() {
-        let toml = r#"
-enabled = true
-next_try_duration_on_success = "3m"
-"#;
-
-        let power_config: PowerManagerOptions =
-            Figment::new().merge(Toml::string(toml)).extract().unwrap();
-
-        println!("{power_config:?}");
-        assert!(power_config.enabled);
-        assert_eq!(
-            Duration::minutes(3),
-            power_config.next_try_duration_on_success
-        );
-        assert_eq!(
-            Duration::minutes(2),
-            power_config.next_try_duration_on_failure
-        );
-        assert_eq!(
-            Duration::minutes(15),
-            power_config.wait_duration_until_host_reboot
-        );
-    }
-
-    #[test]
-    fn test_power_manager_default_1() {
-        let toml = r#""#;
-
-        let power_config: PowerManagerOptions =
-            Figment::new().merge(Toml::string(toml)).extract().unwrap();
-
-        assert!(!power_config.enabled);
-        assert_eq!(
-            Duration::minutes(5),
-            power_config.next_try_duration_on_success
-        );
-        assert_eq!(
-            Duration::minutes(2),
-            power_config.next_try_duration_on_failure
-        );
-        assert_eq!(
-            Duration::minutes(15),
-            power_config.wait_duration_until_host_reboot
         );
     }
 

--- a/crates/api/src/setup.rs
+++ b/crates/api/src/setup.rs
@@ -94,6 +94,7 @@ use crate::mqtt_state_change_hook::hook::MqttStateChangeHook;
 use crate::scout_stream::ConnectionRegistry;
 use crate::state_controller::common_services::CommonStateHandlerServices;
 use crate::state_controller::controller::{Enqueuer, StateController};
+use crate::state_controller::machine::context::MachineStateHandlerServices;
 use crate::state_controller::machine::handler::MachineStateHandlerBuilder;
 use crate::state_controller::machine::io::MachineStateControllerIO;
 use crate::state_controller::power_shelf::context::PowerShelfStateHandlerServices;
@@ -1063,7 +1064,19 @@ pub async fn initialize_and_start_controllers<'a>(
         .database(db_pool.clone(), work_lock_manager_handle.clone())
         .meter("carbide_machines", meter.clone())
         .processor_id(state_controller_id.clone())
-        .services(handler_services.clone())
+        .services(
+            MachineStateHandlerServices {
+                db_pool: handler_services.db_pool.clone(),
+                db_reader: handler_services.db_reader.clone(),
+                redfish_client_pool: handler_services.redfish_client_pool.clone(),
+                ipmi_tool: handler_services.ipmi_tool.clone(),
+                site_config: handler_services
+                    .site_config
+                    .machine_state_handler_site_config()
+                    .into(),
+            }
+            .into(),
+        )
         .iteration_config((&carbide_config.machine_state_controller.controller).into())
         .state_handler(Arc::new(
             MachineStateHandlerBuilder::builder()

--- a/crates/api/src/state_controller/common_services.rs
+++ b/crates/api/src/state_controller/common_services.rs
@@ -24,14 +24,11 @@ use carbide_rack::rms_client::SwitchSystemImageRmsClient;
 use carbide_redfish::libredfish::RedfishClientPool;
 use db::db_read::PgPoolReader;
 use forge_secrets::credentials::CredentialManager;
-use libredfish::Redfish;
 use librms::RmsApi;
-use model::machine::Machine;
 use model::resource_pool::common::IbPools;
 use sqlx::PgPool;
 
 use crate::cfg::file::CarbideConfig;
-use crate::state_controller::state_handler::StateHandlerError;
 
 /// Services that are accessible to all statehandlers within carbide-core
 #[derive(Clone)]
@@ -69,16 +66,4 @@ pub struct CommonStateHandlerServices {
 
     /// Credential manager (Vault) for fetching BMC credentials
     pub credential_manager: Arc<dyn CredentialManager>,
-}
-
-impl CommonStateHandlerServices {
-    pub async fn create_redfish_client_from_machine(
-        &self,
-        machine: &Machine,
-    ) -> Result<Box<dyn Redfish>, StateHandlerError> {
-        self.redfish_client_pool
-            .create_client_from_machine(machine, &self.db_pool)
-            .await
-            .map_err(StateHandlerError::from)
-    }
 }

--- a/crates/api/src/state_controller/machine/config/bom_validation.rs
+++ b/crates/api/src/state_controller/machine/config/bom_validation.rs
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_utils::config::as_std_duration;
+use duration_str::deserialize_duration;
+use serde::{Deserialize, Serialize};
+
+/// MachineValidation related configuration
+#[derive(Default, Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct BomValidationConfig {
+    /// Whether BOM Validation is enabled
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Allow machines that do not have a SKU assigned to bypass SKU validation
+    /// When true, machines in WaitingForSkuAssignment state can proceed without a SKU
+    #[serde(default)]
+    pub ignore_unassigned_machines: bool,
+
+    /// Allow machines to stay in Ready state and remain allocatable even when SKU validation fails
+    /// When false (default): Standard mode - validation failures block allocation (machine enters failed state)
+    /// When true: Allow allocation mode - validation still occurs and health reports are recorded, but machines do not transition
+    /// into failed states (SkuVerificationFailed, SkuMissing, WaitingForSkuAssignment) and can proceed to Ready/MachineValidation
+    #[serde(default)]
+    pub allow_allocation_on_validation_failure: bool,
+
+    /// The interval since the last time the state machine attempted
+    /// to find an existing SKU that matches the machine.
+    #[serde(
+        default = "BomValidationConfig::default_bom_validation_interval",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub find_match_interval: std::time::Duration,
+
+    /// When a SKU is assigned to a machine, but doesn't exist
+    /// attempt to create a SKU for the machine.  This only
+    /// applies to SKUs assigned via expected machines.
+    #[serde(default)]
+    pub auto_generate_missing_sku: bool,
+    /// The inteveral between attempting to generate a SKU from amachine
+    #[serde(
+        default = "BomValidationConfig::default_bom_validation_interval",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub auto_generate_missing_sku_interval: std::time::Duration,
+}
+
+impl BomValidationConfig {
+    const fn default_bom_validation_interval() -> std::time::Duration {
+        std::time::Duration::from_secs(300)
+    }
+}

--- a/crates/api/src/state_controller/machine/config/controller.rs
+++ b/crates/api/src/state_controller/machine/config/controller.rs
@@ -1,0 +1,114 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_state_controller_common::config::StateControllerConfig;
+use carbide_utils::config::as_duration;
+use chrono::Duration;
+use duration_str::deserialize_duration_chrono;
+use serde::{Deserialize, Serialize};
+
+/// MachineStateController related config.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct MachineStateControllerConfig {
+    /// Common state controller configs
+    #[serde(default = "StateControllerConfig::default")]
+    pub controller: StateControllerConfig,
+
+    /// How long should we wait before a DPU goes down for sure.
+    #[serde(
+        default = "MachineStateControllerConfig::dpu_wait_time_default",
+        deserialize_with = "deserialize_duration_chrono",
+        serialize_with = "as_duration"
+    )]
+    pub dpu_wait_time: Duration,
+    /// How long to wait for after power down before power on the machine.
+    #[serde(
+        default = "MachineStateControllerConfig::power_down_wait_default",
+        deserialize_with = "deserialize_duration_chrono",
+        serialize_with = "as_duration"
+    )]
+    pub power_down_wait: Duration,
+    /// After how much time, state machine should retrigger reboot if machine does not call back.
+    #[serde(
+        default = "MachineStateControllerConfig::failure_retry_time_default",
+        deserialize_with = "deserialize_duration_chrono",
+        serialize_with = "as_duration"
+    )]
+    pub failure_retry_time: Duration,
+    /// How long to wait for a health report from the DPU before we assume it's down
+    #[serde(
+        default = "MachineStateControllerConfig::dpu_up_threshold_default",
+        deserialize_with = "deserialize_duration_chrono",
+        serialize_with = "as_duration"
+    )]
+    pub dpu_up_threshold: Duration,
+    /// Duration after which a host is considered unhealthy if scout hasn't reported back
+    #[serde(
+        default = "MachineStateControllerConfig::scout_reporting_timeout_default",
+        deserialize_with = "deserialize_duration_chrono",
+        serialize_with = "as_duration"
+    )]
+    pub scout_reporting_timeout: Duration,
+    /// How long to wait for UEFI boot to complete after rebooting a host
+    #[serde(
+        default = "MachineStateControllerConfig::uefi_boot_wait_default",
+        deserialize_with = "deserialize_duration_chrono",
+        serialize_with = "as_duration"
+    )]
+    pub uefi_boot_wait: Duration,
+}
+
+impl MachineStateControllerConfig {
+    pub fn dpu_wait_time_default() -> Duration {
+        Duration::minutes(5)
+    }
+
+    pub fn power_down_wait_default() -> Duration {
+        Duration::minutes(2)
+    }
+
+    pub fn failure_retry_time_default() -> Duration {
+        Duration::minutes(90)
+    }
+
+    pub fn dpu_up_threshold_default() -> Duration {
+        Duration::minutes(5)
+    }
+
+    fn scout_reporting_timeout_default() -> Duration {
+        Duration::minutes(5)
+    }
+
+    pub fn uefi_boot_wait_default() -> Duration {
+        Duration::minutes(5)
+    }
+}
+
+impl Default for MachineStateControllerConfig {
+    fn default() -> Self {
+        Self {
+            controller: StateControllerConfig::default(),
+            dpu_wait_time: MachineStateControllerConfig::dpu_wait_time_default(),
+            power_down_wait: MachineStateControllerConfig::power_down_wait_default(),
+            failure_retry_time: MachineStateControllerConfig::failure_retry_time_default(),
+            dpu_up_threshold: MachineStateControllerConfig::dpu_up_threshold_default(),
+            scout_reporting_timeout: MachineStateControllerConfig::scout_reporting_timeout_default(
+            ),
+            uefi_boot_wait: MachineStateControllerConfig::uefi_boot_wait_default(),
+        }
+    }
+}

--- a/crates/api/src/state_controller/machine/config/firmware_global.rs
+++ b/crates/api/src/state_controller/machine/config/firmware_global.rs
@@ -1,0 +1,169 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::path::PathBuf;
+
+use carbide_utils::config::as_duration;
+use chrono::Duration;
+use duration_str::deserialize_duration_chrono;
+use serde::{Deserialize, Serialize};
+
+/// Global firmware management settings controlling
+/// update policies, concurrency, and retry behavior.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct FirmwareGlobal {
+    /// Enables automatic host firmware updates via the
+    /// background firmware manager.
+    #[serde(default)]
+    pub autoupdate: bool,
+    /// Host model names to force-enable autoupdate on,
+    /// regardless of the global `autoupdate` setting.
+    #[serde(default)]
+    pub host_enable_autoupdate: Vec<String>,
+    /// Host model names to force-disable autoupdate on,
+    /// regardless of the global `autoupdate` setting.
+    #[serde(default)]
+    pub host_disable_autoupdate: Vec<String>,
+    /// Frequency at which the firmware manager checks for
+    /// and applies updates.
+    /// Default is 30 seconds.
+    #[serde(
+        default = "FirmwareGlobal::run_interval_default",
+        deserialize_with = "deserialize_duration_chrono",
+        serialize_with = "as_duration"
+    )]
+    pub run_interval: Duration,
+    /// Maximum concurrent firmware uploads allowed.
+    /// Default is 4.
+    #[serde(default = "FirmwareGlobal::max_uploads_default")]
+    pub max_uploads: usize,
+    /// Maximum concurrent firmware flashing operations
+    /// across all machines.
+    /// Default is 16.
+    #[serde(default = "FirmwareGlobal::concurrency_limit_default")]
+    pub concurrency_limit: usize,
+    /// Local directory where firmware binaries are stored.
+    /// Default is `/opt/carbide/firmware`.
+    #[serde(default = "FirmwareGlobal::firmware_directory_default")]
+    pub firmware_directory: PathBuf,
+    /// Delay before retrying a failed host firmware
+    /// upgrade.
+    /// Default is 60 minutes.
+    #[serde(
+        default = "FirmwareGlobal::host_firmware_upgrade_retry_interval_default",
+        deserialize_with = "deserialize_duration_chrono",
+        serialize_with = "as_duration"
+    )]
+    pub host_firmware_upgrade_retry_interval: Duration,
+    /// Requires manual tagging of instances before
+    /// firmware updates are applied.
+    #[serde(default = "FirmwareGlobal::instance_updates_manual_tagging_default")]
+    pub instance_updates_manual_tagging: bool,
+    /// Disables retry logic after BMC resets during
+    /// firmware operations.
+    #[serde(default)]
+    pub no_reset_retries: bool,
+    /// Delay after GPU reboot before the HGX BMC can be
+    /// accessed again.
+    /// Default is 30 seconds.
+    #[serde(
+        default = "FirmwareGlobal::hgx_bmc_gpu_reboot_delay_default",
+        deserialize_with = "deserialize_duration_chrono",
+        serialize_with = "as_duration"
+    )]
+    pub hgx_bmc_gpu_reboot_delay: Duration,
+    /// Forces all firmware upgrades to require explicit
+    /// administrator approval.
+    #[serde(default)]
+    pub requires_manual_upgrade: bool,
+    #[serde(default = "FirmwareGlobal::max_concurrent_bfb_copies_default")]
+    pub max_concurrent_bfb_copies: usize,
+}
+
+impl FirmwareGlobal {
+    #[cfg(test)]
+    pub fn test_default() -> Self {
+        FirmwareGlobal {
+            autoupdate: true,
+            host_enable_autoupdate: vec![],
+            host_disable_autoupdate: vec![],
+            max_uploads: 4,
+            run_interval: Duration::seconds(5),
+            concurrency_limit: FirmwareGlobal::concurrency_limit_default(),
+            firmware_directory: PathBuf::default(),
+            host_firmware_upgrade_retry_interval: Self::get_retry_interval(),
+            instance_updates_manual_tagging: false,
+            no_reset_retries: false,
+            hgx_bmc_gpu_reboot_delay: FirmwareGlobal::hgx_bmc_gpu_reboot_delay_default(),
+            requires_manual_upgrade: false,
+            max_concurrent_bfb_copies: FirmwareGlobal::max_concurrent_bfb_copies_default(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn get_retry_interval() -> Duration {
+        Duration::seconds(1)
+    }
+}
+
+impl FirmwareGlobal {
+    pub fn instance_updates_manual_tagging_default() -> bool {
+        true
+    }
+    pub fn run_interval_default() -> Duration {
+        Duration::seconds(30)
+    }
+    pub fn max_uploads_default() -> usize {
+        4
+    }
+    pub fn concurrency_limit_default() -> usize {
+        16
+    }
+    pub fn firmware_directory_default() -> PathBuf {
+        PathBuf::from("/opt/carbide/firmware")
+    }
+    pub fn host_firmware_upgrade_retry_interval_default() -> Duration {
+        Duration::minutes(60)
+    }
+    pub fn hgx_bmc_gpu_reboot_delay_default() -> Duration {
+        Duration::seconds(30)
+    }
+    pub fn max_concurrent_bfb_copies_default() -> usize {
+        10
+    }
+}
+
+impl Default for FirmwareGlobal {
+    fn default() -> FirmwareGlobal {
+        FirmwareGlobal {
+            autoupdate: false,
+            host_enable_autoupdate: vec![],
+            host_disable_autoupdate: vec![],
+            run_interval: FirmwareGlobal::run_interval_default(),
+            max_uploads: FirmwareGlobal::max_uploads_default(),
+            concurrency_limit: FirmwareGlobal::concurrency_limit_default(),
+            firmware_directory: FirmwareGlobal::firmware_directory_default(),
+            host_firmware_upgrade_retry_interval:
+                FirmwareGlobal::host_firmware_upgrade_retry_interval_default(),
+            instance_updates_manual_tagging: false,
+            no_reset_retries: false,
+            hgx_bmc_gpu_reboot_delay: FirmwareGlobal::hgx_bmc_gpu_reboot_delay_default(),
+            requires_manual_upgrade: false,
+            max_concurrent_bfb_copies: FirmwareGlobal::max_concurrent_bfb_copies_default(),
+        }
+    }
+}

--- a/crates/api/src/state_controller/machine/config/mod.rs
+++ b/crates/api/src/state_controller/machine/config/mod.rs
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use model::machine::HostHealthConfig;
+
+pub mod bom_validation;
+pub mod controller;
+pub mod firmware_global;
+pub mod power_manager;
+
+pub use bom_validation::BomValidationConfig;
+pub use controller::MachineStateControllerConfig;
+pub use firmware_global::FirmwareGlobal;
+pub use power_manager::PowerManagerOptions;
+
+pub struct MachineStateHandlerSiteConfig {
+    pub firmware_global: FirmwareGlobal,
+    pub machine_state_controller: MachineStateControllerConfig,
+    pub host_health: HostHealthConfig,
+
+    pub selected_profile: libredfish::BiosProfileType,
+    pub bios_profiles: libredfish::BiosProfileVendor,
+    pub oem_manager_profiles: libredfish::BiosProfileVendor,
+
+    pub dpa_enabled: bool,
+    pub dpf_enabled: bool,
+    pub spdm_enabled: bool,
+
+    pub dpu_enable_secure_boot: bool,
+    pub allow_zero_dpu_hosts: bool,
+}

--- a/crates/api/src/state_controller/machine/config/power_manager.rs
+++ b/crates/api/src/state_controller/machine/config/power_manager.rs
@@ -1,0 +1,135 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_utils::config::as_duration;
+use chrono::Duration;
+use duration_str::deserialize_duration_chrono;
+use serde::{Deserialize, Serialize};
+
+/// Power management configuration controlling retry
+/// intervals and reboot timing.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct PowerManagerOptions {
+    /// Master switch to enable or disable power
+    /// management.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Interval before retrying power operations after
+    /// a successful attempt.
+    /// Default is 5 minutes.
+    #[serde(
+        default = "default_next_duration_success",
+        deserialize_with = "deserialize_duration_chrono",
+        serialize_with = "as_duration"
+    )]
+    pub next_try_duration_on_success: chrono::TimeDelta,
+    /// Interval before retrying power operations after
+    /// a failed attempt.
+    /// Default is 2 minutes.
+    #[serde(
+        default = "default_next_duration_failure",
+        deserialize_with = "deserialize_duration_chrono",
+        serialize_with = "as_duration"
+    )]
+    pub next_try_duration_on_failure: chrono::TimeDelta,
+    /// Time to wait after power-down before powering on
+    /// the host.
+    /// Default is 15 minutes.
+    #[serde(
+        default = "default_wait_duration_next_reboot",
+        deserialize_with = "deserialize_duration_chrono",
+        serialize_with = "as_duration"
+    )]
+    pub wait_duration_until_host_reboot: chrono::TimeDelta,
+}
+
+pub fn default_power_options() -> PowerManagerOptions {
+    PowerManagerOptions {
+        enabled: false,
+        next_try_duration_on_success: default_next_duration_success(),
+        next_try_duration_on_failure: default_next_duration_failure(),
+        wait_duration_until_host_reboot: default_wait_duration_next_reboot(),
+    }
+}
+
+pub fn default_next_duration_success() -> Duration {
+    Duration::minutes(5)
+}
+
+pub fn default_next_duration_failure() -> Duration {
+    Duration::minutes(2)
+}
+
+pub fn default_wait_duration_next_reboot() -> Duration {
+    Duration::minutes(15)
+}
+
+#[cfg(test)]
+mod test {
+    use figment::Figment;
+    use figment::providers::{Format, Toml};
+
+    use super::*;
+
+    #[test]
+    fn test_power_manager_default() {
+        let toml = r#"
+enabled = true
+next_try_duration_on_success = "3m"
+"#;
+
+        let power_config: PowerManagerOptions =
+            Figment::new().merge(Toml::string(toml)).extract().unwrap();
+
+        println!("{power_config:?}");
+        assert!(power_config.enabled);
+        assert_eq!(
+            Duration::minutes(3),
+            power_config.next_try_duration_on_success
+        );
+        assert_eq!(
+            Duration::minutes(2),
+            power_config.next_try_duration_on_failure
+        );
+        assert_eq!(
+            Duration::minutes(15),
+            power_config.wait_duration_until_host_reboot
+        );
+    }
+
+    #[test]
+    fn test_power_manager_default_1() {
+        let toml = r#""#;
+
+        let power_config: PowerManagerOptions =
+            Figment::new().merge(Toml::string(toml)).extract().unwrap();
+
+        assert!(!power_config.enabled);
+        assert_eq!(
+            Duration::minutes(5),
+            power_config.next_try_duration_on_success
+        );
+        assert_eq!(
+            Duration::minutes(2),
+            power_config.next_try_duration_on_failure
+        );
+        assert_eq!(
+            Duration::minutes(15),
+            power_config.wait_duration_until_host_reboot
+        );
+    }
+}

--- a/crates/api/src/state_controller/machine/context.rs
+++ b/crates/api/src/state_controller/machine/context.rs
@@ -15,13 +15,48 @@
  * limitations under the License.
  */
 
-use crate::state_controller::common_services::CommonStateHandlerServices;
+use std::sync::Arc;
+
+use carbide_ipmi::IPMITool;
+use carbide_redfish::libredfish::RedfishClientPool;
+use db::db_read::PgPoolReader;
+use libredfish::Redfish;
+use model::machine::Machine;
+use sqlx::PgPool;
+use state_controller::state_handler::{StateHandlerContextObjects, StateHandlerError};
+
+use crate::state_controller::machine::config::MachineStateHandlerSiteConfig;
 use crate::state_controller::machine::metrics::MachineMetrics;
-use crate::state_controller::state_handler::StateHandlerContextObjects;
 
 pub struct MachineStateHandlerContextObjects {}
 
 impl StateHandlerContextObjects for MachineStateHandlerContextObjects {
-    type Services = CommonStateHandlerServices;
+    type Services = MachineStateHandlerServices;
     type ObjectMetrics = MachineMetrics;
+}
+
+#[derive(Clone)]
+pub struct MachineStateHandlerServices {
+    pub db_pool: PgPool,
+    /// Postgres database pool that can be passed directly to read-only db functions without a
+    /// transaction
+    pub db_reader: PgPoolReader,
+    /// API for interaction with Libredfish
+    pub redfish_client_pool: Arc<dyn RedfishClientPool>,
+    /// An implementation of the IPMITool that understands how to reboot a machine
+    pub ipmi_tool: Arc<dyn IPMITool>,
+    /// Configuration used by MachineStateHandler.
+    pub site_config: Arc<MachineStateHandlerSiteConfig>,
+}
+
+impl MachineStateHandlerServices {
+    pub async fn create_redfish_client_from_machine(
+        &self,
+        machine: &Machine,
+    ) -> Result<Box<dyn Redfish>, StateHandlerError> {
+        self.redfish_client_pool
+            .create_client_from_machine(machine, &self.db_pool)
+            .await
+            .map_err(StateHandlerError::from)
+    }
 }

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -86,6 +86,9 @@ use model::resource_pool::common::CommonPools;
 use model::site_explorer::ExploredEndpoint;
 use sku::{handle_bom_validation_requested, handle_bom_validation_state};
 use sqlx::PgConnection;
+use state_controller::state_handler::{
+    StateHandler, StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt};
 use tokio::sync::Semaphore;
@@ -93,20 +96,17 @@ use tracing::instrument;
 use version_compare::Cmp;
 
 use crate::CarbideError;
-use crate::cfg::file::{
-    BomValidationConfig, CarbideConfig, MachineValidationConfig, PowerManagerOptions, TimePeriod,
-};
+use crate::cfg::file::{MachineValidationConfig, TimePeriod};
 use crate::dpf::DpfOperations;
 use crate::redfish::{
     self, host_power_control, host_power_control_with_location, set_host_uefi_password,
 };
-use crate::state_controller::common_services::CommonStateHandlerServices;
-use crate::state_controller::machine::context::MachineStateHandlerContextObjects;
+use crate::state_controller::machine::config::{FirmwareGlobal, MachineStateHandlerSiteConfig};
+use crate::state_controller::machine::context::{
+    MachineStateHandlerContextObjects, MachineStateHandlerServices,
+};
 use crate::state_controller::machine::{
     MeasuringOutcome, get_measuring_prerequisites, handle_measuring_state,
-};
-use crate::state_controller::state_handler::{
-    StateHandler, StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
 
 mod attestation;
@@ -120,8 +120,9 @@ use helpers::{
     ReprovisionStateHelper, all_equal,
 };
 use rpc::forge_agent_control_response::FileArtifact;
+use state_controller::db_write_batch::DbWriteBatch;
 
-use crate::state_controller::db_write_batch::DbWriteBatch;
+use crate::state_controller::machine::config::{BomValidationConfig, PowerManagerOptions};
 use crate::state_controller::machine::write_ops::MachineWriteOp;
 
 // We can't use http::StatusCode because libredfish has a newer version
@@ -882,7 +883,7 @@ impl MachineStateHandler {
                     let reprov_state = ReprovisionState::next_substate_based_on_bfb_support(
                         self.enable_secure_boot,
                         mh_snapshot,
-                        ctx.services.site_config.dpf.enabled,
+                        ctx.services.site_config.dpf_enabled,
                     );
 
                     let next_state = reprov_state.next_state_with_all_dpus_updated(
@@ -1523,7 +1524,7 @@ impl MachineStateHandler {
                             CleanupState::Init,
                             CleanupContext::Deprovision,
                         );
-                        if !ctx.services.site_config.spdm.enabled {
+                        if !ctx.services.site_config.spdm_enabled {
                             return Ok(StateHandlerOutcome::transition(next_skip_state));
                         }
                         match spdm_measuring_state {
@@ -1561,7 +1562,7 @@ impl MachineStateHandler {
                 spdm_measuring_state,
             } => {
                 let next_skip_state = ManagedHostState::StartAssignmentCycle;
-                if !ctx.services.site_config.spdm.enabled {
+                if !ctx.services.site_config.spdm_enabled {
                     return Ok(StateHandlerOutcome::transition(next_skip_state));
                 }
                 match spdm_measuring_state {
@@ -1621,7 +1622,7 @@ impl MachineStateHandler {
                     instance_state: InstanceState::DpaProvisioning,
                 };
 
-                if !ctx.services.site_config.is_dpa_enabled() {
+                if !ctx.services.site_config.dpa_enabled {
                     // If DPA is not enabled, we don't need to do any DPA provisioning.
                     // So go directly to WaitingForDpaToBeReady state, where we will change
                     // the network status of our DPUs.
@@ -1745,7 +1746,7 @@ impl MachineStateHandler {
         let reprov_state = ReprovisionState::next_substate_based_on_bfb_support(
             self.enable_secure_boot,
             state,
-            ctx.services.site_config.dpf.enabled,
+            ctx.services.site_config.dpf_enabled,
         );
         Ok(Some(reprov_state.next_state_with_all_dpus_updated(
             &state.managed_state,
@@ -1802,7 +1803,7 @@ impl MachineStateHandler {
                     ReprovisionState::next_substate_based_on_bfb_support(
                         self.enable_secure_boot,
                         state,
-                        ctx.services.site_config.dpf.enabled,
+                        ctx.services.site_config.dpf_enabled,
                     )
                     .next_state_with_all_dpus_updated(
                         &state.managed_state,
@@ -3356,7 +3357,7 @@ impl DpuMachineStateHandler {
                     DpuDiscoveringState::next_substate_based_on_bfb_support(
                         self.enable_secure_boot,
                         state,
-                        ctx.services.site_config.dpf.enabled,
+                        ctx.services.site_config.dpf_enabled,
                     );
 
                 tracing::info!(
@@ -5010,7 +5011,7 @@ impl StateHandler for HostMachineStateHandler {
                     let next_skip_state = ManagedHostState::HostInit {
                         machine_state: MachineState::WaitingForDiscovery,
                     };
-                    if !ctx.services.site_config.spdm.enabled {
+                    if !ctx.services.site_config.spdm_enabled {
                         return Ok(StateHandlerOutcome::transition(next_skip_state));
                     }
                     match spdm_measuring_state {
@@ -5923,7 +5924,7 @@ impl StateHandler for InstanceStateHandler {
                         let next_state = ReprovisionState::next_substate_based_on_bfb_support(
                             self.enable_secure_boot,
                             mh_snapshot,
-                            ctx.services.site_config.dpf.enabled,
+                            ctx.services.site_config.dpf_enabled,
                         )
                         .next_state_with_all_dpus_updated(
                             &mh_snapshot.managed_state,
@@ -6026,7 +6027,7 @@ impl StateHandler for InstanceStateHandler {
 
                     // Check each DPA interface associated with the machine to make sure the DPA NIC has updated
                     // its network config (setting VNI to zero in this case).
-                    if ctx.services.site_config.is_dpa_enabled() {
+                    if ctx.services.site_config.dpa_enabled {
                         for dpa_interface in &mh_snapshot.dpa_interface_snapshots {
                             // We're heading back to admin and a DPA still in
                             // Provisioning has nothing to ack -- it never
@@ -6236,7 +6237,7 @@ impl StateHandler for InstanceStateHandler {
                     // DPA state controller re-evaluates with the new host value
                     // (READY -> WaitingForSetVNI, triggering SetVNI).
                     let mut txn = ctx.services.db_pool.begin().await?;
-                    if ctx.services.site_config.is_dpa_enabled() {
+                    if ctx.services.site_config.dpa_enabled {
                         for dpa_interface in &mh_snapshot.dpa_interface_snapshots {
                             db::dpa_interface::try_update_network_config(
                                 &mut txn,
@@ -6257,7 +6258,7 @@ impl StateHandler for InstanceStateHandler {
                     // This involves the DPA State Machine sending SetVNI commands to the NICs, and getting
                     // an ACK. If any of the interfaces has not yet heard back the ACk, we will continue to
                     // be in the current state.
-                    if ctx.services.site_config.is_dpa_enabled() {
+                    if ctx.services.site_config.dpa_enabled {
                         for dpa_interface in &mh_snapshot.dpa_interface_snapshots {
                             if !dpa_interface.managed_host_network_config_version_synced() {
                                 return Ok(StateHandlerOutcome::wait(
@@ -7300,7 +7301,7 @@ impl HostUpgradeState {
         // temporary check if manual upgrade is required before proceeding with automatic ones,
         // should be removed once we complete upgrades through the scout.
         // For now, only gb200s need manual upgrades.
-        if requires_manual_firmware_upgrade(state, &ctx.services.site_config) {
+        if requires_manual_firmware_upgrade(state, &ctx.services.site_config.firmware_global) {
             tracing::info!(
                 "Machine {} (GB200) requires manual firmware upgrade, transitioning to WaitingForManualUpgrade",
                 machine_id
@@ -7734,7 +7735,7 @@ impl HostUpgradeState {
     async fn pre_update_resets(
         &self,
         state: &ManagedHostStateSnapshot,
-        services: &CommonStateHandlerServices,
+        services: &MachineStateHandlerServices,
         scenario: HostFirmwareScenario,
         phase: Option<InitialResetPhase>,
         last_time: &Option<DateTime<Utc>>,
@@ -8696,9 +8697,9 @@ pub async fn host_power_state(
 
 fn requires_manual_firmware_upgrade(
     state: &ManagedHostStateSnapshot,
-    config: &CarbideConfig,
+    firmware_global: &FirmwareGlobal,
 ) -> bool {
-    if !config.firmware_global.requires_manual_upgrade {
+    if !firmware_global.requires_manual_upgrade {
         return false;
     }
 
@@ -9295,7 +9296,7 @@ pub async fn handler_host_power_control_with_location(
 
 async fn restart_dpu(
     machine: &Machine,
-    services: &CommonStateHandlerServices,
+    services: &MachineStateHandlerServices,
     dpf_used_for_ingestion: bool,
 ) -> Result<(), StateHandlerError> {
     let dpu_redfish_client = services.create_redfish_client_from_machine(machine).await?;
@@ -9303,8 +9304,8 @@ async fn restart_dpu(
     // We have seen the boot order be reset on DPUs in some edge cases (for example, after upgrading the BMC and CEC on BF3s)
     // This should take care of handling such cases. It is a no-op most of the time.
     // Skip for DPUs that get their BFB installed via redfish or DPF, they don't need to HTTP boot.
-    let redfish_install = machine.bmc_info.supports_bfb_install()
-        && services.site_config.dpu_config.dpu_enable_secure_boot;
+    let redfish_install =
+        machine.bmc_info.supports_bfb_install() && services.site_config.dpu_enable_secure_boot;
 
     if !redfish_install && !dpf_used_for_ingestion {
         let _ = dpu_redfish_client
@@ -9492,7 +9493,7 @@ async fn call_machine_setup_and_handle_no_dpu_error(
     redfish_client: &dyn Redfish,
     boot_interface_mac: Option<&str>,
     expected_dpu_count: usize,
-    site_config: &CarbideConfig,
+    site_config: &MachineStateHandlerSiteConfig,
 ) -> Result<Option<String>, RedfishError> {
     let setup_result = redfish_client
         .machine_setup(
@@ -9505,7 +9506,7 @@ async fn call_machine_setup_and_handle_no_dpu_error(
     match (
         setup_result,
         expected_dpu_count,
-        site_config.site_explorer.allow_zero_dpu_hosts,
+        site_config.allow_zero_dpu_hosts,
     ) {
         (Err(RedfishError::NoDpu), 0, true) => {
             tracing::info!(
@@ -9522,16 +9523,12 @@ async fn set_boot_order_dpu_first_and_handle_no_dpu_error(
     redfish_client: &dyn Redfish,
     boot_interface_mac: &str,
     expected_dpu_count: usize,
-    site_config: &CarbideConfig,
+    allow_zero_dpu_hosts: bool,
 ) -> Result<Option<String>, RedfishError> {
     let setup_result = redfish_client
         .set_boot_order_dpu_first(boot_interface_mac)
         .await;
-    match (
-        setup_result,
-        expected_dpu_count,
-        site_config.site_explorer.allow_zero_dpu_hosts,
-    ) {
+    match (setup_result, expected_dpu_count, allow_zero_dpu_hosts) {
         (Err(RedfishError::NoDpu), 0, true) => {
             tracing::info!(
                 "redfish set_boot_order_dpu_first failed due to there being no DPUs on the host. This is expected as the host has no DPUs, and we are configured to allow this."
@@ -10440,7 +10437,7 @@ async fn set_host_boot_order(
                 redfish_client,
                 &boot_interface_mac.to_string(),
                 mh_snapshot.host_snapshot.associated_dpu_machine_ids().len(),
-                &ctx.services.site_config,
+                ctx.services.site_config.allow_zero_dpu_hosts,
             )
             .await
             {
@@ -10930,8 +10927,13 @@ mod tests {
             .await
             .unwrap();
 
-        let result =
-            call_machine_setup_and_handle_no_dpu_error(client.as_ref(), None, 1, &config).await;
+        let result = call_machine_setup_and_handle_no_dpu_error(
+            client.as_ref(),
+            None,
+            1,
+            &config.machine_state_handler_site_config(),
+        )
+        .await;
 
         assert!(result.is_ok());
 

--- a/crates/api/src/state_controller/machine/handler/attestation.rs
+++ b/crates/api/src/state_controller/machine/handler/attestation.rs
@@ -28,12 +28,12 @@ use model::machine::{
     ManagedHostStateSnapshot, SpdmMeasuringState, StateMachineArea,
 };
 use sqlx::PgPool;
+use state_controller::state_handler::{
+    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
 
 use crate::handlers::attestation as attestation_handlers;
 use crate::state_controller::machine::context::MachineStateHandlerContextObjects;
-use crate::state_controller::state_handler::{
-    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
-};
 
 /// When SPDM attestation failed, check whether attestation was restarted (admin / status) or
 /// disabled in config; if so, transition back to the appropriate measuring state based on
@@ -44,7 +44,7 @@ pub(crate) async fn handle_spdm_attestation_failed_recovery(
     details: &FailureDetails,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     let mut txn = ctx.services.db_pool.begin().await?;
-    let should_resume_attestation = if !ctx.services.site_config.spdm.enabled {
+    let should_resume_attestation = if !ctx.services.site_config.spdm_enabled {
         true
     } else {
         let attestation_status =

--- a/crates/api/src/state_controller/machine/handler/dpf.rs
+++ b/crates/api/src/state_controller/machine/handler/dpf.rs
@@ -27,15 +27,15 @@ use model::machine::{
     DpfState, DpuInitState, FailureCause, FailureDetails, FailureSource, InstanceState, Machine,
     ManagedHostState, ManagedHostStateSnapshot, ReprovisionState, StateMachineArea,
 };
+use state_controller::state_handler::{
+    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
 
 use super::helpers::{DpuInitStateHelper, ManagedHostStateHelper, ReprovisionStateHelper};
 use super::{handler_host_power_control, host_power_state};
 use crate::dpf::DpfOperations;
 use crate::state_controller::external_service_error::dpf_error;
 use crate::state_controller::machine::context::MachineStateHandlerContextObjects;
-use crate::state_controller::state_handler::{
-    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
-};
 
 // wrapper so we can get an error without copying it at every call site
 fn bmc_ip(machine: &Machine) -> Result<&str, StateHandlerError> {

--- a/crates/api/src/state_controller/machine/handler/helpers.rs
+++ b/crates/api/src/state_controller/machine/handler/helpers.rs
@@ -24,8 +24,7 @@ use model::machine::{
     InstanceNextStateResolver, InstanceState, Machine, MachineNextStateResolver, MachineState,
     ManagedHostState, ManagedHostStateSnapshot, ReprovisionState,
 };
-
-use crate::state_controller::state_handler::StateHandlerError;
+use state_controller::state_handler::StateHandlerError;
 
 pub trait NextState {
     fn next_bfb_install_state(

--- a/crates/api/src/state_controller/machine/handler/machine_validation.rs
+++ b/crates/api/src/state_controller/machine/handler/machine_validation.rs
@@ -20,15 +20,16 @@ use model::machine::{
     ValidationState,
 };
 use model::machine_validation::{MachineValidationState, MachineValidationStatus};
+use state_controller::state_handler::{
+    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
 
 use super::{HostHandlerParams, is_machine_validation_requested, machine_validation_completed};
-use crate::state_controller::common_services::CommonStateHandlerServices;
-use crate::state_controller::machine::context::MachineStateHandlerContextObjects;
+use crate::state_controller::machine::context::{
+    MachineStateHandlerContextObjects, MachineStateHandlerServices,
+};
 use crate::state_controller::machine::handler::{
     handler_host_power_control, rebooted, trigger_reboot_if_needed,
-};
-use crate::state_controller::state_handler::{
-    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
 
 pub(crate) async fn handle_machine_validation_state(
@@ -166,7 +167,7 @@ pub(crate) async fn handle_machine_validation_state(
 }
 
 pub(crate) async fn handle_machine_validation_requested(
-    services: &CommonStateHandlerServices,
+    services: &MachineStateHandlerServices,
     mh_snapshot: &ManagedHostStateSnapshot,
     clear_failure_details: bool,
 ) -> Result<Option<StateHandlerOutcome<ManagedHostState>>, StateHandlerError> {

--- a/crates/api/src/state_controller/machine/handler/power.rs
+++ b/crates/api/src/state_controller/machine/handler/power.rs
@@ -23,12 +23,12 @@ use model::power_manager::{
     get_updated_power_options_for_desired_on_state_off,
     update_power_options_for_desired_on_state_on,
 };
+use state_controller::state_handler::{StateHandlerContext, StateHandlerError};
 
 use crate::state_controller::machine::context::MachineStateHandlerContextObjects;
 use crate::state_controller::machine::handler::{
     PowerOptionConfig, handler_host_power_control, host_power_state,
 };
-use crate::state_controller::state_handler::{StateHandlerContext, StateHandlerError};
 
 // If power state is Paused and Reset, state machine can't take any decision on it.
 // Ignore power manager with a log and moved to state machine.

--- a/crates/api/src/state_controller/machine/handler/sku.rs
+++ b/crates/api/src/state_controller/machine/handler/sku.rs
@@ -23,14 +23,15 @@ use model::machine::{
 };
 use model::sku::diff_skus;
 use sqlx::{PgConnection, PgTransaction};
-
-use super::{HostHandlerParams, discovered_after_state_transition};
-use crate::state_controller::common_services::CommonStateHandlerServices;
-use crate::state_controller::machine::context::MachineStateHandlerContextObjects;
-use crate::state_controller::machine::handler::trigger_reboot_if_needed;
-use crate::state_controller::state_handler::{
+use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
+
+use super::{HostHandlerParams, discovered_after_state_transition};
+use crate::state_controller::machine::context::{
+    MachineStateHandlerContextObjects, MachineStateHandlerServices,
+};
+use crate::state_controller::machine::handler::trigger_reboot_if_needed;
 
 fn get_bom_validation_context(state: &ManagedHostState) -> BomValidatingContext {
     if let ManagedHostState::BomValidating {
@@ -196,7 +197,7 @@ fn should_allow_allocation_on_validation_failure(host_handler_params: &HostHandl
 pub(crate) async fn handle_bom_validation_requested(
     host_handler_params: &HostHandlerParams,
     mh_snapshot: &ManagedHostStateSnapshot,
-    services: &CommonStateHandlerServices,
+    services: &MachineStateHandlerServices,
 ) -> Result<Option<StateHandlerOutcome<ManagedHostState>>, StateHandlerError> {
     if !host_handler_params.bom_validation.enabled {
         tracing::debug!("BOM validation disabled");

--- a/crates/api/src/state_controller/machine/io.rs
+++ b/crates/api/src/state_controller/machine/io.rs
@@ -30,8 +30,8 @@ use model::machine::{
     SpdmMeasuringState, ValidationState,
 };
 use sqlx::PgConnection;
+use state_controller::io::StateControllerIO;
 
-use crate::state_controller::io::StateControllerIO;
 use crate::state_controller::machine::context::MachineStateHandlerContextObjects;
 use crate::state_controller::machine::metrics::MachineMetricsEmitter;
 

--- a/crates/api/src/state_controller/machine/metrics.rs
+++ b/crates/api/src/state_controller/machine/metrics.rs
@@ -28,8 +28,7 @@ use model::hardware_info::MachineInventorySoftwareComponent;
 use model::tenant::TenantOrganizationId;
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Histogram, Meter};
-
-use crate::state_controller::metrics::MetricsEmitter;
+use state_controller::metrics::MetricsEmitter;
 
 #[derive(Debug, Default)]
 pub struct MachineMetrics {

--- a/crates/api/src/state_controller/machine/mod.rs
+++ b/crates/api/src/state_controller/machine/mod.rs
@@ -30,6 +30,7 @@ use model::machine::{
 
 use super::state_handler::StateHandlerError;
 
+pub mod config;
 pub mod context;
 pub mod handler;
 pub mod io;

--- a/crates/api/src/state_controller/machine/write_ops.rs
+++ b/crates/api/src/state_controller/machine/write_ops.rs
@@ -24,9 +24,9 @@ use config_version::ConfigVersion;
 use health_report::{HealthReport, HealthReportApplyMode};
 use model::machine::{MachineLastRebootRequested, MachineLastRebootRequestedMode};
 use sqlx::PgTransaction;
+use state_controller::state_handler::StateHandlerError;
 
 use crate::state_controller::db_write_batch::WriteOp;
-use crate::state_controller::state_handler::StateHandlerError;
 
 /// A deferred-write operation for use in [`MachineStateHandler`].
 ///

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -46,6 +46,7 @@ use carbide_site_explorer::config::{SiteExplorerConfig, SiteExplorerExploreMode}
 use carbide_spdm_controller::context::SpdmStateHandlerServices;
 use carbide_spdm_controller::handler::SpdmAttestationStateHandler;
 use carbide_spdm_controller::io::SpdmStateControllerIO;
+use carbide_state_controller_common::config::StateControllerConfig;
 use carbide_switch_controller::context::SwitchStateHandlerServices;
 use carbide_switch_controller::handler::SwitchStateHandler;
 use carbide_switch_controller::io::SwitchStateControllerIO;
@@ -110,14 +111,13 @@ use tracing_subscriber::EnvFilter;
 use crate::api::Api;
 use crate::api::metrics::ApiMetricsEmitter;
 use crate::cfg::file::{
-    BomValidationConfig, CarbideConfig, ComputeAllocationEnforcement, DpaConfig,
-    DpaInterfaceStateControllerConfig, DpuConfig as InitialDpuConfig, FirmwareGlobal, FnnConfig,
-    IbPartitionStateControllerConfig, ListenMode, MachineStateControllerConfig, MachineUpdater,
-    MachineValidationConfig, MeasuredBootMetricsCollectorConfig, MqttAuthConfig,
-    NetworkSecurityGroupConfig, NetworkSegmentStateControllerConfig, PowerManagerOptions,
+    CarbideConfig, ComputeAllocationEnforcement, DpaConfig, DpaInterfaceStateControllerConfig,
+    DpuConfig as InitialDpuConfig, FnnConfig, IbPartitionStateControllerConfig, ListenMode,
+    MachineUpdater, MachineValidationConfig, MeasuredBootMetricsCollectorConfig, MqttAuthConfig,
+    NetworkSecurityGroupConfig, NetworkSegmentStateControllerConfig,
     PowerShelfStateControllerConfig, RackStateControllerConfig, SpdmConfig,
-    SpdmStateControllerConfig, StateControllerConfig, SwitchStateControllerConfig, VmaasConfig,
-    VpcPeeringPolicy, default_max_find_by_ids,
+    SpdmStateControllerConfig, SwitchStateControllerConfig, VmaasConfig, VpcPeeringPolicy,
+    default_max_find_by_ids,
 };
 use crate::dpf::DpfOperations;
 use crate::ethernet_virtualization::{EthVirtData, SiteFabricPrefixList};
@@ -127,6 +127,10 @@ use crate::measured_boot::convert_vec;
 use crate::scout_stream;
 use crate::state_controller::common_services::CommonStateHandlerServices;
 use crate::state_controller::controller::{Enqueuer, StateController};
+use crate::state_controller::machine::config::{
+    BomValidationConfig, FirmwareGlobal, MachineStateControllerConfig, PowerManagerOptions,
+};
+use crate::state_controller::machine::context::MachineStateHandlerServices;
 use crate::state_controller::machine::handler::{
     MachineStateHandler, MachineStateHandlerBuilder, PowerOptionConfig, ReachabilityParams,
 };
@@ -424,7 +428,19 @@ impl TestEnv {
         }
     }
 
-    /// Creates an instance of CommonStateHandlerServices that are suitable for this
+    /// Creates an instance of MachineStateHandlerServices that are suitable for this
+    /// test environment
+    pub fn machine_state_handler_services(&self) -> MachineStateHandlerServices {
+        MachineStateHandlerServices {
+            db_pool: self.pool.clone(),
+            db_reader: self.pool.clone().into(),
+            redfish_client_pool: self.redfish_sim.clone(),
+            ipmi_tool: self.ipmi_tool.clone(),
+            site_config: self.config.machine_state_handler_site_config().into(),
+        }
+    }
+
+    /// Creates an instance of RackStateHandlerServices that are suitable for this
     /// test environment
     pub fn rack_state_handler_services(&self) -> RackStateHandlerServices {
         RackStateHandlerServices {
@@ -1720,7 +1736,19 @@ pub async fn create_test_env_with_overrides(
         .database(db_pool.clone(), work_lock_manager_handle.clone())
         .meter("carbide_machines", test_meter.meter())
         .processor_id(state_controller_id.clone())
-        .services(handler_services.clone())
+        .services(
+            MachineStateHandlerServices {
+                db_pool: handler_services.db_pool.clone(),
+                db_reader: handler_services.db_reader.clone(),
+                redfish_client_pool: handler_services.redfish_client_pool.clone(),
+                ipmi_tool: handler_services.ipmi_tool.clone(),
+                site_config: handler_services
+                    .site_config
+                    .machine_state_handler_site_config()
+                    .into(),
+            }
+            .into(),
+        )
         .state_handler(Arc::new(machine_swap.clone()))
         .io(Arc::new(MachineStateControllerIO {
             host_health: config.host_health,

--- a/crates/api/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api/src/tests/host_bmc_firmware_test.rs
@@ -49,8 +49,9 @@ use tokio::time::sleep;
 use tonic::Request;
 
 use crate::CarbideResult;
-use crate::cfg::file::{CarbideConfig, FirmwareGlobal, TimePeriod};
+use crate::cfg::file::{CarbideConfig, TimePeriod};
 use crate::machine_update_manager::MachineUpdateManager;
+use crate::state_controller::machine::config::FirmwareGlobal;
 use crate::state_controller::machine::handler::MAX_FIRMWARE_UPGRADE_RETRIES;
 use crate::tests::common;
 use crate::tests::common::api_fixtures::managed_host::HardwareInfoTemplate;

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -2038,7 +2038,7 @@ async fn test_update_reboot_requested_time_off(pool: sqlx::PgPool) {
     let mut txn = env.db_txn().await;
     let snapshot = mh.snapshot(&mut txn).await;
     let mut write_batch = DbWriteBatch::new();
-    let mut services = env.state_handler_services();
+    let mut services = env.machine_state_handler_services();
     let mut metrics = MachineMetrics::default();
     let mut ctx = StateHandlerContext::<MachineStateHandlerContextObjects> {
         services: &mut services,
@@ -2075,7 +2075,7 @@ async fn test_update_reboot_requested_time_off(pool: sqlx::PgPool) {
 
     let mut txn = env.db_txn().await;
     let mut write_batch = DbWriteBatch::new();
-    let mut services = env.state_handler_services();
+    let mut services = env.machine_state_handler_services();
     let mut metrics = MachineMetrics::default();
     let mut ctx = StateHandlerContext::<MachineStateHandlerContextObjects> {
         services: &mut services,
@@ -2107,7 +2107,7 @@ async fn test_update_reboot_requested_time_off(pool: sqlx::PgPool) {
 
     let mut txn = env.db_txn().await;
     let mut write_batch = DbWriteBatch::new();
-    let mut services = env.state_handler_services();
+    let mut services = env.machine_state_handler_services();
     let mut metrics = MachineMetrics::default();
     let mut ctx = StateHandlerContext::<MachineStateHandlerContextObjects> {
         services: &mut services,

--- a/crates/api/src/tests/power_shelf_state_controller/mod.rs
+++ b/crates/api/src/tests/power_shelf_state_controller/mod.rs
@@ -21,9 +21,9 @@ use std::time::Duration;
 use db::power_shelf as db_power_shelf;
 use model::power_shelf::PowerShelfControllerState;
 use rpc::forge::forge_server::Forge;
+use state_controller::config::IterationConfig;
 use tokio_util::sync::CancellationToken;
 
-use crate::state_controller::config::IterationConfig;
 use crate::state_controller::controller::StateController;
 use crate::state_controller::power_shelf::context::PowerShelfStateHandlerServices;
 use crate::state_controller::power_shelf::handler::PowerShelfStateHandler;

--- a/crates/api/src/tests/rack_state_controller/mod.rs
+++ b/crates/api/src/tests/rack_state_controller/mod.rs
@@ -32,9 +32,9 @@ use model::rack::{
 };
 use rpc::forge::StateHistoryRecord;
 use rpc::forge::forge_server::Forge;
+use state_controller::config::IterationConfig;
 use tokio_util::sync::CancellationToken;
 
-use crate::state_controller::config::IterationConfig;
 use crate::state_controller::controller::StateController;
 use crate::state_controller::rack::context::RackStateHandlerContextObjects;
 use crate::state_controller::rack::io::RackStateControllerIO;

--- a/crates/api/src/tests/switch_state_controller/mod.rs
+++ b/crates/api/src/tests/switch_state_controller/mod.rs
@@ -25,9 +25,9 @@ use db::switch as db_switch;
 use forge_secrets::credentials::TestCredentialManager;
 use model::switch::{ConfiguringState, SwitchControllerState};
 use rpc::forge::forge_server::Forge;
+use state_controller::config::IterationConfig;
 use tokio_util::sync::CancellationToken;
 
-use crate::state_controller::config::IterationConfig;
 use crate::state_controller::controller::StateController;
 use crate::tests::common;
 use crate::tests::common::api_fixtures::create_test_env;

--- a/crates/state-controller-common/Cargo.toml
+++ b/crates/state-controller-common/Cargo.toml
@@ -1,0 +1,32 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[package]
+name = "carbide-state-controller-common"
+version = "0.0.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[dependencies]
+carbide-utils = { path = "../utils" }
+state-controller = { path = "../state-controller" }
+
+duration-str = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/state-controller-common/src/config.rs
+++ b/crates/state-controller-common/src/config.rs
@@ -1,0 +1,158 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_utils::config::as_std_duration;
+use duration_str::deserialize_duration;
+use serde::{Deserialize, Serialize};
+use state_controller::config::IterationConfig;
+
+/// Common StateController configurations
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct StateControllerConfig {
+    /// Configures the desired duration for one state controller iteration
+    ///
+    /// Lower iteration times will make the controller react faster to state changes.
+    /// However they will also increase the load on the system
+    #[serde(
+        default = "StateControllerConfig::iteration_time_default",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub iteration_time: std::time::Duration,
+
+    /// Configures the maximum time that the state handler will spend on evaluating
+    /// and advancing the state of a single object. If more time elapses during
+    /// state handling than this timeout allows for, state handling will fail with
+    /// a `TimeoutError`.
+    /// How long to wait for after power down before power on the machine.
+    #[serde(
+        default = "StateControllerConfig::max_object_handling_time_default",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub max_object_handling_time: std::time::Duration,
+
+    /// Configures the maximum amount of concurrency for the object state controller
+    ///
+    /// The controller will attempt to advance the state of this amount of objects
+    /// in parallel.
+    #[serde(default = "StateControllerConfig::max_concurrency_default")]
+    pub max_concurrency: usize,
+
+    /// Configures the maximum time the state processor will wait when checking
+    /// for and dispatching new tasks.
+    /// This value needs to be lower than `iteration_time` in order to assure that
+    /// tasks are executed more often than generated.
+    /// If the value is set to 0, the processor will dispatch object handling tasks
+    /// immediately once they are enqueued. The downside of 0 (or low) interval is
+    /// however that the state controller will poll the database for new tasks
+    /// with the same low interval.
+    #[serde(
+        default = "StateControllerConfig::processor_dispatch_interval_default",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub processor_dispatch_interval: std::time::Duration,
+
+    /// Configures how often the state handling processor will emit log messages
+    #[serde(
+        default = "StateControllerConfig::processor_log_interval_default",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub processor_log_interval: std::time::Duration,
+
+    /// Configures how often the state handling processor will reassess metrics and emit them.
+    /// Calculating aggregate metrics is expensive (all object metrics need to be traversed).
+    /// Therefore this should not happen much more frequently than the observabilty system
+    /// will access them.
+    #[serde(
+        default = "StateControllerConfig::metric_emission_interval",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub metric_emission_interval: std::time::Duration,
+
+    /// Configures for how long metrics for each object managed by the state controller
+    /// will show up before they get evicted.
+    /// The duration of this needs to be longer than the time between state handler
+    /// invocations for the object
+    #[serde(
+        default = "StateControllerConfig::metric_hold_time",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub metric_hold_time: std::time::Duration,
+}
+
+impl StateControllerConfig {
+    pub const fn max_object_handling_time_default() -> std::time::Duration {
+        std::time::Duration::from_secs(3 * 60)
+    }
+
+    pub const fn iteration_time_default() -> std::time::Duration {
+        std::time::Duration::from_secs(30)
+    }
+
+    pub const fn processor_dispatch_interval_default() -> std::time::Duration {
+        std::time::Duration::from_secs(2)
+    }
+
+    pub const fn processor_log_interval_default() -> std::time::Duration {
+        std::time::Duration::from_secs(60)
+    }
+
+    pub const fn metric_emission_interval() -> std::time::Duration {
+        std::time::Duration::from_secs(60)
+    }
+
+    pub const fn metric_hold_time() -> std::time::Duration {
+        std::time::Duration::from_secs(5 * 60)
+    }
+
+    pub const fn max_concurrency_default() -> usize {
+        10
+    }
+}
+
+impl Default for StateControllerConfig {
+    fn default() -> Self {
+        Self {
+            iteration_time: Self::iteration_time_default(),
+            max_object_handling_time: Self::max_object_handling_time_default(),
+            processor_dispatch_interval: Self::processor_dispatch_interval_default(),
+            processor_log_interval: Self::processor_log_interval_default(),
+            max_concurrency: Self::max_concurrency_default(),
+            metric_emission_interval: Self::metric_emission_interval(),
+            metric_hold_time: Self::metric_hold_time(),
+        }
+    }
+}
+
+impl From<&StateControllerConfig> for IterationConfig {
+    fn from(config: &StateControllerConfig) -> Self {
+        IterationConfig {
+            iteration_time: config.iteration_time,
+            max_object_handling_time: config.max_object_handling_time,
+            max_concurrency: config.max_concurrency,
+            processor_dispatch_interval: config.processor_dispatch_interval,
+            processor_log_interval: config.processor_log_interval,
+            metric_emission_interval: config.metric_emission_interval,
+            metric_hold_time: config.metric_hold_time,
+        }
+    }
+}

--- a/crates/state-controller-common/src/lib.rs
+++ b/crates/state-controller-common/src/lib.rs
@@ -15,10 +15,4 @@
  * limitations under the License.
  */
 
-pub mod common_services;
-pub(crate) mod external_service_error;
-pub mod machine;
-pub mod power_shelf;
-pub mod rack;
-
-pub use ::state_controller::{controller, db_write_batch, state_change_emitter, state_handler};
+pub mod config;


### PR DESCRIPTION
## Description

Move machine-specific state controller configuration and services behind dedicated machine modules, and introduce shared state controller config in a new common crate. This reduces direct coupling to the API crate as a first step toward splitting the machine state controller into a separate crate.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

