### PR TITLE
chore(api): drop gating from the allow_zero_dpu_hosts flag

### DIFF
--- a/crates/api-test-helper/src/api_server.rs
+++ b/crates/api-test-helper/src/api_server.rs
@@ -199,7 +199,6 @@ pub async fn start(
         explorations_per_run = 90
         create_machines = true
         machines_created_per_run = 30
-        allow_zero_dpu_hosts = true
         allow_proxy_to_unknown_host = false
         {bmc_proxy_cfg}
         reset_rate_limit = "3600s"

--- a/crates/api/src/cfg/README.md
+++ b/crates/api/src/cfg/README.md
@@ -151,7 +151,6 @@ applicable.
 | `rotate_switch_nvos_credentials` | `bool` | `false` | Auto-rotate switch NVOS admin credentials. |
 | `override_target_ip` | `Option<String>` | — | **Deprecated.** Use `bmc_proxy`. Debug BMC IP override. |
 | `override_target_port` | `Option<u16>` | — | **Deprecated.** Use `bmc_proxy`. Debug BMC port override. |
-| `allow_zero_dpu_hosts` | `bool` | `false` | Allow hosts with zero DPUs (set `false` in prod). |
 | `bmc_proxy` | `HostPortPair` | — | BMC proxy host:port for integration testing/dev. |
 | `allow_changing_bmc_proxy` | `Option<bool>` | *(auto)* | Allow runtime changes to `bmc_proxy`. Auto-detected from initial config. |
 | `reset_rate_limit` | `Duration` | `1h` | Minimum time between SiteExplorer-initiated BMC resets. |

--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -661,7 +661,6 @@ impl CarbideConfig {
             spdm_enabled: self.spdm.enabled,
 
             dpu_enable_secure_boot: self.dpu_config.dpu_enable_secure_boot,
-            allow_zero_dpu_hosts: self.site_explorer.allow_zero_dpu_hosts,
         }
     }
 }
