### PR TITLE
chore: Add [cis] tag to RequestRepair details for repair automation

### DIFF
--- a/crates/admin-cli/src/machine/health_report/cmd.rs
+++ b/crates/admin-cli/src/machine/health_report/cmd.rs
@@ -155,6 +155,14 @@ pub fn get_health_report(template: HealthReportTemplates, message: Option<String
             report.alerts[0].id = HealthProbeId::from_str("RequestRepair")
                 .expect("RequestRepair is a valid non-empty HealthProbeId");
             report.alerts[0].target = Some("repair-requested".to_string());
+            let summary = report.alerts[0].message.clone();
+            let details = health_report::repair_details_with_cis_tag(&summary);
+            report.alerts[0].message = serde_json::json!({
+                "issue_category": "Other",
+                "summary": summary,
+                "details": details,
+            })
+            .to_string();
             report.alerts[0].classifications = vec![
                 HealthAlertClassification::prevent_allocations(),
                 HealthAlertClassification::suppress_external_alerting(),
@@ -268,9 +276,14 @@ mod tests {
         let alert = &report.alerts[0];
         assert_eq!(alert.id, HealthProbeId::from_str("RequestRepair").unwrap());
         assert_eq!(alert.target, Some("repair-requested".to_string()));
+        let message: serde_json::Value = serde_json::from_str(&alert.message).unwrap();
         assert_eq!(
-            alert.message,
-            "Hardware diagnostics indicate memory failure"
+            message["summary"].as_str(),
+            Some("Hardware diagnostics indicate memory failure")
+        );
+        assert_eq!(
+            message["details"].as_str(),
+            Some("[cis] Hardware diagnostics indicate memory failure")
         );
         assert!(alert.tenant_message.is_none());
 
@@ -301,7 +314,22 @@ mod tests {
         let report = get_health_report(HealthReportTemplates::RequestRepair, None);
 
         assert_eq!(report.source, health_report::REPAIR_REQUEST_MERGE_SOURCE);
-        assert_eq!(report.alerts[0].message, "");
+        let message: serde_json::Value = serde_json::from_str(&report.alerts[0].message).unwrap();
+        assert_eq!(message["details"].as_str(), Some("[cis]"));
+    }
+
+    #[test]
+    fn test_request_repair_template_does_not_duplicate_cis_tag() {
+        let report = get_health_report(
+            HealthReportTemplates::RequestRepair,
+            Some("[cis] Hardware diagnostics indicate memory failure".to_string()),
+        );
+
+        let message: serde_json::Value = serde_json::from_str(&report.alerts[0].message).unwrap();
+        assert_eq!(
+            message["details"].as_str(),
+            Some("[cis] Hardware diagnostics indicate memory failure")
+        );
     }
 
     #[test]

--- a/crates/api-core/src/handlers/instance.rs
+++ b/crates/api-core/src/handlers/instance.rs
@@ -343,7 +343,7 @@ fn create_request_repair_override(issue: &rpc::Issue) -> HealthReport {
             message: json!({
                 "issue_category": format!("{:?}", rpc::IssueCategory::try_from(issue.category).unwrap_or(rpc::IssueCategory::Unspecified)),
                 "summary": issue.summary,
-                "details": issue.details
+                "details": health_report::repair_details_with_cis_tag(&issue.details)
             }).to_string(),
             tenant_message: Some(format!(
                 "RepairSystem: Node ready for repair - {}",

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -5786,10 +5786,11 @@ async fn test_instance_release_auto_repair_enabled(_: PgPoolOptions, options: Pg
     );
     assert_eq!(repair_report.alerts.len(), 1);
     assert_eq!(repair_report.alerts[0].id.to_string(), "RequestRepair");
-    assert!(
-        repair_report.alerts[0]
-            .message
-            .contains("Memory DIMM failure detected")
+    let repair_message: serde_json::Value =
+        serde_json::from_str(&repair_report.alerts[0].message).unwrap();
+    assert_eq!(
+        repair_message["details"].as_str(),
+        Some("[cis] ECC errors increasing, DIMM slot 3 needs replacement")
     );
 
     println!("Auto-repair enabled test passed:");

--- a/crates/api-web/templates/health_reports_detail.html
+++ b/crates/api-web/templates/health_reports_detail.html
@@ -162,7 +162,11 @@ const templateMergeBreakfix = {
 	health_report: {
 		source: "repair-request",
 		successes: [],
-		alerts: [{id: "RequestRepair", target: "RequestRepair", message: "Machine is broken, setting RequestRepair tag for automated repair",
+		alerts: [{id: "RequestRepair", target: "RequestRepair", message: JSON.stringify({
+			issue_category: "Other",
+			summary: "Machine is broken, setting RequestRepair tag for automated repair",
+			details: "[cis] Machine is broken, setting RequestRepair tag for automated repair",
+		}),
 			tenant_message: null, classifications: ["PreventAllocations", "SuppressExternalAlerting"]}]
 	}
 };
@@ -221,6 +225,68 @@ const templateReplaceAsHealthy = {
 	}
 };
 
+const cisRepairDetailsTag = "[cis]";
+
+function detailsWithCisTag(details) {
+	if (details.trimStart().startsWith(cisRepairDetailsTag)) {
+		return details;
+	}
+	if (details.length == 0) {
+		return cisRepairDetailsTag;
+	}
+	return `${cisRepairDetailsTag} ${details}`;
+}
+
+function requestRepairMessageWithCisDetails(message) {
+	if (typeof message != "string") {
+		return message;
+	}
+
+	let parsedMessage;
+	try {
+		parsedMessage = JSON.parse(message);
+	} catch {
+		return message;
+	}
+
+	if (parsedMessage == null || typeof parsedMessage != "object" || Array.isArray(parsedMessage) || typeof parsedMessage.details != "string") {
+		return message;
+	}
+
+	parsedMessage.details = detailsWithCisTag(parsedMessage.details);
+	return JSON.stringify(parsedMessage);
+}
+
+function healthReportBodyForSubmit() {
+	const textArea = document.getElementById("health-report");
+	let report;
+	try {
+		report = JSON.parse(textArea.value);
+	} catch {
+		return textArea.value;
+	}
+
+	const alerts = report?.health_report?.alerts;
+	if (!Array.isArray(alerts)) {
+		return textArea.value;
+	}
+
+	let changed = false;
+	for (const alert of alerts) {
+		if (alert?.id == "RequestRepair") {
+			alert.message = requestRepairMessageWithCisDetails(alert.message);
+			changed = true;
+		}
+	}
+
+	if (!changed) {
+		return textArea.value;
+	}
+
+	textArea.value = JSON.stringify(report, null, 2);
+	return textArea.value;
+}
+
 function add_click_listener([id, path, body]) {
 	document.getElementById(id).addEventListener("click", async e => {
 		e.preventDefault();
@@ -253,7 +319,7 @@ function setHealthReportTextBoxToTemplate(template) {
 document.addEventListener("DOMContentLoaded", function (event) {
 	setHealthReportTextBoxToTemplate(templateHealthReport);
 	for (const item of [
-		["submit_add", "/add-report", () => document.getElementById("health-report").value],
+		["submit_add", "/add-report", healthReportBodyForSubmit],
 	]) {
 		add_click_listener(item);
 	}

--- a/crates/health-report/src/lib.rs
+++ b/crates/health-report/src/lib.rs
@@ -25,6 +25,20 @@ use serde::{Deserialize, Serialize};
 pub const REPAIR_REQUEST_MERGE_SOURCE: &str = "repair-request";
 /// `HealthReportSources::merges` key for online repair gating (`RequestOnlineRepair` override).
 pub const REQUEST_ONLINE_REPAIR_MERGE_SOURCE: &str = "request-online-repair";
+/// Marker used by CIS automation in RequestRepair alert message details.
+pub const CIS_REPAIR_DETAILS_TAG: &str = "[cis]";
+
+pub fn repair_details_with_cis_tag(details: &str) -> String {
+    if details.trim_start().starts_with(CIS_REPAIR_DETAILS_TAG) {
+        return details.to_string();
+    }
+
+    if details.is_empty() {
+        return CIS_REPAIR_DETAILS_TAG.to_string();
+    }
+
+    format!("{CIS_REPAIR_DETAILS_TAG} {details}")
+}
 
 /// Reports the aggregate health of a system or subsystem
 #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
@@ -761,6 +775,31 @@ mod tests {
     fn prevent_instance_deletion_classification_string() {
         let c = HealthAlertClassification::prevent_instance_deletion();
         assert_eq!(c.as_str(), "PreventInstanceDeletion");
+    }
+
+    #[test]
+    fn repair_details_with_cis_tag_adds_tag() {
+        assert_eq!(
+            repair_details_with_cis_tag("Hardware diagnostics indicate memory failure"),
+            "[cis] Hardware diagnostics indicate memory failure"
+        );
+    }
+
+    #[test]
+    fn repair_details_with_cis_tag_does_not_duplicate_tag() {
+        assert_eq!(
+            repair_details_with_cis_tag("[cis] Hardware diagnostics indicate memory failure"),
+            "[cis] Hardware diagnostics indicate memory failure"
+        );
+        assert_eq!(
+            repair_details_with_cis_tag("  [cis] Hardware diagnostics indicate memory failure"),
+            "  [cis] Hardware diagnostics indicate memory failure"
+        );
+    }
+
+    #[test]
+    fn repair_details_with_cis_tag_handles_empty_details() {
+        assert_eq!(repair_details_with_cis_tag(""), "[cis]");
     }
 
     #[test]


### PR DESCRIPTION
## Description
The repair automation workflow requires a `[cis]` tag at the beginning of the health override's `message.details` string. This PR automatically prepends the required tag, if not specified by the user.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

DSXSRE-232

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

