### PR TITLE
feat(api): add admin force-delete for racks

### DIFF
--- a/crates/admin-cli/src/rack/force_delete/args.rs
+++ b/crates/admin-cli/src/rack/force_delete/args.rs
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::rack::RackId;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    #[clap(help = "Rack ID to force delete.")]
+    pub rack_id: RackId,
+}

--- a/crates/admin-cli/src/rack/force_delete/cmd.rs
+++ b/crates/admin-cli/src/rack/force_delete/cmd.rs
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use rpc::forge::AdminForceDeleteRackRequest;
+
+use super::args::Args;
+use crate::rpc::ApiClient;
+
+pub async fn force_delete(data: Args, api_client: &ApiClient) -> color_eyre::Result<()> {
+    let response = api_client
+        .0
+        .admin_force_delete_rack(AdminForceDeleteRackRequest {
+            rack_id: Some(data.rack_id),
+        })
+        .await?;
+
+    println!("Rack {} force deleted successfully.", response.rack_id);
+
+    Ok(())
+}

--- a/crates/admin-cli/src/rack/force_delete/mod.rs
+++ b/crates/admin-cli/src/rack/force_delete/mod.rs
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::force_delete(self, &ctx.api_client).await?;
+        Ok(())
+    }
+}

--- a/crates/admin-cli/src/rack/mod.rs
+++ b/crates/admin-cli/src/rack/mod.rs
@@ -16,6 +16,7 @@
  */
 
 mod delete;
+mod force_delete;
 mod list;
 mod maintenance;
 pub mod metadata;
