### PR TITLE
feat(api,agent): Adding per-interface routing-profile option

### DIFF
--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -1242,6 +1242,7 @@ impl ApiClient {
                     virtual_function_id: None,
                     ip_address: None,
                     ipv6_interface_config: None,
+                    routing_profile: None,
                 });
 
                 if let Some(vf_network_segment_chunks) = vf_chunk_iter.next() {
@@ -1257,6 +1258,7 @@ impl ApiClient {
                             virtual_function_id: Some(vf_function_id),
                             ip_address: None,
                             ipv6_interface_config: None,
+                            routing_profile: None,
                         });
                         vf_function_id += 1;
                     }
@@ -1331,6 +1333,7 @@ impl ApiClient {
                                     .get(map_index)
                                     .cloned(),
                             }),
+                        routing_profile: None,
                     };
                     tracing::debug!("Adding interface: {:?}", new_interface);
 
@@ -1361,6 +1364,7 @@ impl ApiClient {
                                                 .cloned()
                                         }),
                                     }),
+                                routing_profile: None,
                             };
                             vf_function_id += 1;
                             tracing::debug!("Adding interface: {:?}", new_interface);

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -234,6 +234,19 @@ impl From<&rpc::RoutingProfile> for nvue::RoutingProfile {
     }
 }
 
