### PR TITLE
fix(preingestion): skip/return on BFB path(s) for NIC-mode DPUs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6496,10 +6496,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.1",
  "libc",
- "plain",
- "redox_syscall 0.8.0",
 ]
 
 [[package]]
@@ -7787,7 +7784,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -8134,12 +8131,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -8951,15 +8942,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7591fa2c6b601dfcfe5f043f65a1c39fcdf50efefcd7f1572e538c1f4b398d"
 dependencies = [
  "bitflags 2.11.1",
 ]

--- a/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
@@ -27,7 +27,7 @@ use mac_address::MacAddress;
 use model::expected_entity::ExpectedEntity;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{LoadSnapshotOptions, MachineInterfaceSnapshot};
-use model::site_explorer::PreingestionState;
+use model::site_explorer::{NicMode, PreingestionState};
 use sqlx::PgConnection;
 use tokio::net::lookup_host;
 use tonic::{Request, Response, Status};
@@ -604,6 +604,22 @@ pub(crate) async fn copy_bfb_to_dpu_rshim(
         kind: "explored_endpoint",
         id: dpu_ip.to_string(),
     })?;
+
+    // If the DPU is in NIC mode, don't allow operators to copy_bfb_to_dpu_rshim
+    // at all to begin with. While the rshim + copy part will technically
+    // work, the problem is there's no ARM OS to actually reboot into. The
+    // BFB preingestion flow will work its way through the states, and then
+    // wait for the ARM OS to come up, which it never will. Waiting will
+    // eventually, time out (SLA), and then the host will mark as failed.
+    if dpu_endpoint.report.nic_mode() == Some(NicMode::Nic) {
+        return Err(CarbideError::InvalidArgument(format!(
+            "Cannot trigger BFB recovery: DPU {dpu_ip} is in NIC mode. \
+             Update the host's `ExpectedMachine.dpu_mode` to `DpuMode` \
+             and wait for site-explorer to reconcile the DPU back to \
+             DPU mode before retrying.",
+        ))
+        .into());
+    }
 
     match &dpu_endpoint.preingestion_state {
         PreingestionState::Initial

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -178,6 +178,8 @@ mod power_shelf_metadata;
 #[cfg(test)]
 mod power_shelf_state_controller;
 #[cfg(test)]
+mod preingestion_dpu_nic_mode;
+#[cfg(test)]
 mod prevent_duplicate_mac_addresses;
 #[cfg(test)]
 mod rack_find;

--- a/crates/api-core/src/tests/preingestion_dpu_nic_mode.rs
+++ b/crates/api-core/src/tests/preingestion_dpu_nic_mode.rs
@@ -1,0 +1,305 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Integration coverage for DPU NIC-mode handling/skipping in
+//! `carbide_preingestion_manager` and a similar guard in
+//! `bmc_endpoint_explorer::copy_bfb_to_dpu_rshim`.
+//!
+//! The BFB preingestion path assumes the DPU ARM OS will boot and emit the
+//! "markers" that `in_bfb_installation_wait` polls for. When the DPU is
+//! configured in NIC mode, the ARM OS never boots, so those states would
+//! otherwise time out and go into `Failed` (per SLA). These tests verify
+//! that our workflows don't let that happen.
+
+use std::net::{IpAddr, Ipv4Addr};
+
+use carbide_preingestion_manager::PreingestionManager;
+use model::site_explorer::{
+    Chassis, ComputerSystem, ComputerSystemAttributes, EndpointExplorationReport, EndpointType,
+    Inventory, NicMode, PowerState, PreingestionState, Service,
+};
+use rpc::forge::forge_server::Forge;
+use tonic::Code;
+
+use crate::tests::common;
+use crate::tests::common::api_fixtures::dpu::DpuConfig;
+
+fn dpu_report(nic_mode: NicMode) -> EndpointExplorationReport {
+    DpuConfig {
+        nic_mode: Some(nic_mode),
+        ..Default::default()
+    }
+    .into()
+}
+
+/// Minimal BMC report for the *host* endpoint side. The cleanup only touches
+/// `pause_remediation` on this row, so the rest of the report is irrelevant;
+/// we just need a row that `set_pause_remediation` can update.
+fn host_bmc_report() -> EndpointExplorationReport {
+    EndpointExplorationReport {
+        endpoint_type: EndpointType::Bmc,
+        vendor: Some(bmc_vendor::BMCVendor::Dell),
+        last_exploration_error: None,
+        last_exploration_latency: None,
+        managers: vec![],
+        systems: vec![ComputerSystem {
+            id: String::new(),
+            ethernet_interfaces: vec![],
+            manufacturer: Some("Dell".to_string()),
+            model: Some("PowerEdge R760".to_string()),
+            serial_number: None,
+            attributes: ComputerSystemAttributes {
+                nic_mode: None,
+                is_infinite_boot_enabled: Some(true),
+            },
+            pcie_devices: vec![],
+            base_mac: None,
+            power_state: PowerState::On,
+            sku: None,
+            boot_order: None,
+        }],
+        chassis: vec![Chassis {
+            id: String::new(),
+            manufacturer: Some("Dell".to_string()),
+            model: Some("PowerEdge R760".to_string()),
+            part_number: None,
+            serial_number: None,
+            network_adapters: vec![],
+            compute_tray_index: None,
+            physical_slot_number: None,
+            revision_id: None,
+            topology_id: None,
+        }],
+        service: vec![Service {
+            id: String::new(),
+            inventories: vec![Inventory {
+                id: "iDRAC".to_string(),
+                description: None,
+                version: Some("6.10.00.00".to_string()),
+                release_date: None,
+            }],
+        }],
+        machine_id: None,
+        versions: Default::default(),
+        model: None,
+        machine_setup_status: None,
+        secure_boot_status: None,
+        lockdown_status: None,
+        power_shelf_id: None,
+        switch_id: None,
+        compute_tray_index: None,
+        physical_slot_number: None,
+        revision_id: None,
+        topology_id: None,
+    }
+}
+
+const DPU_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 100));
+const HOST_BMC_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 200));
+
+fn build_preingestion_manager(env: &common::api_fixtures::TestEnv) -> PreingestionManager {
+    PreingestionManager::new(
+        env.pool.clone(),
+        env.config.preingestion_manager(),
+        env.redfish_sim.clone(),
+        env.test_meter.meter(),
+        None,
+        None,
+        None,
+        env.api.work_lock_manager_handle.clone(),
+    )
+}
+
+/// Seed a NicMode DPU + a host BMC with `pause_remediation = true`. The host
+/// row's flag is the primary marker that the skip's cleanup ran,
+/// since `set_pause_remediation(host_bmc_ip, false)` is the only thing the
+/// skip does to that row.
+async fn seed_nic_mode_pair(env: &common::api_fixtures::TestEnv) {
+    let mut txn = env.pool.begin().await.unwrap();
+    db::explored_endpoints::insert(DPU_IP, &dpu_report(NicMode::Nic), false, &mut txn)
+        .await
+        .unwrap();
+    db::explored_endpoints::insert(HOST_BMC_IP, &host_bmc_report(), false, &mut txn)
+        .await
+        .unwrap();
+    db::explored_endpoints::set_pause_remediation(HOST_BMC_IP, true, &mut txn)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+}
+
+async fn fetch(
+    env: &common::api_fixtures::TestEnv,
+    ip: IpAddr,
+) -> model::site_explorer::ExploredEndpoint {
+    let mut txn = env.pool.begin().await.unwrap();
+    db::explored_endpoints::find_all_by_ip(ip, &mut txn)
+        .await
+        .unwrap()
+        .into_iter()
+        .next()
+        .expect("endpoint not found")
+}
+
+#[crate::sqlx_test]
+async fn test_preingestion_nic_mode_skips_bfb_recovery_needed(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    let mgr = build_preingestion_manager(&env);
+
+    seed_nic_mode_pair(&env).await;
+    let mut txn = pool.begin().await?;
+    db::explored_endpoints::set_preingestion_bfb_recovery_needed(
+        DPU_IP,
+        "test seed".to_string(),
+        HOST_BMC_IP,
+        false,
+        &mut txn,
+    )
+    .await?;
+    txn.commit().await?;
+
+    mgr.run_single_iteration().await?;
+
+    let dpu_after = fetch(&env, DPU_IP).await;
+    let host_after = fetch(&env, HOST_BMC_IP).await;
+
+    assert!(
+        matches!(dpu_after.preingestion_state, PreingestionState::Complete),
+        "DPU should be marked Complete; got {:?}",
+        dpu_after.preingestion_state,
+    );
+    assert!(
+        dpu_after.waiting_for_explorer_refresh,
+        "DPU should be waiting for site-explorer to re-read its state",
+    );
+    assert!(
+        !host_after.pause_remediation,
+        "host BMC pause_remediation should be cleared so remediation can resume",
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_preingestion_nic_mode_skips_bfb_installation_wait(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    let mgr = build_preingestion_manager(&env);
+
+    seed_nic_mode_pair(&env).await;
+    let mut txn = pool.begin().await?;
+    db::explored_endpoints::set_preingestion_bfb_installation_wait(DPU_IP, HOST_BMC_IP, &mut txn)
+        .await?;
+    txn.commit().await?;
+
+    mgr.run_single_iteration().await?;
+
+    let dpu_after = fetch(&env, DPU_IP).await;
+    let host_after = fetch(&env, HOST_BMC_IP).await;
+
+    assert!(
+        matches!(dpu_after.preingestion_state, PreingestionState::Complete),
+        "DPU should be marked Complete; got {:?}",
+        dpu_after.preingestion_state,
+    );
+    assert!(dpu_after.waiting_for_explorer_refresh);
+    assert!(!host_after.pause_remediation);
+
+    Ok(())
+}
+
+/// Small test to make sure BfbCopyInProgress *doesn't* get skipped
+/// by our NIC mode checks. We don't want to skip if we're copying a BFB
+/// or waiting for power cycling.
+#[crate::sqlx_test]
+async fn test_preingestion_nic_mode_does_not_skip_bfb_copy_in_progress(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    let mgr = build_preingestion_manager(&env);
+
+    seed_nic_mode_pair(&env).await;
+    let mut txn = pool.begin().await?;
+    db::explored_endpoints::set_preingestion_bfb_copy_in_progress(DPU_IP, HOST_BMC_IP, &mut txn)
+        .await?;
+    txn.commit().await?;
+
+    mgr.run_single_iteration().await?;
+
+    let dpu_after = fetch(&env, DPU_IP).await;
+    let host_after = fetch(&env, HOST_BMC_IP).await;
+
+    assert!(
+        !matches!(dpu_after.preingestion_state, PreingestionState::Complete),
+        "BfbCopyInProgress must not be skipped to Complete by the NIC-mode guard; \
+         the normal handler should run instead. got {:?}",
+        dpu_after.preingestion_state,
+    );
+    assert!(
+        host_after.pause_remediation,
+        "host BMC pause_remediation should remain set; only the skip cleanup clears it",
+    );
+
+    Ok(())
+}
+
+/// The handler-side guard. preingestion-manager would collapse a freshly
+/// inserted `BfbRecoveryNeeded` for a NIC-mode DPU into `Complete` on its
+/// next tick, so accepting the request would be a silent no-op for the
+/// operator. The handler must reject up front with an actionable message
+/// pointing at `ExpectedMachine.dpu_mode`.
+#[crate::sqlx_test]
+async fn test_copy_bfb_to_dpu_rshim_rejects_nic_mode_dpu(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+
+    let mut txn = pool.begin().await?;
+    db::explored_endpoints::insert(DPU_IP, &dpu_report(NicMode::Nic), false, &mut txn).await?;
+    txn.commit().await?;
+
+    let status = env
+        .api
+        .copy_bfb_to_dpu_rshim(tonic::Request::new(rpc::forge::CopyBfbToDpuRshimRequest {
+            ssh_request: Some(rpc::forge::SshRequest {
+                endpoint_request: Some(rpc::forge::BmcEndpointRequest {
+                    ip_address: DPU_IP.to_string(),
+                    mac_address: None,
+                }),
+            }),
+            host_bmc_ip: HOST_BMC_IP.to_string(),
+            pre_copy_powercycle: false,
+        }))
+        .await
+        .expect_err("NIC-mode DPU should be rejected before host endpoint lookup");
+
+    assert_eq!(status.code(), Code::InvalidArgument);
+    let msg = status.message();
+    assert!(
+        msg.contains("NIC mode"),
+        "error should name NIC mode; got: {msg}",
+    );
+    assert!(
+        msg.contains("ExpectedMachine.dpu_mode"),
+        "error should point at the operator-facing knob (`ExpectedMachine.dpu_mode`); got: {msg}",
+    );
+
+    Ok(())
+}

--- a/crates/preingestion-manager/src/lib.rs
+++ b/crates/preingestion-manager/src/lib.rs
@@ -42,7 +42,8 @@ use libredfish::model::update_service::TransferProtocolType;
 use libredfish::{PowerState, Redfish, RedfishError, SystemPowerControl};
 use model::firmware::{Firmware, FirmwareComponentType, FirmwareEntry};
 use model::site_explorer::{
-    ExploredEndpoint, InitialResetPhase, PowerDrainState, PreingestionState, TimeSyncResetPhase,
+    ExploredEndpoint, InitialResetPhase, NicMode, PowerDrainState, PreingestionState,
+    TimeSyncResetPhase,
 };
 use opentelemetry::metrics::Meter;
 use sqlx::PgPool;
@@ -274,6 +275,59 @@ async fn one_endpoint(
     static_info: Arc<PreingestionManagerStatic>,
 ) -> PreingestionManagerResult<EndpointResult> {
     tracing::debug!("Preingestion on endpoint {:?}", endpoint);
+
+    // BFB-related preingestion doesn't work for a DPU running in NIC
+    // mode -- the Arm OS doesn't boot, so the `in_bfb_installation_wait`
+    // call to `check_dpu_console_install_complete` (which literally greps
+    // the microcom for strings) never succeeds, and we eventually will
+    // hit SLA and fail.
+    //
+    // Soo, we need to skip past a couple of BFB states:
+    // - BfbRecoveryNeeded -- don't even enter to begin with.
+    // - BfbInstallationWait -- if we've gotten to this point,
+    //   but we're in NIC mode, just transition ahead (we'll be=
+    //   waiting forever otherwise).
+    //
+    // ..but, intentionally leave `BfbPlatformPowercycle` and
+    // `BfbCopyInProgress` alone (if they're in it). They're
+    // mid-flight states where skipping risks leaving
+    // the host powered off, or leaving the spawned SSH copy
+    // task orphaned. Existing timeouts will surface if something
+    // fails, but that's fine -- those should succeed regardless
+    // of NIC mode or DPU mode.
+    //
+    // This basically just mirrors the `in_bfb_platform_powercycle`
+    // post-install handling, letting the site-explorer pairing and
+    // remediation loops to continue on.
+    let endpoint_host_bmc_ip = match &endpoint.preingestion_state {
+        PreingestionState::BfbRecoveryNeeded { host_bmc_ip, .. }
+        | PreingestionState::BfbInstallationWait { host_bmc_ip, .. } => Some(*host_bmc_ip),
+        _ => None,
+    };
+    if let Some(host_bmc_ip) = endpoint_host_bmc_ip
+        && endpoint.report.nic_mode() == Some(NicMode::Nic)
+    {
+        tracing::info!(
+            address = %endpoint.address,
+            %host_bmc_ip,
+            from_state = ?endpoint.preingestion_state,
+            "DPU is in NIC mode; skipping BFB preingestion path and marking complete",
+        );
+        db.with_txn(|txn| {
+            async move {
+                db::explored_endpoints::set_preingestion_complete(endpoint.address, txn).await?;
+                db::explored_endpoints::set_waiting_for_explorer_refresh(endpoint.address, txn)
+                    .await?;
+                db::explored_endpoints::set_pause_remediation(host_bmc_ip, false, txn).await?;
+                Ok::<(), DatabaseError>(())
+            }
+            .boxed()
+        })
+        .await??;
+        return Ok(EndpointResult {
+            delayed_upgrade: false,
+        });
+    }
 
     // Main state machine match.
     let delayed_upgrade = match &endpoint.preingestion_state {


### PR DESCRIPTION
## Description

This closes https://github.com/NVIDIA/infra-controller/issues/2115.

When `ExpectedMachine.dpu_mode = NicMode`, `site-explorer` puts the DPU into NIC mode. This means that any subsequent BFB preingestion will stall on `in_bfb_installation_wait`, since there is no microcom/console for us to drop into and wait for string matches (because that would be the ARM OS, and there's no ARM OS in NIC mode). Ultimately we'll "fail" when we hit SLA, at which point the host BMC is left with `pause_remediation = true`, and `site-explorer` remediation stays blocked on the host.

I ran into this, because I had fired off `site-explorer copy-bfb-to-dpu-rshim` to it as part of trying to do some firmware work on on the DPU. The problem is, in NIC mode, there's no Arm OS, so the *copy* to the rshim worked (like `start_bfb_copy`), `BfbCopyInProgress` worked, `BfbPlatformPowercycle` worked, but then `BfbInstallationWait` gets hung forever as part of `check_dpu_console_install_complete`, because it can't microcom into the Arm side to grep for what it's grepping for, lol (like it looks for `"login:"`, `"Running bfb_post_install from bf.cfg", "total 100% complete", etc), and none of this ever works.

So we need to make sure:
- If a DPU is in NIC mode, don't even allow this to happen (so we don't even get into the state(s) to begin with).
- If happen to fire this off on a machine that *is* in DPU mode, and while it's installing, someone flips it to NIC mode and reboots (also guilty of this), then we'd again be stuck in a state where `BfbInstallationWait` would fail, and we'd be stuck again, so the states themselves should be mode-aware.

So this PR takes care of that with two checks:
- If the DPU is in NIC mode, don't let it go into the initial BFB recovery state (e.g. `BfbRecoveryNeeded`).
- If we're in `BfbInstallationWait`, and the DPU is [suddenly] in NIC mode, then stop waiting.

Focusing on just these two states is on purpose; we don't want to break out if we're in `BfbPlatformPowercycle`, since we'd mess with power cycling, and we don't want to mess with `BfbCopyInProgress`, since the copy to the rshim itself is actually fine, and we don't want to cut anything off in there.

This *also* rejects the `copy_bfb_to_dpu_rshim` call up front for NIC-mode DPUs, because without it, we'd end up in `BfbRecoveryNeeded` anyway, which would now jump right to `Complete` anyway, but *without* letting the operator know that their call was a noop. Now we let them know, "hey, you can't do this, the DPU is in NIC mode."

Tests added to cover the key changes here:
- The 2x updated states that transition out when in NIC mode.
- Rejecting attempts to BFB when in NIC Mode.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

