### PR TITLE
Make NICo storage class handling configurable

### DIFF
--- a/helm-prereqs/README.md
+++ b/helm-prereqs/README.md
@@ -63,6 +63,8 @@ Before running `setup.sh`, the following values files must be configured for you
 | `NICO_REST_IMAGE_TAG` | Yes, unless `--skip-rest` | NICo REST image tag (e.g. `v1.0.4`) |
 | `NICO_REST_REPO` | Required unless `--skip-rest` | Path to local clone of `infra-controller-rest`. Auto-detected from sibling directories. `NICO_REPO` is accepted as a deprecated alias. |
 | `NICO_SITE_UUID` | No | Stable UUID for this site. Defaults to `a1b2c3d4-e5f6-4000-8000-000000000001`. |
+| `NICO_MANAGE_DEFAULT_STORAGE_CLASS` | No | Whether `setup.sh` marks `local-path` as the default StorageClass. Defaults to `true`. Set to `false` when the cluster already has an operator-managed default StorageClass. |
+| `NICO_STORAGE_CLASS` | No | StorageClass used by Vault data/audit PVCs. Defaults to `local-path-persistent`. |
 | `PREFLIGHT_CHECK_IMAGE` | No | Image used for preflight per-node checks. Defaults to `busybox:1.36`; set to a local mirror for air-gapped clusters. |
 
 ### `values.yaml`
@@ -76,6 +78,7 @@ Before running `setup.sh`, the following values files must be configured for you
 | `vault.nicoCliClientRole.organization` | `""` | No | Optional certificate `SubjectO` value for deployments that want an additional identity marker. |
 | `postgresql.instances` | `3` | No | Number of PostgreSQL replicas |
 | `postgresql.volumeSize` | `"10Gi"` | No | PVC size per PostgreSQL replica |
+| `postgresql.storageClass` | `"local-path-persistent"` | No | StorageClass for the nico-prereqs PostgreSQL PVCs. Override through Helm values when using a non-local StorageClass. |
 
 ### `values/nico-core.yaml`
 

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -43,6 +43,11 @@
 #                          deprecated alias.
 #   NICO_SITE_UUID          Stable REST site UUID. Used only when REST is
 #                          deployed. Default is a dev placeholder.
+#   NICO_MANAGE_DEFAULT_STORAGE_CLASS
+#                          Whether setup annotates local-path as the default
+#                          StorageClass. Default: true.
+#   NICO_STORAGE_CLASS     StorageClass for Postgres and Vault data and audit PVCs.
+#                          Default: local-path-persistent.
 #   VAULT_NS               Vault namespace. Default: vault
 #   CERT_MANAGER_NS        cert-manager namespace. Default: cert-manager
 #   PREFLIGHT_CHECK_IMAGE  Image for preflight per-node checks.
@@ -122,6 +127,8 @@ source "${SCRIPT_DIR}/preflight.sh"
 
 VAULT_NS="${VAULT_NS:-vault}"
 CERT_MANAGER_NS="${CERT_MANAGER_NS:-cert-manager}"
+NICO_MANAGE_DEFAULT_STORAGE_CLASS="${NICO_MANAGE_DEFAULT_STORAGE_CLASS:-true}"
+NICO_STORAGE_CLASS="${NICO_STORAGE_CLASS:-local-path-persistent}"
 
 # ---------------------------------------------------------------------------
 # Failure handler — offer to run clean.sh if setup exits with an error.
@@ -258,10 +265,15 @@ kubectl delete -f operators/storageclass-local-path-persistent.yaml \
     --ignore-not-found 2>/dev/null || true
 kubectl apply -f operators/storageclass-local-path-persistent.yaml
 kubectl rollout status deployment/local-path-provisioner -n local-path-storage --timeout=120s
-# Mark local-path as the cluster default StorageClass so workloads that don't
-# specify one (e.g. NICo REST postgres, Temporal) get a valid provisioner.
-kubectl annotate storageclass local-path \
-    storageclass.kubernetes.io/is-default-class=true --overwrite
+if [[ "${NICO_MANAGE_DEFAULT_STORAGE_CLASS}" == "true" ]]; then
+    # Mark local-path as the cluster default StorageClass so workloads that
+    # don't specify one (e.g. NICo REST postgres, Temporal) get a valid
+    # provisioner.
+    kubectl annotate storageclass local-path \
+        storageclass.kubernetes.io/is-default-class=true --overwrite
+else
+    echo "NICO_MANAGE_DEFAULT_STORAGE_CLASS=${NICO_MANAGE_DEFAULT_STORAGE_CLASS}; leaving default StorageClass unchanged"
+fi
 
 # ---------------------------------------------------------------------------
 # 1b. postgres-operator — Zalando operator must be up (CRD registered) before
@@ -336,7 +348,9 @@ echo "Vault TLS bootstrap complete"
 # ---------------------------------------------------------------------------
 _SETUP_PHASE="[3/6] vault install"
 echo "=== [3/6] vault ==="
-helmfile sync -l name=vault
+helmfile sync -l name=vault \
+    --set server.dataStorage.storageClass="${NICO_STORAGE_CLASS}" \
+    --set server.auditStorage.storageClass="${NICO_STORAGE_CLASS}"
 
 # ---------------------------------------------------------------------------
 # 4. Initialize + unseal vault

--- a/helm-prereqs/templates/postgresql.yaml
+++ b/helm-prereqs/templates/postgresql.yaml
@@ -32,7 +32,7 @@ spec:
   teamId: nico
   volume:
     size: {{ .Values.postgresql.volumeSize }}
-    storageClass: local-path-persistent
+    storageClass: {{ .Values.postgresql.storageClass | quote }}
   numberOfInstances: {{ .Values.postgresql.instances }}
   resources:
     limits:

--- a/helm-prereqs/values.yaml
+++ b/helm-prereqs/values.yaml
@@ -133,6 +133,7 @@ postgresql:
   enabled: true
   instances: 3
   volumeSize: "10Gi"
+  storageClass: "local-path-persistent"
   ## DB_HOST in nico-system-nico-database-config ConfigMap.
   ## Points at the operator-managed Service in the postgres namespace.
   host: "nico-pg-cluster.postgres.svc.cluster.local"


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
Add postgresql.storageClass to the nico-prereqs chart so operators can choose the StorageClass used by the Zalando-managed NICo Postgres cluster.

The default remains local-path-persistent to preserve existing behavior.

Add NICO_MANAGE_DEFAULT_STORAGE_CLASS to setup.sh. By default setup still annotates local-path as the default StorageClass, but operators can set NICO_MANAGE_DEFAULT_STORAGE_CLASS=false to leave an existing cluster default unchanged.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
Validated chart rendering with an overridden storage class:

```bash
helm template nico-prereqs helm-prereqs --set postgresql.storageClass=rook-ceph-block
```

Confirmed the rendered Postgres CR contains:

```yaml
storageClass: "rook-ceph-block"
```

Existing behavior is preserved unless operators explicitly opt out by setting:

```bash
NICO_MANAGE_DEFAULT_STORAGE_CLASS=false
```

This is useful for clusters where a production StorageClass is already managed outside NICo setup.