### PR TITLE
feat(dns): cache all negative DNS responses, switch to LRU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,6 +1696,7 @@ dependencies = [
  "eyre",
  "hickory-resolver",
  "hickory-server",
+ "lru 0.18.0",
  "metrics-endpoint",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -6496,10 +6497,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.1",
  "libc",
- "plain",
- "redox_syscall 0.8.0",
 ]
 
 [[package]]
@@ -7787,7 +7785,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -8134,12 +8132,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -8951,15 +8943,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7591fa2c6b601dfcfe5f043f65a1c39fcdf50efefcd7f1572e538c1f4b398d"
 dependencies = [
  "bitflags 2.11.1",
 ]

--- a/crates/dns/Cargo.toml
+++ b/crates/dns/Cargo.toml
@@ -54,6 +54,7 @@ carbide-tls = { path = "../tls" }
 carbide-version = { path = "../version" }
 carbide-rpc = { path = "../rpc" }
 thiserror = { workspace = true }
+lru.workspace = true
 
 [build-dependencies]
 carbide-version = { path = "../version" }

--- a/crates/dns/src/config.rs
+++ b/crates/dns/src/config.rs
@@ -16,6 +16,7 @@
  */
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use forge_tls::client_config::ClientCert;
 use rpc::forge_tls_client::ForgeClientConfig;
@@ -25,7 +26,11 @@ use tonic::codegen::http;
 const DEFAULT_LISTEN_ADDRESS: &str = "[::]:53";
 const DEFAULT_METRICS_ADDRESS: &str = "[::]:8053";
 const DEFAULT_NEGATIVE_CACHE_TTL: u64 = 120;
