### PR TITLE
Add node exporter to otelcol

### DIFF
--- a/bluefield/charts/nico-otelcol/templates/daemonset.yaml
+++ b/bluefield/charts/nico-otelcol/templates/daemonset.yaml
@@ -102,6 +102,30 @@ spec:
             - name: config-fragments
               mountPath: /etc/otelcol-contrib/config-fragments
               readOnly: true
+        # Host metrics exporter scraped by the prometheus/node receiver. The pod
+        # uses hostNetwork, so it binds to the host loopback at the port the
+        # collector scrapes (localhost:9200 in otel_config.yaml).
+        - name: node-exporter
+          image: "{{ .Values.nodeExporter.image.repository }}:{{ .Values.nodeExporter.image.tag }}"
+          imagePullPolicy: {{ .Values.nodeExporter.image.pullPolicy }}
+          args:
+            - --path.procfs=/host/proc
+            - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
+            - --web.listen-address=127.0.0.1:{{ .Values.nodeExporter.port }}
+          resources:
+            {{- toYaml .Values.nodeExporter.resources | nindent 12 }}
+          volumeMounts:
+            - name: host-proc
+              mountPath: /host/proc
+              readOnly: true
+            - name: host-sys
+              mountPath: /host/sys
+              readOnly: true
+            - name: host-root
+              mountPath: /host/root
+              mountPropagation: HostToContainer
+              readOnly: true
       volumes:
         - name: config
           configMap:
@@ -120,7 +144,7 @@ spec:
             type: FileOrCreate
         - name: nico-certs
           hostPath:
-            path: {{ .Values.certsDir | default "/opt/nico" }}
+            path: /opt/nico
             type: DirectoryOrCreate
         - name: machine-id
           hostPath:
@@ -134,6 +158,15 @@ spec:
           hostPath:
             path: /etc/otelcol-contrib/config-fragments
             type: DirectoryOrCreate
+        - name: host-proc
+          hostPath:
+            path: /proc
+        - name: host-sys
+          hostPath:
+            path: /sys
+        - name: host-root
+          hostPath:
+            path: /
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/bluefield/charts/nico-otelcol/values.yaml
+++ b/bluefield/charts/nico-otelcol/values.yaml
@@ -24,6 +24,16 @@ image:
   repository: ""
   pullPolicy: IfNotPresent
   tag: ""
+# node-exporter sidecar, scraped by the prometheus/node receiver on
+# localhost:9200 (see files/otel_config.yaml). Override repository/tag to a
+# registry reachable by the deployment (the imagePullSecrets below apply).
+nodeExporter:
+  image:
+    repository: quay.io/prometheus/node-exporter
+    tag: v1.8.2
+    pullPolicy: IfNotPresent
+  port: 9200
+  resources: {}
 imagePullSecrets: []
 podSecurityContext: {}
 securityContext:


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
  The prometheus/node receiver in the nico-otelcol collector scrapes localhost:9200, but nothing served that endpoint in the DPF deployment — node-exporter ran on the host in the old bare-metal model and was
  never carried over — so the scrape failed and host metrics (node_network_*, node_pressure_*, node_timex_*, node_arp_entries, node_boot_time_seconds) were missing.

  Changes (bluefield/charts/nico-otelcol/):
  - templates/daemonset.yaml: added a node-exporter sidecar container to the otelcol DaemonSet. The pod is hostNetwork: true, so it binds 127.0.0.1:9200 — matching the existing scrape target and not exposing
  it on the host's routable IPs — with read-only host mounts of /proc, /sys, and /. Pod-level imagePullSecrets apply to it.
  - values.yaml: added a nodeExporter block (image defaults to quay.io/prometheus/node-exporter:v1.8.2, overridable for a mirrored registry; configurable port and resources).

  No change to otel_config.yaml — its localhost:9200 target was already correct; nothing was answering it.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
Draft because it pulls a public image
