### PR TITLE
carbide-lints: Update nightly rust to 2026-05-27

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -42,7 +42,7 @@ BUILD_CONTAINER_AARCH64_URL = { value = "urm.nvidia.com/swngc-ngcc-docker-local/
 #
 # Make sure to update the RUST_NIGHTLY variable in
 # dev/docker/Dockerfile.build-container-x86_64 if you change this.
-RUST_NIGHTLY = "nightly-2025-11-14"
+RUST_NIGHTLY = "nightly-2026-05-27"
 
 [tasks.book]
 workspace = false
@@ -695,7 +695,7 @@ description = "Set up the `cargo carbide-lints` command"
 dependencies = ["setup-nightly-rust"]
 script = [
   # Don't waste cycles, only install what isn't installed
-  "which cargo-carbide-lints >/dev/null 2>&1 || (cd \"${REPO_ROOT}/lints/carbide-lints\" && cargo +${RUST_NIGHTLY} install --path .)",
+  "cd \"${REPO_ROOT}/lints/carbide-lints\" && cargo +${RUST_NIGHTLY} install --path .",
 ]
 
 [tasks.carbide-lints]

--- a/crates/agent/src/netlink.rs
+++ b/crates/agent/src/netlink.rs
@@ -20,10 +20,11 @@ use std::error::Error;
 
 use futures_util::TryStreamExt;
 use rpc::forge as rpc;
+use rtnetlink;
 use rtnetlink::packet_route::link::{
     LinkAttribute, LinkLayerType, LinkMessage, State as LinkState,
 };
-use {rtnetlink, tokio};
+use tokio;
 
 #[derive(Clone, Debug)]
 // Most of the fields are Option<T> because the netlink protocol allows them

--- a/crates/api-model/src/attestation.rs
+++ b/crates/api-model/src/attestation.rs
@@ -277,7 +277,7 @@ pub mod spdm {
         }
     }
 
