### PR TITLE
chore(rest-api): Apply our FromProto/ToProto modeling to the Instance delete flow

### DIFF
--- a/rest-api/api/pkg/api/handler/instance.go
+++ b/rest-api/api/pkg/api/handler/instance.go
@@ -1555,7 +1555,7 @@ func (cih CreateInstanceHandler) Handle(c echo.Context) error {
 
 		// Prepare the create request workflow object
 		createInstanceRequest := &cwssaws.InstanceAllocationRequest{
-			InstanceId: &cwssaws.InstanceId{Value: common.GetSiteInstanceID(instance).String()},
+			InstanceId: &cwssaws.InstanceId{Value: instance.GetSiteID().String()},
 			MachineId:  &cwssaws.MachineId{Id: *instance.MachineID},
 			Metadata: &cwssaws.Metadata{
 				Name:        instance.Name,
@@ -3516,7 +3516,7 @@ func (uih UpdateInstanceHandler) Handle(c echo.Context) error {
 
 		// Prepare the config update request workflow object
 		updateInstanceRequest := &cwssaws.InstanceConfigUpdateRequest{
-			InstanceId: &cwssaws.InstanceId{Value: common.GetSiteInstanceID(instance).String()},
+			InstanceId: &cwssaws.InstanceId{Value: instance.GetSiteID().String()},
 			Metadata: &cwssaws.Metadata{
 				Name:        ui.Name,
 				Description: description,
@@ -4737,31 +4737,19 @@ func (dih DeleteInstanceHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		// Prepare the delete/release request workflow object
-		releaseInstanceRequest := &cwssaws.InstanceReleaseRequest{
-			Id: &cwssaws.InstanceId{Value: common.GetSiteInstanceID(instance).String()},
-		}
-
-		// This is for enhanced break-fix flow:
-		if apiRequest.MachineHealthIssue != nil {
-			releaseInstanceRequest.Issue = &cwssaws.Issue{
-				Category: cwssaws.IssueCategory(model.MachineIssueCategoriesFromAPIToProtobuf[apiRequest.MachineHealthIssue.Category]),
-			}
-			if apiRequest.MachineHealthIssue.Summary != nil {
-				releaseInstanceRequest.Issue.Summary = *apiRequest.MachineHealthIssue.Summary
-			}
-			if apiRequest.MachineHealthIssue.Details != nil {
-				releaseInstanceRequest.Issue.Details = *apiRequest.MachineHealthIssue.Details
-			}
-		}
-		// if caller attempt to set IsRepairTenant then it must be a tenant with targetedInstanceCreation capability
+		// Authorization stays in the handler: setting `IsRepairTenant`
+		// requires the tenant to carry the TargetedInstanceCreation
+		// capability. By the time `ToProto` runs the request is safe
+		// to trust.
 		if apiRequest.IsRepairTenant != nil && *apiRequest.IsRepairTenant {
 			if instance.Tenant.Config == nil || !instance.Tenant.Config.TargetedInstanceCreation {
 				logger.Warn().Msg("tenant does not have capability to set IsRepairTenant")
 				return cutil.NewAPIError(http.StatusForbidden, "Tenant does not have capability to set IsRepairTenant", nil)
 			}
-			releaseInstanceRequest.IsRepairTenant = apiRequest.IsRepairTenant
 		}
+
+		// Prepare the delete/release request workflow object
+		releaseInstanceRequest := apiRequest.ToProto(instance)
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:                       "instance-delete-" + instance.ID.String(),

--- a/rest-api/api/pkg/api/handler/instancebatch.go
+++ b/rest-api/api/pkg/api/handler/instancebatch.go
@@ -1630,7 +1630,7 @@ func (bcih BatchCreateInstanceHandler) Handle(c echo.Context) error {
 
 			// Build instance allocation request using pre-built configs
 			instanceRequest := &cwssaws.InstanceAllocationRequest{
-				InstanceId: &cwssaws.InstanceId{Value: common.GetSiteInstanceID(instance).String()},
+				InstanceId: &cwssaws.InstanceId{Value: instance.GetSiteID().String()},
 				MachineId:  &cwssaws.MachineId{Id: *instance.MachineID},
 				Metadata: &cwssaws.Metadata{
 					Name:        instance.Name,

--- a/rest-api/api/pkg/api/handler/util/common/common.go
+++ b/rest-api/api/pkg/api/handler/util/common/common.go
@@ -81,14 +81,6 @@ var (
 	RequestAsTenant = "Tenant"
 )
 
-func GetSiteInstanceID(i *cdbm.Instance) *uuid.UUID {
-	if i.ControllerInstanceID != nil {
-		return i.ControllerInstanceID
-	} else {
-		return &i.ID
-	}
-}
-
 func GetSiteNetworkSegmentID(s *cdbm.Subnet) *uuid.UUID {
 	if s.ControllerNetworkSegmentID != nil {
 		return s.ControllerNetworkSegmentID

--- a/rest-api/api/pkg/api/model/instance.go
+++ b/rest-api/api/pkg/api/model/instance.go
@@ -1583,7 +1583,7 @@ type APIInstanceDeleteRequest struct {
 }
 
 // Validate ensures the values passed in request are acceptable
-func (idr APIInstanceDeleteRequest) Validate() error {
+func (idr *APIInstanceDeleteRequest) Validate() error {
 	if idr.MachineHealthIssue != nil {
 		err := validation.ValidateStruct(idr.MachineHealthIssue,
 			validation.Field(&idr.MachineHealthIssue.Category,
@@ -1604,6 +1604,36 @@ func (idr APIInstanceDeleteRequest) Validate() error {
 	}
 
 	return nil
+}
+
+// ToProto builds the workflow request that asks a Site to release
+// (delete) the given Instance for this API request. `instance` is the
+// loaded DB record; its `ToReleaseRequestProto()` is the source of the
+// canonical wire ID. Optional request-side fields (`MachineHealthIssue`,
+// `IsRepairTenant`) are overlaid on top.
+//
+// The method trusts that the request has already been Validated and
+// that the handler has performed any cross-context checks Validate
+// cannot see. In particular, the `IsRepairTenant` capability gate
+// (TargetedInstanceCreation on the Tenant config) is an authorization
+// check that stays in the handler before this method runs.
+func (idr *APIInstanceDeleteRequest) ToProto(instance *cdbm.Instance) *cwssaws.InstanceReleaseRequest {
+	req := instance.ToReleaseRequestProto()
+	if idr.MachineHealthIssue != nil {
+		req.Issue = &cwssaws.Issue{
+			Category: cwssaws.IssueCategory(MachineIssueCategoriesFromAPIToProtobuf[idr.MachineHealthIssue.Category]),
+		}
+		if idr.MachineHealthIssue.Summary != nil {
+			req.Issue.Summary = *idr.MachineHealthIssue.Summary
+		}
+		if idr.MachineHealthIssue.Details != nil {
+			req.Issue.Details = *idr.MachineHealthIssue.Details
+		}
+	}
+	if idr.IsRepairTenant != nil {
+		req.IsRepairTenant = idr.IsRepairTenant
+	}
+	return req
 }
 
 // SSHKeyGroupsSummaryDeprecated ensures we keep returning empty array until deprecation time even with omitempty

--- a/rest-api/api/pkg/api/model/instance_test.go
+++ b/rest-api/api/pkg/api/model/instance_test.go
@@ -14,8 +14,10 @@ import (
 	"github.com/NVIDIA/infra-controller-rest/api/pkg/api/model/util"
 	cdb "github.com/NVIDIA/infra-controller-rest/db/pkg/db"
 	cdbm "github.com/NVIDIA/infra-controller-rest/db/pkg/db/model"
+	cwssaws "github.com/NVIDIA/infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewAPIInstance(t *testing.T) {
@@ -2569,4 +2571,64 @@ func TestAPIInstanceUpdateRequest_Validate_Auto(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAPIInstanceDeleteRequest_ToProto(t *testing.T) {
+	id := uuid.New()
+	ctrlID := uuid.New()
+	instance := &cdbm.Instance{ID: id, ControllerInstanceID: &ctrlID}
+
+	t.Run("empty request sources only the canonical ID", func(t *testing.T) {
+		req := APIInstanceDeleteRequest{}
+		got := req.ToProto(instance)
+		require.NotNil(t, got)
+		require.NotNil(t, got.Id)
+		assert.Equal(t, ctrlID.String(), got.Id.Value)
+		assert.Nil(t, got.Issue)
+		assert.Nil(t, got.IsRepairTenant)
+	})
+
+	t.Run("overlays MachineHealthIssue with summary and details", func(t *testing.T) {
+		req := APIInstanceDeleteRequest{
+			MachineHealthIssue: &APIMachineHealthIssue{
+				Category: MachineIssueCategoryHardware,
+				Summary:  cdb.GetStrPtr("burnt out NIC"),
+				Details:  cdb.GetStrPtr("port 0 returned link-down for 30 minutes"),
+			},
+		}
+		got := req.ToProto(instance)
+		require.NotNil(t, got)
+		require.NotNil(t, got.Issue)
+		assert.Equal(t, cwssaws.IssueCategory_HARDWARE, got.Issue.Category)
+		assert.Equal(t, "burnt out NIC", got.Issue.Summary)
+		assert.Equal(t, "port 0 returned link-down for 30 minutes", got.Issue.Details)
+	})
+
+	t.Run("MachineHealthIssue without optional pointers leaves Summary and Details empty", func(t *testing.T) {
+		req := APIInstanceDeleteRequest{
+			MachineHealthIssue: &APIMachineHealthIssue{
+				Category: MachineIssueCategoryOther,
+			},
+		}
+		got := req.ToProto(instance)
+		require.NotNil(t, got.Issue)
+		assert.Equal(t, cwssaws.IssueCategory_OTHER, got.Issue.Category)
+		assert.Equal(t, "", got.Issue.Summary)
+		assert.Equal(t, "", got.Issue.Details)
+	})
+
+	t.Run("overlays IsRepairTenant when set", func(t *testing.T) {
+		req := APIInstanceDeleteRequest{IsRepairTenant: cdb.GetBoolPtr(true)}
+		got := req.ToProto(instance)
+		require.NotNil(t, got.IsRepairTenant)
+		assert.True(t, *got.IsRepairTenant)
+	})
+
+	t.Run("uses Instance ID when ControllerInstanceID is nil", func(t *testing.T) {
+		bare := &cdbm.Instance{ID: id}
+		req := APIInstanceDeleteRequest{}
+		got := req.ToProto(bare)
+		require.NotNil(t, got.Id)
+		assert.Equal(t, id.String(), got.Id.Value)
+	})
 }

--- a/rest-api/db/pkg/db/model/instance.go
+++ b/rest-api/db/pkg/db/model/instance.go
@@ -12,6 +12,7 @@ import (
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/db"
 	"github.com/NVIDIA/infra-controller-rest/db/pkg/db/paginator"
 	stracer "github.com/NVIDIA/infra-controller-rest/db/pkg/tracer"
+	cwssaws "github.com/NVIDIA/infra-controller-rest/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/google/uuid"
 
 	"github.com/uptrace/bun"
@@ -176,6 +177,25 @@ type Instance struct {
 	CreatedBy                              uuid.UUID                               `bun:"created_by,type:uuid,notnull"`
 	// Not for display, used by the query that sorts on machine capability type, specifically InfiniBand type
 	MCType string `bun:"mc_type,scanonly"`
+}
+
+// GetSiteID returns the Instance ID to use when communicating with the
+// Site: ControllerInstanceID when present, otherwise the Instance's own
+// ID. The Site treats both as opaque identifiers.
+func (i *Instance) GetSiteID() *uuid.UUID {
+	if i.ControllerInstanceID != nil {
+		return i.ControllerInstanceID
+	}
+	return &i.ID
+}
+
+// ToReleaseRequestProto builds the workflow request that asks a Site to
+// release (delete) this Instance. The handler may further set the
+// optional Issue field for break-fix flows after calling this.
+func (i *Instance) ToReleaseRequestProto() *cwssaws.InstanceReleaseRequest {
+	return &cwssaws.InstanceReleaseRequest{
+		Id: &cwssaws.InstanceId{Value: i.GetSiteID().String()},
+	}
 }
 
 // InstanceCreateInput input parameters for Create method

--- a/rest-api/db/pkg/db/model/instance_test.go
+++ b/rest-api/db/pkg/db/model/instance_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	otrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/proto"
 
@@ -3499,4 +3500,31 @@ func TestInstanceSQLDAO_UpdateMultiple_AllFields(t *testing.T) {
 	assert.Equal(t, InstanceStatusReady, updated.Status, "Status not updated")
 	assert.Equal(t, "on", *updated.PowerStatus, "PowerStatus not updated")
 	assert.True(t, updated.IsMissingOnSite, "IsMissingOnSite not updated")
+}
+
+func TestInstance_GetSiteID(t *testing.T) {
+	id := uuid.New()
+	ctrlID := uuid.New()
+	t.Run("falls back to ID when ControllerInstanceID is nil", func(t *testing.T) {
+		i := &Instance{ID: id}
+		got := i.GetSiteID()
+		require.NotNil(t, got)
+		assert.Equal(t, id, *got)
+	})
+	t.Run("uses ControllerInstanceID when set", func(t *testing.T) {
+		i := &Instance{ID: id, ControllerInstanceID: &ctrlID}
+		got := i.GetSiteID()
+		require.NotNil(t, got)
+		assert.Equal(t, ctrlID, *got)
+	})
+}
+
+func TestInstance_ToReleaseRequestProto(t *testing.T) {
+	id := uuid.New()
+	i := &Instance{ID: id}
+	req := i.ToReleaseRequestProto()
+	require.NotNil(t, req)
+	require.NotNil(t, req.Id)
+	assert.Equal(t, id.String(), req.Id.Value)
+	assert.Nil(t, req.Issue)
 }


### PR DESCRIPTION
## Description

Picks up the Instance release/delete flow as part of our proto-modeling work. This one has a pretty small scope -- the delete path has a very small client body (`Issue` / `IsRepairTenant`), so its request-based `ToProto` sits on the API request type. The other Instance flows (Create / Update / Batch) are all more involved and will be a separate PR.

Primary callouts are:
- API request side: `APIInstanceDeleteRequest.ToProto(instance)`, overlaying optional `Issue` / `IsRepairTenant` onto the entity-derived ID.
- Entity side: `Instance.GetSiteID()` and `Instance.ToReleaseRequestProto()`. The former replaces the `common.GetSiteInstanceID` helper.
- Handler keeps the `IsRepairTenant` authorization check, but no longer assembles proto sub-messages inline.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

