### PR TITLE
chore(rest-api): Apply our FromProto/ToProto modeling to NVLinkLogicalPartition

### DIFF
--- a/rest-api/api/pkg/api/handler/instance_test.go
+++ b/rest-api/api/pkg/api/handler/instance_test.go
@@ -826,10 +826,10 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 	assert.NotNil(t, osPhoneHome)
 
 	// create a default NVLink Logical Partition
-	nvllpDefault := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-default", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg, st1, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllpDefault := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-default", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg, st1, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllpDefault)
 
-	nvllpNotDefault := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-not-default", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg, st1, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllpNotDefault := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-not-default", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg, st1, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllpNotDefault)
 
 	vpc1 := testInstanceBuildVPC(t, dbSession, "test-vpc-1", ip, tn1, st1, cdb.GetUUIDPtr(uuid.New()), nil, cdb.GetStrPtr(cdbm.VpcEthernetVirtualizer), cdb.GetUUIDPtr(nvllpDefault.ID), cdbm.VpcStatusReady, tnu1)
@@ -1130,10 +1130,10 @@ func TestCreateInstanceHandler_Handle(t *testing.T) {
 	vpcPrefixSite2 := common.TestBuildVPCPrefix(t, dbSession, "test-vpcprefix-site2", st2, tn1, vpc9Site2.ID, &ipbSite2.ID, cdb.GetStrPtr("192.170.0.0/24"), cdb.GetIntPtr(24), cdbm.VpcPrefixStatusReady, tnu1)
 	assert.NotNil(t, vpcPrefixSite2)
 	// NvLink Logical Partition
-	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg, st1, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg, st1, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp1)
 
-	nvllp2 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-2", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg, st1, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp2 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-2", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg, st1, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp2)
 
 	e := echo.New()
@@ -3946,10 +3946,10 @@ func TestUpdateInstanceHandler_Handle(t *testing.T) {
 	// Add NVLink GPU capability to Machine
 	common.TestBuildMachineCapability(t, dbSession, &mc5.ID, nil, cdbm.MachineCapabilityTypeGPU, "NVIDIA GB200", nil, nil, cdb.GetStrPtr("NVIDIA"), cdb.GetIntPtr(4), cdb.Ptr(cdbm.MachineCapabilityDeviceTypeNVLink), nil)
 
-	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, st3, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, st3, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp1)
 
-	nvllp2 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-2", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, st3, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp2 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-2", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, st3, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp2)
 
 	instnvlifc1 := testInstanceBuildInstanceNVLinkInterface(t, dbSession, st3.ID, inst13.ID, nvllp1.ID, cdb.GetUUIDPtr(uuid.New()), cdb.GetStrPtr("NVIDIA GB200"), 0, cdbm.NVLinkInterfaceStatusReady)

--- a/rest-api/api/pkg/api/handler/instancebatch_test.go
+++ b/rest-api/api/pkg/api/handler/instancebatch_test.go
@@ -140,7 +140,7 @@ func TestBatchCreateInstanceHandler_Handle(t *testing.T) {
 	assert.NotNil(t, ibp1)
 
 	// NVLink Logical Partition for testing NVLink Interfaces
-	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg, st1, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg, st1, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp1)
 
 	// Add NVLink GPU capability to Instance Type 1 for NVLink interface tests

