### PR TITLE
[#1867] fix: convert vault client trust_domain and namespace configurable

### DIFF
--- a/crates/api-core/src/run.rs
+++ b/crates/api-core/src/run.rs
@@ -21,19 +21,35 @@ use carbide_utils::HostPortPair;
 use eyre::WrapErr;
 use forge_secrets::credentials::{CredentialManager, CredentialReader};
 use forge_secrets::{
-    CredentialConfig, MemoryCredentialStore, create_credential_manager_from, create_vault_client,
+    CredentialConfig, MemoryCredentialStore, VaultConfig, create_credential_manager_from,
+    create_vault_client,
 };
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::subscriber::NoSubscriber;
 
+use crate::cfg::file::CarbideConfig;
 use crate::listener::AdminUiRoutesBuilder;
 use crate::logging::metrics_endpoint::{MetricsEndpointConfig, run_metrics_endpoint};
 use crate::logging::setup::{
     Logging, create_metric_for_spancount_reader, create_metrics, setup_logging,
 };
 use crate::{CarbideError, dynamic_settings, setup};
+
+/// Vault machine PKI URI SANs must match `[auth.trust]` when site auth config is present.
+fn vault_config_for_site(vault: &VaultConfig, carbide_config: &CarbideConfig) -> VaultConfig {
+    let mut config = vault.clone();
+    if let Some(trust) = carbide_config
+        .auth
+        .as_ref()
+        .and_then(|auth| auth.trust.as_ref())
+    {
+        config.spiffe_trust_domain = Some(trust.spiffe_trust_domain.clone());
+        config.spiffe_machine_base_path = Some(trust.spiffe_machine_base_path.clone());
+    }
+    config
+}
 
 /// Run the carbide-api server until `cancel_token` is cancelled.
 ///
@@ -168,8 +184,9 @@ pub async fn run(
         "Start carbide-api",
     );
 
-    let certificate_provider =
-        create_vault_client(&credential_config.vault, metrics.meter.clone())?;
+    let vault_config = vault_config_for_site(&credential_config.vault, &carbide_config);
+
+    let certificate_provider = create_vault_client(&vault_config, metrics.meter.clone())?;
 
     // Pick a credential store based on CARBIDE_CREDENTIAL_STORE (default: "vault").
     // Set to "memory" to use an in-memory store with no persistence or shared state between
@@ -180,7 +197,7 @@ pub async fn run(
     .as_deref()
     .unwrap_or("vault")
     {
-        "vault" => create_vault_client(&credential_config.vault, metrics.meter.clone())?,
+        "vault" => create_vault_client(&vault_config, metrics.meter.clone())?,
         "memory" => Arc::new(MemoryCredentialStore::default()),
         other => {
             return Err(eyre::eyre!(

--- a/crates/api-integration-tests/tests/vault_catalogue.rs
+++ b/crates/api-integration-tests/tests/vault_catalogue.rs
@@ -65,6 +65,7 @@ async fn setup_vault_with_secrets() -> Option<(
         pki_role_name: Some("forge-cluster".to_string()),
         token: Some(vault.token.clone()),
         vault_cacert: Some(vault.ca_cert.clone()),
+        ..Default::default()
     };
 
     let meter = opentelemetry::global::meter("vault-catalogue-test");

--- a/crates/api-test-helper/src/utils.rs
+++ b/crates/api-test-helper/src/utils.rs
@@ -128,6 +128,7 @@ impl IntegrationTestEnvironment {
                 pki_role_name: Some("forge-cluster".to_string()),
                 token: Some(vault.token.clone()),
                 vault_cacert: Some(vault.ca_cert.clone()),
+                ..Default::default()
             },
             ..Default::default()
         };

--- a/crates/secrets/src/forge_vault.rs
+++ b/crates/secrets/src/forge_vault.rs
@@ -46,6 +46,10 @@ use crate::credentials::{
 
 const DEFAULT_VAULT_CA_PATH: &str = "/var/run/secrets/forge-roots/ca.crt";
 const VAULT_CACERT_ENV_VAR: &str = "VAULT_CACERT";
+const DEFAULT_SPIFFE_TRUST_DOMAIN: &str = "forge.local";
+const DEFAULT_SPIFFE_MACHINE_BASE_PATH: &str = "/forge-system/machine/";
+const VAULT_SPIFFE_TRUST_DOMAIN_ENV_VAR: &str = "VAULT_SPIFFE_TRUST_DOMAIN";
+const VAULT_SPIFFE_MACHINE_BASE_PATH_ENV_VAR: &str = "VAULT_SPIFFE_MACHINE_BASE_PATH";
 
 #[derive(Clone, Debug)]
 enum ForgeVaultAuthenticationType {
@@ -70,6 +74,8 @@ struct ForgeVaultClientConfig {
     pub kv_mount_location: String,
     pub pki_mount_location: String,
     pub pki_role_name: String,
+    spiffe_trust_domain: String,
+    spiffe_machine_base_path: String,
     vault_root_ca_path: String,
 }
 
@@ -125,6 +131,22 @@ fn service_account_role_name_from_jwt(jwt: &str) -> Result<String, eyre::Report>
         .as_str()
         .wrap_err("JWT payload does not contain /kubernetes.io/serviceaccount/name")
         .map(str::to_string)
+}
+
+/// Builds a machine SPIFFE URI SAN matching site `[auth.trust]` path layout.
+///
+/// `machine_base_path` is the path segment after the trust domain, e.g. `/forge-system/machine/`.
+pub(crate) fn machine_spiffe_uri(
+    trust_domain: &str,
+    machine_base_path: &str,
+    machine_id: &str,
+) -> String {
+    let base = machine_base_path.trim().trim_matches('/');
+    if base.is_empty() {
+        format!("spiffe://{trust_domain}/{machine_id}")
+    } else {
+        format!("spiffe://{trust_domain}/{base}/{machine_id}")
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -643,6 +665,8 @@ struct GetCertificateHelper {
     unique_identifier: String,
     pki_mount_location: String,
     pki_role_name: String,
+    spiffe_trust_domain: String,
+    spiffe_machine_base_path: String,
     /// Alternative requested DNS-type SANs for this certificate
     alt_names: Option<String>,
     /// Requested expiration date of this certificate
@@ -662,13 +686,10 @@ impl VaultTask<Certificate> for GetCertificateHelper {
             .vault_requests_total_counter
             .add(1, &[KeyValue::new("request_type", "get_certificate")]);
 
-        let trust_domain = "forge.local";
-        let namespace = "forge-system";
-
-        // spiffe://<trust_domain>/<namespace>/machine/<stable_machine_id>
-        let spiffe_id = format!(
-            "spiffe://{}/{}/machine/{}",
-            trust_domain, namespace, self.unique_identifier,
+        let spiffe_id = machine_spiffe_uri(
+            &self.spiffe_trust_domain,
+            &self.spiffe_machine_base_path,
+            &self.unique_identifier,
         );
 
         let ttl = if let Some(ttl) = self.ttl.clone() {
@@ -732,6 +753,8 @@ impl CertificateProvider for ForgeVaultClient {
             unique_identifier: unique_identifier.to_string(),
             pki_mount_location: self.vault_client_config.pki_mount_location.clone(),
             pki_role_name: self.vault_client_config.pki_role_name.clone(),
+            spiffe_trust_domain: self.vault_client_config.spiffe_trust_domain.clone(),
+            spiffe_machine_base_path: self.vault_client_config.spiffe_machine_base_path.clone(),
             alt_names,
             ttl,
         };
@@ -884,6 +907,10 @@ pub struct VaultConfig {
     pub pki_role_name: Option<String>,
     pub token: Option<String>,
     pub vault_cacert: Option<String>,
+    /// SPIFFE trust domain for machine PKI URI SANs. Defaults to `forge.local`.
+    pub spiffe_trust_domain: Option<String>,
+    /// Path prefix after the trust domain, e.g. `/forge-system/machine/`.
+    pub spiffe_machine_base_path: Option<String>,
 }
 
 impl VaultConfig {
@@ -927,6 +954,20 @@ impl VaultConfig {
             .clone()
             .or(env::var(VAULT_CACERT_ENV_VAR).ok())
             .context("VAULT_CACERT")
+    }
+
+    pub fn spiffe_trust_domain(&self) -> String {
+        self.spiffe_trust_domain
+            .clone()
+            .or_else(|| env::var(VAULT_SPIFFE_TRUST_DOMAIN_ENV_VAR).ok())
+            .unwrap_or_else(|| DEFAULT_SPIFFE_TRUST_DOMAIN.to_string())
+    }
+
+    pub fn spiffe_machine_base_path(&self) -> String {
+        self.spiffe_machine_base_path
+            .clone()
+            .or_else(|| env::var(VAULT_SPIFFE_MACHINE_BASE_PATH_ENV_VAR).ok())
+            .unwrap_or_else(|| DEFAULT_SPIFFE_MACHINE_BASE_PATH.to_string())
     }
 }
 
@@ -987,6 +1028,8 @@ pub fn create_vault_client(
         kv_mount_location: vault_config.kv_mount_location()?,
         pki_mount_location: vault_config.pki_mount_location()?,
         pki_role_name: vault_config.pki_role_name()?,
+        spiffe_trust_domain: vault_config.spiffe_trust_domain(),
+        spiffe_machine_base_path: vault_config.spiffe_machine_base_path(),
         vault_root_ca_path,
     };
 
@@ -999,7 +1042,23 @@ mod tests {
     use base64::Engine;
     use serde_json::json;
 
-    use super::service_account_role_name_from_jwt;
+    use super::{machine_spiffe_uri, service_account_role_name_from_jwt};
+
+    #[test]
+    fn machine_spiffe_uri_uses_trust_domain_and_base_path() {
+        assert_eq!(
+            machine_spiffe_uri("forge.local", "/forge-system/machine/", "abc-123"),
+            "spiffe://forge.local/forge-system/machine/abc-123"
+        );
+        assert_eq!(
+            machine_spiffe_uri("nico.local", "/forge-system/machine/", "abc-123"),
+            "spiffe://nico.local/forge-system/machine/abc-123"
+        );
+        assert_eq!(
+            machine_spiffe_uri("forge.local", "forge-system/machine", "abc-123"),
+            "spiffe://forge.local/forge-system/machine/abc-123"
+        );
+    }
 
     fn jwt_from_payload(payload_value: serde_json::Value) -> String {
         let header = base64::engine::general_purpose::URL_SAFE_NO_PAD


### PR DESCRIPTION
## Summary
Vault-issued machine certificates previously hardcoded SPIFFE URI SANs as `spiffe://forge.local/forge-system/machine/<id>`. Sites with non-default trust domains (e.g. `nico.local`) received certs that did not match auth/SPIFFE expectations.
This PR wires machine PKI URI SANs to the same trust settings used elsewhere:
- Adds optional `spiffe_trust_domain` and `spiffe_machine_base_path` on `VaultConfig`, with defaults (`forge.local`, `/forge-system/machine/`) and env overrides (`VAULT_SPIFFE_TRUST_DOMAIN`, `VAULT_SPIFFE_MACHINE_BASE_PATH`)
- Introduces `machine_spiffe_uri()` to build URIs consistently from trust domain, base path, and machine ID
- At `carbide-api` startup, `vault_config_for_site()` copies `[auth.trust]` into the Vault client config when site auth config is present, so issued certs align with site SPIFFE layout without a separate namespace field
- **Behavior:** unchanged for deployments using defaults; sites with custom `[auth.trust]` now get matching URI SANs on Vault-issued machine certs.

## Files changed
| Area | Files |
| --- | --- |
| Vault SPIFFE URI construction | `crates/secrets/src/forge_vault.rs` |
| API startup wiring | `crates/api/src/run.rs` |
| Test fixtures | `crates/api-test-helper/src/utils.rs`, `crates/api-integration-tests/tests/vault_catalogue.rs` |

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
#1867

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Machine certificates from Vault can now use configurable SPIFFE trust domain and base path settings.
  * Site-specific Vault configuration is supported through environment variables and initialization.

* **Improvements**
  * Configuration initialization now properly sets all fields with default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->