### PR TITLE
feat(api): skip DPU-tied steps for zero-DPU hosts

### DIFF
--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -4934,6 +4934,14 @@ impl StateHandler for HostMachineStateHandler {
                     let boot_interface_mac =
                         mh_snapshot.boot_interface_mac().map(|m| m.to_string());
 
+                    if mh_snapshot.is_zero_dpu() && ctx.services.site_config.allow_zero_dpu_hosts {
+                        tracing::info!(
+                            machine_id = %mh_snapshot.host_snapshot.id,
+                            "Skipping is_bios_setup: zero-DPU host (allow_zero_dpu_hosts=true); no BIOS profile applied for zero-DPU hosts."
+                        );
+                        return Ok(StateHandlerOutcome::transition(next_state));
+                    }
+
                     match redfish_client
                         .is_bios_setup(boot_interface_mac.as_deref())
                         .await
@@ -5193,6 +5201,20 @@ impl StateHandler for HostMachineStateHandler {
                             }
                         }
                         LockdownState::WaitForDPUUp => {
+                            // Nothing to wait for in zero-DPU mode.
+                            if mh_snapshot.dpu_snapshots.is_empty() {
+                                let next_state = ManagedHostState::BomValidating {
+                                    bom_validating_state: BomValidating::MatchingSku(
+                                        BomValidatingContext {
+                                            machine_validation_context: Some(
+                                                "Discovery".to_string(),
+                                            ),
+                                            reboot_retry_count: None,
+                                        },
+                                    ),
+                                };
+                                return Ok(StateHandlerOutcome::transition(next_state));
+                            }
                             // Has forge-dpu-agent reported state? That means DPU is up.
                             if are_dpus_up_trigger_reboot_if_needed(
                                 mh_snapshot,
@@ -9495,6 +9517,12 @@ async fn call_machine_setup_and_handle_no_dpu_error(
     expected_dpu_count: usize,
     site_config: &MachineStateHandlerSiteConfig,
 ) -> Result<Option<String>, RedfishError> {
+    if expected_dpu_count == 0 && site_config.allow_zero_dpu_hosts {
+        tracing::info!(
+            "Skipping machine_setup: zero-DPU host (allow_zero_dpu_hosts=true); BIOS profile is DPU-tied."
+        );
+        return Ok(None);
+    }
     let setup_result = redfish_client
         .machine_setup(
             boot_interface_mac,
@@ -9901,6 +9929,13 @@ async fn handle_instance_host_platform_config(
                     "Skipping boot order remediation on Viking (known FW/BMC issue)"
                 );
                 false
+            } else if mh_snapshot.is_zero_dpu() && ctx.services.site_config.allow_zero_dpu_hosts {
+                tracing::info!(
+                    machine_id = %mh_snapshot.host_snapshot.id,
+                    bmc_vendor = %vendor,
+                    "Skipping is_boot_order_setup: zero-DPU host (allow_zero_dpu_hosts=true); persistent boot order is not configured for zero-DPU hosts."
+                );
+                false
             } else if redfish_client
                 .is_boot_order_setup(&boot_interface_mac.to_string())
                 .await
@@ -10025,32 +10060,41 @@ async fn handle_instance_host_platform_config(
 
             let boot_interface_mac = mh_snapshot.boot_interface_mac().map(|m| m.to_string());
 
-            match redfish_client
-                .is_bios_setup(boot_interface_mac.as_deref())
-                .await
-            {
-                Ok(true) => {
-                    tracing::info!(
-                        machine_id = %mh_snapshot.host_snapshot.id,
-                        "BIOS setup verified successfully"
-                    );
-                    next_instance_state
-                }
-                Ok(false) => {
-                    return Ok(StateHandlerOutcome::wait(
-                        "Polling BIOS setup status, waiting for settings to be applied".to_string(),
-                    ));
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        machine_id = %mh_snapshot.host_snapshot.id,
-                        error = %e,
-                        "Failed to check BIOS setup status, will retry"
-                    );
-                    return Ok(StateHandlerOutcome::wait(format!(
-                        "Failed to check BIOS setup status: {}. Will retry.",
-                        e
-                    )));
+            if mh_snapshot.is_zero_dpu() && ctx.services.site_config.allow_zero_dpu_hosts {
+                tracing::info!(
+                    machine_id = %mh_snapshot.host_snapshot.id,
+                    "Skipping is_bios_setup: zero-DPU host (allow_zero_dpu_hosts=true); no BIOS profile applied for zero-DPU hosts."
+                );
+                next_instance_state
+            } else {
+                match redfish_client
+                    .is_bios_setup(boot_interface_mac.as_deref())
+                    .await
+                {
+                    Ok(true) => {
+                        tracing::info!(
+                            machine_id = %mh_snapshot.host_snapshot.id,
+                            "BIOS setup verified successfully"
+                        );
+                        next_instance_state
+                    }
+                    Ok(false) => {
+                        return Ok(StateHandlerOutcome::wait(
+                            "Polling BIOS setup status, waiting for settings to be applied"
+                                .to_string(),
+                        ));
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            machine_id = %mh_snapshot.host_snapshot.id,
+                            error = %e,
+                            "Failed to check BIOS setup status, will retry"
+                        );
+                        return Ok(StateHandlerOutcome::wait(format!(
+                            "Failed to check BIOS setup status: {}. Will retry.",
+                            e
+                        )));
+                    }
                 }
             }
         }
@@ -10711,6 +10755,14 @@ async fn set_host_boot_order(
             const CHECK_BOOT_ORDER_TIMEOUT_MINUTES: i64 = 30;
 
             let retry_count = set_boot_order_info.retry_count;
+
+            if mh_snapshot.is_zero_dpu() && ctx.services.site_config.allow_zero_dpu_hosts {
+                tracing::info!(
+                    "Boot order check skipped for {}: zero-DPU host (allow_zero_dpu_hosts=true); persistent boot order is not configured for zero-DPU hosts.",
+                    mh_snapshot.host_snapshot.id,
+                );
+                return Ok(SetBootOrderOutcome::Done);
+            }
 
             let boot_interface_mac = mh_snapshot.boot_interface_mac().ok_or_else(|| {
                 StateHandlerError::GenericError(eyre::eyre!(

--- a/crates/api/src/state_controller/machine/handler.rs
+++ b/crates/api/src/state_controller/machine/handler.rs
@@ -10456,18 +10456,33 @@ async fn set_host_boot_order(
 ) -> Result<SetBootOrderOutcome, StateHandlerError> {
     match set_boot_order_info.set_boot_order_state {
         SetBootOrderState::SetBootOrder => {
-            // There used to be a `force_dpu_nic_mode`-gated short-circuit
-            // here that, for zero-DPU hosts when the flag was set, called
-            // `boot_first(Boot::UefiHttp)` and returned `Done` to skip
-            // the rest of the SetBootOrder flow. Dropped along with the
-            // flag. We don't extend the `boot_first(UefiHttp)` call to
-            // all zero-DPU hosts because libredfish doesn't implement
-            // `boot_first` for every vendor yet (Dell currently returns
-            // `NotSupported`); zero-DPU hosts fall through to the
-            // `set_boot_order_dpu_first` path below, which downgrades
-            // the resulting `NoDpu` error via `allow_zero_dpu_hosts`
-            // and still hits `CheckBootOrder` for verification.
-            //
+            // Zero-DPU dispatch: `set_boot_order_dpu_first` is DPU-targeting and
+            // returns `NotSupported` on vendors without a custom impl. When the
+            // host has no DPU, PATCH BootSourceOverride directly — UefiHttp
+            // first, fall back to Pxe for BMCs that don't accept UefiHttp.
+            // Downstream substates handle `jid = None`.
+            if ctx.services.site_config.allow_zero_dpu_hosts
+                && mh_snapshot
+                    .host_snapshot
+                    .associated_dpu_machine_ids()
+                    .is_empty()
+            {
+                if let Err(uefi_err) = redfish_client.boot_first(Boot::UefiHttp).await {
+                    tracing::warn!(
+                        %uefi_err,
+                        "boot_first(UefiHttp) failed; falling back to Pxe"
+                    );
+                    redfish_client
+                        .boot_first(Boot::Pxe)
+                        .await
+                        .map_err(|e| redfish_error("boot_first Pxe (fallback)", e))?;
+                }
+                return Ok(SetBootOrderOutcome::Continue(SetBootOrderInfo {
+                    set_boot_order_jid: None,
+                    set_boot_order_state: SetBootOrderState::WaitForSetBootOrderJobScheduled,
+                    retry_count: set_boot_order_info.retry_count,
+                }));
+            }
             // Resolve the boot NIC MAC the same way `CheckHostConfig` does,
             // supporting hosts with DPU(s) and zero DPUs alike.
             let boot_interface_mac = mh_snapshot.boot_interface_mac().ok_or_else(|| {

--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -95,6 +95,7 @@ nico-api:
       # Site explorer — periodic background scan of site inventory
       # -----------------------------------------------------------------------
       [site_explorer]
+      allow_zero_dpu_hosts = false
       run_interval = "30s"
 
       # -----------------------------------------------------------------------


### PR DESCRIPTION
## Description

When allow_zero_dpu_hosts is true, zero-DPU hosts skip: is_bios_setup verification, machine_setup (short-circuited before the Redfish call), is_boot_order_setup, and set_host_boot_order's SetBootOrder arm (returns Done — no DPU-first boot ordering to configure). The toggle is surfaced in the local nico-core values (default false).

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

