### PR TITLE
fix(rest-api): Populate RoutingProfileType directly from the controller value

### DIFF
--- a/rest-api/workflow/pkg/activity/tenant/tenant.go
+++ b/rest-api/workflow/pkg/activity/tenant/tenant.go
@@ -194,6 +194,10 @@ func (mt ManageTenant) CreateOrUpdateTenantOnSite(ctx context.Context, siteID uu
 		// Trigger apporpriate workflow on Site
 		updateTenantRequest := tenant.ToUpdateRequestProto()
 
+		// Populate the RoutingProfileType directly from what was sent from the controller
+		// until/unless we start storing this detail in the REST DB.
+		updateTenantRequest.RoutingProfileType = controllerTenant.RoutingProfileType
+
 		we, err := tc.ExecuteWorkflow(ctx, workflowOptions, "UpdateTenant", updateTenantRequest)
 		if err != nil {
 			logger.Error().Err(err).Str("Tenant ID", tenant.ID.String()).Msg("failed to trigger workflow to update Tenant")


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
we don't sync tenant routing profile details from core to rest.  Core expects full updates for objects (i.e., it expects all fields) and empty fields signal a "clear".   If a tenant change in the REST API triggers an update from the inventory processes, rest-api is sending tenant updates and not setting the profile field because it's not aware of it.  From core's pov, it's an attempt to change/clear the profile type, and it will be rejected if the tenant has VPCs.

This PR updates the inventory process to echo back the tenant routing profile until this becomes a new tenant model field in the REST API and is fully synced.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

