### PR TITLE
refactor(api): rename is_zero_dpu() to has_managed_dpus()

### DIFF
--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -265,36 +265,38 @@ fn pick_boot_interface_mac(
 }
 
 impl ManagedHostStateSnapshot {
-    /// Returns `true` if this managed host has no DPU snapshots attached.
+    /// Returns `true` if this managed host has at least one DPU snapshot
+    /// attached -- i.e. a DPU we actively manage as a `Machine`.
     ///
-    /// Most call sites in the state controller use this to follow a "zero-DPU"
-    /// branch -- skip DPU-specific work, use the host's primary interface MAC
-    /// directly, reject DPU-only operations, etc.
+    /// A `false` return ("no managed DPUs") covers two cases that are intended
+    /// to be treated the same: actual zero-DPU hosts (`DpuMode::NoDpu`), and
+    /// `DpuMode::NicMode` hosts. The latter may acutally have DPUs, but
+    /// site-explorer puts them into NIC mode at ingestion, so no DPU snapshot
+    /// is ever attached.
     ///
-    /// Note: Currently, a handful of call sites combine this with
-    /// `host_snapshot.associated_dpu_machine_ids().is_empty()` to distinguish
-    /// "truly zero-DPU" from "DPU expected per topology but the snapshot
-    /// failed to load". Those sites intentionally inspect both fields and
-    /// should NOT be rewritten to use this helper alone. Maybe we can enhance
-    /// that later, but for now this keeps it simple.
+    /// Some callers combine this w/ `associated_dpu_machine_ids().is_empty()`
+    /// to distinguish between truly no managed DPUs vs. DPU expected per
+    /// topology (but something happened, like the snapshot failed to load).
+    /// Those sites intentionally inspect both sides of this, so simply relying
+    /// on this might not be what they'd want (at least for now).
     ///
     /// NOTE(chet): When called from state-controller handlers (anything reached
     /// via `MachineStateHandler::handle_object_state`), there is an upstream
     /// guard that short-circuits with an error if topology reports DPUs but
     /// `dpu_snapshots` is empty -- i.e. the DPU snapshots failed to load.
     /// That guard runs before the `ManagedHostState` dispatch, so by the time
-    /// a state handler asks `is_zero_dpu()`, the potential bug of "topology
-    /// has DPUs, but snapshots are empty, so we think it's zero DPU" has
-    /// already been filtered out. A `true` return in that context means
-    /// genuinely zero-DPU (both topology and snapshots agree).
+    /// a state handler asks `has_managed_dpus()`, the potential bug of "topology
+    /// has DPUs, but snapshots are empty, so we think it has none" has
+    /// already been filtered out. A `false` return in that context means
+    /// genuinely no managed DPUs (both topology and snapshots agree).
     ///
     /// Now, callers OUTSIDE the state-controller path DON'T get that upstream
     /// guard; if you need the stronger guarantee there, you'll need to
     /// check both:
     /// `self.dpu_snapshots.is_empty()` and
     /// `self.host_snapshot.associated_dpu_machine_ids().is_empty()`.
-    pub fn is_zero_dpu(&self) -> bool {
-        self.dpu_snapshots.is_empty()
+    pub fn has_managed_dpus(&self) -> bool {
+        !self.dpu_snapshots.is_empty()
     }
 
     /// Returns `true` if this managed host is currently operating on the
@@ -603,7 +605,7 @@ impl ManagedHostStateSnapshot {
                 let snapshot = self.dpu_snapshots.remove(index);
                 self.dpu_snapshots.insert(0, snapshot);
             }
-        } else if primary_interface.is_none() && !self.is_zero_dpu() {
+        } else if primary_interface.is_none() && self.has_managed_dpus() {
             // DPU hosts still need some primary interface so boot/network callers have a host
             // primary to anchor on. A present primary interface without an attached DPU is valid:
             // ExpectedMachine can declare a non-DPU host admin NIC as primary, and in that case no

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -1162,7 +1162,7 @@ pub(crate) async fn trigger_dpu_reprovisioning(
                 return Err(CarbideError::InvalidArgument("A restart has to be triggered for all DPUs together. Only host_id is accepted for restart operation.".to_string()).into());
             }
 
-            if snapshot.is_zero_dpu() {
+            if !snapshot.has_managed_dpus() {
                 return Err(CarbideError::InvalidArgument(
                     "Machine has no DPUs, cannot trigger DPU reprovisioning.".to_string(),
                 )

--- a/crates/api/src/handlers/instance.rs
+++ b/crates/api/src/handlers/instance.rs
@@ -1366,7 +1366,7 @@ async fn update_instance_network_config(
         // a secondary DPU into some other leg of the network, but we can
         // think about that later; that would mean we'd support a mix of
         // auto AND non-auto interfaces.
-        if !mh_snapshot.is_zero_dpu() {
+        if mh_snapshot.has_managed_dpus() {
             return Err(CarbideError::InvalidArgument(format!(
                 "instance was allocated with `auto: true` but host {} is no longer zero-DPU; cannot update via the auto path",
                 instance.machine_id,

--- a/crates/api/src/handlers/managed_host.rs
+++ b/crates/api/src/handlers/managed_host.rs
@@ -70,7 +70,7 @@ pub(crate) async fn set_primary_dpu(
                 kind: "Machine",
                 id: host_machine_id.to_string(),
             })?;
-    if snapshot.is_zero_dpu() {
+    if !snapshot.has_managed_dpus() {
         return Err(CarbideError::FailedPrecondition(format!(
             "Host {host_machine_id} has no DPUs; set-primary-dpu does not apply to zero-DPU hosts."
         ))

--- a/crates/api/src/instance/mod.rs
+++ b/crates/api/src/instance/mod.rs
@@ -865,7 +865,7 @@ pub async fn batch_allocate_instances(
         // their only valid attachments are HostInband segments, and NICo knows
         // which one(s) the host is on. Conversely, hosts with DPUs cannot use
         // `auto`, and are expected to enumerate their interfaces explicitly.
-        if mh_snapshot.is_zero_dpu() {
+        if !mh_snapshot.has_managed_dpus() {
             if !request.config.network.auto {
                 return Err(CarbideError::InvalidArgument(format!(
                     "zero-DPU host {} requires `InstanceNetworkConfig.auto = true`; cannot allocate an instance with explicitly-listed interfaces or with `auto = false`",

--- a/crates/api/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api/src/tests/common/api_fixtures/site_explorer.rs
@@ -834,7 +834,7 @@ impl<'a> MockExploredHost<'a> {
         }
 
         // Zero-DPU hosts skip the WaitForDPUUp lockdown state and land
-        // directly in BomValidating (see `is_zero_dpu` short-circuit in
+        // directly in BomValidating (see `has_managed_dpus` short-circuit in
         // `LockdownState::TimeWaitForDPUDown`). There are no DPUs to
         // signal as configured, so skip the network_configured handshake.
         if !self.dpu_machine_ids.is_empty() {

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -1450,7 +1450,7 @@ impl MachineStateHandler {
                 // true, which requires non-empty DPUs. Without this guard
                 // the empty loop below falls through to `do_nothing()` and
                 // the host would sit in DPUReprovision forever.
-                if mh_snapshot.is_zero_dpu() {
+                if !mh_snapshot.has_managed_dpus() {
                     return Err(StateHandlerError::GenericError(eyre!(
                         "DPUReprovision state entered on zero-DPU host {host_machine_id}; \
                          reprovision requires DPUs"
@@ -5172,7 +5172,7 @@ impl StateHandler for HostMachineStateHandler {
                             ))
                         }
                         LockdownState::TimeWaitForDPUDown => {
-                            if mh_snapshot.is_zero_dpu() {
+                            if !mh_snapshot.has_managed_dpus() {
                                 // No DPU to wait for going down/up -- skip
                                 // straight to BomValidating. Covers
                                 // NicMode/NoDpu hosts and anything else
@@ -5530,7 +5530,7 @@ impl StateHandler for InstanceStateHandler {
                     // Extension services run on DPUs. A zero-DPU host has no
                     // DPUs to run them on, so there is nothing to wait for;
                     // skip straight to the next state.
-                    if mh_snapshot.is_zero_dpu() {
+                    if !mh_snapshot.has_managed_dpus() {
                         let next_state = ManagedHostState::Assigned {
                             instance_state: InstanceState::WaitingForRebootToReady,
                         };
@@ -5824,7 +5824,7 @@ impl StateHandler for InstanceStateHandler {
                     // A zero-DPU host has no DPUs to wait for. Skip the
                     // readiness check and proceed with the rest of the
                     // handler (custom-PXE reboot, termination flow, etc).
-                    if !mh_snapshot.is_zero_dpu()
+                    if mh_snapshot.has_managed_dpus()
                         && !are_dpus_up_trigger_reboot_if_needed(
                             mh_snapshot,
                             &self.reachability_params,
@@ -6188,7 +6188,7 @@ impl StateHandler for InstanceStateHandler {
                     // skipped upstream. But, without this guard, the empty loop
                     // below falls through to `do_nothing()` and the host
                     // would/could sit in `DPUReprovision` forever.
-                    if mh_snapshot.is_zero_dpu() {
+                    if !mh_snapshot.has_managed_dpus() {
                         return Err(StateHandlerError::GenericError(eyre!(
                             "DPUReprovision state entered on zero-DPU host {host_machine_id}; reprovision requires DPUs"
                         )));
@@ -9891,7 +9891,7 @@ async fn handle_instance_host_platform_config(
             // BIOS state -- the host can report stale Redfish info from before the
             // power cycle until the DPUs have finished initializing. Zero-DPU
             // hosts skip this wait, because there are no DPUs to come up.
-            if !mh_snapshot.is_zero_dpu()
+            if mh_snapshot.has_managed_dpus()
                 && !are_dpus_up_trigger_reboot_if_needed(mh_snapshot, reachability_params, ctx)
                     .await
             {


### PR DESCRIPTION
## Description

This supports https://github.com/NVIDIA/infra-controller/issues/1523.

`ManagedHostStateSnapshot::is_zero_dpu()` is misleading: it returns `true` for both zero-DPU hosts (`DpuMode::NoDpu`) *and* `DpuMode::NicMode` hosts (where `site-explorer` flips them to NIC mode resulting in no subsequent snapshots).

This renames it to `has_managed_dpus()`, which now says what we actually mean: the host has at least one DPU we manage as a `Machine`, reading correctly for both the `NoDpu` and `NicMode` cases. All call sites are flipped accordingly (`is_zero_dpu()` -> `!has_managed_dpus()`, `!is_zero_dpu()` -> `has_managed_dpus()`). This one is a pure refactor with no behavior changes. Tests of course updated with the new naming as well.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

