### PR TITLE
Fixes to facilitate move from dpf to non-dpf and vice versa

### DIFF
--- a/crates/admin-cli/src/dpf/enable/cmd.rs
+++ b/crates/admin-cli/src/dpf/enable/cmd.rs
@@ -19,7 +19,7 @@ use carbide_uuid::machine::MachineId;
 use rpc::admin_cli::OutputFormat;
 
 use crate::dpf::common::DpfQuery;
-use crate::errors::CarbideCliResult;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 pub async fn modify_dpf_state(
@@ -29,7 +29,20 @@ pub async fn modify_dpf_state(
     enabled: bool,
 ) -> CarbideCliResult<()> {
     let host: MachineId = query.try_into()?;
+
+    // Prevent disabling DPF if it was used for ingestion.
+    if !enabled {
+        let dpf_states = api_client.get_dpf_state(vec![host], 1).await?;
+        if dpf_states.iter().any(|s| s.used_for_ingestion) {
+            return Err(CarbideCliError::GenericError(
+                "Cannot disable DPF: machine was ingested via DPF. \
+                 Disabling would leave DPF CRDs in an inconsistent state."
+                    .to_string(),
+            ));
+        }
+    }
+
     api_client.modify_dpf_state(host, enabled).await?;
-    println!("DPF state modified for machine {host} with state {enabled} successfully!!",);
+    println!("DPF state modified for machine {host} with state {enabled} successfully!!");
     Ok(())
 }

--- a/crates/admin-cli/src/expected_machines/patch/args.rs
+++ b/crates/admin-cli/src/expected_machines/patch/args.rs
@@ -48,6 +48,7 @@ use crate::errors::CarbideCliError;
 "sku_id",
 "bmc_ip_address",
 "dpu_mode",
+"dpf_enabled",
 ])))]
 pub struct Args {
     #[clap(short = 'a', long, help = "BMC MAC Address of the expected machine")]
@@ -195,10 +196,11 @@ impl Args {
             && self.fallback_dpu_serial_numbers.is_none()
             && self.sku_id.is_none()
             && self.rack_id.is_none()
+            && self.dpf_enabled.is_none()
             && self.bmc_ip_address.is_none()
             && self.dpu_mode.is_none()
         {
-            return Err(CarbideCliError::GenericError("One of the following options must be specified: bmc-user-name and bmc-password or chassis-serial-number or fallback-dpu-serial-number or bmc-ip-address or dpu-mode".to_string()));
+            return Err(CarbideCliError::GenericError("One of the following options must be specified: bmc-user-name and bmc-password or chassis-serial-number or fallback-dpu-serial-number or bmc-ip-address or dpu-mode or dpf-enabled".to_string()));
         }
         if self
             .fallback_dpu_serial_numbers

--- a/crates/admin-cli/src/machine/force_delete/args.rs
+++ b/crates/admin-cli/src/machine/force_delete/args.rs
@@ -56,6 +56,13 @@ pub struct Args {
         help = "Delete machine with allocated instance. This flag acknowledges destroying the user instance as well."
     )]
     pub allow_delete_with_instance: bool,
+
+    #[clap(
+        long,
+        action,
+        help = "Delete machine even if DPF CRDs exist and DPF is disabled at the site level. This flag acknowledges that orphaned DPF resources may remain"
+    )]
+    pub allow_delete_with_orphaned_dpf_crds: bool,
 }
 
 impl From<&Args> for AdminForceDeleteMachineRequest {
@@ -65,6 +72,7 @@ impl From<&Args> for AdminForceDeleteMachineRequest {
             delete_interfaces: args.delete_interfaces,
             delete_bmc_interfaces: args.delete_bmc_interfaces,
             delete_bmc_credentials: args.delete_bmc_credentials,
+            allow_delete_with_orphaned_dpf_crds: args.allow_delete_with_orphaned_dpf_crds,
         }
     }
 }

--- a/crates/admin-cli/src/machine/tests.rs
+++ b/crates/admin-cli/src/machine/tests.rs
@@ -209,6 +209,7 @@ fn parse_force_delete() {
             assert_eq!(args.machine, TEST_MACHINE_ID);
             assert!(!args.delete_interfaces);
             assert!(!args.allow_delete_with_instance);
+            assert!(!args.allow_delete_with_orphaned_dpf_crds);
         }
         _ => panic!("expected ForceDelete variant"),
     }

--- a/crates/api-core/src/handlers/dpf.rs
+++ b/crates/api-core/src/handlers/dpf.rs
@@ -49,6 +49,14 @@ pub(crate) async fn modify_dpf_state(
             id: machine_id.to_string(),
         })?;
 
+    if !request.dpf_enabled && machine_snapshot.host_snapshot.dpf.used_for_ingestion {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "Cannot disable DPF for host {}: machine was ingested via DPF.",
+            machine_id
+        ))
+        .into());
+    }
+
     db::machine::modify_dpf_state(&mut txn, &machine_id, request.dpf_enabled).await?;
 
     // Keep DPUs also in sync.

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -419,6 +419,21 @@ pub(crate) async fn admin_force_delete_machine(
         response.instance_id = instance_id.to_string();
     }
 
