### PR TITLE
fix(pxe): change "unknown instructions" error to not say "unknown ARM host"

### DIFF
--- a/crates/api/src/ipxe.rs
+++ b/crates/api/src/ipxe.rs
@@ -306,7 +306,7 @@ exit ||
         };
 
         static UNKNOWN_HOST_INSTRUCTIONS: &str = r#"
-echo this is an unknown ARM host, not PXE booting ||
+echo this is an unknown host interface, not PXE booting ||
 sleep 5 ||
 exit ||
         "#;


### PR DESCRIPTION
## Description

When a host goes to UEFI HTTP boot, and we haven't explored it yet, `carbide-pxe` will return an error message that its an unknown machine that we haven't explored yet. However, right now the error says "unknown ARM host", which isn't always the case. For example, if you have a host with a DPU in NIC mode, and you delete the machine to re-initialize it, the UEFI HTTP boot will attempt before `site-explorer` has had a chance to explore it again, and you'll get "unknown ARM host" while trying to boot your x86 Dell/HPE/whatever.

<img width="491" height="52" alt="Screenshot 2026-05-31 at 11 57 29 PM" src="https://github.com/user-attachments/assets/898d1c81-bc31-4d1c-b08d-0de849d37558" />

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

