### PR TITLE
fix: wired direct path for rms firmware update

### DIFF
--- a/crates/api-core/src/handlers/attestation.rs
+++ b/crates/api-core/src/handlers/attestation.rs
@@ -310,6 +310,7 @@ pub(crate) async fn attest_quote(
 }
 
 #[cfg(not(feature = "linux-build"))]
+#[allow(clippy::unused_async)]
 pub(crate) async fn attest_quote(
     _api: &Api,
     _request: Request<rpc::AttestQuoteRequest>,

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -29,6 +29,7 @@ use component_manager::compute_tray_manager::{ComputeTrayEndpoint, ComputeTrayVe
 use component_manager::error::ComponentManagerError;
 use component_manager::nv_switch_manager::SwitchEndpoint;
 use component_manager::power_shelf_manager::{PowerShelfEndpoint, PowerShelfVendor};
+use component_manager::types::FirmwareUpdateOptions;
 use db::{self, WithTransaction};
 use forge_secrets::credentials::{
     BmcCredentialType, CredentialKey, CredentialManager, Credentials,
@@ -389,7 +390,17 @@ fn normalize_access_token(access_token: Option<String>) -> Option<String> {
 fn validate_firmware_object_json_request(target_version: &str) -> Result<(), Status> {
     if target_version.trim().is_empty() {
         return Err(Status::invalid_argument(
-            "target_version must contain SOT JSON for firmware updates routed through rack maintenance",
+            "target_version must contain SOT JSON for firmware updates",
+        ));
+    }
+    let value: serde_json::Value = serde_json::from_str(target_version).map_err(|e| {
+        Status::invalid_argument(format!(
+            "target_version must contain valid SOT JSON for firmware updates: {e}"
+        ))
+    })?;
+    if !value.is_object() {
+        return Err(Status::invalid_argument(
+            "target_version must contain a SOT JSON object for firmware updates",
         ));
     }
     Ok(())
@@ -422,6 +433,25 @@ fn require_firmware_object_json_for_rack_maintenance(
 
     validate_firmware_object_json_request(target_version)?;
     Ok(token)
+}
+
+fn require_firmware_object_json_for_direct_rms(
+    target: &str,
+    access_token: &Option<String>,
+    target_version: &str,
+    force_update: bool,
+) -> Result<FirmwareUpdateOptions, Status> {
+    let Some(token) = access_token.clone() else {
+        return Err(Status::invalid_argument(format!(
+            "access_token is required for {target} firmware updates routed directly to RMS"
+        )));
+    };
+
+    validate_firmware_object_json_request(target_version)?;
+    Ok(FirmwareUpdateOptions {
+        access_token: Some(token),
+        force_update,
+    })
 }
 
 fn reject_firmware_object_json_for_direct_dispatch(
@@ -1503,7 +1533,12 @@ pub(crate) async fn update_component_firmware(
             }
 
             let cm = require_component_manager(api)?;
-            if cm.nv_switch_use_state_controller && !bypass_state_controller {
+            let route_through_state_controller =
+                cm.nv_switch_use_state_controller && !bypass_state_controller;
+            let use_direct_rms_json =
+                !route_through_state_controller && cm.nv_switch.supports_firmware_object_json();
+
+            if route_through_state_controller {
                 let token = require_firmware_object_json_for_rack_maintenance(
                     "switch",
                     &access_token,
@@ -1518,7 +1553,17 @@ pub(crate) async fn update_component_firmware(
                 );
                 rack_maintenance_targets = group_switch_ids_by_rack(api, &list.ids).await?;
             } else {
-                reject_firmware_object_json_for_direct_dispatch("switch", &access_token)?;
+                let options = if use_direct_rms_json {
+                    require_firmware_object_json_for_direct_rms(
+                        "switch",
+                        &access_token,
+                        &req.target_version,
+                        force_update,
+                    )?
+                } else {
+                    reject_firmware_object_json_for_direct_dispatch("switch", &access_token)?;
+                    FirmwareUpdateOptions::default()
+                };
                 let components = map_nv_switch_components(&t.components)?;
                 let endpoints = resolve_switch_endpoints(api, &list.ids).await?;
 
@@ -1534,6 +1579,7 @@ pub(crate) async fn update_component_firmware(
                         &endpoints.resolved.endpoints,
                         &req.target_version,
                         &components,
+                        &options,
                     )
                     .await
                     .map_err(component_manager_error_to_status)?;
@@ -1592,6 +1638,7 @@ pub(crate) async fn update_component_firmware(
                         &resolved.resolved.endpoints,
                         &req.target_version,
                         &components,
+                        &FirmwareUpdateOptions::default(),
                     )
                     .await
                     .map_err(component_manager_error_to_status)?;
@@ -1619,14 +1666,29 @@ pub(crate) async fn update_component_firmware(
             }
 
             let cm = require_component_manager(api)?;
-            if cm.power_shelf_use_state_controller && !bypass_state_controller {
+            let route_through_state_controller =
+                cm.power_shelf_use_state_controller && !bypass_state_controller;
+            if route_through_state_controller {
                 // TODO: implement state controller path for power shelf firmware control
                 return Err(Status::unimplemented(
                     "power shelf firmware control through the state controller is not yet supported",
                 ));
             }
 
-            reject_power_shelf_firmware_object_json(&access_token)?;
+            let options = if cm.power_shelf.supports_firmware_object_json() {
+                require_firmware_object_json_for_direct_rms(
+                    "power shelf",
+                    &access_token,
+                    &req.target_version,
+                    force_update,
+                )?
+            } else {
+                reject_power_shelf_firmware_object_json(&access_token)?;
+                FirmwareUpdateOptions {
+                    force_update,
+                    ..FirmwareUpdateOptions::default()
+                }
+            };
             let components = map_power_shelf_components(&t.components)?;
             let endpoints = resolve_power_shelf_endpoints(api, &list.ids).await?;
 
@@ -1642,6 +1704,7 @@ pub(crate) async fn update_component_firmware(
                     &endpoints.resolved.endpoints,
                     &req.target_version,
                     &components,
+                    &options,
                 )
                 .await
                 .map_err(component_manager_error_to_status)?;
@@ -2098,6 +2161,14 @@ mod tests {
         assert_eq!(err.code(), Code::InvalidArgument);
         assert!(err.message().contains("target_version"));
 
+        let err = validate_firmware_object_json_request("fw-1.0.0").unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("valid SOT JSON"));
+
+        let err = validate_firmware_object_json_request(r#""fw-1.0.0""#).unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("SOT JSON object"));
+
         validate_firmware_object_json_request("{}").unwrap();
     }
 
@@ -2191,7 +2262,31 @@ mod tests {
     }
 
     #[test]
-    fn direct_firmware_update_rejects_access_token() {
+    fn direct_rms_firmware_update_requires_access_token() {
+        let err =
+            require_firmware_object_json_for_direct_rms("switch", &None, "{}", false).unwrap_err();
+
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("access_token"));
+        assert!(err.message().contains("directly to RMS"));
+    }
+
+    #[test]
+    fn direct_rms_firmware_update_returns_options_when_valid() {
+        let options = require_firmware_object_json_for_direct_rms(
+            "switch",
+            &Some("token".to_string()),
+            "{}",
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(options.access_token.as_deref(), Some("token"));
+        assert!(options.force_update);
+    }
+
+    #[test]
+    fn non_rms_direct_firmware_update_rejects_access_token() {
         let err =
             reject_firmware_object_json_for_direct_dispatch("switch", &Some("token".to_string()))
                 .unwrap_err();

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -495,7 +495,7 @@ pub async fn start_api(
     )
     .await?;
 
-    let rms_client = match carbide_config.rms.api_url.clone() {
+    let (rms_client, switch_system_image_rms_api) = match carbide_config.rms.api_url.clone() {
         Some(url) if !url.is_empty() => {
             let rms_client_config = librms::client_config::RmsClientConfig::new(
                 carbide_config.rms.root_ca_path.clone(),
@@ -506,9 +506,11 @@ pub async fn start_api(
             let rms_api_config = librms::client::RmsApiConfig::new(&url, &rms_client_config);
             let rms_client_pool = librms::RmsClientPool::new(&rms_api_config);
             let shared_rms_client = rms_client_pool.create_client().await;
-            Some(shared_rms_client)
+            let switch_system_image_rms_api =
+                Arc::new(librms::RackManagerApi::new(&rms_api_config));
+            (Some(shared_rms_client), Some(switch_system_image_rms_api))
         }
-        _ => None,
+        _ => (None, None),
     };
     let ib_config = carbide_config.ib_config.clone().unwrap_or_default();
     let fabric_manager_type = match ib_config.enabled {
@@ -707,6 +709,9 @@ pub async fn start_api(
         match component_manager::component_manager::build_component_manager(
             cd_config,
             rms_client.clone(),
+            switch_system_image_rms_api.clone().map(|client| {
+                client as Arc<dyn component_manager::rms::RmsSwitchSystemImageStatusApi>
+            }),
             Some(db_pool.clone()),
             Some(shared_redfish_pool.clone()),
         )

--- a/crates/api-test-helper/src/mock_rms.rs
+++ b/crates/api-test-helper/src/mock_rms.rs
@@ -158,6 +158,10 @@ pub struct MockRmsApi {
         Mutex<VecDeque<Result<rms::ApplySwitchSystemImageResponse, RackManagerError>>>,
     apply_switch_system_image_calls: Mutex<Vec<rms::ApplySwitchSystemImageRequest>>,
 
+    get_switch_system_image_job_status_responses:
+        Mutex<VecDeque<Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError>>>,
+    get_switch_system_image_job_status_calls: Mutex<Vec<rms::GetSwitchSystemImageJobStatusRequest>>,
+
     get_firmware_object_history_responses:
         Mutex<VecDeque<Result<rms::GetFirmwareObjectHistoryResponse, RackManagerError>>>,
     get_firmware_object_history_calls: Mutex<Vec<rms::GetFirmwareObjectHistoryRequest>>,
@@ -296,6 +300,8 @@ impl MockRmsApi {
             apply_switch_system_image_from_json_calls: Default::default(),
             apply_switch_system_image_responses: Default::default(),
             apply_switch_system_image_calls: Default::default(),
+            get_switch_system_image_job_status_responses: Default::default(),
+            get_switch_system_image_job_status_calls: Default::default(),
             get_firmware_object_history_responses: Default::default(),
             get_firmware_object_history_calls: Default::default(),
             update_node_firmware_async_responses: Default::default(),
@@ -546,6 +552,14 @@ impl MockRmsApi {
         rms::ApplySwitchSystemImageResponse
     );
     impl_enqueue_inspect!(
+        enqueue_get_switch_system_image_job_status,
+        get_switch_system_image_job_status_calls,
+        get_switch_system_image_job_status_responses,
+        get_switch_system_image_job_status_calls,
+        rms::GetSwitchSystemImageJobStatusRequest,
+        rms::GetSwitchSystemImageJobStatusResponse
+    );
+    impl_enqueue_inspect!(
         enqueue_get_firmware_object_history,
         get_firmware_object_history_calls,
         get_firmware_object_history_responses,
@@ -760,6 +774,106 @@ impl MockRmsApi {
         }
     }
 
+    /// Success response for `apply_firmware_object_from_json` with a child job ID.
+    pub fn firmware_object_apply_ok(
+        node_id: &str,
+        job_id: &str,
+    ) -> rms::ApplyFirmwareObjectResponse {
+        rms::ApplyFirmwareObjectResponse {
+            response: Some(rms::NodeBatchResponse {
+                status: rms::ReturnCode::Success as i32,
+                total_nodes: 1,
+                successful_nodes: 1,
+                failed_nodes: 0,
+                node_results: vec![rms::NodeResult {
+                    node_id: node_id.to_owned(),
+                    status: rms::ReturnCode::Success as i32,
+                    error_message: String::new(),
+                }],
+                ..Default::default()
+            }),
+            node_jobs: vec![rms::NodeFirmwareJobInfo {
+                node_id: node_id.to_owned(),
+                job_id: job_id.to_owned(),
+            }],
+            object_id: "fw-json".to_owned(),
+        }
+    }
+
+    /// Failure response for `apply_firmware_object_from_json`.
+    pub fn firmware_object_apply_fail(
+        node_id: &str,
+        msg: &str,
+    ) -> rms::ApplyFirmwareObjectResponse {
+        rms::ApplyFirmwareObjectResponse {
+            response: Some(rms::NodeBatchResponse {
+                status: rms::ReturnCode::Failure as i32,
+                total_nodes: 1,
+                successful_nodes: 0,
+                failed_nodes: 1,
+                node_results: vec![rms::NodeResult {
+                    node_id: node_id.to_owned(),
+                    status: rms::ReturnCode::Failure as i32,
+                    error_message: msg.to_owned(),
+                }],
+                ..Default::default()
+            }),
+            node_jobs: Vec::new(),
+            object_id: "fw-json".to_owned(),
+        }
+    }
+
+    /// Success response for `apply_switch_system_image_from_json` with a child job ID.
+    pub fn switch_system_image_apply_ok(
+        node_id: &str,
+        job_id: &str,
+    ) -> rms::ApplySwitchSystemImageResponse {
+        rms::ApplySwitchSystemImageResponse {
+            response: Some(rms::NodeBatchResponse {
+                status: rms::ReturnCode::Success as i32,
+                total_nodes: 1,
+                successful_nodes: 1,
+                failed_nodes: 0,
+                node_results: vec![rms::NodeResult {
+                    node_id: node_id.to_owned(),
+                    status: rms::ReturnCode::Success as i32,
+                    error_message: String::new(),
+                }],
+                ..Default::default()
+            }),
+            node_jobs: vec![rms::SwitchSystemImageUpdateJobInfo {
+                node_id: node_id.to_owned(),
+                job_id: job_id.to_owned(),
+            }],
+            object_id: "fw-json".to_owned(),
+            image_filename: "nvos.img".to_owned(),
+        }
+    }
+
+    /// Failure response for `apply_switch_system_image_from_json`.
+    pub fn switch_system_image_apply_fail(
+        node_id: &str,
+        msg: &str,
+    ) -> rms::ApplySwitchSystemImageResponse {
+        rms::ApplySwitchSystemImageResponse {
+            response: Some(rms::NodeBatchResponse {
+                status: rms::ReturnCode::Failure as i32,
+                total_nodes: 1,
+                successful_nodes: 0,
+                failed_nodes: 1,
+                node_results: vec![rms::NodeResult {
+                    node_id: node_id.to_owned(),
+                    status: rms::ReturnCode::Failure as i32,
+                    error_message: msg.to_owned(),
+                }],
+                ..Default::default()
+            }),
+            node_jobs: Vec::new(),
+            object_id: "fw-json".to_owned(),
+            image_filename: "nvos.img".to_owned(),
+        }
+    }
+
     /// Success response for `get_firmware_job_status`.
     pub fn firmware_job_status_ok(
         state: rms::FirmwareJobState,
@@ -769,6 +883,42 @@ impl MockRmsApi {
             job_state: state as i32,
             ..Default::default()
         }
+    }
+
+    /// Success response for `poll_job_status`.
+    pub fn poll_job_status_ok(state: &str) -> rms::PollJobStatusResponse {
+        rms::PollJobStatusResponse {
+            status: rms::ReturnCode::Success as i32,
+            state: state.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    /// Success response for `get_switch_system_image_job_status`.
+    pub fn switch_system_image_job_status_ok(
+        state: &str,
+    ) -> rms::GetSwitchSystemImageJobStatusResponse {
+        rms::GetSwitchSystemImageJobStatusResponse {
+            status: rms::ReturnCode::Success as i32,
+            state: state.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    pub async fn get_switch_system_image_job_status_for_test(
+        &self,
+        cmd: rms::GetSwitchSystemImageJobStatusRequest,
+    ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError> {
+        self.get_switch_system_image_job_status_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(
+            &mut self
+                .get_switch_system_image_job_status_responses
+                .lock()
+                .await,
+        )
     }
 
     /// Success response for `get_node_firmware_inventory`.

--- a/crates/component-manager/src/component_manager.rs
+++ b/crates/component-manager/src/component_manager.rs
@@ -12,6 +12,7 @@ use crate::config::ComponentManagerConfig;
 use crate::error::ComponentManagerError;
 use crate::nv_switch_manager::NvSwitchManager;
 use crate::power_shelf_manager::PowerShelfManager;
+use crate::rms::RmsSwitchSystemImageStatusApi;
 
 /// Holds the configured backend implementations for each component type.
 #[derive(Debug, Clone)]
@@ -64,6 +65,7 @@ impl ComponentManager {
 pub async fn build_component_manager(
     config: &ComponentManagerConfig,
     rms_client: Option<Arc<dyn RmsApi>>,
+    rms_switch_system_image_client: Option<Arc<dyn RmsSwitchSystemImageStatusApi>>,
     db: Option<PgPool>,
     redfish_pool: Option<Arc<dyn RedfishClientPool>>,
 ) -> Result<ComponentManager, ComponentManagerError> {
@@ -90,7 +92,11 @@ pub async fn build_component_manager(
                     "nv_switch_backend is 'rms' but database pool is not configured".into(),
                 )
             })?;
-            Arc::new(crate::rms::RmsBackend::new(client, db))
+            Arc::new(crate::rms::RmsBackend::new(
+                client,
+                rms_switch_system_image_client.clone(),
+                db,
+            ))
         }
         "mock" => Arc::new(crate::mock::MockNvSwitchManager),
         other => {
@@ -124,7 +130,11 @@ pub async fn build_component_manager(
                     "power_shelf_backend is 'rms' but database pool is not configured".into(),
                 )
             })?;
-            Arc::new(crate::rms::RmsBackend::new(client, db))
+            Arc::new(crate::rms::RmsBackend::new(
+                client,
+                rms_switch_system_image_client.clone(),
+                db,
+            ))
         }
         "mock" => Arc::new(crate::mock::MockPowerShelfManager),
         other => {
@@ -178,7 +188,7 @@ mod tests {
             compute_tray_backend: Backend::Mock,
             ..Default::default()
         };
-        let cm = build_component_manager(&config, None, None, None)
+        let cm = build_component_manager(&config, None, None, None, None)
             .await
             .unwrap();
         assert_eq!(cm.nv_switch.name(), "mock-nsm");
@@ -194,7 +204,7 @@ mod tests {
             compute_tray_backend: Backend::Mock,
             ..Default::default()
         };
-        let err = build_component_manager(&config, None, None, None)
+        let err = build_component_manager(&config, None, None, None, None)
             .await
             .unwrap_err();
         assert!(
@@ -210,7 +220,7 @@ mod tests {
             compute_tray_backend: Backend::Mock,
             ..Default::default()
         };
-        let err = build_component_manager(&config, None, None, None)
+        let err = build_component_manager(&config, None, None, None, None)
             .await
             .unwrap_err();
         assert!(
@@ -226,7 +236,7 @@ mod tests {
             compute_tray_backend: Backend::Mock,
             ..Default::default()
         };
-        let err = build_component_manager(&config, None, None, None)
+        let err = build_component_manager(&config, None, None, None, None)
             .await
             .unwrap_err();
         assert!(matches!(err, ComponentManagerError::InvalidArgument(_)));
@@ -240,7 +250,7 @@ mod tests {
             compute_tray_backend: Backend::Mock,
             ..Default::default()
         };
-        let err = build_component_manager(&config, None, None, None)
+        let err = build_component_manager(&config, None, None, None, None)
             .await
             .unwrap_err();
         assert!(matches!(err, ComponentManagerError::InvalidArgument(_)));

--- a/crates/component-manager/src/compute_tray_manager.rs
+++ b/crates/component-manager/src/compute_tray_manager.rs
@@ -8,6 +8,7 @@ use forge_secrets::credentials::Credentials;
 use model::component_manager::{ComputeTrayComponent, FirmwareState, PowerAction};
 
 use crate::error::ComponentManagerError;
+use crate::types::FirmwareUpdateOptions;
 
 /// Physical network identifiers for a compute tray, used to register with and
 /// operate against the backend service (CTM).
@@ -92,6 +93,7 @@ pub trait ComputeTrayManager: Send + Sync + Debug + 'static {
         endpoints: &[ComputeTrayEndpoint],
         target_version: &str,
         components: &[ComputeTrayComponent],
+        options: &FirmwareUpdateOptions,
     ) -> Result<Vec<ComputeTrayResult>, ComponentManagerError>;
 
     async fn get_firmware_status(

--- a/crates/component-manager/src/core_compute_manager.rs
+++ b/crates/component-manager/src/core_compute_manager.rs
@@ -112,6 +112,7 @@ impl crate::compute_tray_manager::ComputeTrayManager for CoreComputeTrayManager 
         _endpoints: &[ComputeTrayEndpoint],
         _target_version: &str,
         _components: &[ComputeTrayComponent],
+        _options: &crate::types::FirmwareUpdateOptions,
     ) -> Result<Vec<ComputeTrayResult>, ComponentManagerError> {
         Err(ComponentManagerError::Internal(
             "firmware update is not supported by the core compute tray backend".into(),

--- a/crates/component-manager/src/mock.rs
+++ b/crates/component-manager/src/mock.rs
@@ -17,6 +17,7 @@ use crate::power_shelf_manager::{
     PowerShelfComponentResult, PowerShelfEndpoint, PowerShelfFirmwareUpdateStatus,
     PowerShelfFirmwareVersions, PowerShelfManager,
 };
+use crate::types::FirmwareUpdateOptions;
 
 #[derive(Debug, Default)]
 pub struct MockNvSwitchManager;
@@ -47,6 +48,7 @@ impl NvSwitchManager for MockNvSwitchManager {
         endpoints: &[SwitchEndpoint],
         _bundle_version: &str,
         _components: &[NvSwitchComponent],
+        _options: &FirmwareUpdateOptions,
     ) -> Result<Vec<SwitchComponentResult>, ComponentManagerError> {
         Ok(endpoints
             .iter()
@@ -107,6 +109,7 @@ impl PowerShelfManager for MockPowerShelfManager {
         endpoints: &[PowerShelfEndpoint],
         _target_version: &str,
         _components: &[PowerShelfComponent],
+        _options: &FirmwareUpdateOptions,
     ) -> Result<Vec<PowerShelfComponentResult>, ComponentManagerError> {
         Ok(endpoints
             .iter()
@@ -181,6 +184,7 @@ impl ComputeTrayManager for MockComputeTrayManager {
         endpoints: &[ComputeTrayEndpoint],
         _target_version: &str,
         _components: &[ComputeTrayComponent],
+        _options: &FirmwareUpdateOptions,
     ) -> Result<Vec<ComputeTrayResult>, ComponentManagerError> {
         Ok(endpoints
             .iter()

--- a/crates/component-manager/src/nsm.rs
+++ b/crates/component-manager/src/nsm.rs
@@ -220,6 +220,7 @@ impl NvSwitchManager for NsmSwitchBackend {
         endpoints: &[SwitchEndpoint],
         bundle_version: &str,
         components: &[NvSwitchComponent],
+        _options: &crate::types::FirmwareUpdateOptions,
     ) -> Result<Vec<SwitchComponentResult>, ComponentManagerError> {
         let (mac_to_uuid, uuid_to_mac) =
             register_and_map(&mut self.client.clone(), endpoints).await?;

--- a/crates/component-manager/src/nv_switch_manager.rs
+++ b/crates/component-manager/src/nv_switch_manager.rs
@@ -9,6 +9,7 @@ use mac_address::MacAddress;
 use model::component_manager::{FirmwareState, NvSwitchComponent, PowerAction};
 
 use crate::error::ComponentManagerError;
+use crate::types::FirmwareUpdateOptions;
 
 /// Physical network identifiers for an NV-Switch, used to register with and
 /// operate against the backend service (NSM).
@@ -47,6 +48,10 @@ pub struct SwitchFirmwareUpdateStatus {
 pub trait NvSwitchManager: Send + Sync + Debug + 'static {
     fn name(&self) -> &str;
 
+    fn supports_firmware_object_json(&self) -> bool {
+        false
+    }
+
     async fn power_control(
         &self,
         endpoints: &[SwitchEndpoint],
@@ -58,6 +63,7 @@ pub trait NvSwitchManager: Send + Sync + Debug + 'static {
         endpoints: &[SwitchEndpoint],
         bundle_version: &str,
         components: &[NvSwitchComponent],
+        options: &FirmwareUpdateOptions,
     ) -> Result<Vec<SwitchComponentResult>, ComponentManagerError>;
 
     async fn get_firmware_status(

--- a/crates/component-manager/src/power_shelf_manager.rs
+++ b/crates/component-manager/src/power_shelf_manager.rs
@@ -9,6 +9,7 @@ use mac_address::MacAddress;
 use model::component_manager::{FirmwareState, PowerAction, PowerShelfComponent};
 
 use crate::error::ComponentManagerError;
+use crate::types::FirmwareUpdateOptions;
 
 /// Physical network identifiers for a power shelf, used to register with and
 /// operate against the backend service (PSM).
@@ -61,6 +62,10 @@ pub struct PowerShelfFirmwareVersions {
 pub trait PowerShelfManager: Send + Sync + Debug + 'static {
     fn name(&self) -> &str;
 
+    fn supports_firmware_object_json(&self) -> bool {
+        false
+    }
+
     async fn power_control(
         &self,
         endpoints: &[PowerShelfEndpoint],
@@ -72,6 +77,7 @@ pub trait PowerShelfManager: Send + Sync + Debug + 'static {
         endpoints: &[PowerShelfEndpoint],
         target_version: &str,
         components: &[PowerShelfComponent],
+        options: &FirmwareUpdateOptions,
     ) -> Result<Vec<PowerShelfComponentResult>, ComponentManagerError>;
 
     async fn get_firmware_status(

--- a/crates/component-manager/src/psm.rs
+++ b/crates/component-manager/src/psm.rs
@@ -223,6 +223,7 @@ impl PowerShelfManager for PsmPowerShelfBackend {
         endpoints: &[PowerShelfEndpoint],
         target_version: &str,
         components: &[PowerShelfComponent],
+        _options: &crate::types::FirmwareUpdateOptions,
     ) -> Result<Vec<PowerShelfComponentResult>, ComponentManagerError> {
         register_with_psm(&mut self.client.clone(), endpoints).await?;
 

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -1158,7 +1158,7 @@ impl NvSwitchManager for RmsBackend {
                 }
             }
 
-            if success && !tracked_jobs.is_empty() {
+            if !tracked_jobs.is_empty() {
                 self.firmware_jobs
                     .lock()
                     .unwrap()
@@ -2262,6 +2262,41 @@ mod tests {
         );
         let status_calls = mock.get_switch_system_image_job_status_calls().await;
         assert_eq!(status_calls[0].job_id, "sw-nvos-job");
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn sw_queue_firmware_updates_mixed_failure_keeps_submitted_job(pool: sqlx::PgPool) {
+        let (mock, backend, _, _, _, sw1, _) = make_backend(&pool).await;
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+            &sw1.to_string(),
+            "sw-fw-job",
+        )))
+        .await;
+        mock.enqueue_apply_switch_system_image_from_json(Ok(
+            MockRmsApi::switch_system_image_apply_fail(&sw1.to_string(), "bad system image"),
+        ))
+        .await;
+
+        let eps = vec![make_sw_endpoint(SW_MAC_1)];
+        let results = backend
+            .queue_firmware_updates(
+                &eps,
+                r#"{"Id":"fw-json"}"#,
+                &[NvSwitchComponent::Bmc, NvSwitchComponent::Nvos],
+                &firmware_update_options(),
+            )
+            .await
+            .unwrap();
+
+        assert!(!results[0].success);
+
+        let jobs = backend.firmware_jobs.lock().unwrap();
+        assert_eq!(
+            jobs.get(&SW_MAC_1.parse::<MacAddress>().unwrap()),
+            Some(&vec![RmsTrackedFirmwareJob::FirmwareObject(
+                "sw-fw-job".to_string()
+            )])
+        );
     }
 
     #[carbide_macros::sqlx_test]

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -19,8 +19,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use forge_secrets::credentials::Credentials;
-use librms::RmsApi;
 use librms::protos::rack_manager as rms;
+use librms::{RackManagerError, RmsApi};
 use mac_address::MacAddress;
 use model::component_manager::{
     FirmwareState, NvSwitchComponent, PowerAction, PowerShelfComponent,
@@ -36,6 +36,7 @@ use crate::power_shelf_manager::{
     PowerShelfComponentResult, PowerShelfEndpoint, PowerShelfFirmwareUpdateStatus,
     PowerShelfFirmwareVersions, PowerShelfManager,
 };
+use crate::types::FirmwareUpdateOptions;
 
 /// RMS identity for a device: the node_id and rack_id that RMS needs
 /// to address it. Used for both power shelves and switches.
@@ -45,11 +46,46 @@ struct RmsIdentity {
     rack_id: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum RmsTrackedFirmwareJob {
+    FirmwareObject(String),
+    SwitchSystemImage {
+        job_id: String,
+        rack_id: String,
+        node_id: String,
+    },
+}
+
+// The direct RMS path matches the rack-maintenance flow and applies production
+// firmware artifacts only.
+const RMS_FIRMWARE_OBJECT_FIRMWARE_TYPE: &str = "prod";
+const RMS_SWITCH_SYSTEM_IMAGE_SOFTWARE_TYPE: &str = "prod";
+const RMS_FIRMWARE_OBJECT_HARDWARE_TYPE: &str = "any";
+
 pub struct RmsBackend {
     client: Arc<dyn RmsApi>,
+    switch_system_image_client: Option<Arc<dyn RmsSwitchSystemImageStatusApi>>,
     db: PgPool,
     /// Tracks firmware update job IDs keyed by device MAC address.
-    firmware_jobs: Mutex<HashMap<MacAddress, String>>,
+    firmware_jobs: Mutex<HashMap<MacAddress, Vec<RmsTrackedFirmwareJob>>>,
+}
+
+#[async_trait::async_trait]
+pub trait RmsSwitchSystemImageStatusApi: Send + Sync + 'static {
+    async fn get_switch_system_image_job_status(
+        &self,
+        cmd: rms::GetSwitchSystemImageJobStatusRequest,
+    ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError>;
+}
+
+#[async_trait::async_trait]
+impl RmsSwitchSystemImageStatusApi for librms::RackManagerApi {
+    async fn get_switch_system_image_job_status(
+        &self,
+        cmd: rms::GetSwitchSystemImageJobStatusRequest,
+    ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError> {
+        Ok(self.client.get_switch_system_image_job_status(cmd).await?)
+    }
 }
 
 impl std::fmt::Debug for RmsBackend {
@@ -61,9 +97,14 @@ impl std::fmt::Debug for RmsBackend {
 }
 
 impl RmsBackend {
-    pub fn new(client: Arc<dyn RmsApi>, db: PgPool) -> Self {
+    pub fn new(
+        client: Arc<dyn RmsApi>,
+        switch_system_image_client: Option<Arc<dyn RmsSwitchSystemImageStatusApi>>,
+        db: PgPool,
+    ) -> Self {
         Self {
             client,
+            switch_system_image_client,
             db,
             firmware_jobs: Mutex::new(HashMap::new()),
         }
@@ -150,11 +191,47 @@ fn map_rms_firmware_job_state(state: i32) -> FirmwareState {
     }
 }
 
-/// Map PowerShelfComponent to a firmware target name used by RMS.
-fn power_shelf_target_name(c: &PowerShelfComponent) -> &'static str {
-    match c {
-        PowerShelfComponent::Pmc => "pmc",
-        PowerShelfComponent::Psu => "psu",
+fn map_rms_switch_system_image_job_state(state: &str) -> FirmwareState {
+    match state.to_ascii_lowercase().as_str() {
+        "queued" | "pending" => FirmwareState::Queued,
+        "running" | "in_progress" | "active" => FirmwareState::InProgress,
+        "verifying" | "verify" | "validating" | "validation" => FirmwareState::Verifying,
+        "completed" | "success" | "done" => FirmwareState::Completed,
+        "failed" | "error" => FirmwareState::Failed,
+        "cancelled" | "canceled" => FirmwareState::Cancelled,
+        _ => FirmwareState::Unknown,
+    }
+}
+
+fn aggregate_firmware_job_states(states: &[FirmwareState]) -> FirmwareState {
+    if states.is_empty() {
+        return FirmwareState::Unknown;
+    }
+    if states.contains(&FirmwareState::Failed) {
+        return FirmwareState::Failed;
+    }
+    if states.contains(&FirmwareState::Cancelled) {
+        return FirmwareState::Cancelled;
+    }
+    if states.contains(&FirmwareState::InProgress) {
+        return FirmwareState::InProgress;
+    }
+    if states.contains(&FirmwareState::Verifying) {
+        return FirmwareState::Verifying;
+    }
+    if states.contains(&FirmwareState::Queued) {
+        return FirmwareState::Queued;
+    }
+    if states.contains(&FirmwareState::Unknown) {
+        return FirmwareState::Unknown;
+    }
+    if states
+        .iter()
+        .all(|state| *state == FirmwareState::Completed)
+    {
+        FirmwareState::Completed
+    } else {
+        FirmwareState::Unknown
     }
 }
 
@@ -190,6 +267,10 @@ fn build_power_shelf_node_info(
 impl PowerShelfManager for RmsBackend {
     fn name(&self) -> &str {
         "rms"
+    }
+
+    fn supports_firmware_object_json(&self) -> bool {
+        true
     }
 
     #[instrument(skip(self), fields(backend = "rms"))]
@@ -250,22 +331,17 @@ impl PowerShelfManager for RmsBackend {
         Ok(results)
     }
 
-    #[instrument(skip(self), fields(backend = "rms"))]
+    #[instrument(skip(self, target_version, options), fields(backend = "rms", force_update = options.force_update))]
     async fn update_firmware(
         &self,
         endpoints: &[PowerShelfEndpoint],
         target_version: &str,
         components: &[PowerShelfComponent],
+        options: &FirmwareUpdateOptions,
     ) -> Result<Vec<PowerShelfComponentResult>, ComponentManagerError> {
         let macs: Vec<MacAddress> = endpoints.iter().map(|ep| ep.pmc_mac).collect();
         let ids = resolve_power_shelf_identities(&self.db, &macs).await?;
-        let firmware_targets: Vec<rms::FirmwareTarget> = components
-            .iter()
-            .map(|c| rms::FirmwareTarget {
-                target: power_shelf_target_name(c).to_owned(),
-                filename: target_version.to_owned(),
-            })
-            .collect();
+        let component_filters = power_shelf_firmware_object_component_filters(components);
 
         let mut results = Vec::with_capacity(endpoints.len());
 
@@ -279,36 +355,48 @@ impl PowerShelfManager for RmsBackend {
                 continue;
             };
 
-            let request = rms::UpdateNodeFirmwareRequest {
-                node_id: identity.node_id.clone(),
-                rack_id: identity.rack_id.clone(),
-                firmware_targets: firmware_targets.clone(),
-                ..Default::default()
+            let device = build_power_shelf_node_info(ep, identity);
+            let request = match apply_firmware_object_from_json_request(
+                device,
+                identity,
+                target_version,
+                options,
+                rms::NodeType::Powershelf,
+                component_filters.clone(),
+            ) {
+                Ok(request) => request,
+                Err(e) => {
+                    results.push(PowerShelfComponentResult {
+                        pmc_mac: ep.pmc_mac,
+                        success: false,
+                        error: Some(e.to_string()),
+                    });
+                    continue;
+                }
             };
 
-            match self.client.update_node_firmware_async(request).await {
+            match self.client.apply_firmware_object_from_json(request).await {
                 Ok(response) => {
-                    let success = response.status == rms::ReturnCode::Success as i32;
+                    let (success, error, job_id) =
+                        summarize_firmware_object_apply_response(response, &identity.node_id);
 
-                    if !response.job_id.is_empty() {
-                        self.firmware_jobs
-                            .lock()
-                            .unwrap()
-                            .insert(ep.pmc_mac, response.job_id.clone());
+                    if success {
+                        if let Some(job_id) = job_id {
+                            self.firmware_jobs.lock().unwrap().insert(
+                                ep.pmc_mac,
+                                vec![RmsTrackedFirmwareJob::FirmwareObject(job_id)],
+                            );
+                        } else {
+                            self.firmware_jobs.lock().unwrap().remove(&ep.pmc_mac);
+                        }
+                    } else {
+                        self.firmware_jobs.lock().unwrap().remove(&ep.pmc_mac);
                     }
 
                     results.push(PowerShelfComponentResult {
                         pmc_mac: ep.pmc_mac,
                         success,
-                        error: if success {
-                            None
-                        } else {
-                            Some(if response.message.is_empty() {
-                                "RMS firmware update failed".to_owned()
-                            } else {
-                                response.message
-                            })
-                        },
+                        error,
                     });
                 }
                 Err(e) => {
@@ -340,7 +428,15 @@ impl PowerShelfManager for RmsBackend {
             let jobs = self.firmware_jobs.lock().unwrap();
             endpoints
                 .iter()
-                .map(|ep| (ep.pmc_mac, jobs.get(&ep.pmc_mac).cloned()))
+                .map(|ep| {
+                    let job_id = jobs.get(&ep.pmc_mac).and_then(|jobs| {
+                        jobs.iter().find_map(|job| match job {
+                            RmsTrackedFirmwareJob::FirmwareObject(job_id) => Some(job_id.clone()),
+                            RmsTrackedFirmwareJob::SwitchSystemImage { .. } => None,
+                        })
+                    });
+                    (ep.pmc_mac, job_id)
+                })
                 .collect()
         };
 
@@ -364,20 +460,24 @@ impl PowerShelfManager for RmsBackend {
 
             match self.client.get_firmware_job_status(request).await {
                 Ok(response) => {
-                    let state = if response.status == rms::ReturnCode::Success as i32 {
+                    let status_success = response.status == rms::ReturnCode::Success as i32;
+                    let state = if status_success {
                         map_rms_firmware_job_state(response.job_state)
                     } else {
                         FirmwareState::Unknown
+                    };
+                    let error = if response.error_message.is_empty() {
+                        (!status_success).then(|| {
+                            format!("RMS could not report status for firmware job {job_id}")
+                        })
+                    } else {
+                        Some(response.error_message)
                     };
                     statuses.push(PowerShelfFirmwareUpdateStatus {
                         pmc_mac: *pmc_mac,
                         state,
                         target_version: String::new(),
-                        error: if response.error_message.is_empty() {
-                            None
-                        } else {
-                            Some(response.error_message)
-                        },
+                        error,
                     });
                 }
                 Err(e) => {
@@ -487,16 +587,6 @@ async fn list_firmware_object_ids(
     Ok(response.objects.into_iter().map(|fw| fw.id).collect())
 }
 
-/// Map NvSwitchComponent to a firmware target name used by RMS.
-fn switch_target_name(c: &NvSwitchComponent) -> &'static str {
-    match c {
-        NvSwitchComponent::Bmc => "bmc",
-        NvSwitchComponent::Cpld => "cpld",
-        NvSwitchComponent::Bios => "bios",
-        NvSwitchComponent::Nvos => "nvos",
-    }
-}
-
 /// Default BMC HTTPS port used when populating `rms::BmcEndpoint` for
 /// switches. Mirrors the value used by `crate::rack::firmware_update`.
 const SWITCH_BMC_PORT: i32 = 443;
@@ -573,10 +663,295 @@ fn summarize_power_batch(batch: rms::NodeBatchResponse) -> (bool, Option<String>
     (false, Some(error))
 }
 
+fn apply_firmware_object_from_json_request(
+    device: rms::NewNodeInfo,
+    identity: &RmsIdentity,
+    config_json: &str,
+    options: &FirmwareUpdateOptions,
+    node_type: rms::NodeType,
+    components: Vec<String>,
+) -> Result<rms::ApplyFirmwareObjectFromJsonRequest, ComponentManagerError> {
+    let access_token = options
+        .access_token
+        .as_deref()
+        .filter(|token| !token.trim().is_empty())
+        .ok_or_else(|| {
+            ComponentManagerError::InvalidArgument(
+                "access_token is required for direct RMS firmware-object JSON updates".into(),
+            )
+        })?;
+
+    if config_json.trim().is_empty() {
+        return Err(ComponentManagerError::InvalidArgument(
+            "target_version must contain firmware-object JSON for direct RMS updates".into(),
+        ));
+    }
+
+    let mut component_filters = HashMap::with_capacity(1);
+    component_filters.insert(
+        node_type as i32,
+        rms::FirmwareObjectComponentFilter { components },
+    );
+
+    Ok(rms::ApplyFirmwareObjectFromJsonRequest {
+        metadata: None,
+        rack_id: identity.rack_id.clone(),
+        config_json: config_json.to_owned(),
+        access_token: access_token.to_owned(),
+        firmware_type: RMS_FIRMWARE_OBJECT_FIRMWARE_TYPE.to_owned(),
+        hardware_type: RMS_FIRMWARE_OBJECT_HARDWARE_TYPE.to_owned(),
+        nodes: Some(rms::NodeSet {
+            devices: vec![device],
+        }),
+        force_update: options.force_update,
+        component_filters,
+    })
+}
+
+fn apply_switch_system_image_from_json_request(
+    device: rms::NewNodeInfo,
+    identity: &RmsIdentity,
+    config_json: &str,
+    options: &FirmwareUpdateOptions,
+) -> Result<rms::ApplySwitchSystemImageFromJsonRequest, ComponentManagerError> {
+    let access_token = options
+        .access_token
+        .as_deref()
+        .filter(|token| !token.trim().is_empty())
+        .ok_or_else(|| {
+            ComponentManagerError::InvalidArgument(
+                "access_token is required for direct RMS switch system-image JSON updates".into(),
+            )
+        })?;
+
+    if config_json.trim().is_empty() {
+        return Err(ComponentManagerError::InvalidArgument(
+            "target_version must contain firmware-object JSON for direct RMS updates".into(),
+        ));
+    }
+
+    Ok(rms::ApplySwitchSystemImageFromJsonRequest {
+        metadata: None,
+        rack_id: identity.rack_id.clone(),
+        config_json: config_json.to_owned(),
+        access_token: access_token.to_owned(),
+        software_type: RMS_SWITCH_SYSTEM_IMAGE_SOFTWARE_TYPE.to_owned(),
+        hardware_type: RMS_FIRMWARE_OBJECT_HARDWARE_TYPE.to_owned(),
+        nodes: Some(rms::NodeSet {
+            devices: vec![device],
+        }),
+        // RMS does not expose force_update on switch system-image JSON updates.
+    })
+}
+
+fn power_shelf_firmware_object_component_filters(
+    components: &[PowerShelfComponent],
+) -> Vec<String> {
+    if components.is_empty() {
+        Vec::new()
+    } else {
+        vec!["PowerShelfFW".to_owned()]
+    }
+}
+
+fn switch_update_includes_firmware_object(components: &[NvSwitchComponent]) -> bool {
+    components.is_empty()
+        || components
+            .iter()
+            .any(|component| !matches!(component, NvSwitchComponent::Nvos))
+}
+
+fn switch_update_includes_system_image(components: &[NvSwitchComponent]) -> bool {
+    components.is_empty()
+        || components
+            .iter()
+            .any(|component| matches!(component, NvSwitchComponent::Nvos))
+}
+
+fn switch_firmware_object_component_filters(components: &[NvSwitchComponent]) -> Vec<String> {
+    components
+        .iter()
+        .filter_map(|c| match c {
+            NvSwitchComponent::Bmc => Some("BMC".to_owned()),
+            NvSwitchComponent::Cpld => Some("CPLD".to_owned()),
+            NvSwitchComponent::Bios => Some("BIOS".to_owned()),
+            NvSwitchComponent::Nvos => None,
+        })
+        .collect()
+}
+
+fn summarize_firmware_object_apply_response(
+    response: rms::ApplyFirmwareObjectResponse,
+    node_id: &str,
+) -> (bool, Option<String>, Option<String>) {
+    let node_job_id = response
+        .node_jobs
+        .iter()
+        .find(|j| j.node_id == node_id && !j.job_id.is_empty())
+        .map(|j| j.job_id.clone());
+
+    summarize_firmware_batch(
+        response.response,
+        node_job_id,
+        node_id,
+        "RMS firmware update failed",
+    )
+}
+
+fn summarize_switch_system_image_apply_response(
+    response: rms::ApplySwitchSystemImageResponse,
+    node_id: &str,
+) -> (bool, Option<String>, Option<String>) {
+    let node_job_id = response
+        .node_jobs
+        .iter()
+        .find(|j| j.node_id == node_id && !j.job_id.is_empty())
+        .map(|j| j.job_id.clone());
+
+    summarize_firmware_batch(
+        response.response,
+        node_job_id,
+        node_id,
+        "RMS switch system image update failed",
+    )
+}
+
+fn summarize_firmware_batch(
+    batch: Option<rms::NodeBatchResponse>,
+    node_job_id: Option<String>,
+    node_id: &str,
+    default_error: &str,
+) -> (bool, Option<String>, Option<String>) {
+    let Some(batch) = batch else {
+        return (false, Some(default_error.to_owned()), node_job_id);
+    };
+    let node_failure = batch
+        .node_results
+        .iter()
+        .find(|r| r.node_id == node_id && r.status != rms::ReturnCode::Success as i32)
+        .or_else(|| {
+            batch
+                .node_results
+                .iter()
+                .find(|r| r.status != rms::ReturnCode::Success as i32)
+        });
+    let success = batch.status == rms::ReturnCode::Success as i32
+        && batch.failed_nodes == 0
+        && node_failure.is_none();
+    let job_id = node_job_id.or_else(|| (!batch.job_id.is_empty()).then_some(batch.job_id.clone()));
+
+    if success {
+        return (true, None, job_id);
+    }
+
+    let error = node_failure
+        .and_then(|r| {
+            if r.error_message.is_empty() {
+                None
+            } else {
+                Some(r.error_message.clone())
+            }
+        })
+        .or({
+            if batch.message.is_empty() {
+                None
+            } else {
+                Some(batch.message)
+            }
+        })
+        .unwrap_or_else(|| default_error.to_owned());
+
+    (false, Some(error), job_id)
+}
+
+async fn query_tracked_firmware_job_status(
+    client: &dyn RmsApi,
+    switch_system_image_client: Option<&dyn RmsSwitchSystemImageStatusApi>,
+    job: &RmsTrackedFirmwareJob,
+) -> (FirmwareState, Option<String>) {
+    match job {
+        RmsTrackedFirmwareJob::FirmwareObject(job_id) => {
+            let request = rms::GetFirmwareJobStatusRequest {
+                job_id: job_id.clone(),
+                ..Default::default()
+            };
+
+            match client.get_firmware_job_status(request).await {
+                Ok(response) => {
+                    let status_success = response.status == rms::ReturnCode::Success as i32;
+                    let state = if status_success {
+                        map_rms_firmware_job_state(response.job_state)
+                    } else {
+                        FirmwareState::Unknown
+                    };
+                    let error = if response.error_message.is_empty() {
+                        (!status_success).then(|| {
+                            format!("RMS could not report status for firmware job {job_id}")
+                        })
+                    } else {
+                        Some(response.error_message)
+                    };
+                    (state, error)
+                }
+                Err(e) => (FirmwareState::Unknown, Some(e.to_string())),
+            }
+        }
+        RmsTrackedFirmwareJob::SwitchSystemImage {
+            job_id,
+            rack_id: _,
+            node_id: _,
+        } => {
+            let Some(client) = switch_system_image_client else {
+                return (
+                    FirmwareState::Unknown,
+                    Some("RMS switch system-image status client is not configured".to_owned()),
+                );
+            };
+            let request = rms::GetSwitchSystemImageJobStatusRequest {
+                job_id: job_id.clone(),
+                ..Default::default()
+            };
+
+            match client.get_switch_system_image_job_status(request).await {
+                Ok(response) if response.status == rms::ReturnCode::Success as i32 => {
+                    let state = map_rms_switch_system_image_job_state(&response.state);
+                    let error = if response.error_message.is_empty() {
+                        (!response.message.is_empty()
+                            && matches!(state, FirmwareState::Failed | FirmwareState::Unknown))
+                        .then_some(response.message)
+                    } else {
+                        Some(response.error_message)
+                    };
+                    (state, error)
+                }
+                Ok(response) => {
+                    let error = if response.error_message.is_empty() {
+                        if response.message.is_empty() {
+                            format!(
+                                "RMS could not report status for switch system-image job {job_id}"
+                            )
+                        } else {
+                            response.message
+                        }
+                    } else {
+                        response.error_message
+                    };
+                    (FirmwareState::Unknown, Some(error))
+                }
+                Err(e) => (FirmwareState::Unknown, Some(e.to_string())),
+            }
+        }
+    }
+}
+
 #[async_trait::async_trait]
 impl NvSwitchManager for RmsBackend {
     fn name(&self) -> &str {
         "rms"
+    }
+
+    fn supports_firmware_object_json(&self) -> bool {
+        true
     }
 
     #[instrument(skip(self), fields(backend = "rms"))]
@@ -637,22 +1012,19 @@ impl NvSwitchManager for RmsBackend {
         Ok(results)
     }
 
-    #[instrument(skip(self), fields(backend = "rms"))]
+    #[instrument(skip(self, bundle_version, options), fields(backend = "rms", force_update = options.force_update))]
     async fn queue_firmware_updates(
         &self,
         endpoints: &[SwitchEndpoint],
         bundle_version: &str,
         components: &[NvSwitchComponent],
+        options: &FirmwareUpdateOptions,
     ) -> Result<Vec<SwitchComponentResult>, ComponentManagerError> {
         let macs: Vec<MacAddress> = endpoints.iter().map(|ep| ep.bmc_mac).collect();
         let ids = resolve_switch_identities(&self.db, &macs).await?;
-        let firmware_targets: Vec<rms::FirmwareTarget> = components
-            .iter()
-            .map(|c| rms::FirmwareTarget {
-                target: switch_target_name(c).to_owned(),
-                filename: bundle_version.to_owned(),
-            })
-            .collect();
+        let include_firmware_object = switch_update_includes_firmware_object(components);
+        let include_system_image = switch_update_includes_system_image(components);
+        let component_filters = switch_firmware_object_component_filters(components);
 
         let mut results = Vec::with_capacity(endpoints.len());
 
@@ -666,51 +1038,140 @@ impl NvSwitchManager for RmsBackend {
                 continue;
             };
 
-            let request = rms::UpdateNodeFirmwareRequest {
-                node_id: identity.node_id.clone(),
-                rack_id: identity.rack_id.clone(),
-                firmware_targets: firmware_targets.clone(),
-                ..Default::default()
-            };
+            let mut success = true;
+            let mut errors = Vec::new();
+            let mut tracked_jobs = Vec::new();
 
-            match self.client.update_node_firmware_async(request).await {
-                Ok(response) => {
-                    let success = response.status == rms::ReturnCode::Success as i32;
+            if include_firmware_object {
+                let device = build_switch_node_info(ep, identity);
+                match apply_firmware_object_from_json_request(
+                    device,
+                    identity,
+                    bundle_version,
+                    options,
+                    rms::NodeType::Switch,
+                    component_filters.clone(),
+                ) {
+                    Ok(request) => match self.client.apply_firmware_object_from_json(request).await
+                    {
+                        Ok(response) => {
+                            let (operation_success, error, job_id) =
+                                summarize_firmware_object_apply_response(
+                                    response,
+                                    &identity.node_id,
+                                );
 
-                    if !response.job_id.is_empty() {
-                        self.firmware_jobs
-                            .lock()
-                            .unwrap()
-                            .insert(ep.bmc_mac, response.job_id.clone());
+                            if !operation_success {
+                                success = false;
+                            }
+                            if let Some(error) = error {
+                                errors.push(error);
+                            }
+                            if operation_success {
+                                if let Some(job_id) = job_id {
+                                    tracked_jobs
+                                        .push(RmsTrackedFirmwareJob::FirmwareObject(job_id));
+                                }
+                            } else if job_id.is_some() {
+                                tracing::debug!(
+                                    bmc_mac = %ep.bmc_mac,
+                                    "RMS returned a firmware-object job id for a failed switch update; not tracking it"
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                bmc_mac = %ep.bmc_mac,
+                                error = %e,
+                                "RMS firmware-object update failed for switch"
+                            );
+                            success = false;
+                            errors.push(e.to_string());
+                        }
+                    },
+                    Err(e) => {
+                        success = false;
+                        errors.push(e.to_string());
                     }
-
-                    results.push(SwitchComponentResult {
-                        bmc_mac: ep.bmc_mac,
-                        success,
-                        error: if success {
-                            None
-                        } else {
-                            Some(if response.message.is_empty() {
-                                "RMS firmware update failed".to_owned()
-                            } else {
-                                response.message
-                            })
-                        },
-                    });
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        bmc_mac = %ep.bmc_mac,
-                        error = %e,
-                        "RMS firmware update failed for switch"
-                    );
-                    results.push(SwitchComponentResult {
-                        bmc_mac: ep.bmc_mac,
-                        success: false,
-                        error: Some(e.to_string()),
-                    });
                 }
             }
+
+            if include_system_image {
+                let device = build_switch_node_info(ep, identity);
+                match apply_switch_system_image_from_json_request(
+                    device,
+                    identity,
+                    bundle_version,
+                    options,
+                ) {
+                    Ok(request) => {
+                        match self
+                            .client
+                            .apply_switch_system_image_from_json(request)
+                            .await
+                        {
+                            Ok(response) => {
+                                let (operation_success, error, job_id) =
+                                    summarize_switch_system_image_apply_response(
+                                        response,
+                                        &identity.node_id,
+                                    );
+
+                                if !operation_success {
+                                    success = false;
+                                }
+                                if let Some(error) = error {
+                                    errors.push(error);
+                                }
+                                if operation_success {
+                                    if let Some(job_id) = job_id {
+                                        tracked_jobs.push(
+                                            RmsTrackedFirmwareJob::SwitchSystemImage {
+                                                job_id,
+                                                rack_id: identity.rack_id.clone(),
+                                                node_id: identity.node_id.clone(),
+                                            },
+                                        );
+                                    }
+                                } else if job_id.is_some() {
+                                    tracing::debug!(
+                                        bmc_mac = %ep.bmc_mac,
+                                        "RMS returned a switch system-image job id for a failed switch update; not tracking it"
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    bmc_mac = %ep.bmc_mac,
+                                    error = %e,
+                                    "RMS switch system-image update failed for switch"
+                                );
+                                success = false;
+                                errors.push(e.to_string());
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        success = false;
+                        errors.push(e.to_string());
+                    }
+                }
+            }
+
+            if success && !tracked_jobs.is_empty() {
+                self.firmware_jobs
+                    .lock()
+                    .unwrap()
+                    .insert(ep.bmc_mac, tracked_jobs);
+            } else {
+                self.firmware_jobs.lock().unwrap().remove(&ep.bmc_mac);
+            }
+
+            results.push(SwitchComponentResult {
+                bmc_mac: ep.bmc_mac,
+                success,
+                error: (!errors.is_empty()).then(|| errors.join("; ")),
+            });
         }
 
         Ok(results)
@@ -721,18 +1182,23 @@ impl NvSwitchManager for RmsBackend {
         &self,
         endpoints: &[SwitchEndpoint],
     ) -> Result<Vec<SwitchFirmwareUpdateStatus>, ComponentManagerError> {
-        let endpoint_jobs: Vec<(MacAddress, Option<String>)> = {
+        let endpoint_jobs: Vec<(MacAddress, Vec<RmsTrackedFirmwareJob>)> = {
             let jobs = self.firmware_jobs.lock().unwrap();
             endpoints
                 .iter()
-                .map(|ep| (ep.bmc_mac, jobs.get(&ep.bmc_mac).cloned()))
+                .map(|ep| {
+                    (
+                        ep.bmc_mac,
+                        jobs.get(&ep.bmc_mac).cloned().unwrap_or_default(),
+                    )
+                })
                 .collect()
         };
 
         let mut statuses = Vec::with_capacity(endpoints.len());
 
-        for (bmc_mac, job_id) in &endpoint_jobs {
-            let Some(job_id) = job_id else {
+        for (bmc_mac, jobs) in &endpoint_jobs {
+            if jobs.is_empty() {
                 statuses.push(SwitchFirmwareUpdateStatus {
                     bmc_mac: *bmc_mac,
                     state: FirmwareState::Unknown,
@@ -740,46 +1206,29 @@ impl NvSwitchManager for RmsBackend {
                     error: Some("no firmware job tracked for this switch".into()),
                 });
                 continue;
-            };
+            }
 
-            let request = rms::GetFirmwareJobStatusRequest {
-                job_id: job_id.clone(),
-                ..Default::default()
-            };
-
-            match self.client.get_firmware_job_status(request).await {
-                Ok(response) => {
-                    let state = if response.status == rms::ReturnCode::Success as i32 {
-                        map_rms_firmware_job_state(response.job_state)
-                    } else {
-                        FirmwareState::Unknown
-                    };
-                    statuses.push(SwitchFirmwareUpdateStatus {
-                        bmc_mac: *bmc_mac,
-                        state,
-                        target_version: String::new(),
-                        error: if response.error_message.is_empty() {
-                            None
-                        } else {
-                            Some(response.error_message)
-                        },
-                    });
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        bmc_mac = %bmc_mac,
-                        job_id = %job_id,
-                        error = %e,
-                        "RMS firmware job status query failed"
-                    );
-                    statuses.push(SwitchFirmwareUpdateStatus {
-                        bmc_mac: *bmc_mac,
-                        state: FirmwareState::Unknown,
-                        target_version: String::new(),
-                        error: Some(e.to_string()),
-                    });
+            let mut states = Vec::with_capacity(jobs.len());
+            let mut errors = Vec::new();
+            for job in jobs {
+                let (state, error) = query_tracked_firmware_job_status(
+                    self.client.as_ref(),
+                    self.switch_system_image_client.as_deref(),
+                    job,
+                )
+                .await;
+                states.push(state);
+                if let Some(error) = error {
+                    errors.push(error);
                 }
             }
+
+            statuses.push(SwitchFirmwareUpdateStatus {
+                bmc_mac: *bmc_mac,
+                state: aggregate_firmware_job_states(&states),
+                target_version: String::new(),
+                error: (!errors.is_empty()).then(|| errors.join("; ")),
+            });
         }
 
         Ok(statuses)
@@ -800,6 +1249,16 @@ mod tests {
 
     use super::*;
     use crate::power_shelf_manager::PowerShelfVendor;
+
+    #[async_trait::async_trait]
+    impl RmsSwitchSystemImageStatusApi for MockRmsApi {
+        async fn get_switch_system_image_job_status(
+            &self,
+            cmd: rms::GetSwitchSystemImageJobStatusRequest,
+        ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError> {
+            self.get_switch_system_image_job_status_for_test(cmd).await
+        }
+    }
     use crate::test_support::{
         PS_MAC_1, PS_MAC_2, SW_MAC_1, SW_MAC_2, UNKNOWN_MAC, seed_test_data,
     };
@@ -883,17 +1342,119 @@ mod tests {
     }
 
     #[test]
-    fn power_shelf_target_names() {
-        assert_eq!(power_shelf_target_name(&PowerShelfComponent::Pmc), "pmc");
-        assert_eq!(power_shelf_target_name(&PowerShelfComponent::Psu), "psu");
+    fn switch_system_image_job_state_maps_cancelled_and_verifying() {
+        assert_eq!(
+            map_rms_switch_system_image_job_state("cancelled"),
+            FirmwareState::Cancelled,
+        );
+        assert_eq!(
+            map_rms_switch_system_image_job_state("verifying"),
+            FirmwareState::Verifying,
+        );
     }
 
     #[test]
-    fn switch_target_names() {
-        assert_eq!(switch_target_name(&NvSwitchComponent::Bmc), "bmc");
-        assert_eq!(switch_target_name(&NvSwitchComponent::Cpld), "cpld");
-        assert_eq!(switch_target_name(&NvSwitchComponent::Bios), "bios");
-        assert_eq!(switch_target_name(&NvSwitchComponent::Nvos), "nvos");
+    fn aggregate_firmware_job_states_prioritizes_active_over_unknown() {
+        assert_eq!(
+            aggregate_firmware_job_states(&[
+                FirmwareState::Completed,
+                FirmwareState::Unknown,
+                FirmwareState::InProgress,
+            ]),
+            FirmwareState::InProgress,
+        );
+        assert_eq!(
+            aggregate_firmware_job_states(&[
+                FirmwareState::Completed,
+                FirmwareState::Queued,
+                FirmwareState::Unknown,
+            ]),
+            FirmwareState::Queued,
+        );
+    }
+
+    #[test]
+    fn aggregate_firmware_job_states_terminal_failures_win() {
+        assert_eq!(
+            aggregate_firmware_job_states(&[
+                FirmwareState::Failed,
+                FirmwareState::InProgress,
+                FirmwareState::Unknown,
+            ]),
+            FirmwareState::Failed,
+        );
+        assert_eq!(
+            aggregate_firmware_job_states(&[
+                FirmwareState::Cancelled,
+                FirmwareState::InProgress,
+                FirmwareState::Unknown,
+            ]),
+            FirmwareState::Cancelled,
+        );
+    }
+
+    #[test]
+    fn power_shelf_firmware_object_filter_collapses_components() {
+        let filters = power_shelf_firmware_object_component_filters(&[
+            PowerShelfComponent::Pmc,
+            PowerShelfComponent::Psu,
+        ]);
+
+        assert_eq!(filters, ["PowerShelfFW"]);
+    }
+
+    #[test]
+    fn switch_firmware_object_filters_map_supported_components() {
+        let filters = switch_firmware_object_component_filters(&[
+            NvSwitchComponent::Bmc,
+            NvSwitchComponent::Cpld,
+            NvSwitchComponent::Bios,
+        ]);
+
+        assert_eq!(filters, ["BMC", "CPLD", "BIOS"]);
+    }
+
+    #[test]
+    fn switch_firmware_object_filters_skip_nvos() {
+        let filters = switch_firmware_object_component_filters(&[
+            NvSwitchComponent::Bmc,
+            NvSwitchComponent::Nvos,
+        ]);
+
+        assert_eq!(filters, ["BMC"]);
+        assert!(switch_update_includes_firmware_object(&[
+            NvSwitchComponent::Bmc,
+            NvSwitchComponent::Nvos,
+        ]));
+        assert!(switch_update_includes_system_image(&[
+            NvSwitchComponent::Bmc,
+            NvSwitchComponent::Nvos,
+        ]));
+    }
+
+    #[test]
+    fn switch_empty_component_list_updates_firmware_object_and_system_image() {
+        assert!(switch_update_includes_firmware_object(&[]));
+        assert!(switch_update_includes_system_image(&[]));
+        assert!(switch_firmware_object_component_filters(&[]).is_empty());
+    }
+
+    #[test]
+    fn firmware_update_missing_batch_response_is_failure() {
+        let response = rms::ApplyFirmwareObjectResponse {
+            response: None,
+            object_id: "fw-json".to_owned(),
+            node_jobs: vec![rms::NodeFirmwareJobInfo {
+                node_id: "node-1".to_owned(),
+                job_id: "job-1".to_owned(),
+            }],
+        };
+
+        let (success, error, job_id) = summarize_firmware_object_apply_response(response, "node-1");
+
+        assert!(!success);
+        assert_eq!(error.as_deref(), Some("RMS firmware update failed"));
+        assert_eq!(job_id.as_deref(), Some("job-1"));
     }
 
     // ---- Test helpers ----
@@ -943,8 +1504,26 @@ mod tests {
     ) {
         let (rack_id, ps1, ps2, sw1, sw2) = seed_test_data(pool).await;
         let mock = Arc::new(MockRmsApi::new());
-        let backend = RmsBackend::new(mock.clone(), pool.clone());
+        let backend = RmsBackend::new(mock.clone(), Some(mock.clone()), pool.clone());
         (mock, backend, rack_id, ps1, ps2, sw1, sw2)
+    }
+
+    fn firmware_update_options() -> FirmwareUpdateOptions {
+        FirmwareUpdateOptions {
+            access_token: Some("token".to_owned()),
+            force_update: true,
+        }
+    }
+
+    fn component_filters_for(
+        request: &rms::ApplyFirmwareObjectFromJsonRequest,
+        node_type: rms::NodeType,
+    ) -> &[String] {
+        &request
+            .component_filters
+            .get(&(node_type as i32))
+            .expect("component filters for node type")
+            .components
     }
 
     // ---- PowerShelfManager tests ----
@@ -1061,71 +1640,105 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn ps_update_firmware_success(pool: sqlx::PgPool) {
         let (mock, backend, rack_id, ps1, _ps2, _, _) = make_backend(&pool).await;
-        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-aaa")))
-            .await;
-        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-bbb")))
-            .await;
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+            &ps1.to_string(),
+            "job-aaa",
+        )))
+        .await;
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+            &_ps2.to_string(),
+            "job-bbb",
+        )))
+        .await;
 
         let eps = vec![make_ps_endpoint(PS_MAC_1), make_ps_endpoint(PS_MAC_2)];
         let results = backend
-            .update_firmware(&eps, "fw-1.0.0", &[PowerShelfComponent::Pmc])
+            .update_firmware(
+                &eps,
+                r#"{"Id":"fw-json"}"#,
+                &[PowerShelfComponent::Pmc],
+                &firmware_update_options(),
+            )
             .await
             .unwrap();
 
         assert!(results[0].success);
         assert!(results[1].success);
 
-        let calls = mock.update_node_firmware_async_calls().await;
-        assert_eq!(calls[0].firmware_targets[0].target, "pmc");
-        assert_eq!(calls[0].node_id, ps1.to_string());
-        assert_eq!(calls[0].rack_id, rack_id.to_string());
+        let calls = mock.apply_firmware_object_from_json_calls().await;
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].config_json, r#"{"Id":"fw-json"}"#);
+        assert_eq!(calls[0].access_token, "token");
+        assert_eq!(calls[0].firmware_type, "prod");
+        assert_eq!(calls[0].hardware_type, "any");
+        assert!(calls[0].force_update);
+        let filters = component_filters_for(&calls[0], rms::NodeType::Powershelf);
+        assert_eq!(filters, ["PowerShelfFW"]);
+        let dev0 = &calls[0].nodes.as_ref().unwrap().devices[0];
+        assert_eq!(dev0.node_id, ps1.to_string());
+        assert_eq!(dev0.rack_id, rack_id.to_string());
+        assert_eq!(dev0.r#type, Some(rms::NodeType::Powershelf as i32));
+        assert!(dev0.bmc_endpoint.is_some());
 
         let jobs = backend.firmware_jobs.lock().unwrap();
         assert_eq!(
             jobs.get(&PS_MAC_1.parse::<MacAddress>().unwrap()),
-            Some(&"job-aaa".to_string())
+            Some(&vec![RmsTrackedFirmwareJob::FirmwareObject(
+                "job-aaa".to_string()
+            )])
         );
         assert_eq!(
             jobs.get(&PS_MAC_2.parse::<MacAddress>().unwrap()),
-            Some(&"job-bbb".to_string())
+            Some(&vec![RmsTrackedFirmwareJob::FirmwareObject(
+                "job-bbb".to_string()
+            )])
         );
     }
 
     #[carbide_macros::sqlx_test]
     async fn ps_update_firmware_multiple_components(pool: sqlx::PgPool) {
-        let (mock, backend, _, _, _, _, _) = make_backend(&pool).await;
-        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-1")))
-            .await;
+        let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+            &ps1.to_string(),
+            "job-1",
+        )))
+        .await;
 
         let eps = vec![make_ps_endpoint(PS_MAC_1)];
         let results = backend
             .update_firmware(
                 &eps,
-                "fw-2.0.0",
+                r#"{"Id":"fw-json"}"#,
                 &[PowerShelfComponent::Pmc, PowerShelfComponent::Psu],
+                &firmware_update_options(),
             )
             .await
             .unwrap();
 
         assert!(results[0].success);
 
-        let calls = mock.update_node_firmware_async_calls().await;
-        assert_eq!(calls[0].firmware_targets.len(), 2);
-        assert_eq!(calls[0].firmware_targets[0].target, "pmc");
-        assert_eq!(calls[0].firmware_targets[1].target, "psu");
+        let calls = mock.apply_firmware_object_from_json_calls().await;
+        let filters = component_filters_for(&calls[0], rms::NodeType::Powershelf);
+        assert_eq!(filters, ["PowerShelfFW"]);
     }
 
     #[carbide_macros::sqlx_test]
     async fn ps_update_firmware_failure(pool: sqlx::PgPool) {
-        let (mock, backend, _, _, _, _, _) = make_backend(&pool).await;
-        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_fail(
+        let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_fail(
+            &ps1.to_string(),
             "bad firmware file",
         )))
         .await;
 
         let eps = vec![make_ps_endpoint(PS_MAC_1)];
         let results = backend
-            .update_firmware(&eps, "fw-bad", &[PowerShelfComponent::Pmc])
+            .update_firmware(
+                &eps,
+                r#"{"Id":"fw-json"}"#,
+                &[PowerShelfComponent::Pmc],
+                &firmware_update_options(),
+            )
             .await
             .unwrap();
 
@@ -1134,14 +1747,61 @@ mod tests {
     }
 
     #[carbide_macros::sqlx_test]
-    async fn ps_firmware_status_running(pool: sqlx::PgPool) {
-        let (mock, backend, _, _, _, _, _) = make_backend(&pool).await;
+    async fn ps_update_firmware_failure_clears_tracked_job(pool: sqlx::PgPool) {
+        let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
+        let eps = vec![make_ps_endpoint(PS_MAC_1)];
 
-        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-xyz")))
-            .await;
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+            &ps1.to_string(),
+            "job-old",
+        )))
+        .await;
+        backend
+            .update_firmware(
+                &eps,
+                r#"{"Id":"fw-json"}"#,
+                &[PowerShelfComponent::Pmc],
+                &firmware_update_options(),
+            )
+            .await
+            .unwrap();
+
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_fail(
+            &ps1.to_string(),
+            "bad firmware file",
+        )))
+        .await;
+        backend
+            .update_firmware(
+                &eps,
+                r#"{"Id":"fw-json"}"#,
+                &[PowerShelfComponent::Pmc],
+                &firmware_update_options(),
+            )
+            .await
+            .unwrap();
+
+        let jobs = backend.firmware_jobs.lock().unwrap();
+        assert!(!jobs.contains_key(&PS_MAC_1.parse::<MacAddress>().unwrap()));
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn ps_firmware_status_running(pool: sqlx::PgPool) {
+        let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
+
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+            &ps1.to_string(),
+            "job-xyz",
+        )))
+        .await;
         let eps = vec![make_ps_endpoint(PS_MAC_1)];
         backend
-            .update_firmware(&eps, "fw-1.0.0", &[PowerShelfComponent::Pmc])
+            .update_firmware(
+                &eps,
+                r#"{"Id":"fw-json"}"#,
+                &[PowerShelfComponent::Pmc],
+                &firmware_update_options(),
+            )
             .await
             .unwrap();
 
@@ -1182,13 +1842,21 @@ mod tests {
 
     #[carbide_macros::sqlx_test]
     async fn ps_firmware_status_completed(pool: sqlx::PgPool) {
-        let (mock, backend, _, _, _, _, _) = make_backend(&pool).await;
+        let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
 
-        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-done")))
-            .await;
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+            &ps1.to_string(),
+            "job-done",
+        )))
+        .await;
         let eps = vec![make_ps_endpoint(PS_MAC_1)];
         backend
-            .update_firmware(&eps, "fw-1.0.0", &[PowerShelfComponent::Pmc])
+            .update_firmware(
+                &eps,
+                r#"{"Id":"fw-json"}"#,
+                &[PowerShelfComponent::Pmc],
+                &firmware_update_options(),
+            )
             .await
             .unwrap();
 
@@ -1205,13 +1873,21 @@ mod tests {
 
     #[carbide_macros::sqlx_test]
     async fn ps_firmware_status_failed(pool: sqlx::PgPool) {
-        let (mock, backend, _, _, _, _, _) = make_backend(&pool).await;
+        let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
 
-        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-fail")))
-            .await;
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+            &ps1.to_string(),
+            "job-fail",
+        )))
+        .await;
         let eps = vec![make_ps_endpoint(PS_MAC_1)];
         backend
-            .update_firmware(&eps, "fw-1.0.0", &[PowerShelfComponent::Pmc])
+            .update_firmware(
+                &eps,
+                r#"{"Id":"fw-json"}"#,
+                &[PowerShelfComponent::Pmc],
+                &firmware_update_options(),
+            )
             .await
             .unwrap();
 
@@ -1228,6 +1904,45 @@ mod tests {
             .unwrap();
         assert_eq!(statuses[0].state, FirmwareState::Failed);
         assert_eq!(statuses[0].error.as_deref(), Some("checksum mismatch"));
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn ps_firmware_status_non_success_without_error_has_diagnostic(pool: sqlx::PgPool) {
+        let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
+
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+            &ps1.to_string(),
+            "job-status-error",
+        )))
+        .await;
+        let eps = vec![make_ps_endpoint(PS_MAC_1)];
+        backend
+            .update_firmware(
+                &eps,
+                r#"{"Id":"fw-json"}"#,
+                &[PowerShelfComponent::Pmc],
+                &firmware_update_options(),
+            )
+            .await
+            .unwrap();
+
+        mock.enqueue_get_firmware_job_status(Ok(rms::GetFirmwareJobStatusResponse {
+            status: rms::ReturnCode::Failure as i32,
+            ..Default::default()
+        }))
+        .await;
+
+        let statuses = PowerShelfManager::get_firmware_status(&backend, &eps)
+            .await
+            .unwrap();
+        assert_eq!(statuses[0].state, FirmwareState::Unknown);
+        assert!(
+            statuses[0]
+                .error
+                .as_deref()
+                .unwrap()
+                .contains("job-status-error")
+        );
     }
 
     #[carbide_macros::sqlx_test]
@@ -1351,42 +2066,221 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn sw_queue_firmware_updates_success(pool: sqlx::PgPool) {
         let (mock, backend, _, _, _, sw1, _) = make_backend(&pool).await;
-        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("sw-job-1")))
-            .await;
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+            &sw1.to_string(),
+            "sw-job-1",
+        )))
+        .await;
 
         let eps = vec![make_sw_endpoint(SW_MAC_1)];
         let results = backend
             .queue_firmware_updates(
                 &eps,
-                "fw-2.0.0",
+                r#"{"Id":"fw-json"}"#,
                 &[NvSwitchComponent::Bmc, NvSwitchComponent::Bios],
+                &firmware_update_options(),
             )
             .await
             .unwrap();
 
         assert!(results[0].success);
 
-        let calls = mock.update_node_firmware_async_calls().await;
-        assert_eq!(calls[0].firmware_targets[0].target, "bmc");
-        assert_eq!(calls[0].firmware_targets[1].target, "bios");
-        assert_eq!(calls[0].node_id, sw1.to_string());
+        let calls = mock.apply_firmware_object_from_json_calls().await;
+        assert_eq!(calls[0].config_json, r#"{"Id":"fw-json"}"#);
+        assert_eq!(calls[0].access_token, "token");
+        assert!(calls[0].force_update);
+        let filters = component_filters_for(&calls[0], rms::NodeType::Switch);
+        assert_eq!(filters, ["BMC", "BIOS"]);
+        let dev0 = &calls[0].nodes.as_ref().unwrap().devices[0];
+        assert_eq!(dev0.node_id, sw1.to_string());
+        assert_eq!(dev0.r#type, Some(rms::NodeType::Switch as i32));
+        assert!(dev0.bmc_endpoint.is_some());
+        assert!(dev0.host_endpoint.is_some());
 
         let jobs = backend.firmware_jobs.lock().unwrap();
         assert_eq!(
             jobs.get(&SW_MAC_1.parse::<MacAddress>().unwrap()),
-            Some(&"sw-job-1".to_string())
+            Some(&vec![RmsTrackedFirmwareJob::FirmwareObject(
+                "sw-job-1".to_string()
+            )])
         );
     }
 
     #[carbide_macros::sqlx_test]
-    async fn sw_firmware_status(pool: sqlx::PgPool) {
-        let (mock, backend, _, _, _, _, _) = make_backend(&pool).await;
+    async fn sw_queue_firmware_updates_failure_clears_tracked_jobs(pool: sqlx::PgPool) {
+        let (mock, backend, _, _, _, sw1, _) = make_backend(&pool).await;
+        let eps = vec![make_sw_endpoint(SW_MAC_1)];
 
-        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("sw-job-2")))
-            .await;
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+            &sw1.to_string(),
+            "sw-job-old",
+        )))
+        .await;
+        backend
+            .queue_firmware_updates(
+                &eps,
+                r#"{"Id":"fw-json"}"#,
+                &[NvSwitchComponent::Bmc],
+                &firmware_update_options(),
+            )
+            .await
+            .unwrap();
+
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_fail(
+            &sw1.to_string(),
+            "bad firmware file",
+        )))
+        .await;
+        let results = backend
+            .queue_firmware_updates(
+                &eps,
+                r#"{"Id":"fw-json"}"#,
+                &[NvSwitchComponent::Bmc],
+                &firmware_update_options(),
+            )
+            .await
+            .unwrap();
+
+        assert!(!results[0].success);
+        let jobs = backend.firmware_jobs.lock().unwrap();
+        assert!(!jobs.contains_key(&SW_MAC_1.parse::<MacAddress>().unwrap()));
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn sw_queue_firmware_updates_nvos_uses_switch_system_image_json(pool: sqlx::PgPool) {
+        let (mock, backend, rack_id, _, _, sw1, _) = make_backend(&pool).await;
+        mock.enqueue_apply_switch_system_image_from_json(Ok(
+            MockRmsApi::switch_system_image_apply_ok(&sw1.to_string(), "nvos-job-1"),
+        ))
+        .await;
+
+        let eps = vec![make_sw_endpoint(SW_MAC_1)];
+        let results = backend
+            .queue_firmware_updates(
+                &eps,
+                r#"{"Id":"fw-json"}"#,
+                &[NvSwitchComponent::Nvos],
+                &firmware_update_options(),
+            )
+            .await
+            .unwrap();
+
+        assert!(results[0].success);
+        assert!(
+            mock.apply_firmware_object_from_json_calls()
+                .await
+                .is_empty()
+        );
+
+        let calls = mock.apply_switch_system_image_from_json_calls().await;
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].config_json, r#"{"Id":"fw-json"}"#);
+        assert_eq!(calls[0].access_token, "token");
+        assert_eq!(calls[0].software_type, "prod");
+        assert_eq!(calls[0].hardware_type, "any");
+        assert_eq!(calls[0].rack_id, rack_id.to_string());
+        let dev0 = &calls[0].nodes.as_ref().unwrap().devices[0];
+        assert_eq!(dev0.node_id, sw1.to_string());
+        assert_eq!(dev0.r#type, Some(rms::NodeType::Switch as i32));
+        assert!(dev0.bmc_endpoint.is_some());
+        assert!(dev0.host_endpoint.is_some());
+
+        let jobs = backend.firmware_jobs.lock().unwrap();
+        assert_eq!(
+            jobs.get(&SW_MAC_1.parse::<MacAddress>().unwrap()),
+            Some(&vec![RmsTrackedFirmwareJob::SwitchSystemImage {
+                job_id: "nvos-job-1".to_string(),
+                rack_id: rack_id.to_string(),
+                node_id: sw1.to_string(),
+            }])
+        );
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn sw_queue_firmware_updates_mixed_tracks_both_jobs(pool: sqlx::PgPool) {
+        let (mock, backend, rack_id, _, _, sw1, _) = make_backend(&pool).await;
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+            &sw1.to_string(),
+            "sw-fw-job",
+        )))
+        .await;
+        mock.enqueue_apply_switch_system_image_from_json(Ok(
+            MockRmsApi::switch_system_image_apply_ok(&sw1.to_string(), "sw-nvos-job"),
+        ))
+        .await;
+
+        let eps = vec![make_sw_endpoint(SW_MAC_1)];
+        let results = backend
+            .queue_firmware_updates(
+                &eps,
+                r#"{"Id":"fw-json"}"#,
+                &[NvSwitchComponent::Bmc, NvSwitchComponent::Nvos],
+                &firmware_update_options(),
+            )
+            .await
+            .unwrap();
+
+        assert!(results[0].success);
+        assert_eq!(mock.apply_firmware_object_from_json_calls().await.len(), 1);
+        assert_eq!(
+            mock.apply_switch_system_image_from_json_calls().await.len(),
+            1
+        );
+
+        {
+            let jobs = backend.firmware_jobs.lock().unwrap();
+            assert_eq!(
+                jobs.get(&SW_MAC_1.parse::<MacAddress>().unwrap()),
+                Some(&vec![
+                    RmsTrackedFirmwareJob::FirmwareObject("sw-fw-job".to_string()),
+                    RmsTrackedFirmwareJob::SwitchSystemImage {
+                        job_id: "sw-nvos-job".to_string(),
+                        rack_id: rack_id.to_string(),
+                        node_id: sw1.to_string(),
+                    },
+                ])
+            );
+        }
+
+        mock.enqueue_get_firmware_job_status(Ok(MockRmsApi::firmware_job_status_ok(
+            rms::FirmwareJobState::FwJobCompleted,
+        )))
+        .await;
+        mock.enqueue_get_switch_system_image_job_status(Ok(
+            MockRmsApi::switch_system_image_job_status_ok("running"),
+        ))
+        .await;
+
+        let statuses = NvSwitchManager::get_firmware_status(&backend, &eps)
+            .await
+            .unwrap();
+
+        assert_eq!(statuses[0].state, FirmwareState::InProgress);
+        assert_eq!(
+            mock.get_firmware_job_status_calls().await[0].job_id,
+            "sw-fw-job"
+        );
+        let status_calls = mock.get_switch_system_image_job_status_calls().await;
+        assert_eq!(status_calls[0].job_id, "sw-nvos-job");
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn sw_firmware_status(pool: sqlx::PgPool) {
+        let (mock, backend, _, _, _, sw1, _) = make_backend(&pool).await;
+
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+            &sw1.to_string(),
+            "sw-job-2",
+        )))
+        .await;
         let eps = vec![make_sw_endpoint(SW_MAC_1)];
         backend
-            .queue_firmware_updates(&eps, "fw-1.0", &[NvSwitchComponent::Bmc])
+            .queue_firmware_updates(
+                &eps,
+                r#"{"Id":"fw-json"}"#,
+                &[NvSwitchComponent::Bmc],
+                &firmware_update_options(),
+            )
             .await
             .unwrap();
 
@@ -1403,6 +2297,48 @@ mod tests {
 
         let calls = mock.get_firmware_job_status_calls().await;
         assert_eq!(calls[0].job_id, "sw-job-2");
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn sw_firmware_object_status_non_success_without_error_has_diagnostic(
+        pool: sqlx::PgPool,
+    ) {
+        let (mock, backend, _, _, _, sw1, _) = make_backend(&pool).await;
+
+        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+            &sw1.to_string(),
+            "sw-job-status-error",
+        )))
+        .await;
+        let eps = vec![make_sw_endpoint(SW_MAC_1)];
+        backend
+            .queue_firmware_updates(
+                &eps,
+                r#"{"Id":"fw-json"}"#,
+                &[NvSwitchComponent::Bmc],
+                &firmware_update_options(),
+            )
+            .await
+            .unwrap();
+
+        mock.enqueue_get_firmware_job_status(Ok(rms::GetFirmwareJobStatusResponse {
+            status: rms::ReturnCode::Failure as i32,
+            ..Default::default()
+        }))
+        .await;
+
+        let statuses = NvSwitchManager::get_firmware_status(&backend, &eps)
+            .await
+            .unwrap();
+
+        assert_eq!(statuses[0].state, FirmwareState::Unknown);
+        assert!(
+            statuses[0]
+                .error
+                .as_deref()
+                .unwrap()
+                .contains("sw-job-status-error")
+        );
     }
 
     #[carbide_macros::sqlx_test]

--- a/crates/component-manager/src/types.rs
+++ b/crates/component-manager/src/types.rs
@@ -5,6 +5,24 @@ use mac_address::MacAddress;
 
 use crate::error::ComponentManagerError;
 
+#[derive(Clone, Default)]
+pub struct FirmwareUpdateOptions {
+    pub access_token: Option<String>,
+    pub force_update: bool,
+}
+
+impl std::fmt::Debug for FirmwareUpdateOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FirmwareUpdateOptions")
+            .field(
+                "access_token",
+                &self.access_token.as_ref().map(|_| "<redacted>"),
+            )
+            .field("force_update", &self.force_update)
+            .finish()
+    }
+}
+
 pub fn parse_mac(s: &str) -> Result<MacAddress, ComponentManagerError> {
     s.parse::<MacAddress>()
         .map_err(|e| ComponentManagerError::Internal(format!("invalid MAC from backend: {e}")))
@@ -14,6 +32,21 @@ pub fn parse_mac(s: &str) -> Result<MacAddress, ComponentManagerError> {
 mod tests {
     use super::*;
     use crate::power_shelf_manager::PowerShelfVendor;
+
+    #[test]
+    fn firmware_update_options_debug_redacts_access_token() {
+        let debug = format!(
+            "{:?}",
+            FirmwareUpdateOptions {
+                access_token: Some("secret-token".to_string()),
+                force_update: true,
+            }
+        );
+
+        assert!(debug.contains("<redacted>"));
+        assert!(debug.contains("force_update: true"));
+        assert!(!debug.contains("secret-token"));
+    }
 
     #[test]
     fn parse_mac_valid_colon_separated() {


### PR DESCRIPTION
## Description

- Replace direct RMS firmware updates that used update_node_firmware_async with firmware-object JSON APIs.
- Route switch NVOS updates to ApplySwitchSystemImageFromJSON; route switch BMC/CPLD/BIOS and power-shelf firmware to ApplyFirmwareObjectFromJSON.
- Add direct-RMS support for SOT JSON/access-token handling when state machine is disabled and RMS backend is enabled.
- Track and poll mixed switch firmware jobs using the correct RMS status APIs.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