@@ -37,6 +38,8 @@ pub enum Cmd {
     List(list::Args),
     #[clap(about = "Delete the rack")]
     Delete(delete::Args),
+    #[clap(about = "Force delete a rack")]
+    ForceDelete(force_delete::Args),
     #[clap(subcommand, about = "Edit Metadata associated with a Rack")]
     Metadata(metadata::Args),
     #[clap(subcommand, about = "Rack profile")]

--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -1244,6 +1244,13 @@ impl Forge for Api {
         crate::handlers::rack::delete_rack(self, request).await
     }
 
+    async fn admin_force_delete_rack(
+        &self,
+        request: Request<rpc::AdminForceDeleteRackRequest>,
+    ) -> Result<Response<rpc::AdminForceDeleteRackResponse>, Status> {
+        crate::handlers::rack::admin_force_delete_rack(self, request).await
+    }
+
     async fn get_rack_profile(
         &self,
         request: Request<rpc::GetRackProfileRequest>,

--- a/crates/api-core/src/auth/internal_rbac_rules.rs
+++ b/crates/api-core/src/auth/internal_rbac_rules.rs
@@ -277,6 +277,7 @@ impl InternalRBACRules {
         x.perm("FindExploredManagedHostIds", vec![ForgeAdminCLI, Flow]);
         x.perm("FindExploredManagedHostsByIds", vec![ForgeAdminCLI, Flow]);
         x.perm("AdminForceDeleteMachine", vec![ForgeAdminCLI, Machineatron]);
+        x.perm("AdminForceDeleteRack", vec![ForgeAdminCLI, Machineatron]);
         x.perm("AdminForceDeleteSwitch", vec![ForgeAdminCLI, Machineatron]);
         x.perm(
             "AdminForceDeletePowerShelf",

--- a/crates/api-core/src/handlers/rack.rs
+++ b/crates/api-core/src/handlers/rack.rs
@@ -209,6 +209,68 @@ pub async fn delete_rack(
     Ok(Response::new(()))
 }
 
+/// Force deletes a rack from the database.
+/// Unlike `delete_rack` (soft delete), this immediately hard-deletes the rack
+/// and its state history.
+pub async fn admin_force_delete_rack(
+    api: &Api,
+    request: Request<rpc::AdminForceDeleteRackRequest>,
+) -> Result<Response<rpc::AdminForceDeleteRackResponse>, Status> {
+    log_request_data(&request);
+    let request = request.into_inner();
+
+    let rack_id = request
+        .rack_id
+        .ok_or_else(|| CarbideError::InvalidArgument("rack_id is required".to_string()))?;
+
+    let mut txn = api.txn_begin().await?;
+
+    let rack_list = db_rack::find_by(
+        &mut txn,
+        ObjectColumnFilter::One(db_rack::IdColumn, &rack_id),
+    )
+    .await
+    .map_err(CarbideError::from)?;
+
+    if rack_list.is_empty() {
+        return Err(CarbideError::NotFoundError {
+            kind: "rack",
+            id: rack_id.to_string(),
+        }
+        .into());
+    }
+
+    db::state_history::delete_by_object_id(
+        &mut txn,
+        db::state_history::StateHistoryTableId::Rack,
+        &rack_id,
+    )
+    .await
+    .map_err(CarbideError::from)?;
+
+    db_rack::final_delete(&mut txn, &rack_id)
+        .await
+        .map_err(CarbideError::from)?;
+
+    txn.commit().await?;
+
+    if let Err(error) = api
+        .credential_manager
+        .delete_credentials(&rack_maintenance_access_token_key(&rack_id))
+        .await
+    {
+        tracing::warn!(
+            rack_id = %rack_id,
+            error = %error,
+            "failed to delete rack maintenance access token during force delete",
+        );
+    }
+
+    Ok(Response::new(rpc::AdminForceDeleteRackResponse {
+        rack_id: rack_id.to_string(),
+    }))
+}
+
 pub async fn list_rack_health_reports(
     api: &Api,
     request: Request<rpc::ListRackHealthReportsRequest>,

--- a/crates/api-core/src/tests/rack_find.rs
+++ b/crates/api-core/src/tests/rack_find.rs
@@ -16,10 +16,11 @@
  */
 
 use carbide_uuid::rack::RackId;
-use common::api_fixtures::create_test_env;
 use rpc::forge::forge_server::Forge;
+use rpc::forge::{AdminForceDeleteRackRequest, DeleteRackRequest};
+use tonic::Code;
 
-use crate::tests::common;
+use crate::tests::common::api_fixtures::create_test_env;
 use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
 
 #[crate::sqlx_test]
@@ -108,4 +109,108 @@ async fn test_find_rack_by_id(pool: sqlx::PgPool) {
     assert!(racks[0].created.is_some());
     assert!(racks[0].deleted.is_none());
     assert!(!racks[0].version.is_empty());
+}
+
+#[crate::sqlx_test]
+async fn test_force_delete_rack_success(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    let rack_id: RackId = "ForceDeleteRack".parse().unwrap();
+    let mut txn = env.pool.acquire().await.unwrap();
+    TestRackDbBuilder::new()
+        .with_rack_id(rack_id.clone())
+        .persist(&mut txn)
+        .await
+        .unwrap();
+    drop(txn);
+
+    let response = env
+        .api
+        .admin_force_delete_rack(tonic::Request::new(AdminForceDeleteRackRequest {
+            rack_id: Some(rack_id.clone()),
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(response.rack_id, rack_id.to_string());
+
+    let racks = env
+        .api
+        .find_racks_by_ids(tonic::Request::new(rpc::forge::RacksByIdsRequest {
+            rack_ids: vec![rack_id.clone()],
+        }))
+        .await?
+        .into_inner()
+        .racks;
+
+    assert!(racks.is_empty(), "Rack should be hard-deleted");
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_force_delete_rack_not_found(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    let non_existent_id: RackId = "MissingRack".parse().unwrap();
+    let result = env
+        .api
+        .admin_force_delete_rack(tonic::Request::new(AdminForceDeleteRackRequest {
+            rack_id: Some(non_existent_id),
+        }))
+        .await;
+
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().code(), Code::NotFound);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_force_delete_rack_already_soft_deleted(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    let rack_id: RackId = "SoftDeletedRack".parse().unwrap();
+    let mut txn = env.pool.acquire().await.unwrap();
+    TestRackDbBuilder::new()
+        .with_rack_id(rack_id.clone())
+        .persist(&mut txn)
+        .await
+        .unwrap();
+    drop(txn);
+
+    env.api
+        .delete_rack(tonic::Request::new(DeleteRackRequest {
+            id: rack_id.to_string(),
+        }))
+        .await?;
+
+    let response = env
+        .api
+        .admin_force_delete_rack(tonic::Request::new(AdminForceDeleteRackRequest {
+            rack_id: Some(rack_id.clone()),
+        }))
+        .await?
+        .into_inner();
+
+    assert_eq!(response.rack_id, rack_id.to_string());
+
+    let racks = env
+        .api
+        .find_racks_by_ids(tonic::Request::new(rpc::forge::RacksByIdsRequest {
+            rack_ids: vec![rack_id],
+        }))
+        .await?
+        .into_inner()
+        .racks;
+
+    assert!(racks.is_empty(), "Rack should be hard-deleted");
+
+    Ok(())
 }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -715,6 +715,8 @@ service Forge {
   // Deprecated: Use FindRackIds
   rpc GetRack(GetRackRequest) returns (GetRackResponse);
   rpc DeleteRack(DeleteRackRequest) returns (google.protobuf.Empty);
+  // Force deletes a Rack from the database.
+  rpc AdminForceDeleteRack(AdminForceDeleteRackRequest) returns (AdminForceDeleteRackResponse);
   rpc GetRackProfile(GetRackProfileRequest) returns (GetRackProfileResponse);
 
   //
@@ -7090,6 +7092,17 @@ message RackStateHistoriesRequest {
 
 message DeleteRackRequest {
   string id = 1;
+}
+
+// Force deletes a Rack from the database.
+message AdminForceDeleteRackRequest {
+  // The Rack ID to force delete.
+  common.RackId rack_id = 1;
+}
+
+message AdminForceDeleteRackResponse {
+  // The ID of the rack that was deleted.
+  string rack_id = 1;
 }
 
 // Rack Capabilities


### PR DESCRIPTION
Extend the existing force-delete operational pattern (already available for machines, switches, and power shelves) to racks so operators can immediately remove a rack record from the database without waiting for the rack state controller to finish a soft-delete lifecycle.

AdminForceDeleteRack hard-deletes the rack row and its state history. Unlike DeleteRack (soft delete), it bypasses the Deleting controller state. Any stored rack maintenance access token is best-effort cleaned up after the DB transaction commits.

Changes:
- Add AdminForceDeleteRack RPC and request/response messages to forge.proto
- Implement admin_force_delete_rack handler and wire it through Api
- Grant AdminForceDeleteRack to ForgeAdminCLI and Machineatron in RBAC
- Add `nico-admin-cli rack force-delete <rack-id>` command
- Add integration tests for success, not-found, and soft-deleted racks

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