--- a/rest-api/api/pkg/api/handler/nvlinkinterface_test.go
+++ b/rest-api/api/pkg/api/handler/nvlinkinterface_test.go
@@ -107,7 +107,7 @@ func TestGetAllNVLinkInterface_Handle(t *testing.T) {
 
 	nvlinklogicalpartitions := []*cdbm.NVLinkLogicalPartition{}
 	for i := 0; i < 3; i++ {
-		nvlinklogicalpartition1 := testBuildNVLinkLogicalPartition(t, dbSession, fmt.Sprintf("test-nvlinklogicalpartition-%d", i), cdb.GetStrPtr("Test NVLink Logical Partition"), tn1.Org, st1, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+		nvlinklogicalpartition1 := testBuildNVLinkLogicalPartition(t, dbSession, fmt.Sprintf("test-nvlinklogicalpartition-%d", i), cdb.GetStrPtr("Test NVLink Logical Partition"), tn1.Org, st1, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 		assert.NotNil(t, nvlinklogicalpartition1)
 		nvlinklogicalpartitions = append(nvlinklogicalpartitions, nvlinklogicalpartition1)
 	}
@@ -800,7 +800,7 @@ func TestGetAllInstanceNVLinkInterfaceHandler_Handle(t *testing.T) {
 
 	nvllps := []*cdbm.NVLinkLogicalPartition{}
 	for i := 0; i < 3; i++ {
-		nvlinklogicalpartition1 := testBuildNVLinkLogicalPartition(t, dbSession, fmt.Sprintf("test-nvlinklogicalpartition-%d", i), cdb.GetStrPtr("Test NVLink Logical Partition"), tn1.Org, st1, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+		nvlinklogicalpartition1 := testBuildNVLinkLogicalPartition(t, dbSession, fmt.Sprintf("test-nvlinklogicalpartition-%d", i), cdb.GetStrPtr("Test NVLink Logical Partition"), tn1.Org, st1, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 		assert.NotNil(t, nvlinklogicalpartition1)
 		nvllps = append(nvllps, nvlinklogicalpartition1)
 	}

--- a/rest-api/api/pkg/api/handler/nvlinklogicalpartition.go
+++ b/rest-api/api/pkg/api/handler/nvlinklogicalpartition.go
@@ -221,7 +221,7 @@ func (cibph CreateNVLinkLogicalPartitionHandler) Handle(c echo.Context) error {
 		}
 
 		// create the status detail record
-		ssd, derr = sdDAO.CreateFromParams(ctx, tx, nvllp.ID.String(), *cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusPending),
+		ssd, derr = sdDAO.CreateFromParams(ctx, tx, nvllp.ID.String(), string(cdbm.NVLinkLogicalPartitionStatusPending),
 			cdb.GetStrPtr("received NVLink Logical Partition creation request, pending"))
 		if derr != nil {
 			logger.Error().Err(derr).Msg("error creating Status Detail DB entry")
@@ -239,20 +239,7 @@ func (cibph CreateNVLinkLogicalPartitionHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		createRequest := &cwssaws.NVLinkLogicalPartitionCreationRequest{
-			Id: &cwssaws.NVLinkLogicalPartitionId{Value: nvllp.ID.String()},
-			Config: &cwssaws.NVLinkLogicalPartitionConfig{
-				Metadata: &cwssaws.Metadata{
-					Name: nvllp.Name,
-				},
-				TenantOrganizationId: orgTenant.Org,
-			},
-		}
-
-		// Include description if it is present
-		if nvllp.Description != nil {
-			createRequest.Config.Metadata.Description = *nvllp.Description
-		}
+		createRequest := apiRequest.ToProto(nvllp)
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:                       "nvlink-logical-partition-create-" + nvllp.ID.String(),
@@ -317,10 +304,12 @@ func (cibph CreateNVLinkLogicalPartitionHandler) Handle(c echo.Context) error {
 	if protoNvllp != nil {
 		logger.Info().Msg("received NVLink Logical Partition info from workflow")
 
-		status, statusMessage := wfutil.GetNVLinkLogicalPartitionStatus(protoNvllp.Status.State)
-		// if status is nil, then default is pending and inventory will be updating status from workflow
-		if status != nil {
-			updatedNvllp, newSSD, err := wfutil.UpdateNVLinkLogicalPartitionStatusInDB(ctx, nil, cibph.dbSession, nvllp.ID, status, statusMessage)
+		var status cdbm.NVLinkLogicalPartitionStatus
+		status.FromProto(protoNvllp.Status.State)
+		// if status is empty, then default is pending and inventory will be updating status from workflow
+		if status != "" {
+			message := status.Message()
+			updatedNvllp, newSSD, err := wfutil.UpdateNVLinkLogicalPartitionStatusInDB(ctx, nil, cibph.dbSession, nvllp.ID, &status, &message)
 			if err != nil {
 				logger.Error().Err(err).Msg("failed to update NVLink Logical Partition status in DB")
 			} else {
@@ -476,7 +465,7 @@ func (gaibph GetAllNVLinkLogicalPartitionHandler) Handle(c echo.Context) error {
 	statusQuery := c.QueryParam("status")
 	if statusQuery != "" {
 		gaibph.tracerSpan.SetAttribute(handlerSpan, attribute.String("status", statusQuery), logger)
-		_, ok := cdbm.NVLinkLogicalPartitionStatusMap[statusQuery]
+		_, ok := cdbm.NVLinkLogicalPartitionStatusMap[cdbm.NVLinkLogicalPartitionStatus(statusQuery)]
 		if !ok {
 			logger.Warn().Msg(fmt.Sprintf("invalid value in status query: %v", statusQuery))
 			return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Invalid Status value in query", nil)
@@ -1030,21 +1019,11 @@ func (uibph UpdateNVLinkLogicalPartitionHandler) Handle(c echo.Context) error {
 			return nil, cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		updateRequest := &cwssaws.NVLinkLogicalPartitionUpdateRequest{
-			Id: &cwssaws.NVLinkLogicalPartitionId{Value: updated.ID.String()},
-			Config: &cwssaws.NVLinkLogicalPartitionConfig{
-				TenantOrganizationId: orgTenant.Org,
-				Metadata:             &cwssaws.Metadata{},
-			},
-		}
-
-		// Site Controller (NICo) requires metadata.name on every update. When the client
-		// sends only description, apiRequest.Name is nil but we must still send the
-		// current partition name from the DB.
-		updateRequest.Config.Metadata.Name = updated.Name
-		if updated.Description != nil {
-			updateRequest.Config.Metadata.Description = *updated.Description
-		}
+		// Site Controller (NICo) requires metadata.name on every update. When the
+		// client sends only description, apiRequest.Name is nil but we must still
+		// send the current partition name from the DB; ToProto reads it directly
+		// off the (already-updated) DB entity via the entity's ToProto().
+		updateRequest := apiRequest.ToProto(updated)
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:                       "nvlink-logical-partition-update-" + updated.ID.String(),
@@ -1270,12 +1249,13 @@ func (dibph DeleteNVLinkLogicalPartitionHandler) Handle(c echo.Context) error {
 	var timeoutResp func() error
 	err = cdb.WithTx(ctx, dibph.dbSession, func(tx *cdb.Tx) error {
 		// Update NVLink Logical Partition and set status to Deleting
+		deletingStatus := cdbm.NVLinkLogicalPartitionStatusDeleting
 		if _, derr := nvllpDAO.Update(
 			ctx,
 			tx,
 			cdbm.NVLinkLogicalPartitionUpdateInput{
 				NVLinkLogicalPartitionID: nvllpID,
-				Status:                   cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusDeleting),
+				Status:                   &deletingStatus,
 			},
 		); derr != nil {
 			logger.Error().Err(derr).Msg("error updating NVLink Logical Partition in DB")
@@ -1283,7 +1263,7 @@ func (dibph DeleteNVLinkLogicalPartitionHandler) Handle(c echo.Context) error {
 		}
 
 		// Create status detail
-		ssd, derr := sdDAO.CreateFromParams(ctx, tx, nvllp.ID.String(), *cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusDeleting),
+		ssd, derr := sdDAO.CreateFromParams(ctx, tx, nvllp.ID.String(), string(deletingStatus),
 			cdb.GetStrPtr("Received request for deletion, pending processing"))
 		if derr != nil {
 			logger.Error().Err(derr).Msg("error creating Status Detail DB entry")
@@ -1301,9 +1281,7 @@ func (dibph DeleteNVLinkLogicalPartitionHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		deleteNvllpRequest := &cwssaws.NVLinkLogicalPartitionDeletionRequest{
-			Id: &cwssaws.NVLinkLogicalPartitionId{Value: nvllp.ID.String()},
-		}
+		deleteNvllpRequest := nvllp.ToDeletionRequestProto()
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:                       "nvlink-logical-partition-delete-" + nvllp.ID.String(),

--- a/rest-api/api/pkg/api/handler/nvlinklogicalpartition_test.go
+++ b/rest-api/api/pkg/api/handler/nvlinklogicalpartition_test.go
@@ -38,9 +38,9 @@ import (
 	tp "go.temporal.io/sdk/temporal"
 )
 
-func testBuildNVLinkLogicalPartition(t *testing.T, dbSession *cdb.Session, name string, description *string, org string, site *cdbm.Site, tenant *cdbm.Tenant, status *string, isMissingOnSite bool) *cdbm.NVLinkLogicalPartition {
+func testBuildNVLinkLogicalPartition(t *testing.T, dbSession *cdb.Session, name string, description *string, org string, site *cdbm.Site, tenant *cdbm.Tenant, status *cdbm.NVLinkLogicalPartitionStatus, isMissingOnSite bool) *cdbm.NVLinkLogicalPartition {
 	if status == nil {
-		status = cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady)
+		status = cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady)
 	}
 	nvllp := &cdbm.NVLinkLogicalPartition{
 		ID:              uuid.New(),
@@ -442,19 +442,19 @@ func TestNVLinkLogicalPartitionHandler_Update(t *testing.T) {
 	ts3 := testBuildTenantSiteAssociation(t, dbSession, tnOrg1, tn1.ID, site3.ID, tnu1.ID)
 	assert.NotNil(t, ts3)
 
-	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, site1, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusPending), false)
+	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, site1, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusPending), false)
 	assert.NotNil(t, nvllp1)
 
-	nvllp2 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-2", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, site2, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusPending), false)
+	nvllp2 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-2", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, site2, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusPending), false)
 	assert.NotNil(t, nvllp2)
 
-	nvllp3 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-3", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg2, site1, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusPending), false)
+	nvllp3 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-3", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg2, site1, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusPending), false)
 	assert.NotNil(t, nvllp3)
 
-	nvllp4 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-4", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, site3, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusPending), false)
+	nvllp4 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-4", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, site3, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusPending), false)
 	assert.NotNil(t, nvllp4)
 
-	nvllp5 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-5", cdb.GetStrPtr("preserved-for-nico"), tnOrg1, site1, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusPending), false)
+	nvllp5 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-5", cdb.GetStrPtr("preserved-for-nico"), tnOrg1, site1, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusPending), false)
 	assert.NotNil(t, nvllp5)
 
 	noupdateObj := model.APINVLinkLogicalPartitionUpdateRequest{Name: cdb.GetStrPtr("test-nvllp-1"), Description: cdb.GetStrPtr("Test NVLink Logical Partition")}
@@ -898,8 +898,8 @@ func TestNVLinkLogicalPartitionHandler_GetAll(t *testing.T) {
 			},
 		)
 		assert.Nil(t, err)
-		common.TestBuildStatusDetail(t, dbSession, nvllp.ID.String(), cdbm.NVLinkLogicalPartitionStatusPending, cdb.GetStrPtr("request received, pending processing"))
-		common.TestBuildStatusDetail(t, dbSession, nvllp.ID.String(), cdbm.NVLinkLogicalPartitionStatusReady, cdb.GetStrPtr("NVLinkLogical Partition is now ready for use"))
+		common.TestBuildStatusDetail(t, dbSession, nvllp.ID.String(), string(cdbm.NVLinkLogicalPartitionStatusPending), cdb.GetStrPtr("request received, pending processing"))
+		common.TestBuildStatusDetail(t, dbSession, nvllp.ID.String(), string(cdbm.NVLinkLogicalPartitionStatusReady), cdb.GetStrPtr("NVLinkLogical Partition is now ready for use"))
 		nvllps = append(nvllps, *nvllp)
 	}
 
@@ -908,17 +908,17 @@ func TestNVLinkLogicalPartitionHandler_GetAll(t *testing.T) {
 
 	//Site 2
 
-	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1-site2", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg4, site2, tn2, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1-site2", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg4, site2, tn2, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp1)
 
-	common.TestBuildStatusDetail(t, dbSession, nvllp1.ID.String(), cdbm.NVLinkLogicalPartitionStatusPending, cdb.GetStrPtr("request received, pending processing"))
-	common.TestBuildStatusDetail(t, dbSession, nvllp1.ID.String(), cdbm.NVLinkLogicalPartitionStatusReady, cdb.GetStrPtr("NVLinkLogical Partition is now ready for use"))
+	common.TestBuildStatusDetail(t, dbSession, nvllp1.ID.String(), string(cdbm.NVLinkLogicalPartitionStatusPending), cdb.GetStrPtr("request received, pending processing"))
+	common.TestBuildStatusDetail(t, dbSession, nvllp1.ID.String(), string(cdbm.NVLinkLogicalPartitionStatusReady), cdb.GetStrPtr("NVLinkLogical Partition is now ready for use"))
 
-	nvllp2 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-2-site2", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg4, site2, tn2, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp2 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-2-site2", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg4, site2, tn2, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp2)
 
-	common.TestBuildStatusDetail(t, dbSession, nvllp2.ID.String(), cdbm.NVLinkLogicalPartitionStatusPending, cdb.GetStrPtr("request received, pending processing"))
-	common.TestBuildStatusDetail(t, dbSession, nvllp2.ID.String(), cdbm.NVLinkLogicalPartitionStatusReady, cdb.GetStrPtr("NVLinkLogical Partition is now ready for use"))
+	common.TestBuildStatusDetail(t, dbSession, nvllp2.ID.String(), string(cdbm.NVLinkLogicalPartitionStatusPending), cdb.GetStrPtr("request received, pending processing"))
+	common.TestBuildStatusDetail(t, dbSession, nvllp2.ID.String(), string(cdbm.NVLinkLogicalPartitionStatusReady), cdb.GetStrPtr("NVLinkLogical Partition is now ready for use"))
 
 	vpc2 := testInstanceBuildVPC(t, dbSession, "test-vpc-2", ip1, tn2, site2, nil, nil, cdb.GetStrPtr(cdbm.VpcEthernetVirtualizer), cdb.GetUUIDPtr(nvllp1.ID), cdbm.VpcStatusPending, tnu1)
 	assert.NotNil(t, vpc2)
@@ -1137,7 +1137,7 @@ func TestNVLinkLogicalPartitionHandler_GetAll(t *testing.T) {
 			reqOrgName:     tnOrg1,
 			user:           tnu1,
 			querySiteID:    cdb.GetStrPtr(site1.ID.String()),
-			queryStatus:    cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusPending),
+			queryStatus:    cdb.GetTypedStrPtr(cdbm.NVLinkLogicalPartitionStatusPending),
 			expectedErr:    false,
 			expectedStatus: http.StatusOK,
 			expectedCnt:    paginator.DefaultLimit,
@@ -1346,10 +1346,10 @@ func TestNVLinkLogicalPartitionHandler_GetByID(t *testing.T) {
 	os1 := testInstanceBuildOperatingSystem(t, dbSession, "test-operating-system-1", tn1, cdbm.OperatingSystemTypeImage, false, nil, false, cdbm.OperatingSystemStatusReady, tnu1)
 	assert.NotNil(t, os1)
 
-	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, site1, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, site1, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp1)
 
-	nvllp2 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-2", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg2, site2, tn2, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp2 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-2", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg2, site2, tn2, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp2)
 
 	vpc1 := testInstanceBuildVPC(t, dbSession, "test-vpc-1", ip1, tn1, site1, cdb.GetUUIDPtr(uuid.New()), nil, cdb.GetStrPtr(cdbm.VpcEthernetVirtualizer), cdb.GetUUIDPtr(nvllp1.ID), cdbm.VpcStatusReady, tnu1)
@@ -1636,13 +1636,13 @@ func TestNVLinkLogicalPartitionHandler_Delete(t *testing.T) {
 	ts4 := testBuildTenantSiteAssociation(t, dbSession, tnOrg4, tn4.ID, site2.ID, tnu4.ID)
 	assert.NotNil(t, ts4)
 
-	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, site1, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, site1, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp1)
 
-	nvllp3 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-3", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg3, site2, tn3, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp3 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-3", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg3, site2, tn3, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp3)
 
-	nvllp4 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-4", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg4, site2, tn4, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp4 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-4", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg4, site2, tn4, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp4)
 
 	ipuNvDel := testFabricBuildUser(t, dbSession, uuid.NewString(), []string{ipOrg1}, []string{authz.ProviderAdminRole})

--- a/rest-api/api/pkg/api/handler/rack_test.go
+++ b/rest-api/api/pkg/api/handler/rack_test.go
@@ -149,7 +149,7 @@ func TestGetRackHandler_Handle(t *testing.T) {
 	_, site, _ := testRackSetupTestData(t, dbSession, org)
 
 	// Create a site without Flow enabled
-	siteNoFlow := &cdbm.Site{
+	siteNoRLA := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -157,7 +157,7 @@ func TestGetRackHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
 	assert.Nil(t, err)
 
 	// Create provider user
@@ -209,7 +209,7 @@ func TestGetRackHandler_Handle(t *testing.T) {
 			user:   providerUser,
 			rackID: rackID,
 			queryParams: map[string]string{
-				"siteId": siteNoFlow.ID.String(),
+				"siteId": siteNoRLA.ID.String(),
 			},
 			expectedStatus: http.StatusPreconditionFailed,
 			wantErr:        true,
@@ -331,7 +331,7 @@ func TestGetAllRackHandler_Handle(t *testing.T) {
 	_, site, _ := testRackSetupTestData(t, dbSession, org)
 
 	// Create a site without Flow enabled
-	siteNoFlow := &cdbm.Site{
+	siteNoRLA := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -339,7 +339,7 @@ func TestGetAllRackHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
 	assert.Nil(t, err)
 
 	// Create provider user
@@ -498,7 +498,7 @@ func TestGetAllRackHandler_Handle(t *testing.T) {
 			reqOrg: org,
 			user:   providerUser,
 			queryParams: map[string]string{
-				"siteId": siteNoFlow.ID.String(),
+				"siteId": siteNoRLA.ID.String(),
 			},
 			mockResponse:   nil,
 			expectedStatus: http.StatusPreconditionFailed,
@@ -630,7 +630,7 @@ func TestValidateRackHandler_Handle(t *testing.T) {
 	_, site, _ := testRackSetupTestData(t, dbSession, org)
 
 	// Create a site without Flow enabled
-	siteNoFlow := &cdbm.Site{
+	siteNoRLA := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -638,7 +638,7 @@ func TestValidateRackHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
 	assert.Nil(t, err)
 
 	// Create provider user
@@ -713,7 +713,7 @@ func TestValidateRackHandler_Handle(t *testing.T) {
 			user:   providerUser,
 			rackID: rackID,
 			queryParams: map[string]string{
-				"siteId": siteNoFlow.ID.String(),
+				"siteId": siteNoRLA.ID.String(),
 			},
 			mockResponse:   nil,
 			expectedStatus: http.StatusPreconditionFailed,
@@ -835,7 +835,7 @@ func TestValidateRacksHandler_Handle(t *testing.T) {
 	_, site, _ := testRackSetupTestData(t, dbSession, org)
 
 	// Create a site without Flow enabled
-	siteNoFlow := &cdbm.Site{
+	siteNoRLA := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -843,7 +843,7 @@ func TestValidateRacksHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
 	assert.Nil(t, err)
 
 	providerUser := testRackBuildUser(t, dbSession, "provider-user-validate-racks", org, []string{authz.ProviderAdminRole})
@@ -948,7 +948,7 @@ func TestValidateRacksHandler_Handle(t *testing.T) {
 			reqOrg: org,
 			user:   providerUser,
 			queryParams: map[string]string{
-				"siteId": siteNoFlow.ID.String(),
+				"siteId": siteNoRLA.ID.String(),
 			},
 			expectedStatus: http.StatusPreconditionFailed,
 		},

--- a/rest-api/api/pkg/api/handler/task_test.go
+++ b/rest-api/api/pkg/api/handler/task_test.go
@@ -42,7 +42,7 @@ func TestGetTaskHandler_Handle(t *testing.T) {
 	org := "test-org"
 	_, site, _ := testRackSetupTestData(t, dbSession, org)
 
-	siteNoFlow := &cdbm.Site{
+	siteNoRLA := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -50,7 +50,7 @@ func TestGetTaskHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
 	assert.Nil(t, err)
 
 	providerUser := testRackBuildUser(t, dbSession, "provider-user-task-get", org, []string{authz.ProviderAdminRole})
@@ -109,7 +109,7 @@ func TestGetTaskHandler_Handle(t *testing.T) {
 			user:     providerUser,
 			taskUUID: taskUUID,
 			queryParams: map[string]string{
-				"siteId": siteNoFlow.ID.String(),
+				"siteId": siteNoRLA.ID.String(),
 			},
 			expectedStatus: http.StatusPreconditionFailed,
 		},
@@ -437,7 +437,7 @@ func TestCancelTaskHandler_Handle(t *testing.T) {
 	org := "test-org"
 	_, site, _ := testRackSetupTestData(t, dbSession, org)
 
-	siteNoFlow := &cdbm.Site{
+	siteNoRLA := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow-cancel",
 		Org:                      org,
@@ -445,7 +445,7 @@ func TestCancelTaskHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
 	assert.Nil(t, err)
 
 	providerUser := testRackBuildUser(t, dbSession, "provider-user-task-cancel", org, []string{authz.ProviderAdminRole})
@@ -491,7 +491,7 @@ func TestCancelTaskHandler_Handle(t *testing.T) {
 			reqOrg:         org,
 			user:           providerUser,
 			taskUUID:       taskUUID,
-			body:           model.APICancelTaskRequest{SiteID: siteNoFlow.ID.String()},
+			body:           model.APICancelTaskRequest{SiteID: siteNoRLA.ID.String()},
 			expectedStatus: http.StatusPreconditionFailed,
 		},
 		{

--- a/rest-api/api/pkg/api/handler/tray_test.go
+++ b/rest-api/api/pkg/api/handler/tray_test.go
@@ -167,7 +167,7 @@ func TestGetTrayHandler_Handle(t *testing.T) {
 	_, site, _ := testTraySetupTestData(t, dbSession, org)
 
 	// Create a site without Flow enabled
-	siteNoFlow := &cdbm.Site{
+	siteNoRLA := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -175,7 +175,7 @@ func TestGetTrayHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
 	assert.Nil(t, err)
 
 	// Create provider user
@@ -225,7 +225,7 @@ func TestGetTrayHandler_Handle(t *testing.T) {
 			user:   providerUser,
 			trayID: trayID,
 			queryParams: map[string]string{
-				"siteId": siteNoFlow.ID.String(),
+				"siteId": siteNoRLA.ID.String(),
 			},
 			expectedStatus: http.StatusPreconditionFailed,
 			wantErr:        true,
@@ -351,7 +351,7 @@ func TestGetAllTrayHandler_Handle(t *testing.T) {
 	_, site, _ := testTraySetupTestData(t, dbSession, org)
 
 	// Create a site without Flow enabled
-	siteNoFlow := &cdbm.Site{
+	siteNoRLA := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -359,7 +359,7 @@ func TestGetAllTrayHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
 	assert.Nil(t, err)
 
 	// Create provider user
@@ -506,7 +506,7 @@ func TestGetAllTrayHandler_Handle(t *testing.T) {
 			reqOrg: org,
 			user:   providerUser,
 			queryParams: map[string]string{
-				"siteId": siteNoFlow.ID.String(),
+				"siteId": siteNoRLA.ID.String(),
 			},
 			mockResponse:   nil,
 			expectedStatus: http.StatusPreconditionFailed,
@@ -710,7 +710,7 @@ func TestValidateTrayHandler_Handle(t *testing.T) {
 	_, site, _ := testTraySetupTestData(t, dbSession, org)
 
 	// Create a site without Flow enabled
-	siteNoFlow := &cdbm.Site{
+	siteNoRLA := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -718,7 +718,7 @@ func TestValidateTrayHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
 	assert.Nil(t, err)
 
 	providerUser := testTrayBuildUser(t, dbSession, "provider-user-validate-tray", org, []string{authz.ProviderAdminRole})
@@ -794,7 +794,7 @@ func TestValidateTrayHandler_Handle(t *testing.T) {
 			user:   providerUser,
 			trayID: trayID,
 			queryParams: map[string]string{
-				"siteId": siteNoFlow.ID.String(),
+				"siteId": siteNoRLA.ID.String(),
 			},
 			expectedStatus: http.StatusPreconditionFailed,
 		},
@@ -914,7 +914,7 @@ func TestValidateTraysHandler_Handle(t *testing.T) {
 	_, site, _ := testTraySetupTestData(t, dbSession, org)
 
 	// Create a site without Flow enabled
-	siteNoFlow := &cdbm.Site{
+	siteNoRLA := &cdbm.Site{
 		ID:                       uuid.New(),
 		Name:                     "test-site-no-flow",
 		Org:                      org,
@@ -922,7 +922,7 @@ func TestValidateTraysHandler_Handle(t *testing.T) {
 		Status:                   cdbm.SiteStatusRegistered,
 		Config:                   &cdbm.SiteConfig{},
 	}
-	_, err := dbSession.DB.NewInsert().Model(siteNoFlow).Exec(context.Background())
+	_, err := dbSession.DB.NewInsert().Model(siteNoRLA).Exec(context.Background())
 	assert.Nil(t, err)
 
 	providerUser := testTrayBuildUser(t, dbSession, "provider-user-validate-trays", org, []string{authz.ProviderAdminRole})
@@ -1100,7 +1100,7 @@ func TestValidateTraysHandler_Handle(t *testing.T) {
 			reqOrg: org,
 			user:   providerUser,
 			queryParams: map[string]string{
-				"siteId": siteNoFlow.ID.String(),
+				"siteId": siteNoRLA.ID.String(),
 			},
 			expectedStatus: http.StatusPreconditionFailed,
 		},

--- a/rest-api/api/pkg/api/handler/vpc_test.go
+++ b/rest-api/api/pkg/api/handler/vpc_test.go
@@ -252,7 +252,7 @@ func testVPCBuildVPCPrefix(t *testing.T, dbSession *cdb.Session, name string, tn
 	return vpcPrefix
 }
 
-func testVPCBuildNVLinkLogicalPartition(t *testing.T, dbSession *cdb.Session, name string, description *string, org string, site *cdbm.Site, tenant *cdbm.Tenant, status string, user *cdbm.User) *cdbm.NVLinkLogicalPartition {
+func testVPCBuildNVLinkLogicalPartition(t *testing.T, dbSession *cdb.Session, name string, description *string, org string, site *cdbm.Site, tenant *cdbm.Tenant, status cdbm.NVLinkLogicalPartitionStatus, user *cdbm.User) *cdbm.NVLinkLogicalPartition {
 	nvllpDAO := cdbm.NewNVLinkLogicalPartitionDAO(dbSession)
 
 	nvllp, err := nvllpDAO.Create(context.Background(), nil, cdbm.NVLinkLogicalPartitionCreateInput{
@@ -372,7 +372,7 @@ func TestCreateVPCHandler_Handle(t *testing.T) {
 	assert.NotNil(t, nsgTenant2Site1)
 
 	// NVLink Logical Partition for tenant 1 on site 1
-	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg, st1, tn, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg, st1, tn, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp1)
 
 	existingVPCSt1 := testVPCBuildVPC(t, dbSession, "test-vpc", ip, tn, st1, cdb.GetStrPtr(cdbm.VpcEthernetVirtualizer), cdb.GetUUIDPtr(nvllp1.ID), map[string]string{"zone": "west1"}, cdbm.VpcStatusReady, tnu)
@@ -1196,10 +1196,10 @@ func TestUpdateVPCHandler_Handle(t *testing.T) {
 	assert.NotNil(t, al1)
 
 	// NVLink Logical Partition for tenant 1 on site 1
-	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg, st, tn, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg, st, tn, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp1)
 
-	nvllp2 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-2", cdb.GetStrPtr("Test NVLink Logical Partition 2"), tnOrg, st, tn, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp2 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-2", cdb.GetStrPtr("Test NVLink Logical Partition 2"), tnOrg, st, tn, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp2)
 
 	vpc := testVPCBuildVPC(t, dbSession, "test-vpc", ip, tn, st, cdb.GetStrPtr(cdbm.VpcEthernetVirtualizer), cdb.GetUUIDPtr(nvllp1.ID), map[string]string{"zone": "west1"}, cdbm.VpcStatusReady, tnu)
@@ -3148,7 +3148,7 @@ func TestDeleteVPCHandler_Handle(t *testing.T) {
 	assert.NotNil(t, ipb1)
 
 	// NVLink Logical Partition for tenant 1 on site 1
-	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, st, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp-1", cdb.GetStrPtr("Test NVLink Logical Partition"), tnOrg1, st, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp1)
 
 	vpc1 := testVPCBuildVPC(t, dbSession, "test-vpc-1", ip, tn1, st, cdb.GetStrPtr(cdbm.VpcEthernetVirtualizer), cdb.GetUUIDPtr(nvllp1.ID), map[string]string{"zone": "east1"}, cdbm.VpcStatusReady, tnu1)
@@ -3184,7 +3184,7 @@ func TestDeleteVPCHandler_Handle(t *testing.T) {
 	vpcPrefix := testVPCBuildVPCPrefix(t, dbSession, "test-vpc-prefix", tn1, vpc3, db.GetUUIDPtr(ipb1.ID), "10.0.0.0/24", tnu1)
 	assert.NotNil(t, vpcPrefix)
 
-	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp", cdb.GetStrPtr("Test NVLink Logical Partition"), tn1.Org, st, tn1, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), false)
+	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, "test-nvllp", cdb.GetStrPtr("Test NVLink Logical Partition"), tn1.Org, st, tn1, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusReady), false)
 	assert.NotNil(t, nvllp)
 
 	e := echo.New()

--- a/rest-api/api/pkg/api/model/nvlinklogicalpartition.go
+++ b/rest-api/api/pkg/api/model/nvlinklogicalpartition.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/NVIDIA/infra-controller-rest/api/pkg/api/model/util"
 	cdbm "github.com/NVIDIA/infra-controller-rest/db/pkg/db/model"
+	cwssaws "github.com/NVIDIA/infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	validationis "github.com/go-ozzo/ozzo-validation/v4/is"
 )
@@ -29,8 +30,8 @@ type APINVLinkLogicalPartitionCreateRequest struct {
 }
 
 // Validate ensure the values passed in request are acceptable
-func (anlpcr APINVLinkLogicalPartitionCreateRequest) Validate() error {
-	err := validation.ValidateStruct(&anlpcr,
+func (anlpcr *APINVLinkLogicalPartitionCreateRequest) Validate() error {
+	err := validation.ValidateStruct(anlpcr,
 		validation.Field(&anlpcr.Name,
 			validation.Required.Error(validationErrorStringLength),
 			validation.By(util.ValidateNameCharacters),
@@ -45,6 +46,22 @@ func (anlpcr APINVLinkLogicalPartitionCreateRequest) Validate() error {
 	return nil
 }
 
+// ToProto builds the workflow request that asks a Site to create the
+// NVLink Logical Partition represented by this API request. `nvllp` is
+// the just-persisted DB record; its `ToProto()` is the source of the
+// canonical wire fields (id, metadata, tenant organization id).
+//
+// The method trusts that the request has already been Validated and
+// that the handler has performed any cross-context checks Validate
+// cannot see.
+func (anlpcr *APINVLinkLogicalPartitionCreateRequest) ToProto(nvllp *cdbm.NVLinkLogicalPartition) *cwssaws.NVLinkLogicalPartitionCreationRequest {
+	entityProto := nvllp.ToProto()
+	return &cwssaws.NVLinkLogicalPartitionCreationRequest{
+		Id:     entityProto.Id,
+		Config: entityProto.Config,
+	}
+}
+
 // APINVLinkLogicalPartitionUpdateRequest is the data structure to capture user request to update a NVLinkLogicalPartition
 type APINVLinkLogicalPartitionUpdateRequest struct {
 	// Name is the name of the NVLinkLogicalPartition
@@ -54,13 +71,32 @@ type APINVLinkLogicalPartitionUpdateRequest struct {
 }
 
 // Validate ensure the values passed in request are acceptable
-func (anlpur APINVLinkLogicalPartitionUpdateRequest) Validate() error {
-	return validation.ValidateStruct(&anlpur,
+func (anlpur *APINVLinkLogicalPartitionUpdateRequest) Validate() error {
+	return validation.ValidateStruct(anlpur,
 		validation.Field(&anlpur.Name,
 			validation.When(anlpur.Name != nil, validation.Required.Error(validationErrorStringLength)),
 			validation.When(anlpur.Name != nil, validation.By(util.ValidateNameCharacters)),
 			validation.When(anlpur.Name != nil, validation.Length(2, 256).Error(validationErrorStringLength))),
 	)
+}
+
+// ToProto builds the workflow request that asks a Site to update the
+// NVLink Logical Partition represented by this API request. `nvllp` is
+// the post-update DB record; its `ToProto()` is the source of the
+// canonical wire fields. NICo requires Metadata.Name on every update,
+// which the entity's `ToProto()` always populates from the entity's
+// current Name (preserving the existing handler comment's intent even
+// when the client sends only `description`).
+//
+// The method trusts that the request has already been Validated and
+// that the handler has performed any cross-context checks Validate
+// cannot see.
+func (anlpur *APINVLinkLogicalPartitionUpdateRequest) ToProto(nvllp *cdbm.NVLinkLogicalPartition) *cwssaws.NVLinkLogicalPartitionUpdateRequest {
+	entityProto := nvllp.ToProto()
+	return &cwssaws.NVLinkLogicalPartitionUpdateRequest{
+		Id:     entityProto.Id,
+		Config: entityProto.Config,
+	}
 }
 
 // APINVLinkLogicalPartition is the data structure to capture API representation of a NVLinkLogicalPartition
@@ -86,7 +122,7 @@ type APINVLinkLogicalPartition struct {
 	// NVLinkLogicalPartitionStats holds GPU and instance counts for a NVLinkLogicalPartition
 	NVLinkLogicalPartitionStats *APINVLinkLogicalPartitionStats `json:"nvLinkLogicalPartitionStats"`
 	// Status is the status o the NVLinkLogicalPartition
-	Status string `json:"status"`
+	Status cdbm.NVLinkLogicalPartitionStatus `json:"status"`
 	// StatusHistory is the status detail records for the NVLinkLogicalPartition over time
 	StatusHistory []APIStatusDetail `json:"statusHistory"`
 	// Created indicates the ISO datetime string for when the NVLinkLogicalPartition was created
@@ -144,7 +180,7 @@ type APINVLinkLogicalPartitionSummary struct {
 	// SiteID is the ID of the Site
 	SiteID string `json:"siteId"`
 	// Status is the status of the NVLinkLogicalPartition
-	Status string `json:"status"`
+	Status cdbm.NVLinkLogicalPartitionStatus `json:"status"`
 }
 
 // NewAPINVLinkLogicalPartitionSummary accepts a DB layer NVLinkLogicalPartition object returns an API layer object

--- a/rest-api/api/pkg/api/model/nvlinklogicalpartition_test.go
+++ b/rest-api/api/pkg/api/model/nvlinklogicalpartition_test.go
@@ -12,6 +12,7 @@ import (
 	cdbm "github.com/NVIDIA/infra-controller-rest/db/pkg/db/model"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAPINVLinkLogicalPartitionCreateRequest_Validate(t *testing.T) {
@@ -45,6 +46,59 @@ func TestAPINVLinkLogicalPartitionCreateRequest_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAPINVLinkLogicalPartitionCreateRequest_ToProto(t *testing.T) {
+	id := uuid.New()
+	t.Run("sources canonical fields from entity's ToProto", func(t *testing.T) {
+		desc := "primary"
+		nvllp := &cdbm.NVLinkLogicalPartition{ID: id, Name: "nvllp-a", Org: "org-1", Description: &desc}
+		req := APINVLinkLogicalPartitionCreateRequest{Name: "nvllp-a", SiteID: uuid.New().String(), Description: &desc}
+		got := req.ToProto(nvllp)
+		require.NotNil(t, got)
+		require.NotNil(t, got.Id)
+		assert.Equal(t, id.String(), got.Id.Value)
+		require.NotNil(t, got.Config)
+		assert.Equal(t, "org-1", got.Config.TenantOrganizationId)
+		require.NotNil(t, got.Config.Metadata)
+		assert.Equal(t, "nvllp-a", got.Config.Metadata.Name)
+		assert.Equal(t, "primary", got.Config.Metadata.Description)
+	})
+
+	t.Run("omits description when entity has none", func(t *testing.T) {
+		nvllp := &cdbm.NVLinkLogicalPartition{ID: id, Name: "nvllp-a", Org: "org-1"}
+		req := APINVLinkLogicalPartitionCreateRequest{Name: "nvllp-a", SiteID: uuid.New().String()}
+		got := req.ToProto(nvllp)
+		require.NotNil(t, got.Config)
+		require.NotNil(t, got.Config.Metadata)
+		assert.Equal(t, "", got.Config.Metadata.Description)
+	})
+}
+
+func TestAPINVLinkLogicalPartitionUpdateRequest_ToProto(t *testing.T) {
+	id := uuid.New()
+	t.Run("always populates metadata.name from entity even when request Name is nil", func(t *testing.T) {
+		nvllp := &cdbm.NVLinkLogicalPartition{ID: id, Name: "current-name", Org: "org-1"}
+		req := APINVLinkLogicalPartitionUpdateRequest{Description: cdb.GetStrPtr("only-desc")}
+		got := req.ToProto(nvllp)
+		require.NotNil(t, got)
+		require.NotNil(t, got.Id)
+		assert.Equal(t, id.String(), got.Id.Value)
+		require.NotNil(t, got.Config)
+		assert.Equal(t, "org-1", got.Config.TenantOrganizationId)
+		require.NotNil(t, got.Config.Metadata)
+		assert.Equal(t, "current-name", got.Config.Metadata.Name)
+	})
+
+	t.Run("uses entity description when present", func(t *testing.T) {
+		desc := "updated-desc"
+		nvllp := &cdbm.NVLinkLogicalPartition{ID: id, Name: "current-name", Org: "org-1", Description: &desc}
+		req := APINVLinkLogicalPartitionUpdateRequest{Description: &desc}
+		got := req.ToProto(nvllp)
+		require.NotNil(t, got.Config)
+		require.NotNil(t, got.Config.Metadata)
+		assert.Equal(t, "updated-desc", got.Config.Metadata.Description)
+	})
 }
 
 func TestAPINVLinkLogicalPartitionUpdateRequest_Validate(t *testing.T) {
@@ -112,7 +166,7 @@ func TestAPINVLinkLogicalPartitionNew(t *testing.T) {
 		{
 			ID:       uuid.New(),
 			EntityID: dbNLP.ID.String(),
-			Status:   cdbm.NVLinkLogicalPartitionStatusPending,
+			Status:   string(cdbm.NVLinkLogicalPartitionStatusPending),
 			Created:  time.Now(),
 			Updated:  time.Now(),
 		},

--- a/rest-api/db/pkg/db/model/helper_test.go
+++ b/rest-api/db/pkg/db/model/helper_test.go
@@ -336,7 +336,7 @@ func testBuildInfiniBandInterface(t *testing.T, dbSession *db.Session, id *uuid.
 	return ibif
 }
 
-func testBuildNVLinkLogicalPartition(t *testing.T, dbSession *db.Session, id *uuid.UUID, name string, description *string, org string, tenantID uuid.UUID, siteID uuid.UUID, status *string, createdBy uuid.UUID) *NVLinkLogicalPartition {
+func testBuildNVLinkLogicalPartition(t *testing.T, dbSession *db.Session, id *uuid.UUID, name string, description *string, org string, tenantID uuid.UUID, siteID uuid.UUID, status *NVLinkLogicalPartitionStatus, createdBy uuid.UUID) *NVLinkLogicalPartition {
 	pid := uuid.New()
 	if id != nil {
 		pid = *id

--- a/rest-api/db/pkg/db/model/nvlinkinterface_test.go
+++ b/rest-api/db/pkg/db/model/nvlinkinterface_test.go
@@ -73,7 +73,7 @@ func TestNVLinkInterfaceSQLDAO_GetByID(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, i1)
 
-	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn.Org, tn.ID, st.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tnu.ID)
+	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn.Org, tn.ID, st.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tnu.ID)
 	nvli := testBuildNVLinkInterface(t, dbSession, nil, st.ID, i1.ID, nvllp.ID, nil, db.GetStrPtr("Nvidia GB200"), 0, nil, db.GetStrPtr(NVLinkInterfaceStatusReady), tnu.ID)
 
 	// OTEL Spanner configuration
@@ -243,8 +243,8 @@ func TestNVLinkInterface_GetAll(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, i2)
 
-	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn1.Org, tn1.ID, st.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tnu1.ID)
-	nvllp2 := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition2", nil, tn2.Org, tn2.ID, st2.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tnu2.ID)
+	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn1.Org, tn1.ID, st.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tnu1.ID)
+	nvllp2 := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition2", nil, tn2.Org, tn2.ID, st2.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tnu2.ID)
 
 	totalCount := 30
 	nvlinkInterfaces := []NVLinkInterface{}
@@ -558,7 +558,7 @@ func TestNVLinkInterfaceSQLDAO_Create(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, i1)
 
-	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn.Org, tn.ID, st.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tnu.ID)
+	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn.Org, tn.ID, st.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tnu.ID)
 
 	nvli := &NVLinkInterface{
 		SiteID:                   st.ID,
@@ -689,7 +689,7 @@ func TestNVLinkInterfaceSQLDAO_Update(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, i1)
 
-	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn.Org, tn.ID, st.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tnu.ID)
+	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn.Org, tn.ID, st.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tnu.ID)
 	nvli := testBuildNVLinkInterface(t, dbSession, nil, st.ID, i1.ID, nvllp.ID, nil, db.GetStrPtr("Nvidia GB200"), 0, db.GetStrPtr("guid"), db.GetStrPtr(NVLinkInterfaceStatusReady), tnu.ID)
 
 	uNVLinkInterface := nvli
@@ -809,7 +809,7 @@ func TestNVLinkInterfaceSQLDAO_UpdateMultiple(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn.Org, tn.ID, st.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tnu.ID)
+	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn.Org, tn.ID, st.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tnu.ID)
 
 	// Create multiple NVLinkInterfaces for batch update testing
 	nvli1 := testBuildNVLinkInterface(t, dbSession, nil, st.ID, instance.ID, nvllp.ID, nil, db.GetStrPtr("Nvidia GB200"), 0, db.GetStrPtr("guid1"), db.GetStrPtr(NVLinkInterfaceStatusReady), tnu.ID)
@@ -957,7 +957,7 @@ func TestNVLinkInterfaceSQLDAO_Clear(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, i1)
 
-	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn.Org, tn.ID, st.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tnu.ID)
+	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn.Org, tn.ID, st.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tnu.ID)
 	nvli := testBuildNVLinkInterface(t, dbSession, nil, st.ID, i1.ID, nvllp.ID, nil, db.GetStrPtr("Nvidia GB200"), 1, db.GetStrPtr("guid"), db.GetStrPtr(NVLinkInterfaceStatusReady), tnu.ID)
 
 	// OTEL Spanner configuration
@@ -1078,7 +1078,7 @@ func TestNVLinkInterfaceSQLDAO_Delete(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, i1)
 
-	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn.Org, tn.ID, st.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tnu.ID)
+	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn.Org, tn.ID, st.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tnu.ID)
 	nvli := testBuildNVLinkInterface(t, dbSession, nil, st.ID, i1.ID, nvllp.ID, nil, db.GetStrPtr("Nvidia GB200"), 0, db.GetStrPtr("guid"), db.GetStrPtr(NVLinkInterfaceStatusReady), tnu.ID)
 
 	// OTEL Spanner configuration
@@ -1169,7 +1169,7 @@ func TestNVLinkInterfaceSQLDAO_CreateMultiple(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn.Org, tn.ID, st.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tnu.ID)
+	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn.Org, tn.ID, st.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tnu.ID)
 
 	nvlisd := NewNVLinkInterfaceDAO(dbSession)
 
@@ -1327,8 +1327,8 @@ func TestNVLinkInterfaceSQLDAO_DeleteAllBySiteID(t *testing.T) {
 	inst1 := buildInstanceForSite(st1, "host1.com", "mcType1")
 	inst2 := buildInstanceForSite(st2, "host2.com", "mcType2")
 
-	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, nil, "nvllp-site-1", nil, tn.Org, tn.ID, st1.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tnu.ID)
-	nvllp2 := testBuildNVLinkLogicalPartition(t, dbSession, nil, "nvllp-site-2", nil, tn.Org, tn.ID, st2.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tnu.ID)
+	nvllp1 := testBuildNVLinkLogicalPartition(t, dbSession, nil, "nvllp-site-1", nil, tn.Org, tn.ID, st1.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tnu.ID)
+	nvllp2 := testBuildNVLinkLogicalPartition(t, dbSession, nil, "nvllp-site-2", nil, tn.Org, tn.ID, st2.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tnu.ID)
 
 	// Two interfaces in the target site, one in another site that should remain.
 	nvli1a := testBuildNVLinkInterface(t, dbSession, nil, st1.ID, inst1.ID, nvllp1.ID, nil, db.GetStrPtr("Nvidia GB200"), 0, db.GetStrPtr("guid-1a"), db.GetStrPtr(NVLinkInterfaceStatusReady), tnu.ID)

--- a/rest-api/db/pkg/db/model/nvlinklogicalpartition.go
+++ b/rest-api/db/pkg/db/model/nvlinklogicalpartition.go
@@ -6,29 +6,48 @@ package model
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/db"
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/db/paginator"
 	stracer "github.com/NVIDIA/infra-controller-rest/db/pkg/tracer"
+	cwssaws "github.com/NVIDIA/infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 
 	"github.com/uptrace/bun"
 )
 
+// NVLinkLogicalPartitionStatus is the domain enum for the lifecycle
+// state of a `NVLinkLogicalPartition`. Defining it as a named string
+// lets us hang the workflow-proto conversion on it as methods
+// (`(*s).FromProto`, `(s).Message`) per the "Named types own their
+// proto behavior" rule, and keeps the DB column comparable as a plain
+// string at the storage layer.
+type NVLinkLogicalPartitionStatus string
+
+// NVLinkLogicalPartitionStatus values. Stored as plain strings in the
+// DB column `nvlink_logical_partition.status`.
 const (
 	// NVLinkLogicalPartitionStatusPending indicates that the NVLinkLogicalPartition request was received but not yet processed
-	NVLinkLogicalPartitionStatusPending = "Pending"
+	NVLinkLogicalPartitionStatusPending NVLinkLogicalPartitionStatus = "Pending"
 	// NVLinkLogicalPartitionStatusProvisioning indicates that the NVLinkLogicalPartition is being provisioned
-	NVLinkLogicalPartitionStatusProvisioning = "Provisioning"
+	NVLinkLogicalPartitionStatusProvisioning NVLinkLogicalPartitionStatus = "Provisioning"
 	// NVLinkLogicalPartitionStatusReady indicates that the NVLinkLogicalPartition has been successfully provisioned on the Site
-	NVLinkLogicalPartitionStatusReady = "Ready"
+	NVLinkLogicalPartitionStatusReady NVLinkLogicalPartitionStatus = "Ready"
 	// NVLinkLogicalPartitionStatusConfiguring indicates that the NVLinkLogicalPartition is being configuring
-	NVLinkLogicalPartitionStatusConfiguring = "Configuring"
+	NVLinkLogicalPartitionStatusConfiguring NVLinkLogicalPartitionStatus = "Configuring"
 	// NVLinkLogicalPartitionStatusError is the status of a NVLinkLogicalPartition that is in error mode
-	NVLinkLogicalPartitionStatusError = "Error"
+	NVLinkLogicalPartitionStatusError NVLinkLogicalPartitionStatus = "Error"
 	// NVLinkLogicalPartitionStatusDeleting indicates that the NVLinkLogicalPartition is being deleted
-	NVLinkLogicalPartitionStatusDeleting = "Deleting"
+	NVLinkLogicalPartitionStatusDeleting NVLinkLogicalPartitionStatus = "Deleting"
+)
+
+const (
 	// NVLinkLogicalPartitionRelationName is the relation name for the NVLinkLogicalPartition model
 	NVLinkLogicalPartitionRelationName = "NVLinkLogicalPartition"
 
@@ -45,7 +64,7 @@ var (
 		TenantRelationName: true,
 	}
 	// NVLinkLogicalPartitionStatusMap is a list of valid status for the NVLinkLogicalPartition model
-	NVLinkLogicalPartitionStatusMap = map[string]bool{
+	NVLinkLogicalPartitionStatusMap = map[NVLinkLogicalPartitionStatus]bool{
 		NVLinkLogicalPartitionStatusPending:      true,
 		NVLinkLogicalPartitionStatusProvisioning: true,
 		NVLinkLogicalPartitionStatusReady:        true,
@@ -55,24 +74,179 @@ var (
 	}
 )
 
+// FromProto maps a workflow `TenantState` proto enum to the
+// corresponding DB-side `NVLinkLogicalPartitionStatus`, mirroring the
+// "leaf-named-type owns its proto behavior" rule. An unknown proto
+// state leaves the receiver as the empty string so the caller can
+// detect "no DB-side equivalent" (the pre-typed helper returned
+// `(nil, nil)` for the same case).
+func (s *NVLinkLogicalPartitionStatus) FromProto(state cwssaws.TenantState) {
+	switch state {
+	case cwssaws.TenantState_PROVISIONING:
+		*s = NVLinkLogicalPartitionStatusProvisioning
+	case cwssaws.TenantState_CONFIGURING:
+		*s = NVLinkLogicalPartitionStatusConfiguring
+	case cwssaws.TenantState_READY:
+		*s = NVLinkLogicalPartitionStatusReady
+	case cwssaws.TenantState_FAILED:
+		*s = NVLinkLogicalPartitionStatusError
+	default:
+		log.Warn().Str("TenantState", state.String()).Msg("unsupported NVLinkLogicalPartitionStatus requested")
+		*s = ""
+	}
+}
+
+// Message returns the canonical human-readable message that pairs
+// with this status. Returns the empty string for an unrecognized
+// status (typically the zero value).
+func (s NVLinkLogicalPartitionStatus) Message() string {
+	switch s {
+	case NVLinkLogicalPartitionStatusProvisioning:
+		return "NVLink Logical Partition is being provisioned on Site"
+	case NVLinkLogicalPartitionStatusConfiguring:
+		return "NVLink Logical Partition is being configured on Site"
+	case NVLinkLogicalPartitionStatusReady:
+		return "NVLink Logical Partition is ready for use"
+	case NVLinkLogicalPartitionStatusError:
+		return "NVLink Logical Partition is in error state"
+	}
+	return ""
+}
+
 // NVLinkLogicalPartition represents entries in the NVLinkLogicalPartition table
 type NVLinkLogicalPartition struct {
 	bun.BaseModel `bun:"table:nvlink_logical_partition,alias:nvllp"`
 
-	ID              uuid.UUID  `bun:"type:uuid,pk"`
-	Name            string     `bun:"name,notnull"`
-	Description     *string    `bun:"description"`
-	Org             string     `bun:"org,notnull"`
-	SiteID          uuid.UUID  `bun:"site_id,type:uuid,notnull"`
-	Site            *Site      `bun:"rel:belongs-to,join:site_id=id"`
-	TenantID        uuid.UUID  `bun:"tenant_id,type:uuid,notnull"`
-	Tenant          *Tenant    `bun:"rel:belongs-to,join:tenant_id=id"`
-	Status          string     `bun:"status,notnull"`
-	IsMissingOnSite bool       `bun:"is_missing_on_site,notnull"`
-	Created         time.Time  `bun:"created,nullzero,notnull,default:current_timestamp"`
-	Updated         time.Time  `bun:"updated,nullzero,notnull,default:current_timestamp"`
-	Deleted         *time.Time `bun:"deleted,soft_delete"`
-	CreatedBy       uuid.UUID  `bun:"type:uuid,notnull"`
+	ID              uuid.UUID                    `bun:"type:uuid,pk"`
+	Name            string                       `bun:"name,notnull"`
+	Description     *string                      `bun:"description"`
+	Org             string                       `bun:"org,notnull"`
+	SiteID          uuid.UUID                    `bun:"site_id,type:uuid,notnull"`
+	Site            *Site                        `bun:"rel:belongs-to,join:site_id=id"`
+	TenantID        uuid.UUID                    `bun:"tenant_id,type:uuid,notnull"`
+	Tenant          *Tenant                      `bun:"rel:belongs-to,join:tenant_id=id"`
+	Status          NVLinkLogicalPartitionStatus `bun:"status,notnull"`
+	IsMissingOnSite bool                         `bun:"is_missing_on_site,notnull"`
+	Created         time.Time                    `bun:"created,nullzero,notnull,default:current_timestamp"`
+	Updated         time.Time                    `bun:"updated,nullzero,notnull,default:current_timestamp"`
+	Deleted         *time.Time                   `bun:"deleted,soft_delete"`
+	CreatedBy       uuid.UUID                    `bun:"type:uuid,notnull"`
+}
+
+// Validate checks that the populated NVLinkLogicalPartition is wire-safe.
+// Mirrors the API-side rules so callers that build a
+// `NVLinkLogicalPartition` from site-supplied or request data can gate
+// it through one consistent contract.
+func (nvllp *NVLinkLogicalPartition) Validate() error {
+	statuses := make([]any, 0, len(NVLinkLogicalPartitionStatusMap))
+	for s := range NVLinkLogicalPartitionStatusMap {
+		statuses = append(statuses, s)
+	}
+	return validation.ValidateStruct(nvllp,
+		validation.Field(&nvllp.Name,
+			validation.Required.Error("NVLinkLogicalPartition Name must be specified"),
+			validation.Length(2, 256).Error("NVLinkLogicalPartition Name must be at least 2 characters and maximum 256 characters"),
+			validation.By(validateNVLinkLogicalPartitionNameWhitespace)),
+		validation.Field(&nvllp.Status,
+			validation.Required.Error("NVLinkLogicalPartition Status must be specified"),
+			validation.In(statuses...).Error(fmt.Sprintf("invalid NVLinkLogicalPartition Status: %q", nvllp.Status))),
+	)
+}
+
+// validateNVLinkLogicalPartitionNameWhitespace rejects Names with
+// leading or trailing whitespace, mirroring the API-side
+// `util.ValidateNameCharacters` rule so the wire-bound DB-model gate
+// matches the API one. Shared by
+// `(*NVLinkLogicalPartition).Validate()` and the partial-field DAO
+// Update path.
+func validateNVLinkLogicalPartitionNameWhitespace(value interface{}) error {
+	s, ok := value.(string)
+	if !ok {
+		return errors.New("NVLinkLogicalPartition Name must be a string")
+	}
+	if strings.TrimSpace(s) != s {
+		return errors.New("NVLinkLogicalPartition Name must not contain leading or trailing whitespace")
+	}
+	return nil
+}
+
+// toMetadataProto builds a workflow Metadata proto from the partition's
+// Name and (optional) Description.
+func (nvllp *NVLinkLogicalPartition) toMetadataProto() *cwssaws.Metadata {
+	md := &cwssaws.Metadata{Name: nvllp.Name}
+	if nvllp.Description != nil {
+		md.Description = *nvllp.Description
+	}
+	return md
+}
+
+// ToProto builds the canonical workflow proto for this NVLink Logical
+// Partition. Config carries Metadata (Name, optional Description) and
+// the owning tenant's organization id sourced from `nvllp.Org`. The
+// request-shape protos (creation/update) layer on top of this canonical
+// form via the API request types' `ToProto` methods.
+func (nvllp *NVLinkLogicalPartition) ToProto() *cwssaws.NVLinkLogicalPartition {
+	return &cwssaws.NVLinkLogicalPartition{
+		Id: &cwssaws.NVLinkLogicalPartitionId{Value: nvllp.ID.String()},
+		Config: &cwssaws.NVLinkLogicalPartitionConfig{
+			Metadata:             nvllp.toMetadataProto(),
+			TenantOrganizationId: nvllp.Org,
+		},
+	}
+}
+
+// FromProto populates this NVLink Logical Partition from its workflow
+// proto representation. A nil proto is a no-op. This is the inverse of
+// `ToProto` and exists for convention symmetry — currently no code
+// path on the cloud side reconstructs a full entity from the workflow
+// proto (the site is the destination, not the source), but the method
+// is provided so future reconciliation flows have a single canonical
+// entry point.
+//
+// Field-level contract:
+//   - `nvllp.ID` is preserved on a missing or unparseable `proto.Id`,
+//     because callers pre-validate the UUID before calling.
+//   - `Name` is sourced from `Config.Metadata.Name` when set.
+//   - `Description` is cleared when the proto omits it or carries an
+//     empty string, so `FromProto` is a clean reset rather than a
+//     partial merge.
+func (nvllp *NVLinkLogicalPartition) FromProto(proto *cwssaws.NVLinkLogicalPartition) {
+	if proto == nil {
+		return
+	}
+	if proto.Id != nil {
+		if id, err := uuid.Parse(proto.Id.Value); err == nil {
+			nvllp.ID = id
+		}
+	}
+	// Reset Config-derived fields up front so the `clean reset rather
+	// than a partial merge` contract holds when proto.Config (or its
+	// Metadata sub-message) is nil or omits a field.
+	nvllp.Name = ""
+	nvllp.Org = ""
+	nvllp.Description = nil
+	if proto.Config == nil {
+		return
+	}
+	nvllp.Org = proto.Config.TenantOrganizationId
+	if proto.Config.Metadata != nil {
+		if proto.Config.Metadata.Name != "" {
+			nvllp.Name = proto.Config.Metadata.Name
+		}
+		if proto.Config.Metadata.Description != "" {
+			desc := proto.Config.Metadata.Description
+			nvllp.Description = &desc
+		}
+	}
+}
+
+// ToDeletionRequestProto builds the workflow request that asks a Site to
+// delete this NVLink Logical Partition. Stays on the entity because
+// there is no API request body for delete (path-param only).
+func (nvllp *NVLinkLogicalPartition) ToDeletionRequestProto() *cwssaws.NVLinkLogicalPartitionDeletionRequest {
+	return &cwssaws.NVLinkLogicalPartitionDeletionRequest{
+		Id: &cwssaws.NVLinkLogicalPartitionId{Value: nvllp.ID.String()},
+	}
 }
 
 // NVLinkLogicalPartitionCreateInput input parameters for Create method
@@ -83,7 +257,7 @@ type NVLinkLogicalPartitionCreateInput struct {
 	TenantOrg                string
 	SiteID                   uuid.UUID
 	TenantID                 uuid.UUID
-	Status                   string
+	Status                   NVLinkLogicalPartitionStatus
 	CreatedBy                uuid.UUID
 }
 
@@ -92,7 +266,7 @@ type NVLinkLogicalPartitionUpdateInput struct {
 	NVLinkLogicalPartitionID uuid.UUID
 	Name                     *string
 	Description              *string
-	Status                   *string
+	Status                   *NVLinkLogicalPartitionStatus
 	IsMissingOnSite          *bool
 }
 
@@ -287,6 +461,10 @@ func (nvllpsd NVLinkLogicalPartitionSQLDAO) Create(ctx context.Context, tx *db.T
 		CreatedBy:       input.CreatedBy,
 	}
 
+	if err := nvllp.Validate(); err != nil {
+		return nil, err
+	}
+
 	_, err := db.GetIDB(tx, nvllpsd.dbSession).NewInsert().Model(nvllp).Exec(ctx)
 	if err != nil {
 		return nil, err
@@ -317,6 +495,12 @@ func (nvllpsd NVLinkLogicalPartitionSQLDAO) Update(ctx context.Context, tx *db.T
 	updatedFields := []string{}
 
 	if input.Name != nil {
+		if err := validation.Validate(*input.Name,
+			validation.Required.Error("NVLinkLogicalPartition Name must be specified"),
+			validation.Length(2, 256).Error("NVLinkLogicalPartition Name must be at least 2 characters and maximum 256 characters"),
+			validation.By(validateNVLinkLogicalPartitionNameWhitespace)); err != nil {
+			return nil, err
+		}
 		nvllp.Name = *input.Name
 		updatedFields = append(updatedFields, "name")
 		nvllpsd.tracerSpan.SetAttribute(NVLinkLogicalPartitionDAOSpan, "name", *input.Name)
@@ -327,6 +511,9 @@ func (nvllpsd NVLinkLogicalPartitionSQLDAO) Update(ctx context.Context, tx *db.T
 		nvllpsd.tracerSpan.SetAttribute(NVLinkLogicalPartitionDAOSpan, "description", *input.Description)
 	}
 	if input.Status != nil {
+		if !NVLinkLogicalPartitionStatusMap[*input.Status] {
+			return nil, fmt.Errorf("invalid NVLinkLogicalPartition Status: %q", *input.Status)
+		}
 		nvllp.Status = *input.Status
 		updatedFields = append(updatedFields, "status")
 		nvllpsd.tracerSpan.SetAttribute(NVLinkLogicalPartitionDAOSpan, "status", *input.Status)

--- a/rest-api/db/pkg/db/model/nvlinklogicalpartition_test.go
+++ b/rest-api/db/pkg/db/model/nvlinklogicalpartition_test.go
@@ -11,11 +11,140 @@ import (
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/db"
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/db/paginator"
 	stracer "github.com/NVIDIA/infra-controller-rest/db/pkg/tracer"
+	cwssaws "github.com/NVIDIA/infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	otrace "go.opentelemetry.io/otel/trace"
 )
+
+func TestNVLinkLogicalPartition_ToProto(t *testing.T) {
+	id := uuid.New()
+	t.Run("includes description when set", func(t *testing.T) {
+		desc := "primary"
+		nvllp := &NVLinkLogicalPartition{ID: id, Name: "nvllp-a", Org: "org-1", Description: &desc}
+		got := nvllp.ToProto()
+		require.NotNil(t, got)
+		require.NotNil(t, got.Id)
+		assert.Equal(t, id.String(), got.Id.Value)
+		require.NotNil(t, got.Config)
+		assert.Equal(t, "org-1", got.Config.TenantOrganizationId)
+		require.NotNil(t, got.Config.Metadata)
+		assert.Equal(t, "nvllp-a", got.Config.Metadata.Name)
+		assert.Equal(t, "primary", got.Config.Metadata.Description)
+	})
+
+	t.Run("populates metadata.name even when description is nil", func(t *testing.T) {
+		nvllp := &NVLinkLogicalPartition{ID: id, Name: "nvllp-a", Org: "org-1"}
+		got := nvllp.ToProto()
+		require.NotNil(t, got)
+		require.NotNil(t, got.Config)
+		require.NotNil(t, got.Config.Metadata)
+		assert.Equal(t, "nvllp-a", got.Config.Metadata.Name)
+		assert.Equal(t, "", got.Config.Metadata.Description)
+	})
+}
+
+func TestNVLinkLogicalPartition_FromProto(t *testing.T) {
+	t.Run("nil proto is a no-op", func(t *testing.T) {
+		id := uuid.New()
+		desc := "kept"
+		nvllp := &NVLinkLogicalPartition{ID: id, Name: "kept", Org: "org-1", Description: &desc}
+		nvllp.FromProto(nil)
+		assert.Equal(t, id, nvllp.ID)
+		assert.Equal(t, "kept", nvllp.Name)
+		assert.Equal(t, "org-1", nvllp.Org)
+		require.NotNil(t, nvllp.Description)
+		assert.Equal(t, "kept", *nvllp.Description)
+	})
+
+	t.Run("populates from proto metadata", func(t *testing.T) {
+		id := uuid.New()
+		nvllp := &NVLinkLogicalPartition{ID: uuid.New()}
+		nvllp.FromProto(&cwssaws.NVLinkLogicalPartition{
+			Id: &cwssaws.NVLinkLogicalPartitionId{Value: id.String()},
+			Config: &cwssaws.NVLinkLogicalPartitionConfig{
+				TenantOrganizationId: "org-1",
+				Metadata:             &cwssaws.Metadata{Name: "nvllp-a", Description: "primary"},
+			},
+		})
+		assert.Equal(t, id, nvllp.ID)
+		assert.Equal(t, "nvllp-a", nvllp.Name)
+		assert.Equal(t, "org-1", nvllp.Org)
+		require.NotNil(t, nvllp.Description)
+		assert.Equal(t, "primary", *nvllp.Description)
+	})
+
+	t.Run("clears Description when proto omits it", func(t *testing.T) {
+		desc := "existing"
+		nvllp := &NVLinkLogicalPartition{ID: uuid.New(), Name: "n", Description: &desc}
+		nvllp.FromProto(&cwssaws.NVLinkLogicalPartition{
+			Config: &cwssaws.NVLinkLogicalPartitionConfig{
+				Metadata: &cwssaws.Metadata{Name: "n"},
+			},
+		})
+		assert.Nil(t, nvllp.Description)
+	})
+
+	t.Run("preserves ID when proto Id is unparseable", func(t *testing.T) {
+		id := uuid.New()
+		nvllp := &NVLinkLogicalPartition{ID: id}
+		nvllp.FromProto(&cwssaws.NVLinkLogicalPartition{
+			Id: &cwssaws.NVLinkLogicalPartitionId{Value: "not-a-uuid"},
+		})
+		assert.Equal(t, id, nvllp.ID)
+	})
+}
+
+func TestNVLinkLogicalPartition_ToDeletionRequestProto(t *testing.T) {
+	id := uuid.New()
+	nvllp := &NVLinkLogicalPartition{ID: id}
+	req := nvllp.ToDeletionRequestProto()
+	require.NotNil(t, req)
+	require.NotNil(t, req.Id)
+	assert.Equal(t, id.String(), req.Id.Value)
+}
+
+func TestNVLinkLogicalPartition_Validate(t *testing.T) {
+	valid := &NVLinkLogicalPartition{
+		Name:   "test-nvllp",
+		Status: NVLinkLogicalPartitionStatusReady,
+	}
+
+	t.Run("populated partition is valid", func(t *testing.T) {
+		assert.NoError(t, valid.Validate())
+	})
+	t.Run("empty Status errors", func(t *testing.T) {
+		nvllp := *valid
+		nvllp.Status = ""
+		assert.Error(t, nvllp.Validate())
+	})
+	t.Run("invalid Status errors", func(t *testing.T) {
+		nvllp := *valid
+		nvllp.Status = "Bogus"
+		assert.Error(t, nvllp.Validate())
+	})
+	t.Run("empty Name errors", func(t *testing.T) {
+		nvllp := *valid
+		nvllp.Name = ""
+		assert.Error(t, nvllp.Validate())
+	})
+	t.Run("Name with leading whitespace errors", func(t *testing.T) {
+		nvllp := *valid
+		nvllp.Name = " test-nvllp"
+		assert.Error(t, nvllp.Validate())
+	})
+	t.Run("Name with trailing whitespace errors", func(t *testing.T) {
+		nvllp := *valid
+		nvllp.Name = "test-nvllp "
+		assert.Error(t, nvllp.Validate())
+	})
+	t.Run("single-character Name errors (too short)", func(t *testing.T) {
+		nvllp := *valid
+		nvllp.Name = "x"
+		assert.Error(t, nvllp.Validate())
+	})
+}
 
 func testNVLinkLogicalPartitionSetupSchema(t *testing.T, dbSession *db.Session) {
 	// Create tables
@@ -57,7 +186,7 @@ func TestNVLinkLogicalPartitionSQLDAO_GetByID(t *testing.T) {
 
 	st := testBuildSite(t, dbSession, nil, ip.ID, "test-site", "Test Site", ip.Org, ipu.ID)
 
-	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-NVLinkLogicalPartition", nil, tn.Org, tn.ID, st.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tnu.ID)
+	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-NVLinkLogicalPartition", nil, tn.Org, tn.ID, st.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tnu.ID)
 
 	// OTEL Spanner configuration
 	_, _, ctx := testCommonTraceProviderSetup(t, context.Background())
@@ -185,9 +314,9 @@ func TestNVLinkLogicalPartition_GetAll(t *testing.T) {
 		}
 
 		if i%2 == 0 {
-			nvllp = testBuildNVLinkLogicalPartition(t, dbSession, nil, fmt.Sprintf("test-NVLinkLogicalPartition-batch-v1-%v", i), db.GetStrPtr(fmt.Sprintf("test-NVLinkLogicalPartition-desc-batch-1-%v", i)), tn.Org, tn.ID, st.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tn.CreatedBy)
+			nvllp = testBuildNVLinkLogicalPartition(t, dbSession, nil, fmt.Sprintf("test-NVLinkLogicalPartition-batch-v1-%v", i), db.GetStrPtr(fmt.Sprintf("test-NVLinkLogicalPartition-desc-batch-1-%v", i)), tn.Org, tn.ID, st.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tn.CreatedBy)
 		} else {
-			nvllp = testBuildNVLinkLogicalPartition(t, dbSession, nil, fmt.Sprintf("test-NVLinkLogicalPartition-batch-v2-%v", i), db.GetStrPtr(fmt.Sprintf("test-NVLinkLogicalPartition-desc-batch-2-%v", i)), tn.Org, tn.ID, st.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusDeleting), tn.CreatedBy)
+			nvllp = testBuildNVLinkLogicalPartition(t, dbSession, nil, fmt.Sprintf("test-NVLinkLogicalPartition-batch-v2-%v", i), db.GetStrPtr(fmt.Sprintf("test-NVLinkLogicalPartition-desc-batch-2-%v", i)), tn.Org, tn.ID, st.ID, db.Ptr(NVLinkLogicalPartitionStatusDeleting), tn.CreatedBy)
 		}
 
 		nvlinkLogicalPartitions = append(nvlinkLogicalPartitions, *nvllp)
@@ -419,7 +548,7 @@ func TestNVLinkLogicalPartition_GetAll(t *testing.T) {
 				tenantIDs:   nil,
 				siteIDs:     nil,
 				orgs:        nil,
-				searchQuery: db.GetStrPtr(NVLinkLogicalPartitionStatusReady),
+				searchQuery: db.GetTypedStrPtr(NVLinkLogicalPartitionStatusReady),
 			},
 			wantCount:      totalCount / 2,
 			wantTotalCount: totalCount / 2,
@@ -435,7 +564,7 @@ func TestNVLinkLogicalPartition_GetAll(t *testing.T) {
 				tenantIDs:   nil,
 				siteIDs:     nil,
 				orgs:        nil,
-				searchQuery: db.GetStrPtr(NVLinkLogicalPartitionStatusDeleting),
+				searchQuery: db.GetTypedStrPtr(NVLinkLogicalPartitionStatusDeleting),
 			},
 			wantCount:      totalCount / 2,
 			wantTotalCount: totalCount / 2,
@@ -531,7 +660,7 @@ func TestNVLinkLogicalPartition_GetAll(t *testing.T) {
 				tenantIDs: nil,
 				siteIDs:   nil,
 				orgs:      nil,
-				statuses:  []string{NVLinkLogicalPartitionStatusDeleting},
+				statuses:  []string{string(NVLinkLogicalPartitionStatusDeleting)},
 			},
 			wantCount:      totalCount / 2,
 			wantTotalCount: totalCount / 2,
@@ -601,7 +730,7 @@ func TestNVLinkLogicalPartitionSQLDAO_Create(t *testing.T) {
 		org         string
 		siteID      uuid.UUID
 		tenantID    uuid.UUID
-		status      string
+		status      NVLinkLogicalPartitionStatus
 		createdBy   User
 	}
 
@@ -661,6 +790,23 @@ func TestNVLinkLogicalPartitionSQLDAO_Create(t *testing.T) {
 			wantErr:            false,
 			verifyChildSpanner: true,
 		},
+		{
+			name: "create with invalid status returns error",
+			fields: fields{
+				dbSession: dbSession,
+			},
+			args: args{
+				ctx:         ctx,
+				name:        "invalid-status-nvllp",
+				description: nvllp.Description,
+				org:         nvllp.Org,
+				tenantID:    nvllp.TenantID,
+				siteID:      nvllp.SiteID,
+				status:      NVLinkLogicalPartitionStatus("Bogus"),
+				createdBy:   User{ID: nvllp.CreatedBy},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -682,6 +828,9 @@ func TestNVLinkLogicalPartitionSQLDAO_Create(t *testing.T) {
 				},
 			)
 			require.Equal(t, tt.wantErr, err != nil)
+			if tt.wantErr {
+				return
+			}
 
 			assert.Equal(t, tt.want.Name, got.Name)
 			assert.Equal(t, *tt.want.Description, *got.Description)
@@ -718,7 +867,7 @@ func TestNVLinkLogicalPartitionSQLDAO_Update(t *testing.T) {
 
 	st := testBuildSite(t, dbSession, nil, ip.ID, "test-site", "Test Site", ip.Org, ipu.ID)
 
-	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-NVLinkLogicalPartition", nil, tn.Org, tn.ID, st.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tnu.ID)
+	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-NVLinkLogicalPartition", nil, tn.Org, tn.ID, st.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tnu.ID)
 
 	uNVLinkLogicalPartition := &NVLinkLogicalPartition{
 		Name:            "test-updated",
@@ -738,7 +887,7 @@ func TestNVLinkLogicalPartitionSQLDAO_Update(t *testing.T) {
 		id              uuid.UUID
 		name            *string
 		description     *string
-		Status          string
+		Status          NVLinkLogicalPartitionStatus
 		IsMissingOnSite bool
 	}
 	tests := []struct {
@@ -766,6 +915,21 @@ func TestNVLinkLogicalPartitionSQLDAO_Update(t *testing.T) {
 			wantErr:            false,
 			verifyChildSpanner: true,
 		},
+		{
+			name: "update with invalid status returns error",
+			fields: fields{
+				dbSession: dbSession,
+			},
+			args: args{
+				ctx:             ctx,
+				id:              nvllp.ID,
+				name:            &uNVLinkLogicalPartition.Name,
+				description:     uNVLinkLogicalPartition.Description,
+				Status:          NVLinkLogicalPartitionStatus("Bogus"),
+				IsMissingOnSite: uNVLinkLogicalPartition.IsMissingOnSite,
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -785,9 +949,12 @@ func TestNVLinkLogicalPartitionSQLDAO_Update(t *testing.T) {
 				},
 			)
 
-			fmt.Printf("\ngot ID: %v, Created: %v, Updated: %v", got.ID.String(), got.Created, got.Updated)
-
 			require.Equal(t, tt.wantErr, err != nil)
+			if tt.wantErr {
+				return
+			}
+
+			fmt.Printf("\ngot ID: %v, Created: %v, Updated: %v", got.ID.String(), got.Created, got.Updated)
 
 			assert.Equal(t, tt.want.Name, got.Name)
 			assert.Equal(t, *tt.want.Description, *got.Description)
@@ -829,7 +996,7 @@ func TestNVLinkLogicalPartitionSQLDAO_Delete(t *testing.T) {
 
 	st := testBuildSite(t, dbSession, nil, ip.ID, "test-site", "Test Site", ip.Org, ipu.ID)
 
-	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-NVLinkLogicalPartition", nil, tn.Org, tn.ID, st.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tnu.ID)
+	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-NVLinkLogicalPartition", nil, tn.Org, tn.ID, st.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tnu.ID)
 
 	// OTEL Spanner configuration
 	_, _, ctx := testCommonTraceProviderSetup(t, context.Background())
@@ -896,7 +1063,7 @@ func TestNVLinkLogicalPartitionSQLDAO_Clear(t *testing.T) {
 
 	st := testBuildSite(t, dbSession, nil, ip.ID, "test-site", "Test Site", ip.Org, ipu.ID)
 
-	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-NVLinkLogicalPartition", nil, tn.Org, tn.ID, st.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tnu.ID)
+	nvllp := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-NVLinkLogicalPartition", nil, tn.Org, tn.ID, st.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tnu.ID)
 
 	// OTEL Spanner configuration
 	_, _, ctx := testCommonTraceProviderSetup(t, context.Background())

--- a/rest-api/db/pkg/db/model/vpc_test.go
+++ b/rest-api/db/pkg/db/model/vpc_test.go
@@ -346,7 +346,7 @@ func TestVpc_GetAll(t *testing.T) {
 
 	networkSecurityGroup := testInstanceBuildNetworkSecurityGroup(t, dbSession, tn1, st, "testNetworkSecurityGroup")
 
-	nvlinkLogicalPartition := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn1.Org, tn1.ID, st.ID, db.GetStrPtr(NVLinkLogicalPartitionStatusReady), tnu1.ID)
+	nvlinkLogicalPartition := testBuildNVLinkLogicalPartition(t, dbSession, nil, "test-nvlinklogicalpartition", nil, tn1.Org, tn1.ID, st.ID, db.Ptr(NVLinkLogicalPartitionStatusReady), tnu1.ID)
 
 	totalCount := 30
 

--- a/rest-api/workflow/pkg/activity/nvlinklogicalpartition/nvlinklogicalpartition.go
+++ b/rest-api/workflow/pkg/activity/nvlinklogicalpartition/nvlinklogicalpartition.go
@@ -107,7 +107,7 @@ func (mnlp ManageNVLinkLogicalPartition) UpdateNVLinkLogicalPartitionsInDB(ctx c
 
 		var name *string
 		var description *string
-		var status *string
+		var status *cdbm.NVLinkLogicalPartitionStatus
 		var statusMessage *string
 
 		// Reset missing flag if necessary
@@ -128,9 +128,12 @@ func (mnlp ManageNVLinkLogicalPartition) UpdateNVLinkLogicalPartitionsInDB(ctx c
 
 		// Update status if necessary
 		if controllerNvllp.Status != nil {
-			status, statusMessage = util.GetNVLinkLogicalPartitionStatus(controllerNvllp.Status.State)
-			if status != nil && *status == nvllp.Status {
-				status = nil
+			var mapped cdbm.NVLinkLogicalPartitionStatus
+			mapped.FromProto(controllerNvllp.Status.State)
+			if mapped != "" && mapped != nvllp.Status {
+				status = &mapped
+				message := mapped.Message()
+				statusMessage = &message
 			}
 		}
 
@@ -156,7 +159,7 @@ func (mnlp ManageNVLinkLogicalPartition) UpdateNVLinkLogicalPartitionsInDB(ctx c
 		}
 
 		if status != nil {
-			_, err = statusDetailDAO.CreateFromParams(ctx, nil, nvllp.ID.String(), *status, statusMessage)
+			_, err = statusDetailDAO.CreateFromParams(ctx, nil, nvllp.ID.String(), string(*status), statusMessage)
 			if err != nil {
 				slogger.Error().Err(err).Msg("failed to create status detail for NVLink Logical Partition in DB")
 				continue
@@ -210,7 +213,7 @@ func (mnlp ManageNVLinkLogicalPartition) UpdateNVLinkLogicalPartitionsInDB(ctx c
 				continue
 			}
 
-			_, _, err = util.UpdateNVLinkLogicalPartitionStatusInDB(ctx, nil, mnlp.dbSession, nvllp.ID, cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusError), cdb.GetStrPtr("NVLink Logical Partition is missing on Site"))
+			_, _, err = util.UpdateNVLinkLogicalPartitionStatusInDB(ctx, nil, mnlp.dbSession, nvllp.ID, cdb.Ptr(cdbm.NVLinkLogicalPartitionStatusError), cdb.GetStrPtr("NVLink Logical Partition is missing on Site"))
 			if err != nil {
 				slogger.Error().Err(err).Msg("failed to update NVLink Logical Partition status detail in DB")
 			}

--- a/rest-api/workflow/pkg/util/common.go
+++ b/rest-api/workflow/pkg/util/common.go
@@ -12,8 +12,6 @@ import (
 	cdb "github.com/NVIDIA/infra-controller-rest/db/pkg/db"
 	cdbm "github.com/NVIDIA/infra-controller-rest/db/pkg/db/model"
 	"github.com/google/uuid"
-
-	cwssaws "github.com/NVIDIA/infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 var (
@@ -86,24 +84,8 @@ func IsTimeWithinStaleInventoryThreshold(actionTime time.Time) bool {
 	return time.Since(actionTime) < cwutil.InventoryReceiptInterval+(time.Second*10)
 }
 
-// GetNVLinkLogicalPartitionStatus returns the NVLinkLogicalPartition status and message from Controller NVLinkLogicalPartition state
-func GetNVLinkLogicalPartitionStatus(controllerNVLinkLogicalPartitionTenantState cwssaws.TenantState) (*string, *string) {
-	switch controllerNVLinkLogicalPartitionTenantState {
-	case cwssaws.TenantState_PROVISIONING:
-		return cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusProvisioning), cdb.GetStrPtr("NVLink Logical Partition is being provisioned on Site")
-	case cwssaws.TenantState_CONFIGURING:
-		return cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusConfiguring), cdb.GetStrPtr("NVLink Logical Partition is being configured on Site")
-	case cwssaws.TenantState_READY:
-		return cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusReady), cdb.GetStrPtr("NVLink Logical Partition is ready for use")
-	case cwssaws.TenantState_FAILED:
-		return cdb.GetStrPtr(cdbm.NVLinkLogicalPartitionStatusError), cdb.GetStrPtr("NVLink Logical Partition is in error state")
-	default:
-		return nil, nil
-	}
-}
-
 // UpdateNVLinkLogicalPartitionStatusInDB updates the NVLinkLogicalPartition status in the DB and creates a new StatusDetail
-func UpdateNVLinkLogicalPartitionStatusInDB(ctx context.Context, tx *cdb.Tx, dbSession *cdb.Session, nvlinklogicalpartitionID uuid.UUID, status *string, statusMessage *string) (*cdbm.NVLinkLogicalPartition, *cdbm.StatusDetail, error) {
+func UpdateNVLinkLogicalPartitionStatusInDB(ctx context.Context, tx *cdb.Tx, dbSession *cdb.Session, nvlinklogicalpartitionID uuid.UUID, status *cdbm.NVLinkLogicalPartitionStatus, statusMessage *string) (*cdbm.NVLinkLogicalPartition, *cdbm.StatusDetail, error) {
 	var updatedNVLinkLogicalPartition *cdbm.NVLinkLogicalPartition
 	var err error
 	var newSSD *cdbm.StatusDetail
@@ -122,7 +104,7 @@ func UpdateNVLinkLogicalPartitionStatusInDB(ctx context.Context, tx *cdb.Tx, dbS
 		}
 
 		statusDetailDAO := cdbm.NewStatusDetailDAO(dbSession)
-		newSSD, err = statusDetailDAO.CreateFromParams(ctx, tx, nvlinklogicalpartitionID.String(), *status, statusMessage)
+		newSSD, err = statusDetailDAO.CreateFromParams(ctx, tx, nvlinklogicalpartitionID.String(), string(*status), statusMessage)
 		if err != nil {
 			return updatedNVLinkLogicalPartition, newSSD, err
 		}

--- a/rest-api/workflow/pkg/util/testing.go
+++ b/rest-api/workflow/pkg/util/testing.go
@@ -291,7 +291,7 @@ func TestBuildInfiniBandPartition(t *testing.T, dbSession *cdb.Session, name str
 }
 
 // TestBuildNVLinkLogicalPartition builds and returns an NVLinkLogicalPartition
-func TestBuildNVLinkLogicalPartition(t *testing.T, dbSession *cdb.Session, name string, description *string, site *cdbm.Site, tenant *cdbm.Tenant, status string, isMissingOnSite bool) *cdbm.NVLinkLogicalPartition {
+func TestBuildNVLinkLogicalPartition(t *testing.T, dbSession *cdb.Session, name string, description *string, site *cdbm.Site, tenant *cdbm.Tenant, status cdbm.NVLinkLogicalPartitionStatus, isMissingOnSite bool) *cdbm.NVLinkLogicalPartition {
 	nvllp := &cdbm.NVLinkLogicalPartition{
 		ID:              uuid.New(),
 		Name:            name,


### PR DESCRIPTION
## Description

Brings `NVLinkLogicalPartition` in line with the proto-modeling changes. Create and Update route through `ToProto` on the API request types.

Primary callouts are:
- API request side: `APINVLinkLogicalPartitionCreateRequest.ToProto` and `APINVLinkLogicalPartitionUpdateRequest.ToProto`, each sourcing corresponding fields via the entity's `ToProto()`.
- Entity side: `NVLinkLogicalPartition.ToProto`, `FromProto`, and `ToDeletionRequestProto`. Metadata now lives in the entity's `ToProto()`.
- There's also a new `NVLinkLogicalPartition.Validate()` so site-driven `FromProto` callers can do `FromProto` + `Validate` -- mirroring the MachineCapability workflow (which went in at [#569](https://github.com/NVIDIA/infra-controller-rest/pull/569)).
- `NVLinkLogicalPartitionStatus` is now a typed string with its own `.FromProto(state)` and `.Message()` methods, replacing the `wfutil.GetNVLinkLogicalPartitionStatus(state)` helper that split a single proto state into `(status, message)`. `UpdateNVLinkLogicalPartitionStatusInDB` is retained but now takes a typed `*NVLinkLogicalPartitionStatus`.
- Handler simplified to one-liners on create / update / delete.

As part of the new typed `NVLinkLogicalPartitionStatus`, the typing propagates through the API and DAO layers, but nothing changes on the wire -- JSON serialization of `type X string` is identical to `string`, the OpenAPI spec still just says "string", and the SDK is unaffected.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated NVLink Logical Partition test fixtures for consistency across handler and database model tests.

* **Refactor**
  * Improved NVLink Logical Partition status handling with stronger type safety and enhanced validation for partition names and status values.
  * Streamlined workflow request payload generation with improved proto conversion utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->