### PR TITLE
Scrape DPU agent logs from container stdout

### DIFF
--- a/bluefield/charts/nico-otelcol/files/otel_config.yaml
+++ b/bluefield/charts/nico-otelcol/files/otel_config.yaml
@@ -25,18 +25,27 @@ receivers:
     start_at: beginning
     storage: file_storage/cursors
 
-  journald/nico-dpu-agent:
-    directory: /var/log/journal
-    units:
-      - nico-dpu-agent
+  # nico-dpu-agent runs as a containerized DaemonSet pod, so its logs are
+  # written to stdout and captured by the container runtime under
+  # /var/log/pods, not to a journald systemd unit. Read them from there.
+  filelog/nico-dpu-agent:
+    include:
+      - /var/log/pods/*_nico-dpu-agent-*/nico-dpu-agent/*.log
+    include_file_name: false
+    include_file_path: true
+    start_at: beginning
     storage: file_storage/cursors
     operators:
-      # If you want to extract more than a few key=value pairs, use
-      # key_value_parser in place of regex_parser to just parse them all then
-      # drop unwanted pairs in the transform processor.
+      # Strip the container runtime (CRI / docker) framing and recombine
+      # partial log lines, leaving the agent's logfmt line in the body.
+      - type: container
+        add_metadata_from_filepath: true
+      # Extract the log level emitted by the agent (logfmt: level=info) for
+      # severity. To extract more key=value pairs, use key_value_parser in
+      # place of regex_parser then drop unwanted pairs in the transform.
       - type: regex_parser
         regex: 'level=(?P<level>\w+)'
-        parse_from: body.MESSAGE
+        parse_from: body
         severity:
           parse_from: attributes.level
           mapping:
@@ -317,15 +326,15 @@ processors:
           enabled: false
         host.id:
           enabled: false
-  # Remove all but the "MESSAGE" and "_SYSTEMD_UNIT" keys from each log record
-  transform/journald:
+  # The agent's logs now arrive via filelog (body is the plain message), so the
+  # journald-specific body extraction does not apply. Preserve the systemd.unit
+  # label so existing dashboards and telemetry_stats groupings keep working.
+  transform/nico-dpu-agent:
     error_mode: ignore
     log_statements:
       - context: log
         statements:
-          - keep_keys(body, ["MESSAGE", "_SYSTEMD_UNIT"])
-          - set(attributes["systemd.unit"], body["_SYSTEMD_UNIT"])
-          - set(body, body["MESSAGE"])
+          - set(attributes["systemd.unit"], "nico-dpu-agent")
           - delete_key(attributes, "level")
   transform/journald-kernel:
     error_mode: ignore
@@ -379,14 +388,14 @@ exporters:
 
 service:
   pipelines:
-    logs/journald:
-      receivers: [journald/nico-dpu-agent]
+    logs/nico-dpu-agent:
+      receivers: [filelog/nico-dpu-agent]
       processors:
         - memory_limiter
         - resourcedetection
         - fileresource
         - resource/logs-journald
-        - transform/journald
+        - transform/nico-dpu-agent
         - telemetry_stats
         - batch/logs
       exporters: [otlp/site]

--- a/bluefield/charts/nico-otelcol/templates/daemonset.yaml
+++ b/bluefield/charts/nico-otelcol/templates/daemonset.yaml
@@ -86,6 +86,9 @@ spec:
             - name: journal
               mountPath: /var/log/journal
               readOnly: true
+            - name: pod-logs
+              mountPath: /var/log/pods
+              readOnly: true
             - name: doca-logs
               mountPath: /var/log/doca
               readOnly: true
@@ -109,6 +112,10 @@ spec:
         - name: journal
           hostPath:
             path: /var/log/journal
+            type: DirectoryOrCreate
+        - name: pod-logs
+          hostPath:
+            path: /var/log/pods
             type: DirectoryOrCreate
         - name: doca-logs
           hostPath:


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
 nico-dpu-agent runs as a containerized DaemonSet pod that logs to stdout, but the otel collector was reading its logs via a journald/nico-dpu-agent receiver expecting a systemd unit by that name. No  such unit exists in the K8s deployment, so the agent's logs were never collected.

  Fix: Read the logs from the pod's stdout, which the container runtime writes under /var/log/pods.

  Changes (bluefield/charts/nico-otelcol/):
  - files/otel_config.yaml
    - Replaced the journald/nico-dpu-agent receiver with a filelog/nico-dpu-agent receiver reading /var/log/pods/*_nico-dpu-agent-*/nico-dpu-agent/*.log, using the container operator to strip CRI/docker
  framing and the existing level= regex for severity.
    - Added transform/nico-dpu-agent to set systemd.unit: nico-dpu-agent, and kept component: journald, so existing dashboards and telemetry_stats groupings are unchanged — only the log source moved.
    - Renamed pipeline logs/journald → logs/nico-dpu-agent; removed the now-unused transform/journald.
  - templates/daemonset.yaml
    - Mounted /var/log/pods as a read-only hostPath into the otelcol DaemonSet.
  
  Scope: K8s chart only. The bare-metal bluefield/otel/otel_config.yaml is untouched, since there the agent really is the forge-dpu-agent systemd unit.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

