### PR TITLE
fix: skip SSH host-key verification for BMC/DPU commands

### DIFF
--- a/crates/libmlx/src/firmware/source.rs
+++ b/crates/libmlx/src/firmware/source.rs
@@ -21,7 +21,7 @@
 
 use std::path::{Path, PathBuf};
 
-use forge_ssh::ssh_client::{AuthConfig, SshClientConfig};
+use forge_ssh::ssh_client::{AuthConfig, HostKeyVerification, SshClientConfig};
 use tokio::io::AsyncWriteExt;
 use tracing;
 
@@ -287,12 +287,17 @@ async fn resolve_ssh(
 
     let auth = credentials.clone().map(AuthConfig::try_from).transpose()?;
 
+    let host_key_verification = match known_hosts_file {
+        Some(path) => HostKeyVerification::KnownHostsFile(path.to_path_buf()),
+        None => HostKeyVerification::DefaultKnownHostsFile,
+    };
+
     let client = SshClientConfig {
         host,
         port: *port,
         username,
         auth: auth.as_ref(),
-        known_hosts_file,
+        host_key_verification,
     }
     .make_authenticated_client()
     .await?;

--- a/crates/ssh/src/ssh.rs
+++ b/crates/ssh/src/ssh.rs
@@ -19,7 +19,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use crate::SshError;
-use crate::ssh_client::AuthConfig;
+use crate::ssh_client::{AuthConfig, HostKeyVerification};
 
 async fn execute_command(
     command: &str,
@@ -34,7 +34,7 @@ async fn execute_command(
         port: 22,
         username: &username,
         auth: Some(&auth),
-        known_hosts_file: None,
+        host_key_verification: HostKeyVerification::Insecure,
     }
     .make_authenticated_client()
     .await?;

--- a/crates/ssh/src/ssh_client.rs
+++ b/crates/ssh/src/ssh_client.rs
@@ -52,18 +52,28 @@ pub struct SshClientConfig<'a> {
     pub port: u16,
     pub username: &'a str,
     pub auth: Option<&'a AuthConfig>,
-    pub known_hosts_file: Option<&'a Path>,
+    pub host_key_verification: HostKeyVerification,
+}
+
+/// How to verify the SSH server's host key.
+pub enum HostKeyVerification {
+    /// Skip host key verification.
+    Insecure,
+    /// Verify against the system default known_hosts file (`~/.ssh/known_hosts`).
+    DefaultKnownHostsFile,
+    /// Verify against an explicit known_hosts file.
+    KnownHostsFile(PathBuf),
 }
 
 impl<'a> SshClientConfig<'a> {
-    pub async fn make_authenticated_client(&'a self) -> SshResult<SshClient> {
+    pub async fn make_authenticated_client(self) -> SshResult<SshClient> {
         let mut client = russh::client::connect(
             russh_client_config(),
             (self.host, self.port),
             KnownHostsCheck {
                 host: self.host.to_string(),
                 port: self.port,
-                known_hosts_file: self.known_hosts_file.map(|p| p.to_path_buf()),
+                check: self.host_key_verification,
             },
         )
         .await?;
@@ -165,7 +175,7 @@ fn russh_client_config() -> Arc<russh::client::Config> {
 struct KnownHostsCheck {
     host: String,
     port: u16,
-    known_hosts_file: Option<PathBuf>,
+    check: HostKeyVerification,
 }
 
 impl russh::client::Handler for KnownHostsCheck {
@@ -175,18 +185,17 @@ impl russh::client::Handler for KnownHostsCheck {
         &mut self,
         server_public_key: &PublicKey,
     ) -> Result<bool, Self::Error> {
-        if let Some(path) = self.known_hosts_file.as_ref() {
-            return russh::keys::check_known_hosts_path(
-                &self.host,
-                self.port,
-                server_public_key,
-                path,
-            )
-            .map_err(russh::Error::from);
+        match &self.check {
+            HostKeyVerification::Insecure => Ok(true),
+            HostKeyVerification::KnownHostsFile(path) => {
+                russh::keys::check_known_hosts_path(&self.host, self.port, server_public_key, path)
+                    .map_err(russh::Error::from)
+            }
+            HostKeyVerification::DefaultKnownHostsFile => {
+                russh::keys::check_known_hosts(&self.host, self.port, server_public_key)
+                    .map_err(russh::Error::from)
+            }
         }
-
-        russh::keys::check_known_hosts(&self.host, self.port, server_public_key)
-            .map_err(russh::Error::from)
     }
 }
 


### PR DESCRIPTION
## Description
The russh 0.60.2 update ([#1439](https://github.com/NVIDIA/infra-controller/pull/1439)) replaced async-ssh2-tokio's `ServerCheckMethod::NoCheck` with a hard check against `~/.ssh/known_hosts`, which broke ssh commands issued by the BFB copy to DPU rshim functionality. 

This PR adds a `HostKeyVerification` enum with an Insecure variant and uses it for the BMC/DPU rshim ops. libmlx's firmware SSH source keeps its previous behavior (verify against the default known_hosts).

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
NVBug-6208024

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

