### PR TITLE
fix(rack-controller): count assigned machines during discovery

### DIFF
--- a/crates/rack-controller/src/discovering.rs
+++ b/crates/rack-controller/src/discovering.rs
@@ -24,7 +24,8 @@
 
 use carbide_rack_controller::context::RackStateHandlerContextObjects;
 use carbide_uuid::rack::{RackId, RackProfileId};
-use db::{machine as db_machine, power_shelf as db_power_shelf, switch as db_switch};
+use db::{ObjectFilter, machine as db_machine, power_shelf as db_power_shelf, switch as db_switch};
+use model::machine::ManagedHostState;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::rack::{FirmwareUpgradeState, RackMaintenanceState, RackState};
 use state_controller::state_handler::{
@@ -32,6 +33,8 @@ use state_controller::state_handler::{
 };
 
 use crate as carbide_rack_controller;
+
+const COMPONENT_READY_STATE: &str = "ready";
 
 pub async fn handle_discovering(
     id: &RackId,
@@ -49,21 +52,28 @@ pub async fn handle_discovering(
 
     let mut txn = ctx.services.db_pool.begin().await?;
 
-    let ready_compute = db_machine::find_machine_ids(
+    let available_compute = db_machine::find(
         txn.as_mut(),
+        ObjectFilter::All,
         MachineSearchConfig {
             rack_id: Some(id.clone()),
-            controller_state: Some("ready".into()),
             ..Default::default()
         },
     )
     .await?
-    .len() as u32;
+    .iter()
+    .filter(|machine| {
+        matches!(
+            &machine.state.value,
+            ManagedHostState::Ready | ManagedHostState::Assigned { .. }
+        )
+    })
+    .count() as u32;
     let ready_switches = db_switch::find_ids(
         txn.as_mut(),
         model::switch::SwitchSearchFilter {
             rack_id: Some(id.clone()),
-            controller_state: Some("ready".to_string()),
+            controller_state: Some(COMPONENT_READY_STATE.to_string()),
             ..Default::default()
         },
     )
@@ -73,20 +83,20 @@ pub async fn handle_discovering(
         txn.as_mut(),
         model::power_shelf::PowerShelfSearchFilter {
             rack_id: Some(id.clone()),
-            controller_state: Some("ready".to_string()),
+            controller_state: Some(COMPONENT_READY_STATE.to_string()),
             ..Default::default()
         },
     )
     .await?
     .len() as u32;
 
-    if ready_compute < capabilities.compute.count
+    if available_compute < capabilities.compute.count
         || ready_switches < capabilities.switch.count
         || ready_shelves < capabilities.power_shelf.count
     {
         return Ok(StateHandlerOutcome::wait(format!(
             "waiting for devices ready: compute={}/{}, switch={}/{}, power_shelf={}/{}",
-            ready_compute,
+            available_compute,
             capabilities.compute.count,
             ready_switches,
             capabilities.switch.count,


### PR DESCRIPTION
Rack discovery should treat machines that have already moved from ready to assigned as available capacity. Counting only ready machines can keep a rack waiting even after compute nodes have been allocated during discovery.

Add explicit controller-state constants and include both ready and assigned machine counts when comparing discovered compute capacity against the rack profile requirements.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

