### PR TITLE
chore(docs): Fix link type in IB docs

### DIFF
--- a/docs/architecture/infiniband/nic_selection.md
+++ b/docs/architecture/infiniband/nic_selection.md
@@ -56,10 +56,11 @@ While the devices for the 2 ports seem mostly independent, there are still a few
     This breaks the illusion of 2 independent devices. Since the tenant can install and use those tools without the availability of a NIC firmware lockdown, they are able to inspect these properties. There however doesn't seem to be an obvious problem with it.
 3. Due to 2), the port configurations for both ports are performed by manipulating a single device object in the Mellanox Firmware tools. E.g. both of the following commands
     ```
-    mlxconfig -d /dev/mst/mt4123_pciconf0 set LINK_TYPE_P1=2 LINK_TYPE_P2=2
-    mlxconfig -d /dev/mst/mt4123_pciconf0.1 set LINK_TYPE_P1=2 LINK_TYPE_P2=2
+    mlxconfig -d /dev/mst/mt4123_pciconf0 set LINK_TYPE_P1=1 LINK_TYPE_P2=1
+    mlxconfig -d /dev/mst/mt4123_pciconf0.1 set LINK_TYPE_P1=1 LINK_TYPE_P2=1
     ```
-    reconfigure both ports of a physical card from ethernet to infiniband, independent of whether the target
+    reconfigure both ports of a physical card from ethernet to infiniband (`LINK_TYPE=2` configures
+    ethernet, `LINK_TYPE=1` configures infiniband), independent of whether the target
     device is the first port (`/dev/mst/mt4123_pciconf0` or 2nd port `/dev/mst/mt4123_pciconf0.1`).
 
     The same applies also for settings like `NUM_OF_VFS` and `SRIOV_EN`.


### PR DESCRIPTION
## Description

Fixing ib mlxconfig docs where the link-type description is backwards.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

