### PR TITLE
chore(rest-api): Apply our new FromProto/ToProto modeling to Machine

### DIFF
--- a/rest-api/api/pkg/api/handler/machine.go
+++ b/rest-api/api/pkg/api/handler/machine.go
@@ -1200,12 +1200,11 @@ func (umh UpdateMachineHandler) Handle(c echo.Context) error {
 				return cutil.NewAPIError(http.StatusBadRequest, "Machine is currently not in maintenance mode, cannot remove maintenance mode", nil)
 			}
 
-			wfReq := &cwssaws.MaintenanceRequest{HostId: &cwssaws.MachineId{Id: machine.ID}}
+			var wfReq *cwssaws.MaintenanceRequest
 			if *apiRequest.SetMaintenanceMode {
-				wfReq.Operation = cwssaws.MaintenanceOperation_Enable
-				wfReq.Reference = apiRequest.MaintenanceMessage
+				wfReq = machine.ToMaintenanceRequestProto(cwssaws.MaintenanceOperation_Enable, apiRequest.MaintenanceMessage)
 			} else {
-				wfReq.Operation = cwssaws.MaintenanceOperation_Disable
+				wfReq = machine.ToMaintenanceRequestProto(cwssaws.MaintenanceOperation_Disable, nil)
 			}
 
 			// Add context deadlines
@@ -1297,21 +1296,10 @@ func (umh UpdateMachineHandler) Handle(c echo.Context) error {
 			}
 
 			labels := util.ProtobufLabelsFromAPILabels(apiRequest.Labels)
-
-			machineName := machine.ID
-			if machine.Metadata != nil && machine.Metadata.Metadata != nil {
-				machineName = machine.Metadata.Metadata.Name
-			}
-
-			wfReq := &cwssaws.MachineMetadataUpdateRequest{
-				MachineId: &cwssaws.MachineId{
-					Id: machine.ID,
-				},
-				Metadata: &cwssaws.Metadata{
-					Name:   machineName, // Site Controller sets Machine ID as name and it must be specified to update labels
-					Labels: labels,
-				},
-			}
+			// Site Controller sets Machine ID as the metadata Name and requires it
+			// on every update; ToMetadataUpdateRequestProto reads the current name
+			// from the machine's stored metadata, with a fallback to the Machine ID.
+			wfReq := machine.ToMetadataUpdateRequestProto(labels)
 
 			// Add context deadlines
 			wfCtx, cancel := context.WithTimeout(ctx, cutil.WorkflowContextTimeout)

--- a/rest-api/db/pkg/db/model/machine.go
+++ b/rest-api/db/pkg/db/model/machine.go
@@ -161,6 +161,45 @@ func (m *Machine) GetControllerState() string {
 	return m.Metadata.GetNormalizedState()
 }
 
