### PR TITLE
feat(component-manager): add power-control CLI and route through per-…

### DIFF
--- a/crates/admin-cli/src/component_manager/common.rs
+++ b/crates/admin-cli/src/component_manager/common.rs
@@ -170,6 +170,45 @@ pub enum DeviceTargetArgs {
     Rack(RackTargetArgs),
 }
 
+/// Component-power-control target subset: no rack target since
+/// `ComponentPowerControlRequest` only supports machines, switches and
+/// power shelves.
+#[derive(Subcommand, Debug)]
+pub enum PowerControlTargetArgs {
+    #[clap(about = "Target NVLink switches")]
+    Switch(SwitchTargetArgs),
+
+    #[clap(about = "Target power shelves")]
+    PowerShelf(PowerShelfTargetArgs),
+
+    #[clap(about = "Target compute trays")]
+    ComputeTray(MachineTargetArgs),
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+#[clap(rename_all = "kebab_case")]
+pub enum PowerActionArg {
+    On,
+    GracefulShutdown,
+    ForceOff,
+    GracefulRestart,
+    ForceRestart,
+    ACPowercycle,
+}
+
+impl From<PowerActionArg> for ::rpc::common::SystemPowerControl {
+    fn from(action: PowerActionArg) -> Self {
+        match action {
+            PowerActionArg::On => Self::On,
+            PowerActionArg::GracefulShutdown => Self::GracefulShutdown,
+            PowerActionArg::ForceOff => Self::ForceOff,
+            PowerActionArg::GracefulRestart => Self::GracefulRestart,
+            PowerActionArg::ForceRestart => Self::ForceRestart,
+            PowerActionArg::ACPowercycle => Self::AcPowercycle,
+        }
+    }
+}
+
 pub fn component_result_status_name(status: i32) -> &'static str {
     match rpc::forge::ComponentManagerStatusCode::try_from(status) {
         Ok(rpc::forge::ComponentManagerStatusCode::Success) => "success",

--- a/crates/admin-cli/src/component_manager/mod.rs
+++ b/crates/admin-cli/src/component_manager/mod.rs
@@ -16,6 +16,7 @@
  */
 
 pub(crate) mod common;
+mod power_control;
 mod status;
 mod update_firmware;
 mod versions;
@@ -40,4 +41,10 @@ pub enum Cmd {
         visible_alias = "versions"
     )]
     GetFirmwareVersions(versions::Args),
+
+    #[clap(
+        about = "Issue a power-control action against components (switches, power shelves, compute trays)",
+        visible_alias = "power-control"
+    )]
+    ComponentPowerControl(power_control::Args),
 }

--- a/crates/admin-cli/src/component_manager/power_control/args.rs
+++ b/crates/admin-cli/src/component_manager/power_control/args.rs
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+
+use crate::component_manager::common::{PowerActionArg, PowerControlTargetArgs};
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    #[clap(subcommand)]
+    pub target: PowerControlTargetArgs,
+
+    #[clap(
+        long = "action",
+        value_enum,
+        help = "Power control action to apply to the targeted components"
+    )]
+    pub action: PowerActionArg,
+}
+
+impl From<Args> for rpc::forge::ComponentPowerControlRequest {
+    fn from(args: Args) -> Self {
+        let action = ::rpc::common::SystemPowerControl::from(args.action) as i32;
+        match args.target {
+            PowerControlTargetArgs::Switch(target) => Self {
+                target: Some(
+                    rpc::forge::component_power_control_request::Target::SwitchIds(target.into()),
+                ),
+                action,
+            },
+            PowerControlTargetArgs::PowerShelf(target) => Self {
+                target: Some(
+                    rpc::forge::component_power_control_request::Target::PowerShelfIds(
+                        target.into(),
+                    ),
+                ),
+                action,
+            },
+            PowerControlTargetArgs::ComputeTray(target) => Self {
+                target: Some(
+                    rpc::forge::component_power_control_request::Target::MachineIds(target.into()),
+                ),
+                action,
+            },
+        }
+    }
+}

