### PR TITLE
fix: rename nmx_m_id column and delete legacy rows

### DIFF
--- a/crates/admin-cli/src/machine/nvlink_info/args.rs
+++ b/crates/admin-cli/src/machine/nvlink_info/args.rs
@@ -22,7 +22,7 @@ use clap::{Parser, Subcommand};
 pub enum Args {
     #[clap(about = "Show existing NVLink info")]
     Show(NvlinkInfoArgs),
-    #[clap(about = "Build NVLink info from Redfish + NMX-M and populate DB")]
+    #[clap(about = "Build NVLink info from Redfish + NMX-C and populate DB")]
     Populate(NvlinkInfoPopulateArgs),
 }
 

--- a/crates/admin-cli/src/nvl_partition/show/cmd.rs
+++ b/crates/admin-cli/src/nvl_partition/show/cmd.rs
@@ -122,7 +122,7 @@ fn convert_nvl_partition_to_nice_format(
                 .map(|logical_partition_id| logical_partition_id.to_string())
                 .unwrap_or_default(),
         ),
-        ("NMX-M-ID", nvl_partition.nmx_m_id),
+        ("NMX-C-ID", nvl_partition.nmx_m_id),
         (
             "NVLINK DOMAIN UUID",
             nvl_partition.domain_uuid.unwrap_or_default().to_string(),

--- a/crates/admin-cli/src/nvl_partition/show/cmd.rs
+++ b/crates/admin-cli/src/nvl_partition/show/cmd.rs
@@ -122,7 +122,7 @@ fn convert_nvl_partition_to_nice_format(
                 .map(|logical_partition_id| logical_partition_id.to_string())
                 .unwrap_or_default(),
         ),
-        ("NMX-C-ID", nvl_partition.nmx_m_id),
+        ("NMX-C PARTITION ID", nvl_partition.nmx_m_id),
         (
             "NVLINK DOMAIN UUID",
             nvl_partition.domain_uuid.unwrap_or_default().to_string(),

--- a/crates/api-db/migrations/20260526120000_nvlink_partitions_nmx_c_partition_id.sql
+++ b/crates/api-db/migrations/20260526120000_nvlink_partitions_nmx_c_partition_id.sql
@@ -1,0 +1,12 @@
+-- delete existing "legacy" rows with nmx_m_id and rename the field to nmx_c_partition_id
+DELETE FROM nvlink_partitions;
+
+ALTER TABLE nvlink_partitions
+    DROP CONSTRAINT IF EXISTS nvlink_partitions_nmx_m_id_key;
+
+ALTER TABLE nvlink_partitions
+    RENAME COLUMN nmx_m_id TO nmx_c_partition_id;
+
+ALTER TABLE nvlink_partitions
+    ALTER COLUMN nmx_c_partition_id TYPE INTEGER
+    USING nmx_c_partition_id::INTEGER;

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -359,7 +359,7 @@ pub async fn find_ids_by_instance_type_id(
         .map_err(|e| DatabaseError::query(builder.sql(), e))
 }
 
-/// Finds NMX-M info for a list of machine IDs
+/// Finds NVLink info for a list of machine IDs
 ///
 /// * `txn` - A reference to an active DB transaction
 /// * `machine_ids` - A slice of machine IDs to query for

--- a/crates/api-db/src/nvl_partition.rs
+++ b/crates/api-db/src/nvl_partition.rs
@@ -41,7 +41,7 @@ pub async fn create(
 ) -> Result<NvlPartition, DatabaseError> {
     let query = "INSERT INTO nvlink_partitions (
                 id,
-                nmx_m_id,
+                nmx_c_partition_id,
                 name,
                 domain_uuid,
                 logical_partition_id)
@@ -50,7 +50,7 @@ pub async fn create(
 
     let partition: NvlPartitionSnapshotPgJson = sqlx::query_as(query)
         .bind(value.id)
-        .bind(&value.nmx_m_id)
+        .bind(value.nmx_c_partition_id)
         .bind(value.name.as_str())
         .bind(value.domain_uuid)
         .bind(value.logical_partition_id)

--- a/crates/api-model/src/instance/status/nvlink.rs
+++ b/crates/api-model/src/instance/status/nvlink.rs
@@ -67,7 +67,7 @@ impl InstanceNvLinkStatus {
                     InstanceNvLinkGpuStatus {
                         logical_partition_id: obs.logical_partition_id,
                         domain_id: obs.domain_id,
-                        gpu_guid: obs.guid.to_string(), // This is the DeviceUID field returned from NMX-M, which I think matches nvidia-smi GUID
+                        gpu_guid: obs.guid.to_string(), // This is the DeviceUID field returned by the NVLink manager, which should match the nvidia-smi GUID.
                     }
                 }
                 None => {

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -776,7 +776,7 @@ pub struct Machine {
     /// If host upgrades have been completed since the last start explicit start request or actual start
     pub update_complete: bool,
 
-    /// The NMX-M GPU info for this machine.
+    /// The NVLink GPU info for this machine.
     pub nvlink_info: Option<MachineNvLinkInfo>,
 
     /// Whether the DPF is enabled for this machine

--- a/crates/api-model/src/machine/nvlink.rs
+++ b/crates/api-model/src/machine/nvlink.rs
@@ -63,7 +63,7 @@ pub fn nvlink_config_synced(
     }
 
     let Some(observation) = observation.as_ref() else {
-        return Err(NvLinkConfigNotSyncedReason("Due to missing NvLink status observation, it can't be verified whether the NvLink config is applied to NMX-M".to_string()));
+        return Err(NvLinkConfigNotSyncedReason("Due to missing NvLink status observation, it can't be verified whether the NvLink config is applied to NMX-C".to_string()));
     };
 
     for gpu_config in config.gpu_configs.iter() {

--- a/crates/api-model/src/nvl_partition.rs
+++ b/crates/api-model/src/nvl_partition.rs
@@ -35,7 +35,7 @@ pub struct NewNvlPartition {
     pub name: NvlPartitionName,
     pub logical_partition_id: NvLinkLogicalPartitionId,
     pub domain_uuid: NvLinkDomainId,
-    pub nmx_m_id: String,
+    pub nmx_c_partition_id: i32,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -68,7 +68,7 @@ impl From<NvlPartitionName> for String {
 #[derive(Debug, Clone)]
 pub struct NvlPartition {
     pub id: NvLinkPartitionId,
-    pub nmx_m_id: String,
+    pub nmx_c_partition_id: i32,
     pub domain_uuid: NvLinkDomainId,
     pub name: NvlPartitionName,
     pub created: DateTime<Utc>,
@@ -85,7 +85,7 @@ pub fn is_marked_as_deleted(partition: &NvlPartition) -> bool {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NvlPartitionSnapshotPgJson {
     pub id: NvLinkPartitionId,
-    pub nmx_m_id: String,
+    pub nmx_c_partition_id: i32,
     pub name: NvlPartitionName,
     pub domain_uuid: NvLinkDomainId,
     pub created: DateTime<Utc>,
@@ -99,7 +99,7 @@ impl TryFrom<NvlPartitionSnapshotPgJson> for NvlPartition {
     fn try_from(value: NvlPartitionSnapshotPgJson) -> sqlx::Result<Self> {
         Ok(Self {
             id: value.id,
-            nmx_m_id: value.nmx_m_id,
+            nmx_c_partition_id: value.nmx_c_partition_id,
             domain_uuid: value.domain_uuid,
             name: value.name,
             created: value.created,

--- a/crates/api/src/cfg/README.md
+++ b/crates/api/src/cfg/README.md
@@ -74,7 +74,7 @@ applicable.
 | `dpa_config` | `Option<DpaConfig>` | — | Cluster Interconnect (east-west Ethernet) config (see [DpaConfig](#dpaconfig)). |
 | `dsx_exchange_event_bus` | `Option<DsxExchangeEventBusConfig>` | — | MQTT event bus for managed-host state publishing plus BMS metadata subscription and rack/isolation/heartbeat publishing (see [DsxExchangeEventBusConfig](#dsxexchangeeventbusconfig)). |
 | `datacenter_asn` | `u32` | `11414` | Datacenter ASN used by FNN for DC-specific route targets. |
-| `nvlink_config` | `Option<NvLinkConfig>` | — | NvLink partitioning via NMX-M (see [NvLinkConfig](#nvlinkconfig)). |
+| `nvlink_config` | `Option<NvLinkConfig>` | — | NvLink partitioning via NMX-C (see [NvLinkConfig](#nvlinkconfig)). |
 | `power_manager_options` | `PowerManagerOptions` | *(see below)* | Power management timing (see [PowerManagerOptions](#powermanageroptions)). |
 | `sitename` | `Option<String>` | — | Human-readable site name exposed to tenants via FMDS. |
 | `auto_machine_repair_plugin` | `AutoMachineRepairPluginConfig` | *(default)* | Auto-repair configuration for failed machines. |
@@ -134,9 +134,11 @@ applicable.
 |-------|------|---------|-------------|
 | `enabled` | `bool` | `false` | Enables NvLink partitioning. |
 | `monitor_run_interval` | `Duration` | `60s` | NvLink monitor polling interval. |
-| `nmx_m_operation_timeout` | `Duration` | `10s` | Timeout for pending NMX-M operations. |
-| `nmx_m_endpoint` | `String` | `"localhost"` | NMX-M endpoint (host:port). |
-| `allow_insecure` | `bool` | `false` | Skip TLS verification for NMX-M. |
+| `nmx_c_tls_ca_cert_path` | `Option<String>` | — | Extra CA bundle for verifying the NMX-C server over HTTPS. |
+| `nmx_c_tls_client_cert_path` | `Option<String>` | — | Client certificate for mTLS to NMX-C. |
+| `nmx_c_tls_client_key_path` | `Option<String>` | — | Client private key for mTLS to NMX-C. |
+| `nmx_c_tls_authority` | `Option<String>` | — | TLS server name used for SNI and certificate verification. |
+| `allow_insecure` | `bool` | `false` | Skip TLS verification for NMX-C. |
 
 ### `SiteExplorerConfig`
 

--- a/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_admin.txt
+++ b/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_admin.txt
@@ -137,14 +137,18 @@ carbide_machines_total{fresh="true"} 1
 carbide_machines_with_state_handling_errors_per_state{error="any",fresh="true",state="deleting",substate="drainallocatedips"} 0
 # HELP carbide_nvlink_partition_monitor_nmxc_changes_applied_total Number of changes requested to NMX-C
 # TYPE carbide_nvlink_partition_monitor_nmxc_changes_applied_total counter
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="create",status="false"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="create",status="true"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove",status="false"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove",status="true"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove_default_partition",status="false"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove_default_partition",status="true"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="update",status="false"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="update",status="true"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="create",status="completed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="create",status="failed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="create",status="timedout"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove",status="completed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove",status="failed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove",status="timedout"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove_default_partition",status="completed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove_default_partition",status="failed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove_default_partition",status="timedout"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="update",status="completed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="update",status="failed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="update",status="timedout"} 0
 
 # HELP carbide_reserved_ips_count The total number of reserved ips in the site
 # TYPE carbide_reserved_ips_count gauge

--- a/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_tenant.txt
+++ b/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_tenant.txt
@@ -134,14 +134,18 @@ carbide_machines_total{fresh="true"} 1
 carbide_machines_with_state_handling_errors_per_state{error="any",fresh="true",state="deleting",substate="drainallocatedips"} 0
 # HELP carbide_nvlink_partition_monitor_nmxc_changes_applied_total Number of changes requested to NMX-C
 # TYPE carbide_nvlink_partition_monitor_nmxc_changes_applied_total counter
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="create",status="false"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="create",status="true"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove",status="false"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove",status="true"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove_default_partition",status="false"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove_default_partition",status="true"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="update",status="false"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="update",status="true"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="create",status="completed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="create",status="failed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="create",status="timedout"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove",status="completed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove",status="failed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove",status="timedout"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove_default_partition",status="completed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove_default_partition",status="failed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove_default_partition",status="timedout"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="update",status="completed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="update",status="failed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="update",status="timedout"} 0
 # HELP carbide_site_explorer_create_machines Whether site-explorer machine creation is enabled (1) or disabled (0)
 # TYPE carbide_site_explorer_create_machines gauge
 carbide_site_explorer_create_machines 1

--- a/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_tor.txt
+++ b/crates/api/src/tests/metrics_fixtures/test_network_segment_metrics_tor.txt
@@ -137,14 +137,18 @@ carbide_machines_total{fresh="true"} 1
 carbide_machines_with_state_handling_errors_per_state{error="any",fresh="true",state="deleting",substate="drainallocatedips"} 0
 # HELP carbide_nvlink_partition_monitor_nmxc_changes_applied_total Number of changes requested to NMX-C
 # TYPE carbide_nvlink_partition_monitor_nmxc_changes_applied_total counter
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="create",status="false"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="create",status="true"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove",status="false"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove",status="true"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove_default_partition",status="false"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove_default_partition",status="true"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="update",status="false"} 0
-carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="update",status="true"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="create",status="completed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="create",status="failed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="create",status="timedout"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove",status="completed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove",status="failed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove",status="timedout"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove_default_partition",status="completed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove_default_partition",status="failed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="remove_default_partition",status="timedout"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="update",status="completed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="update",status="failed"} 0
+carbide_nvlink_partition_monitor_nmxc_changes_applied_total{operation="update",status="timedout"} 0
 # HELP carbide_reserved_ips_count The total number of reserved ips in the site
 # TYPE carbide_reserved_ips_count gauge
 carbide_reserved_ips_count{fresh="true",name="TEST_SEGMENT",prefix="192.0.2.0/24",type="tor"} 1

--- a/crates/api/src/tests/nvl_instance.rs
+++ b/crates/api/src/tests/nvl_instance.rs
@@ -39,6 +39,84 @@ use crate::tests::common::api_fixtures::TestEnvOverrides;
 use crate::tests::common::api_fixtures::nvl_logical_partition::NvlLogicalPartitionFixture;
 
 #[crate::sqlx_test]
+async fn test_nmx_c_partition_id_migration_deletes_legacy_nmx_m_rows(pool: sqlx::PgPool) {
+    let mut conn = pool.acquire().await.unwrap();
+
+    sqlx::query("ALTER TABLE nvlink_partitions RENAME COLUMN nmx_c_partition_id TO nmx_m_id")
+        .execute(conn.as_mut())
+        .await
+        .unwrap();
+    sqlx::query(
+        "ALTER TABLE nvlink_partitions ALTER COLUMN nmx_m_id TYPE VARCHAR USING nmx_m_id::VARCHAR",
+    )
+    .execute(conn.as_mut())
+    .await
+    .unwrap();
+    sqlx::query(
+        "ALTER TABLE nvlink_partitions ADD CONSTRAINT nvlink_partitions_nmx_m_id_key UNIQUE (nmx_m_id)",
+    )
+    .execute(conn.as_mut())
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "WITH lp AS (
+            INSERT INTO nvlink_logical_partitions (tenant_organization_id, config_version)
+            VALUES ('tenant', 'V1-T1666644937952267')
+            RETURNING id
+        )
+        INSERT INTO nvlink_partitions (nmx_m_id, name, domain_uuid, logical_partition_id)
+        SELECT '699c4bdb83acac93e9c1476f', 'legacy_partition', gen_random_uuid(), id
+        FROM lp",
+    )
+    .execute(conn.as_mut())
+    .await
+    .unwrap();
+
+    let row_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM nvlink_partitions")
+        .fetch_one(conn.as_mut())
+        .await
+        .unwrap();
+    assert_eq!(row_count, 1);
+
+    sqlx::raw_sql(include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../api-db/migrations/20260526120000_nvlink_partitions_nmx_c_partition_id.sql"
+    )))
+    .execute(conn.as_mut())
+    .await
+    .unwrap();
+
+    let row_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM nvlink_partitions")
+        .fetch_one(conn.as_mut())
+        .await
+        .unwrap();
+    assert_eq!(row_count, 0);
+
+    let legacy_column_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)
+         FROM information_schema.columns
+         WHERE table_name = 'nvlink_partitions'
+             AND column_name = 'nmx_m_id'",
+    )
+    .fetch_one(conn.as_mut())
+    .await
+    .unwrap();
+    assert_eq!(legacy_column_count, 0);
+
+    let nmx_c_column_type: String = sqlx::query_scalar(
+        "SELECT data_type
+         FROM information_schema.columns
+         WHERE table_name = 'nvlink_partitions'
+             AND column_name = 'nmx_c_partition_id'",
+    )
+    .fetch_one(conn.as_mut())
+    .await
+    .unwrap();
+    assert_eq!(nmx_c_column_type, "integer");
+}
+
+#[crate::sqlx_test]
 async fn test_create_instance_with_nvl_config(pool: sqlx::PgPool) {
     let mut config = common::api_fixtures::get_config();
     if let Some(nvlink_config) = config.nvlink_config.as_mut() {
@@ -2273,7 +2351,7 @@ async fn test_update_nvlink_config_nmxm_existing_partitions_with_nmxc_simulator(
     // a pre-exisiting NMX-M partition
     const NMXC_PARTITION_ID: u32 = 666_666;
     let nmxc_partition_id = NMXC_PARTITION_ID;
-    let nmx_m_id = (u64::from(nmxc_partition_id) + 10_000_000).to_string();
+    let nmx_c_partition_id = i32::try_from(u64::from(nmxc_partition_id) + 10_000_000).unwrap();
     let domain_uuid = machine
         .nvlink_info
         .as_ref()
@@ -2284,7 +2362,7 @@ async fn test_update_nvlink_config_nmxm_existing_partitions_with_nmxc_simulator(
     db_nvl_partition::create(
         &NewNvlPartition {
             id: NvLinkPartitionId::new(),
-            nmx_m_id,
+            nmx_c_partition_id,
             domain_uuid,
             name: NvlPartitionName::try_from("test_partition".to_string()).unwrap(),
             logical_partition_id,

--- a/crates/api/src/web/nvlink.rs
+++ b/crates/api/src/web/nvlink.rs
@@ -84,7 +84,7 @@ impl From<ShowLogicalPartition> for LogicalPartitionRowDisplay {
 struct ShowPhysicalPartitionDetail {
     id: String,
     name: String,
-    nmx_m_id: String,
+    nmx_c_partition_id: String,
     members: Vec<ShowPartitionMember>,
 }
 
@@ -105,7 +105,7 @@ impl From<ShowLogicalPartition> for LogicalPartitionDetail {
             let pp = ShowPhysicalPartitionDetail {
                 id: s.partition.id.map(|i| i.to_string()).unwrap_or_default(),
                 name: s.partition.name,
-                nmx_m_id: s.partition.nmx_m_id,
+                nmx_c_partition_id: s.partition.nmx_m_id,
                 members: s.members,
             };
             physical_partitions.push(pp);

--- a/crates/api/templates/logical_partition_detail.html
+++ b/crates/api/templates/logical_partition_detail.html
@@ -19,7 +19,7 @@
 		<tr>
 			<th>ID</th>
 			<th>Name</th>
-			<th>NMX-M-ID</th>
+			<th>NMX-C-ID</th>
 			<th>Members></th>
 		</tr>
 	</thead>
@@ -29,7 +29,7 @@
 		<tr>
 			<td> {{ p.id }} </td>
 			<td> {{ p.name }} </td>
-			<td> {{ p.nmx_m_id }} </td>
+			<td> {{ p.nmx_c_partition_id }} </td>
 
 			<td styles="padding: 0;">
 				<table>
@@ -63,4 +63,3 @@
 </table>
 
 {% endblock %}
-

--- a/crates/api/templates/logical_partition_detail.html
+++ b/crates/api/templates/logical_partition_detail.html
@@ -19,7 +19,7 @@
 		<tr>
 			<th>ID</th>
 			<th>Name</th>
-			<th>NMX-C-ID</th>
+			<th>NMX-C partition ID</th>
 			<th>Members></th>
 		</tr>
 	</thead>

--- a/crates/nvlink-manager/src/config.rs
+++ b/crates/nvlink-manager/src/config.rs
@@ -45,7 +45,7 @@ pub struct NvLinkConfig {
     /// TLS server name (SNI / cert verification hostname) for NMX-C HTTPS. Defaults to the endpoint URL host if unset.
     #[serde(default)]
     pub nmx_c_tls_authority: Option<String>,
-    /// Set to true if NMX-M doesn't adhere to security requirements. Defaults to false
+    /// Set to true if NMX-C doesn't adhere to security requirements. Defaults to false.
     pub allow_insecure: bool,
 }
 

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -40,7 +40,7 @@ use db::{self, ObjectColumnFilter, TransactionVending, machine};
 use errors::{NvLinkManagerError, NvLinkManagerResult};
 use libnmxc::nmxc_model::{GetPartitionInfoListRequest, PartitionInfo};
 use libnmxc::{Endpoint, NMX_C_GATEWAY_ID, Nmxc, NmxcPool};
-use metrics::{AppliedChange, NmxmPartitionOperationStatus, NvlPartitionMonitorMetrics};
+use metrics::{AppliedChange, NmxcMetricOperationStatus, NvlPartitionMonitorMetrics};
 use model::hardware_info::MachineNvLinkInfo;
 use model::instance::status::SyncState;
 use model::instance::status::nvlink::InstanceNvLinkStatus;
@@ -150,7 +150,7 @@ impl PartitionProcessingContext {
             .collect();
         let db_nvl_partitions = db_nvl_partitions
             .into_iter()
-            .filter_map(|p| p.nmx_m_id.parse::<u32>().ok().map(|id| (id, p)))
+            .filter_map(|p| u32::try_from(p.nmx_c_partition_id).ok().map(|id| (id, p)))
             .collect();
         Self {
             nmx_c_partitions,
@@ -217,7 +217,7 @@ impl PartitionProcessingContext {
     }
 
     // Get the list of GPUs that should remain in a partition after removing a specific GPU from a logical partition.
-    // To remove a GPU from a partition in NMX-M, we need to do an update op with every other GPU in the partition except the one
+    // To remove a GPU from a partition in NMX-C, we need to do an update op with every other GPU in the partition except the one
     // getting removed.
     fn get_gpus_to_keep_after_removal(
         &self,
@@ -546,7 +546,12 @@ impl PartitionProcessingContext {
         };
 
         // Get the GPU IDs that are already in the partition, plus the GPU being added.
-        let nmx_c_partition_id = partition.nmx_m_id.parse::<u32>().unwrap();
+        let Ok(nmx_c_partition_id) = u32::try_from(partition.nmx_c_partition_id) else {
+            return Err(NvLinkManagerError::internal(format!(
+                "NMX-C partition ID is required for DB partition {}",
+                partition.id
+            )));
+        };
         let gpu_uids: Vec<u64> = if let Some(nmx_c_partition) =
             self.nmx_c_partitions
                 .get(&libnmxc::nmxc_model::PartitionId {
@@ -958,7 +963,7 @@ impl NvlPartitionMonitor {
         Ok(num_completed_operations)
     }
 
-    // Check the passed NvLink partition "observations" (physical partition info from NMX-M supplemented by physical and logical partition info from DB)
+    // Check the passed NvLink partition "observations" (physical partition info from NMX-C supplemented by physical and logical partition info from DB)
     // against the instance config and generate NMX-C operations to bring the observations into alignment with the config.
     fn check_nv_link_partitions(
         &self,
@@ -1138,7 +1143,7 @@ impl NvlPartitionMonitor {
                                     .find(|p| {
                                         p.logical_partition_id == gpu_ctx.logical_partition_id
                                             && p.domain_uuid == info.domain_uuid
-                                            && p.nmx_m_id.parse::<u32>().ok().is_some_and(
+                                            && u32::try_from(p.nmx_c_partition_id).ok().is_some_and(
                                                 |partition_id| {
                                                     partition_ctx.nmx_c_partitions.contains_key(
                                                         &libnmxc::nmxc_model::PartitionId {
@@ -1157,7 +1162,7 @@ impl NvlPartitionMonitor {
                                         )
                                     {
                                         tracing::error!(
-                                            gpu_nmx_m_id = %gpu_ctx.gpu_guid,
+                                            gpu_guid = %gpu_ctx.gpu_guid,
                                             machine_id = %instance.machine_id,
                                             "Failed to handle GPU addition to existing partition: {e}"
                                         );
@@ -1168,7 +1173,7 @@ impl NvlPartitionMonitor {
                                         partition_ctx.handle_gpu_addition_new_partition(&gpu_ctx)
                                     {
                                         tracing::error!(
-                                            gpu_nmx_m_id = %gpu_ctx.gpu_guid,
+                                            gpu_guid = %gpu_ctx.gpu_guid,
                                             machine_id = %instance.machine_id,
                                             "Failed to handle GPU addition to new partition: {e}"
                                         );
@@ -1383,7 +1388,7 @@ impl NvlPartitionMonitor {
                 else {
                     if !is_nmx_c_default_partition(nmxc_partition) {
                         tracing::error!(
-                            "No partition found with nmx_m_id = {} while processing removal of GPU {gpu:?} in admin network",
+                            "No partition found with NMX-C ID = {} while processing removal of GPU {gpu:?} in admin network",
                             partition_id,
                         );
                     }
@@ -1423,7 +1428,7 @@ impl NvlPartitionMonitor {
         Ok(())
     }
 
-    // Use a separate transaction to record the observations to avoid blocking the main transaction when we poll NMX-M.
+    // Use a separate transaction to record the observations to avoid blocking the main transaction when we poll NMX-C.
     async fn record_nvlink_status_observation(
         &self,
         observations: HashMap<MachineId, MachineNvLinkStatusObservation>,
@@ -1629,9 +1634,9 @@ impl NvlPartitionMonitor {
                 let applied_change = AppliedChange {
                     operation: operation.operation_type.clone().into(),
                     status: if success {
-                        NmxmPartitionOperationStatus::Completed
+                        NmxcMetricOperationStatus::Completed
                     } else {
-                        NmxmPartitionOperationStatus::Failed
+                        NmxcMetricOperationStatus::Failed
                     },
                 };
                 *metrics
@@ -1665,27 +1670,47 @@ impl NvlPartitionMonitor {
             for operation in operations {
                 match operation.operation_type {
                     NmxcPartitionOperationType::Create => {
+                        let matching_partition = match nmx_c_partitions.values().find(|p| {
+                            let p_uids: HashSet<u64> = p.gpu_uid_list.iter().copied().collect();
+                            let op_uids: HashSet<u64> =
+                                operation.gpu_uids.iter().copied().collect();
+                            p_uids == op_uids
+                        }) {
+                            Some(p) => p,
+                            None => {
+                                tracing::error!(
+                                    "NMX-C partition not found for name {}",
+                                    operation.name
+                                );
+                                continue;
+                            }
+                        };
+                        let Some(nmx_c_partition_id) = matching_partition
+                            .partition_id
+                            .as_ref()
+                            .map(|id| id.partition_id)
+                        else {
+                            tracing::error!(
+                                "NMX-C partition ID not found for name {}",
+                                operation.name
+                            );
+                            continue;
+                        };
+                        let Ok(nmx_c_partition_id) = i32::try_from(nmx_c_partition_id) else {
+                            tracing::error!(
+                                "NMX-C partition ID does not fit in database column for name {}",
+                                operation.name
+                            );
+                            continue;
+                        };
+
                         // Create the nvl partition in the database
                         let new_partition = model::nvl_partition::NewNvlPartition {
                             id: NvLinkPartitionId::new(),
                             logical_partition_id,
                             name: NvlPartitionName::try_from(operation.name.clone())?,
                             domain_uuid: operation.domain_uuid.unwrap_or_default(),
-                            nmx_m_id: match nmx_c_partitions.values().find(|p| {
-                                let p_uids: HashSet<u64> = p.gpu_uid_list.iter().copied().collect();
-                                let op_uids: HashSet<u64> =
-                                    operation.gpu_uids.iter().copied().collect();
-                                p_uids == op_uids
-                            }) {
-                                Some(p) => nmx_c_partition_id_string(p),
-                                None => {
-                                    tracing::error!(
-                                        "NMX-C partition not found for name {}",
-                                        operation.name
-                                    );
-                                    continue;
-                                }
-                            },
+                            nmx_c_partition_id,
                         };
                         let _partition = db::nvl_partition::create(&new_partition, txn).await?;
                     }
@@ -1697,7 +1722,7 @@ impl NvlPartitionMonitor {
                         .await?;
                     }
                     NmxcPartitionOperationType::Update(_) => {
-                        // No-op, since partition membership is not tracked in the partitions table. The status observation of the
+                        // Partition membership is not tracked in the partitions table. The status observation of the
                         // added/removed GPUs will be updated.
                     }
                     NmxcPartitionOperationType::RemoveUnknownPartition(_) => {

--- a/crates/nvlink-manager/src/metrics.rs
+++ b/crates/nvlink-manager/src/metrics.rs
@@ -44,9 +44,9 @@ pub struct NvlPartitionMonitorMetrics {
     pub num_physical_partitions: usize,
     /// Number of completed operations in this run
     pub num_completed_operations: usize,
-    /// Number of NvLink GPU nmx_m_id mismatches between DB and NMX-M
+    /// Number of NVLink GPU partition ID mismatches between DB and NMX-C
     pub num_nvlink_info_mismatches: usize,
-    /// Number of stale partitions deleted from DB (not found in NMX-M)
+    /// Number of stale partitions deleted from DB (not found in NMX-C)
     pub num_stale_partitions_deleted: usize,
     pub applied_changes: HashMap<AppliedChange, usize>,
     pub operation_latencies: HashMap<AppliedChange, Vec<Duration>>,
@@ -55,7 +55,7 @@ pub struct NvlPartitionMonitorMetrics {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum NmxmPartitionOperations {
+pub enum NmxcMetricOperation {
     Create,
     Remove,
     RemoveDefaultPartition,
@@ -63,7 +63,7 @@ pub enum NmxmPartitionOperations {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum NmxmPartitionOperationStatus {
+pub enum NmxcMetricOperationStatus {
     Completed,
     Failed,
     Timedout,
@@ -73,9 +73,9 @@ pub enum NmxmPartitionOperationStatus {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct AppliedChange {
     /// The operation that has been issued
-    pub operation: NmxmPartitionOperations,
+    pub operation: NmxcMetricOperation,
     /// Whether the operation succeeded or failed
-    pub status: NmxmPartitionOperationStatus,
+    pub status: NmxcMetricOperationStatus,
 }
 
 /// Metrics collected for NMX-C data
@@ -277,7 +277,9 @@ impl NvlPartitionMonitorInstruments {
             let metrics = shared_metrics.clone();
             meter
                 .u64_observable_gauge("carbide_nvlink_partition_monitor_nvlink_info_mismatches")
-                .with_description("Number of NvLink GPU nmx_m_id mismatches between DB and NMX-M")
+                .with_description(
+                    "Number of NVLink GPU partition ID mismatches between DB and NMX-C",
+                )
                 .with_callback(move |o| {
                     metrics.if_available(|metrics, attrs| {
                         o.observe(metrics.num_nvlink_info_mismatches as u64, attrs);
@@ -290,7 +292,7 @@ impl NvlPartitionMonitorInstruments {
             let metrics = shared_metrics;
             meter
                 .u64_observable_gauge("carbide_nvlink_partition_monitor_stale_partitions_deleted")
-                .with_description("Number of stale partitions deleted from DB (not found in NMX-M)")
+                .with_description("Number of stale partitions deleted from DB (not found in NMX-C)")
                 .with_callback(move |o| {
                     metrics.if_available(|metrics, attrs| {
                         o.observe(metrics.num_stale_partitions_deleted as u64, attrs);
@@ -341,8 +343,8 @@ impl NvlPartitionMonitorInstruments {
     }
 
     fn init_counters_and_histograms(&self) {
-        for status in [false, true] {
-            for operation in NmxmPartitionOperations::values() {
+        for status in NmxcMetricOperationStatus::values() {
+            for operation in NmxcMetricOperation::values() {
                 self.nmxc_changes_applied.add(
                     0u64,
                     &[
@@ -355,7 +357,7 @@ impl NvlPartitionMonitorInstruments {
     }
 }
 
-impl NmxmPartitionOperations {
+impl NmxcMetricOperation {
     pub fn values() -> impl Iterator<Item = Self> {
         [
             Self::Create,
@@ -367,45 +369,45 @@ impl NmxmPartitionOperations {
     }
 }
 
-impl From<NmxmPartitionOperations> for opentelemetry::Value {
-    fn from(value: NmxmPartitionOperations) -> Self {
+impl From<NmxcMetricOperation> for opentelemetry::Value {
+    fn from(value: NmxcMetricOperation) -> Self {
         let str_value = match value {
-            NmxmPartitionOperations::Create => "create",
-            NmxmPartitionOperations::Update => "update",
-            NmxmPartitionOperations::Remove => "remove",
-            NmxmPartitionOperations::RemoveDefaultPartition => "remove_default_partition",
+            NmxcMetricOperation::Create => "create",
+            NmxcMetricOperation::Update => "update",
+            NmxcMetricOperation::Remove => "remove",
+            NmxcMetricOperation::RemoveDefaultPartition => "remove_default_partition",
         };
 
         Self::from(str_value)
     }
 }
 
-impl From<NmxcPartitionOperationType> for NmxmPartitionOperations {
-    fn from(value: NmxcPartitionOperationType) -> NmxmPartitionOperations {
+impl From<NmxcPartitionOperationType> for NmxcMetricOperation {
+    fn from(value: NmxcPartitionOperationType) -> NmxcMetricOperation {
         match value {
-            NmxcPartitionOperationType::Create => NmxmPartitionOperations::Create,
-            NmxcPartitionOperationType::Remove(_) => NmxmPartitionOperations::Remove,
+            NmxcPartitionOperationType::Create => NmxcMetricOperation::Create,
+            NmxcPartitionOperationType::Remove(_) => NmxcMetricOperation::Remove,
             NmxcPartitionOperationType::RemoveUnknownPartition(_) => {
-                NmxmPartitionOperations::RemoveDefaultPartition
+                NmxcMetricOperation::RemoveDefaultPartition
             }
-            NmxcPartitionOperationType::Update(_) => NmxmPartitionOperations::Update,
+            NmxcPartitionOperationType::Update(_) => NmxcMetricOperation::Update,
         }
     }
 }
 
-impl NmxmPartitionOperationStatus {
+impl NmxcMetricOperationStatus {
     pub fn values() -> impl Iterator<Item = Self> {
         [Self::Completed, Self::Failed, Self::Timedout].into_iter()
     }
 }
 
-impl From<NmxmPartitionOperationStatus> for opentelemetry::Value {
-    fn from(value: NmxmPartitionOperationStatus) -> Self {
+impl From<NmxcMetricOperationStatus> for opentelemetry::Value {
+    fn from(value: NmxcMetricOperationStatus) -> Self {
         let str_value = match value {
-            NmxmPartitionOperationStatus::Completed => "completed",
-            NmxmPartitionOperationStatus::Failed => "failed",
-            NmxmPartitionOperationStatus::Timedout => "timedout",
-            NmxmPartitionOperationStatus::Cancelled => "cancelled",
+            NmxcMetricOperationStatus::Completed => "completed",
+            NmxcMetricOperationStatus::Failed => "failed",
+            NmxcMetricOperationStatus::Timedout => "timedout",
+            NmxcMetricOperationStatus::Cancelled => "cancelled",
         };
 
         Self::from(str_value)

--- a/crates/rpc/src/model/nvl_partition.rs
+++ b/crates/rpc/src/model/nvl_partition.rs
@@ -35,7 +35,8 @@ impl TryFrom<NvlPartition> for rpc_forge::NvLinkPartition {
         Ok(rpc_forge::NvLinkPartition {
             id: Some(src.id),
             name: src.name.clone().into(),
-            nmx_m_id: src.nmx_m_id,
+            // Keep the existing proto field for wire compatibility; it now carries the NMX-C partition ID.
+            nmx_m_id: src.nmx_c_partition_id.to_string(),
             domain_uuid: Some(src.domain_uuid),
             logical_partition_id: src.logical_partition_id,
         })


### PR DESCRIPTION
Delete legacy NMX-M physical partition DB rows during the migration, then rename nmx_m_id to nmx_c_partition_id and convert it to an integer.

Update the API DB/model/NVLink manager paths to use the new column name.

Also cleanup some other references to NMX-M.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