+// ToMaintenanceRequestProto builds the workflow request to enable or
+// disable maintenance mode on this Machine. operation selects the mode;
+// reference is an optional human-readable note recorded with the
+// maintenance event (typically only set when enabling). Returns nil for
+// a nil receiver.
+func (m *Machine) ToMaintenanceRequestProto(operation cwssaws.MaintenanceOperation, reference *string) *cwssaws.MaintenanceRequest {
+	if m == nil {
+		return nil
+	}
+	return &cwssaws.MaintenanceRequest{
+		HostId:    &cwssaws.MachineId{Id: m.ID},
+		Operation: operation,
+		Reference: reference,
+	}
+}
+
+// ToMetadataUpdateRequestProto builds the workflow request that pushes
+// the supplied labels to a Site as a metadata update for this Machine.
+// The Site Controller stores the Machine ID as the metadata Name and
+// requires a non-empty Name on every update; this method reads it from
+// the machine's stored metadata when present and non-empty, falling
+// back to the Machine ID itself. Returns nil for a nil receiver.
+func (m *Machine) ToMetadataUpdateRequestProto(labels []*cwssaws.Label) *cwssaws.MachineMetadataUpdateRequest {
+	if m == nil {
+		return nil
+	}
+	machineName := m.ID
+	if m.Metadata != nil && m.Metadata.Metadata != nil && m.Metadata.Metadata.Name != "" {
+		machineName = m.Metadata.Metadata.Name
+	}
+	return &cwssaws.MachineMetadataUpdateRequest{
+		MachineId: &cwssaws.MachineId{Id: m.ID},
+		Metadata: &cwssaws.Metadata{
+			Name:   machineName,
+			Labels: labels,
+		},
+	}
+}
+
 // MachineCreateInput input parameters for Create method
 type MachineCreateInput struct {
 	MachineID                string

--- a/rest-api/db/pkg/db/model/machine_test.go
+++ b/rest-api/db/pkg/db/model/machine_test.go
@@ -2253,3 +2253,52 @@ func TestMachine_GetControllerState(t *testing.T) {
 	assert.Equal(t, "Ready", mMeta.GetControllerState())
 	assert.Equal(t, "Ready", scm.GetNormalizedState())
 }
+
+func TestMachine_ToMaintenanceRequestProto(t *testing.T) {
+	t.Run("enable with reference", func(t *testing.T) {
+		ref := "scheduled work"
+		m := &Machine{ID: "m-1"}
+		req := m.ToMaintenanceRequestProto(cwssaws.MaintenanceOperation_Enable, &ref)
+		assert.NotNil(t, req)
+		assert.NotNil(t, req.HostId)
+		assert.Equal(t, "m-1", req.HostId.Id)
+		assert.Equal(t, cwssaws.MaintenanceOperation_Enable, req.Operation)
+		assert.Equal(t, &ref, req.Reference)
+	})
+	t.Run("disable with no reference", func(t *testing.T) {
+		m := &Machine{ID: "m-1"}
+		req := m.ToMaintenanceRequestProto(cwssaws.MaintenanceOperation_Disable, nil)
+		assert.NotNil(t, req)
+		assert.NotNil(t, req.HostId)
+		assert.Equal(t, "m-1", req.HostId.Id)
+		assert.Equal(t, cwssaws.MaintenanceOperation_Disable, req.Operation)
+		assert.Nil(t, req.Reference)
+	})
+}
+
+func TestMachine_ToMetadataUpdateRequestProto(t *testing.T) {
+	labelVal := "prod"
+	labels := []*cwssaws.Label{{Key: "env", Value: &labelVal}}
+
+	t.Run("uses Machine.ID as Name fallback when metadata is nil", func(t *testing.T) {
+		m := &Machine{ID: "m-1"}
+		req := m.ToMetadataUpdateRequestProto(labels)
+		assert.NotNil(t, req)
+		assert.NotNil(t, req.MachineId)
+		assert.Equal(t, "m-1", req.MachineId.Id)
+		assert.NotNil(t, req.Metadata)
+		assert.Equal(t, "m-1", req.Metadata.Name)
+		assert.Equal(t, labels, req.Metadata.Labels)
+	})
+
+	t.Run("uses stored metadata Name when present", func(t *testing.T) {
+		m := &Machine{
+			ID: "m-1",
+			Metadata: &SiteControllerMachine{
+				Machine: &cwssaws.Machine{Metadata: &cwssaws.Metadata{Name: "stored-name"}},
+			},
+		}
+		req := m.ToMetadataUpdateRequestProto(labels)
+		assert.Equal(t, "stored-name", req.Metadata.Name)
+	})
+}


### PR DESCRIPTION
## Description

Brings two inline workflow-request builders in the `Machine` handler in line with the proto-modeling changes. Both flows have no API request body -- Maintenance toggles a state and Metadata-update syncs labels -- so the methods live on the entity rather than on an API request type.

Primary callouts are:
- Maintenance: `Machine.ToMaintenanceRequestProto(operation, reference)`.
- Metadata-update: `Machine.ToMetadataUpdateRequestProto(labels)` (reads the current site-metadata Name from stored metadata, falling back to `m.ID`).
- Handler simplified to one-liners at both sites.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