--- a/crates/admin-cli/src/component_manager/power_control/cmd.rs
+++ b/crates/admin-cli/src/component_manager/power_control/cmd.rs
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::admin_cli::OutputFormat;
+use prettytable::{Cell, Row, Table};
+
+use super::args::Args;
+use crate::component_manager::common;
+use crate::errors::CarbideCliError;
+use crate::rpc::ApiClient;
+
+pub async fn power_control(
+    opts: Args,
+    format: OutputFormat,
+    api_client: &ApiClient,
+) -> Result<(), CarbideCliError> {
+    let request: rpc::forge::ComponentPowerControlRequest = opts.into();
+    let response = api_client
+        .0
+        .component_power_control(request)
+        .await
+        .map_err(CarbideCliError::from)?;
+
+    if format == OutputFormat::Json {
+        let results = response
+            .results
+            .iter()
+            .map(|result| common::component_result_json(Some(result)))
+            .collect::<Vec<_>>();
+        println!("{}", serde_json::to_string_pretty(&results)?);
+    } else {
+        let mut table = Table::new();
+        table.set_titles(Row::new(vec![
+            Cell::new("Component ID"),
+            Cell::new("Status"),
+            Cell::new("Error"),
+        ]));
+
+        for result in &response.results {
+            let (component_id, status, error) = common::component_result_fields(Some(result));
+            table.add_row(Row::new(vec![
+                Cell::new(&component_id),
+                Cell::new(&status),
+                Cell::new(&error),
+            ]));
+        }
+
+        table.printstd();
+    }
+
+    let (failures, failure_summary) =
+        common::component_failure_count_and_summary(response.results.iter().map(Some));
+
+    if failures > 0 {
+        return Err(CarbideCliError::GenericError(format!(
+            "{failures} component power control request(s) failed{failure_summary}"
+        )));
+    }
+
+    Ok(())
+}

--- a/crates/admin-cli/src/component_manager/power_control/mod.rs
+++ b/crates/admin-cli/src/component_manager/power_control/mod.rs
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::power_control(self, ctx.config.format, &ctx.api_client).await?;
+        Ok(())
+    }
+}

--- a/crates/component-manager/src/state_controller/power_shelf.rs
+++ b/crates/component-manager/src/state_controller/power_shelf.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! A Component Manager `PowerShelfManager` implementation that routes write
-//! operations to the rack state controller (by writing a `MaintenanceScope`
-//! onto `racks.config.maintenance_requested`) and passes reads through to
-//! the wrapped direct backend.
+//! operations to the per-power-shelf state controller for power control (by
+//! writing `power_shelves.power_shelf_maintenance_requested`) and to the
+//! rack state controller for firmware upgrade (by writing a
+//! `MaintenanceScope` onto `racks.config.maintenance_requested`). Reads are
+//! passed through to the wrapped direct backend.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -14,6 +16,7 @@ use carbide_uuid::rack::RackId;
 use db::ObjectColumnFilter;
 use mac_address::MacAddress;
 use model::component_manager::{PowerAction, PowerShelfComponent};
+use model::power_shelf::PowerShelfMaintenanceOperation;
 use model::rack::{MaintenanceActivity, MaintenanceScope};
 use sqlx::PgPool;
 use tracing::instrument;
