### PR TITLE
fix otel dependency on dts

### DIFF
--- a/crates/api/src/dpf_services.rs
+++ b/crates/api/src/dpf_services.rs
@@ -22,8 +22,8 @@ use std::fmt::Write;
 
 use carbide_dpf::sdk::build_dpu_interfaces_vec;
 use carbide_dpf::types::{
-    DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME, DPU_AGENT_SERVICE_NAME, FMDS_SERVICE_NAME,
-    OTEL_COLLECTOR_SERVICE_NAME,
+    DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME, DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME,
+    FMDS_SERVICE_NAME, OTEL_COLLECTOR_SERVICE_NAME,
 };
 use carbide_dpf::{
     ConfigPortsServiceType, ServiceConfigPort, ServiceConfigPortProtocol, ServiceDefinition,
@@ -58,7 +58,7 @@ pub const DHCP_SERVER_SERVICE_MTU: i64 = 1500;
 pub const DHCP_SERVER_SERVICE_IMAGE_NAME: &str = "forge-dhcp-server";
 
 /// DTS service definitions
-pub const DTS_SERVICE_NAME: &str = "dts";
+/// (DTS_SERVICE_NAME lives in carbide_dpf::types so the DPF SDK can wire its dependencies.)
 pub const DTS_SERVICE_HELM_NAME: &str = "doca-telemetry";
 pub const DTS_SERVICE_HELM_VERSION: &str = "1.22.1";
 

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -76,8 +76,8 @@ use crate::repository::{
 };
 use crate::types::{
     BmcPasswordProvider, ConfigPortsServiceType, DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME,
-    DPU_AGENT_SERVICE_NAME, DpuDeviceInfo, DpuDeviceSummary, DpuMismatch, DpuNodeInfo,
-    DpuNodeSummary, DpuPhase, DpuServiceInterfaceTemplateDefinition,
+    DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME, DpuDeviceInfo, DpuDeviceSummary, DpuMismatch,
+    DpuNodeInfo, DpuNodeSummary, DpuPhase, DpuServiceInterfaceTemplateDefinition,
     DpuServiceInterfaceTemplateType, DpuSummary, FMDS_SERVICE_NAME, HostDpfSnapshot,
     InitDpfResourcesConfig, OTEL_COLLECTOR_SERVICE_NAME, ServiceConfigPortProtocol,
     ServiceDefinition, ServiceNADResourceType, ServiceTemplateVersion,
@@ -664,6 +664,12 @@ pub fn build_deployment<L: ResourceLabeler>(
                             },
                             DpuDeploymentServicesDependsOn {
                                 name: FMDS_SERVICE_NAME.to_string(),
+                            },
+                            // otelcol templates the DTS scrape target from
+                            // `{{ (index .Services "dts").Name }}`; without this
+                            // dependency that lookup renders empty.
+                            DpuDeploymentServicesDependsOn {
+                                name: DTS_SERVICE_NAME.to_string(),
                             },
                         ]),
 
@@ -1828,6 +1834,53 @@ mod tests {
     }
 
     const TEST_NAMESPACE: &str = "test-namespace";
+
+    #[test]
+    fn otelcol_depends_on_includes_dts() {
+        // Regression: otelcol templates its DTS scrape target from
+        // `{{ (index .Services "dts").Name }}`. That lookup only resolves when
+        // dts is declared as a dependency of the otelcol service, otherwise the
+        // rendered target host is `carbide-dpf-cluster--doca-telemetry` (empty
+        // name) and DTS metrics never get scraped.
+        let svc = |name: &str| ServiceDefinition::new(name, "repo", "chart", "1.0.0");
+        let services = vec![
+            svc(OTEL_COLLECTOR_SERVICE_NAME),
+            svc(DTS_SERVICE_NAME),
+            svc(DPU_AGENT_SERVICE_NAME),
+            svc(FMDS_SERVICE_NAME),
+        ];
+
+        let deployment = build_deployment(
+            &services,
+            "dep",
+            "bfb",
+            "flavor",
+            TEST_NAMESPACE,
+            &NoLabels,
+            &[],
+        );
+
+        let otel = deployment
+            .spec
+            .services
+            .get(OTEL_COLLECTOR_SERVICE_NAME)
+            .expect("otelcol service present");
+        let deps: Vec<String> = otel
+            .depends_on
+            .as_ref()
+            .expect("otelcol should declare dependencies")
+            .iter()
+            .map(|d| d.name.clone())
+            .collect();
+
+        assert!(
+            deps.contains(&DTS_SERVICE_NAME.to_string()),
+            "otelcol must depend on dts so its scrape target resolves; got {deps:?}"
+        );
+        // The previously-working dependencies must remain.
+        assert!(deps.contains(&DPU_AGENT_SERVICE_NAME.to_string()));
+        assert!(deps.contains(&FMDS_SERVICE_NAME.to_string()));
+    }
 
     #[derive(Clone, Default)]
     struct SdkMock {

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -43,6 +43,7 @@ pub const FMDS_SERVICE_NAME: &str = "carbide-fmds";
 
 pub const DPU_AGENT_SERVICE_NAME: &str = "carbide-dpu-agent";
 pub const OTEL_COLLECTOR_SERVICE_NAME: &str = "carbide-otelcol";
+pub const DTS_SERVICE_NAME: &str = "dts";
 
 /// Configuration for creating DPF operator resources (BFB, DPUFlavor,
 /// DPUDeployment, service templates, etc.) during initialization.


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
Updates the DTS service to be a dependency of the otel service so that the otel service gets the correct scrape endpoint for dts


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

