### PR TITLE
feat: configurable history + "infinite" scrollback in the admin log viewer

### DIFF
--- a/crates/api/src/cfg/file.rs
+++ b/crates/api/src/cfg/file.rs
@@ -643,6 +643,13 @@ pub struct CarbideConfig {
     /// hidden when the list is empty.
     #[serde(default)]
     pub web_ui_sidebar_tools: Vec<ToolLink>,
+
+    /// In-memory log history for the admin web live log viewer
+    /// (`/admin/logs`): how much recent log data to keep for
+    /// replay-on-connect and scrollback, and how many lines to send
+    /// per page to the browser.
+    #[serde(default)]
+    pub log_history: LogHistoryConfig,
 }
 
 impl CarbideConfig {
@@ -676,6 +683,40 @@ pub struct ToolLink {
     pub display_name: String,
     /// Absolute URL the link points to.
     pub url: String,
+}
+
+/// In-memory log history for the admin web live log viewer
+/// (`crate::web::logs`). Bounds memory use and the page size served
+/// to the browser.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LogHistoryConfig {
+    /// Maximum amount of recent log history to retain in memory, in
+    /// MiB. Oldest lines are evicted once the budget is exceeded.
+    /// Default 128.
+    #[serde(default = "default_log_history_max_megabytes")]
+    pub max_megabytes: usize,
+
+    /// Number of lines sent in the initial view and in each
+    /// scrollback page. Default 500.
+    #[serde(default = "default_log_history_page_size")]
+    pub page_size: usize,
+}
+
+impl Default for LogHistoryConfig {
+    fn default() -> Self {
+        Self {
+            max_megabytes: default_log_history_max_megabytes(),
+            page_size: default_log_history_page_size(),
+        }
+    }
+}
+
+fn default_log_history_max_megabytes() -> usize {
+    128
+}
+
+fn default_log_history_page_size() -> usize {
+    500
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]