+/// Converts an RPC interface routing profile into the NVUE renderer model.
+impl From<&rpc::FlatInterfaceRoutingProfile> for nvue::InterfaceRoutingProfile {
+    fn from(profile: &rpc::FlatInterfaceRoutingProfile) -> Self {
+        nvue::InterfaceRoutingProfile {
+            allowed_anycast_prefixes: profile
+                .allowed_anycast_prefixes
+                .iter()
+                .map(|p| p.prefix.to_owned())
+                .collect(),
+        }
+    }
+}
+
 /// Update the NVUE network config. Returns Ok(true) if the configuration changed, and
 /// Ok(false) if not.
 pub async fn update_nvue(
@@ -316,6 +329,16 @@ pub async fn update_nvue(
             vec![nvue::PortConfig {
                 interface_name: physical_name,
                 is_phy: true,
+                host_ip: admin_interface.ip.clone(),
+                host_route: admin_interface.interface_prefix.clone(),
+                host_ipv6: admin_interface
+                    .ipv6_interface_config
+                    .as_ref()
+                    .map(|v6| v6.ip.clone()),
+                host_ipv6_route: admin_interface
+                    .ipv6_interface_config
+                    .as_ref()
+                    .map(|v6| v6.interface_prefix.clone()),
                 vlan: admin_interface.vlan_id as u16,
                 vni: if nc.network_virtualization_type() == ::rpc::forge::VpcVirtualizationType::Fnn
                 {
@@ -344,9 +367,13 @@ pub async fn update_nvue(
                 tenant_vrf_loopback_ip: admin_interface.tenant_vrf_loopback_ip.clone(),
                 network_security_group_id: None, // NSGs are not applied on the admin network.
                 routing_profile: admin_interface
-                    .routing_profile
+                    .vpc_routing_profile
                     .as_ref()
                     .map(nvue::RoutingProfile::from),
+                interface_routing_profile: admin_interface
+                    .interface_routing_profile
+                    .as_ref()
+                    .map(nvue::InterfaceRoutingProfile::from),
                 is_l2_segment: if nc.network_virtualization_type()
                     == ::rpc::forge::VpcVirtualizationType::Fnn
                 {
@@ -379,6 +406,13 @@ pub async fn update_nvue(
                 interface_name: name,
                 is_phy: net.function_type == rpc::InterfaceFunctionType::Physical as i32,
                 vlan: net.vlan_id as u16,
+                host_ip: net.ip.clone(),
+                host_route: net.interface_prefix.clone(),
+                host_ipv6: net.ipv6_interface_config.as_ref().map(|v6| v6.ip.clone()),
+                host_ipv6_route: net
+                    .ipv6_interface_config
+                    .as_ref()
+                    .map(|v6| v6.interface_prefix.clone()),
                 vni: Some(net.vni), // TODO should this be nc.vni_device?
                 l3_vni: Some(net.vpc_vni),
                 gateway_cidr: net.gateway.clone(),
@@ -397,7 +431,14 @@ pub async fn update_nvue(
                     .network_security_group
                     .as_ref()
                     .map(|n| n.id.clone()),
-                routing_profile: net.routing_profile.as_ref().map(nvue::RoutingProfile::from),
+                routing_profile: net
+                    .vpc_routing_profile
+                    .as_ref()
+                    .map(nvue::RoutingProfile::from),
+                interface_routing_profile: net
+                    .interface_routing_profile
+                    .as_ref()
+                    .map(nvue::InterfaceRoutingProfile::from),
                 is_l2_segment: net.is_l2_segment,
             });
         }
@@ -1999,7 +2040,27 @@ mod tests {
     async fn test_with_tenant_fnn_with_leaks() -> Result<(), Box<dyn std::error::Error>> {
         let virtualization_type = VpcVirtualizationType::Fnn;
 
-        let network_config = netconf(virtualization_type, 32, 24, false, None, false, true);
+        //let network_config = netconf(virtualization_type, 32, 24, false, None, false, true);
+
+        let mut network_config = netconf(virtualization_type, 32, 24, false, None, false, true);
+
+        // Set an interface profile for a prefix that falls within the VPC profile's prefix.
+        network_config.tenant_interfaces[0].interface_routing_profile =
+            Some(rpc::FlatInterfaceRoutingProfile {
+                allowed_anycast_prefixes: vec![rpc::PrefixFilterPolicyEntry {
+                    prefix: "5.255.254.67/32".to_string(),
+                }],
+            });
+
+        // Set an interface profile for a prefix that falls OUTSIDE the VPC profile's prefix.
+        // This should trigger policy to empty out and block prefixes from the tenant.
+        // Because a VPC profiles exists and has a prefix list, there is no fallback to AnycastSitePrefixes.
+        network_config.tenant_interfaces[1].interface_routing_profile =
+            Some(rpc::FlatInterfaceRoutingProfile {
+                allowed_anycast_prefixes: vec![rpc::PrefixFilterPolicyEntry {
+                    prefix: "67.67.67.6/7".to_string(),
+                }],
+            });
 
         let td = tempfile::tempdir()?;
         let hbn_root = td.path();
@@ -2386,7 +2447,8 @@ mod tests {
             internal_uuid: None,
             mtu: None,
             ipv6_interface_config: None,
-            routing_profile: None,
+            vpc_routing_profile: None,
+            interface_routing_profile: None,
         };
         assert_eq!(admin_interface.svi_ip, None);
 
@@ -2438,7 +2500,7 @@ mod tests {
                 internal_uuid: None,
                 mtu: None,
                 ipv6_interface_config: None,
-                routing_profile: Some(rpc::RoutingProfile {
+                vpc_routing_profile: Some(rpc::RoutingProfile {
                     leak_default_route_from_underlay:
                         include_network_host_route_and_default_leaking,
                     leak_tenant_host_routes_to_underlay:
@@ -2465,6 +2527,7 @@ mod tests {
                         vni: 800,
                     }],
                 }),
+                interface_routing_profile: None,
             },
             rpc::FlatInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Physical.into(),
@@ -2639,7 +2702,7 @@ mod tests {
                 internal_uuid: None,
                 mtu: None,
                 ipv6_interface_config: None,
-                routing_profile: Some(rpc::RoutingProfile {
+                vpc_routing_profile: Some(rpc::RoutingProfile {
                     leak_default_route_from_underlay:
                         include_network_host_route_and_default_leaking,
                     leak_tenant_host_routes_to_underlay:
@@ -2666,6 +2729,7 @@ mod tests {
                         vni: 800,
                     }],
                 }),
+                interface_routing_profile: None,
             },
         ];
 
@@ -2899,6 +2963,10 @@ mod tests {
             network_security_group_id: Some(network_security_groups[0].id.clone()),
             interface_name: HBNDeviceNames::hbn_23().reps[0].to_string(),
             is_phy: true,
+            host_ip: "10.217.4.70".to_string(),
+            host_route: "10.217.4.70/32".to_string(),
+            host_ipv6: None,
+            host_ipv6_route: None,
             vlan: 123u16,
             vni: Some(5555),
             l3_vni: Some(7777),
@@ -2917,6 +2985,7 @@ mod tests {
             vpc_peer_prefixes: vec![],
             vpc_peer_vnis: vec![],
             routing_profile: None,
+            interface_routing_profile: None,
             is_l2_segment: true,
             ipv6_port_config: None,
         }];
@@ -3100,7 +3169,8 @@ mod tests {
             internal_uuid: None,
             mtu: None,
             ipv6_interface_config: None,
-            routing_profile: None,
+            vpc_routing_profile: None,
+            interface_routing_profile: None,
         };
 
         let mut admin_interface_with_mtu = admin_interface.clone();
@@ -3137,7 +3207,8 @@ mod tests {
                 internal_uuid: None,
                 mtu: None,
                 ipv6_interface_config: None,
-                routing_profile: None,
+                vpc_routing_profile: None,
+                interface_routing_profile: None,
             },
             rpc::FlatInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Physical.into(),
@@ -3163,7 +3234,8 @@ mod tests {
                 internal_uuid: None,
                 mtu: None,
                 ipv6_interface_config: None,
-                routing_profile: None,
+                vpc_routing_profile: None,
+                interface_routing_profile: None,
             },
         ];
 

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -79,29 +79,60 @@ const NETWORK_SECURITY_GROUP_RULE_PRIORITY_START: u32 = 2000;
 /// associations per interface._*
 const NETWORK_SECURITY_GROUP_RULE_COUNT_MAX: usize = 10000;
 
-/// split_prefixes_by_family splits a list of CIDR prefix strings
+/// `split_prefixes_by_family` splits a list of CIDR prefix strings
 /// into IPv4 and IPv6 buckets. Each bucket gets sequential indices
 /// starting at `start_index`. Unparseable prefixes are warned and
 /// dropped (because NVUE would fail on invalid addresses anyway).
 ///
-/// start_index should usually be set to 1 to avoid nvue config complaints when
+/// `filter` accepts a set of prefixes that can be compared to `prefixes`, and any prefix not
+/// found in `filter` will be removed.
+/// `start_index` should usually be set to 1 to avoid nvue config complaints when
 /// using the output as part of policy generation.
-fn split_prefixes_by_family(prefixes: &[String], start_index: usize) -> (Vec<Prefix>, Vec<Prefix>) {
-    let valid: Vec<_> = prefixes
-        .iter()
-        .filter_map(|s| match s.parse::<IpNet>() {
-            Ok(net) => Some((s.clone(), net)),
-            Err(e) => {
-                tracing::warn!(prefix = %s, error = %e, "dropping unparseable prefix");
-                None
-            }
-        })
-        .collect();
+fn split_prefixes_by_family(
+    prefixes: &[String],
+    filter: Option<&[IpNet]>,
+    start_index: usize,
+) -> (Vec<Prefix>, Vec<Prefix>) {
+    let valid: Vec<_> = if let Some(filter) = filter {
+        prefixes
+            .iter()
+            .filter_map(|s| match s.parse::<IpNet>() {
+                Ok(net) => {
+                    if filter.iter().any(|f| prefix_contains(f, &net)) {
+                        Some((s.clone(), net))
+                    } else {
+                        tracing::warn!(
+                            prefix = %net,
+                            "excluding prefix outside filter list");
+                        None
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(prefix = %s, error = %e, "dropping unparseable prefix");
+                    None
+                }
+            })
+            .collect()
+    } else {
+        prefixes
+            .iter()
+            .filter_map(|s| match s.parse::<IpNet>() {
+                Ok(net) => Some((s.clone(), net)),
+                Err(e) => {
+                    tracing::warn!(prefix = %s, error = %e, "dropping unparseable prefix");
+                    None
+                }
+            })
+            .collect()
+    };
 
     let (v4, v6): (Vec<_>, Vec<_>) = valid
         .into_iter()
         .partition(|(_, net)| matches!(net, IpNet::V4(_)));
 
+    // NOTE: The implicit assumption here is that v4 and v6 prefixes will always be listed separately (in policies, etc),
+    // and so they can share the same index starting point.
+    // This is probably true, but might be good to not work under that assumption.
     let make_prefixes = |items: Vec<(String, IpNet)>| -> Vec<Prefix> {
         items
             .into_iter()
@@ -116,10 +147,44 @@ fn split_prefixes_by_family(prefixes: &[String], start_index: usize) -> (Vec<Pre
     (make_prefixes(v4), make_prefixes(v6))
 }
 
+/// Returns whether `candidate` is equal to or narrower than `allowed`.
+fn prefix_contains(allowed: &IpNet, candidate: &IpNet) -> bool {
+    match (allowed, candidate) {
+        (IpNet::V4(allowed), IpNet::V4(candidate)) => {
+            allowed.prefix_len() <= candidate.prefix_len() && allowed.contains(&candidate.network())
+        }
+        (IpNet::V6(allowed), IpNet::V6(candidate)) => {
+            allowed.prefix_len() <= candidate.prefix_len() && allowed.contains(&candidate.network())
+        }
+        _ => false,
+    }
+}
+
+/// Parses a list of strings to a Vec of IpNet, dropping
+/// and warning about parse failures.
+fn parse_prefixes(prefixes: &[String]) -> Vec<IpNet> {
+    prefixes
+        .iter()
+        .filter_map(|prefix| match prefix.parse::<IpNet>() {
+            Ok(prefix) => Some(prefix),
+            Err(e) => {
+                tracing::warn!(
+                    prefix = %prefix,
+                    error = %e,
+                    "dropping unparseable VPC anycast prefix"
+                );
+                None
+            }
+        })
+        .collect()
+}
+
 pub fn build(conf: NvueConfig) -> eyre::Result<String> {
     let template = template_for(conf.vpc_virtualization_type)?;
     let is_dpu_os = conf.is_dpu_os;
     let fmds_gateway_vlan = conf.fmds_gateway_vlan;
+    // HostInterfaces is the legacy template shape. The same host-facing values
+    // are mirrored into TmplConfigPort so templates can move off HostInterfaces.
     let host_interfaces: Vec<TmplHostInterfaces> = conf
         .ct_access_vlans
         .into_iter()
@@ -197,7 +262,7 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
         .ct_port_configs
         .iter()
         .find(|p| !p.vpc_peer_prefixes.is_empty())
-        .map(|p| split_prefixes_by_family(&p.vpc_peer_prefixes, 1))
+        .map(|p| split_prefixes_by_family(&p.vpc_peer_prefixes, None, 1))
         .unwrap_or_default();
     let vpc_peer_vnis: Vec<TmplVni> = conf
         .ct_port_configs
@@ -225,21 +290,100 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
 
     let mut has_any_vpc_vrf_loopback = false;
     let mut fmds_gateway_matched = false;
+    let mut vpc_anycast_prefix_cache = HashMap::<u32, Vec<IpNet>>::new();
 
     for (base_i, network) in conf.ct_port_configs.into_iter().enumerate() {
         let l3_vni = network.l3_vni.unwrap_or_default();
-        let routing_profile = network
+        // Prefer the per-port VPC routing profile, falling back to the deprecated tenant-level profile.
+        let vpc_routing_profile = network
             .routing_profile
             .as_ref()
-            .or(deprecated_routing_profile.as_ref())
-            .map(TmplRoutingProfile::from);
+            .or(deprecated_routing_profile.as_ref());
+
+        // This check is already done in the primary caller, but it's cheap and it matters here,
+        // so just being extra defensive.
+        if conf.vpc_virtualization_type == VpcVirtualizationType::Fnn
+            && vpc_routing_profile.is_none()
+        {
+            return Err(eyre::eyre!(
+                "BUG: FNN config provided without routing-profile"
+            ));
+        }
+
+        // Cache the allowed_anycast_prefixes for the first VPC seen for this l3_vni
+        // so that we don't keep reparsing in the event that multiple interfaces are in the same VPC.
+        // l3_vni to VPC is 1:1, and the same l3_vni shouldn't see a different profile.
+        // This only matters for FNN, and we've just checked that a routing profile exists
+        // if this is an FNN config.
+        // Here's what we expect:
+        // - If a user wants to apply per-interface prefix filters, there must be a VPC-level
+        //   prefix list specified to compare for validity.
+        // - If the list in the VPC profile is empty, then we're going to end up intentionally
+        //   filtering out any per-interface anycast prefixes.
+        // - The template then, for now, provides a fallback that allows anything in site_anycast_prefixes,
+        //   which will soon be ignored for FNN.
+        // - Once that fallback is removed, an empty VPC profile prefix list filters out all interface-level prefixes.
+        // This continues the pattern of explicit opt-in for for anycast prefix filtering by VPC profile
+        // until we finally remove the site_anycast_prefix support for FNN.
+        vpc_anycast_prefix_cache.entry(l3_vni).or_insert_with(|| {
+            parse_prefixes(
+                vpc_routing_profile
+                    .map(|p| p.allowed_anycast_prefixes.as_slice())
+                    .unwrap_or_default(),
+            )
+        });
+
+        let routing_profile = vpc_routing_profile.map(TmplRoutingProfile::from);
+        let interface_profile = network.interface_routing_profile.as_ref();
+        let interface_routing_profile = {
+            match (vpc_routing_profile, interface_profile) {
+                // If there's an interface-specific profile, make sure it's a subset of what's
+                // on the VPC.
+                (Some(_), Some(interface_profile)) => {
+                    let filter = vpc_anycast_prefix_cache
+                        .get(&l3_vni)
+                        .map(|v| v.as_slice())
+                        .unwrap_or_default();
+
+                    let (v4, v6) = split_prefixes_by_family(
+                        &interface_profile.allowed_anycast_prefixes,
+                        Some(filter),
+                        1,
+                    );
+
+                    Some(TmplInterfaceRoutingProfile {
+                        HasAllowedAnycastPrefixesIpv4: !v4.is_empty(),
+                        HasAllowedAnycastPrefixesIpv6: !v6.is_empty(),
+                        AllowedAnycastPrefixesIpv4: v4,
+                        AllowedAnycastPrefixesIpv6: v6,
+                    })
+                }
+                // If there's no interface-specific profile, just inherit from the VPC.
+                // Let this happen in the template for now.
+                (Some(_), None) => None,
+
+                // If there's no VPC routing profile, then lock it down by default.
+                // For FNN, there should always be a routing profile.
+                // For the legacy ETV, it won't be referencing interface routing profiles.
+                (None, _) => None,
+            }
+        };
         let svi_mac = vni_to_svi_mac(network.vni.unwrap_or(0))?.to_string();
+
         let (vpc_ipv4, vpc_ipv6) =
-            split_prefixes_by_family(&network.vpc_prefixes, (base_i + 1) * 10);
+            split_prefixes_by_family(&network.vpc_prefixes, None, (base_i + 1) * 10);
+
         let port = TmplConfigPort {
             InterfaceName: network.interface_name.clone(),
             Index: format!("{}", (base_i + 1) * 10),
             VlanID: network.vlan,
+            HostIP: network.host_ip.clone(),
+            HostIPv6: network.host_ipv6.clone(),
+            HostRoute: network.host_route.clone(),
+            HostIPv6Route: network.host_ipv6_route.clone(),
+            // HasRoutingProfile means this port has an interface override; otherwise templates inherit from the VPC profile.
+            HasRoutingProfile: interface_routing_profile.is_some(),
+            RoutingProfile: interface_routing_profile.unwrap_or_default(),
             IsPhy: network.is_phy,
             L2VNI: network.vni.map(|x| x.to_string()).unwrap_or("".to_string()),
             IPs: {
@@ -269,6 +413,8 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
                 .iter()
                 .any(|p| matches!(p.parse::<IpNet>(), Ok(IpNet::V6(_)))),
             HasVpcPrefixes: !vpc_ipv4.is_empty(),
+            // Only used directly by ETV template now.
+            // FNN template uses PortPrefixes, which is built from this.
             VpcPrefixes: vpc_ipv4,
             HasVpcPrefixesIpv6: !vpc_ipv6.is_empty(),
             VpcPrefixesIpv6: vpc_ipv6,
@@ -296,7 +442,7 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
         }
 
         let (vpc_peer_ipv4, vpc_peer_ipv6) =
-            split_prefixes_by_family(&network.vpc_peer_prefixes, 1);
+            split_prefixes_by_family(&network.vpc_peer_prefixes, None, 1);
 
         has_any_vpc_vrf_loopback =
             has_any_vpc_vrf_loopback || network.tenant_vrf_loopback_ip.is_some();
@@ -325,11 +471,6 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
                 L3VNI: l3_vni,
                 HasVrfLoopback: network.tenant_vrf_loopback_ip.is_some(),
                 VrfLoopback: network.tenant_vrf_loopback_ip.unwrap_or_default(),
-                // TODO: This is wasteful because it should be specific to a VPC.
-                // Otherwise, all VPCs will have a BGP peer config for each
-                // interface, regardless of whether the interface is owned by
-                // that VPC.
-                HostInterfaces: host_interfaces.clone(),
                 PortConfigs: vec![port.clone()],
                 HasVpcPeerPrefixes: !vpc_peer_ipv4.is_empty(),
                 VpcPeerPrefixes: vpc_peer_ipv4,
@@ -443,12 +584,13 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
     });
 
     let (traffic_intercept_ipv4, traffic_intercept_ipv6) =
-        split_prefixes_by_family(&conf.traffic_intercept_public_prefixes, 1);
-    let (anycast_ipv4, anycast_ipv6) = split_prefixes_by_family(&conf.anycast_site_prefixes, 1000);
+        split_prefixes_by_family(&conf.traffic_intercept_public_prefixes, None, 1);
+    let (anycast_ipv4, anycast_ipv6) =
+        split_prefixes_by_family(&conf.anycast_site_prefixes, None, 1000);
     let (site_fabric_ipv4, site_fabric_ipv6) =
-        split_prefixes_by_family(&conf.site_fabric_prefixes, 1000);
+        split_prefixes_by_family(&conf.site_fabric_prefixes, None, 1000);
     let (deny_ipv4, deny_ipv6) =
-        split_prefixes_by_family(&conf.deny_prefixes, 1000 + deny_prefix_index_offset);
+        split_prefixes_by_family(&conf.deny_prefixes, None, 1000 + deny_prefix_index_offset);
 
     let params = TmplNvue {
         HasBgpLeafSessionPassword: conf.bgp_leaf_session_password.is_some(),
@@ -521,6 +663,7 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
             PortConfigs: port_configs,
             HasHostASN: conf.tenant_host_asn.is_some(),
             HostASN: conf.tenant_host_asn.unwrap_or_default(),
+            // Keep legacy tenant-wide HostInterfaces for pre-FNN templates; new templates should use PortConfigs.
             HostInterfaces: host_interfaces,
             NetworkSecurityGroups: network_security_groups,
             HasNetworkSecurityGroup: has_network_security_group,
@@ -930,9 +1073,10 @@ pub struct RouteTargetConfig {
 impl From<&RoutingProfile> for TmplRoutingProfile {
     fn from(profile: &RoutingProfile) -> Self {
         // Split mixed-family prefix lists before passing them to the template.
-        let (v4leaks, v6leaks) = split_prefixes_by_family(&profile.accepted_leaks_from_underlay, 1);
+        let (v4leaks, v6leaks) =
+            split_prefixes_by_family(&profile.accepted_leaks_from_underlay, None, 1);
         let (v4allowed_anycast, v6allowed_anycast) =
-            split_prefixes_by_family(&profile.allowed_anycast_prefixes, 1);
+            split_prefixes_by_family(&profile.allowed_anycast_prefixes, None, 1);
         let has_leaks_from_underlay_ipv4 =
             profile.leak_default_route_from_underlay || !v4leaks.is_empty();
         let has_leaks_from_underlay_ipv6 =
@@ -1039,6 +1183,11 @@ pub struct RoutingProfile {
     pub tenant_leak_communities_accepted: bool,
     pub accepted_leaks_from_underlay: Vec<String>,
     #[serde(default)]
+    pub allowed_anycast_prefixes: Vec<String>,
+}
+
+#[derive(Clone, Deserialize, Debug, PartialEq)]
+pub struct InterfaceRoutingProfile {
     pub allowed_anycast_prefixes: Vec<String>,
 }
 
@@ -1151,6 +1300,10 @@ pub struct Ipv6PortConfig {
 pub struct PortConfig {
     pub interface_name: String,
     pub vlan: u16,
+    pub host_ip: String,
+    pub host_route: String,
+    pub host_ipv6: Option<String>,
+    pub host_ipv6_route: Option<String>,
     pub vni: Option<u32>, // In FNN, admin network has both an l2vni and an l3vni
     pub l3_vni: Option<u32>,
     pub gateway_cidr: String,
@@ -1167,6 +1320,7 @@ pub struct PortConfig {
     pub network_security_group_id: Option<String>,
     #[serde(default)]
     pub routing_profile: Option<RoutingProfile>,
+    pub interface_routing_profile: Option<InterfaceRoutingProfile>,
 }
 
 //
@@ -1342,6 +1496,15 @@ struct TmplRoutingProfile {
 }
 
 #[allow(non_snake_case)]
+#[derive(Clone, Gtmpl, Debug, PartialEq, Default)]
+struct TmplInterfaceRoutingProfile {
+    HasAllowedAnycastPrefixesIpv4: bool,
+    HasAllowedAnycastPrefixesIpv6: bool,
+    AllowedAnycastPrefixesIpv4: Vec<Prefix>,
+    AllowedAnycastPrefixesIpv6: Vec<Prefix>,
+}
+
+#[allow(non_snake_case)]
 #[derive(Clone, Gtmpl, Debug)]
 struct TmplComputeTenant {
     Vpcs: Vec<TmplVpc>,
@@ -1426,7 +1589,6 @@ struct TmplVpc {
     HasVrfLoopback: bool,
     VrfLoopback: String,
 
-    HostInterfaces: Vec<TmplHostInterfaces>,
     PortConfigs: Vec<TmplConfigPort>,
 
     HasVpcPeerPrefixes: bool,
@@ -1469,6 +1631,12 @@ struct TmplConfigPort {
     InterfaceName: String,
     Index: String,
     VlanID: u16,
+    HostIP: String,
+    HostIPv6: Option<String>,
+    HostRoute: String,
+    HostIPv6Route: Option<String>,
+    HasRoutingProfile: bool,
+    RoutingProfile: TmplInterfaceRoutingProfile,
 
     /// Format: 24bit integer (usable range: 4096 to 16777215).
     /// Empty string if no tenant
@@ -1547,7 +1715,7 @@ mod tests {
             "192.168.0.0/16".to_string(),
             "fd00::/8".to_string(),
         ];
-        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, 1000);
+        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, None, 1000);
 
         assert_eq!(ipv4.len(), 2);
         assert_eq!(ipv6.len(), 2);
@@ -1566,7 +1734,7 @@ mod tests {
     #[test]
     fn test_split_prefixes_ipv4_only() {
         let prefixes = vec!["10.0.0.0/8".to_string(), "172.16.0.0/12".to_string()];
-        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, 1);
+        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, None, 1);
 
         assert_eq!(ipv4.len(), 2);
         assert!(ipv6.is_empty());
@@ -1575,7 +1743,7 @@ mod tests {
     #[test]
     fn test_split_prefixes_ipv6_only() {
         let prefixes = vec!["2001:db8::/32".to_string(), "fd00::/8".to_string()];
-        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, 1);
+        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, None, 1);
 
         assert!(ipv4.is_empty());
         assert_eq!(ipv6.len(), 2);
@@ -1584,7 +1752,7 @@ mod tests {
     #[test]
     fn test_split_prefixes_empty() {
         let prefixes: Vec<String> = vec![];
-        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, 1000);
+        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, None, 1000);
 
         assert!(ipv4.is_empty());
         assert!(ipv6.is_empty());
@@ -1593,7 +1761,7 @@ mod tests {
     #[test]
     fn test_split_prefixes_unparseable_dropped() {
         let prefixes = vec!["not-a-cidr".to_string(), "10.0.0.0/8".to_string()];
-        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, 1);
+        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, None, 1);
 
         assert_eq!(ipv4.len(), 1);
         assert_eq!(ipv4[0].Prefix, "10.0.0.0/8");
@@ -1609,7 +1777,7 @@ mod tests {
             "10.0.0.0/8".to_string(),
             "2001:db8::/32".to_string(),
         ];
-        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, 1);
+        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, None, 1);
 
         assert_eq!(ipv4.len(), 1);
         assert_eq!(ipv4[0].Prefix, "10.0.0.0/8");
@@ -1617,6 +1785,30 @@ mod tests {
         assert_eq!(ipv6.len(), 2);
         assert_eq!(ipv6[0].Prefix, "::ffff:192.0.2.33/128");
         assert_eq!(ipv6[1].Prefix, "2001:db8::/32");
+    }
+
+    #[test]
+    fn test_split_prefixes_filters_to_containing_prefixes() {
+        // Build mixed-family inputs with one contained and one excluded prefix per family.
+        let prefixes = vec![
+            "192.0.2.64/26".to_string(),
+            "198.51.100.0/24".to_string(),
+            "2001:db8:1::/64".to_string(),
+            "2001:db9::/48".to_string(),
+        ];
+        let filter = parse_prefixes(&["192.0.2.0/24".to_string(), "2001:db8::/32".to_string()]);
+
+        // Filter through the VPC allow-list while preserving family-specific indexes.
+        let (ipv4, ipv6) = split_prefixes_by_family(&prefixes, Some(&filter), 1);
+
+        // Verify only prefixes contained by the filter remain.
+        let ipv4_prefixes: Vec<_> = ipv4.iter().map(|prefix| prefix.Prefix.as_str()).collect();
+        let ipv6_prefixes: Vec<_> = ipv6.iter().map(|prefix| prefix.Prefix.as_str()).collect();
+
+        assert_eq!(ipv4_prefixes, vec!["192.0.2.64/26"]);
+        assert_eq!(ipv6_prefixes, vec!["2001:db8:1::/64"]);
+        assert_eq!(ipv4[0].Index, "1");
+        assert_eq!(ipv6[0].Index, "1");
     }
 
     /// Helper to build a minimal NvueConfig for template rendering tests.
@@ -1714,6 +1906,10 @@ mod tests {
         conf.ct_port_configs = vec![PortConfig {
             interface_name: "pf0vf0_if".into(),
             vlan: 100,
+            host_ip: "10.0.1.2".into(),
+            host_route: "10.0.1.0/24".into(),
+            host_ipv6: None,
+            host_ipv6_route: None,
             vni: Some(1000),
             l3_vni: Some(100),
             gateway_cidr: "10.0.1.1/24".into(),
@@ -1726,6 +1922,7 @@ mod tests {
             is_phy: false,
             network_security_group_id: None,
             routing_profile: None,
+            interface_routing_profile: None,
             ipv6_port_config: None,
         }];
         conf.ct_access_vlans = vec![VlanConfig {
@@ -1760,6 +1957,10 @@ mod tests {
         conf.ct_port_configs = vec![PortConfig {
             interface_name: "pf0vf0_if".into(),
             vlan: 100,
+            host_ip: "10.0.1.2".into(),
+            host_route: "10.0.1.0/24".into(),
+            host_ipv6: None,
+            host_ipv6_route: None,
             vni: Some(1000),
             l3_vni: Some(100),
             gateway_cidr: "10.0.1.1/24".into(),
@@ -1772,6 +1973,7 @@ mod tests {
             is_phy: false,
             network_security_group_id: None,
             routing_profile: None,
+            interface_routing_profile: None,
             ipv6_port_config: None,
         }];
         conf.ct_access_vlans = vec![VlanConfig {
@@ -1795,6 +1997,10 @@ mod tests {
         conf.ct_port_configs = vec![PortConfig {
             interface_name: "pf0vf0_if".into(),
             vlan: 100,
+            host_ip: "10.0.1.2".into(),
+            host_route: "10.0.1.0/24".into(),
+            host_ipv6: None,
+            host_ipv6_route: None,
             vni: Some(1000),
             l3_vni: Some(100),
             gateway_cidr: "10.0.1.1/24".into(),
@@ -1807,6 +2013,7 @@ mod tests {
             is_phy: false,
             network_security_group_id: None,
             routing_profile: None,
+            interface_routing_profile: None,
             ipv6_port_config: None,
         }];
         conf.ct_access_vlans = vec![VlanConfig {
@@ -1844,6 +2051,10 @@ mod tests {
         conf.ct_port_configs = vec![PortConfig {
             interface_name: "pf0vf0_if".into(),
             vlan: 100,
+            host_ip: "10.0.1.2".into(),
+            host_route: "10.0.1.0/24".into(),
+            host_ipv6: None,
+            host_ipv6_route: None,
             vni: Some(1000),
             l3_vni: Some(100),
             gateway_cidr: "10.0.1.1/24".into(),
@@ -1856,6 +2067,7 @@ mod tests {
             is_phy: false,
             network_security_group_id: None,
             routing_profile: None,
+            interface_routing_profile: None,
             ipv6_port_config: None,
         }];
         conf.ct_access_vlans = vec![VlanConfig {
@@ -1884,6 +2096,10 @@ mod tests {
         conf.ct_port_configs = vec![PortConfig {
             interface_name: "pf0vf0_if".into(),
             vlan: 100,
+            host_ip: "10.0.1.2".into(),
+            host_route: "10.0.1.0/24".into(),
+            host_ipv6: None,
+            host_ipv6_route: None,
             vni: Some(1000),
             l3_vni: Some(100),
             gateway_cidr: "10.0.1.1/24".into(),
@@ -1896,6 +2112,7 @@ mod tests {
             is_phy: false,
             network_security_group_id: None,
             routing_profile: None,
+            interface_routing_profile: None,
             ipv6_port_config: None,
         }];
         conf.ct_access_vlans = vec![VlanConfig {
@@ -1932,6 +2149,10 @@ mod tests {
             PortConfig {
                 interface_name: "pf0vf0_if".into(),
                 vlan: 100,
+                host_ip: "10.0.1.2".into(),
+                host_route: "10.0.1.0/24".into(),
+                host_ipv6: None,
+                host_ipv6_route: None,
                 vni: Some(1000),
                 l3_vni: Some(200),
                 gateway_cidr: "10.0.1.1/24".into(),
@@ -1944,11 +2165,16 @@ mod tests {
                 is_phy: false,
                 network_security_group_id: None,
                 routing_profile: None,
+                interface_routing_profile: None,
                 ipv6_port_config: None,
             },
             PortConfig {
                 interface_name: "pf0hpf_if".into(),
                 vlan: 101,
+                host_ip: "10.0.2.2".into(),
+                host_route: "10.0.2.0/24".into(),
+                host_ipv6: None,
+                host_ipv6_route: None,
                 vni: Some(1001),
                 l3_vni: Some(200),
                 gateway_cidr: "10.0.2.1/24".into(),
@@ -1961,6 +2187,7 @@ mod tests {
                 is_phy: false,
                 network_security_group_id: None,
                 routing_profile: None,
+                interface_routing_profile: None,
                 ipv6_port_config: None,
             },
         ];
@@ -2005,6 +2232,10 @@ mod tests {
         conf.ct_port_configs = vec![PortConfig {
             interface_name: "pf0vf0_if".into(),
             vlan: 100,
+            host_ip: "10.0.1.1".into(),
+            host_route: "10.0.1.0/31".into(),
+            host_ipv6: Some("2001:db8::1".into()),
+            host_ipv6_route: Some("2001:db8::0/127".into()),
             vni: Some(1000),
             l3_vni: Some(100),
             gateway_cidr: "10.0.1.0/31".into(),
@@ -2021,6 +2252,7 @@ mod tests {
             is_phy: false,
             network_security_group_id: None,
             routing_profile: None,
+            interface_routing_profile: None,
         }];
         conf.ct_access_vlans = vec![VlanConfig {
             vlan_id: 100,
@@ -2079,6 +2311,10 @@ mod tests {
         PortConfig {
             interface_name: "pf0hpf_if".into(),
             vlan,
+            host_ip: "10.0.1.2".into(),
+            host_route: "10.0.1.0/24".into(),
+            host_ipv6: None,
+            host_ipv6_route: None,
             vni: Some(1000),
             l3_vni: Some(100),
             gateway_cidr: "10.0.1.1/24".into(),
@@ -2091,6 +2327,7 @@ mod tests {
             is_phy: true,
             network_security_group_id: None,
             routing_profile: None,
+            interface_routing_profile: None,
             ipv6_port_config: None,
         }
     }
@@ -2200,5 +2437,33 @@ mod tests {
             !output.contains("169.254.169.253/30") || output.contains("pf0dpu1_if"),
             "DPU-OS mode should not put 169.254.169.253/30 on the vlan SVI in FNN"
         );
+    }
+
+    #[test]
+    fn test_fnn_no_interface_routing_profile_uses_vpc_allowed_anycast_prefixes() {
+        // Build an FNN config with a VPC routing profile and no interface override.
+        let mut conf = minimal_nvue_config();
+        conf.is_fnn = true;
+        conf.vpc_virtualization_type = VpcVirtualizationType::Fnn;
+        conf.ct_routing_profile = Some(RoutingProfile {
+            allowed_anycast_prefixes: vec!["192.0.2.0/24".into(), "2001:db8::/32".into()],
+            ..minimal_fnn_routing_profile()
+        });
+        conf.ct_port_configs = vec![phy_port_config(274)];
+
+        // Render through the template to exercise the VPC-level fallback path.
+        let output = build(conf).expect("build should succeed");
+
+        // Verify the VPC allow-list is emitted for both IPv4 and IPv6.
+        assert!(
+            output.contains("DPU_FROM_INSTANCE_PREFIX_LIST_vpc_100_if_10:"),
+            "expected IPv4 VPC prefix-list in output:\n{output}"
+        );
+        assert!(output.contains("192.0.2.0/24:"));
+        assert!(
+            output.contains("DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_100_if_10:"),
+            "expected IPv6 VPC prefix-list in output:\n{output}"
+        );
+        assert!(output.contains("2001:db8::/32:"));
     }
 }

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -462,7 +462,8 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
         internal_uuid: None,
         mtu: None,
         ipv6_interface_config: None,
-        routing_profile: None,
+        vpc_routing_profile: None,
+        interface_routing_profile: None,
     };
     assert_eq!(admin_interface.svi_ip, None);
 
@@ -632,7 +633,8 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
         internal_uuid: None,
         mtu: None,
         ipv6_interface_config: None,
-        routing_profile: None,
+        vpc_routing_profile: None,
+        interface_routing_profile: None,
     };
 
     let network_security_policy_overrides = vec![
@@ -777,6 +779,7 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
                     virtual_function_id: None,
                     ip_address: None,
                     ipv6_interface_config: None,
+                    routing_profile: None,
                 }],
                 auto: false,
             }),

--- a/crates/agent/templates/nvue_startup_fnn.conf
+++ b/crates/agent/templates/nvue_startup_fnn.conf
@@ -229,8 +229,9 @@
                 action: deny
                 match:
                   any: {}
-          {{- range $vpc := $tenant.Vpcs }}
-          DPU_FROM_INSTANCE_PREFIX_LIST_{{ $vpc.VrfName }}:
+        {{- range $vpc := $tenant.Vpcs }}
+          {{- range $port := $vpc.PortConfigs }}
+          DPU_FROM_INSTANCE_PREFIX_LIST_{{ $vpc.VrfName }}_if_{{ $port.Index }}:
             rule:
             {{- if not $vpc.RoutingProfile.HasAllowedAnycastPrefixesIpv4 }}{{/* This can be removed after a version or two to allow a grace/deprecation period. */}}
               {{- range $nvueConfig.AnycastSitePrefixes }}
@@ -241,33 +242,54 @@
                     max-prefix-len: 32
               {{- end }}
             {{- else }}
-              {{- range $vpc.RoutingProfile.AllowedAnycastPrefixesIpv4 }}
+              {{- if $port.HasRoutingProfile }}
+                {{- range $port.RoutingProfile.AllowedAnycastPrefixesIpv4 }}
               '{{ .Index }}':
                 action: permit
                 match:
                   {{ .Prefix }}:
                     max-prefix-len: 32
+                {{- end }}
+              {{- else }}
+                {{- range $vpc.RoutingProfile.AllowedAnycastPrefixesIpv4 }}
+              '{{ .Index }}':
+                action: permit
+                match:
+                  {{ .Prefix }}:
+                    max-prefix-len: 32
+                {{- end }}
               {{- end }}
             {{- end }}
               '65535':
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_{{ $vpc.VrfName }}:
+          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_{{ $vpc.VrfName }}_if_{{ $port.Index }}:
             type: ipv6
             rule:
-            {{- range $vpc.RoutingProfile.AllowedAnycastPrefixesIpv6 }}
+            {{- if $port.HasRoutingProfile }}
+              {{- range $port.RoutingProfile.AllowedAnycastPrefixesIpv6 }}
               '{{ .Index }}':
                 action: permit
                 match:
                   {{ .Prefix }}:
                     max-prefix-len: 128
+              {{- end }}
+            {{- else }}
+              {{- range $vpc.RoutingProfile.AllowedAnycastPrefixesIpv6 }}
+              '{{ .Index }}':
+                action: permit
+                match:
+                  {{ .Prefix }}:
+                    max-prefix-len: 128
+              {{- end }}            
             {{- end }}
               '65535':
                 action: deny
                 match:
                   any: {}
           {{- end }}
+        {{- end }}
           DPU_FROM_TRAFFIC_INTERCEPT_PEER_PREFIX_LIST:
             rule:
                   {{- range $nvueConfig.TrafficInterceptPublicPrefixes }}
@@ -463,8 +485,9 @@
               '65535':
                 action:
                   deny: {}
-          {{- range $vpc := $tenant.Vpcs }}   
-          dpu_from_instance_{{ $vpc.VrfName }}:
+          {{- range $vpc := $tenant.Vpcs }}
+            {{- range $port := $vpc.PortConfigs }}
+          dpu_from_instance_{{ $vpc.VrfName }}_if_{{ $port.Index }}:
             rule:
               {{- if $vpc.RoutingProfile.TenantLeakCommunitiesAccepted }}
               '9':
@@ -472,7 +495,7 @@
                   permit: {}{{/* We allow it in because we might need to leak to some targets and drop to others, so we tag it for later.  */}}
                 match:
                   type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_{{ $vpc.VrfName }}
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_{{ $vpc.VrfName }}_if_{{ $port.Index }}
                   community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
                 set:
                   tag: 65102{{/* tag it so we can match on the tag and use it for leaking and dropping later */}}
@@ -485,7 +508,7 @@
                   permit: {}
                 match:
                   type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_{{ $vpc.VrfName }}
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_{{ $vpc.VrfName }}_if_{{ $port.Index }}
                   community-list: BYOIP_LEAK_COMMUNITY_LIST
                 set:
                   tag: 65100{{/* tag it so we can match on the tag and use it for leaking later */}}
@@ -499,7 +522,7 @@
                   permit: {}
                 match:
                   type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_{{ $vpc.VrfName }}
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_{{ $vpc.VrfName }}_if_{{ $port.Index }}
                 set:
                   tag: 65101{{/* tag it so we can match on the tag and use it for leaking later */}}
                   community:
@@ -509,7 +532,7 @@
               '65535':
                 action:
                   deny: {}
-          dpu_from_instance_ipv6_{{ $vpc.VrfName }}:
+          dpu_from_instance_ipv6_{{ $vpc.VrfName }}_if_{{ $port.Index }}:
             rule:
               {{- if $vpc.RoutingProfile.TenantLeakCommunitiesAccepted }}
               '9':
@@ -517,7 +540,7 @@
                   permit: {}{{/* We allow it in because we might need to leak to some targets and drop to others, so we tag it for later.  */}}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_{{ $vpc.VrfName }}
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_{{ $vpc.VrfName }}_if_{{ $port.Index }}
                   community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
                 set:
                   tag: 65102{{/* tag it so we can match on the tag and use it for leaking and dropping later */}}
@@ -530,7 +553,7 @@
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_{{ $vpc.VrfName }}
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_{{ $vpc.VrfName }}_if_{{ $port.Index }}
                   community-list: BYOIP_LEAK_COMMUNITY_LIST
                 set:
                   tag: 65100
@@ -544,7 +567,7 @@
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_{{ $vpc.VrfName }}
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_{{ $vpc.VrfName }}_if_{{ $port.Index }}
                 set:
                   tag: 65101
                   community:
@@ -554,6 +577,7 @@
               '65535':
                 action:
                   deny: {}
+            {{- end }}
           {{- end }}
           dpu_to_instance:
             rule:
@@ -770,11 +794,11 @@
         router:
         {{- if $nvueConfig.UseAdminNetwork }}
           static:
-            {{- range $vpc.HostInterfaces }}
+            {{- range $vpc.PortConfigs }}
             {{ .HostRoute }}:
               address-family: ipv4-unicast
               via:
-                vlan{{ .ID }}:
+                vlan{{ .VlanID }}:
                   type: interface
             {{- end }}
         {{- end }}
@@ -786,7 +810,7 @@
               ipv4-unicast:
               {{- if $nvueConfig.UseAdminNetwork }}
                 network:
-                  {{- range $vpc.HostInterfaces }}
+                  {{- range $vpc.PortConfigs }}
                   {{ .HostRoute }}: {}
                   {{- end }}              
               {{- end }}
@@ -823,18 +847,46 @@
                 {{- end}}
             enable: on
             neighbor:
-  {{- range $vpc.HostInterfaces}}
+  {{- range $vpc.PortConfigs}}
     {{- if .HostIP }}
               {{ .HostIP }}:
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_{{ $vpc.VrfName }}_if_{{ .Index }}
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_{{ $vpc.VrfName }}_if_{{ .Index }}
+                      outbound:
+                        route-map: dpu_to_instance
     {{- end }}
     {{- if .HostIPv6 }}
               {{ .HostIPv6 }}:
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_{{ $vpc.VrfName }}_if_{{ .Index }}
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_{{ $vpc.VrfName }}_if_{{ .Index }}
+                      outbound:
+                        route-map: dpu_to_instance
     {{- end }}
   {{- end }}
   {{- if $nvueConfig.PublicPrefixInternalNextHop }}
@@ -867,20 +919,6 @@
                   keepalive: 3
                   route-advertisement: none
               tenant:
-                address-family:
-                  ipv4-unicast:
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_{{ $vpc.VrfName }}
-                      outbound:
-                        route-map: dpu_to_instance
-                  ipv6-unicast:
-                    enable: on
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_ipv6_{{ $vpc.VrfName }}
-                      outbound:
-                        route-map: dpu_to_instance
                 nexthop-connected-check: off
                 {{- if $nvueConfig.Tenant.HasHostASN }}
                 remote-as: {{ $nvueConfig.Tenant.HostASN }}

--- a/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
+++ b/crates/agent/templates/tests/full_nvue_startup_fnn_l3.yaml.expected
@@ -96,7 +96,7 @@
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_10101:
+          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_10101_if_10:
             rule:
               '1000':
                 action: permit
@@ -107,7 +107,7 @@
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_10101:
+          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_10101_if_10:
             type: ipv6
             rule:
               '65535':
@@ -261,15 +261,15 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}   
-          dpu_from_instance_vpc_10101:
+                  deny: {}
+          dpu_from_instance_vpc_10101_if_10:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_10101
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_10101_if_10
                 set:
                   tag: 65101
                   community:
@@ -279,14 +279,14 @@
               '65535':
                 action:
                   deny: {}
-          dpu_from_instance_ipv6_vpc_10101:
+          dpu_from_instance_ipv6_vpc_10101_if_10:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_10101
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_10101_if_10
                 set:
                   tag: 65101
                   community:
@@ -480,6 +480,20 @@
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_vpc_10101_if_10
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_vpc_10101_if_10
+                      outbound:
+                        route-map: dpu_to_instance
               10.255.255.3:
                 passive-mode: on
                 peer-group: traffic_intercept_gw_peer
@@ -508,20 +522,6 @@
                   keepalive: 3
                   route-advertisement: none
               tenant:
-                address-family:
-                  ipv4-unicast:
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_vpc_10101
-                      outbound:
-                        route-map: dpu_to_instance
-                  ipv6-unicast:
-                    enable: on
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_ipv6_vpc_10101
-                      outbound:
-                        route-map: dpu_to_instance
                 nexthop-connected-check: off
                 remote-as: 65100
                 timers:

--- a/crates/agent/templates/tests/nvue_build_fnn_dual_stack.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_dual_stack.yaml.expected
@@ -74,13 +74,13 @@
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_100:
+          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_100_if_10:
             rule:
               '65535':
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_100:
+          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_100_if_10:
             type: ipv6
             rule:
               '65535':
@@ -230,15 +230,15 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}   
-          dpu_from_instance_vpc_100:
+                  deny: {}
+          dpu_from_instance_vpc_100_if_10:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_100
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_100_if_10
                 set:
                   tag: 65101
                   community:
@@ -248,14 +248,14 @@
               '65535':
                 action:
                   deny: {}
-          dpu_from_instance_ipv6_vpc_100:
+          dpu_from_instance_ipv6_vpc_100_if_10:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_100
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_100_if_10
                 set:
                   tag: 65101
                   community:
@@ -427,10 +427,38 @@
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_vpc_100_if_10
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_vpc_100_if_10
+                      outbound:
+                        route-map: dpu_to_instance
               2001:db8::1:
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_vpc_100_if_10
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_vpc_100_if_10
+                      outbound:
+                        route-map: dpu_to_instance
             peer-group:
               traffic_intercept_gw_peer:
                 address-family:
@@ -455,20 +483,6 @@
                   keepalive: 3
                   route-advertisement: none
               tenant:
-                address-family:
-                  ipv4-unicast:
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_vpc_100
-                      outbound:
-                        route-map: dpu_to_instance
-                  ipv6-unicast:
-                    enable: on
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_ipv6_vpc_100
-                      outbound:
-                        route-map: dpu_to_instance
                 nexthop-connected-check: off
                 remote-as: 65100
                 timers:

--- a/crates/agent/templates/tests/nvue_build_fnn_ipv6_acls.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_ipv6_acls.yaml.expected
@@ -85,13 +85,13 @@
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_100:
+          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_100_if_10:
             rule:
               '65535':
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_100:
+          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_100_if_10:
             type: ipv6
             rule:
               '65535':
@@ -241,15 +241,15 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}   
-          dpu_from_instance_vpc_100:
+                  deny: {}
+          dpu_from_instance_vpc_100_if_10:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_100
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_100_if_10
                 set:
                   tag: 65101
                   community:
@@ -259,14 +259,14 @@
               '65535':
                 action:
                   deny: {}
-          dpu_from_instance_ipv6_vpc_100:
+          dpu_from_instance_ipv6_vpc_100_if_10:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_100
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_100_if_10
                 set:
                   tag: 65101
                   community:
@@ -438,6 +438,20 @@
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_vpc_100_if_10
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_vpc_100_if_10
+                      outbound:
+                        route-map: dpu_to_instance
             peer-group:
               traffic_intercept_gw_peer:
                 address-family:
@@ -462,20 +476,6 @@
                   keepalive: 3
                   route-advertisement: none
               tenant:
-                address-family:
-                  ipv4-unicast:
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_vpc_100
-                      outbound:
-                        route-map: dpu_to_instance
-                  ipv6-unicast:
-                    enable: on
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_ipv6_vpc_100
-                      outbound:
-                        route-map: dpu_to_instance
                 nexthop-connected-check: off
                 remote-as: 65100
                 timers:

--- a/crates/agent/templates/tests/nvue_build_fnn_ipv6_only_vpc.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_ipv6_only_vpc.yaml.expected
@@ -75,13 +75,13 @@
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_100:
+          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_100_if_10:
             rule:
               '65535':
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_100:
+          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_100_if_10:
             type: ipv6
             rule:
               '65535':
@@ -231,15 +231,15 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}   
-          dpu_from_instance_vpc_100:
+                  deny: {}
+          dpu_from_instance_vpc_100_if_10:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_100
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_100_if_10
                 set:
                   tag: 65101
                   community:
@@ -249,14 +249,14 @@
               '65535':
                 action:
                   deny: {}
-          dpu_from_instance_ipv6_vpc_100:
+          dpu_from_instance_ipv6_vpc_100_if_10:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_100
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_100_if_10
                 set:
                   tag: 65101
                   community:
@@ -428,6 +428,20 @@
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_vpc_100_if_10
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_vpc_100_if_10
+                      outbound:
+                        route-map: dpu_to_instance
             peer-group:
               traffic_intercept_gw_peer:
                 address-family:
@@ -452,20 +466,6 @@
                   keepalive: 3
                   route-advertisement: none
               tenant:
-                address-family:
-                  ipv4-unicast:
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_vpc_100
-                      outbound:
-                        route-map: dpu_to_instance
-                  ipv6-unicast:
-                    enable: on
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_ipv6_vpc_100
-                      outbound:
-                        route-map: dpu_to_instance
                 nexthop-connected-check: off
                 remote-as: 65100
                 timers:

--- a/crates/agent/templates/tests/nvue_build_fnn_multi_port_ipv6.yaml.expected
+++ b/crates/agent/templates/tests/nvue_build_fnn_multi_port_ipv6.yaml.expected
@@ -84,13 +84,26 @@
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_200:
+          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_200_if_10:
             rule:
               '65535':
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_200:
+          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_200_if_10:
+            type: ipv6
+            rule:
+              '65535':
+                action: deny
+                match:
+                  any: {}
+          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_200_if_20:
+            rule:
+              '65535':
+                action: deny
+                match:
+                  any: {}
+          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_200_if_20:
             type: ipv6
             rule:
               '65535':
@@ -240,15 +253,15 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}   
-          dpu_from_instance_vpc_200:
+                  deny: {}
+          dpu_from_instance_vpc_200_if_10:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_200
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_200_if_10
                 set:
                   tag: 65101
                   community:
@@ -258,14 +271,48 @@
               '65535':
                 action:
                   deny: {}
-          dpu_from_instance_ipv6_vpc_200:
+          dpu_from_instance_ipv6_vpc_200_if_10:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_200
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_200_if_10
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_vpc_200_if_20:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_200_if_20
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_200_if_20:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv6
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_200_if_20
                 set:
                   tag: 65101
                   community:
@@ -437,10 +484,38 @@
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_vpc_200_if_10
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_vpc_200_if_10
+                      outbound:
+                        route-map: dpu_to_instance
               10.0.2.2:
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_vpc_200_if_20
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_vpc_200_if_20
+                      outbound:
+                        route-map: dpu_to_instance
             peer-group:
               traffic_intercept_gw_peer:
                 address-family:
@@ -465,20 +540,6 @@
                   keepalive: 3
                   route-advertisement: none
               tenant:
-                address-family:
-                  ipv4-unicast:
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_vpc_200
-                      outbound:
-                        route-map: dpu_to_instance
-                  ipv6-unicast:
-                    enable: on
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_ipv6_vpc_200
-                      outbound:
-                        route-map: dpu_to_instance
                 nexthop-connected-check: off
                 remote-as: 65100
                 timers:

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic.yaml.expected
@@ -127,7 +127,7 @@
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186:
+          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186_if_20:
             rule:
               '1':
                 action: permit
@@ -138,14 +138,14 @@
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186:
+          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186_if_20:
             type: ipv6
             rule:
               '65535':
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197:
+          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197_if_10:
             rule:
               '1':
                 action: permit
@@ -156,7 +156,7 @@
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197:
+          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197_if_10:
             type: ipv6
             rule:
               '65535':
@@ -310,15 +310,15 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}   
-          dpu_from_instance_vpc_1025186:
+                  deny: {}
+          dpu_from_instance_vpc_1025186_if_20:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186_if_20
                 set:
                   tag: 65101
                   community:
@@ -328,31 +328,14 @@
               '65535':
                 action:
                   deny: {}
-          dpu_from_instance_ipv6_vpc_1025186:
+          dpu_from_instance_ipv6_vpc_1025186_if_20:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186
-                set:
-                  tag: 65101
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '65535':
-                action:
-                  deny: {}   
-          dpu_from_instance_vpc_1025197:
-            rule:
-              '11':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186_if_20
                 set:
                   tag: 65101
                   community:
@@ -362,14 +345,31 @@
               '65535':
                 action:
                   deny: {}
-          dpu_from_instance_ipv6_vpc_1025197:
+          dpu_from_instance_vpc_1025197_if_10:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197_if_10
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_1025197_if_10:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197_if_10
                 set:
                   tag: 65101
                   community:
@@ -547,14 +547,24 @@
                     enable: on
             enable: on
             neighbor:
-              10.217.5.170:
-                passive-mode: on
-                peer-group: tenant
-                type: numbered
               10.217.5.162:
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_vpc_1025186_if_20
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_vpc_1025186_if_20
+                      outbound:
+                        route-map: dpu_to_instance
               10.10.10.3:
                 passive-mode: on
                 peer-group: traffic_intercept_gw_peer
@@ -583,20 +593,6 @@
                   keepalive: 3
                   route-advertisement: none
               tenant:
-                address-family:
-                  ipv4-unicast:
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_vpc_1025186
-                      outbound:
-                        route-map: dpu_to_instance
-                  ipv6-unicast:
-                    enable: on
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_ipv6_vpc_1025186
-                      outbound:
-                        route-map: dpu_to_instance
                 nexthop-connected-check: off
                 remote-as: 65100
                 timers:
@@ -650,10 +646,20 @@
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
-              10.217.5.162:
-                passive-mode: on
-                peer-group: tenant
-                type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_vpc_1025197_if_10
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_vpc_1025197_if_10
+                      outbound:
+                        route-map: dpu_to_instance
               10.10.10.3:
                 passive-mode: on
                 peer-group: traffic_intercept_gw_peer
@@ -682,20 +688,6 @@
                   keepalive: 3
                   route-advertisement: none
               tenant:
-                address-family:
-                  ipv4-unicast:
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_vpc_1025197
-                      outbound:
-                        route-map: dpu_to_instance
-                  ipv6-unicast:
-                    enable: on
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_ipv6_vpc_1025197
-                      outbound:
-                        route-map: dpu_to_instance
                 nexthop-connected-check: off
                 remote-as: 65100
                 timers:

--- a/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_classic_with_empty_nsg_default_deny.yaml.expected
@@ -135,7 +135,7 @@
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186:
+          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186_if_20:
             rule:
               '1':
                 action: permit
@@ -146,14 +146,14 @@
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186:
+          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186_if_20:
             type: ipv6
             rule:
               '65535':
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197:
+          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197_if_10:
             rule:
               '1':
                 action: permit
@@ -164,7 +164,7 @@
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197:
+          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197_if_10:
             type: ipv6
             rule:
               '65535':
@@ -318,15 +318,15 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}   
-          dpu_from_instance_vpc_1025186:
+                  deny: {}
+          dpu_from_instance_vpc_1025186_if_20:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186_if_20
                 set:
                   tag: 65101
                   community:
@@ -336,31 +336,14 @@
               '65535':
                 action:
                   deny: {}
-          dpu_from_instance_ipv6_vpc_1025186:
+          dpu_from_instance_ipv6_vpc_1025186_if_20:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186
-                set:
-                  tag: 65101
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '65535':
-                action:
-                  deny: {}   
-          dpu_from_instance_vpc_1025197:
-            rule:
-              '11':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186_if_20
                 set:
                   tag: 65101
                   community:
@@ -370,14 +353,31 @@
               '65535':
                 action:
                   deny: {}
-          dpu_from_instance_ipv6_vpc_1025197:
+          dpu_from_instance_vpc_1025197_if_10:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197_if_10
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_1025197_if_10:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197_if_10
                 set:
                   tag: 65101
                   community:
@@ -557,14 +557,24 @@
                     enable: on
             enable: on
             neighbor:
-              10.217.5.170:
-                passive-mode: on
-                peer-group: tenant
-                type: numbered
               10.217.5.162:
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_vpc_1025186_if_20
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_vpc_1025186_if_20
+                      outbound:
+                        route-map: dpu_to_instance
               10.10.10.3:
                 passive-mode: on
                 peer-group: traffic_intercept_gw_peer
@@ -593,20 +603,6 @@
                   keepalive: 3
                   route-advertisement: none
               tenant:
-                address-family:
-                  ipv4-unicast:
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_vpc_1025186
-                      outbound:
-                        route-map: dpu_to_instance
-                  ipv6-unicast:
-                    enable: on
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_ipv6_vpc_1025186
-                      outbound:
-                        route-map: dpu_to_instance
                 nexthop-connected-check: off
                 remote-as: 65100
                 timers:
@@ -660,10 +656,20 @@
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
-              10.217.5.162:
-                passive-mode: on
-                peer-group: tenant
-                type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_vpc_1025197_if_10
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_vpc_1025197_if_10
+                      outbound:
+                        route-map: dpu_to_instance
               10.10.10.3:
                 passive-mode: on
                 peer-group: traffic_intercept_gw_peer
@@ -692,20 +698,6 @@
                   keepalive: 3
                   route-advertisement: none
               tenant:
-                address-family:
-                  ipv4-unicast:
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_vpc_1025197
-                      outbound:
-                        route-map: dpu_to_instance
-                  ipv6-unicast:
-                    enable: on
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_ipv6_vpc_1025197
-                      outbound:
-                        route-map: dpu_to_instance
                 nexthop-connected-check: off
                 remote-as: 65100
                 timers:

--- a/crates/agent/templates/tests/nvue_startup_fnn_with_leaks.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_fnn_with_leaks.yaml.expected
@@ -132,36 +132,31 @@
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186:
+          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186_if_20:
             rule:
-              '1':
-                action: permit
-                match:
-                  5.255.254.0/24:
-                    max-prefix-len: 32
               '65535':
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186:
+          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186_if_20:
             type: ipv6
             rule:
               '65535':
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197:
+          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197_if_10:
             rule:
               '1':
                 action: permit
                 match:
-                  5.255.254.0/24:
+                  5.255.254.67/32:
                     max-prefix-len: 32
               '65535':
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197:
+          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197_if_10:
             type: ipv6
             rule:
               '65535':
@@ -351,15 +346,15 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}   
-          dpu_from_instance_vpc_1025186:
+                  deny: {}
+          dpu_from_instance_vpc_1025186_if_20:
             rule:
               '9':
                 action:
                   permit: {}
                 match:
                   type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186_if_20
                   community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
                 set:
                   tag: 65102
@@ -372,7 +367,7 @@
                   permit: {}
                 match:
                   type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186_if_20
                   community-list: BYOIP_LEAK_COMMUNITY_LIST
                 set:
                   tag: 65100
@@ -385,7 +380,7 @@
                   permit: {}
                 match:
                   type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186_if_20
                 set:
                   tag: 65101
                   community:
@@ -395,14 +390,14 @@
               '65535':
                 action:
                   deny: {}
-          dpu_from_instance_ipv6_vpc_1025186:
+          dpu_from_instance_ipv6_vpc_1025186_if_20:
             rule:
               '9':
                 action:
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186_if_20
                   community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
                 set:
                   tag: 65102
@@ -415,7 +410,7 @@
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186_if_20
                   community-list: BYOIP_LEAK_COMMUNITY_LIST
                 set:
                   tag: 65100
@@ -428,50 +423,7 @@
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186
-                set:
-                  tag: 65101
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '65535':
-                action:
-                  deny: {}   
-          dpu_from_instance_vpc_1025197:
-            rule:
-              '9':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197
-                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
-                set:
-                  tag: 65102
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '10':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197
-                  community-list: BYOIP_LEAK_COMMUNITY_LIST
-                set:
-                  tag: 65100
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '11':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186_if_20
                 set:
                   tag: 65101
                   community:
@@ -481,14 +433,57 @@
               '65535':
                 action:
                   deny: {}
-          dpu_from_instance_ipv6_vpc_1025197:
+          dpu_from_instance_vpc_1025197_if_10:
+            rule:
+              '9':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197_if_10
+                  community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
+                set:
+                  tag: 65102
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '10':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197_if_10
+                  community-list: BYOIP_LEAK_COMMUNITY_LIST
+                set:
+                  tag: 65100
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197_if_10
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_1025197_if_10:
             rule:
               '9':
                 action:
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197_if_10
                   community-list: BYOIP_LEAK_AND_DROP_EVPN_COMMUNITY_LIST
                 set:
                   tag: 65102
@@ -501,7 +496,7 @@
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197_if_10
                   community-list: BYOIP_LEAK_COMMUNITY_LIST
                 set:
                   tag: 65100
@@ -514,7 +509,7 @@
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197_if_10
                 set:
                   tag: 65101
                   community:
@@ -736,14 +731,24 @@
                       default: {}
             enable: on
             neighbor:
-              10.217.5.170:
-                passive-mode: on
-                peer-group: tenant
-                type: numbered
               10.217.5.162:
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_vpc_1025186_if_20
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_vpc_1025186_if_20
+                      outbound:
+                        route-map: dpu_to_instance
               10.10.10.3:
                 passive-mode: on
                 peer-group: traffic_intercept_gw_peer
@@ -772,20 +777,6 @@
                   keepalive: 3
                   route-advertisement: none
               tenant:
-                address-family:
-                  ipv4-unicast:
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_vpc_1025186
-                      outbound:
-                        route-map: dpu_to_instance
-                  ipv6-unicast:
-                    enable: on
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_ipv6_vpc_1025186
-                      outbound:
-                        route-map: dpu_to_instance
                 nexthop-connected-check: off
                 remote-as: 65100
                 timers:
@@ -851,10 +842,20 @@
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
-              10.217.5.162:
-                passive-mode: on
-                peer-group: tenant
-                type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_vpc_1025197_if_10
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_vpc_1025197_if_10
+                      outbound:
+                        route-map: dpu_to_instance
               10.10.10.3:
                 passive-mode: on
                 peer-group: traffic_intercept_gw_peer
@@ -883,20 +884,6 @@
                   keepalive: 3
                   route-advertisement: none
               tenant:
-                address-family:
-                  ipv4-unicast:
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_vpc_1025197
-                      outbound:
-                        route-map: dpu_to_instance
-                  ipv6-unicast:
-                    enable: on
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_ipv6_vpc_1025197
-                      outbound:
-                        route-map: dpu_to_instance
                 nexthop-connected-check: off
                 remote-as: 65100
                 timers:

--- a/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
+++ b/crates/agent/templates/tests/nvue_startup_quarantined_fnn.yaml.expected
@@ -147,7 +147,7 @@
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186:
+          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186_if_20:
             rule:
               '1':
                 action: permit
@@ -158,14 +158,14 @@
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186:
+          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186_if_20:
             type: ipv6
             rule:
               '65535':
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197:
+          DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197_if_10:
             rule:
               '1':
                 action: permit
@@ -176,7 +176,7 @@
                 action: deny
                 match:
                   any: {}
-          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197:
+          DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197_if_10:
             type: ipv6
             rule:
               '65535':
@@ -330,15 +330,15 @@
                     none: {}
               '65535':
                 action:
-                  deny: {}   
-          dpu_from_instance_vpc_1025186:
+                  deny: {}
+          dpu_from_instance_vpc_1025186_if_20:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025186_if_20
                 set:
                   tag: 65101
                   community:
@@ -348,31 +348,14 @@
               '65535':
                 action:
                   deny: {}
-          dpu_from_instance_ipv6_vpc_1025186:
+          dpu_from_instance_ipv6_vpc_1025186_if_20:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186
-                set:
-                  tag: 65101
-                  community:
-                      none: {}
-                  large-community:
-                    none: {}
-              '65535':
-                action:
-                  deny: {}   
-          dpu_from_instance_vpc_1025197:
-            rule:
-              '11':
-                action:
-                  permit: {}
-                match:
-                  type: ipv4
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025186_if_20
                 set:
                   tag: 65101
                   community:
@@ -382,14 +365,31 @@
               '65535':
                 action:
                   deny: {}
-          dpu_from_instance_ipv6_vpc_1025197:
+          dpu_from_instance_vpc_1025197_if_10:
+            rule:
+              '11':
+                action:
+                  permit: {}
+                match:
+                  type: ipv4
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_vpc_1025197_if_10
+                set:
+                  tag: 65101
+                  community:
+                      none: {}
+                  large-community:
+                    none: {}
+              '65535':
+                action:
+                  deny: {}
+          dpu_from_instance_ipv6_vpc_1025197_if_10:
             rule:
               '11':
                 action:
                   permit: {}
                 match:
                   type: ipv6
-                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197
+                  ip-prefix-list: DPU_FROM_INSTANCE_PREFIX_LIST_IPV6_vpc_1025197_if_10
                 set:
                   tag: 65101
                   community:
@@ -569,14 +569,24 @@
                     enable: on
             enable: on
             neighbor:
-              10.217.5.170:
-                passive-mode: on
-                peer-group: tenant
-                type: numbered
               10.217.5.162:
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_vpc_1025186_if_20
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_vpc_1025186_if_20
+                      outbound:
+                        route-map: dpu_to_instance
               10.10.10.3:
                 passive-mode: on
                 peer-group: traffic_intercept_gw_peer
@@ -605,20 +615,6 @@
                   keepalive: 3
                   route-advertisement: none
               tenant:
-                address-family:
-                  ipv4-unicast:
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_vpc_1025186
-                      outbound:
-                        route-map: dpu_to_instance
-                  ipv6-unicast:
-                    enable: on
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_ipv6_vpc_1025186
-                      outbound:
-                        route-map: dpu_to_instance
                 nexthop-connected-check: off
                 remote-as: 65100
                 timers:
@@ -672,10 +668,20 @@
                 passive-mode: on
                 peer-group: tenant
                 type: numbered
-              10.217.5.162:
-                passive-mode: on
-                peer-group: tenant
-                type: numbered
+                address-family:
+                  ipv4-unicast:
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_vpc_1025197_if_10
+                      outbound:
+                        route-map: dpu_to_instance
+                  ipv6-unicast:
+                    enable: on
+                    policy:
+                      inbound:
+                        route-map: dpu_from_instance_ipv6_vpc_1025197_if_10
+                      outbound:
+                        route-map: dpu_to_instance
               10.10.10.3:
                 passive-mode: on
                 peer-group: traffic_intercept_gw_peer
@@ -704,20 +710,6 @@
                   keepalive: 3
                   route-advertisement: none
               tenant:
-                address-family:
-                  ipv4-unicast:
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_vpc_1025197
-                      outbound:
-                        route-map: dpu_to_instance
-                  ipv6-unicast:
-                    enable: on
-                    policy:
-                      inbound:
-                        route-map: dpu_from_instance_ipv6_vpc_1025197
-                      outbound:
-                        route-map: dpu_to_instance
                 nexthop-connected-check: off
                 remote-as: 65100
                 timers:

--- a/crates/api-db/src/instance_address.rs
+++ b/crates/api-db/src/instance_address.rs
@@ -705,6 +705,7 @@ mod tests {
                     ip_addrs: HashMap::default(),
                     requested_ip_addr: None,
                     ipv6_interface_config: None,
+                    routing_profile: None,
                     interface_prefixes: HashMap::default(),
                     network_segment_gateways: HashMap::default(),
                     host_inband_mac_address: None,

--- a/crates/api-db/src/instance_network_config.rs
+++ b/crates/api-db/src/instance_network_config.rs
@@ -93,6 +93,7 @@ pub fn add_inband_interfaces_to_config(
             internal_uuid: uuid::Uuid::new_v4(),
             requested_ip_addr: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         });
     }
 

--- a/crates/api-model/src/instance/config/network.rs
+++ b/crates/api-model/src/instance/config/network.rs
@@ -159,6 +159,7 @@ impl InstanceNetworkConfig {
                     ip_addrs: HashMap::default(),
                     requested_ip_addr: None,
                     ipv6_interface_config: None,
+                    routing_profile: None,
                     interface_prefixes: HashMap::default(),
                     network_segment_gateways: HashMap::default(),
                     host_inband_mac_address: None,
@@ -181,6 +182,7 @@ impl InstanceNetworkConfig {
                         ip_addrs: HashMap::default(),
                         requested_ip_addr: None,
                         ipv6_interface_config: None,
+                        routing_profile: None,
                         interface_prefixes: HashMap::default(),
                         network_segment_gateways: HashMap::default(),
                         host_inband_mac_address: None,
@@ -206,6 +208,7 @@ impl InstanceNetworkConfig {
                 ip_addrs: HashMap::default(),
                 requested_ip_addr: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
                 interface_prefixes: HashMap::default(),
                 network_segment_gateways: HashMap::default(),
                 host_inband_mac_address: None,
@@ -522,6 +525,14 @@ pub struct Ipv6InterfaceConfig {
     pub requested_ip_addr: Option<std::net::Ipv6Addr>,
 }
 
+/// Routing-profile options that can be narrowed for an instance interface.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstanceInterfaceRoutingProfile {
+    /// Prefixes this interface is allowed to announce as anycast routes.
+    #[serde(default)]
+    pub allowed_anycast_prefixes: Vec<IpNetwork>,
+}
+
 /// The configuration that a customer desires for an instances network interface
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InstanceInterfaceConfig {
@@ -550,6 +561,10 @@ pub struct InstanceInterfaceConfig {
     /// VpcPrefixId in network_details, both prefixes are allocated to a single segment.
     #[serde(rename = "ipv6")]
     pub ipv6_interface_config: Option<Ipv6InterfaceConfig>,
+
+    /// Optional routing-profile settings that narrow the owning VPC profile for this interface.
+    #[serde(default)]
+    pub routing_profile: Option<InstanceInterfaceRoutingProfile>,
 
     /// The interface-specific prefix allocation we carved out from each
     /// network prefix for this interface (e.g. in FNN we might carve out
@@ -726,6 +741,7 @@ mod tests {
             ip_addrs,
             requested_ip_addr,
             ipv6_interface_config: None,
+            routing_profile: None,
             interface_prefixes,
             network_segment_gateways,
             host_inband_mac_address: None,
@@ -736,7 +752,7 @@ mod tests {
         let serialized = serde_json::to_string(&interface).unwrap();
         assert_eq!(
             serialized,
-            r#"{"function_id":{"type":"physical"},"network_details":null,"network_segment_id":"91609f10-c91d-470d-a260-6293ea0c1200","ip_addrs":{"91609f10-c91d-470d-a260-6293ea0c1201":"192.168.1.2"},"requested_ip_addr":"192.168.1.2","ipv6":null,"interface_prefixes":{"91609f10-c91d-470d-a260-6293ea0c1201":"192.168.1.2/32"},"network_segment_gateways":{},"host_inband_mac_address":null,"device_locator":null,"internal_uuid":"37c3dc65-9aef-4439-b7ca-d532a0a41d7f"}"#
+            r#"{"function_id":{"type":"physical"},"network_details":null,"network_segment_id":"91609f10-c91d-470d-a260-6293ea0c1200","ip_addrs":{"91609f10-c91d-470d-a260-6293ea0c1201":"192.168.1.2"},"requested_ip_addr":"192.168.1.2","ipv6":null,"routing_profile":null,"interface_prefixes":{"91609f10-c91d-470d-a260-6293ea0c1201":"192.168.1.2/32"},"network_segment_gateways":{},"host_inband_mac_address":null,"device_locator":null,"internal_uuid":"37c3dc65-9aef-4439-b7ca-d532a0a41d7f"}"#
         );
 
         assert_eq!(
@@ -763,6 +779,7 @@ mod tests {
                     ip_addrs: HashMap::default(),
                     requested_ip_addr: None,
                     ipv6_interface_config: None,
+                    routing_profile: None,
                     interface_prefixes: HashMap::default(),
                     network_segment_gateways: HashMap::default(),
                     host_inband_mac_address: None,

--- a/crates/api-model/src/instance/status/network.rs
+++ b/crates/api-model/src/instance/status/network.rs
@@ -638,6 +638,7 @@ mod tests {
                     ip_addrs: HashMap::from([(prefix_uuid, "127.0.0.1".parse().unwrap())]),
                     requested_ip_addr: None,
                     ipv6_interface_config: None,
+                    routing_profile: None,
                     interface_prefixes: HashMap::from([(
                         prefix_uuid,
                         "127.0.0.1/32".parse().unwrap(),
@@ -660,6 +661,7 @@ mod tests {
                     )]),
                     requested_ip_addr: None,
                     ipv6_interface_config: None,
+                    routing_profile: None,
                     interface_prefixes: HashMap::from([(
                         prefix_uuid.offset(1),
                         "127.0.0.2/32".parse().unwrap(),
@@ -682,6 +684,7 @@ mod tests {
                     )]),
                     requested_ip_addr: None,
                     ipv6_interface_config: None,
+                    routing_profile: None,
                     interface_prefixes: HashMap::from([(
                         prefix_uuid.offset(2),
                         "127.0.0.3/32".parse().unwrap(),
@@ -717,6 +720,7 @@ mod tests {
                     ip_addrs: HashMap::from([(prefix_uuid, "127.0.1.2".parse().unwrap())]),
                     requested_ip_addr: None,
                     ipv6_interface_config: None,
+                    routing_profile: None,
                     interface_prefixes: HashMap::from([(
                         prefix_uuid,
                         "127.0.1.0/24".parse().unwrap(),
@@ -739,6 +743,7 @@ mod tests {
                     )]),
                     requested_ip_addr: None,
                     ipv6_interface_config: None,
+                    routing_profile: None,
                     interface_prefixes: HashMap::from([(
                         prefix_uuid.offset(1),
                         "127.0.2.0/24".parse().unwrap(),
@@ -761,6 +766,7 @@ mod tests {
                     )]),
                     requested_ip_addr: None,
                     ipv6_interface_config: None,
+                    routing_profile: None,
                     interface_prefixes: HashMap::from([(
                         prefix_uuid.offset(2),
                         "127.0.3.0/24".parse().unwrap(),

--- a/crates/api/src/ethernet_virtualization.rs
+++ b/crates/api/src/ethernet_virtualization.rs
@@ -26,7 +26,10 @@ use db::vpc::{self};
 use db::vpc_peering::get_prefixes_by_vpcs;
 use db::{self, ObjectColumnFilter, network_security_group};
 use ipnetwork::{IpNetwork, Ipv4Network};
-use model::instance::config::network::{InstanceInterfaceConfig, InterfaceFunctionId};
+use model::instance::config::network::{
+    InstanceInterfaceConfig, InstanceInterfaceRoutingProfile, InstanceNetworkConfig,
+    InterfaceFunctionId,
+};
 use model::machine::ManagedHostStateSnapshot;
 use model::network_prefix::NetworkPrefix;
 use model::network_security_group::{
@@ -91,6 +94,95 @@ impl SiteFabricPrefixList {
                 _ => false,
             })
     }
+}
+
+/// Returns whether `candidate` is equal to or narrower than `allowed`.
+fn prefix_contains(allowed: IpNetwork, candidate: IpNetwork) -> bool {
+    match (candidate, allowed) {
+        (IpNetwork::V4(candidate), IpNetwork::V4(allowed)) => candidate.is_subnet_of(allowed),
+        (IpNetwork::V6(candidate), IpNetwork::V6(allowed)) => candidate.is_subnet_of(allowed),
+        _ => false,
+    }
+}
+
+/// Validates that an interface-level routing profile only narrows the owning VPC profile.
+fn validate_interface_routing_profile(
+    vpc_profile: &FnnRoutingProfileConfig,
+    interface_profile: &InstanceInterfaceRoutingProfile,
+) -> Result<(), CarbideError> {
+    // Validate every requested anycast prefix against the owning VPC profile.
+    // This helper is used when tenant input is accepted. DPU render-time
+    // validation is handled by the agent, which filters invalid prefixes and
+    // logs warnings so operator profile changes after instance creation do not
+    // block config rendering. If routing profiles become DB-backed, this
+    // should also be enforced on profile updates before committing changes
+    // that would invalidate existing interface overrides.
+    for prefix in &interface_profile.allowed_anycast_prefixes {
+        if !vpc_profile
+            .allowed_anycast_prefixes
+            .iter()
+            .any(|allowed| prefix_contains(allowed.prefix, *prefix))
+        {
+            return Err(CarbideError::InvalidArgument(format!(
+                "instance interface routing_profile.allowed_anycast_prefixes entry `{prefix}` is not within the owning VPC routing profile"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Validates all interface-level routing profiles in an instance network config.
+pub(crate) async fn validate_instance_interface_routing_profiles(
+    txn: &mut PgConnection,
+    network_config: &InstanceNetworkConfig,
+    fnn_config: Option<&FnnConfig>,
+) -> Result<(), CarbideError> {
+    for iface in &network_config.interfaces {
+        let Some(interface_profile) = iface.routing_profile.as_ref() else {
+            continue;
+        };
+
+        // Resolve the owning VPC after any VPC-prefix request has become a segment.
+        let segment_id = iface.network_segment_id.ok_or_else(|| {
+            CarbideError::InvalidArgument(
+                "instance interface routing_profile requires a network segment".to_string(),
+            )
+        })?;
+        let vpc = db::vpc::find_by_segment(&mut *txn, segment_id).await?;
+
+        // Interface routing profiles are only valid on FNN VPC interfaces.
+        if vpc.network_virtualization_type != VpcVirtualizationType::Fnn {
+            return Err(CarbideError::InvalidArgument(
+                "instance interface routing_profile is only supported for FNN VPC interfaces"
+                    .to_string(),
+            ));
+        }
+
+        let fnn = fnn_config.ok_or_else(|| {
+            CarbideError::InvalidArgument(
+                "instance interface routing_profile requires FNN routing profiles".to_string(),
+            )
+        })?;
+        let profile_type =
+            vpc.routing_profile_type
+                .as_ref()
+                .ok_or_else(|| CarbideError::Internal {
+                    message: "tenant routing profile type not found in VPC record".to_string(),
+                })?;
+        let vpc_profile =
+            fnn.routing_profiles
+                .get(profile_type)
+                .ok_or_else(|| CarbideError::NotFoundError {
+                    kind: "routing_profile_type",
+                    id: profile_type.to_string(),
+                })?;
+
+        // The interface profile must be a subset of the operator profile.
+        validate_interface_routing_profile(vpc_profile, interface_profile)?;
+    }
+
+    Ok(())
 }
 
 /// Groups the optional IPv4 prefix with the optional IPv6 prefix for a
@@ -416,7 +508,8 @@ pub async fn admin_network(
         internal_uuid: None,
         mtu: u32::try_from(admin_segment.config.mtu).ok(),
         ipv6_interface_config: None,
-        routing_profile: admin_vpc_routing_profile.map(rpc::RoutingProfile::from),
+        vpc_routing_profile: admin_vpc_routing_profile.map(rpc::RoutingProfile::from),
+        interface_routing_profile: None,
     };
     Ok((cfg, interface.id))
 }
@@ -556,7 +649,7 @@ pub async fn tenant_network(
         .unwrap_or_default() as u32;
 
     // Resolve the routing profile from the VPC attached to this interface.
-    let routing_profile = match (vpc.as_ref(), fnn_config) {
+    let (vpc_routing_profile, interface_routing_profile) = match (vpc.as_ref(), fnn_config) {
         (Some(vpc), Some(fnn)) if vpc.network_virtualization_type == VpcVirtualizationType::Fnn => {
             let profile_type =
                 vpc.routing_profile_type
@@ -571,9 +664,28 @@ pub async fn tenant_network(
                 }
             })?;
 
-            Some(rpc::RoutingProfile::from(profile))
+            (
+                Some(rpc::RoutingProfile::from(profile)),
+                iface
+                    .routing_profile
+                    .as_ref()
+                    .map(rpc::FlatInterfaceRoutingProfile::from),
+            )
         }
-        _ => None,
+        (Some(vpc), None) if vpc.network_virtualization_type == VpcVirtualizationType::Fnn => {
+            return Err(CarbideError::Internal {
+                message: "FNN VPC found but no FNN config found".to_string(),
+            }
+            .into());
+        }
+        _ if iface.routing_profile.is_some() => {
+            return Err(CarbideError::InvalidArgument(
+                "instance interface routing_profile is only supported for FNN VPC interfaces"
+                    .to_string(),
+            )
+            .into());
+        }
+        _ => (None, None),
     };
 
     let rpc_ft: rpc::InterfaceFunctionType = iface.function_id.function_type().into();
@@ -686,7 +798,8 @@ pub async fn tenant_network(
                 .unwrap_or_default(),
             svi_ip: svi_ip_v6,
         }),
-        routing_profile,
+        vpc_routing_profile,
+        interface_routing_profile,
     })
 }
 
@@ -714,6 +827,71 @@ pub fn resolve_security_group_rule(
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// Returns a test FNN routing profile with the provided allowed anycast prefixes.
+    fn routing_profile_with_anycast(prefixes: &[&str]) -> FnnRoutingProfileConfig {
+        FnnRoutingProfileConfig {
+            allowed_anycast_prefixes: prefixes
+                .iter()
+                .map(|prefix| crate::cfg::file::PrefixFilterPolicyEntry {
+                    prefix: prefix.parse().unwrap(),
+                })
+                .collect(),
+            leak_default_route_from_underlay: true,
+            ..Default::default()
+        }
+    }
+
+    /// Returns a test interface routing profile with the provided anycast prefixes.
+    fn interface_routing_profile(prefixes: &[&str]) -> InstanceInterfaceRoutingProfile {
+        InstanceInterfaceRoutingProfile {
+            allowed_anycast_prefixes: prefixes
+                .iter()
+                .map(|prefix| prefix.parse().unwrap())
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn test_interface_routing_profile_conversion_preserves_interface_anycast_prefixes() {
+        let vpc_profile = routing_profile_with_anycast(&["192.0.2.0/24", "2001:db8::/32"]);
+        let interface_profile = interface_routing_profile(&["192.0.2.64/26", "2001:db8:1::/64"]);
+
+        validate_interface_routing_profile(&vpc_profile, &interface_profile).unwrap();
+        let vpc_routing_profile = rpc::RoutingProfile::from(&vpc_profile);
+        let interface_routing_profile = rpc::FlatInterfaceRoutingProfile::from(&interface_profile);
+
+        assert!(vpc_routing_profile.leak_default_route_from_underlay);
+        assert_eq!(
+            vpc_routing_profile
+                .allowed_anycast_prefixes
+                .into_iter()
+                .map(|entry| entry.prefix)
+                .collect::<Vec<_>>(),
+            vec!["192.0.2.0/24".to_string(), "2001:db8::/32".to_string()]
+        );
+        assert_eq!(
+            interface_routing_profile
+                .allowed_anycast_prefixes
+                .into_iter()
+                .map(|entry| entry.prefix)
+                .collect::<Vec<_>>(),
+            vec!["192.0.2.64/26".to_string(), "2001:db8:1::/64".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_interface_routing_profile_rejects_anycast_prefix_outside_vpc_profile() {
+        let vpc_profile = routing_profile_with_anycast(&["192.0.2.0/24"]);
+        let interface_profile = interface_routing_profile(&["198.51.100.0/24"]);
+
+        // Attempt to validate an interface profile outside the VPC profile.
+        let err = validate_interface_routing_profile(&vpc_profile, &interface_profile)
+            .expect_err("interface profile should be rejected");
+
+        // Verify the API surfaces the violation as caller-provided invalid input.
+        assert!(matches!(err, CarbideError::InvalidArgument(_)));
+    }
 
     #[test]
     fn test_site_prefix_list() {

--- a/crates/api/src/handlers/dpu.rs
+++ b/crates/api/src/handlers/dpu.rs
@@ -440,13 +440,13 @@ pub(crate) async fn get_managed_host_network_config_inner(
     };
 
     // Deprecated compatibility field for DPU agents that do not yet read
-    // FlatInterfaceConfig.routing_profile.
+    // FlatInterfaceConfig.vpc_routing_profile.
     let deprecated_routing_profile = if tenant_interfaces.is_empty() {
         admin_vpc_routing_profile.map(rpc::RoutingProfile::from)
     } else {
         tenant_interfaces
             .first()
-            .and_then(|interface| interface.routing_profile.clone())
+            .and_then(|interface| interface.vpc_routing_profile.clone())
     };
 
     let network_config = build_consolidated_network_config(

--- a/crates/api/src/handlers/instance.rs
+++ b/crates/api/src/handlers/instance.rs
@@ -50,6 +50,8 @@ use serde_json::json;
 use tonic::{Request, Response, Status};
 
 use crate::api::{Api, log_machine_id, log_request_data, log_tenant_organization_id};
+use crate::cfg::file::FnnConfig;
+use crate::ethernet_virtualization::validate_instance_interface_routing_profiles;
 use crate::handlers::utils::convert_and_log_machine_id;
 use crate::instance::{
     InstanceAllocationRequest, allocate_ib_port_guid, allocate_instance, allocate_network,
@@ -1279,6 +1281,7 @@ pub(crate) async fn update_instance_config(
             .as_ref()
             .map(|vc| vc.allow_instance_vf)
             .unwrap_or(true),
+        api.runtime_config.fnn.as_ref(),
         &instance,
         &mut config.network,
         &mh_snapshot,
@@ -1335,6 +1338,7 @@ pub(crate) async fn update_instance_config(
 /// network_config_version.
 async fn update_instance_network_config(
     allow_instance_vf: bool,
+    fnn_config: Option<&FnnConfig>,
     instance: &InstanceSnapshot,
     network: &mut InstanceNetworkConfig,
     mh_snapshot: &ManagedHostStateSnapshot,
@@ -1418,6 +1422,7 @@ async fn update_instance_network_config(
     network
         .validate(allow_instance_vf)
         .map_err(CarbideError::from)?;
+    validate_instance_interface_routing_profiles(txn, network, fnn_config).await?;
 
     // Allocate IPs and add them to the network config
     let updated_network_config = db::instance_network_config::with_allocated_ips(

--- a/crates/api/src/instance/mod.rs
+++ b/crates/api/src/instance/mod.rs
@@ -54,6 +54,7 @@ use sqlx::PgConnection;
 
 use crate::api::Api;
 use crate::cfg::file::ComputeAllocationEnforcement;
+use crate::ethernet_virtualization::validate_instance_interface_routing_profiles;
 use crate::network_segment::allocate::PrefixAllocator;
 
 /// Validate a requested IP address for a linknet allocation and wrap it as
@@ -860,6 +861,12 @@ pub async fn batch_allocate_instances(
                 .map(|vc| vc.allow_instance_vf)
                 .unwrap_or(true),
         )?;
+        validate_instance_interface_routing_profiles(
+            &mut txn,
+            &request.config.network,
+            api.runtime_config.fnn.as_ref(),
+        )
+        .await?;
 
         // Zero-DPU hosts (no DPU, or DPU in NIC mode) MUST use `auto`, because
         // their only valid attachments are HostInband segments, and NICo knows

--- a/crates/api/src/tests/common/api_fixtures/instance.rs
+++ b/crates/api/src/tests/common/api_fixtures/instance.rs
@@ -204,6 +204,7 @@ pub fn single_interface_network_config(segment_id: NetworkSegmentId) -> rpc::Ins
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }],
         auto: false,
     }
@@ -223,6 +224,7 @@ pub fn single_interface_network_config_with_vfs(
         virtual_function_id: None,
         ip_address: None,
         ipv6_interface_config: None,
+        routing_profile: None,
     }];
 
     interfaces.extend(
@@ -235,6 +237,7 @@ pub fn single_interface_network_config_with_vfs(
             virtual_function_id: Some(function_id as u32),
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }),
     );
 
@@ -260,6 +263,7 @@ pub fn interface_network_config_with_devices(
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         })
         .collect();
     rpc::InstanceNetworkConfig {
@@ -281,6 +285,7 @@ pub fn single_interface_network_config_with_vpc_prefix(
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }],
         auto: false,
     }

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -920,7 +920,32 @@ impl TestEnv {
         Option<u32>,
         NetworkSegmentId,
     ) {
-        let vpc_details = VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+        self.create_vpc_and_peer_vpc_with_tenant_segments_for_tenants(
+            "2829bbe3-c169-4cd9-8b2a-19a8b1618a93",
+            vtype1,
+            "e65a9d69-39d2-4872-a53e-e5cb87c84e75",
+            vtype2,
+        )
+        .await
+    }
+
+    /// Creates two VPCs for the provided tenants and attaches one tenant segment to each.
+    pub async fn create_vpc_and_peer_vpc_with_tenant_segments_for_tenants(
+        &self,
+        tenant_organization_id: &str,
+        vtype1: VpcVirtualizationType,
+        peer_tenant_organization_id: &str,
+        vtype2: VpcVirtualizationType,
+    ) -> (
+        Option<VpcId>,
+        Option<u32>,
+        NetworkSegmentId,
+        Option<VpcId>,
+        Option<u32>,
+        NetworkSegmentId,
+    ) {
+        // Create the primary VPC and tenant segment.
+        let vpc_details = VpcCreationRequest::builder(tenant_organization_id)
             .metadata(Metadata {
                 name: "test vpc".to_string(),
                 description: "".to_string(),
@@ -940,11 +965,12 @@ impl TestEnv {
         )
         .await;
 
-        // Get the tenant segment into ready state
+        // Drive the primary tenant segment to ready state.
         self.run_network_segment_controller_iteration().await;
         self.run_network_segment_controller_iteration().await;
 
-        let peer_vpc_details = VpcCreationRequest::builder("e65a9d69-39d2-4872-a53e-e5cb87c84e75")
+        // Create the peer VPC and tenant segment.
+        let peer_vpc_details = VpcCreationRequest::builder(peer_tenant_organization_id)
             .metadata(Metadata {
                 name: "test peer vpc".to_string(),
                 ..Default::default()
@@ -968,7 +994,7 @@ impl TestEnv {
         )
         .await;
 
-        // Get the tenant segment into ready state
+        // Drive the peer tenant segment to ready state.
         self.run_network_segment_controller_iteration().await;
         self.run_network_segment_controller_iteration().await;
 

--- a/crates/api/src/tests/common/api_fixtures/tenant.rs
+++ b/crates/api/src/tests/common/api_fixtures/tenant.rs
@@ -20,6 +20,32 @@ use rpc::forge_server::Forge;
 
 use super::TestEnv;
 
+/// Creates a tenant using the test site's default tenant routing behavior.
+pub async fn create_fixture_tenant(
+    env: &TestEnv,
+    organization_id: impl Into<String>,
+) -> Result<rpc::Tenant, tonic::Status> {
+    let organization_id = organization_id.into();
+
+    // Let the API apply the runtime default routing-profile behavior.
+    let response = env
+        .api
+        .create_tenant(tonic::Request::new(rpc::CreateTenantRequest {
+            organization_id: organization_id.clone(),
+            routing_profile_type: None,
+            metadata: Some(rpc::Metadata {
+                name: organization_id,
+                ..Default::default()
+            }),
+        }))
+        .await?;
+
+    Ok(response
+        .into_inner()
+        .tenant
+        .expect("created tenant response must include tenant"))
+}
+
 pub async fn create_tenant_keyset(
     env: &TestEnv,
     organization_id: String,

--- a/crates/api/src/tests/instance.rs
+++ b/crates/api/src/tests/instance.rs
@@ -35,6 +35,7 @@ use common::api_fixtures::instance::{
     single_interface_network_config_with_vpc_prefix, update_instance_network_status_observation,
 };
 use common::api_fixtures::managed_host::ManagedHostConfig;
+use common::api_fixtures::tenant::create_fixture_tenant;
 use common::api_fixtures::tpm_attestation::{CA_CERT_SERIALIZED, EK_CERT_SERIALIZED};
 use common::api_fixtures::{
     TestEnvOverrides, create_managed_host, create_test_env, create_test_env_with_overrides, dpu,
@@ -68,7 +69,6 @@ use model::machine::{
 use model::metadata::Metadata;
 use model::network_security_group::NetworkSecurityGroupStatusObservation;
 use model::network_segment::{NetworkSegmentSearchConfig, NetworkSegmentSearchFilter};
-use model::vpc::UpdateVpcVirtualization;
 use model::vpc_prefix::VpcPrefixConfig;
 use rpc::forge::{
     DpuExtensionService, Issue, IssueCategory, ManagedHostQuarantineMode, TpmCaCert, TpmCaCertId,
@@ -992,6 +992,7 @@ async fn test_instance_dns_resolution(_: PgPoolOptions, options: PgConnectOption
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Virtual as i32,
@@ -1002,6 +1003,7 @@ async fn test_instance_dns_resolution(_: PgPoolOptions, options: PgConnectOption
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
         ],
         auto: false,
@@ -1788,6 +1790,7 @@ async fn test_instance_address_creation(_: PgPoolOptions, options: PgConnectOpti
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Virtual as i32,
@@ -1798,6 +1801,7 @@ async fn test_instance_address_creation(_: PgPoolOptions, options: PgConnectOpti
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
         ],
         auto: false,
@@ -2381,6 +2385,7 @@ async fn test_allocate_network_vpc_prefix_id(_: PgPoolOptions, options: PgConnec
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }],
         auto: false,
     };
@@ -2439,8 +2444,28 @@ async fn test_allocate_and_release_instance_vpc_prefix_id(
     options: PgConnectOptions,
 ) {
     let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
-    let env = create_test_env(pool).await;
-    let segment_id = env.create_vpc_and_tenant_segment().await;
+    let env =
+        create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
+            .await;
+    let expected_tenant_config = default_tenant_config();
+
+    // Create the fixture tenant so the FNN VPC inherits a DPU-renderable routing profile.
+    create_fixture_tenant(&env, expected_tenant_config.tenant_organization_id.clone())
+        .await
+        .unwrap();
+
+    // Create the VPC as FNN up front so the routing profile is persisted with it.
+    let segment_id = env
+        .create_vpc_and_tenant_segment_with_vpc_details(
+            VpcCreationRequest::builder(expected_tenant_config.tenant_organization_id.clone())
+                .metadata(Metadata {
+                    name: "test vpc 1".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .rpc(),
+        )
+        .await;
     let mh = create_managed_host(&env).await;
 
     let mut txn = env.db_txn().await;
@@ -2454,20 +2479,12 @@ async fn test_allocate_and_release_instance_vpc_prefix_id(
         mh.host().db_machine(&mut txn).await.current_state(),
         ManagedHostState::Ready
     ));
+    txn.commit().await.unwrap();
+
     let mut vpc = db::vpc::find_by_name(&env.pool, "test vpc 1")
         .await
         .unwrap();
     let vpc = vpc.remove(0);
-
-    let update_vpc = UpdateVpcVirtualization {
-        id: vpc.id,
-        if_version_match: None,
-        network_virtualization_type: carbide_network::virtualization::VpcVirtualizationType::Fnn,
-    };
-    db::vpc::update_virtualization(&update_vpc, &mut txn)
-        .await
-        .unwrap();
-    txn.commit().await.unwrap();
 
     let vpc_prefix_id = create_tenant_overlay_prefix(&env, vpc.id).await;
     let vpc_prefix = env
@@ -2515,7 +2532,6 @@ async fn test_allocate_and_release_instance_vpc_prefix_id(
     let os = instance.config().os();
     assert_eq!(os, &expected_os);
 
-    let expected_tenant_config = default_tenant_config();
     assert_eq!(tenant_config, &expected_tenant_config);
 
     let mut txn = env.db_txn().await;
@@ -2946,6 +2962,7 @@ fn dual_physical_network_config_with_vpc_prefixes(
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
         )
         .collect();
@@ -3334,6 +3351,7 @@ async fn test_network_details_migration(
                                 virtual_function_id: None,
                                 ip_address: None,
                                 ipv6_interface_config: None,
+                                routing_profile: None,
                             }],
                             auto: false,
                         })
@@ -3410,6 +3428,7 @@ async fn test_network_details_migration(
                     interfaces: vec![rpc::InstanceInterfaceConfig {
                         ip_address: None,
                         ipv6_interface_config: None,
+                        routing_profile: None,
 
                         function_type: rpc::InterfaceFunctionType::Physical as i32,
                         network_segment_id: None,
@@ -3493,6 +3512,7 @@ async fn test_network_details_migration(
                     interfaces: vec![rpc::InstanceInterfaceConfig {
                         ip_address: None,
                         ipv6_interface_config: None,
+                        routing_profile: None,
 
                         function_type: rpc::InterfaceFunctionType::Physical as i32,
                         network_segment_id: None,
@@ -3645,6 +3665,7 @@ async fn test_instance_cannot_allocate_requested_ip_with_network_segment(
                         interfaces: vec![rpc::InstanceInterfaceConfig {
                             ip_address: Some("192.168.0.1".to_string()),
                             ipv6_interface_config: None,
+                            routing_profile: None,
 
                             function_type: rpc::InterfaceFunctionType::Physical as i32,
                             network_segment_id: None,
@@ -3722,6 +3743,7 @@ async fn test_allocate_and_update_network_config_instance(
         interfaces: vec![rpc::InstanceInterfaceConfig {
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
             function_type: rpc::InterfaceFunctionType::Physical as i32,
             network_segment_id: None,
             network_details: Some(
@@ -3850,6 +3872,7 @@ async fn test_allocate_and_update_network_config_instance_add_vf(
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Virtual as i32,
@@ -3862,6 +3885,7 @@ async fn test_allocate_and_update_network_config_instance_add_vf(
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
         ],
         auto: false,
@@ -3997,6 +4021,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_delete_vf(
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Virtual as i32,
@@ -4009,6 +4034,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_delete_vf(
                 virtual_function_id: Some(0),
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Virtual as i32,
@@ -4021,6 +4047,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_delete_vf(
                 virtual_function_id: Some(1),
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Virtual as i32,
@@ -4033,6 +4060,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_delete_vf(
                 virtual_function_id: Some(2),
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
         ],
         auto: false,
@@ -4101,6 +4129,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_delete_vf(
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Virtual as i32,
@@ -4113,6 +4142,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_delete_vf(
                 virtual_function_id: Some(0),
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             // VF 1 is deleted.
             rpc::InstanceInterfaceConfig {
@@ -4126,6 +4156,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_delete_vf(
                 virtual_function_id: Some(2),
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
         ],
         auto: false,
@@ -4266,6 +4297,7 @@ async fn test_allocate_and_update_network_config_instance_state_machine(
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }],
         auto: false,
     };
@@ -4400,6 +4432,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_state_machine(
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }],
         auto: false,
     };
@@ -4449,6 +4482,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_state_machine(
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Virtual as i32,
@@ -4461,6 +4495,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_state_machine(
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
         ],
         auto: false,
@@ -4599,6 +4634,7 @@ async fn test_allocate_network_multi_dpu_vpc_prefix_id(
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: 0,
@@ -4613,6 +4649,7 @@ async fn test_allocate_network_multi_dpu_vpc_prefix_id(
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
         ],
         auto: false,
@@ -5202,6 +5239,7 @@ async fn test_allocate_instance_rejects_dual_stack_prefixes_from_different_vpcs(
                                 vpc_prefix_id: Some(ipv6_prefix_id),
                                 ip_address: None,
                             }),
+                            routing_profile: None,
                         }],
                         auto: false,
                     },

--- a/crates/api/src/tests/instance_allocate.rs
+++ b/crates/api/src/tests/instance_allocate.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::collections::HashMap;
 use std::ops::DerefMut;
 
 use ::rpc::forge::ManagedHostNetworkConfigRequest;
@@ -24,6 +25,7 @@ use itertools::Itertools;
 use model::machine::{ManagedHostState, ManagedHostStateSnapshot};
 use rpc::{Metadata, forge};
 
+use crate::cfg::file::{FnnConfig, FnnRoutingProfileConfig, PrefixFilterPolicyEntry};
 use crate::tests::common;
 use crate::tests::common::api_fixtures;
 use crate::tests::common::api_fixtures::managed_host::ManagedHostConfig;
@@ -187,6 +189,105 @@ async fn create_test_env_for_instance_allocation(
     env
 }
 
+#[crate::sqlx_test]
+async fn test_allocate_instance_rejects_interface_anycast_prefix_outside_vpc_profile(
+    pool: sqlx::PgPool,
+) {
+    let profile_type = "ANYCAST_ALLOC_TEST";
+    let tenant_org = "anycast-alloc-test";
+
+    // Configure the operator-owned VPC profile with one allowed anycast prefix.
+    let env = common::api_fixtures::create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::default().with_fnn_config(Some(FnnConfig {
+            admin_vpc: None,
+            common_internal_route_target: None,
+            additional_route_target_imports: vec![],
+            routing_profiles: HashMap::from([(
+                profile_type.to_string(),
+                FnnRoutingProfileConfig {
+                    internal: true,
+                    access_tier: 0,
+                    allowed_anycast_prefixes: vec![PrefixFilterPolicyEntry {
+                        prefix: "192.0.2.0/24".parse().unwrap(),
+                    }],
+                    ..Default::default()
+                },
+            )]),
+            use_vpc_vrf_loopback: false,
+        })),
+    )
+    .await;
+
+    // Create a tenant and FNN VPC that use that routing profile.
+    env.api
+        .create_tenant(tonic::Request::new(forge::CreateTenantRequest {
+            organization_id: tenant_org.to_string(),
+            routing_profile_type: Some(profile_type.to_string()),
+            metadata: Some(forge::Metadata {
+                name: tenant_org.to_string(),
+                description: "".to_string(),
+                labels: vec![],
+            }),
+        }))
+        .await
+        .unwrap();
+    let segment_id = env
+        .create_vpc_and_tenant_segment_with_vpc_details(
+            VpcCreationRequest::builder(tenant_org)
+                .metadata(Metadata {
+                    name: "anycast allocation vpc".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(forge::VpcVirtualizationType::Fnn as i32)
+                .routing_profile_type(profile_type.to_string())
+                .rpc(),
+        )
+        .await;
+
+    // Request an interface anycast prefix outside the owning VPC profile.
+    let mut network_config =
+        common::api_fixtures::instance::single_interface_network_config(segment_id);
+    network_config.interfaces[0].routing_profile = Some(forge::InstanceInterfaceRoutingProfile {
+        allowed_anycast_prefixes: vec![forge::PrefixFilterPolicyEntry {
+            prefix: "198.51.100.0/24".to_string(),
+        }],
+    });
+
+    // Allocate the instance and verify invalid tenant input is rejected before persistence.
+    let mh = api_fixtures::create_managed_host(&env).await;
+    let err = env
+        .api
+        .allocate_instance(tonic::Request::new(forge::InstanceAllocationRequest {
+            machine_id: Some(mh.host().id),
+            instance_type_id: None,
+            config: Some(forge::InstanceConfig {
+                tenant: Some(forge::TenantConfig {
+                    tenant_organization_id: tenant_org.to_string(),
+                    tenant_keyset_ids: vec![],
+                    hostname: None,
+                }),
+                os: Some(common::api_fixtures::instance::default_os_config()),
+                network: Some(network_config),
+                infiniband: None,
+                network_security_group_id: None,
+                dpu_extension_services: None,
+                nvlink: None,
+            }),
+            instance_id: None,
+            metadata: None,
+            allow_unhealthy_machine: false,
+        }))
+        .await
+        .expect_err("interface anycast prefix outside VPC profile should be rejected");
+
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    assert!(
+        err.message()
+            .contains("routing_profile.allowed_anycast_prefixes")
+    );
+}
+
 /// Zero-DPU instance allocation that supplies explicit interfaces (instead
 /// of `auto: true`) must be rejected. The requirement on zero-DPU hosts is
 /// to send auto:true with empty interfaces, and we populate them. There's
@@ -238,6 +339,7 @@ async fn test_zero_dpu_instance_allocation_rejects_explicit_interfaces(
                         virtual_function_id: None,
                         ip_address: None,
                         ipv6_interface_config: None,
+                        routing_profile: None,
                     }],
                     auto: false,
                 }),
@@ -698,6 +800,7 @@ async fn test_reject_single_dpu_instance_allocation_host_inband_network_config(
                         virtual_function_id: None,
                         ip_address: None,
                         ipv6_interface_config: None,
+                        routing_profile: None,
                     }],
                     auto: false,
                 }),
@@ -916,6 +1019,7 @@ async fn test_single_dpu_instance_allocation(
                         virtual_function_id: Some(0),
                         ip_address: None,
                         ipv6_interface_config: None,
+                        routing_profile: None,
                     }],
                     auto: false,
                 }),
@@ -1061,6 +1165,7 @@ async fn test_reject_zero_dpu_instance_with_tenant_network_segment(
                         virtual_function_id: None,
                         ip_address: None,
                         ipv6_interface_config: None,
+                        routing_profile: None,
                     }],
                     auto: false,
                 }),
@@ -1329,6 +1434,7 @@ async fn test_instance_allocation_rejects_auto_with_explicit_interfaces(
                         virtual_function_id: None,
                         ip_address: None,
                         ipv6_interface_config: None,
+                        routing_profile: None,
                     }],
                     auto: true,
                 }),

--- a/crates/api/src/tests/instance_config_update.rs
+++ b/crates/api/src/tests/instance_config_update.rs
@@ -15,18 +15,25 @@
  * limitations under the License.
  */
 
+use std::collections::HashMap;
+
 use carbide_uuid::network::NetworkSegmentId;
 use common::api_fixtures::instance::{default_tenant_config, single_interface_network_config};
-use common::api_fixtures::{create_managed_host, create_test_env};
+use common::api_fixtures::{
+    TestEnvOverrides, create_managed_host, create_test_env, create_test_env_with_overrides,
+};
 use config_version::ConfigVersion;
 use rpc::forge::forge_server::Forge;
 use rpc::forge::instance_interface_config::NetworkDetails;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use tonic::Request;
 
+use crate::cfg::file::{FnnConfig, FnnRoutingProfileConfig, PrefixFilterPolicyEntry};
 use crate::tests::common::api_fixtures::instance::advance_created_instance_into_ready_state;
 use crate::tests::common::api_fixtures::{create_managed_host_multi_dpu, get_vpc_fixture_id};
-use crate::tests::common::rpc_builder::{InstanceAllocationRequest, InstanceConfigUpdateRequest};
+use crate::tests::common::rpc_builder::{
+    InstanceAllocationRequest, InstanceConfigUpdateRequest, VpcCreationRequest,
+};
 use crate::tests::common::{self};
 
 /// Compares an expected instance configuration with the actual instance configuration
@@ -432,6 +439,7 @@ async fn test_reject_invalid_instance_config_updates(_: PgPoolOptions, options: 
         virtual_function_id: None,
         ip_address: Some("192.168.0.1".to_string()),
         ipv6_interface_config: None,
+        routing_profile: None,
     }];
 
     let err = env
@@ -476,6 +484,7 @@ async fn test_reject_invalid_instance_config_updates(_: PgPoolOptions, options: 
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         });
     let err = env
         .api
@@ -579,6 +588,120 @@ async fn test_reject_invalid_instance_config_updates(_: PgPoolOptions, options: 
             expected_err
         );
     }
+}
+
+#[crate::sqlx_test]
+async fn test_update_instance_config_rejects_interface_anycast_prefix_outside_vpc_profile(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
+    let profile_type = "ANYCAST_UPDATE_TEST";
+    let tenant_org = "anycast-update-test";
+
+    // Configure the operator-owned VPC profile with one allowed anycast prefix.
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::default().with_fnn_config(Some(FnnConfig {
+            admin_vpc: None,
+            common_internal_route_target: None,
+            additional_route_target_imports: vec![],
+            routing_profiles: HashMap::from([(
+                profile_type.to_string(),
+                FnnRoutingProfileConfig {
+                    internal: true,
+                    access_tier: 0,
+                    allowed_anycast_prefixes: vec![PrefixFilterPolicyEntry {
+                        prefix: "192.0.2.0/24".parse().unwrap(),
+                    }],
+                    ..Default::default()
+                },
+            )]),
+            use_vpc_vrf_loopback: false,
+        })),
+    )
+    .await;
+
+    // Create a tenant and FNN VPC that use that routing profile.
+    env.api
+        .create_tenant(tonic::Request::new(rpc::forge::CreateTenantRequest {
+            organization_id: tenant_org.to_string(),
+            routing_profile_type: Some(profile_type.to_string()),
+            metadata: Some(rpc::forge::Metadata {
+                name: tenant_org.to_string(),
+                description: "".to_string(),
+                labels: vec![],
+            }),
+        }))
+        .await
+        .unwrap();
+    let segment_id = env
+        .create_vpc_and_tenant_segment_with_vpc_details(
+            VpcCreationRequest::builder(tenant_org)
+                .metadata(rpc::forge::Metadata {
+                    name: "anycast update vpc".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .routing_profile_type(profile_type.to_string())
+                .rpc(),
+        )
+        .await;
+
+    // Allocate a ready instance before requesting the invalid routing-profile update.
+    let mh = create_managed_host(&env).await;
+    let tinstance = mh
+        .instance_builer(&env)
+        .tenant_org(tenant_org)
+        .single_interface_network_config(segment_id)
+        .build()
+        .await;
+    let instance = tinstance.rpc_instance().await;
+
+    // Request an interface anycast prefix outside the owning VPC profile.
+    let mut network_config = single_interface_network_config(segment_id);
+    network_config.interfaces[0].routing_profile =
+        Some(rpc::forge::InstanceInterfaceRoutingProfile {
+            allowed_anycast_prefixes: vec![rpc::forge::PrefixFilterPolicyEntry {
+                prefix: "198.51.100.0/24".to_string(),
+            }],
+        });
+
+    // Update the instance and verify invalid tenant input is rejected before queuing work.
+    let err = env
+        .api
+        .update_instance_config(tonic::Request::new(
+            rpc::forge::InstanceConfigUpdateRequest {
+                if_version_match: None,
+                config: Some(rpc::InstanceConfig {
+                    tenant: Some(rpc::TenantConfig {
+                        tenant_organization_id: tenant_org.to_string(),
+                        tenant_keyset_ids: vec![],
+                        hostname: None,
+                    }),
+                    os: Some(common::api_fixtures::instance::default_os_config()),
+                    network: Some(network_config),
+                    infiniband: None,
+                    nvlink: None,
+                    network_security_group_id: None,
+                    dpu_extension_services: None,
+                }),
+                instance_id: instance.rpc_id(),
+                metadata: Some(rpc::forge::Metadata {
+                    name: "newinstance".to_string(),
+                    description: "desc".to_string(),
+                    labels: vec![],
+                }),
+            },
+        ))
+        .await
+        .expect_err("interface anycast prefix outside VPC profile should be rejected");
+
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    assert!(
+        err.message()
+            .contains("routing_profile.allowed_anycast_prefixes")
+    );
 }
 
 #[crate::sqlx_test]
@@ -769,6 +892,7 @@ async fn test_update_instance_config_vpc_prefix_network_update(
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }],
         auto: false,
     };
@@ -821,6 +945,7 @@ async fn test_update_instance_config_vpc_prefix_network_update(
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Virtual as i32,
@@ -831,6 +956,7 @@ async fn test_update_instance_config_vpc_prefix_network_update(
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
         ],
         auto: false,
@@ -888,6 +1014,7 @@ async fn test_update_instance_config_vpc_prefix_network_update(
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }],
         auto: false,
     };
@@ -972,6 +1099,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_post_instance_del
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }],
         auto: false,
     };
@@ -1029,6 +1157,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_post_instance_del
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Virtual as i32,
@@ -1039,6 +1168,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_post_instance_del
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
         ],
         auto: false,
@@ -1125,6 +1255,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu(
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }],
         auto: false,
     };
@@ -1177,6 +1308,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu(
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Physical as i32,
@@ -1187,6 +1319,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu(
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
         ],
         auto: false,
@@ -1316,6 +1449,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu_differen
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }],
         auto: false,
     };
@@ -1368,6 +1502,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu_differen
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Physical as i32,
@@ -1378,6 +1513,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_multidpu_differen
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
         ],
         auto: false,
@@ -1493,6 +1629,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_different_prefix_
                             virtual_function_id: None,
                             ip_address: Some("5.5.5.1".to_string()),
                             ipv6_interface_config: None,
+                            routing_profile: None,
                         }],
                         auto: false,
                     }),
@@ -1531,6 +1668,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_different_prefix_
                             virtual_function_id: None,
                             ip_address: Some("192.1.4.0".to_string()),
                             ipv6_interface_config: None,
+                            routing_profile: None,
                         }],
                         auto: false,
                     }),
@@ -1571,6 +1709,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_different_prefix_
                             virtual_function_id: None,
                             ip_address: Some(expected_ip.to_string()),
                             ipv6_interface_config: None,
+                            routing_profile: None,
                         }],
                         auto: false,
                     }),
@@ -1693,6 +1832,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_different_prefix_
                                 virtual_function_id: None,
                                 ip_address: Some("5.5.5.5".to_string()),
                                 ipv6_interface_config: None,
+                                routing_profile: None,
                             },
                             rpc::InstanceInterfaceConfig {
                                 function_type: rpc::InterfaceFunctionType::Physical as i32,
@@ -1703,6 +1843,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_different_prefix_
                                 virtual_function_id: None,
                                 ip_address: Some("6.6.6.6".to_string()),
                                 ipv6_interface_config: None,
+                                routing_profile: None,
                             },
                         ],
                         auto: false,
@@ -1748,6 +1889,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_different_prefix_
                                 virtual_function_id: None,
                                 ip_address: Some(expected_ip.to_string()),
                                 ipv6_interface_config: None,
+                                routing_profile: None,
                             },
                             rpc::InstanceInterfaceConfig {
                                 function_type: rpc::InterfaceFunctionType::Physical as i32,
@@ -1758,6 +1900,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_different_prefix_
                                 virtual_function_id: None,
                                 ip_address: Some(expected_ip.to_string()),
                                 ipv6_interface_config: None,
+                                routing_profile: None,
                             },
                         ],
                         auto: false,
@@ -1803,6 +1946,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_different_prefix_
                                 virtual_function_id: None,
                                 ip_address: Some(expected_ip.to_string()),
                                 ipv6_interface_config: None,
+                                routing_profile: None,
                             },
                             rpc::InstanceInterfaceConfig {
                                 function_type: rpc::InterfaceFunctionType::Physical as i32,
@@ -1813,6 +1957,7 @@ async fn test_update_instance_config_vpc_prefix_network_update_different_prefix_
                                 virtual_function_id: None,
                                 ip_address: Some(expected_ip2.to_string()),
                                 ipv6_interface_config: None,
+                                routing_profile: None,
                             },
                         ],
                         auto: false,

--- a/crates/api/src/tests/machine_dhcp.rs
+++ b/crates/api/src/tests/machine_dhcp.rs
@@ -342,6 +342,7 @@ async fn test_machine_dhcp_with_api_for_instance_physical_virtual(
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Virtual as i32,
@@ -352,6 +353,7 @@ async fn test_machine_dhcp_with_api_for_instance_physical_virtual(
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
         ],
         auto: false,

--- a/crates/api/src/tests/machine_network.rs
+++ b/crates/api/src/tests/machine_network.rs
@@ -188,7 +188,7 @@ async fn test_managed_host_network_config_includes_routing_profile_prefix_lists(
         .build()
         .await;
 
-    // Fetch the DPU network config and extract its per-interface routing profile.
+    // Fetch the DPU network config and extract its per-VPC routing profile.
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
@@ -198,9 +198,14 @@ async fn test_managed_host_network_config_includes_routing_profile_prefix_lists(
         .unwrap()
         .into_inner();
     let routing_profile = response.tenant_interfaces[0]
-        .routing_profile
+        .vpc_routing_profile
         .clone()
         .unwrap();
+    assert!(
+        response.tenant_interfaces[0]
+            .interface_routing_profile
+            .is_none()
+    );
 
     // Verify the configured leak prefixes are preserved in the gRPC response.
     let actual_leaks: Vec<_> = routing_profile
@@ -223,6 +228,145 @@ async fn test_managed_host_network_config_includes_routing_profile_prefix_lists(
 
     // Verify the deprecated top-level field is still populated for rollout compatibility.
     assert!(response.routing_profile.is_some());
+}
+
+#[crate::sqlx_test]
+async fn test_managed_host_network_config_narrows_interface_anycast_prefixes(pool: sqlx::PgPool) {
+    let profile_type = "ANYCAST_SUBSET_TEST";
+    let vpc_allowed_anycast_prefixes = ["192.0.2.0/24".to_string(), "2001:db8:99::/48".to_string()];
+    let interface_allowed_anycast_prefixes = vec![
+        "192.0.2.64/26".to_string(),
+        "2001:db8:99:1::/64".to_string(),
+    ];
+    let inherited_import = RouteTargetConfig {
+        asn: 65001,
+        vni: 123,
+    };
+
+    // Configure an FNN routing profile with anycast prefixes broad enough for the interface.
+    let env = api_fixtures::create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::default().with_fnn_config(Some(FnnConfig {
+            admin_vpc: None,
+            common_internal_route_target: None,
+            additional_route_target_imports: vec![],
+            routing_profiles: HashMap::from([(
+                profile_type.to_string(),
+                FnnRoutingProfileConfig {
+                    internal: true,
+                    access_tier: 0,
+                    leak_default_route_from_underlay: true,
+                    route_target_imports: vec![inherited_import.clone()],
+                    allowed_anycast_prefixes: vpc_allowed_anycast_prefixes
+                        .iter()
+                        .map(|prefix| PrefixFilterPolicyEntry {
+                            prefix: prefix.parse().unwrap(),
+                        })
+                        .collect(),
+                    ..Default::default()
+                },
+            )]),
+            use_vpc_vrf_loopback: false,
+        })),
+    )
+    .await;
+
+    // Create a tenant and FNN VPC using that VPC-level routing profile.
+    let tenant = env
+        .api
+        .create_tenant(tonic::Request::new(rpc::forge::CreateTenantRequest {
+            organization_id: "anycast-subset-test".to_string(),
+            routing_profile_type: Some(profile_type.to_string()),
+            metadata: Some(rpc::forge::Metadata {
+                name: "anycast-subset-test".to_string(),
+                description: "".to_string(),
+                labels: vec![],
+            }),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .tenant
+        .unwrap();
+
+    let segment_id = env
+        .create_vpc_and_tenant_segment_with_vpc_details(
+            VpcCreationRequest::builder(tenant.organization_id.as_str())
+                .metadata(Metadata {
+                    name: "anycast subset vpc".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .routing_profile_type(profile_type.to_string())
+                .rpc(),
+        )
+        .await;
+
+    // Allocate an instance with a per-interface anycast prefix subset.
+    let mut network_config =
+        common::api_fixtures::instance::single_interface_network_config(segment_id);
+    network_config.interfaces[0].routing_profile =
+        Some(rpc::forge::InstanceInterfaceRoutingProfile {
+            allowed_anycast_prefixes: interface_allowed_anycast_prefixes
+                .iter()
+                .map(|prefix| rpc::forge::PrefixFilterPolicyEntry {
+                    prefix: prefix.to_string(),
+                })
+                .collect(),
+        });
+    let mh = create_managed_host(&env).await;
+    mh.instance_builer(&env)
+        .tenant_org(tenant.organization_id)
+        .network(network_config)
+        .build()
+        .await;
+
+    // Fetch the DPU network config and extract its split routing profiles.
+    let response = env
+        .api
+        .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
+            dpu_machine_id: Some(mh.dpu().id),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    let vpc_routing_profile = response.tenant_interfaces[0]
+        .vpc_routing_profile
+        .clone()
+        .unwrap();
+    let interface_routing_profile = response.tenant_interfaces[0]
+        .interface_routing_profile
+        .clone()
+        .unwrap();
+
+    // Verify the VPC-level anycast prefixes remain unchanged.
+    let actual_vpc_allowed_anycast_prefixes: Vec<_> = vpc_routing_profile
+        .allowed_anycast_prefixes
+        .clone()
+        .into_iter()
+        .map(|prefix| prefix.prefix)
+        .collect();
+    assert_eq!(
+        actual_vpc_allowed_anycast_prefixes,
+        vpc_allowed_anycast_prefixes.to_vec()
+    );
+
+    // Verify the interface-level anycast prefixes are sent separately.
+    let actual_interface_allowed_anycast_prefixes: Vec<_> = interface_routing_profile
+        .allowed_anycast_prefixes
+        .into_iter()
+        .map(|prefix| prefix.prefix)
+        .collect();
+    assert_eq!(
+        actual_interface_allowed_anycast_prefixes,
+        interface_allowed_anycast_prefixes
+    );
+
+    // Verify non-interface profile fields remain on the VPC profile.
+    assert!(vpc_routing_profile.leak_default_route_from_underlay);
+    assert_eq!(vpc_routing_profile.route_target_imports.len(), 1);
+    assert_eq!(vpc_routing_profile.route_target_imports[0].asn, 65001);
+    assert_eq!(vpc_routing_profile.route_target_imports[0].vni, 123);
 }
 
 #[crate::sqlx_test]
@@ -379,7 +523,7 @@ async fn test_managed_host_network_config_includes_per_vpc_routing_profiles(pool
             (
                 interface.vpc_vni,
                 interface
-                    .routing_profile
+                    .vpc_routing_profile
                     .expect("FNN interface should include a routing profile"),
             )
         })
@@ -610,9 +754,10 @@ async fn test_managed_host_network_config_omits_admin_fnn_vrf_loopback_by_defaul
     assert!(response.routing_profile.is_some());
 
     let routing_profile = admin_interface
-        .routing_profile
+        .vpc_routing_profile
         .as_ref()
-        .expect("admin interface should include per-interface routing profile");
+        .expect("admin interface should include per-VPC routing profile");
+    assert!(admin_interface.interface_routing_profile.is_none());
     assert!(routing_profile.leak_default_route_from_underlay);
     assert_eq!(routing_profile.route_target_imports.len(), 1);
     assert_eq!(routing_profile.route_target_imports[0].asn, 64512);
@@ -954,6 +1099,7 @@ async fn test_managed_host_network_status(pool: sqlx::PgPool) {
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }],
         auto: false,
     };
@@ -1055,6 +1201,7 @@ async fn test_managed_host_network_config_with_extension_services(pool: sqlx::Pg
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }],
         auto: false,
     };

--- a/crates/api/src/tests/vpc_peering.rs
+++ b/crates/api/src/tests/vpc_peering.rs
@@ -29,10 +29,14 @@ use tonic::{Request, Response, Status};
 use uuid::Uuid;
 
 use super::common::api_fixtures::{self, TestEnv};
+use crate::tests::common::api_fixtures::instance::default_tenant_config;
 use crate::tests::common::api_fixtures::network_segment::{
     FIXTURE_TENANT_NETWORK_SEGMENT_GATEWAYS, create_network_segment, create_tenant_network_segment,
 };
-use crate::tests::common::api_fixtures::{create_managed_host, create_test_env};
+use crate::tests::common::api_fixtures::tenant::create_fixture_tenant;
+use crate::tests::common::api_fixtures::{
+    TestEnvOverrides, create_managed_host, create_test_env, create_test_env_with_overrides,
+};
 use crate::tests::common::rpc_builder::VpcCreationRequest;
 
 async fn create_test_vpcs(
@@ -40,6 +44,15 @@ async fn create_test_vpcs(
     count: i32,
     vtype: Option<VpcVirtualizationType>,
 ) -> Result<MachineId, Box<dyn std::error::Error>> {
+    let default_tenant = default_tenant_config();
+    let tenant_organization_id =
+        if matches!(vtype, Some(VpcVirtualizationType::Fnn)) && env.config.fnn.is_some() {
+            create_fixture_tenant(env, default_tenant.tenant_organization_id.clone()).await?;
+            default_tenant.tenant_organization_id
+        } else {
+            String::new()
+        };
+
     let mut first_segment_id = None;
     for i in 0..count {
         let name = format!("test vpc {}", i + 1); // start from 1 for readability
@@ -48,7 +61,7 @@ async fn create_test_vpcs(
             Some(vtype) => env
                 .api
                 .create_vpc(
-                    VpcCreationRequest::builder("")
+                    VpcCreationRequest::builder(tenant_organization_id.clone())
                         .metadata(Metadata {
                             name,
                             ..Default::default()
@@ -105,6 +118,7 @@ async fn create_test_vpcs(
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }],
         auto: false,
     };
@@ -340,9 +354,29 @@ async fn create_vpc_peering(
     vtype1: VpcVirtualizationType,
     vtype2: VpcVirtualizationType,
 ) -> Result<(VpcId, VpcId, u32, u32, MachineId), Box<dyn std::error::Error>> {
-    let (vpc_id, vpc_vni, segment_id, peer_vpc_id, peer_vpc_vni, _peer_segment_id) = env
-        .create_vpc_and_peer_vpc_with_tenant_segments(vtype1, vtype2)
-        .await;
+    let default_tenant = default_tenant_config();
+    let peer_tenant_organization_id = "Tenant2";
+    let use_fixture_tenants = env.config.fnn.is_some()
+        && (vtype1 == VpcVirtualizationType::Fnn || vtype2 == VpcVirtualizationType::Fnn);
+
+    if use_fixture_tenants {
+        create_fixture_tenant(env, default_tenant.tenant_organization_id.clone()).await?;
+        create_fixture_tenant(env, peer_tenant_organization_id).await?;
+    }
+
+    let (vpc_id, vpc_vni, segment_id, peer_vpc_id, peer_vpc_vni, _peer_segment_id) =
+        if use_fixture_tenants {
+            env.create_vpc_and_peer_vpc_with_tenant_segments_for_tenants(
+                &default_tenant.tenant_organization_id,
+                vtype1,
+                peer_tenant_organization_id,
+                vtype2,
+            )
+            .await
+        } else {
+            env.create_vpc_and_peer_vpc_with_tenant_segments(vtype1, vtype2)
+                .await
+        };
     let vpc_id = vpc_id.expect("Expected vpc_id to be Some, but was None");
     let peer_vpc_id = peer_vpc_id.expect("Expected peer_vpc_id to be Some, but was None");
     let vpc_vni = vpc_vni.expect("Expected vpc_vni to be Some, but was None");
@@ -369,6 +403,7 @@ async fn create_vpc_peering(
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }],
         auto: false,
     };
@@ -385,7 +420,9 @@ async fn create_vpc_peering(
 async fn test_vpc_peering_network_config(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = api_fixtures::create_test_env(pool).await;
+    let env =
+        create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
+            .await;
     let (_, _, _, peer_vpc_vni, dpu_machine_id) =
         create_vpc_peering(&env, VpcVirtualizationType::Fnn, VpcVirtualizationType::Fnn).await?;
 
@@ -542,7 +579,9 @@ async fn test_vpc_peering_deletion_upon_vpc_deletion(
 async fn test_vpc_peering_network_config_ordered_peerings(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = api_fixtures::create_test_env(pool).await;
+    let env =
+        create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
+            .await;
 
     let dpu_machine_id = create_test_vpcs(&env, 4, Some(VpcVirtualizationType::Fnn)).await?;
     let vpc_id_1 = find_vpc_id_by_name(&env, "test vpc 1").await?;
@@ -741,13 +780,17 @@ async fn flat_vpc_can_peer_with_flat_under_exclusive_policy(
 async fn test_fnn_vpc_with_flat_peer_exchanges_prefixes_and_vnis(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = api_fixtures::create_test_env(pool).await;
+    let env =
+        create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
+            .await;
+    let default_tenant = default_tenant_config();
+    create_fixture_tenant(&env, default_tenant.tenant_organization_id.clone()).await?;
 
     // FNN VPC + Tenant segment (the side the instance allocates on).
     let fnn_vpc = env
         .api
         .create_vpc(
-            VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+            VpcCreationRequest::builder(default_tenant.tenant_organization_id.clone())
                 .metadata(Metadata {
                     name: "test fnn vpc".to_string(),
                     ..Default::default()
@@ -771,7 +814,7 @@ async fn test_fnn_vpc_with_flat_peer_exchanges_prefixes_and_vnis(
     let (flat_vpc_id, _) = api_fixtures::vpc::create_flat_vpc(
         &env,
         "test flat vpc".to_string(),
-        Some("2829bbe3-c169-4cd9-8b2a-19a8b1618a93".to_string()),
+        Some(default_tenant.tenant_organization_id),
     )
     .await;
     // Use a different fixture-tenant gateway than the FNN side so the
@@ -812,6 +855,7 @@ async fn test_fnn_vpc_with_flat_peer_exchanges_prefixes_and_vnis(
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }],
         auto: false,
     };

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -265,6 +265,7 @@ impl ApiClient {
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         };
 
         let tenant_config = rpc::TenantConfig {

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -108,7 +108,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .type_attribute("forge.FabricManagerStatus", "#[derive(serde::Serialize)]")
         .type_attribute("forge.FlatInterfaceConfig", "#[derive(serde::Serialize)]")
         .type_attribute("forge.FlatInterfaceIpv6Config", "#[derive(serde::Serialize)]")
+        .type_attribute("forge.FlatInterfaceRoutingProfile", "#[derive(serde::Serialize)]")
         .type_attribute("forge.InstanceInterfaceIpv6Config", "#[derive(serde::Serialize, serde::Deserialize)]")
+        .type_attribute(
+            "forge.InstanceInterfaceRoutingProfile",
+            "#[derive(serde::Serialize)]",
+        )
         .type_attribute(
             "forge.InstanceInterfaceConfig",
             "#[derive(serde::Serialize)]",

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -2995,6 +2995,11 @@ message InstanceInterfaceConfig {
   // Optional IPv6 configuration for dual-stack interfaces. When set alongside
   // vpc_prefix_id (field 6), both prefixes are allocated to a single network segment.
   optional InstanceInterfaceIpv6Config ipv6_interface_config = 11;
+
+  // Optional per-interface routing profile overrides. API callers can only
+  // narrow prefix-list options that are already allowed by the owning VPC's
+  // routing profile.
+  optional InstanceInterfaceRoutingProfile routing_profile = 12;
 }
 
 // IPv6 configuration for a dual-stack instance interface.
@@ -3004,6 +3009,14 @@ message InstanceInterfaceIpv6Config {
   common.VpcPrefixId vpc_prefix_id = 1;
   // Explicit host IPv6 address requested for this interface.
   optional string ip_address = 2;
+}
+
+// Routing-profile options API callers may narrow on an instance interface.
+message InstanceInterfaceRoutingProfile {
+  // IP prefixes this interface is allowed to announce as anycast routes.
+  // Every entry must be contained by an allowed_anycast_prefixes entry on the
+  // owning VPC's routing profile.
+  repeated PrefixFilterPolicyEntry allowed_anycast_prefixes = 1;
 }
 
 // The configuration that a customer desires for an instances IB interface
@@ -3976,7 +3989,7 @@ message ManagedHostNetworkConfigResponse {
 
   // Route imports and tagging details for exports
   // used by FNN configs.
-  // Deprecated: use FlatInterfaceConfig.routing_profile for per-VPC routing.
+  // Deprecated: use FlatInterfaceConfig.vpc_routing_profile for per-VPC routing.
   // NOTE: This will replace internet_l3_vni and common_internal_route_target but could allow
   //       common_internal_route_target to be renamed/repurposed as a site-level RT.
   //       to become a site-level common route target.
@@ -4203,7 +4216,11 @@ message FlatInterfaceConfig {
 
   // Route imports and tagging details for exports used by FNN configs.
   // This is scoped to the VPC that owns this interface.
-  optional RoutingProfile routing_profile = 20;
+  optional RoutingProfile vpc_routing_profile = 20;
+
+  // Interface-local routing profile details. These narrow the VPC routing
+  // profile for this interface.
+  optional FlatInterfaceRoutingProfile interface_routing_profile = 21;
 
   // The details of the network security group associated with
   // either the instance or its parent VPC.
@@ -4217,6 +4234,10 @@ message FlatInterfaceConfig {
 
   // A UUID used to associate a network status with an interface config.
   optional common.UUID internal_uuid = 108;
+}
+
+message FlatInterfaceRoutingProfile {
+  repeated PrefixFilterPolicyEntry allowed_anycast_prefixes = 1;
 }
 
 // IPv6 configuration for a dual-stack FNN interface, sent from the API to

--- a/crates/rpc/src/model/instance/config/network.rs
+++ b/crates/rpc/src/model/instance/config/network.rs
@@ -20,8 +20,8 @@ use std::net::IpAddr;
 
 use itertools::Itertools;
 use model::instance::config::network::{
-    DeviceLocator, InstanceInterfaceConfig, InstanceNetworkConfig, InterfaceFunctionId,
-    InterfaceFunctionType, Ipv6InterfaceConfig, NetworkDetails,
+    DeviceLocator, InstanceInterfaceConfig, InstanceInterfaceRoutingProfile, InstanceNetworkConfig,
+    InterfaceFunctionId, InterfaceFunctionType, Ipv6InterfaceConfig, NetworkDetails,
 };
 
 use crate as rpc;
@@ -272,6 +272,23 @@ impl TryFrom<rpc::InstanceNetworkConfig> for InstanceNetworkConfig {
                 device_instance: iface.device_instance as usize,
             });
 
+            let routing_profile = iface
+                .routing_profile
+                .map(
+                    |profile| -> Result<InstanceInterfaceRoutingProfile, RpcDataConversionError> {
+                        let allowed_anycast_prefixes = profile
+                            .allowed_anycast_prefixes
+                            .into_iter()
+                            .map(|entry| entry.prefix.parse())
+                            .collect::<Result<Vec<_>, _>>()?;
+
+                        Ok(InstanceInterfaceRoutingProfile {
+                            allowed_anycast_prefixes,
+                        })
+                    },
+                )
+                .transpose()?;
+
             interfaces.push(InstanceInterfaceConfig {
                 function_id,
                 network_segment_id,
@@ -283,6 +300,7 @@ impl TryFrom<rpc::InstanceNetworkConfig> for InstanceNetworkConfig {
                     .transpose()
                     .map_err(|e| RpcDataConversionError::InvalidIpAddress(e.to_string()))?,
                 ipv6_interface_config,
+                routing_profile,
                 interface_prefixes: HashMap::default(),
                 network_segment_gateways: HashMap::new(),
                 host_inband_mac_address: None,
@@ -337,10 +355,35 @@ impl TryFrom<InstanceNetworkConfig> for rpc::InstanceNetworkConfig {
                         ip_address: v6.requested_ip_addr.map(|i| i.to_string()),
                     }
                 }),
+                routing_profile: iface.routing_profile.map(|profile| {
+                    rpc::forge::InstanceInterfaceRoutingProfile {
+                        allowed_anycast_prefixes: profile
+                            .allowed_anycast_prefixes
+                            .into_iter()
+                            .map(|prefix| rpc::forge::PrefixFilterPolicyEntry {
+                                prefix: prefix.to_string(),
+                            })
+                            .collect(),
+                    }
+                }),
             });
         }
 
         Ok(rpc::InstanceNetworkConfig { interfaces, auto })
+    }
+}
+
+impl From<&InstanceInterfaceRoutingProfile> for rpc::forge::FlatInterfaceRoutingProfile {
+    fn from(profile: &InstanceInterfaceRoutingProfile) -> Self {
+        Self {
+            allowed_anycast_prefixes: profile
+                .allowed_anycast_prefixes
+                .iter()
+                .map(|prefix| rpc::forge::PrefixFilterPolicyEntry {
+                    prefix: prefix.to_string(),
+                })
+                .collect(),
+        }
     }
 }
 
@@ -401,6 +444,7 @@ mod tests {
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             }],
             auto: false,
         };
@@ -414,6 +458,7 @@ mod tests {
                 ip_addrs: HashMap::new(),
                 requested_ip_addr: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
                 interface_prefixes: HashMap::new(),
                 network_segment_gateways: HashMap::new(),
                 host_inband_mac_address: None,
@@ -435,6 +480,7 @@ mod tests {
             virtual_function_id: None,
             ip_address: None,
             ipv6_interface_config: None,
+            routing_profile: None,
         }];
         for vfid in INTERFACE_VFID_MIN..=INTERFACE_VFID_MAX {
             interfaces.push(rpc::InstanceInterfaceConfig {
@@ -446,6 +492,7 @@ mod tests {
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             });
         }
 
@@ -462,6 +509,7 @@ mod tests {
             ip_addrs: HashMap::new(),
             requested_ip_addr: None,
             ipv6_interface_config: None,
+            routing_profile: None,
             interface_prefixes: HashMap::new(),
             network_segment_gateways: HashMap::new(),
             host_inband_mac_address: None,
@@ -478,6 +526,7 @@ mod tests {
                 ip_addrs: HashMap::new(),
                 requested_ip_addr: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
                 interface_prefixes: HashMap::new(),
                 network_segment_gateways: HashMap::new(),
                 host_inband_mac_address: None,
@@ -504,6 +553,7 @@ mod tests {
                 device_instance: 0u32,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Virtual as i32,
@@ -518,6 +568,7 @@ mod tests {
                 device_instance: 0u32,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Virtual as i32,
@@ -532,6 +583,7 @@ mod tests {
                 device_instance: 0u32,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
             rpc::InstanceInterfaceConfig {
                 function_type: rpc::InterfaceFunctionType::Virtual as i32,
@@ -546,6 +598,7 @@ mod tests {
                 device_instance: 0u32,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             },
         ]
     }
@@ -705,6 +758,7 @@ mod tests {
                     vpc_prefix_id: v6_id,
                     requested_ip_addr: Some("2001:db8::1".parse().unwrap()),
                 }),
+                routing_profile: None,
                 interface_prefixes: HashMap::default(),
                 network_segment_gateways: HashMap::default(),
                 host_inband_mac_address: None,
@@ -747,6 +801,89 @@ mod tests {
     }
 
     #[test]
+    fn test_interface_routing_profile_rpc_roundtrip() {
+        let segment_id = NetworkSegmentId::new();
+        let anycast_prefix = "192.0.2.0/24";
+
+        // Convert a wire interface profile into the internal model.
+        let rpc_config = rpc::InstanceNetworkConfig {
+            interfaces: vec![rpc::InstanceInterfaceConfig {
+                function_type: rpc::InterfaceFunctionType::Physical as i32,
+                network_segment_id: Some(segment_id),
+                network_details: Some(
+                    rpc::forge::instance_interface_config::NetworkDetails::SegmentId(segment_id),
+                ),
+                device: None,
+                device_instance: 0,
+                virtual_function_id: None,
+                ip_address: None,
+                ipv6_interface_config: None,
+                routing_profile: Some(rpc::forge::InstanceInterfaceRoutingProfile {
+                    allowed_anycast_prefixes: vec![rpc::forge::PrefixFilterPolicyEntry {
+                        prefix: anycast_prefix.to_string(),
+                    }],
+                }),
+            }],
+            auto: false,
+        };
+
+        let model: InstanceNetworkConfig = rpc_config.try_into().unwrap();
+        assert_eq!(
+            model.interfaces[0]
+                .routing_profile
+                .as_ref()
+                .unwrap()
+                .allowed_anycast_prefixes,
+            vec![anycast_prefix.parse::<ipnetwork::IpNetwork>().unwrap()]
+        );
+
+        // Convert the model back to the wire shape and verify the prefix is preserved.
+        let rpc_config: rpc::InstanceNetworkConfig = model.try_into().unwrap();
+        assert_eq!(
+            rpc_config.interfaces[0]
+                .routing_profile
+                .as_ref()
+                .unwrap()
+                .allowed_anycast_prefixes[0]
+                .prefix,
+            anycast_prefix
+        );
+    }
+
+    #[test]
+    fn test_interface_routing_profile_rejects_invalid_prefix() {
+        let segment_id = NetworkSegmentId::new();
+
+        // Invalid anycast prefixes should be rejected at the RPC boundary.
+        let rpc_config = rpc::InstanceNetworkConfig {
+            interfaces: vec![rpc::InstanceInterfaceConfig {
+                function_type: rpc::InterfaceFunctionType::Physical as i32,
+                network_segment_id: Some(segment_id),
+                network_details: Some(
+                    rpc::forge::instance_interface_config::NetworkDetails::SegmentId(segment_id),
+                ),
+                device: None,
+                device_instance: 0,
+                virtual_function_id: None,
+                ip_address: None,
+                ipv6_interface_config: None,
+                routing_profile: Some(rpc::forge::InstanceInterfaceRoutingProfile {
+                    allowed_anycast_prefixes: vec![rpc::forge::PrefixFilterPolicyEntry {
+                        prefix: "not-a-prefix".to_string(),
+                    }],
+                }),
+            }],
+            auto: false,
+        };
+
+        let result: Result<InstanceNetworkConfig, _> = rpc_config.try_into();
+        assert!(matches!(
+            result,
+            Err(RpcDataConversionError::NetworkParseError(_))
+        ));
+    }
+
+    #[test]
     fn test_ipv6_requires_vpc_prefix_id() {
         // ipv6 without vpc_prefix_id should be rejected.
         let v6_id = VpcPrefixId::new();
@@ -767,6 +904,7 @@ mod tests {
                     vpc_prefix_id: Some(v6_id),
                     ip_address: None,
                 }),
+                routing_profile: None,
             }],
             auto: false,
         };
@@ -790,6 +928,7 @@ mod tests {
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             }],
             auto: false,
         };
@@ -821,6 +960,7 @@ mod tests {
                     vpc_prefix_id: Some(v6_id),
                     ip_address: None,
                 }),
+                routing_profile: None,
             }],
             auto: false,
         };
@@ -848,6 +988,7 @@ mod tests {
                     vpc_prefix_id: Some(v6_id),
                     ip_address: None,
                 }),
+                routing_profile: None,
             }],
             auto: false,
         };
@@ -869,6 +1010,7 @@ mod tests {
                 virtual_function_id: None,
                 ip_address: None,
                 ipv6_interface_config: None,
+                routing_profile: None,
             }],
             auto: true,
         };


### PR DESCRIPTION
## Description
We currently allow per-VPC routing profiles, which allow operators to restrict host-to-DPU BGP announcements with a prefix list, but there are known use-cases where users would want to restrict announcements even further, down to instance or interface-level to decide what a specific interface is allowed to announce to the DPU.

This PR introduces a per-interface routing-profile, with initial support for only the anycast prefix list field.
On instance creation or network config update, callers can specify an anycast prefix list per interface, and we check that the prefix list entirely falls within the prefix list of the VPC level profile.

When sending network config to dpu-agents, we send the details as stored, but dpu-agent performs another check before rendering, allowing site operators to update VPC profiles to immediately further restrict or block announcements at the VPC-level if needed.

If no interface-level profile is provided, prefix list filtering falls back to the VPC-level prefix list.

The current VPC-level fall-back to `site_anycast_prefixes` is still intact, and operators must still explicitly opt-out of `site_anycast_prefixes` as we wait to finish deprecating it and remove support for it from FNN network configs.


## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

