### PR TITLE
feat(api,agent): Allow interceptor bridges per host-owned PF/VF

### DIFF
--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -511,11 +511,7 @@ pub async fn update_nvue(
                 .as_ref()
                 .map(|b| b.vf_intercept_bridge_sf.clone())
         }),
-        host_intercept_bridge_port_name: nc.traffic_intercept_config.as_ref().and_then(|vc| {
-            vc.bridging
-                .as_ref()
-                .map(|b| b.host_intercept_bridge_port.clone())
-        }),
+        host_intercept_bridge_port_name: None,
         secondary_overlay_vtep_ip: nc
             .traffic_intercept_config
             .as_ref()
@@ -679,6 +675,7 @@ pub async fn update_nvue(
 // Update internal bridge configuration for traffic-intercept routing and bridging.
 pub async fn update_traffic_intercept_bridging(
     nc: &rpc::ManagedHostNetworkConfigResponse,
+    hbn_device_names: HBNDeviceNames,
     skip_post: bool,
 ) -> eyre::Result<bool> {
     // Read the traffic-intercept inputs supplied by the controller.
@@ -710,6 +707,53 @@ pub async fn update_traffic_intercept_bridging(
         )
     };
 
+    // Get the map of interface to bridge.
+    let interface_to_bridge: HashMap<String, &rpc::HostRepresentorInterceptBridging> =
+        bridge_config
+            .host_representor_intercept_bridging
+            .iter()
+            .map(|(rep, c)| (rep.clone(), c))
+            .collect();
+
+    // Now get the list of VNI to Bridge maps.
+    let physical_name = hbn_device_names.reps[0].to_string();
+    let host_representor_bridge_vni_mappings = nc
+        .tenant_interfaces
+        .iter()
+        .filter_map(|i| {
+            let name = if i.function_type == rpc::InterfaceFunctionType::Physical as i32 {
+                physical_name.replace(hbn_device_names.sf_id, "")
+            } else {
+                match i.virtual_function_id {
+                    Some(id) => hbn_device_names
+                        .build_virt(id)
+                        .replace(hbn_device_names.sf_id, ""),
+                    None => {
+                        return {
+                            // This is an error at the point of rebuilding NVUE config,
+                            // but this is us used only for signaling with OVN here.
+                            // The values only change as interfaces come and go.
+                            // If it's a new interface, it would go un-configured, and the signaling
+                            // here won't matter anyway.
+                            tracing::warn!("function ID not found for non-physical interface");
+                            None
+                        };
+                    }
+                }
+            };
+
+            interface_to_bridge.get(&name).map(|bridging| {
+                tracing::debug!("update_traffic_intercept_bridging representor={name} bridge={} vni={} gateway={}", bridging.bridge, i.vni, i.gateway);
+                traffic_intercept_bridging::TrafficInterceptBridgeMapping {
+                    bridge: bridging.bridge.clone(),
+                    patch_port: bridging.patch_port.clone(),
+                    vni: i.vni,
+                    gateway: i.gateway.clone(),
+                }
+            })
+        })
+        .collect();
+
     let conf = traffic_intercept_bridging::TrafficInterceptBridgingConfig {
         secondary_overlay_vtep_ip: secondary_overlay_vtep_ip.to_owned(),
         secondary_vtep_aggregate_prefixes: traffic_intercept_config
@@ -720,6 +764,7 @@ pub async fn update_traffic_intercept_bridging(
         // We use the bridge name here because the OVS will create a link/dev on the
         // DPU OS side of that name.
         vf_intercept_bridge_name: bridge_config.vf_intercept_bridge_name.clone(),
+        host_representor_bridge_vni_mappings,
     };
 
     // Write the config we're going to apply
@@ -2091,6 +2136,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_with_tenant_with_bridging() -> Result<(), Box<dyn std::error::Error>> {
+        let virtualization_type = VpcVirtualizationType::Fnn;
+
+        let mut network_config = netconf(virtualization_type, 32, 24, false, None, false, true);
+
+        network_config.traffic_intercept_config = Some(rpc::TrafficInterceptConfig {
+            additional_overlay_vtep_ip: Some("1.2.2.2".to_string()),
+            public_prefixes: vec![],
+            secondary_vtep_aggregate_prefixes: vec![],
+
+            bridging: Some(rpc::TrafficInterceptBridging {
+                internal_bridge_routing_prefix: "2.2.2.0/24".to_string(),
+                hbn_bridge: "br-hbn".to_string(),
+                vf_intercept_bridge_name: "br-beans".to_string(),
+                vf_intercept_bridge_port: "patch-br-beans-to-hbn".to_string(),
+                vf_intercept_bridge_sf: "pf0dpu5".to_string(),
+                host_representor_intercept_bridging: HashMap::from([(
+                    "pf0hpf".to_string(),
+                    rpc::HostRepresentorInterceptBridging {
+                        bridge: "br-pf0".to_string(),
+                        patch_port: "pp-pf0".to_string(),
+                    },
+                )]),
+            }),
+        });
+
+        fs::remove_file(traffic_intercept_bridging::SAVE_PATH).unwrap_or_default();
+        let has_changes = super::update_traffic_intercept_bridging(
+            &network_config,
+            HBNDeviceNames::hbn_23(),
+            true,
+        )
+        .await?;
+        assert!(
+            has_changes,
+            "update_traffic_intercept_bridging should have written the file, there should be changes"
+        );
+
+        // check startup.yaml
+        let expected = include_str!("../templates/tests/test_with_tenant_with_bridging.expected");
+        compare_diffed(traffic_intercept_bridging::SAVE_PATH, expected)?;
+
+        Ok(())
+    }
+    #[tokio::test]
     async fn test_with_tenant_fnn_with_missing_vpcs() -> Result<(), Box<dyn std::error::Error>> {
         let virtualization_type = VpcVirtualizationType::Fnn;
 
@@ -2833,11 +2923,17 @@ mod tests {
             traffic_intercept_config: Some(rpc::TrafficInterceptConfig {
                 bridging: Some(rpc::TrafficInterceptBridging {
                     vf_intercept_bridge_port: "dpuVf0mg".to_string(),
-                    host_intercept_bridge_port: "dpuVf1mg".to_string(),
-                    host_intercept_bridge_name: "br-host".to_string(),
                     vf_intercept_bridge_name: "br-dpu".to_string(),
                     vf_intercept_bridge_sf: "pf0dpu5".to_string(),
                     internal_bridge_routing_prefix: "10.10.10.0/29".to_string(),
+                    hbn_bridge: "br-hbn".to_string(),
+                    host_representor_intercept_bridging: HashMap::from([(
+                        "pf0hpf".to_string(),
+                        rpc::HostRepresentorInterceptBridging {
+                            bridge: "br-pf0".to_string(),
+                            patch_port: "pp-pf0".to_string(),
+                        },
+                    )]),
                 }),
                 additional_overlay_vtep_ip: Some("10.255.254.253".to_string()),
                 public_prefixes: vec!["7.6.5.0/24".to_string()],

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -674,6 +674,7 @@ impl MainLoop {
                         {
                             ethernet_virtualization::update_traffic_intercept_bridging(
                                 &conf,
+                                self.hbn_device_names.clone(),
                                 self.agent_config.hbn.skip_reload,
                             )
                             .await

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -94,6 +94,14 @@ async fn test_traffic_intercept_bridging() -> eyre::Result<()> {
             vf_intercept_bridge_ip: "10.10.10.2".to_string(),
             vf_intercept_bridge_name: "pfdpu000br-dpu".to_string(),
             intercept_bridge_prefix_len: 29,
+            host_representor_bridge_vni_mappings: vec![
+                traffic_intercept_bridging::TrafficInterceptBridgeMapping {
+                    bridge: "pf0-br".to_string(),
+                    vni: 333,
+                    patch_port: "patch-pf01".to_string(),
+                    gateway: "10.1.1.0/31".to_string(),
+                },
+            ],
         },
     )?;
 
@@ -865,11 +873,11 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
         traffic_intercept_config: Some(rpc::forge::TrafficInterceptConfig {
             bridging: Some(rpc::forge::TrafficInterceptBridging {
                 internal_bridge_routing_prefix: "10.255.255.0/29".to_string(),
-                host_intercept_bridge_name: "br-host".to_string(),
+                hbn_bridge: "br-hbn".to_string(),
                 vf_intercept_bridge_name: "br-dpu".to_string(),
                 vf_intercept_bridge_port: "pfdpu000br-dpu".to_string(),
                 vf_intercept_bridge_sf: "pf0dpu5".to_string(),
-                host_intercept_bridge_port: "pfdpu000br-host".to_string(),
+                host_representor_intercept_bridging: Default::default(),
             }),
             additional_overlay_vtep_ip: Some("10.2.2.1".to_string()),
             public_prefixes: vec!["7.8.0.0/16".to_string()],

--- a/crates/agent/src/traffic_intercept_bridging.rs
+++ b/crates/agent/src/traffic_intercept_bridging.rs
@@ -31,11 +31,28 @@ pub struct TrafficInterceptBridgingConfig {
     pub vf_intercept_bridge_ip: String,
     pub vf_intercept_bridge_name: String,
     pub intercept_bridge_prefix_len: u8,
+    pub host_representor_bridge_vni_mappings: Vec<TrafficInterceptBridgeMapping>,
+}
+
+pub struct TrafficInterceptBridgeMapping {
+    pub bridge: String,
+    pub patch_port: String,
+    pub gateway: String,
+    pub vni: u32,
 }
 
 //
 // Go template objects, hence allow(non_snake_case)
 //
+
+#[allow(non_snake_case)]
+#[derive(Clone, Gtmpl, Debug)]
+pub struct TmplTrafficInterceptBridgeMapping {
+    Bridge: String,
+    Gateway: String,
+    PatchPort: String,
+    VNI: u32,
+}
 
 #[allow(non_snake_case)]
 #[derive(Clone, Gtmpl, Debug)]
@@ -45,6 +62,7 @@ struct TmplTrafficInterceptBridging {
     VfInterceptBridgeIP: String,
     VfInterceptBridgeName: String,
     InterceptBridgePrefixLen: u8,
+    HostRepresentorBridgeMappings: Vec<TmplTrafficInterceptBridgeMapping>,
 }
 
 pub fn build(conf: TrafficInterceptBridgingConfig) -> eyre::Result<String> {
@@ -54,6 +72,16 @@ pub fn build(conf: TrafficInterceptBridgingConfig) -> eyre::Result<String> {
         VfInterceptBridgeIP: conf.vf_intercept_bridge_ip,
         VfInterceptBridgeName: conf.vf_intercept_bridge_name,
         InterceptBridgePrefixLen: conf.intercept_bridge_prefix_len,
+        HostRepresentorBridgeMappings: conf
+            .host_representor_bridge_vni_mappings
+            .iter()
+            .map(|i| TmplTrafficInterceptBridgeMapping {
+                Bridge: i.bridge.clone(),
+                Gateway: i.gateway.clone(),
+                PatchPort: i.patch_port.clone(),
+                VNI: i.vni,
+            })
+            .collect(),
     };
 
     gtmpl::template(TMPL_BRIDGING, params).map_err(|e| {

--- a/crates/agent/templates/tests/test_with_tenant_with_bridging.expected
+++ b/crates/agent/templates/tests/test_with_tenant_with_bridging.expected
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 
-ovs-vsctl br-set-external-id pf0-br host-link-prefix 10.1.1.0/31
+ovs-vsctl br-set-external-id br-pf0 host-link-prefix 10.217.5.161/30
 
 # Get the IPs currently on the bridge used for intercepting VMaaS traffic.
-VF_BRIDGE_IPS=$(ip addr show dev pfdpu000br-dpu | grep -oP 'inet\s\K[\d.\/]+')
+VF_BRIDGE_IPS=$(ip addr show dev br-beans | grep -oP 'inet\s\K[\d.\/]+')
 
-INCOMING_IPS=("10.10.10.2/29" "1.1.1.1/32")
+INCOMING_IPS=("2.2.2.1/24" "1.2.2.2/32")
 
 # Find only the bridge IPs that need to be removed.
 OLD_VF_BRIDGE_IPS=$(diff --old-line-format="%L" --unchanged-line-format="" --new-line-format="" \
@@ -15,25 +15,25 @@ OLD_VF_BRIDGE_IPS=$(diff --old-line-format="%L" --unchanged-line-format="" --new
 
 
 # Add the new internal routing IPs to the bridge if they need to be added.
-if ! ip addr show pfdpu000br-dpu | grep 10.10.10.2/29; then
-    ip addr add 10.10.10.2/29 dev pfdpu000br-dpu || exit $?
+if ! ip addr show br-beans | grep 2.2.2.1/24; then
+    ip addr add 2.2.2.1/24 dev br-beans || exit $?
 fi
 
-if ! ip addr show pfdpu000br-dpu | grep 1.1.1.1/32; then
-    ip link set pfdpu000br-dpu up
+if ! ip addr show br-beans | grep 1.2.2.2/32; then
+    ip link set br-beans up
     # This is how Catalyst learns the current local GENEVE VTEP IP.
-    ovs-vsctl set Open_vSwitch . external_ids:ovn-encap-ip=1.1.1.1 || exit $?
+    ovs-vsctl set Open_vSwitch . external_ids:ovn-encap-ip=1.2.2.2 || exit $?
 
-    ip addr add 1.1.1.1/32 dev pfdpu000br-dpu || exit $?
+    ip addr add 1.2.2.2/32 dev br-beans || exit $?
 fi
 
 #### Now update the routes
 
 # Get the existing routes point toward the bridge
-VF_BRIDGE_ROUTES=$(ip route | grep -oP '\K[\d.\/]+\svia\s[\d.\/]+(?=\sdev\spfdpu000br-dpu)')
+VF_BRIDGE_ROUTES=$(ip route | grep -oP '\K[\d.\/]+\svia\s[\d.\/]+(?=\sdev\sbr-beans)')
 
 # Get the incoming routes
-INCOMING_ROUTES=( "1.1.1.0/24 via 1.1.1.1" )
+INCOMING_ROUTES=()
 
 # Find only the routes that need to be removed.
 OLD_VF_BRIDGE_ROUTES=$(diff --old-line-format="%L" --unchanged-line-format="" --new-line-format="" \
@@ -57,5 +57,5 @@ done;
 # If something went wrong, we'll have exited and won't rip down the old IPs.
 # The next cycle will put things in order if there are no errors.
 for OLD_IP in "${OLD_VF_BRIDGE_IPS[@]}";do
-    ip addr del $OLD_IP dev pfdpu000br-dpu &>/dev/null || true
+    ip addr del $OLD_IP dev br-beans &>/dev/null || true
 done;

--- a/crates/agent/templates/update_intercept_bridging.sh.tmpl
+++ b/crates/agent/templates/update_intercept_bridging.sh.tmpl
@@ -1,6 +1,10 @@
 #!/bin/bash
 {{- $bridgingConfig := . }}
 
+{{ range .HostRepresentorBridgeMappings }}
+ovs-vsctl br-set-external-id {{ .Bridge }} host-link-prefix {{ .Gateway }}
+{{- end }}
+
 # Get the IPs currently on the bridge used for intercepting VMaaS traffic.
 VF_BRIDGE_IPS=$(ip addr show dev {{ .VfInterceptBridgeName }} | grep -oP 'inet\s\K[\d.\/]+')
 

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -250,6 +250,25 @@ Extends `StateControllerConfig` with:
 | `secondary_vtep_aggregate_prefixes` | `Vec<IpNetwork>` | `[]` | IPv4 or IPv6 aggregate prefixes used only for routing and filtering. IP allocation is provided by the secondary VTEP resource pool. |
 | `secondary_overlay_support` | `bool` | `true` | Whether secondary overlay VTEP IPs are expected for DPUs. |
 
+### `TrafficInterceptBridging`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `internal_bridge_routing_prefix` | `Ipv4Network` | **required** | Prefix used for internal routing between HBN and intercept bridges within the DPU. |
+| `hbn_bridge` | `String` | `"br-hbn"` | Bridge that intercept patch ports attach to during BlueField provisioning. |
+| `vf_intercept_bridge_name` | `String` | `"br-dpu"` | Bridge between VM-owned VFs and br-hbn. |
+| `vf_intercept_bridge_port` | `String` | `"patch-br-dpu-to-hbn"` | Patch port on the VF intercept bridge side. |
+| `vf_intercept_bridge_sf` | `String` | **required** | SF used for internal routing of VF traffic. |
+| `host_representor_intercept_bridging` | `HashMap<String, HostInterceptBridging>` | `{}` | Host-owned PF/VF representor bridge layout keyed by representor name. Non-skipped entries are sent to BlueField provisioning as `<representor>:<bridge>:<patch_port>`. |
+
+### `HostInterceptBridging`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `bridge` | `String` | **required** | Bridge that sits between the host PF/VF representor and br-hbn or br-sfc. |
+| `patch_port` | `String` | **required** | Patch port on this bridge that connects it toward HBN or SFC. |
+| `skip_create` | `bool` | `false` | When true, the entry is sent to DPU agents but omitted from provisioning-time bridge creation. |
+
 ### `DpuConfig`
 
 | Field | Type | Default | Description |

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -2118,13 +2118,11 @@ pub struct TrafficInterceptBridging {
     /// within the DPU.
     pub internal_bridge_routing_prefix: Ipv4Network,
 
-    /// The name of the bridge (aka br-host) that sits between host PF and br-hbn
-    /// It will be connected to br-hbn or the hbn pod via a patch_point or
-    /// patch port of some kind.
-    #[serde(default = "default_host_intercept_bridge_name")]
-    pub host_intercept_bridge_name: String,
+    /// The HBN/SFC bridge that intercept patch ports attach to during provisioning.
+    #[serde(default = "default_hbn_bridge")]
+    pub hbn_bridge: String,
 
-    /// The name of the bridge that sits between VFs and br-hbn.
+    /// The name of the bridge that sits between VFs and br-hbn _**for VM-owned VFs**_.
     /// This bridge will be assigned an address from <internal_bridge_routing_prefix>
     /// so that we can route traffic to a /32 bound to it and used as a VTEP for
     /// an additional GENEVE VPN.
@@ -2132,21 +2130,55 @@ pub struct TrafficInterceptBridging {
     pub vf_intercept_bridge_name: String,
 
     /// The <vf_intercept_bridge_name> side of the SF representor that connects the HBN pod to br-hbn.
-    /// This will be the side owned by the <vf_intercept_bridge_name> bridge
+    /// This will be the side owned by the <vf_intercept_bridge_name> bridge _**for VM-owned VFs**_
     #[serde(default = "default_vf_intercept_bridge_port")]
     pub vf_intercept_bridge_port: String,
 
-    /// The <host_intercept_bridge_name> side of the SF representor that connects the HBN pod to br-hbn.
-    /// This will be the side owned by the <host_intercept_bridge_name> bridge.
-    #[serde(default = "default_host_intercept_bridge_port")]
-    pub host_intercept_bridge_port: String,
-
     /// The SF used for internal routing of VF traffic.
     pub vf_intercept_bridge_sf: String,
+
+    /// The layout of host-owned representors that will have intermediary bridges.
+    /// E.g., [{"pf0hpf" => {bridge: "br-host", patch_port: "brh"}}]
+    #[serde(default)]
+    pub host_representor_intercept_bridging: HashMap<String, HostInterceptBridging>,
 }
 
-pub fn default_host_intercept_bridge_name() -> String {
-    "br-host".to_string()
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct HostInterceptBridging {
+    /// The name of the bridge (e.g., br-host) that will sit between host PF/VF and br-hbn.
+    /// It will be connected to br-hbn or br-sfc.
+    pub bridge: String,
+
+    /// The patch port on this bridge that connects it toward HBN or SFC.
+    pub patch_port: String,
+
+    /// Control whether this bridging should be created during DPU (re)provisioning or not.
+    /// By default, we expect to create these bridges.
+    #[serde(default)]
+    pub skip_create: bool,
+}
+
+impl TrafficInterceptBridging {
+    /// Formats host-owned representor bridge config for BlueField provisioning.
+    pub fn host_representor_intercept_bridging_provisioning_config(&self) -> Option<String> {
+        // Keep bf.cfg input stable and omit entries that should not be provisioned.
+        let config = self
+            .host_representor_intercept_bridging
+            .iter()
+            .filter(|(_, bridge)| !bridge.skip_create)
+            .sorted_by(|(left, _), (right, _)| left.cmp(right))
+            .map(|(representor, bridge)| {
+                format!("{representor}:{}:{}", bridge.bridge, bridge.patch_port)
+            })
+            .join(",");
+
+        // An empty map, or one with only skipped entries, means no provisioning config.
+        (!config.is_empty()).then_some(config)
+    }
+}
+
+pub fn default_hbn_bridge() -> String {
+    "br-hbn".to_string()
 }
 
 pub fn default_vf_intercept_bridge_name() -> String {
@@ -2155,10 +2187,6 @@ pub fn default_vf_intercept_bridge_name() -> String {
 
 pub fn default_vf_intercept_bridge_port() -> String {
     "patch-br-dpu-to-hbn".to_string()
-}
-
-pub fn default_host_intercept_bridge_port() -> String {
-    "patch-br-host-to-hbn".to_string()
 }
 
 #[cfg(test)]

--- a/crates/api-core/src/handlers/client_resolution.rs
+++ b/crates/api-core/src/handlers/client_resolution.rs
@@ -193,6 +193,10 @@ pub(crate) async fn resolve_cloud_init_instructions(
                 (None, None)
             };
 
+            // Resolve VMaaS config once so the cloud-init fields are derived consistently.
+            let vmaas_config = api.runtime_config.vmaas_config.as_ref();
+            let traffic_intercept_bridging = vmaas_config.and_then(|vc| vc.bridging.as_ref());
+
             Ok(rpc::CloudInitInstructions {
                 custom_cloud_init,
                 discovery_instructions: Some(rpc::CloudInitDiscoveryInstructions {
@@ -200,52 +204,18 @@ pub(crate) async fn resolve_cloud_init_instructions(
                     domain: Some(rpc::PxeDomain {
                         domain: Some(rpc::pxe_domain::Domain::NewDomain(domain.into())),
                     }),
-                    hbn_reps: api
-                        .runtime_config
-                        .vmaas_config
-                        .as_ref()
-                        .and_then(|vc| vc.hbn_reps.clone()),
-                    hbn_sfs: api
-                        .runtime_config
-                        .vmaas_config
-                        .as_ref()
-                        .and_then(|vc| vc.hbn_sfs.clone()),
-                    vf_intercept_bridge_name: api.runtime_config.vmaas_config.as_ref().and_then(
-                        |vc| {
-                            vc.bridging
-                                .as_ref()
-                                .map(|b| b.vf_intercept_bridge_name.clone())
-                        },
-                    ),
-                    host_intercept_bridge_name: api.runtime_config.vmaas_config.as_ref().and_then(
-                        |vc| {
-                            vc.bridging
-                                .as_ref()
-                                .map(|b| b.host_intercept_bridge_name.clone())
-                        },
-                    ),
-                    host_intercept_bridge_port: api.runtime_config.vmaas_config.as_ref().and_then(
-                        |vc| {
-                            vc.bridging
-                                .as_ref()
-                                .map(|b| b.host_intercept_bridge_port.clone())
-                        },
-                    ),
-                    vf_intercept_bridge_port: api.runtime_config.vmaas_config.as_ref().and_then(
-                        |vc| {
-                            vc.bridging
-                                .as_ref()
-                                .map(|b| b.vf_intercept_bridge_port.clone())
-                        },
-                    ),
-                    vf_intercept_bridge_sf: api.runtime_config.vmaas_config.as_ref().and_then(
-                        |vc| {
-                            vc.bridging
-                                .as_ref()
-                                .map(|b| b.vf_intercept_bridge_sf.clone())
-                        },
-                    ),
+                    hbn_reps: vmaas_config.and_then(|vc| vc.hbn_reps.clone()),
+                    hbn_sfs: vmaas_config.and_then(|vc| vc.hbn_sfs.clone()),
+                    vf_intercept_bridge_name: traffic_intercept_bridging
+                        .map(|b| b.vf_intercept_bridge_name.clone()),
+                    vf_intercept_bridge_port: traffic_intercept_bridging
+                        .map(|b| b.vf_intercept_bridge_port.clone()),
+                    vf_intercept_bridge_sf: traffic_intercept_bridging
+                        .map(|b| b.vf_intercept_bridge_sf.clone()),
                     num_of_vfs: Some(api.runtime_config.dpu_config.num_of_vfs),
+                    hbn_bridge: traffic_intercept_bridging.map(|b| b.hbn_bridge.clone()),
+                    host_representor_intercept_bridging: traffic_intercept_bridging
+                        .and_then(|b| b.host_representor_intercept_bridging_provisioning_config()),
                 }),
                 metadata,
                 api_url_override,

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -671,11 +671,23 @@ pub(crate) async fn get_managed_host_network_config_inner(
             rpc::TrafficInterceptConfig {
                 bridging: c.bridging.as_ref().map(|b| rpc::TrafficInterceptBridging {
                     internal_bridge_routing_prefix: b.internal_bridge_routing_prefix.to_string(),
-                    host_intercept_bridge_name: b.host_intercept_bridge_name.clone(),
+                    hbn_bridge: b.hbn_bridge.clone(),
                     vf_intercept_bridge_name: b.vf_intercept_bridge_name.clone(),
                     vf_intercept_bridge_port: b.vf_intercept_bridge_port.clone(),
-                    host_intercept_bridge_port: b.host_intercept_bridge_port.clone(),
                     vf_intercept_bridge_sf: b.vf_intercept_bridge_sf.clone(),
+                    host_representor_intercept_bridging: b
+                        .host_representor_intercept_bridging
+                        .iter()
+                        .map(|(representor, bridge)| {
+                            (
+                                representor.clone(),
+                                rpc::HostRepresentorInterceptBridging {
+                                    bridge: bridge.bridge.clone(),
+                                    patch_port: bridge.patch_port.clone(),
+                                },
+                            )
+                        })
+                        .collect(),
                 }),
                 public_prefixes: c.public_prefixes.iter().map(|p| p.to_string()).collect(),
                 secondary_vtep_aggregate_prefixes: c

--- a/crates/pxe/src/routes/cloud_init.rs
+++ b/crates/pxe/src/routes/cloud_init.rs
@@ -32,6 +32,7 @@ use rpc::forge::PxeDomain;
 use crate::common::{AppState, Machine};
 
 const DEFAULT_NUM_OF_VFS: u32 = 16;
+const DEFAULT_HBN_BRIDGE: &str = "br-hbn";
 
 /// Generates the content of the /etc/forge/config.toml file.
 ///
@@ -74,8 +75,8 @@ fn user_data_handler(
     hbn_sfs: Option<String>,
     num_of_vfs: Option<u32>,
     vf_intercept_bridge_name: Option<String>,
-    host_intercept_bridge_name: Option<String>,
-    host_intercept_bridge_port: Option<String>,
+    host_representor_intercept_bridging: Option<String>,
+    hbn_bridge: Option<String>,
     vf_intercept_bridge_port: Option<String>,
     vf_intercept_bridge_sf: Option<String>,
     api_url_override: Option<String>,
@@ -141,6 +142,10 @@ fn user_data_handler(
 
     let num_of_vfs = num_of_vfs.unwrap_or(DEFAULT_NUM_OF_VFS);
     context.insert("num_of_vfs".to_string(), num_of_vfs.to_string());
+    context.insert(
+        "forge_hbn_bridge".to_string(),
+        hbn_bridge.unwrap_or_else(|| DEFAULT_HBN_BRIDGE.to_string()),
+    );
 
     if let Some(vf_intercept_bridge_name) = vf_intercept_bridge_name {
         context.insert(
@@ -149,22 +154,10 @@ fn user_data_handler(
         );
     }
 
-    if let Some(host_intercept_bridge_name) = host_intercept_bridge_name {
+    if let Some(host_representor_intercept_bridging) = host_representor_intercept_bridging {
         context.insert(
-            "forge_host_intercept_bridge_name".to_string(),
-            host_intercept_bridge_name,
-        );
-    }
-
-    if let Some(host_intercept_bridge_port) = host_intercept_bridge_port {
-        context.insert(
-            "forge_host_intercept_hbn_port".to_string(),
-            format!("patch-hbn-{host_intercept_bridge_port}"),
-        );
-
-        context.insert(
-            "forge_host_intercept_bridge_port".to_string(),
-            host_intercept_bridge_port,
+            "forge_host_representor_intercept_bridging".to_string(),
+            host_representor_intercept_bridging,
         );
     }
 
@@ -224,8 +217,8 @@ pub async fn user_data(machine: Machine, state: State<AppState>) -> impl IntoRes
                         discovery_instructions.hbn_sfs,
                         discovery_instructions.num_of_vfs,
                         discovery_instructions.vf_intercept_bridge_name,
-                        discovery_instructions.host_intercept_bridge_name,
-                        discovery_instructions.host_intercept_bridge_port,
+                        discovery_instructions.host_representor_intercept_bridging,
+                        discovery_instructions.hbn_bridge,
                         discovery_instructions.vf_intercept_bridge_port,
                         discovery_instructions.vf_intercept_bridge_sf,
                         machine.instructions.api_url_override,
@@ -420,13 +413,10 @@ mod tests {
             ("forge_hbn_reps".to_string(), String::new()),
             ("forge_hbn_sfs".to_string(), String::new()),
             (
-                "forge_host_intercept_bridge_name".to_string(),
+                "forge_host_representor_intercept_bridging".to_string(),
                 String::new(),
             ),
-            (
-                "forge_host_intercept_bridge_port".to_string(),
-                String::new(),
-            ),
+            ("forge_hbn_bridge".to_string(), "br-hbn".to_string()),
             ("forge_vf_intercept_bridge_name".to_string(), String::new()),
             ("forge_vf_intercept_bridge_port".to_string(), String::new()),
             ("hostname".to_string(), "test-host".to_string()),
@@ -456,6 +446,68 @@ mod tests {
         assert!(rendered.contains("--physdev-in pf0vf1_if"));
         assert!(rendered.contains("--physdev-in pf0vf2_if"));
         assert!(!rendered.contains("--physdev-in pf0vf3_if"));
+    }
+
+    /// Verifies the real user-data template renders each host representor bridge entry.
+    #[test]
+    fn user_data_template_renders_host_representor_intercept_bridging() {
+        let template_glob = concat!(env!("CARGO_MANIFEST_DIR"), "/../../pxe/templates/**/*");
+        let tera = tera::Tera::new(template_glob).unwrap();
+
+        // Use a non-empty provisioning string so the host representor bridge loop renders.
+        let context = HashMap::from([
+            (
+                "api_url".to_string(),
+                "https://carbide-api.forge".to_string(),
+            ),
+            (
+                "forge_agent_config_b64".to_string(),
+                "W21hY2hpbmVdCg==".to_string(),
+            ),
+            ("forge_bmc_fw_update".to_string(), String::new()),
+            ("forge_hbn_reps".to_string(), String::new()),
+            ("forge_hbn_sfs".to_string(), String::new()),
+            (
+                "forge_host_representor_intercept_bridging".to_string(),
+                "pf0hpf:br-host:patch-br-host-to-hbn,pf0vf0:br-vf0:patch-br-vf0-to-hbn".to_string(),
+            ),
+            ("forge_hbn_bridge".to_string(), "br-sfc".to_string()),
+            ("forge_vf_intercept_bridge_name".to_string(), String::new()),
+            ("forge_vf_intercept_bridge_port".to_string(), String::new()),
+            ("hostname".to_string(), "test-host".to_string()),
+            (
+                "interface_id".to_string(),
+                "91609f10-c91d-470d-a260-6293ea0c1234".to_string(),
+            ),
+            ("num_of_vfs".to_string(), "3".to_string()),
+            (
+                "pxe_url".to_string(),
+                "http://carbide-pxe.forge".to_string(),
+            ),
+            ("seconds_since_epoch".to_string(), "0".to_string()),
+        ]);
+        let rendered = tera
+            .render(
+                "user-data",
+                &tera::Context::from_serialize(context).unwrap(),
+            )
+            .unwrap();
+
+        // The loop should emit one assignment and invocation per bridge entry.
+        assert!(rendered.contains("ovs-vsctl get bridge br-sfc external_ids"));
+        assert!(rendered.contains("ovs-vsctl --may-exist add-port br-sfc"));
+        assert!(rendered.contains(
+            "host_representor_intercept_bridge_config=\"pf0hpf:br-host:patch-br-host-to-hbn\""
+        ));
+        assert!(rendered.contains(
+            "host_representor_intercept_bridge_config=\"pf0vf0:br-vf0:patch-br-vf0-to-hbn\""
+        ));
+        assert_eq!(
+            rendered
+                .matches(r#"add_host_representor_intercept_bridge "${host_representor}" "${host_intercept_bridge_name}" "${host_intercept_bridge_port}""#)
+                .count(),
+            2
+        );
     }
 
     #[test]

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -318,6 +318,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .type_attribute("forge.TrafficInterceptConfig", "#[derive(serde::Serialize)]")
         .type_attribute("forge.TrafficInterceptBridging", "#[derive(serde::Serialize)]")
+        .type_attribute("forge.HostRepresentorInterceptBridging", "#[derive(serde::Serialize)]")
         .type_attribute("forge.NetworkPrefix", "#[derive(serde::Serialize)]")
         .type_attribute("forge.NetworkPrefixEvent", "#[derive(serde::Serialize)]")
         .type_attribute("forge.NetworkSegmentConfig", "#[derive(serde::Serialize)]")

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4081,24 +4081,18 @@ message TrafficInterceptConfig {
   repeated string secondary_vtep_aggregate_prefixes = 4;
 }
 
-
 message TrafficInterceptBridging {
+  reserved 2, 4;
+  reserved "host_intercept_bridge_name", "host_intercept_bridge_port";
+
   // Prefix to be used for assigning gateway IPs
   // to bridges used for VMaaS routing within the DPU.
   string internal_bridge_routing_prefix  = 1;
-
-  // Name of the bridge acting as the last hop before the PF
-  // on the host.
-  string host_intercept_bridge_name      = 2;
 
   // Name of the bridge acting as the gateway for packets
   // leaving VMaaS pods and destined for the outside.
   // (E.g., internet or pods on other hosts)
   string vf_intercept_bridge_name        = 3;
-
-  // The name of the patch-port on the intercept bridge side
-  // that connects to the host_intercept_bridge.
-  string host_intercept_bridge_port      = 4;
 
   // Name of the patch-port on the intercept bridge side
   // of the vf_intercept_bridge that connects to the HBN pod
@@ -4108,6 +4102,12 @@ message TrafficInterceptBridging {
   // Name of SF used for routing VMaaS VF traffic into
   // the HBN pod.
   string vf_intercept_bridge_sf          = 6;
+
+  // Host-owned PF/VF representor bridging layout keyed by representor name.
+  map<string, HostRepresentorInterceptBridging> host_representor_intercept_bridging = 7;
+
+  // Bridge that intercept patch ports attach to during provisioning.
+  string hbn_bridge = 8;
 }
 
 message ManagedHostDpuExtensionServiceConfig {
@@ -4760,14 +4760,16 @@ message CloudInitDiscoveryInstructions {
   optional string hbn_reps = 3;
   optional string hbn_sfs = 4;
   optional string vf_intercept_bridge_name = 5;
-  optional string host_intercept_bridge_name = 6;
+
+  reserved 6;
+  reserved "host_intercept_bridge_name";
+
   // The <vf_intercept_bridge_name> side of the SF representor that connects the HBN pod to br-hbn.
   // This will be the side owned by the <vf_intercept_bridge_name> bridge
   optional string vf_intercept_bridge_port   = 7;
 
-  // The <host_intercept_bridge_name> side of the SF representor that connects the HBN pod to br-hbn.
-  // This will be the side owned by the <host_intercept_bridge_name> bridge.
-  optional string host_intercept_bridge_port = 8;
+  reserved 8;
+  reserved "host_intercept_bridge_port";
 
   // The representor that will plug into the HBN container to connect it to br-hbn
   // to open connectivity between all the VFs.
@@ -4776,6 +4778,13 @@ message CloudInitDiscoveryInstructions {
   // Number of VFs to configure per DPU PF during BlueField provisioning.
   // If absent, carbide-pxe uses the legacy default of 16 for rolling upgrades.
   optional uint32 num_of_vfs = 10;
+
+  // The layout for any desired additional bridging between
+  // host PF/VFs and HBN.
+  optional string host_representor_intercept_bridging = 11;
+
+  // Bridge that intercept patch ports attach to during BlueField provisioning.
+  optional string hbn_bridge = 12;
 }
 
 message CloudInitMetaData {
@@ -8357,4 +8366,9 @@ message IpxeTemplateArtifactUpdateRequest {
 message UpdateOperatingSystemIpxeTemplateArtifactRequest {
   common.OperatingSystemId id = 1;
   repeated IpxeTemplateArtifactUpdateRequest updates = 2;
+}
+
+message HostRepresentorInterceptBridging {
+  string bridge     = 1;
+  string patch_port = 2;
 }

--- a/pxe/templates/user-data
+++ b/pxe/templates/user-data
@@ -224,19 +224,19 @@ write_files:
         {% if forge_vf_intercept_bridge_port %}
 
           # Grab the current port index of the hbn bridge and increment it
-          next_br_hbn_ofport_index=$(($(ovs-vsctl get bridge br-hbn external_ids | grep -o '[0-9]*')+1))
+          next_br_hbn_ofport_index=$(($(ovs-vsctl get bridge {{ forge_hbn_bridge }} external_ids | grep -o '[0-9]*')+1))
 
           # Set the port index of the hbn bridge to the new index
-          ovs-vsctl set bridge br-hbn external_ids:ofport_index=${next_br_hbn_ofport_index}
+          ovs-vsctl set bridge {{ forge_hbn_bridge }} external_ids:ofport_index=${next_br_hbn_ofport_index}
 
           # Add the hbn side of our patch port and set its ofport index to match what we set on the hbn bridge
-          ovs-vsctl --may-exist add-port br-hbn {{ forge_vf_intercept_hbn_port }} -- set interface {{ forge_vf_intercept_hbn_port }} type=patch options:peer={{ forge_vf_intercept_bridge_port }} ofport_request="${next_br_hbn_ofport_index}"
+          ovs-vsctl --may-exist add-port {{ forge_hbn_bridge }} {{ forge_vf_intercept_hbn_port }} -- set interface {{ forge_vf_intercept_hbn_port }} type=patch options:peer={{ forge_vf_intercept_bridge_port }} ofport_request="${next_br_hbn_ofport_index}"
 
           # Add our side of the patch to our new bridge
           ovs-vsctl --may-exist add-port {{ forge_vf_intercept_bridge_name }} {{ forge_vf_intercept_bridge_port }} -- set interface {{ forge_vf_intercept_bridge_port }} type=patch options:peer={{ forge_vf_intercept_hbn_port }}
 
           # Adjust the sfc.conf to insert our patch port where {{ forge_vf_intercept_bridge_sf }} used to be
-          sed -i 's/br-hbn~{{ forge_vf_intercept_bridge_sf_representor }}~{{ forge_vf_intercept_bridge_sf_hbn_bridge_representor }}/br-hbn~{{ forge_vf_intercept_hbn_port }}~{{ forge_vf_intercept_bridge_sf_hbn_bridge_representor }}/' /etc/mellanox/sfc.conf
+          sed -i 's#{{ forge_hbn_bridge }}~{{ forge_vf_intercept_bridge_sf_representor }}~{{ forge_vf_intercept_bridge_sf_hbn_bridge_representor }}#{{ forge_hbn_bridge }}~{{ forge_vf_intercept_hbn_port }}~{{ forge_vf_intercept_bridge_sf_hbn_bridge_representor }}#' /etc/mellanox/sfc.conf
 
           # Match ofport and ofport_request match so that sfc.sh doesn't error out.
           ovs-vsctl set interface {{ forge_vf_intercept_bridge_port }} ofport_request=$(ovs-vsctl get interface {{ forge_vf_intercept_bridge_port }} ofport)
@@ -255,37 +255,55 @@ write_files:
         {% endif %}
       {% endif %}
 
-      {% if forge_host_intercept_bridge_name %}
+      {% if forge_host_representor_intercept_bridging %}
+        add_host_representor_intercept_bridge() {
+          local host_representor="$1"
+          local host_intercept_bridge_name="$2"
+          local host_intercept_bridge_port="$3"
+          local host_intercept_hbn_port="hpp-${host_intercept_bridge_port}"
 
-        # Create our new bridge
-        ovs-vsctl --may-exist add-br {{ forge_host_intercept_bridge_name }} -- set bridge {{ forge_host_intercept_bridge_name }} datapath_type=netdev
-
-        {% if forge_host_intercept_bridge_port %}
+          # Create our new bridge
+          ovs-vsctl --may-exist add-br "${host_intercept_bridge_name}" -- set bridge "${host_intercept_bridge_name}" datapath_type=netdev
 
           # Grab the current port index of the hbn bridge and increment it
-          next_br_hbn_ofport_index=$(($(ovs-vsctl get bridge br-hbn external_ids | grep -o '[0-9]*')+1))
+          next_br_hbn_ofport_index=$(($(ovs-vsctl get bridge {{ forge_hbn_bridge }} external_ids | grep -o '[0-9]*')+1))
 
           # Set the port index of the hbn bridge to the new index
-          ovs-vsctl set bridge br-hbn external_ids:ofport_index=${next_br_hbn_ofport_index}
+          ovs-vsctl set bridge {{ forge_hbn_bridge }} external_ids:ofport_index="${next_br_hbn_ofport_index}"
 
           # Add our patch port to br-hbn and set its ofport index to match what we set on the hbn bridge
-          ovs-vsctl --may-exist add-port br-hbn {{ forge_host_intercept_hbn_port }} -- set interface {{ forge_host_intercept_hbn_port }} type=patch options:peer={{ forge_host_intercept_bridge_port }} ofport_request="${next_br_hbn_ofport_index}" external_ids='{dependencies=pf0hpf_if_r, hbn_netdev=pf0hpf_if, hbn_rep_ofport=pf0hpf_if_r}'
+          ovs-vsctl --may-exist add-port {{ forge_hbn_bridge }} "${host_intercept_hbn_port}" -- set interface "${host_intercept_hbn_port}" type=patch options:peer="${host_intercept_bridge_port}" ofport_request="${next_br_hbn_ofport_index}" external_ids="{dependencies=${host_representor}_if_r, hbn_netdev=${host_representor}_if, hbn_rep_ofport=${host_representor}_if_r}"
 
           # Add our side of the patch to our new bridge
-          ovs-vsctl --may-exist add-port {{ forge_host_intercept_bridge_name }} {{ forge_host_intercept_bridge_port }} -- set interface {{ forge_host_intercept_bridge_port }} type=patch options:peer={{ forge_host_intercept_hbn_port }}
+          ovs-vsctl --may-exist add-port "${host_intercept_bridge_name}" "${host_intercept_bridge_port}" -- set interface "${host_intercept_bridge_port}" type=patch options:peer="${host_intercept_hbn_port}"
 
           # Match ofport and ofport_request match so that sfc.sh doesn't error out.
-          ovs-vsctl set interface {{ forge_host_intercept_bridge_port }} ofport_request=$(ovs-vsctl get interface {{ forge_host_intercept_bridge_port }} ofport)
+          ovs-vsctl set interface "${host_intercept_bridge_port}" ofport_request=$(ovs-vsctl get interface "${host_intercept_bridge_port}" ofport)
 
-          # Adjust the sfc.conf to insert our patch port where pf0hpf used to be
-          sed -i 's/br-hbn~pf0hpf~pf0hpf_if_r~pf0hpf_if~pf0hpf_if_r/br-hbn~{{ forge_host_intercept_hbn_port }}~pf0hpf_if_r~pf0hpf_if~pf0hpf_if_r/' /etc/mellanox/sfc.conf
+          # Adjust the sfc.conf to insert our patch port where the host representor used to be
+          sed -i "s#{{ forge_hbn_bridge }}~${host_representor}~${host_representor}_if_r~${host_representor}_if~${host_representor}_if_r#{{ forge_hbn_bridge }}~${host_intercept_hbn_port}~${host_representor}_if_r~${host_representor}_if~${host_representor}_if_r#" /etc/mellanox/sfc.conf
 
-          # Now pop pf0hpf off of br-hbn and attach it to br-host
-          ovs-vsctl --if-exists del-port pf0hpf -- \
-            --may-exist add-port {{ forge_host_intercept_bridge_name }} pf0hpf -- \
-            set interface pf0hpf type=dpdk mtu_request=9216 external_ids='{}'
-          ovs-vsctl set interface pf0hpf ofport_request=$(ovs-vsctl get interface pf0hpf ofport)
-        {% endif %}
+          # Now pop the host representor off of br-hbn and attach it to the host intercept bridge
+          ovs-vsctl --if-exists del-port "${host_representor}" -- \
+            --may-exist add-port "${host_intercept_bridge_name}" "${host_representor}" -- \
+            set interface "${host_representor}" type=dpdk mtu_request=9216 external_ids='{}'
+          ovs-vsctl set interface "${host_representor}" ofport_request=$(ovs-vsctl get interface "${host_representor}" ofport)
+
+          # Add the detail about the "uplink" for this bridge to external ids for the bridge
+          ovs-vsctl br-set-external-id "${host_intercept_bridge_name}" bridge-uplink "${host_intercept_bridge_port}"
+        }
+
+        {% for entry in forge_host_representor_intercept_bridging | split(pat=",") %}
+          host_representor_intercept_bridge_config={{ entry | json_encode | safe }}
+          IFS=':' read -r host_representor host_intercept_bridge_name host_intercept_bridge_port extra <<< "${host_representor_intercept_bridge_config}"
+
+          if [[ -z "${host_representor}" || -z "${host_intercept_bridge_name}" || -z "${host_intercept_bridge_port}" || -n "${extra}" ]]; then
+            echo "invalid host representor intercept bridge config: ${host_representor_intercept_bridge_config}" >&2
+            exit 1
+          fi
+
+          add_host_representor_intercept_bridge "${host_representor}" "${host_intercept_bridge_name}" "${host_intercept_bridge_port}"
+        {% endfor %}
       {% endif %}
 
       # Now restart sfc. This might not be necessary since OVS restart seems


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
This PR adds support for configuring intermediate bridges on any PF or VF owned by the host to aid packet steering by OVN custom flows.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

