### PR TITLE
Render correct tenant cloud-init for zero-dpu hosts

### DIFF
--- a/crates/api-core/src/handlers/client_resolution.rs
+++ b/crates/api-core/src/handlers/client_resolution.rs
@@ -32,38 +32,53 @@ use crate::api::Api;
 /// tenant-allocated `instance_address` (instance case).
 #[allow(clippy::large_enum_variant)]
 enum ResolvedClient {
-    Interface(MachineInterfaceSnapshot),
+    MachineInterface(MachineInterfaceSnapshot),
     Instance(InstanceSnapshot),
 }
 
-/// This is a shared two-table lookup that both cloud-init and pxe boot
-/// flows use for resolving a client IP . Check `machine_interface_addresses`
-/// first (the common admin path), then fall back to `instance_address`.
+enum PreferredLookup {
+    MachineInterface,
+    Instance,
+}
+
+/// Resolve a client IP to a ResolvedClient.
+///
+///- `preferred_lookup`:  Use [`PreferredLookup::MachineInterface`] to prefer returning a
+/// `ResolvedClient::MachineInterface` if it's found, falling back on a `ResolvedClient::Instance`
+/// if not. Use [`PreferredLookup::Instance`] to do the reverse, returning a
+/// `ResolvedClient::Instance` first and a `ResolvedClient::MachineInterface` otherwise.
 async fn resolve_client_ip(
     conn: &mut PgConnection,
     client_ip: IpAddr,
+    preferred_lookup: PreferredLookup,
 ) -> Result<ResolvedClient, CarbideError> {
-    if let Some(iface) = db::machine_interface::find_by_ip(&mut *conn, client_ip).await? {
-        return Ok(ResolvedClient::Interface(iface));
+    match preferred_lookup {
+        PreferredLookup::MachineInterface => {
+            if let Some(iface) = db::machine_interface::find_by_ip(&mut *conn, client_ip).await? {
+                return Ok(ResolvedClient::MachineInterface(iface));
+            }
+            Ok(db::instance::find_by_address(&mut *conn, client_ip)
+                .await?
+                .map(ResolvedClient::Instance)
+                .ok_or_else(|| CarbideError::NotFoundError {
+                    kind: "Client",
+                    id: client_ip.to_string(),
+                })?)
+        }
+        PreferredLookup::Instance => {
+            if let Some(instance) = db::instance::find_by_address(&mut *conn, client_ip).await? {
+                return Ok(ResolvedClient::Instance(instance));
+            }
+
+            db::machine_interface::find_by_ip(&mut *conn, client_ip)
+                .await?
+                .map(ResolvedClient::MachineInterface)
+                .ok_or_else(|| CarbideError::NotFoundError {
+                    kind: "Client",
+                    id: client_ip.to_string(),
+                })
+        }
     }
-
-    let instance_address = db::instance_address::find_by_address(&mut *conn, client_ip)
-        .await?
-        .ok_or_else(|| CarbideError::NotFoundError {
-            kind: "Client",
-            id: client_ip.to_string(),
-        })?;
-
-    let instance = db::instance::find_by_id(&mut *conn, instance_address.instance_id)
-        .await?
-        .ok_or_else(|| {
-            CarbideError::internal(format!(
-                "instance_address {client_ip} references missing instance {}",
-                instance_address.instance_id,
-            ))
-        })?;
-
-    Ok(ResolvedClient::Instance(instance))
 }
 
 /// Resolve a client IP to the host's `machine_interface` for PXE-script
@@ -74,8 +89,8 @@ pub(crate) async fn resolve_machine_interface(
     conn: &mut PgConnection,
     client_ip: IpAddr,
 ) -> Result<MachineInterfaceSnapshot, CarbideError> {
-    match resolve_client_ip(conn, client_ip).await? {
-        ResolvedClient::Interface(iface) => Ok(iface),
+    match resolve_client_ip(conn, client_ip, PreferredLookup::MachineInterface).await? {
+        ResolvedClient::MachineInterface(iface) => Ok(iface),
         ResolvedClient::Instance(instance) => {
             let interfaces_by_machine =
                 db::machine_interface::find_by_machine_ids(&mut *conn, &[instance.machine_id])
@@ -123,7 +138,7 @@ pub(crate) async fn resolve_cloud_init_instructions(
     let cloud_name = "nvidia".to_string();
     let platform = "forge".to_string();
 
-    match resolve_client_ip(conn, client_ip).await? {
+    match resolve_client_ip(conn, client_ip, PreferredLookup::Instance).await? {
         ResolvedClient::Instance(instance) => Ok(rpc::CloudInitInstructions {
             custom_cloud_init: instance.config.os.user_data,
             discovery_instructions: None,
@@ -135,7 +150,7 @@ pub(crate) async fn resolve_cloud_init_instructions(
             api_url_override: None,
             pxe_url_override: None,
         }),
-        ResolvedClient::Interface(machine_interface) => {
+        ResolvedClient::MachineInterface(machine_interface) => {
             let domain_id = machine_interface.domain_id.ok_or_else(|| {
                 CarbideError::internal(format!(
                     "Machine Interface did not have an associated domain {}",

--- a/crates/api-core/src/tests/client_resolution.rs
+++ b/crates/api-core/src/tests/client_resolution.rs
@@ -15,13 +15,23 @@
  * limitations under the License.
  */
 
-use common::api_fixtures::{create_managed_host, create_test_env};
+use common::api_fixtures::{
+    TestEnvOverrides, create_managed_host, create_managed_host_with_config, create_test_env,
+    create_test_env_with_overrides,
+};
+use ipnetwork::IpNetwork;
+use rpc::forge::forge_server::Forge;
 
 use crate::CarbideError;
 use crate::handlers::client_resolution::resolve_machine_interface;
 use crate::tests::common;
 use crate::tests::common::api_fixtures::instance::{
     default_os_config, default_tenant_config, single_interface_network_config,
+};
+use crate::tests::common::api_fixtures::managed_host::ManagedHostConfig;
+use crate::tests::common::api_fixtures::network_segment::{
+    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY,
+    create_host_inband_network_segment,
 };
 
 // A client_ip that matches a row in machine_interface_addresses (the
@@ -117,4 +127,111 @@ async fn test_resolve_machine_interface_unknown_ip_returns_not_found(pool: sqlx:
         }
         other => panic!("expected NotFoundError, got {other:?}"),
     }
+}
+
+#[crate::sqlx_test]
+async fn test_zero_dpu_cloud_init_prefers_instance_when_ip_matches_host_interface(
+    pool: sqlx::PgPool,
+) {
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides {
+            site_prefixes: Some(vec![
+                IpNetwork::new(
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+                IpNetwork::new(
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+            ]),
+            ..Default::default()
+        },
+    )
+    .await;
+    create_host_inband_network_segment(&env.api, None).await;
+    env.run_network_segment_controller_iteration().await;
+    env.run_network_segment_controller_iteration().await;
+
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::with_dpus(Vec::new())).await;
+    assert!(
+        mh.dpu_ids.is_empty(),
+        "zero-DPU fixture should produce no DPU machines"
+    );
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let host_interfaces = db::machine_interface::find_by_machine_ids(txn.as_mut(), &[mh.host().id])
+        .await
+        .unwrap();
+    let host_ip = host_interfaces[&mh.host().id][0].addresses[0];
+    txn.rollback().await.unwrap();
+
+    let tenant_user_data = "#cloud-config\ntenant-user-data";
+    let instance = env
+        .api
+        .allocate_instance(tonic::Request::new(rpc::InstanceAllocationRequest {
+            machine_id: Some(mh.host().id),
+            instance_type_id: None,
+            config: Some(rpc::InstanceConfig {
+                tenant: Some(default_tenant_config()),
+                os: Some(rpc::forge::InstanceOperatingSystemConfig {
+                    user_data: Some(tenant_user_data.to_string()),
+                    ..default_os_config()
+                }),
+                network: Some(rpc::forge::InstanceNetworkConfig {
+                    interfaces: vec![],
+                    auto: true,
+                }),
+                infiniband: None,
+                network_security_group_id: None,
+                dpu_extension_services: None,
+                nvlink: None,
+                spxconfig: None,
+            }),
+            instance_id: None,
+            metadata: None,
+            allow_unhealthy_machine: false,
+        }))
+        .await
+        .expect("zero-DPU instance allocation should succeed")
+        .into_inner();
+    let instance_id = instance.id.expect("allocated instance should have an ID");
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let instance_address = db::instance_address::find_by_address(txn.as_mut(), host_ip)
+        .await
+        .unwrap()
+        .expect("zero-DPU instance should reuse the host interface IP");
+    txn.rollback().await.unwrap();
+    assert_eq!(instance_address.instance_id, instance_id);
+
+    let cloud_init = env
+        .api
+        .get_cloud_init_instructions(tonic::Request::new(
+            rpc::forge::CloudInitInstructionsRequest {
+                ip: host_ip.to_string(),
+            },
+        ))
+        .await
+        .expect("get_cloud_init_instructions returned an error")
+        .into_inner();
+
+    assert_eq!(
+        cloud_init.custom_cloud_init.as_deref(),
+        Some(tenant_user_data)
+    );
+    assert!(
+        cloud_init.discovery_instructions.is_none(),
+        "tenant cloud-init must not render discovery instructions for the shared zero-DPU IP"
+    );
+    assert_eq!(
+        cloud_init
+            .metadata
+            .expect("tenant cloud-init should include metadata")
+            .instance_id,
+        instance_id.to_string()
+    );
 }

--- a/crates/api-db/src/instance.rs
+++ b/crates/api-db/src/instance.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+use std::net::IpAddr;
 use std::ops::DerefMut;
 use std::str::FromStr;
 
@@ -36,6 +36,7 @@ use model::instance::snapshot::{self, InstanceSnapshot, InstanceSnapshotPgJson};
 use model::metadata::Metadata;
 use model::os::{InlineIpxe, OperatingSystem, OperatingSystemVariant};
 use sqlx::PgConnection;
+use sqlx::types::Json;
 
 use crate::db_read::DbReader;
 use crate::operating_system::{self, OperatingSystem as OsRow};
@@ -267,45 +268,80 @@ fn build_operating_system_for_snapshot(
     }
 }
 
+/// Represents the data we get back from find_by_id and related functions that bring in the
+/// operating system as well as the instance.
+#[derive(sqlx::FromRow)]
+struct InstanceAndOsRow {
+    instance: Json<InstanceSnapshotPgJson>,
+    operating_system: Option<Json<OsRow>>,
+}
+
+impl TryFrom<InstanceAndOsRow> for InstanceSnapshot {
+    type Error = DatabaseError;
+    fn try_from(pg_row: InstanceAndOsRow) -> Result<Self, Self::Error> {
+        let instance_row = pg_row.instance.0;
+        let os_row = pg_row.operating_system.map(|r| r.0);
+
+        let snapshot = match os_row {
+            Some(os_row) => {
+                let os = build_operating_system_for_snapshot(&os_row, &instance_row);
+                snapshot::from_pg_json_and_os(instance_row, os).map_err(|e| {
+                    DatabaseError::Internal {
+                        message: format!("instance snapshot from_pg_json_and_os: {e}"),
+                    }
+                })?
+            }
+            None => {
+                // No OS reference: derive OS from instance columns only (legacy behavior).
+                InstanceSnapshot::try_from(instance_row).map_err(|e| DatabaseError::Internal {
+                    message: format!("instance snapshot try_from: {e}"),
+                })?
+            }
+        };
+
+        Ok(snapshot)
+    }
+}
+
 pub async fn find_by_id(
     txn: impl DbReader<'_>,
     id: InstanceId,
 ) -> Result<Option<InstanceSnapshot>, DatabaseError> {
     // Single query; LEFT JOIN so we get instance even when operating_system_id is NULL.
-    let query = "SELECT row_to_json(i.*), row_to_json(o.*) FROM instances i
+    let query = "SELECT row_to_json(i.*) AS instance, row_to_json(o.*) AS operating_system
+        FROM instances i
         LEFT JOIN operating_systems o ON i.operating_system_id = o.id AND o.deleted IS NULL
         WHERE i.id = $1";
-    let row: Option<(serde_json::Value, Option<serde_json::Value>)> = sqlx::query_as(query)
+    let Some(instance_and_os_row) = sqlx::query_as::<_, InstanceAndOsRow>(query)
         .bind(id)
         .fetch_optional(txn)
         .await
-        .map_err(|e| DatabaseError::query(query, e))?;
-    let Some((instance_json, os_json)) = row else {
+        .map_err(|e| DatabaseError::query(query, e))?
+    else {
         return Ok(None);
     };
-    let pg_json: InstanceSnapshotPgJson =
-        serde_json::from_value(instance_json).map_err(|e| DatabaseError::Internal {
-            message: format!("instance snapshot json decode: {e}"),
-        })?;
-    let snapshot = match os_json {
-        Some(oj) => {
-            let os_row: OsRow =
-                serde_json::from_value(oj).map_err(|e| DatabaseError::Internal {
-                    message: format!("operating_system row json decode: {e}"),
-                })?;
-            let os = build_operating_system_for_snapshot(&os_row, &pg_json);
-            snapshot::from_pg_json_and_os(pg_json, os).map_err(|e| DatabaseError::Internal {
-                message: format!("instance snapshot from_pg_json_and_os: {e}"),
-            })?
-        }
-        None => {
-            // No OS reference: derive OS from instance columns only (legacy behavior).
-            InstanceSnapshot::try_from(pg_json).map_err(|e| DatabaseError::Internal {
-                message: format!("instance snapshot try_from: {e}"),
-            })?
-        }
+    Ok(Some(instance_and_os_row.try_into()?))
+}
+
+pub async fn find_by_address(
+    txn: impl DbReader<'_>,
+    address: IpAddr,
+) -> Result<Option<InstanceSnapshot>, DatabaseError> {
+    // Single query; LEFT JOIN so we get instance even when operating_system_id is NULL.
+    let query = "SELECT row_to_json(i.*) AS instance, row_to_json(o.*) AS operating_system
+        FROM instances i
+        LEFT JOIN operating_systems o ON i.operating_system_id = o.id AND o.deleted IS NULL
+        INNER JOIN instance_addresses a ON a.instance_id = i.id
+        WHERE a.address = $1";
+    let Some(instance_and_os_row) = sqlx::query_as::<_, InstanceAndOsRow>(query)
+        .bind(address)
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?
+    else {
+        return Ok(None);
     };
-    Ok(Some(snapshot))
+    Ok(Some(instance_and_os_row.try_into()?))
 }
 
 pub async fn find_id_by_machine_id(


### PR DESCRIPTION
## Description
A recent change seems to have regressed zero-dpu instances such that the admin/scout cloud-init instructions are given to tenant instances. Fix by preferring to resolve the client IP as an instance address when rendering cloud-init, falling back on the machine address if there is no instance.

While we're at it, resolve the instance from the client address in a single database query, with a new db::instance::find_by_address function, with a simplified deserializer to share with find_by_ip.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
#2009

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [X] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes