### PR TITLE
fix: Clear phone_home_last_contact when rebooting with custom ipxe.

### DIFF
--- a/crates/api-db/src/instance.rs
+++ b/crates/api-db/src/instance.rs
@@ -468,6 +468,22 @@ pub async fn update_phone_home_last_contact(
     Ok(query_result.0)
 }
 
+pub async fn clear_phone_home_last_contact(
+    txn: &mut PgConnection,
+    instance_id: InstanceId,
+) -> Result<(), DatabaseError> {
+    let query = "UPDATE instances SET phone_home_last_contact=NULL WHERE id=$1 RETURNING id";
+
+    let _id = sqlx::query_as::<_, InstanceId>(query)
+        .bind(instance_id)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    tracing::info!("Phone home last contact cleared for instance {instance_id}");
+    Ok(())
+}
+
 /// Updates updateable configurations of an instance
 /// - OS
 /// - Keyset IDs

--- a/crates/api/src/handlers/instance.rs
+++ b/crates/api/src/handlers/instance.rs
@@ -884,6 +884,7 @@ pub(crate) async fn invoke_power(
 
     let run_provisioning_instructions_on_every_boot = snapshot
         .instance
+        .as_ref()
         .map(|instance| {
             instance
                 .config
@@ -917,6 +918,13 @@ pub(crate) async fn invoke_power(
 
     if use_state_machine_for_reboot {
         db::instance::set_custom_pxe_reboot_requested(&machine_id, true, &mut txn).await?;
+    }
+
+    if request.boot_with_custom_ipxe
+        && let Some(instance) = snapshot.instance.as_ref()
+        && instance.config.os.phone_home_enabled
+    {
+        db::instance::clear_phone_home_last_contact(&mut txn, instance.id).await?;
     }
 
     // For non-always-PXE instances, set use_custom_pxe_on_boot based on the request.


### PR DESCRIPTION
## Description
The cloud-init phone home option works on initial install, but when doing a re-install or an os change, the state goes to Ready before the OS is even installing.    This PR clears the last contact time when a user requests reboot with custom ipxe.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://github.com/NVIDIA/infra-controller/issues/1935

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