+    if let Some(machine) = &host_machine
+        && machine.dpf.used_for_ingestion
+        && api.dpf_sdk.is_none()
+        && !request.allow_delete_with_orphaned_dpf_crds
+    {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "Failed force-delete host {}: DPF was used for ingestion \
+                    but DPF is not configured. Use \
+                    --allow-delete-with-orphaned-dpf-crds to proceed, \
+                    though this will require manual cleanup of DPF CRDs.",
+            machine.id
+        ))
+        .into());
+    }
+
     // So far we only inspected state - now we start the deletion process
     // TODO: In the new model we might just need to move one Machine to this state
     if let Some(host_machine) = &host_machine {

--- a/crates/api-core/src/tests/lldp.rs
+++ b/crates/api-core/src/tests/lldp.rs
@@ -104,6 +104,7 @@ async fn test_lldp_topology_force_delete(
                 delete_interfaces: true,
                 delete_bmc_interfaces: true,
                 delete_bmc_credentials: false,
+                allow_delete_with_orphaned_dpf_crds: false,
             },
         ))
         .await

--- a/crates/api-core/src/tests/machine_admin_force_delete.rs
+++ b/crates/api-core/src/tests/machine_admin_force_delete.rs
@@ -285,6 +285,7 @@ async fn force_delete(
             delete_interfaces: false,
             delete_bmc_interfaces: false,
             delete_bmc_credentials: false,
+            allow_delete_with_orphaned_dpf_crds: false,
         }))
         .await
         .unwrap()
@@ -715,6 +716,7 @@ async fn test_admin_force_delete_with_instance_type(pool: sqlx::PgPool) {
             delete_interfaces: false,
             delete_bmc_interfaces: false,
             delete_bmc_credentials: false,
+            allow_delete_with_orphaned_dpf_crds: false,
         }))
         .await
         .unwrap_err();

--- a/crates/api-core/src/tests/machine_history.rs
+++ b/crates/api-core/src/tests/machine_history.rs
@@ -198,6 +198,7 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
                 delete_interfaces: false,
                 delete_bmc_interfaces: false,
                 delete_bmc_credentials: false,
+                allow_delete_with_orphaned_dpf_crds: false,
             },
         ))
         .await

--- a/crates/api-web/src/tests/health.rs
+++ b/crates/api-web/src/tests/health.rs
@@ -72,6 +72,7 @@ async fn test_health_of_nonexisting_machine(pool: sqlx::PgPool) {
             delete_interfaces: false,
             delete_bmc_interfaces: false,
             delete_bmc_credentials: false,
+            allow_delete_with_orphaned_dpf_crds: false,
         }))
         .await
         .unwrap()

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -322,6 +322,7 @@ impl ApiClient {
                 delete_interfaces: true,
                 delete_bmc_interfaces: true,
                 delete_bmc_credentials: false,
+                allow_delete_with_orphaned_dpf_crds: false,
             })
             .await
             .map_err(ClientApiError::InvocationError)

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -400,6 +400,7 @@ fn handle_dpf_device_ready(
 async fn handle_dpf_reprovisioning(
     state: &ManagedHostStateSnapshot,
     dpu_snapshot: &Machine,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     dpf_sdk: &dyn DpfOperations,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
@@ -419,7 +420,12 @@ async fn handle_dpf_reprovisioning(
             DpfState::WaitingForReady { phase_detail: None },
             state,
         )?;
-        return Ok(StateHandlerOutcome::transition(next));
+
+        let outcome = StateHandlerOutcome::transition(next);
+        let mut txn = ctx.services.db_pool.begin().await?;
+        db::machine::mark_machine_ingestion_done_with_dpf(&mut txn, &state.host_snapshot.id)
+            .await?;
+        return Ok(outcome.with_txn(txn));
     }
 
     tracing::info!("DPF initiate reprovision of DPU {}", dpu_snapshot.id);
@@ -481,7 +487,9 @@ pub async fn handle_dpf_state(
             handle_dpf_waiting_for_ready(state, dpu_snapshot, phase_detail, ctx, dpf_sdk).await
         }
         DpfState::DeviceReady => handle_dpf_device_ready(state),
-        DpfState::Reprovisioning => handle_dpf_reprovisioning(state, dpu_snapshot, dpf_sdk).await,
+        DpfState::Reprovisioning => {
+            handle_dpf_reprovisioning(state, dpu_snapshot, ctx, dpf_sdk).await
+        }
         DpfState::Unknown => {
             tracing::warn!(dpu_id = %dpu_snapshot.id, "unknown DPF state in DB, transitioning to provisioning");
             let next = set_one_dpu_dpf_state(state, &dpu_snapshot.id, DpfState::Provisioning)?;

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4398,6 +4398,9 @@ message AdminForceDeleteMachineRequest {
   // Should we delete the BMC credentials? Please note, this will depend on if site explore configured
   // credentials for this machine.
   bool delete_bmc_credentials = 4;
+
+  // Allow force delete of machine with orphaned dpf crds
+  bool allow_delete_with_orphaned_dpf_crds = 5;
 }
 
 // Response to AdminForceDeleteMachine call


### PR DESCRIPTION
## Description
   - sets used_for_ingestion true during reprovisioning
   - admin-cli dpf disable should only work if host is not ingested via dpf
   - Fix expected-machine patch to be able to patch with only the mandatory parameter
   - Disable force-delete of the host if dpf is not enabled unless we specify the option to allow orphaned dpf crds

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

[dpf_fixes.txt](https://github.com/user-attachments/files/28533513/dpf_fixes.txt)