-const DEFAULT_NEGATIVE_CACHE_ENTRIES_MAX_COUNT: u64 = 200_000;
+const DEFAULT_NEGATIVE_CACHE_SERVFAIL_TTL: u64 = 5;
+pub const NEGATIVE_CACHE_SERVFAIL_TTL_MIN_SECS: u64 = 1;
+pub const NEGATIVE_CACHE_SERVFAIL_TTL_MAX_SECS: u64 = 300;
+const DEFAULT_NEGATIVE_CACHE_ENTRIES_MAX_COUNT: u64 = 50_000;
+const DEFAULT_UPSTREAM_LOOKUP_TIMEOUT_SECS: u64 = 5;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Config {
@@ -65,11 +70,21 @@ pub struct Config {
     /// Default: `120`.
     #[serde(default = "Defaults::negative_cache_ttl_secs")]
     pub negative_cache_ttl_secs: u64,
+    /// How long to cache ServFail responses, in seconds. Unlike NXDomain and
+    /// Refused, a ServFail reflects a transient
+    /// nico-api failure, so it is cached only briefly Clamped to
+    /// [1, 300]s (RFC 9520). Default: `5`.
+    #[serde(default = "Defaults::negative_cache_servfail_ttl_secs")]
+    pub negative_cache_servfail_ttl_secs: u64,
     /// Maximum number of entries the negative cache may hold. Once reached, new
     /// negative responses are not cached, bounding memory under a flood of
-    /// distinct non-existent names. Default: `200000`.
+    /// distinct non-existent names. Default: `50000`.
     #[serde(default = "Defaults::negative_cache_entries_max_count")]
     pub negative_cache_entries_max_count: u64,
+    /// Maximum time to wait for a single upstream `lookup_record` call before
+    /// giving up and returning ServFail, in seconds. Default: `5`.
+    #[serde(default = "Defaults::upstream_lookup_timeout_secs")]
+    pub upstream_lookup_timeout_secs: u64,
     /// Address (host:port) the Prometheus metrics server listens on.
     /// Default: `[::]:8053`.
     #[serde(default = "Defaults::metrics_listen_addr")]
@@ -88,8 +103,16 @@ impl Defaults {
         DEFAULT_NEGATIVE_CACHE_TTL
     }
 
+    pub fn negative_cache_servfail_ttl_secs() -> u64 {
+        DEFAULT_NEGATIVE_CACHE_SERVFAIL_TTL
+    }
+
     pub fn negative_cache_entries_max_count() -> u64 {
         DEFAULT_NEGATIVE_CACHE_ENTRIES_MAX_COUNT
+    }
+
+    pub fn upstream_lookup_timeout_secs() -> u64 {
+        DEFAULT_UPSTREAM_LOOKUP_TIMEOUT_SECS
     }
 
     pub fn listen_addr() -> SocketAddr {
@@ -144,7 +167,9 @@ impl Default for Config {
             client_key_path: Defaults::client_key_path(),
             otlp_endpoint: Defaults::otlp_endpoint(),
             negative_cache_ttl_secs: Defaults::negative_cache_ttl_secs(),
+            negative_cache_servfail_ttl_secs: Defaults::negative_cache_servfail_ttl_secs(),
             negative_cache_entries_max_count: Defaults::negative_cache_entries_max_count(),
+            upstream_lookup_timeout_secs: Defaults::upstream_lookup_timeout_secs(),
             metrics_listen_address: Defaults::metrics_listen_addr(),
         }
     }
@@ -187,6 +212,15 @@ impl Config {
         ForgeClientConfig::new(forge_root_ca, Some(client_cert))
     }
 
+    /// The ServFail cache TTL as a `Duration`, clamped to the supported
+    /// [1, 300]s range (RFC 9520).
+    pub fn servfail_cache_ttl(&self) -> Duration {
+        Duration::from_secs(self.negative_cache_servfail_ttl_secs.clamp(
+            NEGATIVE_CACHE_SERVFAIL_TTL_MIN_SECS,
+            NEGATIVE_CACHE_SERVFAIL_TTL_MAX_SECS,
+        ))
+    }
+
     pub fn load(path: &Path) -> Result<Self, ConfigError> {
         let cfg = std::fs::read_to_string(path).map_err(|error| ConfigError::CouldNotRead {
             path: path.to_string_lossy().to_string(),
@@ -217,7 +251,27 @@ mod tests {
         assert_eq!(config.listen_address, "[::]:53".parse().unwrap());
         assert_eq!(config.metrics_listen_address, "[::]:8053".parse().unwrap());
         assert_eq!(config.negative_cache_ttl_secs, 120);
-        assert_eq!(config.negative_cache_entries_max_count, 200_000);
+        assert_eq!(config.negative_cache_servfail_ttl_secs, 5);
+        assert_eq!(config.upstream_lookup_timeout_secs, 5);
+        assert_eq!(config.negative_cache_entries_max_count, 50_000);
+    }
+
+    #[test]
+    fn servfail_ttl_is_clamped_to_supported_range() {
+        let with_ttl = |secs| Config {
+            negative_cache_servfail_ttl_secs: secs,
+            ..Config::default()
+        };
+
+        assert_eq!(
+            with_ttl(0).servfail_cache_ttl(),
+            Duration::from_secs(NEGATIVE_CACHE_SERVFAIL_TTL_MIN_SECS)
+        );
+        assert_eq!(
+            with_ttl(u64::MAX).servfail_cache_ttl(),
+            Duration::from_secs(NEGATIVE_CACHE_SERVFAIL_TTL_MAX_SECS)
+        );
+        assert_eq!(with_ttl(5).servfail_cache_ttl(), Duration::from_secs(5));
     }
 
     // Serializing the defaults and reading them back must complete successfully

--- a/crates/dns/src/lib.rs
+++ b/crates/dns/src/lib.rs
@@ -35,12 +35,12 @@ use hickory_server::server::{Request, RequestHandler, ResponseHandler, ResponseI
 use hickory_server::zone_handler::MessageResponseBuilder;
 use metrics_endpoint::{MetricsEndpointConfig, new_metrics_setup, run_metrics_endpoint};
 use opentelemetry::KeyValue;
-use opentelemetry::metrics::{Counter, Meter};
+use opentelemetry::metrics::{Counter, Meter, ObservableGauge};
 use rpc::forge_tls_client::{ApiConfig, ForgeClientT, ForgeTlsClient};
 use rpc::protos::dns::DnsResourceRecordLookupRequest;
 use tokio::net::{TcpListener, UdpSocket};
 use tokio::sync::Mutex;
-use tracing::{error, info, warn};
+use tracing::{Instrument, error, info, warn};
 
 pub mod config;
 mod negative_cache;
@@ -52,11 +52,14 @@ struct DnsMetrics {
     negative_cache_hit: Counter<u64>,
     negative_cache_miss: Counter<u64>,
     negative_cache_eviction: Counter<u64>,
-    negative_cache_drop: Counter<u64>,
+    // Observable gauge of current cache occupancy: its callback reads the
+    // cache length on each scrape. Held only to keep that callback registered
+    // for the lifetime of the meter; never accessed directly.
+    _negative_cache_size: ObservableGauge<u64>,
 }
 
 impl DnsMetrics {
-    fn new(meter: &Meter) -> Self {
+    fn new(meter: &Meter, negative_cache: Arc<NegativeCache>) -> Self {
         Self {
             negative_cache_hit: meter
                 .u64_counter("carbide_dns_negative_cache_hit_count")
@@ -67,8 +70,12 @@ impl DnsMetrics {
             negative_cache_eviction: meter
                 .u64_counter("carbide_dns_negative_cache_eviction_count")
                 .build(),
-            negative_cache_drop: meter
-                .u64_counter("carbide_dns_negative_cache_drop_count")
+            _negative_cache_size: meter
+                .u64_observable_gauge("carbide_dns_negative_cache_size")
+                .with_description("Current number of entries in the negative DNS cache")
+                .with_callback(move |observer| {
+                    observer.observe(negative_cache.entry_count() as u64, &[]);
+                })
                 .build(),
         }
     }
@@ -85,7 +92,46 @@ impl std::fmt::Debug for DnsMetrics {
 pub struct DnsServer {
     forge_client: Mutex<ForgeClientT>,
     negative_cache: Arc<NegativeCache>,
+    /// Per-request ceiling on the upstream `lookup_record` call.
+    upstream_lookup_timeout: Duration,
     metrics: DnsMetrics,
+}
+
+/// How an upstream gRPC failure is surfaced to the DNS client.
+struct NegativeClassification {
+    /// The DNS response code returned to the client.
+    code: ResponseCode,
+    /// Whether the failure is transient (a momentary upstream problem, cached
+    /// only briefly) rather than a stable/authoritative negative cached for the
+    /// full TTL.
+    transient: bool,
+}
+
+/// Maps an upstream gRPC status to the DNS response code we return and how long
+/// it may be cached, following the closest RFC 1035 RCODE semantics.
+fn classify_failure(code: tonic::Code) -> NegativeClassification {
+    use tonic::Code;
+
+    let (code, transient) = match code {
+        // The name genuinely does not exist: a stable, authoritative negative.
+        Code::NotFound => (ResponseCode::NXDomain, false),
+        // The query itself was malformed (empty qname, unparseable qtype). It
+        // will stay malformed on retry, so the answer is stable.
+        Code::InvalidArgument => (ResponseCode::FormErr, false),
+        // The upstream does not implement this qtype/operation; stable, and
+        // consistent with the NotImp we already return for unsupported qtypes.
+        Code::Unimplemented => (ResponseCode::NotImp, false),
+        // An authorization/policy rejection — surfaced as a policy refusal.
+        Code::PermissionDenied | Code::Unauthenticated => (ResponseCode::Refused, false),
+        // Everything else —
+        // Surface it as ServFail and cache it only briefly: RFC 9520 requires
+        // caching resolution failures so a client retry storm collapses into one
+        // upstream call per name per window, while the short TTL keeps the
+        // failure from outliving the upstream's recovery.
+        _ => (ResponseCode::ServFail, true),
+    };
+
+    NegativeClassification { code, transient }
 }
 
 #[async_trait::async_trait]
@@ -95,6 +141,8 @@ impl RequestHandler for DnsServer {
         request: &Request,
         mut response_handle: R,
     ) -> ResponseInfo {
+        // `request_info()` is fallible in hickory: a request we can't even
+        // interpret gets a FormErr and no further processing.
         let request_info = match request.request_info() {
             Ok(request_info) => request_info,
             Err(_) => {
@@ -110,133 +158,168 @@ impl RequestHandler for DnsServer {
         let qtype = request_info.query.query_type();
         let qname = request_info.query.name().to_string();
 
+        // Attach the span to the request future with `Instrument` rather than an
+        // `Entered` guard. A guard held across an `.await` is not dropped when the
+        // task yields.
         let span = tracing::info_span!("dns_request", %qname, %qtype);
-        let _guard = span.enter();
 
-        let start = Instant::now();
+        async move {
+            let start = Instant::now();
 
-        // Only handle types that DnsResourceRecordType supports and that we can build
-        // RData for; return NotImp for everything else. Currently, A and AAAA are
-        // supported; add arms here as the API and RData parsing are extended.
-        let dns_qtype = match DnsResourceRecordType::try_from(qtype.to_string().as_str()) {
-            Ok(t @ (DnsResourceRecordType::A | DnsResourceRecordType::AAAA)) => t,
-            _ => {
-                warn!(%qname, %qtype, "Unsupported query type");
-                let response = MessageResponseBuilder::from_message_request(request);
-                return response_handle
-                    .send_response(response.error_msg(request_info.metadata, ResponseCode::NotImp))
-                    .await
-                    .unwrap();
-            }
-        };
-
-        let cache_key = CacheKey {
-            qname: qname.clone(),
-            qtype,
-        };
-
-        let cached = self.negative_cache.get(&cache_key).await;
-
-        let record_name = Name::from(request_info.query.name());
-        let message = MessageResponseBuilder::from_message_request(request);
-        let mut response_header = Metadata::response_from_request(request_info.metadata);
-
-        let (response_code, records) = if let Some(code) = cached {
-            self.metrics
-                .negative_cache_hit
-                .add(1, &[KeyValue::new("response_code", format!("{code:?}"))]);
-            tracing::debug!("Negative cache hit");
-            (code, vec![])
-        } else {
-            // Clone the client out under the lock, then release it so the
-            // upstream RPC runs without serializing other in-flight queries.
-            let client = {
-                let guard = self.forge_client.lock().await;
-                guard.clone()
-            };
-            match Self::retrieve_records(client, &qname, dns_qtype, &record_name).await {
-                Ok(records) => {
-                    tracing::info!(record_count = records.len(), "DNS lookup succeeded");
-                    (ResponseCode::NoError, records)
+            // Only handle types that DnsResourceRecordType supports and that we can build
+            // RData for; return NotImp for everything else. Currently, A and AAAA are
+            // supported; add arms here as the API and RData parsing are extended.
+            let dns_qtype = match DnsResourceRecordType::try_from(qtype.to_string().as_str()) {
+                Ok(t @ (DnsResourceRecordType::A | DnsResourceRecordType::AAAA)) => t,
+                _ => {
+                    warn!(%qname, %qtype, "Unsupported query type");
+                    let response = MessageResponseBuilder::from_message_request(request);
+                    return response_handle
+                        .send_response(
+                            response.error_msg(request_info.metadata, ResponseCode::NotImp),
+                        )
+                        .await
+                        .unwrap();
                 }
-                Err(e) => {
-                    warn!(error = %e, "DNS lookup failed");
-                    let code = match e.code() {
-                        tonic::Code::NotFound => ResponseCode::NXDomain,
-                        tonic::Code::InvalidArgument => ResponseCode::Refused,
-                        _ => ResponseCode::ServFail,
-                    };
+            };
 
-                    if matches!(code, ResponseCode::NXDomain | ResponseCode::Refused) {
-                        // Count the upstream negative regardless of whether it
-                        // ends up cached below.
+            let cache_key = CacheKey {
+                qname: qname.clone(),
+                qtype,
+            };
+
+            let cached = self.negative_cache.get(&cache_key);
+
+            let record_name = Name::from(request_info.query.name());
+            let message = MessageResponseBuilder::from_message_request(request);
+            let mut response_header = Metadata::response_from_request(request_info.metadata);
+
+            let (response_code, records) = if let Some(code) = cached {
+                self.metrics
+                    .negative_cache_hit
+                    .add(1, &[KeyValue::new("response_code", format!("{code:?}"))]);
+                tracing::debug!("Negative cache hit");
+                (code, vec![])
+            } else {
+                // Clone the client out under the lock, then release it so the
+                // upstream RPC runs without serializing other in-flight queries.
+                let client = {
+                    let guard = self.forge_client.lock().await;
+                    guard.clone()
+                };
+                // a slow or overloaded carbide-api would otherwise
+                // hold this handler open, piling up in-flight work and
+                // stalling new queries. On timeout we Err on DeadlineExceeded,
+                // which `classify_failure` maps to a briefly-cached ServFail, so we
+                // fail fast
+                //
+                // TODO: this limits each call's *duration* but not the *number* of calls
+                // Add a `tokio::sync::Semaphore`
+                let result = match tokio::time::timeout(
+                    self.upstream_lookup_timeout,
+                    Self::retrieve_records(client, &qname, dns_qtype, &record_name),
+                )
+                .await
+                {
+                    Ok(inner) => inner,
+                    Err(_elapsed) => Err(tonic::Status::deadline_exceeded(format!(
+                        "upstream lookup_record exceeded {}s",
+                        self.upstream_lookup_timeout.as_secs()
+                    ))),
+                };
+                match result {
+                    Ok(records) => {
+                        tracing::info!(record_count = records.len(), "DNS lookup succeeded");
+                        (ResponseCode::NoError, records)
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "DNS lookup failed");
+                        let NegativeClassification { code, transient } = classify_failure(e.code());
+
+                        // Count the upstream negative regardless of how it is cached
+                        // below.
                         self.metrics
                             .negative_cache_miss
                             .add(1, &[KeyValue::new("response_code", format!("{code:?}"))]);
 
-                        if self.negative_cache.record(cache_key, code).await {
-                            tracing::debug!(%code, "Caching negative response");
-                        } else {
-                            self.metrics
-                                .negative_cache_drop
-                                .add(1, &[KeyValue::new("response_code", format!("{code:?}"))]);
-                            warn!(
-                                %code,
-                                max_entries = self.negative_cache.max_entries(),
-                                "Negative cache full; not caching this response"
-                            );
+                        // The LRU cache always admits the entry; a `true` return means
+                        // a least-recently-used entry was evicted to make room.  Both are
+                        // entries leaving the cache — so capacity pressure surfaces as
+                        // a rising eviction rate.
+                        if self.negative_cache.record(cache_key, code, transient) {
+                            self.metrics.negative_cache_eviction.add(1, &[]);
                         }
+                        tracing::debug!(%code, "Caching negative response");
+
+                        (code, vec![])
                     }
-
-                    (code, vec![])
                 }
-            }
-        };
+            };
 
-        let duration = start.elapsed();
-        tracing::info!(
-            response_code = ?response_code,
-            record_count = records.len(),
-            duration_ms = duration.as_millis(),
-            "Request completed"
-        );
+            let duration = start.elapsed();
+            tracing::info!(
+                response_code = ?response_code,
+                record_count = records.len(),
+                duration_ms = duration.as_millis(),
+                "Request completed"
+            );
 
-        response_header.response_code = response_code;
-        let message = message.build(
-            response_header,
-            records.iter(),
-            iter::empty(),
-            iter::empty(),
-            iter::empty(),
-        );
+            response_header.response_code = response_code;
+            let message = message.build(
+                response_header,
+                records.iter(),
+                iter::empty(),
+                iter::empty(),
+                iter::empty(),
+            );
 
-        response_handle.send_response(message).await.unwrap()
+            response_handle.send_response(message).await.unwrap()
+        }
+        .instrument(span)
+        .await
     }
 }
 
 impl DnsServer {
     pub fn new(forge_client: Mutex<ForgeClientT>, meter: &Meter, config: &Config) -> Self {
+        let servfail_ttl = config.servfail_cache_ttl();
+        if servfail_ttl.as_secs() != config.negative_cache_servfail_ttl_secs {
+            warn!(
+                configured = config.negative_cache_servfail_ttl_secs,
+                clamped_secs = servfail_ttl.as_secs(),
+                min_secs = config::NEGATIVE_CACHE_SERVFAIL_TTL_MIN_SECS,
+                max_secs = config::NEGATIVE_CACHE_SERVFAIL_TTL_MAX_SECS,
+                "negative_cache_servfail_ttl_secs out of range; clamped"
+            );
+        }
+
+        let negative_cache = Arc::new(NegativeCache::new(
+            Duration::from_secs(config.negative_cache_ttl_secs),
+            servfail_ttl,
+            config.negative_cache_entries_max_count as usize,
+        ));
+
         Self {
             forge_client,
-            negative_cache: Arc::new(NegativeCache::new(
-                Duration::from_secs(config.negative_cache_ttl_secs),
-                config.negative_cache_entries_max_count as usize,
-            )),
-            metrics: DnsMetrics::new(meter),
+            upstream_lookup_timeout: Duration::from_secs(config.upstream_lookup_timeout_secs),
+            // The metrics gauge callback holds a clone of the cache to read its
+            // occupancy on scrape.
+            metrics: DnsMetrics::new(meter, negative_cache.clone()),
+            negative_cache,
         }
     }
 
     /// Queries carbide-api for DNS records matching `qname` and `qtype`, then
-    /// converts the results into trust-dns `Record` objects ready for the response.
+    /// converts the results into hickory `Record` objects ready for the response.
+    // `#[instrument]` attaches the span to the returned future. skip_all fields by default,
+    // then include only qname and qtype1
+    #[tracing::instrument(level = "debug", skip_all, fields(qname = %qname, qtype = %qtype))]
     async fn retrieve_records(
         mut forge_client: ForgeClientT,
         qname: &str,
         qtype: DnsResourceRecordType,
         record_name: &Name,
     ) -> Result<Vec<Record>, tonic::Status> {
-        let span = tracing::debug_span!("retrieve_records", %qname, %qtype);
-        let _guard = span.enter();
-
         let request = tonic::Request::new(DnsResourceRecordLookupRequest {
             qtype: qtype.to_string(),
             qname: qname.to_string(),
@@ -280,6 +363,8 @@ impl DnsServer {
                     // Unreachable: handle_request only dispatches A and AAAA to this function.
                     _ => return None,
                 };
+                // hickory infers the record type from the rdata; set the class
+                // explicitly since `from_rdata` defaults it.
                 let mut record = Record::from_rdata(record_name.clone(), r.ttl, rdata);
                 record.dns_class = DNSClass::IN;
                 Some(record)
@@ -314,7 +399,15 @@ impl DnsServer {
 
         let client = Mutex::new(ForgeTlsClient::retry_build(&api_config).await?);
 
-        let negative_ttl = Duration::from_secs(config.negative_cache_ttl_secs);
+        // Sweep at the shorter of the two negative-cache lifetimes. ServFail
+        // entries expire far sooner than NXDomain/Refused, and although an
+        // expired entry is never *served* (get() filters on expiry), it still
+        // occupies a slot against the entry cap until swept. Reclaiming on the
+        // short cadence keeps a ServFail flood from filling the cap with
+        // already-expired entries and starving genuinely-new negatives.
+        let sweep_interval = Duration::from_secs(config.negative_cache_ttl_secs)
+            .min(config.servfail_cache_ttl())
+            .max(Duration::from_secs(1));
 
         let metrics_setup = new_metrics_setup("carbide-dns", "carbide", true)?;
 
@@ -342,10 +435,10 @@ impl DnsServer {
 
         // Periodically remove expired negative cache entries.
         tokio::spawn(async move {
-            let mut interval = tokio::time::interval(negative_ttl);
+            let mut interval = tokio::time::interval(sweep_interval);
             loop {
                 interval.tick().await;
-                let evicted = cache.evict_expired().await;
+                let evicted = cache.evict_expired();
                 if evicted > 0 {
                     cache_eviction_counter.add(evicted as u64, &[]);
                 }
@@ -357,8 +450,8 @@ impl DnsServer {
         srv.register_socket(udp_socket);
 
         let tcp_socket = TcpListener::bind(&listen).await?;
-        // Note: 32 is hickory_server's default response buffer size when running it as a binary, so
-        // use that size here.
+        // 32 is hickory_server's default response buffer size when run as a
+        // binary; match it here.
         srv.register_listener(tcp_socket, Duration::new(5, 0), 32);
 
         info!(
@@ -379,5 +472,41 @@ impl DnsServer {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_failure_maps_grpc_codes_to_dns_response_codes() {
+        use tonic::Code;
+
+        let cases = [
+            (Code::NotFound, ResponseCode::NXDomain, false),
+            (Code::InvalidArgument, ResponseCode::FormErr, false),
+            (Code::Unimplemented, ResponseCode::NotImp, false),
+            (Code::PermissionDenied, ResponseCode::Refused, false),
+            (Code::Unauthenticated, ResponseCode::Refused, false),
+            (Code::Internal, ResponseCode::ServFail, true),
+            (Code::Unavailable, ResponseCode::ServFail, true),
+            (Code::DeadlineExceeded, ResponseCode::ServFail, true),
+            (Code::ResourceExhausted, ResponseCode::ServFail, true),
+            (Code::Aborted, ResponseCode::ServFail, true),
+            (Code::Unknown, ResponseCode::ServFail, true),
+        ];
+
+        for (code, expected_code, expected_transient) in cases {
+            let classification = classify_failure(code);
+            assert_eq!(
+                classification.code, expected_code,
+                "response code for {code:?}"
+            );
+            assert_eq!(
+                classification.transient, expected_transient,
+                "transience for {code:?}"
+            );
+        }
     }
 }

--- a/crates/dns/src/negative_cache.rs
+++ b/crates/dns/src/negative_cache.rs
@@ -14,26 +14,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// TODO - Change this to LRU Cache - https://docs.rs/lru/latest/lru/
-//! TTL-expiring cache of negative DNS responses (NXDomain / Refused).
+//! TTL-expiring, LRU-bounded cache of negative DNS responses.
 //!
-//! Caching negatives keeps repeated lookups for the same non-existent name from querying
-//! the api server.
+//! Caching negatives keeps repeated lookups for the same name from re-querying
+//! the api server. Two classes of negative are cached with different lifetimes:
+//!
+//! * *authoritative* negatives (NXDomain, Refused) — stable answers, cached for
+//!   the full `ttl`; and
+//! * *transient* failures (ServFail) — a momentary upstream error, cached only
+//!   for the short `transient_ttl` so a client retry storm collapses into one
+//!   upstream call per name per window without outliving the api server's
+//!   recovery (RFC 2308 §7.1, RFC 9520).
+//!
 //! Two mechanisms keep memory bounded:
 //!
-//! * a hard cap on the number of live entries (`max_entries`): once full, a new
-//!   name is refused rather than admitted, so a flood of *distinct* non-existent
-//!   names cannot grow the HashMap without limit — the time-based sweep alone cannot
-//!   contain this because it only removes *expired* entries; and
+//! * an LRU capacity bound (`max_entries`): inserting into a full cache evicts
+//!   the *least-recently-used* entry rather than refusing the newcomer, so a
+//!   flood of distinct names keeps the hot working set cached instead of
+//!   pinning whichever names happened to arrive first; and
 //! * a periodic sweep ([`NegativeCache::evict_expired`]) that drops entries past
-//!   their TTL and returns the backing allocation after a burst subsides.
+//!   their TTL, reclaiming capacity that expired-but-not-yet-re-queried entries
+//!   would otherwise hold.
 
-use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use hickory_resolver::proto::op::ResponseCode;
 use hickory_server::proto::rr::RecordType;
-use tokio::sync::RwLock;
+use lru::LruCache;
 
 /// Identifies a cached negative response: the queried name and record type.
 #[derive(Hash, Debug, Eq, PartialEq, Clone)]
@@ -50,78 +59,110 @@ struct NegativeEntry {
 
 #[derive(Debug)]
 pub(crate) struct NegativeCache {
-    entries: RwLock<HashMap<CacheKey, NegativeEntry>>,
+    // A plain `std::sync::Mutex`, not an async one: every critical section is a
+    // handful of synchronous map operations and the guard is never held across
+    // an `.await`. (`LruCache::get` bumps recency, so even the read path needs
+    // `&mut`, ruling out an `RwLock`.) Using the sync mutex also lets the
+    // observable metrics gauge read the length from a synchronous callback.
+    entries: Mutex<LruCache<CacheKey, NegativeEntry>>,
+    /// Lifetime for authoritative negatives (NXDomain, Refused).
     ttl: Duration,
-    max_entries: usize,
+    /// Lifetime for transient failures (ServFail); kept short on purpose.
+    transient_ttl: Duration,
 }
 
 impl NegativeCache {
-    pub(crate) fn new(ttl: Duration, max_entries: usize) -> Self {
+    pub(crate) fn new(ttl: Duration, transient_ttl: Duration, max_entries: usize) -> Self {
+        // A zero capacity would evict every entry the instant it was inserted,
+        // defeating the cache, and `NonZeroUsize::new(0)` is `None` — floor it
+        // at 1 rather than panic on a misconfigured bound.
+        let capacity = NonZeroUsize::new(max_entries).unwrap_or(NonZeroUsize::MIN);
         Self {
-            entries: RwLock::new(HashMap::new()),
+            entries: Mutex::new(LruCache::new(capacity)),
             ttl,
-            max_entries,
+            transient_ttl,
         }
     }
 
-    /// The configured maximum number of entries possible in the cache
-    pub(crate) fn max_entries(&self) -> usize {
-        self.max_entries
+    /// The lifetime for an entry given whether the negative is `transient`.
+    /// Authoritative negatives live for the full `ttl`; a transient failure is
+    /// held only for the short `transient_ttl` so it does not outlive the
+    /// upstream's recovery. The caller classifies transience (see the DNS
+    /// handler), since it cannot be derived from the response code alone.
+    // TODO: RFC 9520 RECOMMENDS exponential/linear backoff that lengthens the
+    // cached-failure lifetime for *persistent* failures.
+    fn ttl_for(&self, transient: bool) -> Duration {
+        if transient {
+            self.transient_ttl
+        } else {
+            self.ttl
+        }
     }
 
-    /// Returns the cached response code for `key` if a non-expired entry exists.
+    /// The number of cache entries currently held, including any that have expired but
+    /// not yet been swept. Backs the cache-occupancy metrics gauge.
+    pub(crate) fn entry_count(&self) -> usize {
+        self.entries
+            .lock()
+            .expect("negative cache mutex poisoned")
+            .len()
+    }
+
+    /// Returns the cached response code for `key` if a non-expired entry exists,
+    /// marking it most-recently-used.
     ///
-    /// An entry that has expired but has not yet been swept is treated as absent, so
-    /// a stale negative is never served in the window between expiry and the
-    /// next [`Self::evict_expired`].
-    pub(crate) async fn get(&self, key: &CacheKey) -> Option<ResponseCode> {
-        let entries = self.entries.read().await;
-        entries
+    /// An entry that has expired but has not yet been swept is treated as absent
+    /// and dropped on the spot, so a stale negative is never served and the
+    /// expired entry stops counting against the capacity bound.
+    pub(crate) fn get(&self, key: &CacheKey) -> Option<ResponseCode> {
+        let mut entries = self.entries.lock().expect("negative cache mutex poisoned");
+        let code = entries
             .get(key)
             .filter(|entry| entry.expires_at > Instant::now())
-            .map(|entry| entry.reason_code)
+            .map(|entry| entry.reason_code);
+        // Either the key was absent (no-op) or it was present but expired; in
+        // the latter case remove it so it neither serves nor occupies a slot.
+        if code.is_none() {
+            entries.pop(key);
+        }
+        code
     }
 
-    /// Records a negative `code` for `key`, honoring the entry-count cap.
+    /// Records a negative `code` for `key`. `transient` selects the entry's
+    /// lifetime (see [`Self::ttl_for`]).
     ///
-    /// Returns `true` if the entry was stored. A *new* key is refused once the
-    /// cache holds `max_entries` entries. A key that is *already present* is
-    /// always refreshed.
-    pub(crate) async fn record(&self, key: CacheKey, code: ResponseCode) -> bool {
-        let mut entries = self.entries.write().await;
-        if entries.len() >= self.max_entries && !entries.contains_key(&key) {
-            return false;
+    /// The cache always admits the entry: inserting into a full cache evicts the
+    /// least-recently-used entry. Returns `true` when such a capacity eviction
+    /// occurred (a *different* key was pushed out to make room), and `false`
+    /// when the entry fit without eviction or merely refreshed an existing key.
+    pub(crate) fn record(&self, key: CacheKey, code: ResponseCode, transient: bool) -> bool {
+        let entry = NegativeEntry {
+            reason_code: code,
+            expires_at: Instant::now() + self.ttl_for(transient),
+        };
+        let mut entries = self.entries.lock().expect("negative cache mutex poisoned");
+        // `push` returns the displaced (key, value): the same key on an in-place
+        // refresh, or a *different* key when a full cache evicted its LRU entry
+        // to admit this one.
+        match entries.push(key.clone(), entry) {
+            Some((displaced_key, _)) => displaced_key != key,
+            None => false,
         }
-        entries.insert(
-            key,
-            NegativeEntry {
-                reason_code: code,
-                expires_at: Instant::now() + self.ttl,
-            },
-        );
-        true
     }
 
     /// Removes expired entries and returns the number evicted.
-    // `HashMap::retain` removes entries but never shrinks the backing
-    // allocation, so without the `shrink_to_fit` the peak capacity reached
-    // during a burst would be held indefinitely. Once capacity exceeds 4x the
-    // live entry count, the memory is handed back to the allocator.
-    pub(crate) async fn evict_expired(&self) -> usize {
-        let mut entries = self.entries.write().await;
-        let before = entries.len();
-        entries.retain(|_, entry| entry.expires_at > Instant::now());
-        let evicted = before - entries.len();
-
-        if entries.capacity() > 4 * entries.len() {
-            entries.shrink_to_fit();
+    pub(crate) fn evict_expired(&self) -> usize {
+        let now = Instant::now();
+        let mut entries = self.entries.lock().expect("negative cache mutex poisoned");
+        let expired: Vec<CacheKey> = entries
+            .iter()
+            .filter(|(_, entry)| entry.expires_at <= now)
+            .map(|(key, _)| key.clone())
+            .collect();
+        for key in &expired {
+            entries.pop(key);
         }
-        evicted
-    }
-
-    #[cfg(test)]
-    async fn len(&self) -> usize {
-        self.entries.read().await.len()
+        expired.len()
     }
 }
 
@@ -136,67 +177,73 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn refuses_new_keys_once_full() {
-        let cache = NegativeCache::new(Duration::from_secs(120), 2);
-        assert!(
-            cache
-                .record(key("a.example.com."), ResponseCode::NXDomain)
-                .await
-        );
-        assert!(
-            cache
-                .record(key("b.example.com."), ResponseCode::NXDomain)
-                .await
+    #[test]
+    fn evicts_least_recently_used_when_full() {
+        let cache = NegativeCache::new(Duration::from_secs(120), Duration::from_secs(5), 2);
+        cache.record(key("a.example.com."), ResponseCode::NXDomain, false);
+        cache.record(key("b.example.com."), ResponseCode::NXDomain, false);
+
+        // Touch `a`, making `b` the least-recently-used entry.
+        assert_eq!(
+            cache.get(&key("a.example.com.")),
+            Some(ResponseCode::NXDomain)
         );
 
-        assert!(
-            !cache
-                .record(key("c.example.com."), ResponseCode::NXDomain)
-                .await
+        // Admitting `c` reports an eviction and pushes out `b`, not `a`.
+        let evicted = cache.record(key("c.example.com."), ResponseCode::NXDomain, false);
+        assert!(evicted);
+        assert_eq!(cache.entry_count(), 2);
+        assert_eq!(cache.get(&key("b.example.com.")), None);
+        assert_eq!(
+            cache.get(&key("a.example.com.")),
+            Some(ResponseCode::NXDomain)
         );
-        assert_eq!(cache.len().await, 2);
+        assert_eq!(
+            cache.get(&key("c.example.com.")),
+            Some(ResponseCode::NXDomain)
+        );
     }
 
-    #[tokio::test]
-    async fn refreshes_existing_key_when_full() {
-        let cache = NegativeCache::new(Duration::from_secs(120), 2);
-        cache
-            .record(key("a.example.com."), ResponseCode::NXDomain)
-            .await;
-        cache
-            .record(key("b.example.com."), ResponseCode::NXDomain)
-            .await;
+    #[test]
+    fn refreshes_existing_key_without_eviction_when_full() {
+        let cache = NegativeCache::new(Duration::from_secs(120), Duration::from_secs(5), 2);
+        cache.record(key("a.example.com."), ResponseCode::NXDomain, false);
+        cache.record(key("b.example.com."), ResponseCode::NXDomain, false);
 
-        assert!(
-            cache
-                .record(key("a.example.com."), ResponseCode::NXDomain)
-                .await
-        );
-        assert_eq!(cache.len().await, 2);
+        let evicted = cache.record(key("a.example.com."), ResponseCode::NXDomain, false);
+        assert!(!evicted);
+        assert_eq!(cache.entry_count(), 2);
     }
 
-    #[tokio::test]
-    async fn get_returns_none_for_expired_entry() {
+    #[test]
+    fn get_returns_none_for_expired_entry() {
         // A zero TTL means every entry is already expired when read back.
-        let cache = NegativeCache::new(Duration::from_secs(0), 16);
-        cache
-            .record(key("gone.example.com."), ResponseCode::NXDomain)
-            .await;
-        assert_eq!(cache.get(&key("gone.example.com.")).await, None);
+        let cache = NegativeCache::new(Duration::from_secs(0), Duration::from_secs(0), 16);
+        cache.record(key("gone.example.com."), ResponseCode::NXDomain, false);
+        assert_eq!(cache.get(&key("gone.example.com.")), None);
     }
 
-    #[tokio::test]
-    async fn evict_expired_drops_only_expired_entries() {
-        let cache = NegativeCache::new(Duration::from_secs(0), 16);
-        cache
-            .record(key("a.example.com."), ResponseCode::NXDomain)
-            .await;
-        cache
-            .record(key("b.example.com."), ResponseCode::Refused)
-            .await;
+    #[test]
+    fn evict_expired_drops_only_expired_entries() {
+        let cache = NegativeCache::new(Duration::from_secs(0), Duration::from_secs(0), 16);
+        cache.record(key("a.example.com."), ResponseCode::NXDomain, false);
+        cache.record(key("b.example.com."), ResponseCode::Refused, false);
 
-        assert_eq!(cache.evict_expired().await, 2);
-        assert_eq!(cache.len().await, 0);
+        assert_eq!(cache.evict_expired(), 2);
+        assert_eq!(cache.entry_count(), 0);
+    }
+
+    #[test]
+    fn servfail_uses_transient_ttl_not_authoritative_ttl() {
+        let cache = NegativeCache::new(Duration::from_secs(120), Duration::from_secs(0), 16);
+
+        cache.record(key("fail.example.com."), ResponseCode::ServFail, true);
+        assert_eq!(cache.get(&key("fail.example.com.")), None);
+
+        cache.record(key("gone.example.com."), ResponseCode::NXDomain, false);
+        assert_eq!(
+            cache.get(&key("gone.example.com.")),
+            Some(ResponseCode::NXDomain)
+        );
     }
 }

--- a/crates/dns/src/test/carbide-dns.toml
+++ b/crates/dns/src/test/carbide-dns.toml
@@ -41,10 +41,19 @@
 # How long to cache NXDomain and Refused responses, in seconds.
 # negative_cache_ttl_secs = 120
 
+# How long to cache ServFail responses (transient nico-api failures), in
+# seconds. Kept short so a failure is not pinned across the upstream's recovery;
+# clamped to [1, 300]. Default: 5.
+# negative_cache_servfail_ttl_secs = 5
+
 # Maximum number of entries the negative cache may hold. Once reached, new
 # negative responses are not cached, bounding memory under a flood of distinct
 # non-existent names.
-# negative_cache_entries_max_count = 200000
+# negative_cache_entries_max_count = 50000
+
+# Maximum time to wait for a single upstream lookup_record call before giving up
+# and returning ServFail, in seconds. Default: 3.
+# upstream_lookup_timeout_secs = 5
 
 # Address (host:port) the Prometheus metrics server listens on.
 # metrics_listen_address = "[::]:8053"

--- a/helm/charts/nico-dns/templates/podmonitor.yaml
+++ b/helm/charts/nico-dns/templates/podmonitor.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: nico-dns-metrics
+  namespace: {{ include "nico-dns.namespace" . }}
+  labels:
+    {{- include "nico-dns.labels" . | nindent 4 }}
+    {{- with .Values.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ include "nico-dns.namespace" . }}
+  selector:
+    matchLabels:
+      {{- include "nico-dns.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    # `metrics` is the container port name on the StatefulSet (8053/TCP).
+    - targetPort: metrics
+      {{- with .Values.podMonitor.path }}
+      path: {{ . }}
+      {{- end }}
+      {{- with .Values.podMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+{{- end }}

--- a/helm/charts/nico-dns/templates/statefulset.yaml
+++ b/helm/charts/nico-dns/templates/statefulset.yaml
@@ -51,12 +51,20 @@ spec:
             capabilities:
               add:
                 - SYS_PTRACE
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: udp
               containerPort: 53
               protocol: UDP
             - name: tcp
               containerPort: 53
+              protocol: TCP
+            # Prometheus metrics endpoint; scraped via a PodMonitor (no Service).
+            - name: metrics
+              containerPort: 8053
               protocol: TCP
           volumeMounts:
             - name: spiffe

--- a/helm/charts/nico-dns/values.yaml
+++ b/helm/charts/nico-dns/values.yaml
@@ -44,6 +44,31 @@ service:
 
 apiServiceName: nico-api
 
+## Pod resource requests/limits for the nico-dns container. Rendered verbatim,
+## so override any field as needed. Defaults: no CPU limit (a hard CPU cap would
+## throttle the latency-sensitive DNS path) and a 256Mi memory limit sized for
+## the negative cache plus allocator high-water under load.
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    memory: 256Mi
+
+## PodMonitor for the Prometheus Operator to scrape the metrics container port
+## (8053) directly off each pod. Disabled by default; requires the Prometheus
+## Operator CRDs (monitoring.coreos.com/v1).
+podMonitor:
+  enabled: false
+  ## Label your Prometheus instance's podMonitorSelector matches to discover it.
+  labels:
+    prometheus: nico-monitoring
+  ## Metrics HTTP path served by nico-dns.
+  path: /metrics
+  ## Optional scrape tuning; left blank, so the operator defaults apply.
+  interval: ""
+  scrapeTimeout: ""
+
 certificate:
   ## serviceName is used to auto-generate dnsNames and SPIFFE URIs based on the release namespace
   serviceName: ""


### PR DESCRIPTION
### Description

Only authoritative negatives (NXDomain, Refused) were cached, so a high-rate flood of failing lookups - ServFail would result in no caching.  We now cache all negative responses but the TTL of the cache entry depends on tonic::Code (see below)

Map gRPC status to the closest RFC 1035 RCODE, classified as authoritative (full TTL) or transient (short TTL):
```
    NotFound                         -> NXDomain   authoritative
    InvalidArgument                  -> FormErr    authoritative
    Unimplemented                    -> NotImp     authoritative
    PermissionDenied|Unauthenticated -> Refused    authoritative
    everything else                  -> ServFail   transient
```
Transience is tracked separately from the RCODE, since the two are not equivalent (a rate limit could read as `Refused` yet must expire quickly). ServFail uses a short, configurable TTL (default 5s, clamped to [1, 300]). So a transient communication problem with the api server is cached at a lower rate than a `NotFound`.

Move the cache to LRU (`Mutex<LruCache>`) that evicts the least-recently-used entry instead of refusing new keys once full, so a flood of distinct names keeps the hot set cached. Sweep expired entries at the shorter of the two TTLs so short-lived ServFails do not hold capacity until the next NXDomain-cadence sweep. Fold capacity evictions into `negative_cache_eviction` metric and retire `negative_cache_drop`, as well as adding `negative_cache_size` metrics


Bug fix: `handle_request` and `retrieve_records` created a span and held a guard across their `.await` points. A guard is dropped only when it goes out of scope, so on yield the span stayed current on the worker thread; the next request entered its span as a child of the parked one, and under load `dns_request` spans chained arbitrarily deep.

 Attach the span to the request future with `Instrument` (and `#[tracing::instrument]` for `retrieve_records`) so it suspends and resumes with the task across awaits and never leaks onto the thread. Requests no longer nest.

Added a timeout to `retrieve_records` so a slow or overloaded API server would not keep the DNS handler open for as long as the api takes to respond. Under DB pool connection exhaustion, every DNS `lookup_record`  that is stuck waiting on a DB connection, the request keeps a handler alive, causing a backlog that keeps draining after the DNS client gives up.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [X] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
## Performance testing

I load-tested the negative cache path with `dnsperf` simulating 50 clients against 5,000,000 distinct hostnames that don't exist, so every query exercises the negative cache code. QPS was capped at deliberately unrealistic values (well above what we see in production) to stress the implementation.

The size-5000 cache fills almost immediately and was used to confirm that eviction works and that memory climbs and then plateaus once full. The size-100,000 cache never fills — we evict fast enough that it only reaches a little under half capacity — and was used to gauge peak memory consumption.

| QPS | LRU cache size | Entries reached | Peak memory |
|-----|---------------|-----------------|-------------|
| 200 | 5,000 | 5,000 | ~35–45 MB |
| 200 | 100,000 | 27,000 | ~80–90 MB |
| 500 | 100,000 | 45,000 | ~130–140 MB |
| 200 | 50,000 | 46,000 | ~85–90 MB |

Most of this memory is overhead rather than the cache entries themselves.
To protect the cluster from a runaway `carbide-dns` (which shouldn't happen now), I also add memory limits to the carbide-dns podSpec. 


If you are interested in reproducing the perf tests

```
# Tests cache performance against a massive amount of unique host entries that are not present in DB

seq 1 5000000 | awk '{print "host-" $1 ".nonexistent.example. A"}' > flood_distinct.txt
dnsperf -s <IP> -p 53 -d flood_distinct.txt -c 50 -q 200 -l 3600 -S 10 -t 15

```