### PR TITLE
feat: HostInband segment support for DPU-less provisioning

### DIFF
--- a/crates/admin-cli/src/devenv/config/apply/args.rs
+++ b/crates/admin-cli/src/devenv/config/apply/args.rs
@@ -34,7 +34,11 @@ pub struct Args {
     )]
     pub path: String,
 
-    #[clap(long, short, help = "Vpc prefix or network segment?")]
+    #[clap(
+        long,
+        short,
+        help = "Vpc prefix, tenant network segment, or HostInband segment?"
+    )]
     pub mode: NetworkChoice,
 }
 
@@ -42,4 +46,6 @@ pub struct Args {
 pub enum NetworkChoice {
     NetworkSegment,
     VpcPrefix,
+    /// Flat VPC plus HostInband segment for hosts with no DPU.
+    HostInbandSegment,
 }

--- a/crates/admin-cli/src/devenv/config/apply/cmd.rs
+++ b/crates/admin-cli/src/devenv/config/apply/cmd.rs
@@ -29,9 +29,21 @@ use crate::rpc::ApiClient;
 struct DevEnvFileConfig {
     #[serde(default)]
     overlay_networks: Vec<Ipv4Network>,
+    /// Networks for HostInband segments on hosts with no DPU. `reserve_first`
+    /// is the number of leading IPs to reserve for the gateway and infra.
+    #[serde(default)]
+    host_inband_networks: Vec<HostInbandNetwork>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct HostInbandNetwork {
+    prefix: Ipv4Network,
+    #[serde(default)]
+    reserve_first: i32,
 }
 
 const DEVENV_VPC_NAME: &str = "devenv_tenant_vpc";
+const DEVENV_FLAT_VPC_NAME: &str = "devenv_flat_vpc";
 
 async fn get_or_create_vpc(api_client: &ApiClient) -> CarbideCliResult<Vpc> {
     // Get or create VPC with name "devenv_tenant_vpc"
@@ -137,12 +149,103 @@ async fn handle_devenv_config(
     config: DevEnvFileConfig,
     api_client: &ApiClient,
 ) -> eyre::Result<()> {
-    if !config.overlay_networks.is_empty() {
-        if mode == NetworkChoice::NetworkSegment {
+    match mode {
+        NetworkChoice::NetworkSegment => {
+            if config.overlay_networks.is_empty() {
+                eyre::bail!(
+                    "mode network-segment selected but overlay_networks is empty in the config"
+                );
+            }
             handle_overlay_segment_creation(api_client, &config.overlay_networks).await?;
-        } else {
+        }
+        NetworkChoice::VpcPrefix => {
+            if config.overlay_networks.is_empty() {
+                eyre::bail!("mode vpc-prefix selected but overlay_networks is empty in the config");
+            }
             handle_overlay_vpc_prefix_creation(api_client, &config.overlay_networks).await?;
         }
+        NetworkChoice::HostInbandSegment => {
+            if config.host_inband_networks.is_empty() {
+                eyre::bail!(
+                    "mode host-inband-segment selected but host_inband_networks is empty in the config"
+                );
+            }
+            handle_host_inband_segment_creation(api_client, &config.host_inband_networks).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn get_or_create_flat_vpc(api_client: &ApiClient) -> CarbideCliResult<Vpc> {
+    let vpcs = api_client.get_vpc_by_name(DEVENV_FLAT_VPC_NAME).await?;
+    if let Some(vpc) = vpcs.vpcs.first().cloned() {
+        return Ok(vpc);
+    }
+    let vpc_id = uuid::Uuid::new_v4().into();
+    let vpc = api_client
+        .create_flat_vpc(DEVENV_FLAT_VPC_NAME, vpc_id)
+        .await?;
+    println!(
+        "Created Flat VPC with ID: {}, name: {}",
+        vpc.id.unwrap(),
+        vpc.metadata
+            .as_ref()
+            .map(|x| x.name.as_str())
+            .unwrap_or_default()
+    );
+    Ok(vpc)
+}
+
+async fn handle_host_inband_segment_creation(
+    api_client: &ApiClient,
+    networks: &[HostInbandNetwork],
+) -> CarbideCliResult<()> {
+    let vpc = get_or_create_flat_vpc(api_client).await?;
+    let vpc_id = vpc.id.ok_or_else(|| {
+        CarbideCliError::GenericError("Flat VPC missing id after creation".to_string())
+    })?;
+
+    for net in networks {
+        if net.reserve_first < 0 {
+            return Err(CarbideCliError::GenericError(format!(
+                "reserve_first must be >= 0 for host_inband network {}",
+                net.prefix
+            )));
+        }
+        let prefix = net.prefix;
+        let name = format!("devenv_host_inband_{prefix}");
+        let existing = api_client
+            .get_all_segments(None, Some(name.clone()), 2)
+            .await?;
+
+        if let Some(ns) = existing.network_segments.first() {
+            println!(
+                "Found HostInband segment id: {}, name: {} for prefix: {}",
+                ns.id.unwrap(),
+                name,
+                prefix,
+            );
+            continue;
+        }
+
+        let ns_id: NetworkSegmentId = uuid::Uuid::new_v4().into();
+        let ns = api_client
+            .create_host_inband_segment(
+                ns_id,
+                vpc_id,
+                name.clone(),
+                prefix.to_string(),
+                prefix.nth(1).map(|x| x.to_string()),
+                net.reserve_first,
+            )
+            .await?;
+
+        println!(
+            "Created HostInband segment id: {}, name: {} for prefix: {}",
+            ns.id.unwrap(),
+            name,
+            prefix,
+        );
     }
     Ok(())
 }

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -1167,6 +1167,81 @@ impl ApiClient {
         Ok(self.0.create_network_segment(request).await?)
     }
 
+    pub async fn create_flat_vpc(&self, name: &str, vpc_id: VpcId) -> CarbideCliResult<rpc::Vpc> {
+        Ok(self
+            .0
+            .create_vpc(VpcCreationRequest {
+                vni: None,
+                routing_profile_type: None,
+                tenant_organization_id: "devenv_test_org".to_string(),
+                tenant_keyset_id: None,
+                network_virtualization_type: Some(VpcVirtualizationType::Flat.into()),
+                id: Some(vpc_id),
+                metadata: Some(rpc::Metadata {
+                    name: name.to_string(),
+                    description: "Flat VPC for zero-DPU HostInband segments".to_string(),
+                    labels: vec![],
+                }),
+                network_security_group_id: None,
+                default_nvlink_logical_partition_id: None,
+            })
+            .await?)
+    }
+
+    pub async fn create_host_inband_segment(
+        &self,
+        id: NetworkSegmentId,
+        vpc_id: VpcId,
+        name: String,
+        prefix: String,
+        gateway: Option<String>,
+        reserve_first: i32,
+    ) -> CarbideCliResult<NetworkSegment> {
+        // Without a subdomain_id link the machine_dhcp_records view's inner
+        // join on `domains` drops every interface created on this segment,
+        // and Kea can't issue OFFERs. Require exactly one domain rather than
+        // silently creating a segment that cannot DHCP or binding to an
+        // arbitrary domain when several exist.
+        let mut domain_ids = self
+            .get_domains(None)
+            .await?
+            .domains
+            .into_iter()
+            .filter_map(|d| d.id);
+        let subdomain_id = match (domain_ids.next(), domain_ids.next()) {
+            (Some(id), None) => Some(id),
+            (None, _) => {
+                return Err(CarbideCliError::GenericError(
+                    "no domain available for HostInband segment, create a domain first".to_string(),
+                ));
+            }
+            (Some(_), Some(_)) => {
+                return Err(CarbideCliError::GenericError(
+                    "multiple domains found, cannot pick one for the HostInband segment"
+                        .to_string(),
+                ));
+            }
+        };
+        let request = NetworkSegmentCreationRequest {
+            vpc_id: Some(vpc_id),
+            name,
+            subdomain_id,
+            mtu: Some(1500),
+            prefixes: vec![NetworkPrefix {
+                id: None,
+                prefix,
+                gateway,
+                reserve_first,
+                // computed by the server, ignored on create
+                free_ip_count: 1,
+                svi_ip: None,
+            }],
+            segment_type: NetworkSegmentType::HostInband as i32,
+            id: Some(id),
+        };
+        Ok(self.0.create_network_segment(request).await?)
+    }
+
     // Fetch from Carbide and return a vector of Dpa interface IDs
     async fn get_dpa_ids(&self) -> CarbideCliResult<rpc::DpaInterfaceIdList> {
         Ok(self.0.get_all_dpa_interface_ids().await?)

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -1821,6 +1821,12 @@ impl SiteExplorer {
         let underlay_segments =
             db::network_segment::list_segment_ids(&mut txn, Some(NetworkSegmentType::Underlay))
                 .await?;
+        // A BMC that shares the host network is preallocated on a HostInband segment so scan
+        // those too, but only for BMC interfaces. The host in-band NIC also DHCPs onto a
+        // HostInband segment with no machine_id and must never be treated as a Redfish endpoint.
+        let host_inband_segments =
+            db::network_segment::list_segment_ids(&mut txn, Some(NetworkSegmentType::HostInband))
+                .await?;
         let explored_endpoints = db::explored_endpoints::find_all(txn.as_pgconn()).await?;
         let expected_switches = db::expected_switch::find_all(&mut txn).await?;
         let expected_machines = db::expected_machine::find_all(&mut txn).await?;
@@ -1990,21 +1996,28 @@ impl SiteExplorer {
         );
 
         let build_index_start = Instant::now();
-        let underlay_interfaces: Vec<MachineInterfaceSnapshot> = interfaces
+        let scannable_interfaces: Vec<MachineInterfaceSnapshot> = interfaces
             .into_iter()
             .filter(|iface| {
-                underlay_segments.contains(&iface.segment_id)
-                    && (iface.machine_id.is_none() || iface.interface_type == InterfaceType::Bmc)
+                let is_bmc = iface.interface_type == InterfaceType::Bmc;
+                // On Underlay an unadopted interface is a BMC to explore, and adopted BMCs
+                // stay visible too.
+                let underlay = underlay_segments.contains(&iface.segment_id)
+                    && (iface.machine_id.is_none() || is_bmc);
+                // On HostInband only scan BMCs. The host in-band NIC also DHCPs here with no
+                // machine_id and is not a Redfish endpoint.
+                let host_inband = host_inband_segments.contains(&iface.segment_id) && is_bmc;
+                underlay || host_inband
             })
             .collect();
-        let underlay_interface_count = underlay_interfaces.len();
+        let scannable_interface_count = scannable_interfaces.len();
         metrics.record_update_explored_endpoints_count(
-            "underlay_interfaces",
-            underlay_interface_count,
+            "scannable_interfaces",
+            scannable_interface_count,
         );
 
-        // Start an index of all underlay interfaces, expected machines, expected power shelves, and expected switches.
-        let index = ExploredEndpointIndex::builder(explored_endpoints, underlay_interfaces)
+        // Start an index of all scannable interfaces, expected machines, expected power shelves, and expected switches.
+        let index = ExploredEndpointIndex::builder(explored_endpoints, scannable_interfaces)
             .with_expected_machines(expected_machines)
             .with_expected_switches(expected_switches)
             .with_expected_power_shelves(expected_power_shelves)

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -36,6 +36,7 @@ use model::machine::{
     CURRENT_STATE_MODEL_VERSION, DpuDiscoveringState, DpuDiscoveringStates, Machine,
     MachineInterfaceSnapshot, ManagedHostState,
 };
+use model::machine_interface::InterfaceType;
 use model::machine_interface_address::MachineInterfaceAssociation;
 use model::network_segment::NetworkSegmentType;
 use model::predicted_machine_interface::NewPredictedMachineInterface;
@@ -476,9 +477,26 @@ impl MachineCreator {
             {
                 // There's already a machine_interface with this MAC...
                 if let Some(existing_machine_id) = machine_interface.machine_id {
-                    // ...If it has a MachineId, something's gone wrong. We already checked db::machine::find_by_mac()
-                    // above for all mac addresses, and returned Ok(false) if any were found. Finding an interface
-                    // with this MAC with a non-nil machine_id is a contradiction.
+                    // Same machine_id means the preallocated BMC interface row we
+                    // just attached via update_machine_topology(), not a contradiction.
+                    if existing_machine_id == *machine_id {
+                        // Reconcile its primary flag like the anonymous path
+                        // below, so a stale primary does not collide when the
+                        // real primary NIC is adopted. A BMC interface is never
+                        // primary, even when it shares the host NIC MAC.
+                        let want_primary =
+                            is_primary && machine_interface.interface_type != InterfaceType::Bmc;
+                        if machine_interface.primary_interface != want_primary {
+                            db::machine_interface::set_primary_interface(
+                                &machine_interface.id,
+                                want_primary,
+                                txn,
+                            )
+                            .await?;
+                        }
+                        continue;
+                    }
+                    // Different machine_id contradicts the find_by_mac() above.
                     tracing::error!(
                         %mac_address,
                         %machine_id,


### PR DESCRIPTION
## Description
Add HostInband as a first-class provisioning network: site-explorer includes HostInband segments in its scan set and tolerates a BMC interface preallocated on one (same machine_id), and admin-cli gains a host-inband-segment mode that creates a flat VPC + HostInband segment via new RPCs.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

