### PR TITLE
chore(api-db): make the dpa-vni resource pool optional

### DIFF
--- a/crates/api-db/src/resource_pool.rs
+++ b/crates/api-db/src/resource_pool.rs
@@ -936,7 +936,7 @@ pub async fn create_common_pools(
 
     let pool_dpa_vni: Arc<ResourcePool<i32>> =
         Arc::new(ResourcePool::new(DPA_VNI.to_string(), ValueType::Integer));
-    pool_names.push(pool_dpa_vni.name().to_string());
+    optional_pool_names.push(pool_dpa_vni.name().to_string());
 
     let pool_vpc_dpu_loopback_ip: Arc<ResourcePool<IpAddr>> = Arc::new(ResourcePool::new(
         VPC_DPU_LOOPBACK.to_string(),


### PR DESCRIPTION
## Description

Any new attempts to run `nico-api` without `[pools.dpa-vni]` set in the site config TOML file will result in `nico-api` crashing with the error:

```
Error: Resource pool 'dpa-vni' missing or full. Edit config file and restart.
```

This should be an optional resource pool since not all sites will need a `"dpa-vni"` resource pool. I think in the past when we managed all NICo sites, we'd prep all site configs with new resource pools, so it wasn't a big deal. Now, however, other teams/orgs/groups run their own NICo stack(s), so it is now up to them whether or not they need to configure this or not.

Luckily, we already have `optional_pool_names` for this!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

