### PR TITLE
logfmt: Don't include dead end time in timing_elapsed_us

### DIFF
--- a/crates/logfmt/src/lib.rs
+++ b/crates/logfmt/src/lib.rs
@@ -38,6 +38,7 @@ where
         _registry: PhantomData,
         make_writer: Arc::new(|| Box::new(std::io::stdout())),
         emit_span_logs: true,
+        write_end_time: false,
         extra_event_fields: Vec::new(),
     }
 }
@@ -54,6 +55,7 @@ pub struct LogFmtLayer<S> {
     _registry: std::marker::PhantomData<S>,
     make_writer: Arc<dyn Fn() -> Box<dyn Write> + Send + Sync>,
     emit_span_logs: bool,
+    write_end_time: bool,
     extra_event_fields: Vec<String>,
 }
 
@@ -77,6 +79,14 @@ where
         }
     }
 
+    /// Whether to write a timing_end_time field in spans
+    pub fn with_end_time(self, write_end_time: bool) -> Self {
+        Self {
+            write_end_time,
+            ..self
+        }
+    }
+
     /// Add extra span attribute keys to emit in event logs
     pub fn with_event_fields(self, extra_event_fields: Vec<String>) -> Self {
         Self {
@@ -88,6 +98,7 @@ where
 
 struct Timing {
     start_time: chrono::DateTime<chrono::Utc>,
+    start_time_monotonic: std::time::Instant,
     busy_ns: i64,
     idle_ns: i64,
     last: std::time::Instant,
@@ -95,11 +106,13 @@ struct Timing {
 
 impl Timing {
     pub fn new() -> Self {
+        let now = std::time::Instant::now();
         Self {
             busy_ns: 0,
             idle_ns: 0,
-            last: std::time::Instant::now(),
+            last: now,
             start_time: chrono::Utc::now(),
+            start_time_monotonic: now,
         }
     }
 }
@@ -285,13 +298,22 @@ where
             "timing_start_time".to_string(),
             format!("{:?}", data.timing.start_time),
         );
-        let end_time = chrono::Utc::now();
-        data.attributes
-            .insert("timing_end_time".to_string(), format!("{end_time:?}"));
-        let elapsed = end_time.signed_duration_since(data.timing.start_time);
+        if self.write_end_time {
+            let end_time = chrono::Utc::now();
+            data.attributes
+                .insert("timing_end_time".to_string(), format!("{end_time:?}"));
+        }
+
+        // We use the time when the span was exited the last time to calculate elapsed_us
+        // That prevents the time to look high in case any other piece of code held a reference to the span.
+        let elapsed = data
+            .timing
+            .last
+            .checked_duration_since(data.timing.start_time_monotonic)
+            .unwrap_or_default();
         data.attributes.insert(
             "timing_elapsed_us".to_string(),
-            elapsed.num_microseconds().unwrap_or_default().to_string(),
+            elapsed.as_micros().to_string(),
         );
         data.attributes.insert(
             "timing_busy_ns".to_string(),
@@ -620,10 +642,13 @@ mod tests {
             &std::io::Error::new(std::io::ErrorKind::Unsupported, "cc") as &dyn std::error::Error,
         );
 
-        // Write the span event
+        // Wait a bit before exiting the span. The busy time should be logged as part of timing_elapsed_us
         std::thread::sleep(std::time::Duration::from_millis(100));
         drop(_entered);
 
+        // Before closing the span, wait a bit more. This time should not be logged.
+        // It purely exists because something else still holds a reference to the span - even in case it might not be useful
+        std::thread::sleep(std::time::Duration::from_millis(500));
         drop(span);
 
         // Check the written data
@@ -648,7 +673,7 @@ mod tests {
         let elapsed_str = &elapsed_str[..elapsed_str_end_idx];
         let elapsed_us: u64 = elapsed_str.parse().unwrap();
         assert!(
-            (100_000..1_000_000).contains(&elapsed_us),
+            (100_000..400_000).contains(&elapsed_us),
             "Elapsed duration is {elapsed_us}us"
         );
     }

--- a/crates/state-controller/src/controller/periodic_enqueuer.rs
+++ b/crates/state-controller/src/controller/periodic_enqueuer.rs
@@ -122,8 +122,6 @@ impl<IO: StateControllerIO> PeriodicEnqueuer<IO> {
             otel.status_message = tracing::field::Empty,
             skipped_iteration = tracing::field::Empty,
             num_enqueued_objects = tracing::field::Empty,
-            app_timing_start_time = format!("{:?}", chrono::Utc::now()),
-            app_timing_end_time = tracing::field::Empty,
         );
 
         let res = self
@@ -156,8 +154,6 @@ impl<IO: StateControllerIO> PeriodicEnqueuer<IO> {
             emitter.emit_iteration_counters_and_histograms(&metrics);
             emitter.set_iteration_span_attributes(&controller_span, &metrics);
         }
-
-        controller_span.record("app_timing_end_time", format!("{:?}", chrono::Utc::now()));
 
         iteration_result
     }


### PR DESCRIPTION
## Description

When the logfmt library writed a span log, it included the full lifetime of the span, from creation to its final `on_close` call in `timing_elapsed_us`.

However we noticed that in some usage scenarios, detached child spans might hold a parent span alive for their whole lifetime, which made the logged time looking very high even all the logic inside the span already concluded.

With this change, the time logged will only contain the time until the spans last on_exit() event, which means only the time for which the span is doing something meaningful is logged.

Note: The log entry will still just disappear later on, and therefore might be reordered.

The change also
- Removes the app_timing fields, which had been introduced long ago just to debug this issue
- Makes the timing_end_time field optional. It's usually not adding too much value (can be calculated from start_time plus elapsed, and matches the log timestamp).

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

nvbug 4573190

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