@@ -27,6 +30,31 @@ use crate::power_shelf_manager::{
 
 const UNKNOWN_MAC_ERROR: &str = "no power shelf row found for this BMC MAC address";
 const DEVICE_KIND: &str = "power shelves";
+
+/// Initiator string recorded on `power_shelf_maintenance_requested` rows
+/// originating from a Component Manager `power_control` call. The per-shelf
+/// state controller surfaces this in its logs and reports.
+const COMPONENT_MANAGER_INITIATOR: &str = "component-manager";
+
+/// Map a `PowerAction` into the per-power-shelf maintenance operation set
+/// (`PowerOn` / `PowerOff`). The per-shelf state machine does not model
+/// reboots or AC powercycles, so those actions are rejected up-front.
+fn map_power_action_to_shelf_operation(
+    action: PowerAction,
+) -> Result<PowerShelfMaintenanceOperation, ComponentManagerError> {
+    match action {
+        PowerAction::On => Ok(PowerShelfMaintenanceOperation::PowerOn),
+        PowerAction::GracefulShutdown | PowerAction::ForceOff => {
+            Ok(PowerShelfMaintenanceOperation::PowerOff)
+        }
+        PowerAction::GracefulRestart | PowerAction::ForceRestart | PowerAction::AcPowercycle => {
+            Err(ComponentManagerError::InvalidArgument(format!(
+                "power action {action:?} is not supported on power shelves; \
+             only On, GracefulShutdown and ForceOff are accepted"
+            )))
+        }
+    }
+}
 
 /// Wraps a direct `PowerShelfManager` backend (e.g., `RmsBackend`,
 /// `PsmBackend`) and routes state-changing operations through the rack state
@@ -52,14 +80,14 @@ impl StateControllerPowerShelf {
         Self { db, direct }
     }
 
-    /// Resolve endpoints, preflight, write a `MaintenanceScope` to the rack,
-    /// and return the per-endpoint result vector. Shared by `power_control`
-    /// and `update_firmware`.
-    async fn write_scope(
+    /// Resolve endpoints to `(PowerShelfId, BMC MAC)` pairs and return the
+    /// per-endpoint result vector along with the resolved IDs. Endpoints
+    /// whose MAC does not map to any known power shelf row are flagged as a
+    /// per-endpoint error.
+    async fn resolve_endpoints(
         &self,
         endpoints: &[PowerShelfEndpoint],
-        activity: MaintenanceActivity,
-    ) -> Result<Vec<PowerShelfComponentResult>, ComponentManagerError> {
+    ) -> Result<EndpointResolution, ComponentManagerError> {
         let macs: Vec<MacAddress> = endpoints.iter().map(|ep| ep.pmc_mac).collect();
         let resolved = db::power_shelf::find_ids_by_bmc_macs(&self.db, &macs)
             .await
@@ -74,8 +102,82 @@ impl StateControllerPowerShelf {
             .map(|r| (r.bmc_mac_address, (r.id, r.rack_id)))
             .collect();
 
+        Ok(EndpointResolution { id_by_mac })
+    }
+
+    /// Issue per-power-shelf maintenance requests (`PowerOn` / `PowerOff`)
+    /// for the resolved endpoints. Each request is written to
+    /// `power_shelves.power_shelf_maintenance_requested`; the per-shelf
+    /// state controller will then drive the actual transition through the
+    /// configured direct backend.
+    async fn write_per_shelf_maintenance(
+        &self,
+        endpoints: &[PowerShelfEndpoint],
+        operation: PowerShelfMaintenanceOperation,
+    ) -> Result<Vec<PowerShelfComponentResult>, ComponentManagerError> {
+        let resolution = self.resolve_endpoints(endpoints).await?;
+
+        // All MACs unknown: nothing to write; return per-endpoint errors.
+        if resolution.id_by_mac.is_empty() {
+            return Ok(endpoints
+                .iter()
+                .map(|ep| unknown_mac_result(ep.pmc_mac))
+                .collect());
+        }
+
+        let mut txn = self.db.begin().await.map_err(|e| {
+            ComponentManagerError::Internal(format!("failed to begin transaction: {e}"))
+        })?;
+
+        for ep in endpoints {
+            if let Some((id, _)) = resolution.id_by_mac.get(&ep.pmc_mac) {
+                db::power_shelf::set_power_shelf_maintenance_requested(
+                    txn.as_mut(),
+                    *id,
+                    COMPONENT_MANAGER_INITIATOR,
+                    operation,
+                )
+                .await
+                .map_err(|e| {
+                    ComponentManagerError::Internal(format!(
+                        "failed to write power shelf maintenance request for {id}: {e}"
+                    ))
+                })?;
+            }
+        }
+
+        txn.commit().await.map_err(|e| {
+            ComponentManagerError::Internal(format!("failed to commit transaction: {e}"))
+        })?;
+
+        Ok(endpoints
+            .iter()
+            .map(|ep| {
+                if resolution.id_by_mac.contains_key(&ep.pmc_mac) {
+                    PowerShelfComponentResult {
+                        pmc_mac: ep.pmc_mac,
+                        success: true,
+                        error: None,
+                    }
+                } else {
+                    unknown_mac_result(ep.pmc_mac)
+                }
+            })
+            .collect())
+    }
+
+    /// Resolve endpoints, preflight, write a rack-level `MaintenanceScope`,
+    /// and return the per-endpoint result vector. Used by `update_firmware`
+    /// (firmware upgrade is a rack-scoped activity).
+    async fn write_scope(
+        &self,
+        endpoints: &[PowerShelfEndpoint],
+        activity: MaintenanceActivity,
+    ) -> Result<Vec<PowerShelfComponentResult>, ComponentManagerError> {
+        let resolution = self.resolve_endpoints(endpoints).await?;
+
         // All MACs unknown: no rack to target; just return per-endpoint errors.
-        if id_by_mac.is_empty() {
+        if resolution.id_by_mac.is_empty() {
             return Ok(endpoints
                 .iter()
                 .map(|ep| unknown_mac_result(ep.pmc_mac))
@@ -83,15 +185,18 @@ impl StateControllerPowerShelf {
         }
 
         let rack_id = unique_rack_id(
-            endpoints
-                .iter()
-                .filter_map(|ep| id_by_mac.get(&ep.pmc_mac).map(|(_, rack)| rack.as_ref())),
+            endpoints.iter().filter_map(|ep| {
+                resolution
+                    .id_by_mac
+                    .get(&ep.pmc_mac)
+                    .map(|(_, rack)| rack.as_ref())
+            }),
             DEVICE_KIND,
         )?;
 
         let power_shelf_ids: Vec<PowerShelfId> = endpoints
             .iter()
-            .filter_map(|ep| id_by_mac.get(&ep.pmc_mac).map(|(id, _)| *id))
+            .filter_map(|ep| resolution.id_by_mac.get(&ep.pmc_mac).map(|(id, _)| *id))
             .collect();
 
         self.persist_scope(&rack_id, power_shelf_ids, activity)
@@ -100,7 +205,7 @@ impl StateControllerPowerShelf {
         Ok(endpoints
             .iter()
             .map(|ep| {
-                if id_by_mac.contains_key(&ep.pmc_mac) {
+                if resolution.id_by_mac.contains_key(&ep.pmc_mac) {
                     PowerShelfComponentResult {
                         pmc_mac: ep.pmc_mac,
                         success: true,
@@ -170,8 +275,8 @@ impl PowerShelfManager for StateControllerPowerShelf {
         endpoints: &[PowerShelfEndpoint],
         action: PowerAction,
     ) -> Result<Vec<PowerShelfComponentResult>, ComponentManagerError> {
-        self.write_scope(endpoints, MaintenanceActivity::PowerControl { action })
-            .await
+        let operation = map_power_action_to_shelf_operation(action)?;
+        self.write_per_shelf_maintenance(endpoints, operation).await
     }
 
     #[instrument(skip(self), fields(backend = "state-controller"))]
@@ -220,11 +325,20 @@ fn unknown_mac_result(pmc_mac: MacAddress) -> PowerShelfComponentResult {
     }
 }
 
+/// Lookup result built by [`StateControllerPowerShelf::resolve_endpoints`].
+/// Owning this map separately keeps `power_control` (per-shelf) and
+/// `update_firmware` (rack-scoped) sharing the same MAC -> ID resolution
+/// without duplicating the `find_ids_by_bmc_macs` round-trip.
+struct EndpointResolution {
+    id_by_mac: HashMap<MacAddress, (PowerShelfId, Option<RackId>)>,
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;
 
     use forge_secrets::credentials::Credentials;
+    use model::power_shelf::PowerShelfMaintenanceRequest;
     use model::rack::{FirmwareUpgradeState, RackMaintenanceState};
 
     use super::*;
@@ -323,8 +437,24 @@ mod tests {
         rack.config.maintenance_requested
     }
 
+    async fn load_power_shelf_maintenance_request(
+        pool: &PgPool,
+        power_shelf_id: &PowerShelfId,
+    ) -> Option<PowerShelfMaintenanceRequest> {
+        let mut conn = pool.acquire().await.unwrap();
+        let shelf = db::power_shelf::find_by(
+            &mut conn,
+            db::ObjectColumnFilter::One(db::power_shelf::IdColumn, power_shelf_id),
+        )
+        .await
+        .expect("find power shelf")
+        .pop()
+        .expect("power shelf exists");
+        shelf.power_shelf_maintenance_requested
+    }
+
     #[carbide_macros::sqlx_test]
-    async fn power_control_writes_maintenance_scope(pool: PgPool) {
+    async fn power_control_writes_per_shelf_maintenance(pool: PgPool) {
         let (rack_id, ps1, ps2, _, _) = seed_test_data(&pool).await;
         let direct = Arc::new(RecordingDirect::default());
         let wrapper = StateControllerPowerShelf::new(pool.clone(), direct.clone());
@@ -338,20 +468,84 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert!(results.iter().all(|r| r.success));
 
-        let scope = load_maintenance_scope(&pool, &rack_id)
-            .await
-            .expect("scope");
-        assert!(scope.machine_ids.is_empty());
-        assert!(scope.switch_ids.is_empty());
-        assert_eq!(scope.power_shelf_ids, vec![ps1, ps2]);
-        assert_eq!(scope.activities.len(), 1);
-        match &scope.activities[0] {
-            MaintenanceActivity::PowerControl { action } => {
-                assert_eq!(*action, PowerAction::GracefulShutdown);
-            }
-            other => panic!("expected PowerControl activity, got {other:?}"),
+        for ps_id in [ps1, ps2] {
+            let req = load_power_shelf_maintenance_request(&pool, &ps_id)
+                .await
+                .unwrap_or_else(|| panic!("expected per-shelf maintenance request for {ps_id}"));
+            assert_eq!(req.operation, PowerShelfMaintenanceOperation::PowerOff);
+            assert_eq!(req.initiator, COMPONENT_MANAGER_INITIATOR);
         }
+
+        assert!(
+            load_maintenance_scope(&pool, &rack_id).await.is_none(),
+            "power_control must not write a rack-level MaintenanceScope"
+        );
         assert_eq!(*direct.power_control_calls.lock().unwrap(), 0);
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn power_control_on_maps_to_power_on(pool: PgPool) {
+        let (_rack_id, ps1, _, _, _) = seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerPowerShelf::new(pool.clone(), direct);
+
+        let eps = vec![make_ep(PS_MAC_1)];
+        wrapper.power_control(&eps, PowerAction::On).await.unwrap();
+
+        let req = load_power_shelf_maintenance_request(&pool, &ps1)
+            .await
+            .expect("per-shelf maintenance request");
+        assert_eq!(req.operation, PowerShelfMaintenanceOperation::PowerOn);
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn power_control_force_off_maps_to_power_off(pool: PgPool) {
+        let (_rack_id, ps1, _, _, _) = seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerPowerShelf::new(pool.clone(), direct);
+
+        let eps = vec![make_ep(PS_MAC_1)];
+        wrapper
+            .power_control(&eps, PowerAction::ForceOff)
+            .await
+            .unwrap();
+
+        let req = load_power_shelf_maintenance_request(&pool, &ps1)
+            .await
+            .expect("per-shelf maintenance request");
+        assert_eq!(req.operation, PowerShelfMaintenanceOperation::PowerOff);
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn power_control_unsupported_action_is_rejected(pool: PgPool) {
+        let (_rack_id, ps1, _, _, _) = seed_test_data(&pool).await;
+        let direct = Arc::new(RecordingDirect::default());
+        let wrapper = StateControllerPowerShelf::new(pool.clone(), direct);
+
+        let eps = vec![make_ep(PS_MAC_1)];
+        for unsupported in [
+            PowerAction::GracefulRestart,
+            PowerAction::ForceRestart,
+            PowerAction::AcPowercycle,
+        ] {
+            let err = wrapper.power_control(&eps, unsupported).await.unwrap_err();
+            match err {
+                ComponentManagerError::InvalidArgument(msg) => {
+                    assert!(
+                        msg.contains("not supported"),
+                        "unexpected error message: {msg}"
+                    );
+                }
+                other => panic!("expected InvalidArgument, got {other:?}"),
+            }
+        }
+
+        assert!(
+            load_power_shelf_maintenance_request(&pool, &ps1)
+                .await
+                .is_none(),
+            "no per-shelf maintenance request should have been written for unsupported actions",
+        );
     }
 
     #[carbide_macros::sqlx_test]
@@ -424,15 +618,19 @@ mod tests {
         );
         assert!(results[1].success);
 
-        let scope = load_maintenance_scope(&pool, &rack_id)
+        let req = load_power_shelf_maintenance_request(&pool, &ps2)
             .await
-            .expect("scope");
-        assert_eq!(scope.power_shelf_ids, vec![ps2]);
+            .expect("per-shelf maintenance request for ps2");
+        assert_eq!(req.operation, PowerShelfMaintenanceOperation::PowerOn);
+        assert!(
+            load_maintenance_scope(&pool, &rack_id).await.is_none(),
+            "power_control must not write a rack-level MaintenanceScope"
+        );
     }
 
     #[carbide_macros::sqlx_test]
-    async fn all_unknown_macs_no_scope_written(pool: PgPool) {
-        let (rack_id, _, _, _, _) = seed_test_data(&pool).await;
+    async fn all_unknown_macs_nothing_written(pool: PgPool) {
+        let (rack_id, ps1, ps2, _, _) = seed_test_data(&pool).await;
         let direct = Arc::new(RecordingDirect::default());
         let wrapper = StateControllerPowerShelf::new(pool.clone(), direct);
 
@@ -440,12 +638,24 @@ mod tests {
         let results = wrapper.power_control(&eps, PowerAction::On).await.unwrap();
 
         assert!(!results[0].success);
+        for ps_id in [ps1, ps2] {
+            assert!(
+                load_power_shelf_maintenance_request(&pool, &ps_id)
+                    .await
+                    .is_none(),
+                "no per-shelf maintenance request expected for {ps_id}"
+            );
+        }
         assert!(load_maintenance_scope(&pool, &rack_id).await.is_none());
     }
 
+    /// `power_control` is not gated on the rack's maintenance state because
+    /// it routes through the per-shelf state controller, not the rack-level
+    /// `MaintenanceScope`. A rack stuck in firmware-upgrade maintenance must
+    /// not block a power-on/power-off request to one of its shelves.
     #[carbide_macros::sqlx_test]
-    async fn rack_not_ready_or_error_is_rejected(pool: PgPool) {
-        let (rack_id, _, _, _, _) = seed_test_data(&pool).await;
+    async fn power_control_ignores_rack_maintenance_state(pool: PgPool) {
+        let (rack_id, ps1, _, _, _) = seed_test_data(&pool).await;
         set_rack_state(
             &pool,
             &rack_id,
@@ -461,51 +671,36 @@ mod tests {
         let wrapper = StateControllerPowerShelf::new(pool.clone(), direct);
 
         let eps = vec![make_ep(PS_MAC_1)];
-        let err = wrapper
-            .power_control(&eps, PowerAction::On)
-            .await
-            .unwrap_err();
-        match err {
-            ComponentManagerError::InvalidArgument(msg) => {
-                assert!(msg.contains("Ready or Error"), "unexpected message: {msg}");
-            }
-            other => panic!("expected InvalidArgument, got {other:?}"),
-        }
+        let results = wrapper.power_control(&eps, PowerAction::On).await.unwrap();
+        assert!(results[0].success);
 
-        assert!(load_maintenance_scope(&pool, &rack_id).await.is_none());
+        let req = load_power_shelf_maintenance_request(&pool, &ps1)
+            .await
+            .expect("per-shelf maintenance request");
+        assert_eq!(req.operation, PowerShelfMaintenanceOperation::PowerOn);
     }
 
+    /// A second `power_control` call overwrites the first per-shelf
+    /// maintenance request (mirrors the behaviour of the existing
+    /// `set_power_shelf_maintenance` API handler so operators can flip
+    /// On -> Off before the controller has acted on either request).
     #[carbide_macros::sqlx_test]
-    async fn maintenance_already_pending_is_rejected(pool: PgPool) {
-        let (rack_id, _, _, _, _) = seed_test_data(&pool).await;
+    async fn power_control_overwrites_pending_request(pool: PgPool) {
+        let (_rack_id, ps1, _, _, _) = seed_test_data(&pool).await;
         let direct = Arc::new(RecordingDirect::default());
         let wrapper = StateControllerPowerShelf::new(pool.clone(), direct);
 
         let eps = vec![make_ep(PS_MAC_1)];
         wrapper.power_control(&eps, PowerAction::On).await.unwrap();
-
-        // Second call should be rejected because scope is already pending.
-        let err = wrapper
+        wrapper
             .power_control(&eps, PowerAction::ForceOff)
             .await
-            .unwrap_err();
-        match err {
-            ComponentManagerError::InvalidArgument(msg) => {
-                assert!(msg.contains("already has a pending"), "unexpected: {msg}");
-            }
-            other => panic!("expected InvalidArgument, got {other:?}"),
-        }
+            .unwrap();
 
-        // First call's scope is preserved unchanged.
-        let scope = load_maintenance_scope(&pool, &rack_id)
+        let req = load_power_shelf_maintenance_request(&pool, &ps1)
             .await
-            .expect("scope");
-        match &scope.activities[0] {
-            MaintenanceActivity::PowerControl { action } => {
-                assert_eq!(*action, PowerAction::On);
-            }
-            other => panic!("expected PowerControl::On, got {other:?}"),
-        }
+            .expect("per-shelf maintenance request");
+        assert_eq!(req.operation, PowerShelfMaintenanceOperation::PowerOff);
     }
 
     #[carbide_macros::sqlx_test]


### PR DESCRIPTION
…shelf maintenance

Add admin-cli component-manager power-control (alias power-control) that drives the existing ComponentPowerControl gRPC for switches, power shelves, and compute trays. The new subcommand reuses the component-manager target subcommands and introduces a PowerActionArg value-enum mapped to rpc::common::SystemPowerControl. Switch StateControllerPowerShelf::power_control from writing a rack-level MaintenanceActivity::PowerControl onto
racks.config.maintenance_requested to writing the per-power-shelf power_shelves.power_shelf_maintenance_requested row instead, so power-on/off requests flow through the per-shelf state controller and do not contend with rack-level firmware maintenance. update_firmware keeps the existing rack-scoped path. PowerAction::On, GracefulShutdown, and ForceOff map to the per-shelf PowerOn/PowerOff operations; restart and AC-powercycle actions are rejected because the per-shelf state machine does not model them.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