@@ -2605,7 +2604,6 @@ mod tests {
                 machines_created_per_run: 1,
                 override_target_ip: None,
                 override_target_port: None,
-                allow_zero_dpu_hosts: false,
                 bmc_proxy: carbide_site_explorer::config::bmc_proxy(None),
                 allow_changing_bmc_proxy: None,
                 reset_rate_limit: Duration::hours(1),
@@ -2781,7 +2779,6 @@ mod tests {
                 machines_created_per_run: 2,
                 override_target_ip: Some("1.2.3.4".to_owned()),
                 override_target_port: Some(10443),
-                allow_zero_dpu_hosts: false,
                 bmc_proxy: carbide_site_explorer::config::bmc_proxy(None),
                 allow_changing_bmc_proxy: None,
                 reset_rate_limit: Duration::hours(2),
@@ -3092,7 +3089,6 @@ mod tests {
                 machines_created_per_run: 2,
                 override_target_ip: Some("1.2.3.4".to_owned()),
                 override_target_port: Some(10443),
-                allow_zero_dpu_hosts: false,
                 bmc_proxy: carbide_site_explorer::config::bmc_proxy(None),
                 allow_changing_bmc_proxy: None,
                 reset_rate_limit: Duration::hours(2),

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -256,7 +256,6 @@ lazy_static! {
 
 #[derive(Clone, Debug, Default)]
 pub struct TestEnvOverrides {
-    pub allow_zero_dpu_hosts: Option<bool>,
     pub site_prefixes: Option<Vec<IpNetwork>>,
     pub config: Option<CarbideConfig>,
     pub create_network_segments: Option<bool>,
@@ -1902,7 +1901,6 @@ pub async fn create_test_env_with_overrides(
             machines_created_per_run: 1,
             override_target_ip: None,
             override_target_port: None,
-            allow_zero_dpu_hosts: overrides.allow_zero_dpu_hosts.unwrap_or(false),
             bmc_proxy: Arc::new(Default::default()),
             allow_changing_bmc_proxy: None,
             reset_rate_limit: Duration::hours(1),

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -1326,6 +1326,12 @@ pub async fn register_expected_machine(
     if data.dpf_enabled.is_none() {
         data.dpf_enabled = default_dpf_enabled;
     }
+    // For fixtures that intentionally create zero-DPU hosts (no DpuConfigs),
+    // declare them as `NoDpu` so site-explorer accepts them. Tests that
+    // explicitly set `dpu_mode` via `expected_machine_data` are left alone.
+    if config.dpus.is_empty() && data.dpu_mode == model::expected_machine::DpuMode::DpuMode {
+        data.dpu_mode = model::expected_machine::DpuMode::NoDpu;
+    }
 
     let em = ExpectedMachine {
         id: Some(uuid::Uuid::new_v4()),

--- a/crates/api/src/tests/fixtures/create_expected_machine_no_default_poweron.sql
+++ b/crates/api/src/tests/fixtures/create_expected_machine_no_default_poweron.sql
@@ -1,1 +1,1 @@
-INSERT INTO expected_machines (bmc_mac_address, serial_number, bmc_username, bmc_password, metadata_name, metadata_description, metadata_labels, default_pause_ingestion_and_poweron) VALUES ('6a:6b:6c:6d:6e:6f', 'VVG121GL', 'ADMIN', 'Pwd2023x0x0x0x0x7', '', '', '{}', true);
+INSERT INTO expected_machines (bmc_mac_address, serial_number, bmc_username, bmc_password, metadata_name, metadata_description, metadata_labels, default_pause_ingestion_and_poweron, dpu_mode) VALUES ('6a:6b:6c:6d:6e:6f', 'VVG121GL', 'ADMIN', 'Pwd2023x0x0x0x0x7', '', '', '{}', true, 'no_dpu');

--- a/crates/api/src/tests/instance_allocate.rs
+++ b/crates/api/src/tests/instance_allocate.rs
@@ -90,7 +90,6 @@ async fn create_test_env_for_instance_allocation(
     let env = common::api_fixtures::create_test_env_with_overrides(
         pool.clone(),
         TestEnvOverrides {
-            allow_zero_dpu_hosts: Some(true),
             site_prefixes: Some(site_prefixes),
             create_network_segments: Some(false),
             ..Default::default()

--- a/crates/api/src/tests/machine_creator.rs
+++ b/crates/api/src/tests/machine_creator.rs
@@ -23,7 +23,6 @@ use std::sync::Arc;
 use carbide_machine_controller::handler::MachineStateHandlerBuilder;
 use carbide_site_explorer::MachineCreator;
 use carbide_site_explorer::config::SiteExplorerConfig;
-use carbide_site_explorer::errors::SiteExplorerError;
 use carbide_utils::arch::CpuArchitecture;
 use carbide_uuid::machine::MachineId;
 use itertools::Itertools;
@@ -61,93 +60,6 @@ async fn discover_dpu_bmc_ip(
         .into_inner();
 
     Ok(response.address.parse()?)
-}
-
-#[crate::sqlx_test]
-async fn test_site_explorer_reject_zero_dpu_hosts(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let config = common::api_fixtures::get_config();
-    let env = common::api_fixtures::create_test_env_with_overrides(
-        pool,
-        TestEnvOverrides::with_config(config),
-    )
-    .await;
-
-    let explorer_config = SiteExplorerConfig {
-        enabled: Arc::new(true.into()),
-        explorations_per_run: 2,
-        concurrent_explorations: 1,
-        run_interval: std::time::Duration::from_secs(1),
-        create_machines: Arc::new(true.into()),
-        create_power_shelves: Arc::new(true.into()),
-        explore_power_shelves_from_static_ip: Arc::new(true.into()),
-        power_shelves_created_per_run: 1,
-        create_switches: Arc::new(true.into()),
-        switches_created_per_run: 1,
-        allow_zero_dpu_hosts: false,
-        ..Default::default()
-    };
-    let machine_creator = MachineCreator::new(
-        env.pool.clone(),
-        explorer_config,
-        env.common_pools.clone(),
-        None,
-        env.test_credential_manager.clone(),
-    );
-
-    let host_bmc_mac = MacAddress::from_str("a0:88:c2:08:81:98")?;
-    let response = env
-        .api
-        .discover_dhcp(
-            DhcpDiscovery::builder(host_bmc_mac, "192.0.1.1")
-                .vendor_string("SomeVendor")
-                .tonic_request(),
-        )
-        .await
-        .unwrap()
-        .into_inner();
-    assert!(!response.address.is_empty());
-
-    let interface_id = response.machine_interface_id;
-    let mut ifaces = env
-        .api
-        .find_interfaces(tonic::Request::new(rpc::forge::InterfaceSearchQuery {
-            id: Some(interface_id.unwrap()),
-            ip: None,
-        }))
-        .await
-        .unwrap()
-        .into_inner();
-
-    assert_eq!(ifaces.interfaces.len(), 1);
-    let iface = ifaces.interfaces.remove(0);
-    let mut addresses = iface.address;
-    let host_bmc_ip = addresses.remove(0);
-
-    let exploration_report = ExploredManagedHost {
-        host_bmc_ip: IpAddr::from_str(&host_bmc_ip)?,
-        dpus: vec![],
-    };
-
-    let expected_machine = ExpectedMachine {
-        id: Some(uuid::Uuid::new_v4()),
-        bmc_mac_address: host_bmc_mac,
-        data: ExpectedMachineData::default(),
-    };
-
-    let Err(SiteExplorerError::NoDpusInMachine(_)) = machine_creator
-        .create_managed_host(
-            &exploration_report,
-            &mut EndpointExplorationReport::default(),
-            Some(&expected_machine),
-            &env.pool,
-        )
-        .await
-    else {
-        panic!("explorer.create_managed_host should have failed with a NoDpusInMachine error")
-    };
-    Ok(())
 }
 
 #[crate::sqlx_test]

--- a/crates/api/src/tests/machine_dhcp.rs
+++ b/crates/api/src/tests/machine_dhcp.rs
@@ -745,7 +745,6 @@ async fn test_dhcp_allows_zero_dpu_host_with_instance(
     let env = create_test_env_with_overrides(
         pool,
         TestEnvOverrides {
-            allow_zero_dpu_hosts: Some(true),
             site_prefixes: Some(vec![
                 IpNetwork::new(
                     FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),

--- a/crates/api/src/tests/machine_states.rs
+++ b/crates/api/src/tests/machine_states.rs
@@ -2811,7 +2811,6 @@ async fn zero_dpu_host_with_instance(pool: sqlx::PgPool) -> (TestEnv, TestManage
     let env = create_test_env_with_overrides(
         pool,
         TestEnvOverrides {
-            allow_zero_dpu_hosts: Some(true),
             site_prefixes: Some(vec![
                 IpNetwork::new(
                     FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),

--- a/crates/api/src/tests/set_primary_dpu.rs
+++ b/crates/api/src/tests/set_primary_dpu.rs
@@ -42,7 +42,6 @@ async fn test_set_primary_dpu_rejects_zero_dpu_host(
     let env = api_fixtures::create_test_env_with_overrides(
         pool,
         api_fixtures::TestEnvOverrides {
-            allow_zero_dpu_hosts: Some(true),
             site_prefixes: Some(vec![
                 IpNetwork::new(
                     FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),

--- a/crates/api/src/tests/site_explorer.rs
+++ b/crates/api/src/tests/site_explorer.rs
@@ -226,7 +226,6 @@ async fn test_site_explorer_default_pause_ingestion_and_poweron(
         concurrent_explorations: 1,
         run_interval: std::time::Duration::from_secs(1),
         create_machines: Arc::new(true.into()),
-        allow_zero_dpu_hosts: true,
         ..Default::default()
     };
     let test_meter = TestMeter::default();
@@ -394,7 +393,6 @@ async fn test_handle_redfish_error_powers_on_machine(
         concurrent_explorations: 1,
         run_interval: std::time::Duration::from_secs(1),
         create_machines: Arc::new(true.into()),
-        allow_zero_dpu_hosts: true,
         ..Default::default()
     };
     let test_meter = TestMeter::default();
@@ -484,6 +482,37 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
     );
     txn.commit().await.unwrap();
 
+    // Register `expected_machines` so site-explorer accepts these hosts: the
+    // host with a DPU pair takes the default `DpuMode`, and the zero-DPU host
+    // declares `NoDpu` to pass the strict ingestion gate.
+    let mut txn = env.pool.begin().await?;
+    db::expected_machine::create(
+        &mut txn,
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: machines[1].mac,
+            data: ExpectedMachineData {
+                serial_number: "host-with-dpu".to_string(),
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    db::expected_machine::create(
+        &mut txn,
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: machines[2].mac,
+            data: ExpectedMachineData {
+                serial_number: "host-with-no-dpu".to_string(),
+                dpu_mode: model::expected_machine::DpuMode::NoDpu,
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
     let endpoint_explorer = Arc::new(MockEndpointExplorer::default());
     let mock_dpu = machines[0].as_mock_dpu();
 
@@ -533,7 +562,6 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
         concurrent_explorations: 1,
         run_interval: std::time::Duration::from_secs(1),
         create_machines: Arc::new(true.into()),
-        allow_zero_dpu_hosts: true,
         create_power_shelves: Arc::new(true.into()),
         explore_power_shelves_from_static_ip: Arc::new(true.into()),
         power_shelves_created_per_run: 1,
@@ -816,6 +844,293 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
     Ok(())
 }
 
+/// Strict ingestion gate: a host whose BMC reports no DPU PCIe devices
+/// and whose `ExpectedMachine` does not declare `NoDpu` is skipped (with
+/// a warning + a `NoDpuReportedByHost` pairing-blocker metric) rather
+/// than ingested. Operators must explicitly opt in to zero-DPU.
+#[crate::sqlx_test]
+async fn test_site_explorer_skips_unexpected_zero_dpu_host(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+
+    let mut machine = FakeMachine::new(
+        "AA:AB:AC:AD:AA:11",
+        "Vendor1",
+        env.underlay_segment.unwrap(),
+    );
+    machine.discover_dhcp(&env).await?;
+
+    // expected_machine WITHOUT a NoDpu declaration -- the host is
+    // "expected to have DPUs" by default.
+    let mut txn = env.pool.begin().await?;
+    db::expected_machine::create(
+        &mut txn,
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: machine.mac,
+            data: ExpectedMachineData {
+                serial_number: "host-expected-dpus-but-has-none".to_string(),
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    // BMC report with no PCIe devices / no chassis -- the gate sees
+    // zero DPUs.
+    let endpoint_explorer = Arc::new(MockEndpointExplorer::default());
+    endpoint_explorer.insert_endpoint_results(vec![(
+        machine.ip.parse().unwrap(),
+        Ok(EndpointExplorationReport {
+            endpoint_type: EndpointType::Bmc,
+            vendor: Some(bmc_vendor::BMCVendor::Lenovo),
+            systems: vec![ComputerSystem {
+                serial_number: Some("0123456789".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }),
+    )]);
+
+    let explorer_config = SiteExplorerConfig {
+        enabled: Arc::new(true.into()),
+        explorations_per_run: 1,
+        concurrent_explorations: 1,
+        run_interval: std::time::Duration::from_secs(1),
+        create_machines: Arc::new(true.into()),
+        ..Default::default()
+    };
+    let test_meter = TestMeter::default();
+    let explorer = SiteExplorer::new(
+        env.pool.clone(),
+        explorer_config,
+        test_meter.meter(),
+        endpoint_explorer,
+        Arc::new(env.config.get_firmware_config()),
+        env.common_pools.clone(),
+        env.api.work_lock_manager_handle.clone(),
+        env.rms_sim.as_rms_client(),
+        env.test_credential_manager.clone(),
+    );
+
+    // First iteration populates `explored_endpoints`; second runs
+    // `identify_managed_hosts` after preingestion is complete.
+    explorer.run_single_iteration().await.unwrap();
+    let mut txn = env.pool.begin().await?;
+    db::explored_endpoints::set_preingestion_complete(machine.ip.parse().unwrap(), &mut txn)
+        .await?;
+    txn.commit().await?;
+    explorer.run_single_iteration().await.unwrap();
+
+    // No managed host should have been identified.
+    let explored_managed_hosts = db::explored_managed_host::find_all(&env.pool).await?;
+    assert!(
+        explored_managed_hosts.is_empty(),
+        "strict gate should refuse to ingest a zero-DPU host without a `NoDpu` declaration, got {:?}",
+        explored_managed_hosts,
+    );
+    assert_eq!(
+        test_meter
+            .formatted_metric("carbide_site_exploration_identified_managed_hosts_count")
+            .unwrap(),
+        "0"
+    );
+
+    // The pairing-blocker metric should have ticked for `NoDpuReportedByHost`.
+    let blocker_metric = test_meter
+        .formatted_metric("carbide_host_dpu_pairing_blockers_count")
+        .expect("expected `carbide_host_dpu_pairing_blockers_count` to be emitted");
+    assert!(
+        blocker_metric.contains("no_dpu_reported_by_host"),
+        "expected pairing-blocker metric to mention `no_dpu_reported_by_host`, got {blocker_metric}",
+    );
+
+    Ok(())
+}
+
+/// Companion to `test_site_explorer_skips_unexpected_zero_dpu_host`: when
+/// the operator explicitly declares `dpu_mode = "nic_mode"`, a host whose
+/// BMC reports zero usable DPU PCIe devices (because anything that is a
+/// BlueField has been stripped as "DPU in NIC mode") should be ingested as
+/// a zero-DPU managed host -- the operator has already opted into "treat
+/// as zero-DPU" semantics by declaring NicMode.
+#[crate::sqlx_test]
+async fn test_site_explorer_ingests_nic_mode_host_with_no_observed_dpus(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+
+    let mut machine = FakeMachine::new(
+        "AA:AB:AC:AD:AA:22",
+        "Vendor1",
+        env.underlay_segment.unwrap(),
+    );
+    machine.discover_dhcp(&env).await?;
+
+    let mut txn = env.pool.begin().await?;
+    db::expected_machine::create(
+        &mut txn,
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: machine.mac,
+            data: ExpectedMachineData {
+                serial_number: "host-nic-mode-no-observed-dpus".to_string(),
+                dpu_mode: model::expected_machine::DpuMode::NicMode,
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    let endpoint_explorer = Arc::new(MockEndpointExplorer::default());
+    endpoint_explorer.insert_endpoint_results(vec![(
+        machine.ip.parse().unwrap(),
+        Ok(EndpointExplorationReport {
+            endpoint_type: EndpointType::Bmc,
+            vendor: Some(bmc_vendor::BMCVendor::Lenovo),
+            systems: vec![ComputerSystem {
+                serial_number: Some("0123456789".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }),
+    )]);
+
+    let explorer_config = SiteExplorerConfig {
+        enabled: Arc::new(true.into()),
+        explorations_per_run: 1,
+        concurrent_explorations: 1,
+        run_interval: std::time::Duration::from_secs(1),
+        create_machines: Arc::new(true.into()),
+        ..Default::default()
+    };
+    let test_meter = TestMeter::default();
+    let explorer = SiteExplorer::new(
+        env.pool.clone(),
+        explorer_config,
+        test_meter.meter(),
+        endpoint_explorer,
+        Arc::new(env.config.get_firmware_config()),
+        env.common_pools.clone(),
+        env.api.work_lock_manager_handle.clone(),
+        env.rms_sim.as_rms_client(),
+        env.test_credential_manager.clone(),
+    );
+
+    explorer.run_single_iteration().await.unwrap();
+    let mut txn = env.pool.begin().await?;
+    db::explored_endpoints::set_preingestion_complete(machine.ip.parse().unwrap(), &mut txn)
+        .await?;
+    txn.commit().await?;
+    explorer.run_single_iteration().await.unwrap();
+
+    let explored_managed_hosts = db::explored_managed_host::find_all(&env.pool).await?;
+    assert_eq!(
+        explored_managed_hosts.len(),
+        1,
+        "NicMode declaration should let the host through the strict gate even with zero observed DPUs",
+    );
+    assert!(
+        explored_managed_hosts[0].dpus.is_empty(),
+        "NicMode hosts ingest with an empty `dpus` vector",
+    );
+
+    Ok(())
+}
+
+/// Third member of the zero-DPU triad (alongside the `DpuMode::DpuMode`
+/// skip test and the `DpuMode::NicMode` ingest test): a host explicitly
+/// declared `dpu_mode = "no_dpu"` ingests as a zero-DPU managed host. The
+/// `NoDpu` fast-path in `identify_managed_hosts` short-circuits before any
+/// DPU PCIe enumeration, so this holds regardless of what the BMC reports.
+#[crate::sqlx_test]
+async fn test_site_explorer_ingests_no_dpu_host(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+
+    let mut machine = FakeMachine::new(
+        "AA:AB:AC:AD:AA:33",
+        "Vendor1",
+        env.underlay_segment.unwrap(),
+    );
+    machine.discover_dhcp(&env).await?;
+
+    let mut txn = env.pool.begin().await?;
+    db::expected_machine::create(
+        &mut txn,
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: machine.mac,
+            data: ExpectedMachineData {
+                serial_number: "host-no-dpu-declared".to_string(),
+                dpu_mode: model::expected_machine::DpuMode::NoDpu,
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    let endpoint_explorer = Arc::new(MockEndpointExplorer::default());
+    endpoint_explorer.insert_endpoint_results(vec![(
+        machine.ip.parse().unwrap(),
+        Ok(EndpointExplorationReport {
+            endpoint_type: EndpointType::Bmc,
+            vendor: Some(bmc_vendor::BMCVendor::Lenovo),
+            systems: vec![ComputerSystem {
+                serial_number: Some("0123456789".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }),
+    )]);
+
+    let explorer_config = SiteExplorerConfig {
+        enabled: Arc::new(true.into()),
+        explorations_per_run: 1,
+        concurrent_explorations: 1,
+        run_interval: std::time::Duration::from_secs(1),
+        create_machines: Arc::new(true.into()),
+        ..Default::default()
+    };
+    let test_meter = TestMeter::default();
+    let explorer = SiteExplorer::new(
+        env.pool.clone(),
+        explorer_config,
+        test_meter.meter(),
+        endpoint_explorer,
+        Arc::new(env.config.get_firmware_config()),
+        env.common_pools.clone(),
+        env.api.work_lock_manager_handle.clone(),
+        env.rms_sim.as_rms_client(),
+        env.test_credential_manager.clone(),
+    );
+
+    explorer.run_single_iteration().await.unwrap();
+    let mut txn = env.pool.begin().await?;
+    db::explored_endpoints::set_preingestion_complete(machine.ip.parse().unwrap(), &mut txn)
+        .await?;
+    txn.commit().await?;
+    explorer.run_single_iteration().await.unwrap();
+
+    let explored_managed_hosts = db::explored_managed_host::find_all(&env.pool).await?;
+    assert_eq!(
+        explored_managed_hosts.len(),
+        1,
+        "NoDpu declaration should ingest the host as zero-DPU",
+    );
+    assert!(
+        explored_managed_hosts[0].dpus.is_empty(),
+        "NoDpu hosts ingest with an empty `dpus` vector",
+    );
+
+    Ok(())
+}
+
 #[crate::sqlx_test(fixtures("create_expected_machine"))]
 async fn test_site_explorer_audit_exploration_results(
     pool: sqlx::PgPool,
@@ -1022,7 +1337,6 @@ async fn test_site_explorer_audit_exploration_results(
         machines_created_per_run: 1,
         override_target_ip: None,
         override_target_port: None,
-        allow_zero_dpu_hosts: false,
         allow_changing_bmc_proxy: None,
         bmc_proxy: Arc::default(),
         reset_rate_limit: chrono::Duration::hours(1),
@@ -1902,7 +2216,6 @@ async fn test_site_explorer_new_host_fixture(
     let env = common::api_fixtures::create_test_env_with_overrides(
         pool.clone(),
         TestEnvOverrides {
-            allow_zero_dpu_hosts: Some(true),
             site_prefixes: Some(vec![
                 IpNetwork::new(
                     FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),
@@ -2091,7 +2404,6 @@ async fn test_site_explorer_fixtures_zerodpu_site_explorer_before_host_dhcp(
     let env = common::api_fixtures::create_test_env_with_overrides(
         pool.clone(),
         TestEnvOverrides {
-            allow_zero_dpu_hosts: Some(true),
             site_prefixes: Some(vec![
                 IpNetwork::new(
                     FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),
@@ -2181,7 +2493,6 @@ async fn test_site_explorer_fixtures_zerodpu_dhcp_before_site_explorer(
     let env = common::api_fixtures::create_test_env_with_overrides(
         pool.clone(),
         TestEnvOverrides {
-            allow_zero_dpu_hosts: Some(true),
             site_prefixes: Some(vec![
                 IpNetwork::new(
                     FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),
@@ -2335,7 +2646,6 @@ async fn test_site_explorer_unknown_vendor(
         concurrent_explorations: 1,
         run_interval: std::time::Duration::from_secs(1),
         create_machines: Arc::new(true.into()),
-        allow_zero_dpu_hosts: true,
         allocate_secondary_vtep_ip: true,
         create_power_shelves: Arc::new(true.into()),
         explore_power_shelves_from_static_ip: Arc::new(true.into()),
@@ -3079,7 +3389,6 @@ async fn test_site_explorer_power_shelf_discovery(
         create_power_shelves: Arc::new(true.into()),
         explore_power_shelves_from_static_ip: Arc::new(false.into()),
         power_shelves_created_per_run: 1,
-        allow_zero_dpu_hosts: true,
         ..Default::default()
     };
     let test_meter = TestMeter::default();
@@ -3235,7 +3544,6 @@ async fn test_site_explorer_switch_discovery(
         create_machines: Arc::new(true.into()),
         create_switches: Arc::new(true.into()),
         switches_created_per_run: 1,
-        allow_zero_dpu_hosts: true,
         ..Default::default()
     };
     let test_meter = TestMeter::default();
@@ -3385,7 +3693,6 @@ async fn test_site_explorer_power_shelf_with_expected_config(
         create_power_shelves: Arc::new(true.into()),
         explore_power_shelves_from_static_ip: Arc::new(false.into()),
         power_shelves_created_per_run: 1,
-        allow_zero_dpu_hosts: true,
         ..Default::default()
     };
     let test_meter = TestMeter::default();
@@ -3540,7 +3847,6 @@ async fn test_site_explorer_power_shelf_creation_limit(
         create_power_shelves: Arc::new(true.into()),
         explore_power_shelves_from_static_ip: Arc::new(false.into()),
         power_shelves_created_per_run: 2, // Limit to 2 per run
-        allow_zero_dpu_hosts: true,
         ..Default::default()
     };
     let test_meter = TestMeter::default();
@@ -3675,7 +3981,6 @@ async fn test_site_explorer_power_shelf_disabled(
         create_power_shelves: Arc::new(false.into()), // Disabled
         explore_power_shelves_from_static_ip: Arc::new(false.into()),
         power_shelves_created_per_run: 1,
-        allow_zero_dpu_hosts: true,
         ..Default::default()
     };
     let test_meter = TestMeter::default();
@@ -3779,7 +4084,6 @@ async fn test_site_explorer_power_shelf_error_handling(
         create_power_shelves: Arc::new(true.into()),
         explore_power_shelves_from_static_ip: Arc::new(false.into()),
         power_shelves_created_per_run: 1,
-        allow_zero_dpu_hosts: true,
         ..Default::default()
     };
     let test_meter = TestMeter::default();
@@ -4849,7 +5153,6 @@ async fn test_site_explorer_power_shelf_discovery_with_static_ip(
         create_power_shelves: Arc::new(true.into()),
         explore_power_shelves_from_static_ip: Arc::new(true.into()),
         power_shelves_created_per_run: 1,
-        allow_zero_dpu_hosts: true,
         ..Default::default()
     };
     let test_meter = TestMeter::default();

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -501,10 +501,13 @@ impl ApiClient {
 
     /// Registers a mock expected machine. Static BMC (`bmc_ip_address`) is left unset here;
     /// real environments set it through the admin CLI / API when DHCP discovery is not used.
+    /// `dpu_mode` is the per-host operating mode -- pass `Some(NoDpu)` for zero-DPU mock hosts
+    /// or `Some(NicMode)` for DPU-in-NIC-mode mock hosts; `None` for normal DPU hosts.
     pub async fn add_expected_machine(
         &self,
         bmc_mac_address: String,
         chassis_serial_number: String,
+        dpu_mode: Option<rpc::forge::DpuMode>,
     ) -> ClientApiResult<()> {
         self.0
             .add_expected_machine(ExpectedMachine {
@@ -524,7 +527,7 @@ impl ApiClient {
                 is_dpf_enabled: Some(true),
                 bmc_ip_address: None,
                 bmc_retain_credentials: None,
-                dpu_mode: None,
+                dpu_mode: dpu_mode.map(|m| m as i32),
                 host_lifecycle_profile: None,
             })
             .await

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -573,6 +573,10 @@ impl HostMachineHandle {
         &self.0.host_info
     }
 
+    pub fn machine_config_section(&self) -> &str {
+        &self.0.machine_config_section
+    }
+
     pub fn persisted(&self) -> PersistedHostMachine {
         let live_state = self.0.live_state.read().unwrap();
         PersistedHostMachine {

--- a/crates/machine-a-tron/src/machine_a_tron.rs
+++ b/crates/machine-a-tron/src/machine_a_tron.rs
@@ -99,13 +99,33 @@ impl MachineATron {
 
         if self.app_context.app_config.register_expected_machines {
             for machine in &machines {
+                // Derive the expected `dpu_mode` from the machine's
+                // MachineConfig: zero-DPU hosts declare `NoDpu`, hosts
+                // running their DPUs as NICs declare `NicMode`, everything
+                // else defers to the absolute default (DpuMode).
+                // Site-explorer's ingestion gate requires this explicit
+                // declaration for any host without DPU PCIe devices.
+                let dpu_mode = self
+                    .app_context
+                    .app_config
+                    .machines
+                    .get(machine.machine_config_section())
+                    .and_then(|config| {
+                        if config.dpu_per_host_count == 0 {
+                            Some(rpc::forge::DpuMode::NoDpu)
+                        } else if config.dpus_in_nic_mode {
+                            Some(rpc::forge::DpuMode::NicMode)
+                        } else {
+                            None
+                        }
+                    });
                 // Inform the API that we have finished our reboot (ie. scout is now running)
                 self.app_context
                     .api_client()
                     .add_expected_machine(
                         machine.host_info().bmc_mac_address.to_string(),
                         machine.host_info().serial.clone(),
-
+                        dpu_mode,
                     )
                     .await
                     .inspect_err(|e| {

--- a/crates/machine-controller/src/config/mod.rs
+++ b/crates/machine-controller/src/config/mod.rs
@@ -44,7 +44,6 @@ pub struct MachineStateHandlerSiteConfig {
     pub spdm_enabled: bool,
 
     pub dpu_enable_secure_boot: bool,
-    pub allow_zero_dpu_hosts: bool,
 }
 
 /// A UTC time window defined by a start and end timestamp.

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -9521,13 +9521,9 @@ fn can_restart_reprovision(dpu_snapshots: &[Machine], version: ConfigVersion) ->
     dpu_reprovision_restart_requested_after_state_transition(version, *latest_requested_at)
 }
 
-/// Call [`Redfish::machine_setup`], but ignore any [`RedfishError::NoDpu`] if we expect there to be no DPUs.
-/// Returns `Ok(Some(job_id))` when the vendor (e.g. Dell) creates a BIOS config job that must complete
-/// before configuring boot order; `Ok(None)` when no job to wait for.
-///
-/// TODO(ken): This is a temporary workaround for work-in-progress on zero-DPU support (August 2024)
-/// The way we should do this going forward is to plumb the actual non-DPU MAC address we want to
-/// boot from, instead of special-casing NoDpu errors.
+/// Call [`Redfish::machine_setup`], but ignore any [`RedfishError::NoDpu`] if we expect there to
+/// be no DPUs on the host. Returns `Ok(Some(job_id))` when the vendor (e.g. Dell) creates a BIOS
+/// config job that must complete before configuring boot order; `Ok(None)` when no job to wait for.
 pub async fn call_machine_setup_and_handle_no_dpu_error(
     redfish_client: &dyn Redfish,
     boot_interface_mac: Option<&str>,
@@ -9542,40 +9538,38 @@ pub async fn call_machine_setup_and_handle_no_dpu_error(
             &site_config.oem_manager_profiles,
         )
         .await;
-    match (
-        setup_result,
-        expected_dpu_count,
-        site_config.allow_zero_dpu_hosts,
-    ) {
-        (Err(RedfishError::NoDpu), 0, true) => {
-            tracing::info!(
-                "redfish machine_setup failed due to there being no DPUs on the host. This is expected as the host has no DPUs, and we are configured to allow this."
-            );
-            Ok(None)
-        }
-        (Ok(maybe_jid), _, _) => Ok(maybe_jid),
-        (Err(e), _, _) => Err(e),
-    }
+    handle_no_dpu_error(setup_result, expected_dpu_count, "machine_setup")
 }
 
 async fn set_boot_order_dpu_first_and_handle_no_dpu_error(
     redfish_client: &dyn Redfish,
     boot_interface_mac: &str,
     expected_dpu_count: usize,
-    allow_zero_dpu_hosts: bool,
 ) -> Result<Option<String>, RedfishError> {
     let setup_result = redfish_client
         .set_boot_order_dpu_first(boot_interface_mac)
         .await;
-    match (setup_result, expected_dpu_count, allow_zero_dpu_hosts) {
-        (Err(RedfishError::NoDpu), 0, true) => {
+    handle_no_dpu_error(setup_result, expected_dpu_count, "set_boot_order_dpu_first")
+}
+
+/// Treat `Err(RedfishError::NoDpu)` as `Ok(None)` *only* when the host is
+/// declared zero-DPU (`expected_dpu_count == 0`). Other error variants and
+/// successful results pass through untouched. The `dpu_mode` gate in
+/// site-explorer is what guarantees `expected_dpu_count == 0` actually
+/// means the host was configured as `NoDpu`.
+fn handle_no_dpu_error(
+    result: Result<Option<String>, RedfishError>,
+    expected_dpu_count: usize,
+    operation: &'static str,
+) -> Result<Option<String>, RedfishError> {
+    match (result, expected_dpu_count) {
+        (Err(RedfishError::NoDpu), 0) => {
             tracing::info!(
-                "redfish set_boot_order_dpu_first failed due to there being no DPUs on the host. This is expected as the host has no DPUs, and we are configured to allow this."
+                "redfish {operation} failed with NoDpu on a zero-DPU host; treating as Ok"
             );
             Ok(None)
         }
-        (Ok(job_id), _, _) => Ok(job_id),
-        (Err(e), _, _) => Err(e),
+        (other, _) => other,
     }
 }
 
@@ -10190,9 +10184,9 @@ async fn set_host_boot_order(
             // all zero-DPU hosts because libredfish doesn't implement
             // `boot_first` for every vendor yet (Dell currently returns
             // `NotSupported`); zero-DPU hosts fall through to the
-            // `set_boot_order_dpu_first` path below, which downgrades
-            // the resulting `NoDpu` error via `allow_zero_dpu_hosts`
-            // and still hits `CheckBootOrder` for verification.
+            // `set_boot_order_dpu_first` path below, which treats the
+            // resulting `NoDpu` error as `Ok` and still hits `CheckBootOrder`
+            // for verification.
             //
             // Resolve the boot NIC MAC the same way `CheckHostConfig` does,
             // supporting hosts with DPU(s) and zero DPUs alike.
@@ -10207,7 +10201,6 @@ async fn set_host_boot_order(
                 redfish_client,
                 &boot_interface_mac.to_string(),
                 mh_snapshot.host_snapshot.associated_dpu_machine_ids().len(),
-                ctx.services.site_config.allow_zero_dpu_hosts,
             )
             .await
             {
@@ -10651,6 +10644,37 @@ mod tests {
             .expect("stale CX7 inventory should require upgrade");
 
         assert_eq!(to_install.version, target_version);
+    }
+
+    #[test]
+    fn handle_no_dpu_error_treats_as_ok_on_zero_dpu_host() {
+        let result = handle_no_dpu_error(Err(RedfishError::NoDpu), 0, "machine_setup");
+        assert!(matches!(result, Ok(None)));
+    }
+
+    #[test]
+    fn handle_no_dpu_error_surfaces_when_dpus_were_expected() {
+        let result = handle_no_dpu_error(Err(RedfishError::NoDpu), 2, "machine_setup");
+        assert!(matches!(result, Err(RedfishError::NoDpu)));
+    }
+
+    #[test]
+    fn handle_no_dpu_error_passes_through_success() {
+        let job_id = "bios-job-1".to_string();
+        let result = handle_no_dpu_error(Ok(Some(job_id.clone())), 0, "machine_setup");
+        assert!(matches!(result, Ok(Some(ref s)) if s == &job_id));
+
+        let result = handle_no_dpu_error(Ok(None), 2, "machine_setup");
+        assert!(matches!(result, Ok(None)));
+    }
+
+    #[test]
+    fn handle_no_dpu_error_does_not_touch_other_errors() {
+        // Other error variants must surface, even on zero-DPU hosts -- we
+        // only ignore the *specific* NoDpu signal.
+        let result =
+            handle_no_dpu_error(Err(RedfishError::Lockdown), 0, "set_boot_order_dpu_first");
+        assert!(matches!(result, Err(RedfishError::Lockdown)));
     }
 
     #[test]

--- a/crates/site-explorer/src/config.rs
+++ b/crates/site-explorer/src/config.rs
@@ -96,13 +96,6 @@ pub struct SiteExplorerConfig {
     /// This is a debug override and should not be used in production.
     pub override_target_port: Option<u16>,
 
-    /// Whether to allow hosts with zero DPUs in site-explorer. This should typically be set to
-    /// false in production environments where we expect all hosts to have DPUs. When false, if we
-    /// encounter a host with no DPUs, site-explorer will throw an error for that host (because it
-    /// should be assumed that there's a bug in detecting the DPUs).
-    #[serde(default)]
-    pub allow_zero_dpu_hosts: bool,
-
     /// The host:port to use as a proxy when making BMC calls to all hosts in NICo. This is used
     /// for integration testing, and for local development with machine-a-tron/bmc-mock. Should not
     /// be used in production.
@@ -206,7 +199,6 @@ impl Default for SiteExplorerConfig {
             machines_created_per_run: Self::default_machines_created_per_run(),
             override_target_ip: None,
             override_target_port: None,
-            allow_zero_dpu_hosts: false,
             bmc_proxy: bmc_proxy(None),
             allow_changing_bmc_proxy: None,
             reset_rate_limit: Self::default_reset_rate_limit(),

--- a/crates/site-explorer/src/errors.rs
+++ b/crates/site-explorer/src/errors.rs
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-use std::net::IpAddr;
-
 use db::DatabaseError;
 use model::errors::ModelError;
 use model::site_explorer::EndpointExplorationError;
@@ -27,8 +25,6 @@ pub enum SiteExplorerError {
     DatabaseError(#[from] DatabaseError),
     #[error("Model error: {0}")]
     ModelError(#[from] ModelError),
-    #[error("Explored machine at {0} has no DPUs")]
-    NoDpusInMachine(IpAddr),
     #[error("{kind} already exists: {id}")]
     AlreadyFoundError {
         /// The type of the resource that already exists (e.g. Machine)

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -1238,10 +1238,10 @@ impl SiteExplorer {
                                         ep.address,
                                     );
 
-                                    self.redfish_powercycle(
-                                        ep.address,
-                                    )
-                                        .await.inspect_err(|err| tracing::warn!("site explorer failed to power cycle host {} to apply DPU mode changes: {err}", ep.address)).ok();
+                                    self.redfish_powercycle(ep.address)
+                                        .await
+                                        .inspect_err(|err| tracing::warn!("site explorer failed to power cycle host {} to apply DPU mode changes: {err}", ep.address))
+                                        .ok();
                                 }
                             } else {
                                 tracing::warn!(
@@ -1256,11 +1256,29 @@ impl SiteExplorer {
                         }
 
                         continue;
-                    } else if !self.config.allow_zero_dpu_hosts {
+                    } else if matches!(host_dpu_mode, DpuMode::DpuMode) {
+                        // Host has no DPU PCIe devices reported by its
+                        // BMC, and the effective `dpu_mode` is the
+                        // default (`DpuMode`) -- i.e. neither per-host
+                        // on `ExpectedMachine.dpu_mode` nor site-wide on
+                        // `[site_explorer] dpu_mode` declared this host
+                        // as zero-DPU. We expect DPUs but found none --
+                        // probably a misconfiguration or a DPU-discovery
+                        // bug. Skip ingestion this cycle; site-explorer
+                        // will retry on the next iteration, giving the
+                        // operator a chance to either fix the host or
+                        // declare it as `NoDpu`.
+                        //
+                        // (`NoDpu` hosts are handled by the fast-path
+                        // earlier in the loop; `NicMode` hosts fall
+                        // through to the push below with an empty `dpus`
+                        // vector -- the operator already declared
+                        // "treat as zero-DPU.")
                         tracing::warn!(
                             address = %ep.address,
                             exploration_report = ?ep,
-                            "cannot identify managed host because the site explorer does not see any DPUs on this host, and zero-DPU hosts are not allowed by configuration; expected_num_dpus_attached_to_host: {expected_num_dpus_attached_to_host}; dpus_explored_for_host: {dpus_explored_for_host:#?}",
+                            ?host_dpu_mode,
+                            "cannot identify managed host: site explorer sees no DPUs on this host and it isn't declared as `NoDpu`; declare `dpu_mode = \"no_dpu\"` to ingest as zero-DPU",
                         );
                         metrics.increment_host_dpu_pairing_blocker(
                             PairingBlockerReason::NoDpuReportedByHost,

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -148,12 +148,6 @@ impl MachineCreator {
 
         // Zero-dpu case: If the explored host had no DPUs, we can create the machine now
         if managed_host.explored_host.dpus.is_empty() {
-            if !self.config.allow_zero_dpu_hosts {
-                let error =
-                    SiteExplorerError::NoDpusInMachine(managed_host.explored_host.host_bmc_ip);
-                tracing::error!(%error, "Cannot create managed host for explored endpoint with no DPUs: Zero-dpu hosts are disallowed by config");
-                return Err(error);
-            }
             if let Some(machine_id) = self
                 .create_zero_dpu_machine(&mut txn, &managed_host, report, machine_data)
                 .await?

--- a/crates/site-explorer/src/metrics.rs
+++ b/crates/site-explorer/src/metrics.rs
@@ -43,7 +43,9 @@ pub enum PairingBlockerReason {
     HostSystemReportMissing,
     /// Host's boot MAC not found in any discovered DPU
     BootInterfaceMacMismatch,
-    /// Host BMC did not report any DPUs in its PCIE device list
+    /// Host BMC reports no Bluefield PCIe devices but the host isn't
+    /// declared as `dpu_mode = "no_dpu"`. We expect DPUs but didn't
+    /// find any -- likely a misconfiguration or DPU-discovery bug.
     NoDpuReportedByHost,
 }
 

--- a/dev/deployment/devspace/values.base.yaml
+++ b/dev/deployment/devspace/values.base.yaml
@@ -88,7 +88,6 @@ nico-api:
       enabled = true
       create_machines = true
       allow_changing_bmc_proxy = true
-      allow_zero_dpu_hosts = true
       bmc_proxy = "machine-a-tron-bmc-mock.nico-system.svc.cluster.local:1266"
       run_interval = "10s"
       machines_created_per_run = 1000

--- a/dev/mac-local-dev/carbide-api-config.toml
+++ b/dev/mac-local-dev/carbide-api-config.toml
@@ -154,7 +154,6 @@ create_machines = true
 allow_changing_bmc_proxy = true
 bmc_proxy = ":2000"
 run_interval = "10s"
-allow_zero_dpu_hosts = true
 
 [component_manager]
 nv_switch_backend = "nsm"

--- a/dev/webdev-env/carbide-api-config.toml
+++ b/dev/webdev-env/carbide-api-config.toml
@@ -83,4 +83,3 @@ create_machines = false
 allow_changing_bmc_proxy = false
 bmc_proxy = ":2000"
 run_interval = "600s"
-allow_zero_dpu_hosts = true


### PR DESCRIPTION
## Description

This supports https://github.com/NVIDIA/infra-controller/issues/1523.

This rips out the `allow_zero_dpu_hosts` flag entirely. With per-host and site-wide `dpu_mode` available, we shouldn't need to say "*allow zero DPU hosts*" -- we should simply express what `ExpectedMachines` are *expected* to be `DpuMode::NoDpu` (or `::NicMode`, or `::DpuMode`), which we can also set at the site level now too.

For example we explicitly say:
- If an `ExpectedMachine` is marked `DpuMode::DpuMode` (per-host or site-level default), we *expect* DPUs; if `site-explorer` doesn't find any, it logs a warning and skips ingestion.
- If an `ExpectedMachine` is marked as `DpuMode::NoDpu`, we *DON'T* expect DPUs; if the BMC reports some, `site-explorer` ignores them and ingests the host as zero-DPU.
- If an `ExpectedMachine` is marked as `DpuMode::NicMode`, `site-explorer` effectively ingests the host as zero-DPU; when it explores a `NicMode` host with DPUs, it will `set_nic_mode` on them as needed, naturally removing them from the DPU list across exploration cycles until all DPUs are reporting `NicMode`.

...no need for saying `allow_zero_dpu_hosts`. If an `ExpectedMachine` isn't marked `NoDpu`, then we don't expect it to be. If it is, then we do.

Any configs out there that still have `allow_zero_dpu_hosts = true` will keep parsing fine -- it just won't do anything going forward; setting `dpu_mode: no_dpu` or `dpu_mode: nic_mode` (or `dpu_mode: dpu_mode`) is all that needs to be set on the `ExpectedMachine` (or site-level config).

Went through existing tests to make sure we've got good coverage (and added some). Table below:

| Case                               | Action                                  | Coverage                                                                  |
|----------------------------------------------|--------------------------------------------------------|---------------------------------------------------------------------------|
| Zero-DPU host w/ `::NoDpu` set | ingest as zero-DPU             | `test_site_explorer_ingests_no_dpu_host` (and `test_site_explorer_main`) |
| Zero-DPU host, w/ `::DpuMode` set | skip/warn/metric | `test_site_explorer_skips_unexpected_zero_dpu_host`                      |
| Zero-DPU host w/ `::NicMode` set | ingest as zero-DPU | `test_site_explorer_ingests_nic_mode_host_with_no_observed_dpus`       |
| `NicMode` set w/ DPU still in DPU mode   | fix via `set_nic_mode` | `test_site_explorer_auto_corrects_nic_mode_per_expected_machine` |
| `Err(NoDpu) + expected_dpu_count == 0`       | return `Ok(None)`     | `handle_no_dpu_error_treats_as_ok_on_zero_dpu_host`                     |
| `Err(NoDpu) + expected_dpu_count > 0`        | return the error | `handle_no_dpu_error_surfaces_when_dpus_were_expected`                |
| BMC call succeeded (any `expected_dpu_count`) | return the success untouched | `handle_no_dpu_error_passes_through_success`                          |
| BMC failed for a non-`NoDpu` reason (e.g. lockdown) | return the error untouched (only `NoDpu` is ever swallowed) | `handle_no_dpu_error_does_not_touch_other_errors`                     |
| Integration e2e for Zero-DPU (machine-a-tron) | (None)             | `test_machine_a_tron_singledpu_nic_mode` + integration tests |

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

Technically it just makes it so `dpu_mode: no_dpu` works now without needing to also set `allow_zero_dpu_hosts: true`.

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->



Closes #1523