-    #[derive(FromRow, Debug, Clone)]
+    #[derive(Debug, Clone)]
     pub struct SpdmDeviceAttestationDetails {
         pub machine_id: MachineId,
         pub device_id: String,

--- a/crates/libmlx/src/embedded/cmd/cmds.rs
+++ b/crates/libmlx/src/embedded/cmd/cmds.rs
@@ -21,7 +21,8 @@ use std::time::Duration;
 use carbide_libmlx_model::device::info::MlxDeviceInfo;
 use prettytable::{Cell, Row, Table};
 use regex::Regex;
-use {serde_json, tracing};
+use serde_json;
+use tracing;
 
 use crate::device::cmd::device::args::DeviceArgs;
 use crate::device::cmd::device::cmds::handle as handle_device;

--- a/crates/nras/src/parser.rs
+++ b/crates/nras/src/parser.rs
@@ -17,7 +17,8 @@
 
 use std::collections as stdcol;
 
-use {jsonwebtoken as jst, serde_json as sj};
+use jsonwebtoken as jst;
+use serde_json as sj;
 
 use crate::{NrasError, ProcessedAttestationOutcome, RawAttestationOutcome};
 

--- a/crates/nras/tests/integration.rs
+++ b/crates/nras/tests/integration.rs
@@ -22,8 +22,9 @@ mod mock_server;
 use std::collections as stdcol;
 
 use fixtures::*;
+use mock_keystore as mks;
+use mock_server as ms;
 use nras::{DeviceAttestationInfo, NrasError, VerifierClient};
-use {mock_keystore as mks, mock_server as ms};
 
 // --> NrasVerifierClient <--
 #[tokio::test]

--- a/dev/docker/Dockerfile.build-container-x86_64
+++ b/dev/docker/Dockerfile.build-container-x86_64
@@ -21,7 +21,7 @@ FROM rust:1.95.0-slim-bookworm
 # Set in gitlab-templates/scripts/build-push-container-image.sh
 ARG CI_COMMIT_SHORT_SHA
 ENV CI_COMMIT_SHORT_SHA $CI_COMMIT_SHORT_SHA
-ENV RUST_NIGHTLY nightly-2025-11-14
+ENV RUST_NIGHTLY nightly-2026-05-27
 
 # Change CACHEKEY to whatever so docker doesn't re-use the cache from before if you want apt to actually run.
 #

--- a/lints/carbide-lints/build.rs
+++ b/lints/carbide-lints/build.rs
@@ -16,7 +16,9 @@
  */
 fn main() {
     let rustc = std::env::var("RUSTC").unwrap();
-    let output = std::process::Command::new(rustc).arg("--print=sysroot").output();
+    let output = std::process::Command::new(rustc)
+        .arg("--print=sysroot")
+        .output();
     let stdout = String::from_utf8(output.unwrap().stdout).unwrap();
     let sysroot = stdout.trim_end();
     println!("cargo:rustc-link-arg=-Wl,-rpath={sysroot}/lib")

--- a/lints/carbide-lints/rust-toolchain.toml
+++ b/lints/carbide-lints/rust-toolchain.toml
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 [toolchain]
-channel = "nightly-2025-11-14"
+channel = "nightly-2026-05-27"

--- a/lints/carbide-lints/src/main.rs
+++ b/lints/carbide-lints/src/main.rs
@@ -77,13 +77,13 @@ impl Callbacks for CarbideLints {
         // Override the `mir_borrowck` query from rustc. This query has the right information
         // available, namely both type-checker results and borrow-checker results.
         config.override_queries = Some(|_session, queries| {
-            let orig_borrowck_query = Box::new(queries.mir_borrowck);
+            let orig_borrowck_query = Box::new(queries.queries.mir_borrowck);
             // Keep the original query in a global so we can call it.
             borrowck_shim::ORIG_BORROWCK_QUERY
                 .write()
                 .unwrap()
                 .replace(orig_borrowck_query);
-            queries.mir_borrowck = |tcx, def_id| {
+            queries.queries.mir_borrowck = |tcx, def_id| {
                 let mut shim = BorrowckShim::new();
                 let result = shim.mir_borrowck(tcx, def_id);
                 result
@@ -92,15 +92,18 @@ impl Callbacks for CarbideLints {
     }
 }
 
-fn main() {
+fn main() -> std::process::ExitCode {
     let early_dcx = EarlyDiagCtxt::new(ErrorOutputType::default());
     rustc_driver::install_ice_hook("https://github.com/NVIDIA/carbide/issues/new", |_| ());
     let handler = EarlyDiagCtxt::new(ErrorOutputType::HumanReadable {
-        kind: HumanReadableErrorType::Default { short: false },
+        kind: HumanReadableErrorType {
+            short: false,
+            unicode: false,
+        },
         color_config: ColorConfig::Auto,
     });
     rustc_driver::init_rustc_env_logger(&handler);
-    std::process::exit(rustc_driver::catch_with_exit_code(move || {
+    rustc_driver::catch_with_exit_code(move || {
         let mut orig_args = rustc_driver::args::raw_args(&early_dcx);
 
         // Taken from clippy's driver: Support the `--sysroot` rustc arg.
@@ -156,7 +159,7 @@ fn main() {
             let mut driver = DefaultCallbacks;
             rustc_driver::run_compiler(&args, &mut driver);
         }
-    }))
+    })
 }
 
 fn has_arg(args: &[String], find_arg: &str) -> bool {

--- a/lints/carbide-lints/src/txn_held_across_await.rs
+++ b/lints/carbide-lints/src/txn_held_across_await.rs
@@ -16,6 +16,7 @@
  */
 use rustc_ast::UnOp;
 use rustc_data_structures::fx::FxHashMap;
+use rustc_errors::DiagDecorator;
 use rustc_hir as hir;
 use rustc_hir::def::Res;
 use rustc_hir::intravisit::{self, Visitor};
@@ -27,13 +28,11 @@ use rustc_lint_defs::{Lint, LintPass, LintVec};
 use rustc_middle::hir::nested_filter;
 use rustc_middle::hir::place::{Place as HirPlace, PlaceBase};
 use rustc_middle::mir::{Location, ProjectionElem};
-use rustc_middle::ty::{
-    Adt, ParamEnv, Ty as MiddleTy, TyCtxt, TypeckResults, UpvarId, UpvarPath,
-};
+use rustc_middle::ty::{Adt, ParamEnv, Ty as MiddleTy, TyCtxt, TypeckResults, UpvarId, UpvarPath};
 use rustc_middle::{bug, mir};
+use rustc_mir_dataflow::Analysis;
 use rustc_mir_dataflow::impls::{MaybeInitializedPlaces, MaybeUninitializedPlaces};
 use rustc_mir_dataflow::move_paths::{LookupResult, MoveData};
-use rustc_mir_dataflow::Analysis;
 use rustc_span::def_id::DefId;
 use rustc_span::{Span, Symbol};
 use rustc_type_ir::inherent::SliceLike;
@@ -267,16 +266,16 @@ impl TxnHeldAcrossAwait {
                     continue;
                 }
 
-                tcx.node_span_lint(
+                tcx.emit_node_span_lint(
                     TXN_HELD_ACROSS_AWAIT,
                     hir_body.id().hir_id,
                     source_info.span,
-                    |diag| {
+                    DiagDecorator(|diag| {
                         diag.primary_message(
                             "A sqlx::Transaction is being held across this 'await' point",
                         );
                         diag.span_note(local_span, "Transaction declared here");
-                    },
+                    }),
                 );
             }
         }
@@ -395,16 +394,16 @@ impl TxnHeldAcrossAwait {
                     continue;
                 }
 
-                tcx.node_span_lint(
+                tcx.emit_node_span_lint(
                     TXN_HELD_ACROSS_AWAIT,
                     closure.body.hir_id,
                     source_info.span,
-                    |diag| {
+                    DiagDecorator(|diag| {
                         diag.primary_message(
                             "A sqlx::Transaction is being held across this 'await' point",
                         );
                         diag.span_note(hir_local_place.var_ident.span, "Transaction declared here");
-                    },
+                    }),
                 );
             }
         }
@@ -811,26 +810,20 @@ impl<'tcx> DbAwaitFinder<'tcx> {
         };
 
         let Some(await_expr) = finder.awaited_expr() else {
-            tcx.node_span_lint(
+            tcx.emit_node_span_lint(
                 TXN_HELD_ACROSS_AWAIT,
                 body.id().hir_id,
                 params.await_span,
-                |diag| {
+                DiagDecorator(|diag| {
                     diag.primary_message(
                         "DbAwaitFinder could not find the awaited expression for this await span",
                     );
-                },
+                }),
             );
             return false;
         };
 
-        lint.is_passing_txn(
-            txn_local_hir_id,
-            await_expr,
-            tcx,
-            typeck_results,
-            param_env,
-        )
+        lint.is_passing_txn(txn_local_hir_id, await_expr, tcx, typeck_results, param_env)
     }
 
     fn awaited_expr(&self) -> Option<&'tcx Expr<'tcx>> {

--- a/lints/carbide-lints/src/txn_without_commit.rs
+++ b/lints/carbide-lints/src/txn_without_commit.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use rustc_errors::DiagDecorator;
 use rustc_lint_defs::{Lint, LintPass, LintVec};
 use rustc_middle::mir::{self, LocalKind};
 use rustc_middle::ty::{Ty as MiddleTy, TyCtxt};
@@ -130,15 +131,15 @@ impl TxnWithoutCommit {
                 continue;
             }
 
-            tcx.node_span_lint(
+            tcx.emit_node_span_lint(
                 TXN_WITHOUT_COMMIT,
                 body_id.hir_id,
                 decl.source_info.span,
-                |diag| {
+                DiagDecorator(|diag| {
                     diag.primary_message(
                         "sqlx::Transaction is dropped by this function without commit()/rollback(), or being moved out",
                     );
-                },
+                }),
             );
         }
     }

--- a/lints/carbide-lints/tests/integration.rs
+++ b/lints/carbide-lints/tests/integration.rs
@@ -46,6 +46,17 @@ fn driver_runs_and_emits_expected_lint() {
 
     let cargo = std::env::var("CARGO").expect("Cargo should set $CARGO to the running binary");
 
+    let clean_status = Command::new(&cargo)
+        .arg("clean")
+        .arg("--manifest-path")
+        .arg(&manifest_path)
+        .arg("-p")
+        .arg("sqlx_app")
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .status()
+        .expect("failed to clean sqlx_app fixture");
+    assert!(clean_status.success(), "failed to clean sqlx_app fixture");
+
     let output = Command::new(cargo)
         .arg("check")
         .arg("--manifest-path")


### PR DESCRIPTION
## Description
As part of testing out an upgrade to sqlx 0.9, it won't build with our (pretty old now) nightly rust from 2025-11-14.

Update the version of nightly rust we use, including for carbide-lints and the custom cargo fmt in `cargo make format-nightly`.

Relevant changes:

- Update carbide-lints itself for some changes to the rustc internal API
- Fix a duplicate FromRow impl issue that only the new nightly rust seems to have caught
- Run the latest nightly cargo fmt, which seems to expand some of our combined import lines.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Reminder that the nightly rust here is only use to run the `carbide-lints` lint and to run the custom rustfmt flags we use (which are unstable and only available in nightly.) We don't use it for any of the actual infra-controller artifacts.