### PR TITLE
feat(api): allow HostInband network segments in config TOML

### DIFF
--- a/crates/api-model/src/network_segment/mod.rs
+++ b/crates/api-model/src/network_segment/mod.rs
@@ -98,6 +98,7 @@ pub struct NetworkDefinition {
 pub enum NetworkDefinitionSegmentType {
     Admin,
     Underlay,
+    HostInband,
     // Tenant networks are created via the API, not the config file
 }
 
@@ -339,6 +340,7 @@ impl NewNetworkSegment {
             segment_type: match value.segment_type {
                 NetworkDefinitionSegmentType::Admin => NetworkSegmentType::Admin,
                 NetworkDefinitionSegmentType::Underlay => NetworkSegmentType::Underlay,
+                NetworkDefinitionSegmentType::HostInband => NetworkSegmentType::HostInband,
             },
             can_stretch: None,
             allocation_strategy: value.allocation_strategy,

--- a/crates/api/src/handlers/network_segment.rs
+++ b/crates/api/src/handlers/network_segment.rs
@@ -97,7 +97,12 @@ pub(crate) async fn create(
 
     let new_network_segment = NewNetworkSegment::try_from(request)?;
 
-    if new_network_segment.segment_type.is_tenant()
+    // Only actual ::Tenant segments need to be contained within site
+    // fabric prefixes. ::HostInband segments (which, yes, are also part
+    // of `is_tenant()` for binding rules) are underlay networks not
+    // part of the overlay/site fabric prefixes, exist before VPCs, and
+    // can exist without ever needing to be associated with a VPC.
+    if new_network_segment.segment_type == NetworkSegmentType::Tenant
         && let Some(site_fabric_prefixes) = api.eth_data.site_fabric_prefixes.as_ref()
     {
         let segment_prefixes: Vec<_> = new_network_segment

--- a/crates/api/src/tests/network_segment.rs
+++ b/crates/api/src/tests/network_segment.rs
@@ -514,6 +514,17 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
                 allocation_strategy: Default::default(),
             },
         ),
+        (
+            "ZERO-DPU-HOST-01-SWP7".to_string(),
+            NetworkDefinition {
+                segment_type: NetworkDefinitionSegmentType::HostInband,
+                prefix: "10.217.18.192/30".to_string(),
+                gateway: "10.217.18.193".to_string(),
+                mtu: 1500,
+                reserve_first: 1,
+                allocation_strategy: Default::default(),
+            },
+        ),
     ]);
 
     // Create them the first time, they should exist
@@ -527,6 +538,14 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
     let underlay = db::network_segment::find_by_name(&mut txn, "DEV1-C09-IPMI-01").await?;
     assert_eq!(underlay.config.mtu, 1500);
     assert_eq!(underlay.config.segment_type, NetworkSegmentType::Underlay);
+
+    let host_inband = db::network_segment::find_by_name(&mut txn, "ZERO-DPU-HOST-01-SWP7").await?;
+    assert_eq!(host_inband.config.mtu, 1500);
+    assert_eq!(
+        host_inband.config.segment_type,
+        NetworkSegmentType::HostInband
+    );
+    assert_eq!(host_inband.config.vpc_id, None);
     txn.commit().await?;
 
     // Now create them again. It should succeed but not create any more


### PR DESCRIPTION
## Description

This makes it so `HostInband` segments can be defined in the config TOML. They're an interesting case in that they're not overlay networks, but that they also are used for tenant instances. These can still be associated with VPCs, but they don't *have* to be. They come before VPCs do, and will then get attached/associated later.

There will probably be some more fiddling around in here in the coming days -- I think both TOML and the API should support management of all segment types, and we should do something similar to like we do with route servers, where you can independently manage them via both config or the API.

We also have some fiddling to do with VPC <-> HostInband segment association, but again, that's in the coming days.

Tests included!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