--- a/crates/api/src/logging/setup.rs
+++ b/crates/api/src/logging/setup.rs
@@ -77,6 +77,7 @@ pub fn setup_logging(
     debug: u8,
     extra_logfmt_event_fields: Vec<String>,
     override_logging_subscriber: Option<impl SubscriberInitExt>,
+    log_history_max_bytes: usize,
 ) -> eyre::Result<Logging> {
     // This configures emission of logs in LogFmt syntax
     // and emission of metrics
@@ -107,7 +108,7 @@ pub fn setup_logging(
 
     // Used as part of a layer for collecting + brodcasting
     // log events to the admin web UI.
-    let log_stream = LogStream::default();
+    let log_stream = LogStream::with_max_bytes(log_history_max_bytes);
 
     // == Dynamic filter for tracing enabled/disabled ==
     // This doesn't track levels but instead just enabled/disabled (when we want tracing enabled, we

--- a/crates/api/src/logging/stream.rs
+++ b/crates/api/src/logging/stream.rs
@@ -34,6 +34,7 @@
 //! are fine dropping/losing lines in this case.
 
 use std::collections::{BTreeMap, VecDeque};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -51,14 +52,17 @@ use tracing_subscriber::registry::LookupSpan;
 /// blocking the sender.
 const BROADCAST_CAPACITY: usize = 1024;
 
-/// Number of recent lines retained for replay-on-connect, so a freshly opened
-/// viewer shows recent (but not all) history instead of a blank pane.
-const REPLAY_CAPACITY: usize = 500;
+/// Default in-memory byte budget for retained history, used when no config is
+/// supplied. Overridden by `CarbideConfig.log_history.max_megabytes`. 128 MiB.
+const DEFAULT_MAX_BYTES: usize = 128 * 1024 * 1024;
 
 /// A single structured log line, serialized to the browser as JSON. Produced
 /// both for `tracing` events and for span completions (`level == "SPAN"`).
 #[derive(Debug, Clone, Serialize)]
 pub struct LogLine {
+    /// Monotonic per-process sequence number, assigned at publish time.
+    /// Used as the cursor for scrollback pagination in the viewer.
+    pub seq: u64,
     /// RFC 3339 timestamp captured when the line was observed.
     pub timestamp: String,
     /// Log level, e.g. `"INFO"`, or `"SPAN"` for a span-completion summary.
@@ -82,18 +86,36 @@ pub struct LogLine {
 #[derive(Debug, Clone)]
 pub struct LogStream {
     tx: broadcast::Sender<Arc<LogLine>>,
-    recent: Arc<Mutex<VecDeque<Arc<LogLine>>>>,
-    replay_capacity: usize,
+    recent: Arc<Mutex<Recent>>,
+    /// Byte budget for `recent`; the oldest lines are evicted past this.
+    max_bytes: usize,
+    /// Source of monotonic `LogLine::seq` values.
+    next_seq: Arc<AtomicU64>,
+}
+
+/// The retained-history ring plus a running byte total, kept together under one
+/// lock so eviction stays consistent.
+#[derive(Debug, Default)]
+struct Recent {
+    lines: VecDeque<Arc<LogLine>>,
+    bytes: usize,
 }
 
 impl LogStream {
-    pub fn new(broadcast_capacity: usize, replay_capacity: usize) -> Self {
+    pub fn new(broadcast_capacity: usize, max_bytes: usize) -> Self {
         let (tx, _rx) = broadcast::channel(broadcast_capacity);
         Self {
             tx,
-            recent: Arc::new(Mutex::new(VecDeque::with_capacity(replay_capacity))),
-            replay_capacity,
+            recent: Arc::new(Mutex::new(Recent::default())),
+            max_bytes,
+            next_seq: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// Construct with the default broadcast capacity and the given history byte
+    /// budget (from `CarbideConfig.log_history.max_megabytes`).
+    pub fn with_max_bytes(max_bytes: usize) -> Self {
+        Self::new(BROADCAST_CAPACITY, max_bytes)
     }
 
     /// Subscribe to lines published from this point forward.
@@ -101,23 +123,56 @@ impl LogStream {
         self.tx.subscribe()
     }
 
-    /// Snapshot of recent lines, oldest first, for replay when a viewer connects.
-    pub fn recent(&self) -> Vec<Arc<LogLine>> {
+    /// The newest `limit` lines, oldest-first, for replay when a viewer connects.
+    pub fn latest(&self, limit: usize) -> Vec<Arc<LogLine>> {
         match self.recent.lock() {
-            Ok(q) => q.iter().cloned().collect(),
+            Ok(r) => {
+                let start = r.lines.len().saturating_sub(limit);
+                r.lines.iter().skip(start).cloned().collect()
+            }
             Err(_) => Vec::new(),
         }
     }
 
-    /// Record a lineby appending to the ring buffer (dropping the oldest
-    /// if full), and broadcast to live subscribers.
-    fn publish(&self, line: LogLine) {
-        let line = Arc::new(line);
-        if let Ok(mut q) = self.recent.lock() {
-            while q.len() >= self.replay_capacity {
-                q.pop_front();
+    /// Up to `limit` lines with `seq < before`, oldest-first — one page of
+    /// scrollback history older than the cursor the viewer already holds.
+    pub fn history(&self, before: u64, limit: usize) -> Vec<Arc<LogLine>> {
+        match self.recent.lock() {
+            Ok(r) => {
+                let end = r
+                    .lines
+                    .iter()
+                    .position(|line| line.seq >= before)
+                    .unwrap_or(r.lines.len());
+                let start = end.saturating_sub(limit);
+                r.lines
+                    .iter()
+                    .skip(start)
+                    .take(end - start)
+                    .cloned()
+                    .collect()
             }
-            q.push_back(Arc::clone(&line));
+            Err(_) => Vec::new(),
+        }
+    }
+
+    /// Record a line: assign its sequence number, append to the ring buffer
+    /// (evicting the oldest lines once over the byte budget), and broadcast it
+    /// to live subscribers.
+    fn publish(&self, mut line: LogLine) {
+        line.seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
+        let size = line_size(&line);
+        let line = Arc::new(line);
+        if let Ok(mut r) = self.recent.lock() {
+            r.lines.push_back(Arc::clone(&line));
+            r.bytes += size;
+            // Evict oldest until back under budget, but always keep at least the
+            // newest line (so one oversized line can't empty the buffer).
+            while r.bytes > self.max_bytes && r.lines.len() > 1 {
+                if let Some(old) = r.lines.pop_front() {
+                    r.bytes = r.bytes.saturating_sub(line_size(&old));
+                }
+            }
         }
         // `send` errors when there are no subscribers, so we just
         // ignore the error.
@@ -127,7 +182,7 @@ impl LogStream {
 
 impl Default for LogStream {
     fn default() -> Self {
-        Self::new(BROADCAST_CAPACITY, REPLAY_CAPACITY)
+        Self::new(BROADCAST_CAPACITY, DEFAULT_MAX_BYTES)
     }
 }
 
@@ -182,6 +237,7 @@ where
         event.record(&mut visitor);
 
         self.stream.publish(LogLine {
+            seq: 0, // real value assigned in publish()
             timestamp: now_rfc3339(),
             level: meta.level().as_str(),
             target: meta.target().to_string(),
@@ -210,6 +266,7 @@ where
 
         let meta = span.metadata();
         self.stream.publish(LogLine {
+            seq: 0, // real value assigned in publish()
             timestamp: now_rfc3339(),
             level: "SPAN",
             target: meta.target().to_string(),
@@ -231,6 +288,25 @@ fn location_of(meta: &tracing::Metadata<'_>) -> Option<String> {
         (Some(file), None) => Some(file.to_string()),
         _ => None,
     }
+}
+
+/// Rough in-memory footprint of a line, for the history byte budget: the text it
+/// carries plus a small fixed overhead per line and per field (Arc, struct, and
+/// map-node bookkeeping).
+fn line_size(line: &LogLine) -> usize {
+    const PER_LINE_OVERHEAD: usize = 64;
+    const PER_FIELD_OVERHEAD: usize = 16;
+    let mut bytes = PER_LINE_OVERHEAD
+        + line.level.len()
+        + line.timestamp.len()
+        + line.target.len()
+        + line.message.len()
+        + line.location.as_deref().map_or(0, str::len)
+        + line.span_id.as_deref().map_or(0, str::len);
+    for (key, value) in &line.fields {
+        bytes += PER_FIELD_OVERHEAD + key.len() + value.len();
+    }
+    bytes
 }
 
 /// Walk from the event's span up through its ancestors and
@@ -305,7 +381,7 @@ mod tests {
 
     #[test]
     fn captures_event_level_target_message_and_fields() {
-        let stream = LogStream::new(16, 8);
+        let stream = LogStream::new(16, 64 * 1024);
         let mut rx = stream.subscribe();
         let subscriber = tracing_subscriber::registry().with(LogStreamLayer::new(stream.clone()));
 
@@ -319,33 +395,49 @@ mod tests {
         assert_eq!(line.message, "hello world");
         assert_eq!(line.fields.get("answer").map(String::as_str), Some("42"));
         assert_eq!(line.span_id, None);
+        assert_eq!(line.seq, 0);
 
         // The same line is retained for replay-on-connect.
-        let recent = stream.recent();
+        let recent = stream.latest(10);
         assert_eq!(recent.len(), 1);
         assert_eq!(recent[0].message, "hello world");
     }
 
     #[test]
-    fn replay_buffer_drops_oldest_at_capacity() {
-        let stream = LogStream::new(8, 3);
+    fn ring_evicts_oldest_when_over_byte_budget() {
+        // A budget small enough to hold only a handful of the lines below.
+        let stream = LogStream::new(64, 512);
         let subscriber = tracing_subscriber::registry().with(LogStreamLayer::new(stream.clone()));
 
         tracing::subscriber::with_default(subscriber, || {
-            for i in 0..5 {
+            for i in 0..50 {
                 tracing::info!(target: "t", "line {i}");
             }
         });
 
-        let recent = stream.recent();
-        assert_eq!(recent.len(), 3, "ring buffer should cap at replay_capacity");
-        assert_eq!(recent[0].message, "line 2");
-        assert_eq!(recent[2].message, "line 4");
+        let recent = stream.latest(1000);
+        assert!(
+            !recent.is_empty(),
+            "buffer should retain the most recent lines"
+        );
+        assert!(
+            recent.len() < 50,
+            "older lines should have been evicted past the byte budget"
+        );
+        // Newest line kept, oldest evicted.
+        assert_eq!(recent.last().unwrap().message, "line 49");
+        assert_ne!(recent.first().unwrap().message, "line 0");
+        // Sequence numbers are contiguous and increasing.
+        let seqs: Vec<u64> = recent.iter().map(|l| l.seq).collect();
+        assert!(
+            seqs.windows(2).all(|w| w[1] == w[0] + 1),
+            "retained seqs should be contiguous"
+        );
     }
 
     #[test]
     fn carries_span_id_on_events_and_emits_span_summary() {
-        let stream = LogStream::new(32, 16);
+        let stream = LogStream::new(32, 64 * 1024);
         let mut rx = stream.subscribe();
         let subscriber = tracing_subscriber::registry().with(LogStreamLayer::new(stream));
 
@@ -359,17 +451,45 @@ mod tests {
         let event_line = rx.try_recv().expect("event line");
         assert_eq!(event_line.message, "inside span");
         assert_eq!(event_line.span_id.as_deref(), Some("0xabc"));
+        assert_eq!(event_line.seq, 0);
 
         // Closing the span produces a SPAN summary line carrying its fields.
         let span_line = rx.try_recv().expect("span summary line");
         assert_eq!(span_line.level, "SPAN");
         assert_eq!(span_line.message, "request");
         assert_eq!(span_line.span_id.as_deref(), Some("0xabc"));
+        assert_eq!(span_line.seq, 1);
         assert_eq!(
             span_line.fields.get("http_url").map(String::as_str),
             Some("/x")
         );
         assert!(span_line.fields.contains_key("elapsed_ms"));
         assert!(!span_line.fields.contains_key("span_id"));
+    }
+
+    #[test]
+    fn paginates_history_by_seq() {
+        let stream = LogStream::new(64, 64 * 1024);
+        let subscriber = tracing_subscriber::registry().with(LogStreamLayer::new(stream.clone()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            for i in 0..10 {
+                tracing::info!(target: "t", "line {i}");
+            }
+        });
+
+        // Newest page.
+        let latest = stream.latest(3);
+        assert_eq!(latest.len(), 3);
+        assert_eq!(latest.first().unwrap().message, "line 7");
+        assert_eq!(latest.last().unwrap().message, "line 9");
+
+        // The page just older than the oldest line we already hold.
+        let cursor = latest.first().unwrap().seq;
+        let older = stream.history(cursor, 3);
+        assert_eq!(older.len(), 3);
+        assert_eq!(older.first().unwrap().message, "line 4");
+        assert_eq!(older.last().unwrap().message, "line 6");
+        assert!(older.iter().all(|line| line.seq < cursor));
     }
 }

--- a/crates/api/src/run.rs
+++ b/crates/api/src/run.rs
@@ -70,6 +70,10 @@ pub async fn run(
         }
     }
 
+    let log_history_max_bytes = carbide_config
+        .log_history
+        .max_megabytes
+        .saturating_mul(1024 * 1024);
     let tconf = if skip_logging_setup {
         Logging::default()
     } else {
@@ -77,6 +81,7 @@ pub async fn run(
             debug,
             carbide_machine_controller::extra_logfmt_logging_fields(),
             None::<NoSubscriber>,
+            log_history_max_bytes,
         )
         .wrap_err("setup_telemetry")?
     };

--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1166,6 +1166,7 @@ pub fn get_config() -> CarbideConfig {
     CarbideConfig {
         default_tenant_routing_profile_type: "EXTERNAL".to_string(),
         web_ui_sidebar_tools: vec![],
+        log_history: Default::default(),
         bgp_leaf_session_password: None,
         rack_validation_config: RackValidationConfig {
             enabled: true,

--- a/crates/api/src/web/logs.rs
+++ b/crates/api/src/web/logs.rs
@@ -27,7 +27,7 @@ use std::convert::Infallible;
 use std::sync::Arc;
 
 use askama::Template;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{Html, IntoResponse, Response};
@@ -37,6 +37,10 @@ use tokio::sync::broadcast::error::RecvError;
 use super::Base;
 use crate::api::Api;
 use crate::logging::stream::LogLine;
+
+/// Hard cap on a single page, so a client can't request an unbounded slice
+/// regardless of the configured default page size.
+const MAX_PAGE_SIZE: usize = 5000;
 
 #[derive(Template)]
 #[template(path = "api_logs.html")]
@@ -60,11 +64,12 @@ pub async fn stream(State(state): State<Arc<Api>>, Path(source): Path<String>) -
             .into_response();
     }
 
+    let page_size = state.runtime_config.log_history.page_size;
     let log_stream = state.dynamic_settings.log_stream.clone();
     // Subscribe before snapshotting the backlog so no line slips through the gap
     // between the two.
     let rx = log_stream.subscribe();
-    let backlog = log_stream.recent();
+    let backlog = log_stream.latest(page_size);
 
     let replay = stream::iter(
         backlog
@@ -87,6 +92,49 @@ pub async fn stream(State(state): State<Arc<Api>>, Path(source): Path<String>) -
 
     Sse::new(replay.chain(live))
         .keep_alive(KeepAlive::default())
+        .into_response()
+}
+
+/// Query parameters for the scrollback history endpoint.
+#[derive(serde::Deserialize)]
+pub struct HistoryQuery {
+    /// Return lines older than this `seq` cursor. Absent = newest page.
+    before: Option<u64>,
+    /// Max lines to return; clamped to `MAX_PAGE_SIZE`. Absent = `DEFAULT_PAGE_SIZE`.
+    limit: Option<usize>,
+}
+
+/// `GET /admin/logs/{source}/history?before=<seq>&limit=<n>` — one page of
+/// buffered lines (oldest-first) for scrollback. With `before`, returns the
+/// page just older than that cursor; without it, the newest page.
+pub async fn history(
+    State(state): State<Arc<Api>>,
+    Path(source): Path<String>,
+    Query(query): Query<HistoryQuery>,
+) -> Response {
+    if source != "api" {
+        return (
+            StatusCode::NOT_FOUND,
+            format!("log source {source:?} is not available yet"),
+        )
+            .into_response();
+    }
+
+    let limit = query
+        .limit
+        .unwrap_or(state.runtime_config.log_history.page_size)
+        .min(MAX_PAGE_SIZE);
+    let log_stream = &state.dynamic_settings.log_stream;
+    let lines = match query.before {
+        Some(before) => log_stream.history(before, limit),
+        None => log_stream.latest(limit),
+    };
+
+    let body = serde_json::to_string(&lines).unwrap_or_else(|_| "[]".to_string());
+    (
+        [(axum::http::header::CONTENT_TYPE, "application/json")],
+        body,
+    )
         .into_response()
 }
 

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -777,6 +777,7 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
             .route("/ufm-browser", get(ufm_browser::query))
             .route("/logs", get(logs::page))
             .route("/logs/{source}/stream", get(logs::stream))
+            .route("/logs/{source}/history", get(logs::history))
             .layer(axum::middleware::from_fn(auth_oauth2))
             .layer(Extension(oauth_extension_layer))
             .with_state(api),

--- a/crates/api/templates/api_logs.html
+++ b/crates/api/templates/api_logs.html
@@ -4,6 +4,10 @@
 
 {% block head %}
 <style>
+  /* Lock the Logs page to the viewport so only the log pane scrolls (no
+     page-level wiggle), and let that pane fill the leftover height. */
+  html, body { overflow: hidden; }
+  main { height: 100vh; min-height: 0; box-sizing: border-box; display: flex; flex-direction: column; }
   .log-source-bar { display: flex; gap: .25rem; margin: .5rem 0; }
   .log-source-bar button {
     padding: .3rem .9rem; border: 1px solid #ccc; background: #f4f4f4;
@@ -17,7 +21,7 @@
   #log-output {
     font-family: ui-monospace, Menlo, Consolas, monospace;
     font-size: 12px; line-height: 1.45;
-    height: 70vh; overflow-y: auto;
+    flex: 1 1 auto; min-height: 0; overflow-y: auto; overflow-anchor: none; scrollbar-gutter: stable;
     background: #0f1115; color: #d4d4d4;
     border: 1px solid #333; border-radius: 6px;
     padding: .5rem; white-space: pre-wrap; word-break: break-word;
@@ -112,12 +116,18 @@
     return out.scrollHeight - out.scrollTop - out.clientHeight < 40;
   }
 
-  function addLine(line) {
-    const stick = !paused && atBottom();
+  // Backstop on total rows held even while scrolled up reading history, so a
+  // long browse session can't grow the DOM without bound.
+  const HARD_MAX_ROWS = 20000;
+
+  // Build (but don't attach) a row element for a line. Shared by the live
+  // append path and the history-prepend path.
+  function buildRow(line) {
     const row = document.createElement('div');
     const level = line.level || 'INFO';
     row.className = 'log-row lvl-' + level;
     row.dataset.level = level;
+    row.dataset.seq = line.seq;
 
     let fieldsStr = '';
     if (line.fields) {
@@ -139,9 +149,21 @@
       (line.location ? ' <span class="loc">' + escapeHtml(line.location) + '</span>' : '');
 
     applyFilter(row);
-    out.appendChild(row);
-    while (out.childElementCount > MAX_ROWS) out.removeChild(out.firstChild);
-    if (stick) out.scrollTop = out.scrollHeight;
+    return row;
+  }
+
+  // Append a live line at the bottom. We only trim from the top while tailing
+  // (at the bottom); when scrolled up reading history we leave the top alone so
+  // it isn't yanked out from under the reader (bounded by HARD_MAX_ROWS).
+  function addLine(line) {
+    const stick = !paused && atBottom();
+    out.appendChild(buildRow(line));
+    if (stick) {
+      while (out.childElementCount > MAX_ROWS) out.removeChild(out.firstChild);
+      out.scrollTop = out.scrollHeight;
+    } else {
+      while (out.childElementCount > HARD_MAX_ROWS) out.removeChild(out.firstChild);
+    }
   }
 
   function addLag(n) {
@@ -154,6 +176,59 @@
     out.appendChild(row);
     if (stick) out.scrollTop = out.scrollHeight;
   }
+
+  // --- Scrollback history (infinite scroll up) ---
+  let loadingOlder = false;
+  let reachedStart = false;
+  // Fire at most once per approach to the top; only re-arm after scrolling well
+  // away again. Without this, inertial/momentum scrolling keeps the scroll
+  // pinned near the top and re-triggers loads in a runaway loop (paging all the
+  // way back to the start).
+  let armed = true;
+
+  // Fetch the page just older than the topmost line we hold and prepend it,
+  // keeping the user's scroll position stable.
+  function loadOlder() {
+    const top = out.querySelector('.log-row[data-seq]');
+    if (!top) return;
+    loadingOlder = true;
+    // Freeze the scroller for the load: switching to overflow:hidden cancels any
+    // in-flight momentum/inertial scroll (the runaway's root cause), so when we
+    // restore it below, our prepended position sticks instead of being overridden.
+    out.style.overflowY = 'hidden';
+    fetch('/admin/logs/api/history?before=' + encodeURIComponent(top.dataset.seq))
+      .then(function (r) { return r.ok ? r.json() : []; })
+      .then(function (lines) {
+        if (!lines.length) { reachedStart = true; return; }
+        // Keep the first *visible* row fixed: measure how far it moves once the
+        // older page is prepended, then scroll by exactly that. Using a visible
+        // row avoids a hidden/filtered top row (zero-size rect) defeating the
+        // measurement; with overflow-anchor off the browser won't also adjust.
+        const anchor = out.querySelector('.log-row:not(.hidden)');
+        const anchorBefore = anchor ? anchor.getBoundingClientRect().top : 0;
+        const frag = document.createDocumentFragment();
+        for (const line of lines) frag.appendChild(buildRow(line)); // oldest-first
+        out.insertBefore(frag, anchor);
+        if (anchor) {
+          out.scrollTop += anchor.getBoundingClientRect().top - anchorBefore;
+        }
+      })
+      .catch(function () { /* transient; user can retry by scrolling */ })
+      .finally(function () {
+        out.style.overflowY = ''; // unfreeze (revert to the stylesheet overflow)
+        loadingOlder = false;
+      });
+  }
+
+  out.addEventListener('scroll', function () {
+    // Re-arm only once we're well clear of the top, so momentum scrolling that
+    // piles up at the top can't re-trigger loads in a loop.
+    if (out.scrollTop > 600) armed = true;
+    if (armed && !loadingOlder && !reachedStart && out.scrollTop < 120) {
+      armed = false;
+      loadOlder();
+    }
+  });
 
   levelSel.addEventListener('change', refilterAll);
   textInput.addEventListener('input', refilterAll);
@@ -169,7 +244,7 @@
     pauseBtn.textContent = paused ? 'Resume' : 'Pause';
     if (!paused) out.scrollTop = out.scrollHeight;
   });
-  clearBtn.addEventListener('click', function () { out.replaceChildren(); });
+  clearBtn.addEventListener('click', function () { out.replaceChildren(); reachedStart = false; });
 
   const es = new EventSource('/admin/logs/api/stream');
   es.onopen = function () { statusEl.textContent = 'streaming'; };


### PR DESCRIPTION
## Description

The admin log viewer (at `/admin/logs`) from https://github.com/NVIDIA/infra-controller/pull/1959 now retains a configurable, size-bounded (as in, bytes) window of recent history and supports "infinite scrollback, until we either hit the beginning of the log, or the back side of our window/buffer, pulling down pages as it goes.

This buffer is capped by byte size (evicting the oldest lines once exceeded), and each line carries a sequence number used as a pagination cursor. Opening the page replays only the most recent page instead of the entire buffer, and scrolling to the top loads older pages on demand via a new `/admin/logs/{source}/history` endpoint, so the full buffer is never dumped into the browser at once. Users still get a single "page" (the current one), which then continues scrolling as more tracing events arrive, with the ability to also scroll back through history.

New configuration under `[log_history]` has been added to `CarbideConfig`:
- `max_megabytes` (default: 128): in-memory byte budget for retained history; memory stays bounded while the window floats with log volume.
- `page_size` (default: 500): lines sent in the initial page view and per scrollback page.

Tested in my local dev environment. Video attached showing it in action.

https://github.com/user-attachments/assets/6d6a25ee-839f-4d0c-8160-9ae0b5a44f61

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

