### PR TITLE
Fix Fern preview build workflow

### DIFF
--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -15,7 +15,7 @@
 
 # Workflow 1 of 2 for Fern doc previews.
 #
-# Collects fern/, docs/, and PR metadata and uploads an artifact.
+# Collects fern/, docs/, rest-api/openapi/, and PR metadata and uploads an artifact.
 #
 # The companion workflow (fern-docs-preview-comment.yml) runs after this one;
 # it skips cleanly when no artifact exists (e.g. skipped fork pull_request).
@@ -27,6 +27,7 @@ on:
     paths:
       - 'fern/**'
       - 'docs/**'
+      - 'rest-api/openapi/**'
       - '.github/workflows/fern-docs-preview-build.yml'
   push:
     branches:
@@ -34,6 +35,7 @@ on:
     paths:
       - 'fern/**'
       - 'docs/**'
+      - 'rest-api/openapi/**'
       - '.github/workflows/fern-docs-preview-build.yml'
 
 permissions:
@@ -76,5 +78,6 @@ jobs:
           path: |
             fern/
             docs/
+            rest-api/openapi/
             preview-metadata/
           retention-days: 1


### PR DESCRIPTION
## Description

The preview build workflow isn't loading the new location for the REST API spec file, causing Fern docs build to fail. This change makes the new API location visible to build.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

