### PR TITLE
Feat/spiffe machine identity key encryption key rotation

### DIFF
--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -3032,6 +3032,14 @@ impl Forge for Api {
         crate::handlers::tenant_identity_config::delete_token_delegation(self, request).await
     }
 
+    async fn reencrypt_tenant_identity_secrets(
+        &self,
+        request: Request<rpc::ReencryptTenantIdentitySecretsRequest>,
+    ) -> Result<Response<rpc::ReencryptTenantIdentitySecretsResponse>, Status> {
+        crate::handlers::tenant_identity_config::reencrypt_tenant_identity_secrets(self, request)
+            .await
+    }
+
     async fn get_jwks(
         &self,
         request: Request<rpc::JwksRequest>,

--- a/crates/api-core/src/auth/internal_rbac_rules.rs
+++ b/crates/api-core/src/auth/internal_rbac_rules.rs
@@ -347,6 +347,7 @@ impl InternalRBACRules {
         x.perm("GetTokenDelegation", vec![ForgeAdminCLI, SiteAgent]);
         x.perm("SetTokenDelegation", vec![ForgeAdminCLI, SiteAgent]);
         x.perm("DeleteTokenDelegation", vec![ForgeAdminCLI, SiteAgent]);
+        x.perm("ReencryptTenantIdentitySecrets", vec![ForgeAdminCLI]);
         x.perm("GetJWKS", vec![Anonymous, Agent, ForgeAdminCLI, SiteAgent]);
         x.perm(
             "GetOpenIDConfiguration",

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -921,7 +921,7 @@ pub struct MachineIdentityConfig {
     /// Optional HTTP proxy for token endpoint calls (SSRF mitigation).
     #[serde(default)]
     pub token_endpoint_http_proxy: Option<String>,
-    /// Key-id for encryption/decryption of signing keys (selects from secrets `machine_identity.encryption_keys`).
+    /// Key-id for encrypting new tenant identity ciphertext (selects from secrets `machine_identity.encryption_keys`).
     #[serde(default)]
     pub current_encryption_key_id: Option<String>,
     /// Trust domains allowed for tenant JWT `iss` (normalized host). Empty = allow any.

--- a/crates/api-core/src/handlers/machine_identity.rs
+++ b/crates/api-core/src/handlers/machine_identity.rs
@@ -26,7 +26,6 @@ use ::rpc::forge::{
 use carbide_uuid::machine::MachineId;
 use chrono::Utc;
 use db::{WithTransaction, tenant_identity_config};
-use forge_secrets::key_encryption;
 use model::tenant::{InvalidTenantOrg, TenantIdentityConfig, TenantOrganizationId};
 use serde_json::json;
 use tonic::{Request, Response, Status};
@@ -35,9 +34,9 @@ use crate::CarbideError;
 use crate::api::{Api, log_request_data};
 use crate::auth::AuthContext;
 use crate::machine_identity::{
-    Es256Signer, SignOptions, Signer, decrypt_token_delegation_encrypted_blob,
-    machine_identity_encryption_secret, token_delegation_credentials, token_exchange_http_client,
-    token_exchange_request,
+    Es256Signer, SignOptions, Signer, decrypt_machine_identity_ciphertext,
+    decrypt_token_delegation_encrypted_blob, token_delegation_credentials,
+    token_exchange_http_client, token_exchange_request,
 };
 
 /// Shared gate for APIs that require site `[machine_identity].enabled` (identity admin + discovery).
@@ -186,22 +185,22 @@ pub(crate) async fn sign_machine_identity(
     };
     validate_audiences_in_allowlist(&audiences, allowed)?;
 
-    let aes = machine_identity_encryption_secret(
-        api.credential_manager.as_ref(),
-        &identity_row.encryption_key_id,
-    )
-    .await?;
     let enc_key = identity_row
         .current_encrypted_signing_key()
         .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?;
-    let private_pem = key_encryption::decrypt(enc_key.as_str(), &aes).map_err(|e| {
-        tracing::error!(
-            error = %e,
-            org_id = %identity_row.organization_id.as_str(),
-            "tenant signing key decrypt failed"
-        );
-        CarbideError::internal("stored signing key could not be decrypted".to_string())
-    })?;
+    let private_pem =
+        decrypt_machine_identity_ciphertext(api.credential_manager.as_ref(), enc_key.as_str())
+            .await
+            .inspect_err(|e| {
+                tracing::error!(
+                    org_id = %identity_row.organization_id.as_str(),
+                    message = %e.message(),
+                    "tenant signing key decrypt failed"
+                );
+            })
+            .map_err(|_| {
+                CarbideError::internal("stored signing key could not be decrypted".to_string())
+            })?;
 
     let active_pub = identity_row
         .current_signing_public()
@@ -242,7 +241,6 @@ pub(crate) async fn sign_machine_identity(
 
         let delegation_plain = decrypt_token_delegation_encrypted_blob(
             api.credential_manager.as_ref(),
-            &identity_row.encryption_key_id,
             identity_row.encrypted_auth_method_config.as_ref(),
         )
         .await

--- a/crates/api-core/src/handlers/machine_identity.rs
+++ b/crates/api-core/src/handlers/machine_identity.rs
@@ -71,7 +71,7 @@ async fn load_enabled_identity_for_well_known(
             let org_id = org_id.clone();
             Box::pin(async move {
                 tenant_identity_config::gc_expired_non_active_signing_key(&org_id, txn).await?;
-                tenant_identity_config::find(&org_id, txn).await
+                tenant_identity_config::find(&org_id, txn.as_mut()).await
             })
         })
         .await??;

--- a/crates/api-core/src/handlers/tenant_identity_config.rs
+++ b/crates/api-core/src/handlers/tenant_identity_config.rs
@@ -683,43 +683,50 @@ enum SigningKeySlot {
     Key2,
 }
 
-async fn reencrypt_signing_key_field(
+async fn reencrypt_signing_key_fields(
     credentials: &dyn CredentialReader,
     org_id_str: &str,
-    slot: SigningKeySlot,
     plan: &mut ReencryptOrgPlan,
     target_key_id: &EncryptionKeyId,
     target_aes: &key_encryption::Aes256Key,
     dry_run: bool,
 ) -> Result<(), Status> {
-    let (field, ciphertext) = match slot {
-        SigningKeySlot::Key1 => (
-            "encrypted_signing_key_1",
-            plan.enc1.as_ref().map(|v| v.as_str()).map(str::to_string),
-        ),
-        SigningKeySlot::Key2 => (
-            "encrypted_signing_key_2",
-            plan.enc2.as_ref().map(|v| v.as_str()).map(str::to_string),
-        ),
-    };
-    if let Some(new_ciphertext) = tally_reencrypt_field(
-        plan,
-        reencrypt_one_field(
-            credentials,
-            org_id_str,
-            field,
-            ciphertext.as_deref(),
-            target_key_id,
-            target_aes,
-            dry_run,
-        )
-        .await?,
-    ) {
-        let slot = match slot {
-            SigningKeySlot::Key1 => &mut plan.enc1,
-            SigningKeySlot::Key2 => &mut plan.enc2,
+    for slot in [SigningKeySlot::Key1, SigningKeySlot::Key2] {
+        let (field, ciphertext) = match slot {
+            SigningKeySlot::Key1 => (
+                "encrypted_signing_key_1",
+                plan.enc1.as_ref().map(|v| v.as_str()).map(str::to_string),
+            ),
+            SigningKeySlot::Key2 => (
+                "encrypted_signing_key_2",
+                plan.enc2.as_ref().map(|v| v.as_str()).map(str::to_string),
+            ),
         };
-        store_reencrypted_signing_key(org_id_str, field, slot, &mut plan.failures, new_ciphertext);
+        if let Some(new_ciphertext) = tally_reencrypt_field(
+            plan,
+            reencrypt_one_field(
+                credentials,
+                org_id_str,
+                field,
+                ciphertext.as_deref(),
+                target_key_id,
+                target_aes,
+                dry_run,
+            )
+            .await?,
+        ) {
+            let enc_slot = match slot {
+                SigningKeySlot::Key1 => &mut plan.enc1,
+                SigningKeySlot::Key2 => &mut plan.enc2,
+            };
+            store_reencrypted_signing_key(
+                org_id_str,
+                field,
+                enc_slot,
+                &mut plan.failures,
+                new_ciphertext,
+            );
+        }
     }
     Ok(())
 }
@@ -743,20 +750,9 @@ async fn plan_org_reencrypt(
         failures: Vec::new(),
     };
 
-    reencrypt_signing_key_field(
+    reencrypt_signing_key_fields(
         credentials,
         org_id_str,
-        SigningKeySlot::Key1,
-        &mut plan,
-        target_key_id,
-        target_aes,
-        dry_run,
-    )
-    .await?;
-    reencrypt_signing_key_field(
-        credentials,
-        org_id_str,
-        SigningKeySlot::Key2,
         &mut plan,
         target_key_id,
         target_aes,
@@ -832,6 +828,7 @@ pub(crate) async fn reencrypt_tenant_identity_secrets(
         fields_skipped_on_target: 0,
         rows_failed: 0,
         failures: Vec::new(),
+        current_encryption_key_id: target_key_id.as_str().to_string(),
     };
 
     for org_id in org_ids {

--- a/crates/api-core/src/handlers/tenant_identity_config.rs
+++ b/crates/api-core/src/handlers/tenant_identity_config.rs
@@ -56,7 +56,6 @@ async fn tenant_identity_with_decrypted_token_delegation(
 ) -> Result<TenantIdentityConfigDecrypted, Status> {
     let auth_method_config = decrypt_token_delegation_encrypted_blob(
         credentials,
-        &cfg.encryption_key_id,
         cfg.encrypted_auth_method_config.as_ref(),
     )
     .await
@@ -465,8 +464,7 @@ pub(crate) async fn set_token_delegation(
     })?;
 
     let org_id_for_find = org_id.clone();
-    let id_row = api
-        .database_connection
+    api.database_connection
         .with_txn(|txn| {
             Box::pin(async move { tenant_identity_config::find(&org_id_for_find, txn).await })
         })
@@ -477,17 +475,16 @@ pub(crate) async fn set_token_delegation(
         })?;
 
     let (auth_method, plaintext_json) = config.to_db_format();
+    let encryption_key_id =
+        IdentityConfigValidationBounds::from(api.runtime_config.machine_identity.clone())
+            .encryption_key_id;
     let secret =
-        machine_identity_encryption_secret(&api.credential_manager, &id_row.encryption_key_id)
-            .await?;
-    let encrypted_blob: EncryptedTokenDelegationAuthConfig = key_encryption::encrypt(
-        plaintext_json.as_bytes(),
-        &secret,
-        &id_row.encryption_key_id,
-    )
-    .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?
-    .try_into()
-    .map_err(|e: InvalidNonEmptyStr| CarbideError::InvalidArgument(e.to_string()))?;
+        machine_identity_encryption_secret(&api.credential_manager, &encryption_key_id).await?;
+    let encrypted_blob: EncryptedTokenDelegationAuthConfig =
+        key_encryption::encrypt(plaintext_json.as_bytes(), &secret, &encryption_key_id)
+            .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?
+            .try_into()
+            .map_err(|e: InvalidNonEmptyStr| CarbideError::InvalidArgument(e.to_string()))?;
 
     let cfg = api
         .database_connection

--- a/crates/api-core/src/handlers/tenant_identity_config.rs
+++ b/crates/api-core/src/handlers/tenant_identity_config.rs
@@ -24,19 +24,22 @@
 
 use ::rpc::Timestamp;
 use ::rpc::forge::{
-    GetTenantIdentityConfigRequest, GetTokenDelegationRequest, SetTenantIdentityConfigRequest,
-    TenantIdentityConfig as ProtoTenantIdentityConfig, TenantIdentityConfigResponse,
-    TenantIdentitySigningKey, TokenDelegationRequest, TokenDelegationResponse, token_delegation,
+    GetTenantIdentityConfigRequest, GetTokenDelegationRequest, ReencryptTenantIdentityFailure,
+    ReencryptTenantIdentitySecretsRequest, ReencryptTenantIdentitySecretsResponse,
+    SetTenantIdentityConfigRequest, TenantIdentityConfig as ProtoTenantIdentityConfig,
+    TenantIdentityConfigResponse, TenantIdentitySigningKey, TokenDelegationRequest,
+    TokenDelegationResponse, token_delegation,
 };
 use db::{WithTransaction, tenant, tenant_identity_config};
 use forge_secrets::credentials::CredentialReader;
 use forge_secrets::key_encryption;
 use model::tenant::identity_config::TenantIdentityCurrentSigningKeySlot;
 use model::tenant::{
-    EncryptedSigningPrivateKey, EncryptedTokenDelegationAuthConfig, IdentityConfigValidationBounds,
-    IdentityConfigValidationError, InvalidNonEmptyStr, InvalidTenantOrg, KeyId, SigningKeyMaterial,
-    SigningPublicKeyPem, TenantIdentityConfig, TenantIdentityConfigDecrypted, TenantOrganizationId,
-    TokenDelegation, TokenDelegationValidationBounds, TokenDelegationValidationError,
+    EncryptedSigningPrivateKey, EncryptedTokenDelegationAuthConfig, EncryptionKeyId,
+    IdentityConfigValidationBounds, IdentityConfigValidationError, InvalidNonEmptyStr,
+    InvalidTenantOrg, KeyId, SigningKeyMaterial, SigningPublicKeyPem, TenantIdentityConfig,
+    TenantIdentityConfigDecrypted, TenantOrganizationId, TokenDelegation,
+    TokenDelegationValidationBounds, TokenDelegationValidationError,
 };
 use rpc::model::tenant::{identity_config_try_from_proto, validate_identity_overlap_for_rotation};
 use tonic::{Request, Response, Status};
@@ -45,7 +48,8 @@ use crate::CarbideError;
 use crate::api::{Api, log_request_data, log_request_data_redacted};
 use crate::handlers::machine_identity::require_machine_identity_site_enabled;
 use crate::machine_identity::{
-    decrypt_token_delegation_encrypted_blob, machine_identity_encryption_secret,
+    ReencryptBlobOutcome, decrypt_token_delegation_encrypted_blob,
+    machine_identity_encryption_secret, reencrypt_ciphertext_if_needed,
 };
 
 /// Decrypts DB ciphertext into [`TenantIdentityConfigDecrypted`]: `row` keeps envelope in
@@ -174,7 +178,7 @@ pub(crate) async fn get_configuration(
         .with_txn(|txn| {
             Box::pin(async move {
                 tenant_identity_config::gc_expired_non_active_signing_key(&org_id, txn).await?;
-                tenant_identity_config::find(&org_id, txn).await
+                tenant_identity_config::find(&org_id, txn.as_mut()).await
             })
         })
         .await??;
@@ -296,7 +300,9 @@ pub(crate) async fn set_configuration(
     let existing = api
         .database_connection
         .with_txn(|txn| {
-            Box::pin(async move { tenant_identity_config::find(&org_id_for_find, txn).await })
+            Box::pin(
+                async move { tenant_identity_config::find(&org_id_for_find, txn.as_mut()).await },
+            )
         })
         .await??;
 
@@ -401,7 +407,9 @@ pub(crate) async fn get_token_delegation(
 
     let cfg = api
         .database_connection
-        .with_txn(|txn| Box::pin(async move { tenant_identity_config::find(&org_id, txn).await }))
+        .with_txn(|txn| {
+            Box::pin(async move { tenant_identity_config::find(&org_id, txn.as_mut()).await })
+        })
         .await??;
 
     let cfg = match cfg {
@@ -466,7 +474,9 @@ pub(crate) async fn set_token_delegation(
     let org_id_for_find = org_id.clone();
     api.database_connection
         .with_txn(|txn| {
-            Box::pin(async move { tenant_identity_config::find(&org_id_for_find, txn).await })
+            Box::pin(
+                async move { tenant_identity_config::find(&org_id_for_find, txn.as_mut()).await },
+            )
         })
         .await??
         .ok_or_else(|| CarbideError::NotFoundError {
@@ -552,4 +562,340 @@ pub(crate) async fn delete_token_delegation(
         .await??;
 
     Ok(Response::new(()))
+}
+
+enum ReencryptFieldResult {
+    Absent,
+    SkippedOnTarget,
+    WouldReencrypt,
+    Reencrypted(String),
+    Failed(ReencryptTenantIdentityFailure),
+}
+
+fn tally_reencrypt_field(
+    plan: &mut ReencryptOrgPlan,
+    result: ReencryptFieldResult,
+) -> Option<String> {
+    match result {
+        ReencryptFieldResult::Absent => None,
+        ReencryptFieldResult::SkippedOnTarget => {
+            plan.fields_skipped_on_target += 1;
+            None
+        }
+        ReencryptFieldResult::WouldReencrypt => {
+            plan.any_change = true;
+            plan.fields_reencrypted += 1;
+            None
+        }
+        ReencryptFieldResult::Reencrypted(new_ciphertext) => {
+            plan.any_change = true;
+            plan.fields_reencrypted += 1;
+            Some(new_ciphertext)
+        }
+        ReencryptFieldResult::Failed(failure) => {
+            plan.failures.push(failure);
+            None
+        }
+    }
+}
+
+async fn reencrypt_one_field(
+    credentials: &dyn CredentialReader,
+    org_id: &str,
+    field: &str,
+    ciphertext: Option<&str>,
+    target_key_id: &EncryptionKeyId,
+    target_aes: &key_encryption::Aes256Key,
+    dry_run: bool,
+) -> Result<ReencryptFieldResult, Status> {
+    let Some(ciphertext) = ciphertext.filter(|s| !s.is_empty()) else {
+        return Ok(ReencryptFieldResult::Absent);
+    };
+    match reencrypt_ciphertext_if_needed(
+        credentials,
+        ciphertext,
+        target_key_id,
+        target_aes,
+        dry_run,
+    )
+    .await
+    {
+        Ok(ReencryptBlobOutcome::SkippedOnTarget) => Ok(ReencryptFieldResult::SkippedOnTarget),
+        Ok(ReencryptBlobOutcome::DryRunWouldReencrypt) => Ok(ReencryptFieldResult::WouldReencrypt),
+        Ok(ReencryptBlobOutcome::Reencrypted(new_ciphertext)) => {
+            Ok(ReencryptFieldResult::Reencrypted(new_ciphertext))
+        }
+        Err(status) => Ok(ReencryptFieldResult::Failed(
+            ReencryptTenantIdentityFailure {
+                organization_id: org_id.to_string(),
+                field: field.to_string(),
+                error: status.message().to_string(),
+            },
+        )),
+    }
+}
+
+struct ReencryptOrgPlan {
+    enc1: Option<EncryptedSigningPrivateKey>,
+    enc2: Option<EncryptedSigningPrivateKey>,
+    delegation: Option<EncryptedTokenDelegationAuthConfig>,
+    fields_reencrypted: u32,
+    fields_skipped_on_target: u32,
+    any_change: bool,
+    failures: Vec<ReencryptTenantIdentityFailure>,
+}
+
+fn store_reencrypted_signing_key(
+    org_id_str: &str,
+    field: &str,
+    slot: &mut Option<EncryptedSigningPrivateKey>,
+    failures: &mut Vec<ReencryptTenantIdentityFailure>,
+    new_ciphertext: String,
+) {
+    match new_ciphertext.try_into() {
+        Ok(parsed) => *slot = Some(parsed),
+        Err(_) => failures.push(ReencryptTenantIdentityFailure {
+            organization_id: org_id_str.to_string(),
+            field: field.to_string(),
+            error: "reencrypted ciphertext was empty".to_string(),
+        }),
+    }
+}
+
+fn store_reencrypted_delegation(
+    org_id_str: &str,
+    delegation: &mut Option<EncryptedTokenDelegationAuthConfig>,
+    failures: &mut Vec<ReencryptTenantIdentityFailure>,
+    new_ciphertext: String,
+) {
+    match new_ciphertext.try_into() {
+        Ok(parsed) => *delegation = Some(parsed),
+        Err(_) => failures.push(ReencryptTenantIdentityFailure {
+            organization_id: org_id_str.to_string(),
+            field: "encrypted_auth_method_config".to_string(),
+            error: "reencrypted ciphertext was empty".to_string(),
+        }),
+    }
+}
+
+enum SigningKeySlot {
+    Key1,
+    Key2,
+}
+
+async fn reencrypt_signing_key_field(
+    credentials: &dyn CredentialReader,
+    org_id_str: &str,
+    slot: SigningKeySlot,
+    plan: &mut ReencryptOrgPlan,
+    target_key_id: &EncryptionKeyId,
+    target_aes: &key_encryption::Aes256Key,
+    dry_run: bool,
+) -> Result<(), Status> {
+    let (field, ciphertext) = match slot {
+        SigningKeySlot::Key1 => (
+            "encrypted_signing_key_1",
+            plan.enc1.as_ref().map(|v| v.as_str()).map(str::to_string),
+        ),
+        SigningKeySlot::Key2 => (
+            "encrypted_signing_key_2",
+            plan.enc2.as_ref().map(|v| v.as_str()).map(str::to_string),
+        ),
+    };
+    if let Some(new_ciphertext) = tally_reencrypt_field(
+        plan,
+        reencrypt_one_field(
+            credentials,
+            org_id_str,
+            field,
+            ciphertext.as_deref(),
+            target_key_id,
+            target_aes,
+            dry_run,
+        )
+        .await?,
+    ) {
+        let slot = match slot {
+            SigningKeySlot::Key1 => &mut plan.enc1,
+            SigningKeySlot::Key2 => &mut plan.enc2,
+        };
+        store_reencrypted_signing_key(org_id_str, field, slot, &mut plan.failures, new_ciphertext);
+    }
+    Ok(())
+}
+
+async fn plan_org_reencrypt(
+    credentials: &dyn CredentialReader,
+    org_id: &TenantOrganizationId,
+    row: &TenantIdentityConfig,
+    target_key_id: &EncryptionKeyId,
+    target_aes: &key_encryption::Aes256Key,
+    dry_run: bool,
+) -> Result<ReencryptOrgPlan, Status> {
+    let org_id_str = org_id.as_str();
+    let mut plan = ReencryptOrgPlan {
+        enc1: row.encrypted_signing_key_1.clone(),
+        enc2: row.encrypted_signing_key_2.clone(),
+        delegation: row.encrypted_auth_method_config.clone(),
+        fields_reencrypted: 0,
+        fields_skipped_on_target: 0,
+        any_change: false,
+        failures: Vec::new(),
+    };
+
+    reencrypt_signing_key_field(
+        credentials,
+        org_id_str,
+        SigningKeySlot::Key1,
+        &mut plan,
+        target_key_id,
+        target_aes,
+        dry_run,
+    )
+    .await?;
+    reencrypt_signing_key_field(
+        credentials,
+        org_id_str,
+        SigningKeySlot::Key2,
+        &mut plan,
+        target_key_id,
+        target_aes,
+        dry_run,
+    )
+    .await?;
+
+    let delegation_ciphertext = plan
+        .delegation
+        .as_ref()
+        .map(|v| v.as_str())
+        .map(str::to_string);
+    if let Some(new_ciphertext) = tally_reencrypt_field(
+        &mut plan,
+        reencrypt_one_field(
+            credentials,
+            org_id_str,
+            "encrypted_auth_method_config",
+            delegation_ciphertext.as_deref(),
+            target_key_id,
+            target_aes,
+            dry_run,
+        )
+        .await?,
+    ) {
+        store_reencrypted_delegation(
+            org_id_str,
+            &mut plan.delegation,
+            &mut plan.failures,
+            new_ciphertext,
+        );
+    }
+
+    Ok(plan)
+}
+
+/// Site-operator RPC: re-wrap encrypted tenant identity fields with site
+/// `[machine_identity].current_encryption_key_id`.
+pub(crate) async fn reencrypt_tenant_identity_secrets(
+    api: &Api,
+    request: Request<ReencryptTenantIdentitySecretsRequest>,
+) -> Result<Response<ReencryptTenantIdentitySecretsResponse>, Status> {
+    log_request_data(&request);
+    require_machine_identity_site_enabled(api)?;
+
+    let req = request.into_inner();
+    let dry_run = req.dry_run;
+    let bounds = IdentityConfigValidationBounds::from(api.runtime_config.machine_identity.clone());
+    let target_key_id = bounds.encryption_key_id.clone();
+    let target_aes =
+        machine_identity_encryption_secret(&api.credential_manager, &target_key_id).await?;
+
+    let org_filter: Option<TenantOrganizationId> = match req.organization_id {
+        Some(ref id) if !id.trim().is_empty() => Some(
+            id.trim()
+                .parse()
+                .map_err(|e: InvalidTenantOrg| CarbideError::InvalidArgument(e.to_string()))?,
+        ),
+        _ => None,
+    };
+
+    let org_ids = {
+        let mut db = api.db_reader();
+        tenant_identity_config::list_organization_ids_for_reencrypt(org_filter.as_ref(), &mut db)
+            .await?
+    };
+
+    let mut response = ReencryptTenantIdentitySecretsResponse {
+        rows_examined: u32::try_from(org_ids.len()).unwrap_or(u32::MAX),
+        rows_updated: 0,
+        rows_skipped_all_on_target: 0,
+        fields_reencrypted: 0,
+        fields_skipped_on_target: 0,
+        rows_failed: 0,
+        failures: Vec::new(),
+    };
+
+    for org_id in org_ids {
+        let mut db = api.db_reader();
+        let Some(row) = tenant_identity_config::find(&org_id, &mut db).await? else {
+            return Err(CarbideError::NotFoundError {
+                kind: "tenant_identity_config",
+                id: org_id.as_str().to_string(),
+            }
+            .into());
+        };
+
+        let plan = plan_org_reencrypt(
+            api.credential_manager.as_ref(),
+            &org_id,
+            &row,
+            &target_key_id,
+            &target_aes,
+            dry_run,
+        )
+        .await?;
+
+        if !plan.failures.is_empty() {
+            response.rows_failed += 1;
+            response.failures.extend(plan.failures);
+            continue;
+        }
+
+        response.fields_reencrypted += plan.fields_reencrypted;
+        response.fields_skipped_on_target += plan.fields_skipped_on_target;
+        if plan.any_change {
+            response.rows_updated += 1;
+            if !dry_run {
+                let enc1 = plan.enc1;
+                let enc2 = plan.enc2;
+                let delegation = plan.delegation;
+                let org_id_for_txn = org_id.clone();
+                api.database_connection
+                    .with_txn(|txn| {
+                        Box::pin(async move {
+                            tenant_identity_config::find_for_update(&org_id_for_txn, txn)
+                                .await?
+                                .ok_or_else(|| db::DatabaseError::NotFoundError {
+                                    kind: "tenant_identity_config",
+                                    id: org_id_for_txn.as_str().to_string(),
+                                })?;
+                            tenant_identity_config::update_encrypted_fields(
+                                &org_id_for_txn,
+                                enc1,
+                                enc2,
+                                delegation,
+                                txn,
+                            )
+                            .await?;
+                            tenant::increment_version(org_id_for_txn.as_str(), txn).await?;
+                            Ok::<(), db::DatabaseError>(())
+                        })
+                    })
+                    .await??;
+            }
+        } else {
+            response.rows_skipped_all_on_target += 1;
+        }
+    }
+
+    Ok(Response::new(response))
 }

--- a/crates/api-core/src/machine_identity/crypto.rs
+++ b/crates/api-core/src/machine_identity/crypto.rs
@@ -166,9 +166,8 @@ pub(crate) fn token_delegation_credentials(
 #[cfg(test)]
 mod tests {
     use base64::Engine;
-    use forge_secrets::credentials::{
-        CredentialKey, CredentialWriter, Credentials, TestCredentialManager,
-    };
+    use forge_secrets::credentials::{CredentialKey, CredentialWriter, Credentials};
+    use forge_secrets::test_support::credentials::TestCredentialManager;
     use model::tenant::EncryptionKeyId;
 
     use super::*;

--- a/crates/api-core/src/machine_identity/crypto.rs
+++ b/crates/api-core/src/machine_identity/crypto.rs
@@ -18,6 +18,9 @@
 //! Machine-identity encryption: Vault-backed AES keys for `tenant_identity_config` ciphertext
 //! (signing private key + token delegation auth JSON), and parsing of stored delegation
 //! `client_secret_basic` JSON for outbound token exchange.
+//!
+//! Decrypt uses the `key_id` embedded in each ciphertext envelope. Encrypt uses site
+//! `[machine_identity].current_encryption_key_id`.
 
 use forge_secrets::credentials::{CredentialKey, CredentialReader, Credentials};
 use forge_secrets::key_encryption;
@@ -33,8 +36,15 @@ pub(crate) async fn machine_identity_encryption_secret(
     credentials: &dyn CredentialReader,
     encryption_key_id: &EncryptionKeyId,
 ) -> Result<key_encryption::Aes256Key, Status> {
+    machine_identity_encryption_secret_for_key_id(credentials, encryption_key_id.as_str()).await
+}
+
+async fn machine_identity_encryption_secret_for_key_id(
+    credentials: &dyn CredentialReader,
+    encryption_key_id: &str,
+) -> Result<key_encryption::Aes256Key, Status> {
     let cred_key = CredentialKey::MachineIdentityEncryptionKey {
-        key_id: encryption_key_id.as_str().to_string(),
+        key_id: encryption_key_id.to_string(),
     };
     let creds = credentials
         .get_credentials(&cred_key)
@@ -42,8 +52,7 @@ pub(crate) async fn machine_identity_encryption_secret(
         .map_err(|e| CarbideError::InvalidArgument(e.to_string()))?
         .ok_or_else(|| {
             CarbideError::InvalidArgument(format!(
-                "encryption key '{}' not found in secrets (machine_identity.encryption_keys)",
-                encryption_key_id.as_str()
+                "encryption key '{encryption_key_id}' not found in secrets (machine_identity.encryption_keys)"
             ))
         })?;
     let stored = match &creds {
@@ -53,10 +62,25 @@ pub(crate) async fn machine_identity_encryption_secret(
         .map_err(|e| CarbideError::InvalidArgument(e.to_string()).into())
 }
 
+/// Decrypts a machine-identity envelope using the `key_id` embedded in the blob.
+pub(crate) async fn decrypt_machine_identity_ciphertext(
+    credentials: &dyn CredentialReader,
+    encrypted_base64: &str,
+) -> Result<Vec<u8>, Status> {
+    let envelope_key_id = key_encryption::envelope_key_id(encrypted_base64).map_err(|e| {
+        CarbideError::internal(format!("stored ciphertext envelope is invalid: {e}"))
+    })?;
+    let aes = machine_identity_encryption_secret_for_key_id(credentials, &envelope_key_id).await?;
+    key_encryption::decrypt(encrypted_base64, &aes)
+        .map_err(|e| {
+            CarbideError::internal(format!("stored ciphertext could not be decrypted: {e}"))
+        })
+        .map_err(Into::into)
+}
+
 /// Decrypts `encrypted_auth_method_config` when set, otherwise `None`.
 pub(crate) async fn decrypt_token_delegation_encrypted_blob(
     credentials: &dyn CredentialReader,
-    encryption_key_id: &EncryptionKeyId,
     encrypted_auth_method_config: Option<&EncryptedTokenDelegationAuthConfig>,
 ) -> Result<Option<String>, Status> {
     let Some(enc) = encrypted_auth_method_config else {
@@ -65,12 +89,14 @@ pub(crate) async fn decrypt_token_delegation_encrypted_blob(
     if enc.as_str().is_empty() {
         return Ok(None);
     }
-    let aes = machine_identity_encryption_secret(credentials, encryption_key_id).await?;
-    let plain = key_encryption::decrypt(enc.as_str(), &aes).map_err(|e| {
-        CarbideError::internal(format!(
-            "stored token delegation configuration could not be decrypted: {e}"
-        ))
-    })?;
+    let plain = decrypt_machine_identity_ciphertext(credentials, enc.as_str())
+        .await
+        .map_err(|e| {
+            CarbideError::internal(format!(
+                "stored token delegation configuration could not be decrypted: {}",
+                e.message()
+            ))
+        })?;
     let utf8 = String::from_utf8(plain).map_err(|e| {
         CarbideError::internal(format!(
             "stored token delegation configuration plaintext was not valid UTF-8: {e}"

--- a/crates/api-core/src/machine_identity/crypto.rs
+++ b/crates/api-core/src/machine_identity/crypto.rs
@@ -78,6 +78,36 @@ pub(crate) async fn decrypt_machine_identity_ciphertext(
         .map_err(Into::into)
 }
 
+/// Outcome of evaluating one encrypted blob for master-key re-wrap.
+pub(crate) enum ReencryptBlobOutcome {
+    SkippedOnTarget,
+    DryRunWouldReencrypt,
+    Reencrypted(String),
+}
+
+/// Re-wraps `ciphertext` when envelope `key_id` differs from `target_key_id`.
+pub(crate) async fn reencrypt_ciphertext_if_needed(
+    credentials: &dyn CredentialReader,
+    ciphertext: &str,
+    target_key_id: &EncryptionKeyId,
+    target_aes: &key_encryption::Aes256Key,
+    dry_run: bool,
+) -> Result<ReencryptBlobOutcome, Status> {
+    let current_key_id = key_encryption::envelope_key_id(ciphertext).map_err(|e| {
+        CarbideError::internal(format!("stored ciphertext envelope is invalid: {e}"))
+    })?;
+    if current_key_id == target_key_id.as_str() {
+        return Ok(ReencryptBlobOutcome::SkippedOnTarget);
+    }
+    let plaintext = decrypt_machine_identity_ciphertext(credentials, ciphertext).await?;
+    if dry_run {
+        return Ok(ReencryptBlobOutcome::DryRunWouldReencrypt);
+    }
+    let reencrypted = key_encryption::encrypt(&plaintext, target_aes, target_key_id.as_str())
+        .map_err(|e| CarbideError::internal(format!("failed to reencrypt ciphertext: {e}")))?;
+    Ok(ReencryptBlobOutcome::Reencrypted(reencrypted))
+}
+
 /// Decrypts `encrypted_auth_method_config` when set, otherwise `None`.
 pub(crate) async fn decrypt_token_delegation_encrypted_blob(
     credentials: &dyn CredentialReader,
@@ -135,7 +165,81 @@ pub(crate) fn token_delegation_credentials(
 
 #[cfg(test)]
 mod tests {
+    use base64::Engine;
+    use forge_secrets::credentials::{
+        CredentialKey, CredentialWriter, Credentials, TestCredentialManager,
+    };
+    use model::tenant::EncryptionKeyId;
+
     use super::*;
+
+    fn stored_secret(key_byte: u8) -> String {
+        base64::engine::general_purpose::STANDARD.encode([key_byte; 32])
+    }
+
+    async fn test_credentials_with_keys(key_v1: &str, key_v2: &str) -> TestCredentialManager {
+        let credentials = TestCredentialManager::default();
+        for (key_id, byte) in [(key_v1, 1u8), (key_v2, 2u8)] {
+            credentials
+                .set_credentials(
+                    &CredentialKey::MachineIdentityEncryptionKey {
+                        key_id: key_id.to_string(),
+                    },
+                    &Credentials::UsernamePassword {
+                        username: String::new(),
+                        password: stored_secret(byte),
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        credentials
+    }
+
+    #[tokio::test]
+    async fn reencrypt_ciphertext_if_needed_skips_on_target_and_rewraps() {
+        let key_v1 = "key-v1";
+        let key_v2 = "key-v2";
+        let credentials = test_credentials_with_keys(key_v1, key_v2).await;
+        let aes_v1 = key_encryption::aes256_key_from_stored_secret(&stored_secret(1)).unwrap();
+        let aes_v2 = key_encryption::aes256_key_from_stored_secret(&stored_secret(2)).unwrap();
+        let plaintext = b"tenant signing key material";
+        let ciphertext =
+            key_encryption::encrypt(plaintext, &aes_v1, key_v1).expect("encrypt test blob");
+
+        let target_v1: EncryptionKeyId = key_v1.parse().unwrap();
+        let target_v2: EncryptionKeyId = key_v2.parse().unwrap();
+
+        assert!(matches!(
+            reencrypt_ciphertext_if_needed(&credentials, &ciphertext, &target_v1, &aes_v1, false,)
+                .await
+                .unwrap(),
+            ReencryptBlobOutcome::SkippedOnTarget
+        ));
+
+        assert!(matches!(
+            reencrypt_ciphertext_if_needed(&credentials, &ciphertext, &target_v2, &aes_v2, true,)
+                .await
+                .unwrap(),
+            ReencryptBlobOutcome::DryRunWouldReencrypt
+        ));
+
+        let ReencryptBlobOutcome::Reencrypted(reencrypted) =
+            reencrypt_ciphertext_if_needed(&credentials, &ciphertext, &target_v2, &aes_v2, false)
+                .await
+                .unwrap()
+        else {
+            panic!("expected Reencrypted outcome");
+        };
+        assert_eq!(
+            key_encryption::envelope_key_id(&reencrypted).unwrap(),
+            key_v2
+        );
+        let decrypted = decrypt_machine_identity_ciphertext(&credentials, &reencrypted)
+            .await
+            .unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
 
     #[test]
     fn token_delegation_credentials_none_and_client_secret_basic() {

--- a/crates/api-core/src/machine_identity/mod.rs
+++ b/crates/api-core/src/machine_identity/mod.rs
@@ -30,8 +30,8 @@ use std::fmt;
 
 use base64::Engine;
 pub(crate) use crypto::{
-    decrypt_token_delegation_encrypted_blob, machine_identity_encryption_secret,
-    token_delegation_credentials,
+    decrypt_machine_identity_ciphertext, decrypt_token_delegation_encrypted_blob,
+    machine_identity_encryption_secret, token_delegation_credentials,
 };
 use jsonwebtoken::{EncodingKey, Header, encode};
 use model::tenant::identity_config::TENANT_IDENTITY_SIGNING_JWT_ALG;

--- a/crates/api-core/src/machine_identity/mod.rs
+++ b/crates/api-core/src/machine_identity/mod.rs
@@ -30,8 +30,9 @@ use std::fmt;
 
 use base64::Engine;
 pub(crate) use crypto::{
-    decrypt_machine_identity_ciphertext, decrypt_token_delegation_encrypted_blob,
-    machine_identity_encryption_secret, token_delegation_credentials,
+    ReencryptBlobOutcome, decrypt_machine_identity_ciphertext,
+    decrypt_token_delegation_encrypted_blob, machine_identity_encryption_secret,
+    reencrypt_ciphertext_if_needed, token_delegation_credentials,
 };
 use jsonwebtoken::{EncodingKey, Header, encode};
 use model::tenant::identity_config::TENANT_IDENTITY_SIGNING_JWT_ALG;

--- a/crates/api-db/migrations/20260528120000_drop_tenant_identity_encryption_key_id.sql
+++ b/crates/api-db/migrations/20260528120000_drop_tenant_identity_encryption_key_id.sql
@@ -1,0 +1,3 @@
+-- Master encryption key id is stored in each ciphertext envelope (key_encryption v1 JSON).
+-- Site config `current_encryption_key_id` selects the key for new encryption only.
+ALTER TABLE tenant_identity_config DROP COLUMN encryption_key_id;

--- a/crates/api-db/src/tenant_identity_config.rs
+++ b/crates/api-db/src/tenant_identity_config.rs
@@ -29,6 +29,7 @@ use model::tenant::{
 use sqlx::PgConnection;
 use sqlx::types::Json;
 
+use crate::db_read::DbReader;
 use crate::{DatabaseError, DatabaseResult};
 
 /// After `non_active_slot_expires_at`, clears the non-current slot (public + private ciphertext).
@@ -276,13 +277,16 @@ pub async fn set(
     .map_err(|e| DatabaseError::query("UPSERT tenant_identity_config", e))
 }
 
-pub async fn find(
+pub async fn find<DB>(
     org_id: &TenantOrganizationId,
-    txn: &mut PgConnection,
-) -> DatabaseResult<Option<TenantIdentityConfig>> {
+    db: &mut DB,
+) -> DatabaseResult<Option<TenantIdentityConfig>>
+where
+    for<'db> &'db mut DB: DbReader<'db>,
+{
     sqlx::query_as("SELECT * FROM tenant_identity_config WHERE organization_id = $1")
         .bind(org_id.as_str())
-        .fetch_optional(txn)
+        .fetch_optional(&mut *db)
         .await
         .map_err(|e| DatabaseError::query("SELECT tenant_identity_config BY organization_id", e))
 }
@@ -382,6 +386,71 @@ pub async fn delete_token_delegation(
     .fetch_optional(txn)
     .await
     .map_err(|e| DatabaseError::query("CLEAR tenant_identity_config token_delegation", e))
+}
+
+/// Organization ids to re-wrap: one org (must exist) or all rows ordered by id.
+pub async fn list_organization_ids_for_reencrypt<DB>(
+    org_filter: Option<&TenantOrganizationId>,
+    db: &mut DB,
+) -> DatabaseResult<Vec<TenantOrganizationId>>
+where
+    for<'db> &'db mut DB: DbReader<'db>,
+{
+    if let Some(org_id) = org_filter {
+        if find(org_id, &mut *db).await?.is_none() {
+            return Err(DatabaseError::NotFoundError {
+                kind: "tenant_identity_config",
+                id: org_id.as_str().to_string(),
+            });
+        }
+        return Ok(vec![org_id.clone()]);
+    }
+    sqlx::query_scalar::<_, TenantOrganizationId>(
+        "SELECT organization_id FROM tenant_identity_config ORDER BY organization_id",
+    )
+    .fetch_all(&mut *db)
+    .await
+    .map_err(|e| DatabaseError::query("LIST tenant_identity_config organization_ids", e))
+}
+
+/// Loads a row for update during master-key re-wrap.
+pub async fn find_for_update(
+    org_id: &TenantOrganizationId,
+    txn: &mut PgConnection,
+) -> DatabaseResult<Option<TenantIdentityConfig>> {
+    sqlx::query_as("SELECT * FROM tenant_identity_config WHERE organization_id = $1 FOR UPDATE")
+        .bind(org_id.as_str())
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::query("SELECT tenant_identity_config FOR UPDATE", e))
+}
+
+/// Updates encrypted signing-key and token-delegation ciphertext columns only.
+pub async fn update_encrypted_fields(
+    org_id: &TenantOrganizationId,
+    enc1: Option<EncryptedSigningPrivateKey>,
+    enc2: Option<EncryptedSigningPrivateKey>,
+    delegation: Option<EncryptedTokenDelegationAuthConfig>,
+    txn: &mut PgConnection,
+) -> DatabaseResult<()> {
+    sqlx::query(
+        r#"
+        UPDATE tenant_identity_config
+        SET encrypted_signing_key_1 = $2,
+            encrypted_signing_key_2 = $3,
+            encrypted_auth_method_config = $4,
+            updated_at = NOW()
+        WHERE organization_id = $1
+        "#,
+    )
+    .bind(org_id.as_str())
+    .bind(enc1)
+    .bind(enc2)
+    .bind(delegation)
+    .execute(txn)
+    .await
+    .map_err(|e| DatabaseError::query("UPDATE tenant_identity_config encrypted fields", e))?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -522,7 +591,7 @@ ecbC7Qcisdw2/9l8bk/zfF9gvu4kh3hXZzMWgk+vj1e8KSX+NYswYiacQA==
         );
         assert!(cfg.signing_key_public_1.is_some());
 
-        let found = find(&org_id, &mut txn).await.unwrap().unwrap();
+        let found = find(&org_id, txn.as_mut()).await.unwrap().unwrap();
         assert_eq!(found.issuer, cfg.issuer);
         assert_eq!(found.default_audience, cfg.default_audience);
         assert_eq!(found.allowed_audiences.0, cfg.allowed_audiences.0);
@@ -534,7 +603,7 @@ ecbC7Qcisdw2/9l8bk/zfF9gvu4kh3hXZzMWgk+vj1e8KSX+NYswYiacQA==
         let deleted = delete(&org_id, &mut txn).await.unwrap();
         assert!(deleted);
 
-        let not_found = find(&org_id, &mut txn).await.unwrap();
+        let not_found = find(&org_id, txn.as_mut()).await.unwrap();
         assert!(not_found.is_none());
     }
 

--- a/crates/api-db/src/tenant_identity_config.rs
+++ b/crates/api-db/src/tenant_identity_config.rs
@@ -31,59 +31,6 @@ use sqlx::types::Json;
 
 use crate::{DatabaseError, DatabaseResult};
 
-/// Resolve tenant identity config for machine-identity RPCs: one join query, then overlap GC, then
-/// reload by org PK so the row matches the post-GC database state (GC may clear a JWKS slot).
-const TENANT_IDENTITY_FIND_BY_MACHINE_SQL: &str = r"
-SELECT tic.*
-FROM tenant_identity_config tic
-INNER JOIN instances i ON tic.organization_id = i.tenant_org
-WHERE i.machine_id = $1 AND i.deleted IS NULL AND tic.enabled = true";
-
-const TENANT_IDENTITY_FIND_BY_ORG_SQL: &str =
-    "SELECT * FROM tenant_identity_config WHERE organization_id = $1";
-
-const UPSERT_TENANT_IDENTITY_CONFIG_SQL: &str = r#"
-        INSERT INTO tenant_identity_config (
-            organization_id, issuer, default_audience, allowed_audiences,
-            token_ttl_sec, subject_prefix, enabled, created_at, updated_at,
-            encrypted_signing_key_1, encrypted_signing_key_2,
-            signing_key_public_1, signing_key_public_2,
-            current_signing_key_slot, non_active_slot_expires_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW(), $8, $9, $10, $11, $12, $13)
-        ON CONFLICT (organization_id) DO UPDATE SET
-            issuer = EXCLUDED.issuer,
-            default_audience = EXCLUDED.default_audience,
-            allowed_audiences = EXCLUDED.allowed_audiences,
-            token_ttl_sec = EXCLUDED.token_ttl_sec,
-            subject_prefix = EXCLUDED.subject_prefix,
-            enabled = EXCLUDED.enabled,
-            updated_at = NOW(),
-            encrypted_signing_key_1 = EXCLUDED.encrypted_signing_key_1,
-            encrypted_signing_key_2 = EXCLUDED.encrypted_signing_key_2,
-            signing_key_public_1 = EXCLUDED.signing_key_public_1,
-            signing_key_public_2 = EXCLUDED.signing_key_public_2,
-            current_signing_key_slot = EXCLUDED.current_signing_key_slot,
-            non_active_slot_expires_at = EXCLUDED.non_active_slot_expires_at
-        RETURNING tenant_identity_config.*
-    "#;
-
-const UPDATE_TENANT_IDENTITY_TOKEN_DELEGATION_SQL: &str = r#"
-        UPDATE tenant_identity_config
-        SET token_endpoint = $2, auth_method = $3, encrypted_auth_method_config = $4,
-            subject_token_audience = $5, updated_at = NOW(),
-            token_delegation_created_at = COALESCE(token_delegation_created_at, NOW())
-        WHERE organization_id = $1
-        RETURNING tenant_identity_config.*
-    "#;
-
-const CLEAR_TENANT_IDENTITY_TOKEN_DELEGATION_SQL: &str = r#"
-        UPDATE tenant_identity_config
-        SET token_endpoint = NULL, auth_method = NULL, encrypted_auth_method_config = NULL,
-            subject_token_audience = NULL, token_delegation_created_at = NULL, updated_at = NOW()
-        WHERE organization_id = $1
-        RETURNING tenant_identity_config.*
-    "#;
-
 /// After `non_active_slot_expires_at`, clears the non-current slot (public + private ciphertext).
 pub async fn gc_expired_non_active_signing_key(
     org_id: &TenantOrganizationId,
@@ -285,45 +232,78 @@ pub async fn set(
         }
     };
 
-    sqlx::query_as(UPSERT_TENANT_IDENTITY_CONFIG_SQL)
-        .bind(org_id.as_str())
-        .bind(&config.issuer)
-        .bind(&config.default_audience)
-        .bind(Json(allowed))
-        .bind(token_ttl_i32)
-        .bind(&config.subject_prefix)
-        .bind(config.enabled)
-        .bind(key_rows.enc1)
-        .bind(key_rows.enc2)
-        .bind(key_rows.pub1)
-        .bind(key_rows.pub2)
-        .bind(key_rows.current_slot)
-        .bind(key_rows.non_active_expires_at)
-        .fetch_one(txn)
-        .await
-        .map_err(|e| DatabaseError::query(UPSERT_TENANT_IDENTITY_CONFIG_SQL, e))
+    sqlx::query_as(
+        r#"
+        INSERT INTO tenant_identity_config (
+            organization_id, issuer, default_audience, allowed_audiences,
+            token_ttl_sec, subject_prefix, enabled, created_at, updated_at,
+            encrypted_signing_key_1, encrypted_signing_key_2,
+            signing_key_public_1, signing_key_public_2,
+            current_signing_key_slot, non_active_slot_expires_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW(), $8, $9, $10, $11, $12, $13)
+        ON CONFLICT (organization_id) DO UPDATE SET
+            issuer = EXCLUDED.issuer,
+            default_audience = EXCLUDED.default_audience,
+            allowed_audiences = EXCLUDED.allowed_audiences,
+            token_ttl_sec = EXCLUDED.token_ttl_sec,
+            subject_prefix = EXCLUDED.subject_prefix,
+            enabled = EXCLUDED.enabled,
+            updated_at = NOW(),
+            encrypted_signing_key_1 = EXCLUDED.encrypted_signing_key_1,
+            encrypted_signing_key_2 = EXCLUDED.encrypted_signing_key_2,
+            signing_key_public_1 = EXCLUDED.signing_key_public_1,
+            signing_key_public_2 = EXCLUDED.signing_key_public_2,
+            current_signing_key_slot = EXCLUDED.current_signing_key_slot,
+            non_active_slot_expires_at = EXCLUDED.non_active_slot_expires_at
+        RETURNING tenant_identity_config.*
+        "#,
+    )
+    .bind(org_id.as_str())
+    .bind(&config.issuer)
+    .bind(&config.default_audience)
+    .bind(Json(allowed))
+    .bind(token_ttl_i32)
+    .bind(&config.subject_prefix)
+    .bind(config.enabled)
+    .bind(key_rows.enc1)
+    .bind(key_rows.enc2)
+    .bind(key_rows.pub1)
+    .bind(key_rows.pub2)
+    .bind(key_rows.current_slot)
+    .bind(key_rows.non_active_expires_at)
+    .fetch_one(txn)
+    .await
+    .map_err(|e| DatabaseError::query("UPSERT tenant_identity_config", e))
 }
 
 pub async fn find(
     org_id: &TenantOrganizationId,
     txn: &mut PgConnection,
 ) -> DatabaseResult<Option<TenantIdentityConfig>> {
-    sqlx::query_as(TENANT_IDENTITY_FIND_BY_ORG_SQL)
+    sqlx::query_as("SELECT * FROM tenant_identity_config WHERE organization_id = $1")
         .bind(org_id.as_str())
         .fetch_optional(txn)
         .await
-        .map_err(|e| DatabaseError::query(TENANT_IDENTITY_FIND_BY_ORG_SQL, e))
+        .map_err(|e| DatabaseError::query("SELECT tenant_identity_config BY organization_id", e))
 }
 
+/// Resolve tenant identity config for machine-identity RPCs: one join query, then overlap GC, then
+/// reload by org PK so the row matches the post-GC database state (GC may clear a JWKS slot).
 pub async fn find_by_machine_id(
     txn: &mut PgConnection,
     machine_id: &MachineId,
 ) -> DatabaseResult<TenantIdentityConfig> {
-    let row = sqlx::query_as::<_, TenantIdentityConfig>(TENANT_IDENTITY_FIND_BY_MACHINE_SQL)
-        .bind(machine_id)
-        .fetch_optional(&mut *txn)
-        .await
-        .map_err(|e| DatabaseError::query(TENANT_IDENTITY_FIND_BY_MACHINE_SQL, e))?;
+    let row = sqlx::query_as::<_, TenantIdentityConfig>(
+        r"
+        SELECT tic.*
+        FROM tenant_identity_config tic
+        INNER JOIN instances i ON tic.organization_id = i.tenant_org
+        WHERE i.machine_id = $1 AND i.deleted IS NULL AND tic.enabled = true",
+    )
+    .bind(machine_id)
+    .fetch_optional(&mut *txn)
+    .await
+    .map_err(|e| DatabaseError::query("SELECT tenant_identity_config BY machine_id", e))?;
     let Some(cfg) = row else {
         return Err(DatabaseError::NotFoundError {
             kind: "machine_identity",
@@ -350,15 +330,24 @@ pub async fn set_token_delegation(
     encrypted_auth_method_config: &EncryptedTokenDelegationAuthConfig,
     txn: &mut PgConnection,
 ) -> DatabaseResult<TenantIdentityConfig> {
-    let row = sqlx::query_as(UPDATE_TENANT_IDENTITY_TOKEN_DELEGATION_SQL)
-        .bind(org_id.as_str())
-        .bind(&config.token_endpoint)
-        .bind(auth_method)
-        .bind(encrypted_auth_method_config.as_str())
-        .bind(Some(config.subject_token_audience.as_str()))
-        .fetch_optional(txn)
-        .await
-        .map_err(|e| DatabaseError::query(UPDATE_TENANT_IDENTITY_TOKEN_DELEGATION_SQL, e))?;
+    let row = sqlx::query_as(
+        r#"
+        UPDATE tenant_identity_config
+        SET token_endpoint = $2, auth_method = $3, encrypted_auth_method_config = $4,
+            subject_token_audience = $5, updated_at = NOW(),
+            token_delegation_created_at = COALESCE(token_delegation_created_at, NOW())
+        WHERE organization_id = $1
+        RETURNING tenant_identity_config.*
+        "#,
+    )
+    .bind(org_id.as_str())
+    .bind(&config.token_endpoint)
+    .bind(auth_method)
+    .bind(encrypted_auth_method_config.as_str())
+    .bind(Some(config.subject_token_audience.as_str()))
+    .fetch_optional(txn)
+    .await
+    .map_err(|e| DatabaseError::query("UPDATE tenant_identity_config token_delegation", e))?;
     row.ok_or_else(|| DatabaseError::NotFoundError {
         kind: "tenant_identity_config",
         id: org_id.as_str().to_string(),
@@ -380,11 +369,19 @@ pub async fn delete_token_delegation(
     org_id: &TenantOrganizationId,
     txn: &mut PgConnection,
 ) -> DatabaseResult<Option<TenantIdentityConfig>> {
-    sqlx::query_as(CLEAR_TENANT_IDENTITY_TOKEN_DELEGATION_SQL)
-        .bind(org_id.as_str())
-        .fetch_optional(txn)
-        .await
-        .map_err(|e| DatabaseError::query(CLEAR_TENANT_IDENTITY_TOKEN_DELEGATION_SQL, e))
+    sqlx::query_as(
+        r#"
+        UPDATE tenant_identity_config
+        SET token_endpoint = NULL, auth_method = NULL, encrypted_auth_method_config = NULL,
+            subject_token_audience = NULL, token_delegation_created_at = NULL, updated_at = NOW()
+        WHERE organization_id = $1
+        RETURNING tenant_identity_config.*
+        "#,
+    )
+    .bind(org_id.as_str())
+    .fetch_optional(txn)
+    .await
+    .map_err(|e| DatabaseError::query("CLEAR tenant_identity_config token_delegation", e))
 }
 
 #[cfg(test)]

--- a/crates/api-db/src/tenant_identity_config.rs
+++ b/crates/api-db/src/tenant_identity_config.rs
@@ -248,7 +248,7 @@ pub async fn set(
         }
     };
 
-    sqlx::query_as(&format!(
+    let query = format!(
         r#"
         INSERT INTO tenant_identity_config (
             organization_id, issuer, default_audience, allowed_audiences,
@@ -273,23 +273,24 @@ pub async fn set(
             non_active_slot_expires_at = EXCLUDED.non_active_slot_expires_at
         {}"#,
         tenant_identity_config_returning(),
-    ))
-    .bind(org_id.as_str())
-    .bind(&config.issuer)
-    .bind(&config.default_audience)
-    .bind(Json(allowed))
-    .bind(token_ttl_i32)
-    .bind(&config.subject_prefix)
-    .bind(config.enabled)
-    .bind(key_rows.enc1)
-    .bind(key_rows.enc2)
-    .bind(key_rows.pub1)
-    .bind(key_rows.pub2)
-    .bind(key_rows.current_slot)
-    .bind(key_rows.non_active_expires_at)
-    .fetch_one(txn)
-    .await
-    .map_err(|e| DatabaseError::query("UPSERT tenant_identity_config", e))
+    );
+    sqlx::query_as(sqlx::AssertSqlSafe(query.as_str()))
+        .bind(org_id.as_str())
+        .bind(&config.issuer)
+        .bind(&config.default_audience)
+        .bind(Json(allowed))
+        .bind(token_ttl_i32)
+        .bind(&config.subject_prefix)
+        .bind(config.enabled)
+        .bind(key_rows.enc1)
+        .bind(key_rows.enc2)
+        .bind(key_rows.pub1)
+        .bind(key_rows.pub2)
+        .bind(key_rows.current_slot)
+        .bind(key_rows.non_active_expires_at)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query("UPSERT tenant_identity_config", e))
 }
 
 pub async fn find<DB>(
@@ -302,7 +303,7 @@ where
     let query = format!(
         "SELECT {TENANT_IDENTITY_CONFIG_COLUMNS} FROM tenant_identity_config WHERE organization_id = $1"
     );
-    sqlx::query_as(&query)
+    sqlx::query_as(sqlx::AssertSqlSafe(query.as_str()))
         .bind(org_id.as_str())
         .fetch_optional(&mut *db)
         .await
@@ -358,7 +359,7 @@ pub async fn set_token_delegation(
     encrypted_auth_method_config: &EncryptedTokenDelegationAuthConfig,
     txn: &mut PgConnection,
 ) -> DatabaseResult<TenantIdentityConfig> {
-    let row = sqlx::query_as(&format!(
+    let query = format!(
         r#"
         UPDATE tenant_identity_config
         SET token_endpoint = $2, auth_method = $3, encrypted_auth_method_config = $4,
@@ -367,15 +368,16 @@ pub async fn set_token_delegation(
         WHERE organization_id = $1
         {}"#,
         tenant_identity_config_returning(),
-    ))
-    .bind(org_id.as_str())
-    .bind(&config.token_endpoint)
-    .bind(auth_method)
-    .bind(encrypted_auth_method_config.as_str())
-    .bind(Some(config.subject_token_audience.as_str()))
-    .fetch_optional(txn)
-    .await
-    .map_err(|e| DatabaseError::query("UPDATE tenant_identity_config token_delegation", e))?;
+    );
+    let row = sqlx::query_as(sqlx::AssertSqlSafe(query.as_str()))
+        .bind(org_id.as_str())
+        .bind(&config.token_endpoint)
+        .bind(auth_method)
+        .bind(encrypted_auth_method_config.as_str())
+        .bind(Some(config.subject_token_audience.as_str()))
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::query("UPDATE tenant_identity_config token_delegation", e))?;
     row.ok_or_else(|| DatabaseError::NotFoundError {
         kind: "tenant_identity_config",
         id: org_id.as_str().to_string(),
@@ -397,7 +399,7 @@ pub async fn delete_token_delegation(
     org_id: &TenantOrganizationId,
     txn: &mut PgConnection,
 ) -> DatabaseResult<Option<TenantIdentityConfig>> {
-    sqlx::query_as(&format!(
+    let query = format!(
         r#"
         UPDATE tenant_identity_config
         SET token_endpoint = NULL, auth_method = NULL, encrypted_auth_method_config = NULL,
@@ -405,11 +407,12 @@ pub async fn delete_token_delegation(
         WHERE organization_id = $1
         {}"#,
         tenant_identity_config_returning(),
-    ))
-    .bind(org_id.as_str())
-    .fetch_optional(txn)
-    .await
-    .map_err(|e| DatabaseError::query("CLEAR tenant_identity_config token_delegation", e))
+    );
+    sqlx::query_as(sqlx::AssertSqlSafe(query.as_str()))
+        .bind(org_id.as_str())
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::query("CLEAR tenant_identity_config token_delegation", e))
 }
 
 /// Organization ids to re-wrap: one org (must exist) or all rows ordered by id.
@@ -445,7 +448,7 @@ pub async fn find_for_update(
     let query = format!(
         "SELECT {TENANT_IDENTITY_CONFIG_COLUMNS} FROM tenant_identity_config WHERE organization_id = $1 FOR UPDATE"
     );
-    sqlx::query_as(&query)
+    sqlx::query_as(sqlx::AssertSqlSafe(query.as_str()))
         .bind(org_id.as_str())
         .fetch_optional(txn)
         .await

--- a/crates/api-db/src/tenant_identity_config.rs
+++ b/crates/api-db/src/tenant_identity_config.rs
@@ -32,6 +32,21 @@ use sqlx::types::Json;
 use crate::db_read::DbReader;
 use crate::{DatabaseError, DatabaseResult};
 
+/// Explicit column list for [`TenantIdentityConfig`] queries. Avoid `SELECT *` so schema migrations
+/// (e.g. dropped columns) do not invalidate cached prepared statements on live connections.
+const TENANT_IDENTITY_CONFIG_COLUMNS: &str = "\
+    organization_id, issuer, default_audience, allowed_audiences, \
+    token_ttl_sec, subject_prefix, enabled, created_at, updated_at, \
+    encrypted_signing_key_1, encrypted_signing_key_2, \
+    signing_key_public_1, signing_key_public_2, \
+    current_signing_key_slot, non_active_slot_expires_at, \
+    token_endpoint, auth_method, encrypted_auth_method_config, \
+    subject_token_audience, token_delegation_created_at";
+
+fn tenant_identity_config_returning() -> String {
+    format!("RETURNING {TENANT_IDENTITY_CONFIG_COLUMNS}")
+}
+
 /// After `non_active_slot_expires_at`, clears the non-current slot (public + private ciphertext).
 pub async fn gc_expired_non_active_signing_key(
     org_id: &TenantOrganizationId,
@@ -233,7 +248,7 @@ pub async fn set(
         }
     };
 
-    sqlx::query_as(
+    sqlx::query_as(&format!(
         r#"
         INSERT INTO tenant_identity_config (
             organization_id, issuer, default_audience, allowed_audiences,
@@ -256,9 +271,9 @@ pub async fn set(
             signing_key_public_2 = EXCLUDED.signing_key_public_2,
             current_signing_key_slot = EXCLUDED.current_signing_key_slot,
             non_active_slot_expires_at = EXCLUDED.non_active_slot_expires_at
-        RETURNING tenant_identity_config.*
-        "#,
-    )
+        {}"#,
+        tenant_identity_config_returning(),
+    ))
     .bind(org_id.as_str())
     .bind(&config.issuer)
     .bind(&config.default_audience)
@@ -284,7 +299,10 @@ pub async fn find<DB>(
 where
     for<'db> &'db mut DB: DbReader<'db>,
 {
-    sqlx::query_as("SELECT * FROM tenant_identity_config WHERE organization_id = $1")
+    let query = format!(
+        "SELECT {TENANT_IDENTITY_CONFIG_COLUMNS} FROM tenant_identity_config WHERE organization_id = $1"
+    );
+    sqlx::query_as(&query)
         .bind(org_id.as_str())
         .fetch_optional(&mut *db)
         .await
@@ -299,7 +317,13 @@ pub async fn find_by_machine_id(
 ) -> DatabaseResult<TenantIdentityConfig> {
     let row = sqlx::query_as::<_, TenantIdentityConfig>(
         r"
-        SELECT tic.*
+        SELECT tic.organization_id, tic.issuer, tic.default_audience, tic.allowed_audiences,
+            tic.token_ttl_sec, tic.subject_prefix, tic.enabled, tic.created_at, tic.updated_at,
+            tic.encrypted_signing_key_1, tic.encrypted_signing_key_2,
+            tic.signing_key_public_1, tic.signing_key_public_2,
+            tic.current_signing_key_slot, tic.non_active_slot_expires_at,
+            tic.token_endpoint, tic.auth_method, tic.encrypted_auth_method_config,
+            tic.subject_token_audience, tic.token_delegation_created_at
         FROM tenant_identity_config tic
         INNER JOIN instances i ON tic.organization_id = i.tenant_org
         WHERE i.machine_id = $1 AND i.deleted IS NULL AND tic.enabled = true",
@@ -334,16 +358,16 @@ pub async fn set_token_delegation(
     encrypted_auth_method_config: &EncryptedTokenDelegationAuthConfig,
     txn: &mut PgConnection,
 ) -> DatabaseResult<TenantIdentityConfig> {
-    let row = sqlx::query_as(
+    let row = sqlx::query_as(&format!(
         r#"
         UPDATE tenant_identity_config
         SET token_endpoint = $2, auth_method = $3, encrypted_auth_method_config = $4,
             subject_token_audience = $5, updated_at = NOW(),
             token_delegation_created_at = COALESCE(token_delegation_created_at, NOW())
         WHERE organization_id = $1
-        RETURNING tenant_identity_config.*
-        "#,
-    )
+        {}"#,
+        tenant_identity_config_returning(),
+    ))
     .bind(org_id.as_str())
     .bind(&config.token_endpoint)
     .bind(auth_method)
@@ -373,15 +397,15 @@ pub async fn delete_token_delegation(
     org_id: &TenantOrganizationId,
     txn: &mut PgConnection,
 ) -> DatabaseResult<Option<TenantIdentityConfig>> {
-    sqlx::query_as(
+    sqlx::query_as(&format!(
         r#"
         UPDATE tenant_identity_config
         SET token_endpoint = NULL, auth_method = NULL, encrypted_auth_method_config = NULL,
             subject_token_audience = NULL, token_delegation_created_at = NULL, updated_at = NOW()
         WHERE organization_id = $1
-        RETURNING tenant_identity_config.*
-        "#,
-    )
+        {}"#,
+        tenant_identity_config_returning(),
+    ))
     .bind(org_id.as_str())
     .fetch_optional(txn)
     .await
@@ -418,7 +442,10 @@ pub async fn find_for_update(
     org_id: &TenantOrganizationId,
     txn: &mut PgConnection,
 ) -> DatabaseResult<Option<TenantIdentityConfig>> {
-    sqlx::query_as("SELECT * FROM tenant_identity_config WHERE organization_id = $1 FOR UPDATE")
+    let query = format!(
+        "SELECT {TENANT_IDENTITY_CONFIG_COLUMNS} FROM tenant_identity_config WHERE organization_id = $1 FOR UPDATE"
+    );
+    sqlx::query_as(&query)
         .bind(org_id.as_str())
         .fetch_optional(txn)
         .await

--- a/crates/api-db/src/tenant_identity_config.rs
+++ b/crates/api-db/src/tenant_identity_config.rs
@@ -48,9 +48,8 @@ const UPSERT_TENANT_IDENTITY_CONFIG_SQL: &str = r#"
             token_ttl_sec, subject_prefix, enabled, created_at, updated_at,
             encrypted_signing_key_1, encrypted_signing_key_2,
             signing_key_public_1, signing_key_public_2,
-            current_signing_key_slot, non_active_slot_expires_at,
-            encryption_key_id
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW(), $8, $9, $10, $11, $12, $13, $14)
+            current_signing_key_slot, non_active_slot_expires_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW(), $8, $9, $10, $11, $12, $13)
         ON CONFLICT (organization_id) DO UPDATE SET
             issuer = EXCLUDED.issuer,
             default_audience = EXCLUDED.default_audience,
@@ -64,8 +63,7 @@ const UPSERT_TENANT_IDENTITY_CONFIG_SQL: &str = r#"
             signing_key_public_1 = EXCLUDED.signing_key_public_1,
             signing_key_public_2 = EXCLUDED.signing_key_public_2,
             current_signing_key_slot = EXCLUDED.current_signing_key_slot,
-            non_active_slot_expires_at = EXCLUDED.non_active_slot_expires_at,
-            encryption_key_id = EXCLUDED.encryption_key_id
+            non_active_slot_expires_at = EXCLUDED.non_active_slot_expires_at
         RETURNING tenant_identity_config.*
     "#;
 
@@ -301,7 +299,6 @@ pub async fn set(
         .bind(key_rows.pub2)
         .bind(key_rows.current_slot)
         .bind(key_rows.non_active_expires_at)
-        .bind(&config.encryption_key_id)
         .fetch_one(txn)
         .await
         .map_err(|e| DatabaseError::query(UPSERT_TENANT_IDENTITY_CONFIG_SQL, e))
@@ -522,7 +519,6 @@ ecbC7Qcisdw2/9l8bk/zfF9gvu4kh3hXZzMWgk+vj1e8KSX+NYswYiacQA==
         assert_eq!(cfg.token_ttl_sec, 3600);
         assert_eq!(cfg.subject_prefix, "spiffe://issuer.example.com/org-x");
         assert!(cfg.enabled);
-        assert_eq!(cfg.encryption_key_id.as_str(), "test-master");
         assert_eq!(
             cfg.current_signing_key_slot,
             TenantIdentityCurrentSigningKeySlot::SigningKey1
@@ -536,7 +532,6 @@ ecbC7Qcisdw2/9l8bk/zfF9gvu4kh3hXZzMWgk+vj1e8KSX+NYswYiacQA==
         assert_eq!(found.token_ttl_sec, cfg.token_ttl_sec);
         assert_eq!(found.subject_prefix, cfg.subject_prefix);
         assert_eq!(found.enabled, cfg.enabled);
-        assert_eq!(found.encryption_key_id, cfg.encryption_key_id);
         assert_eq!(found.current_signing_key_slot, cfg.current_signing_key_slot);
 
         let deleted = delete(&org_id, &mut txn).await.unwrap();

--- a/crates/api-model/src/tenant/mod.rs
+++ b/crates/api-model/src/tenant/mod.rs
@@ -248,7 +248,6 @@ pub struct TenantIdentityConfig {
     pub signing_key_public_2: Option<Json<identity_config::SigningKeyPublicV1>>,
     pub current_signing_key_slot: identity_config::TenantIdentityCurrentSigningKeySlot,
     pub non_active_slot_expires_at: Option<DateTime<Utc>>,
-    pub encryption_key_id: EncryptionKeyId,
     // Token delegation (optional)
     pub token_endpoint: Option<String>,
     pub auth_method: Option<TokenDelegationAuthMethod>,

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -793,6 +793,9 @@ service Forge {
   rpc GetTokenDelegation(GetTokenDelegationRequest) returns (TokenDelegationResponse);
   rpc SetTokenDelegation(TokenDelegationRequest) returns (TokenDelegationResponse);
   rpc DeleteTokenDelegation(GetTokenDelegationRequest) returns (google.protobuf.Empty);
+  // Site-operator: re-wrap tenant_identity_config ciphertext with a new master encryption key.
+  rpc ReencryptTenantIdentitySecrets(ReencryptTenantIdentitySecretsRequest)
+      returns (ReencryptTenantIdentitySecretsResponse);
   // Public discovery: JWKS and OpenID provider metadata (intended for unauthenticated fetch via REST gateway).
   rpc GetJWKS(JwksRequest) returns (Jwks);
   rpc GetOpenIDConfiguration(OpenIdConfigRequest) returns (OpenIdConfiguration);
@@ -1089,6 +1092,29 @@ message TokenDelegation {
 message TokenDelegationRequest {
   string organization_id = 1;
   TokenDelegation config = 2;
+}
+
+message ReencryptTenantIdentitySecretsRequest {
+  // If set, only this org; otherwise all rows in tenant_identity_config.
+  optional string organization_id = 1;
+  // Decrypt and validate only; no DB writes.
+  bool dry_run = 2;
+}
+
+message ReencryptTenantIdentityFailure {
+  string organization_id = 1;
+  string field = 2;
+  string error = 3;
+}
+
+message ReencryptTenantIdentitySecretsResponse {
+  uint32 rows_examined = 1;
+  uint32 rows_updated = 2;
+  uint32 rows_skipped_all_on_target = 3;
+  uint32 fields_reencrypted = 4;
+  uint32 fields_skipped_on_target = 5;
+  uint32 rows_failed = 6;
+  repeated ReencryptTenantIdentityFailure failures = 7;
 }
 
 // Carried JWKS document for GetJWKS. Standard key fields live in `jwks` only (RFC 7517).

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1115,6 +1115,8 @@ message ReencryptTenantIdentitySecretsResponse {
   uint32 fields_skipped_on_target = 5;
   uint32 rows_failed = 6;
   repeated ReencryptTenantIdentityFailure failures = 7;
+  // Site [machine_identity].current_encryption_key_id used as the re-wrap target.
+  string current_encryption_key_id = 8;
 }
 
 // Carried JWKS document for GetJWKS. Standard key fields live in `jwks` only (RFC 7517).

--- a/crates/secrets/src/key_encryption.rs
+++ b/crates/secrets/src/key_encryption.rs
@@ -29,8 +29,8 @@
 //!
 //! - **scheme_version** `1`: AES-256-GCM; key material is 32 bytes from base64-decoding the
 //!   configured encryption secret (`openssl rand -base64 32`).
-//! - **key_id**: map key under `machine_identity.encryption_keys` (e.g. `kv1`), must match site
-//!   `current_encryption_key_id` (from a secrets file, env-backed credentials, or another store).
+//! - **key_id**: map key under `machine_identity.encryption_keys` (e.g. `kv1`). Decrypt loads
+//!   credentials by this envelope field. Encrypt uses site `current_encryption_key_id`.
 
 use aes_gcm::Aes256Gcm;
 use aes_gcm::aead::{Aead, KeyInit};
@@ -85,6 +85,13 @@ struct EncryptionEnvelopeV1 {
     ciphertext: Vec<u8>,
 }
 
+#[derive(Debug, Clone)]
+struct ParsedEnvelopeV1 {
+    key_id: String,
+    nonce: [u8; 12],
+    ciphertext: Vec<u8>,
+}
+
 fn envelope_json_bytes(
     key_id: impl AsRef<str>,
     nonce: &[u8; 12],
@@ -106,7 +113,7 @@ fn envelope_json_bytes(
     serde_json::to_vec(&env).map_err(|e| KeyEncryptionError::Encrypt(e.to_string()))
 }
 
-fn parse_envelope_json(data: &[u8]) -> Result<([u8; 12], Vec<u8>), KeyEncryptionError> {
+fn parse_envelope(data: &[u8]) -> Result<ParsedEnvelopeV1, KeyEncryptionError> {
     let env: EncryptionEnvelopeV1 =
         serde_json::from_slice(data).map_err(|e| KeyEncryptionError::Decrypt(e.to_string()))?;
     if env.scheme_version != SCHEME_VERSION_V1 {
@@ -114,7 +121,30 @@ fn parse_envelope_json(data: &[u8]) -> Result<([u8; 12], Vec<u8>), KeyEncryption
             "unsupported scheme_version".into(),
         ));
     }
-    Ok((env.nonce, env.ciphertext))
+    if env.key_id.is_empty() || env.key_id.len() > 255 {
+        return Err(KeyEncryptionError::Decrypt(
+            "envelope key_id must be 1..=255 UTF-8 bytes".into(),
+        ));
+    }
+    Ok(ParsedEnvelopeV1 {
+        key_id: env.key_id,
+        nonce: env.nonce,
+        ciphertext: env.ciphertext,
+    })
+}
+
+fn parse_envelope_from_base64(
+    encrypted_base64: &str,
+) -> Result<ParsedEnvelopeV1, KeyEncryptionError> {
+    let combined = BASE64
+        .decode(encrypted_base64.trim())
+        .map_err(|e| KeyEncryptionError::Decrypt(e.to_string()))?;
+    parse_envelope(&combined)
+}
+
+/// Returns the `key_id` embedded in a stored envelope (standard base64 of JSON v1).
+pub fn envelope_key_id(encrypted_base64: &str) -> Result<String, KeyEncryptionError> {
+    Ok(parse_envelope_from_base64(encrypted_base64)?.key_id)
 }
 
 /// Encrypts plaintext with AES-256-GCM using envelope v1.
@@ -147,16 +177,12 @@ pub fn decrypt(
     encrypted_base64: &str,
     encryption_secret: &Aes256Key,
 ) -> Result<Vec<u8>, KeyEncryptionError> {
-    let combined = BASE64
-        .decode(encrypted_base64.trim())
-        .map_err(|e| KeyEncryptionError::Decrypt(e.to_string()))?;
-
-    let (nonce, ciphertext) = parse_envelope_json(&combined)?;
+    let envelope = parse_envelope_from_base64(encrypted_base64)?;
     let cipher = Aes256Gcm::new_from_slice(encryption_secret)
         .map_err(|e| KeyEncryptionError::Decrypt(e.to_string()))?;
-    let nonce_ga = aes_gcm::aead::generic_array::GenericArray::from_slice(&nonce);
+    let nonce_ga = aes_gcm::aead::generic_array::GenericArray::from_slice(&envelope.nonce);
     cipher
-        .decrypt(nonce_ga, ciphertext.as_slice())
+        .decrypt(nonce_ga, envelope.ciphertext.as_slice())
         .map_err(|e| KeyEncryptionError::Decrypt(e.to_string()))
 }
 
@@ -220,5 +246,12 @@ mod tests {
         let key = test_aes256_key();
         let plaintext_json = r#"{"client_id":"c","client_secret":"s"}"#;
         assert!(decrypt(plaintext_json, &key).is_err());
+    }
+
+    #[test]
+    fn envelope_key_id_reads_embedded_key_id() {
+        let key = test_aes256_key();
+        let encrypted = encrypt(b"secret", &key, "kv2").unwrap();
+        assert_eq!(envelope_key_id(&encrypted).unwrap(), "kv2");
     }
 }

--- a/docs/design/machine-identity/spiffe-svid-sdd.md
+++ b/docs/design/machine-identity/spiffe-svid-sdd.md
@@ -10,6 +10,7 @@
 | 0.2 | 03/11/2026 | Binu Ramakrishnan | gRPC/API updates and incorporated review feedback |
 | 0.3 | 05/11/2026 | Binu Ramakrishnan | DPU agent / FMDS optional HTTP sign proxy (`[machine-identity]` `sign-proxy-url`, `sign-proxy-tls-root-ca`); `FmdsMachineIdentityConfig` in FMDS config push |
 | 0.4 | 05/11/2026 | Binu Ramakrishnan | Signing key rotation (two slots), overlap policy on rotate only |
+| 0.5 | 06/02/2026 | Binu Ramakrishnan | Site master encryption key re-wrap (`ReencryptTenantIdentitySecrets` gRPC); envelope `key_id` in ciphertext (drop DB `encryption_key_id` column) |
 |  |  |  |  |
 
 # **1\. Introduction**
@@ -95,11 +96,12 @@ The system is composed of the following major components:
 
 # **3\. Detailed Design**
 
-There are three different flows associated with implementing this feature:
+There are four operational areas associated with implementing this feature:
 
 1. *Per-tenant signing key provisioning*: Describes how a new signing key associated with a tenant is provisioned, and optionally the token delegation/exchange flows.  
 2. *SPIFFE key bundle discovery*: Discusses how the signing public keys are distributed to interested parties (verifiers)  
 3. *JWT-SVID node identity request flow*: The run time flow used by tenant applications to fetch JWT-SVIDs from NICo.
+4. *Site master encryption key rotation*: Re-wraps stored ciphertext when the site **`current_encryption_key_id`** changes (§3.1.1, **`ReencryptTenantIdentitySecrets`**).
 
 Each of these flows are discussed below.
 
@@ -141,6 +143,40 @@ SetTenantIdentityConfiguration (PUT identity/config)
 *Figure-3 Per-tenant identity configuration and signing key provisioning flow*
 
 **Signing key rotation (two slots):** `tenant_identity_config` holds **two** optional encrypted private keys and matching public-key JSON documents (`signing_key_public_*`). Exactly one slot is **current** (`current_signing_key_slot`). On **first** provisioning, material is written to slot 1. On **rotate** (`rotate_key=true`), the new pair goes into the other slot, the current pointer moves, and **`non_active_slot_expires_at`** records when the previous key may be dropped from JWKS. Overlap duration is **not** stored as a column; each **SetTenantIdentityConfiguration** that rotates must supply **`signing_key_overlap_sec`**, which must be **≥ `token_ttl_sec`** (so tokens signed with the old key stay verifiable until `exp`) and **≤** site **`signing_key_overlap_max_sec`**. While two keys are published, **GetTenantIdentityConfiguration** returns **`signing_keys`**: one entry has **`current_signer`** true; the inactive entry may include **`expire_at`** (JSON **`expireAt`**) — the JWKS overlap end.
+
+### **3.1.1 Site master encryption key rotation (KEK re-wrap)**
+
+Per-org signing private keys and token-delegation credentials are encrypted at rest with a **site master encryption key** (AES-256-GCM envelope, scheme version 1). This is **separate** from per-org **JWT signing key rotation** (§3.1 above).
+
+| Concept | Where it lives |
+| :------ | :------------- |
+| Site **current** master key id | `[machine_identity].current_encryption_key_id` in site config |
+| Master key material | Site secrets `machine_identity.encryption_keys` (e.g. Vault `…/machine_identity/encryption_keys/kv1`) |
+| Key id used to encrypt a given blob | **`key_id` inside the ciphertext envelope JSON** (standard base64 in DB), not a table column |
+
+**New encrypts** (first org provisioning, signing-key rotation, token-delegation writes) use the site **`current_encryption_key_id`**. **Decrypt** loads the AES key named by the envelope’s embedded **`key_id`**, so older keys must remain in secrets until all blobs are re-wrapped.
+
+**Operator workflow to rotate the site master key** (e.g. `kv1` → `kv2`):
+
+1. Add the new key to site secrets (`machine_identity.encryption_keys.kv2`); **keep** the old key until step 4 completes.
+2. Set `current_encryption_key_id = "kv2"` in site config and **restart** the NICo API (not hot-reloaded).
+3. Call **`ReencryptTenantIdentitySecrets`** with **`dry_run: true`** (optionally scoped to one `organization_id`), then apply with **`dry_run: false`**.
+4. Verify dry-run shows all rows **`rows_skipped_all_on_target`** / **`fields_skipped_on_target`** only; then optionally remove the retired key from secrets.
+
+Fields re-wrapped per org (when present): `encrypted_signing_key_1`, `encrypted_signing_key_2`, `encrypted_auth_method_config`.
+
+```
+Add kv2 to secrets ──► current_encryption_key_id=kv2 + restart API
+              │
+              ▼
+ReencryptTenantIdentitySecrets (dry_run=true)
+              │
+              ▼
+ReencryptTenantIdentitySecrets (dry_run=false)
+              │
+              ▼
+(Optional) remove retired key from secrets
+```
 
 ## **3.2 Per-tenant SPIFFE Key Bundle Discovery**
 
@@ -337,7 +373,6 @@ A new table will be created to store tenant signing key pairs and optional token
 | `JSONB` | `signing_key_public_2` | Public metadata JSON slot 2 (nullable) |
 | `tenant_identity_current_signing_key_slot_t` (ENUM) | `current_signing_key_slot` | `signing_key_1` or `signing_key_2` — active signer |
 | `TIMESTAMPTZ` | `non_active_slot_expires_at` | When inactive-slot JWKS publication may end (nullable) |
-| `VARCHAR(255)` | `encryption_key_id` | Envelope encryption key id (Vault / secrets) |
 | `TIMESTAMPTZ` | `created_at` | Created |
 | `TIMESTAMPTZ` | `updated_at` | Updated |
 | `VARCHAR(512)` | `token_endpoint` | Token exchange URL (optional) |
@@ -346,7 +381,7 @@ A new table will be created to store tenant signing key pairs and optional token
 | `VARCHAR(255)` | `subject_token_audience` | Subject JWT audience for exchange (optional) |
 | `TIMESTAMPTZ` | `token_delegation_created_at` | First delegation registration (optional) |
 
-_Previous single-column layout (`encrypted_signing_key`, `signing_key_public`, `key_id`, `algorithm`) is replaced by the slotted model above via migration._
+_Previous single-column layout (`encrypted_signing_key`, `signing_key_public`, `key_id`, `algorithm`) is replaced by the slotted model above via migration. The per-row **`encryption_key_id`** column was removed; master key selection for **new** encryption uses site **`current_encryption_key_id`**, while **decrypt** uses the **`key_id` field inside each stored envelope** (see §3.1.1)._
 
 ### **3.4.2 Configuration**
 
@@ -377,7 +412,7 @@ token_endpoint_domain_allowlist = []    # token delegation token_endpoint URL ho
 Global config provides:
   * the master switch (`enabled`)
   * site-wide signing algorithm (`algorithm`)
-  * **`current_encryption_key_id`**: selects which master encryption key from site secrets is used for per-org signing-key material; required when `enabled` is `true`
+  * **`current_encryption_key_id`**: selects which master encryption key from site secrets is used for **new** per-org ciphertext (signing private keys and token-delegation auth JSON); required when `enabled` is `true`. Decrypt uses the envelope’s embedded `key_id`. Rotate via §3.1.1 and **`ReencryptTenantIdentitySecrets`**.
   * optional token TTL bounds (`token_ttl_min_sec`, `token_ttl_max_sec`), and
   * optional **`signing_key_overlap_max_sec`**: max allowed **`signing_key_overlap_sec`** on a **rotate** request (default in the tens of days range; tune per environment)
   * optional HTTP proxy for token endpoint calls (`token_endpoint_http_proxy`)
@@ -598,6 +633,66 @@ Response:
 ```
 
 `signingKeys` lists **published** public keys (metadata only). Exactly one object has **`currentSigner`: true**. During rotation overlap, the **inactive** key may include **`expireAt`** (proto: `expire_at`) — end of the JWKS overlap window. With a single active key, only one object is returned and **`expireAt`** is omitted.
+
+##### **Site master encryption key re-wrap (gRPC only)**
+
+Site operators use this admin RPC after changing **`current_encryption_key_id`** to re-wrap existing ciphertext in `tenant_identity_config` with the new master key. It does **not** rotate per-org JWT signing keys (use **`rotateKey`** on Set identity config for that).
+
+**Auth:** Forge Admin CLI (internal RBAC); not exposed via NICo-rest.
+
+**Scope:** If **`organization_id`** is set, only that org (must exist). If omitted, all rows in `tenant_identity_config` are examined in stable order.
+
+**Dry run:** When **`dry_run`** is **`true`**, decrypt and validate only; **no DB writes**. Counters still reflect what would change.
+
+```bash
+# gRPC (Forge service)
+Forge.ReencryptTenantIdentitySecrets
+```
+
+Request (all orgs, dry run):
+
+```json
+{
+  "dryRun": true
+}
+```
+
+Request (single org, apply):
+
+```json
+{
+  "organizationId": "my-org-id",
+  "dryRun": false
+}
+```
+
+Response:
+
+```json
+{
+  "currentEncryptionKeyId": "kv2",
+  "rowsExamined": 1,
+  "rowsUpdated": 1,
+  "rowsSkippedAllOnTarget": 0,
+  "fieldsReencrypted": 3,
+  "fieldsSkippedOnTarget": 0,
+  "rowsFailed": 0,
+  "failures": []
+}
+```
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| `currentEncryptionKeyId` | string | Site **`current_encryption_key_id`** used as the re-wrap target (from running API config). |
+| `rowsExamined` | number | Org rows processed (1 per org, or all orgs). |
+| `rowsUpdated` | number | Orgs where at least one field would be or was re-wrapped. |
+| `rowsSkippedAllOnTarget` | number | Orgs where every present encrypted field already matches **`currentEncryptionKeyId`**. |
+| `fieldsReencrypted` | number | Fields that would be or were re-wrapped (counts toward update). |
+| `fieldsSkippedOnTarget` | number | Fields already on the current master key. |
+| `rowsFailed` | number | Orgs with at least one field failure (see **`failures`**). |
+| `failures` | array | Per-field errors: `organizationId`, `field` (e.g. `encrypted_signing_key_1`), `error`. |
+
+Partial failures do not fail the whole RPC; check **`rowsFailed`** and **`failures`**.
 
 #### **NICo Token Exchange Server Registration APIs**
 
@@ -937,11 +1032,37 @@ message TenantIdentityConfigResponse {
   repeated TenantIdentitySigningKey signing_keys = 11;
 }
 
-// gRPC service (extract; see crates/rpc/proto/nico.proto for full NICo service)
+message ReencryptTenantIdentitySecretsRequest {
+  // If set, only this org; otherwise all rows in tenant_identity_config.
+  optional string organization_id = 1;
+  // Decrypt and validate only; no DB writes.
+  bool dry_run = 2;
+}
+
+message ReencryptTenantIdentityFailure {
+  string organization_id = 1;
+  string field = 2;
+  string error = 3;
+}
+
+message ReencryptTenantIdentitySecretsResponse {
+  uint32 rows_examined = 1;
+  uint32 rows_updated = 2;
+  uint32 rows_skipped_all_on_target = 3;
+  uint32 fields_reencrypted = 4;
+  uint32 fields_skipped_on_target = 5;
+  uint32 rows_failed = 6;
+  repeated ReencryptTenantIdentityFailure failures = 7;
+  // Site [machine_identity].current_encryption_key_id used as the re-wrap target.
+  string current_encryption_key_id = 8;
+}
+
+// gRPC service (extract; see crates/rpc/proto/forge.proto for full Forge service)
 service NICo {
   rpc GetTenantIdentityConfiguration(GetTenantIdentityConfigRequest) returns (TenantIdentityConfigResponse);
   rpc SetTenantIdentityConfiguration(SetTenantIdentityConfigRequest) returns (TenantIdentityConfigResponse);
   rpc DeleteTenantIdentityConfiguration(GetTenantIdentityConfigRequest) returns (google.protobuf.Empty);
+  rpc ReencryptTenantIdentitySecrets(ReencryptTenantIdentitySecretsRequest) returns (ReencryptTenantIdentitySecretsResponse);
   rpc GetJWKS(JWKSRequest) returns (JWKS);
   rpc GetOpenIDConfiguration(OpenIDConfigRequest) returns (OpenIDConfiguration);
 }
@@ -960,6 +1081,7 @@ service NICo {
 | `GET /v2/org/{org-id}/nico/site/{site-id}/identity/token-delegation` | `NICo.GetTokenDelegation` | Retrieve token delegation config |
 | `PUT /v2/org/{org-id}/nico/site/{site-id}/identity/token-delegation` | `NICo.SetTokenDelegation` | Create or replace token delegation |
 | `DELETE /v2/org/{org-id}/nico/site/{site-id}/identity/token-delegation` | `NICo.DeleteTokenDelegation` | Delete token delegation |
+| _(gRPC only; Forge Admin CLI)_ | `Forge.ReencryptTenantIdentitySecrets` | Re-wrap tenant identity ciphertext with site **`current_encryption_key_id`** (§3.1.1) |
 
 ### **3.5.2.2 Error Handling**
 


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->

Adds **site master encryption key (KEK) rotation** for SPIFFE machine identity. Operators can change `[machine_identity].current_encryption_key_id`, re-wrap existing `tenant_identity_config` ciphertext via a new admin gRPC, and rely on envelope-embedded `key_id` instead of a redundant DB column.
- **Drop per-row `encryption_key_id`** — Migration removes the column; decrypt uses `key_id` in the AES-GCM envelope JSON; new encrypts use site `current_encryption_key_id` from config/secrets (`machine_identity.encryption_keys`).
- **New `Forge.ReencryptTenantIdentitySecrets` RPC** — Site-operator API (Forge Admin CLI) re-wraps `encrypted_signing_key_1`, `encrypted_signing_key_2`, and `encrypted_auth_method_config` for one org or all orgs; supports `dry_run` for validate-only runs.
- **Response includes `current_encryption_key_id`** — Echoes the site key used as the re-wrap target so dry-run output is self-explanatory (e.g. already on `kv2` vs still on `kv1`).
- **SQL hardening** — Replace `SELECT *` / `RETURNING *` on `tenant_identity_config` with explicit column lists to avoid PostgreSQL “cached plan must not change result type” errors after schema migrations.
- **Docs** — Update `docs/design/machine-identity/spiffe-svid-sdd.md` (§3.1.1 KEK rotation workflow, API reference, proto.
### Commits ([#847](https://github.com/NVIDIA/infra-controller-core/issues/847))
| Commit | Description |
|--------|-------------|
| `cc0376b97` | Remove redundant DB `encryption_key_id`; envelope-driven decrypt |
| `cdab38045` | Inline SQL statements (review feedback) |
| `8d7215e4c` | Add `ReencryptTenantIdentitySecrets` API |
| `3dc23c1df` | Add `current_encryption_key_id` response field; SQL refactor; SDD |
### Key files
- `crates/rpc/proto/forge.proto`
- `crates/api-core/src/handlers/tenant_identity_config.rs`
- `crates/api-core/src/machine_identity/crypto.rs`
- `crates/api-db/src/tenant_identity_config.rs`
- `crates/api-db/migrations/20260528120000_drop_tenant_identity_encryption_key_id.sql`
- `docs/design/machine-identity/spiffe-svid-sdd.md`
### Operator workflow (post-merge)
1. Add new key to Vault (`machine_identity/encryption_keys/kv2`); keep the old key.
2. Set `current_encryption_key_id = "kv2"` and restart `carbide-api`.
3. Call `ReencryptTenantIdentitySecrets` with `dryRun: true`, then `dryRun: false`.
4. Confirm `currentEncryptionKeyId`, `rowsFailed: 0`, and identity/sign RPCs still work.

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
#847

## Breaking Changes

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
#261 Epic
