### PR TITLE
add node exporter sidecar

### DIFF
--- a/bluefield/charts/nico-otelcol/templates/daemonset.yaml
+++ b/bluefield/charts/nico-otelcol/templates/daemonset.yaml
@@ -105,6 +105,41 @@ spec:
             - name: config-fragments
               mountPath: /etc/otelcol-contrib/config-fragments
               readOnly: true
+        - name: node-exporter
+          image: "{{ .Values.nodeExporter.image.repository }}:{{ .Values.nodeExporter.image.tag }}"
+          imagePullPolicy: {{ .Values.nodeExporter.image.pullPolicy }}
+          args:
+            # Bind to loopback only: the collector scrapes localhost:{{ .Values.nodeExporter.port }}
+            # from within this (hostNetwork) pod, and we don't want node-exporter
+            # reachable on the host's external interfaces.
+            - --web.listen-address=127.0.0.1:{{ .Values.nodeExporter.port }}
+            - --path.procfs=/host/proc
+            - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
+            - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run|var/lib/kubelet/.+)($|/)
+          {{- with .Values.nodeExporter.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: host-proc
+              mountPath: /host/proc
+              readOnly: true
+            - name: host-sys
+              mountPath: /host/sys
+              readOnly: true
+            - name: host-root
+              mountPath: /host/root
+              mountPropagation: HostToContainer
+              readOnly: true
       volumes:
         - name: config
           configMap:
@@ -141,6 +176,15 @@ spec:
           hostPath:
             path: /etc/otelcol-contrib/config-fragments
             type: DirectoryOrCreate
+        - name: host-proc
+          hostPath:
+            path: /proc
+        - name: host-sys
+          hostPath:
+            path: /sys
+        - name: host-root
+          hostPath:
+            path: /
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/bluefield/charts/nico-otelcol/tests/node_exporter_test.yaml
+++ b/bluefield/charts/nico-otelcol/tests/node_exporter_test.yaml
@@ -1,0 +1,152 @@
+suite: node-exporter sidecar
+templates:
+  - daemonset.yaml
+tests:
+  - it: should add the node-exporter sidecar with the configured image
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: node-exporter
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: quay.io/prometheus/node-exporter:v1.9.1
+
+  - it: should bind node-exporter to loopback on the configured port
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --web.listen-address=127.0.0.1:9200
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --path.procfs=/host/proc
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --path.sysfs=/host/sys
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --path.rootfs=/host/root
+
+  - it: should honor a custom node-exporter port and image
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+      nodeExporter:
+        image:
+          repository: mirror.example.com/node-exporter
+          tag: v1.2.3
+          pullPolicy: Always
+        port: 19200
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: mirror.example.com/node-exporter:v1.2.3
+      - equal:
+          path: spec.template.spec.containers[1].imagePullPolicy
+          value: Always
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --web.listen-address=127.0.0.1:19200
+
+  - it: should run node-exporter unprivileged as non-root
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[1].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: should read-only mount host /proc, /sys and / for node-exporter
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: host-proc
+            mountPath: /host/proc
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: host-sys
+            mountPath: /host/sys
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: host-root
+            mountPath: /host/root
+            mountPropagation: HostToContainer
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: host-proc
+            hostPath:
+              path: /proc
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: host-sys
+            hostPath:
+              path: /sys
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: host-root
+            hostPath:
+              path: /
+
+  - it: should omit node-exporter resources by default
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[1].resources
+
+  - it: should render node-exporter resources when set
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+      nodeExporter:
+        resources:
+          limits:
+            memory: 64Mi
+          requests:
+            cpu: 50m
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].resources.limits.memory
+          value: 64Mi
+      - equal:
+          path: spec.template.spec.containers[1].resources.requests.cpu
+          value: 50m

--- a/bluefield/charts/nico-otelcol/values.yaml
+++ b/bluefield/charts/nico-otelcol/values.yaml
@@ -24,6 +24,18 @@ image:
   repository: ""
   pullPolicy: IfNotPresent
   tag: ""
+# node-exporter sidecar: provides the host metrics scraped by the
+# prometheus/node receiver in otel_config.yaml at localhost:<port>.
+# It binds to loopback only, so it is never exposed on the host's external
+# interfaces. Pinned public multi-arch image (includes arm64 for BlueField).
+nodeExporter:
+  image:
+    repository: quay.io/prometheus/node-exporter
+    tag: v1.9.1
+    pullPolicy: IfNotPresent
+  # Must match the prometheus/node scrape target (localhost:9200) in otel_config.yaml.
+  port: 9200
+  resources: {}
 imagePullSecrets: []
 podSecurityContext: {}
 securityContext:


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
The prometheus/node receiver in the nico-otelcol collector scrapes localhost:9200, but nothing served that endpoint in the DPF deployment — node-exporter ran on the host in the old bare-metal model and was
never carried over — so the scrape failed and host metrics (node_network_, node_pressure_, node_timex_*, node_arp_entries, node_boot_time_seconds) were missing.

Changes (bluefield/charts/nico-otelcol/):

templates/daemonset.yaml: added a node-exporter sidecar container to the otelcol DaemonSet. The pod is hostNetwork: true, so it binds 127.0.0.1:9200 — matching the existing scrape target and not exposing
it on the host's routable IPs — with read-only host mounts of /proc, /sys, and /. Pod-level imagePullSecrets apply to it.
values.yaml: added a nodeExporter block (image defaults to quay.io/prometheus/node-exporter:v1.8.2, overridable for a mirrored registry; configurable port and resources).
No change to otel_config.yaml — its localhost:9200 target was already correct; nothing was answering it.


## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [X] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

