### PR TITLE
Add instance ID to managed host api page, if appropriate.

### DIFF
--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -796,21 +796,23 @@ pub async fn detail(
     let mut display: MachineDetail = machine.into();
 
     if display.is_host {
-        match state.database_connection.acquire().await {
-            Ok(mut conn) => {
-                match db::instance::find_id_by_machine_id(&mut conn, &machine_id).await {
-                    Ok(Some(instance_id)) => {
-                        display.lifecycle_detail.associated_instance_id =
-                            instance_id.to_string();
-                    }
-                    Ok(None) => {}
-                    Err(err) => {
-                        tracing::warn!(%err, %machine_id, "find_id_by_machine_id failed");
-                    }
+        match state
+            .find_instance_by_machine_id(tonic::Request::new(machine_id))
+            .await
+            .map(|response| response.into_inner())
+        {
+            Ok(instances) => {
+                if let Some(instance_id) = instances
+                    .instances
+                    .first()
+                    .and_then(|instance| instance.id.as_ref())
+                {
+                    display.lifecycle_detail.associated_instance_id =
+                        instance_id.to_string();
                 }
             }
             Err(err) => {
-                tracing::warn!(%err, %machine_id, "failed to acquire database connection");
+                tracing::warn!(%err, %machine_id, "find_instance_by_machine_id failed");
             }
         }
     }

--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -798,7 +798,7 @@ pub async fn detail(
     if display.is_host {
         match state.database_connection.acquire().await {
             Ok(mut conn) => {
-                match db::instance::find_id_by_machine_id(&mut *conn, &machine_id).await {
+                match db::instance::find_id_by_machine_id(&mut conn, &machine_id).await {
                     Ok(Some(instance_id)) => {
                         display.lifecycle_detail.associated_instance_id =
                             instance_id.to_string();

--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -807,7 +807,7 @@ pub async fn detail(
                     .first()
                     .and_then(|instance| instance.id.as_ref())
                 {
-                    display.lifecycle_detail.associated_instance_id = instance_id.to_string();
+                    display.lifecycle_detail.associated_instance_id = Some(instance_id.to_string());
                 }
             }
             Err(err) => {

--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -807,8 +807,7 @@ pub async fn detail(
                     .first()
                     .and_then(|instance| instance.id.as_ref())
                 {
-                    display.lifecycle_detail.associated_instance_id =
-                        instance_id.to_string();
+                    display.lifecycle_detail.associated_instance_id = instance_id.to_string();
                 }
             }
             Err(err) => {

--- a/crates/api/src/web/machine.rs
+++ b/crates/api/src/web/machine.rs
@@ -795,6 +795,26 @@ pub async fn detail(
 
     let mut display: MachineDetail = machine.into();
 
+    if display.is_host {
+        match state.database_connection.acquire().await {
+            Ok(mut conn) => {
+                match db::instance::find_id_by_machine_id(&mut *conn, &machine_id).await {
+                    Ok(Some(instance_id)) => {
+                        display.lifecycle_detail.associated_instance_id =
+                            instance_id.to_string();
+                    }
+                    Ok(None) => {}
+                    Err(err) => {
+                        tracing::warn!(%err, %machine_id, "find_id_by_machine_id failed");
+                    }
+                }
+            }
+            Err(err) => {
+                tracing::warn!(%err, %machine_id, "failed to acquire database connection");
+            }
+        }
+    }
+
     if display.has_instance_type {
         match fetch_instance_type_names(&state, vec![display.instance_type_id.clone()]).await {
             Ok(mut instance_types) => {

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -162,7 +162,7 @@ pub(crate) struct StateSlaDetail {
 #[template(path = "lifecycle_detail.html")]
 pub(crate) struct LifecycleDetail {
     pub state_display: StateDisplay,
-    pub associated_instance_id: String,
+    pub associated_instance_id: Option<String>,
     pub json_state: Option<String>,
     pub version: String,
     pub time_in_state: String,
@@ -188,7 +188,7 @@ impl LifecycleDetail {
                 state,
                 time_in_state_above_sla,
             },
-            associated_instance_id: String::new(),
+            associated_instance_id: None,
             json_state,
             time_in_state: config_version::since_state_change_humanized(&version),
             version,

--- a/crates/api/src/web/mod.rs
+++ b/crates/api/src/web/mod.rs
@@ -162,6 +162,7 @@ pub(crate) struct StateSlaDetail {
 #[template(path = "lifecycle_detail.html")]
 pub(crate) struct LifecycleDetail {
     pub state_display: StateDisplay,
+    pub associated_instance_id: String,
     pub json_state: Option<String>,
     pub version: String,
     pub time_in_state: String,
@@ -187,6 +188,7 @@ impl LifecycleDetail {
                 state,
                 time_in_state_above_sla,
             },
+            associated_instance_id: String::new(),
             json_state,
             time_in_state: config_version::since_state_change_humanized(&version),
             version,

--- a/crates/api/templates/lifecycle_detail.html
+++ b/crates/api/templates/lifecycle_detail.html
@@ -4,6 +4,9 @@
 		<th>State</th>
 		<td>{{ state_display|safe }}</td>
 	</tr>
+	{% if !associated_instance_id.is_empty() %}
+	<tr><th>Instance</th><td><a href="/admin/instance/{{ associated_instance_id }}">{{ associated_instance_id }}</a></td></tr>
+	{% endif %}
 	{% if let Some(json_state) = json_state %}
 	<tr>
 		<th>JSON State</th>

--- a/crates/api/templates/lifecycle_detail.html
+++ b/crates/api/templates/lifecycle_detail.html
@@ -4,7 +4,7 @@
 		<th>State</th>
 		<td>{{ state_display|safe }}</td>
 	</tr>
-	{% if !associated_instance_id.is_empty() %}
+	{% if let Some(associated_instance_id) = associated_instance_id %}
 	<tr><th>Instance</th><td><a href="/admin/instance/{{ associated_instance_id }}">{{ associated_instance_id }}</a></td></tr>
 	{% endif %}
 	{% if let Some(json_state) = json_state %}


### PR DESCRIPTION
## Description
In the api web page for a managed host, this adds an "INSTANCE" row under lifecycle if the host is assigned to an instance.   We have the link going from instance to host, but we did not have one going back.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

