### PR TITLE
Otel transceiver fix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1058,6 +1058,22 @@ jobs:
       load: false
     secrets: inherit
 
+  build-bluefield-transceiver-exporter:
+    needs:
+      - prepare
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      dockerfile_path: bluefield/containers/transceiver-exporter/Dockerfile
+      context_path: .
+      image_name: nvcr.io/0837451325059433/carbide-dev/transceiver-exporter
+      image_tag: ${{ needs.prepare.outputs.version }}
+      platforms: linux/arm64
+      runner: linux-arm64-cpu4
+      push: ${{ !contains(github.ref, 'pull-request/') }}
+      load: false
+    secrets: inherit
+
   download-mft-aarch64:
     needs:
       - prepare
@@ -1273,6 +1289,7 @@ jobs:
       - build-release-artifacts-arm-host
       - build-bluefield-binaries
       - build-bluefield-otelcol-contrib
+      - build-bluefield-transceiver-exporter
       - build-bluefield-forge-dpu-agent
       - build-bluefield-forge-dhcp-server
       - build-bluefield-carbide-fmds
@@ -1376,6 +1393,7 @@ jobs:
       - build-release-artifacts-arm-host
       - build-bluefield-binaries
       - build-bluefield-otelcol-contrib
+      - build-bluefield-transceiver-exporter
       - build-bluefield-forge-dpu-agent
       - build-bluefield-forge-dhcp-server
       - build-bluefield-carbide-fmds

--- a/bluefield/charts/nico-otelcol/templates/daemonset.yaml
+++ b/bluefield/charts/nico-otelcol/templates/daemonset.yaml
@@ -140,6 +140,34 @@ spec:
               mountPath: /host/root
               mountPropagation: HostToContainer
               readOnly: true
+        - name: transceiver-exporter
+          image: "{{ .Values.transceiverExporter.image.repository }}:{{ .Values.transceiverExporter.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.transceiverExporter.image.pullPolicy }}
+          args:
+            # Bind to loopback only: the collector scrapes localhost:{{ .Values.transceiverExporter.port }}
+            # from within this (hostNetwork) pod, and we don't want the exporter
+            # reachable on the host's external interfaces.
+            - -web.listen-address=127.0.0.1:{{ .Values.transceiverExporter.port }}
+            # Optic/DOM metrics only; the interface-features collector is noisy
+            # and not consumed downstream (matches the host systemd unit).
+            - -collector.interface-features.enable=false
+          {{- with .Values.transceiverExporter.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          # Reads module EEPROM/DOM data via ethtool netlink over the host
+          # network namespace (hostNetwork), which requires CAP_NET_ADMIN.
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_ADMIN
+                - NET_RAW
       volumes:
         - name: config
           configMap:

--- a/bluefield/charts/nico-otelcol/tests/transceiver_exporter_test.yaml
+++ b/bluefield/charts/nico-otelcol/tests/transceiver_exporter_test.yaml
@@ -1,0 +1,121 @@
+suite: transceiver-exporter sidecar
+templates:
+  - daemonset.yaml
+tests:
+  - it: should add the transceiver-exporter sidecar with the default image
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: v1.2.3
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[2].name
+          value: transceiver-exporter
+      # tag defaults to the otelcol-contrib image tag when unset
+      - equal:
+          path: spec.template.spec.containers[2].image
+          value: nvcr.io/0837451325059433/carbide-dev/transceiver-exporter:v1.2.3
+
+  - it: should fall back to chart appVersion when no tag is set anywhere
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[2].image
+          value: nvcr.io/0837451325059433/carbide-dev/transceiver-exporter:0.1.0
+
+  - it: should bind transceiver-exporter to loopback on the configured port
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[2].args
+          content: -web.listen-address=127.0.0.1:9300
+      - contains:
+          path: spec.template.spec.containers[2].args
+          content: -collector.interface-features.enable=false
+
+  - it: should honor a custom transceiver-exporter port and image
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+      transceiverExporter:
+        image:
+          repository: mirror.example.com/transceiver-exporter
+          tag: v9.9.9
+          pullPolicy: Always
+        port: 19300
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[2].image
+          value: mirror.example.com/transceiver-exporter:v9.9.9
+      - equal:
+          path: spec.template.spec.containers[2].imagePullPolicy
+          value: Always
+      - contains:
+          path: spec.template.spec.containers[2].args
+          content: -web.listen-address=127.0.0.1:19300
+
+  - it: should run transceiver-exporter as root with only NET_ADMIN/NET_RAW
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[2].securityContext.runAsUser
+          value: 0
+      - equal:
+          path: spec.template.spec.containers[2].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[2].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[2].securityContext.capabilities.add
+          content: NET_ADMIN
+      - contains:
+          path: spec.template.spec.containers[2].securityContext.capabilities.add
+          content: NET_RAW
+      - contains:
+          path: spec.template.spec.containers[2].securityContext.capabilities.drop
+          content: ALL
+
+  - it: should omit transceiver-exporter resources by default
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[2].resources
+
+  - it: should render transceiver-exporter resources when set
+    template: daemonset.yaml
+    set:
+      image:
+        repository: test
+        tag: test
+      transceiverExporter:
+        resources:
+          limits:
+            memory: 64Mi
+          requests:
+            cpu: 50m
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[2].resources.limits.memory
+          value: 64Mi
+      - equal:
+          path: spec.template.spec.containers[2].resources.requests.cpu
+          value: 50m

--- a/bluefield/charts/nico-otelcol/values.yaml
+++ b/bluefield/charts/nico-otelcol/values.yaml
@@ -36,6 +36,21 @@ nodeExporter:
   # Must match the prometheus/node scrape target (localhost:9200) in otel_config.yaml.
   port: 9200
   resources: {}
+# transceiver-exporter sidecar: provides optical transceiver (DOM) metrics
+# scraped by the prometheus/transceiver receiver in otel_config.yaml at
+# localhost:<port>. It binds to loopback only, so it is never exposed on the
+# host's external interfaces. Unlike node-exporter there is no public image, so
+# it is built from the wobcom transceiver-exporter release and published
+# alongside otelcol-contrib (see bluefield/containers/transceiver-exporter).
+transceiverExporter:
+  image:
+    repository: nvcr.io/0837451325059433/carbide-dev/transceiver-exporter
+    # Defaults to the otelcol-contrib image tag (built in the same CI run).
+    tag: ""
+    pullPolicy: IfNotPresent
+  # Must match the prometheus/transceiver scrape target (localhost:9300) in otel_config.yaml.
+  port: 9300
+  resources: {}
 imagePullSecrets: []
 podSecurityContext: {}
 securityContext:

--- a/bluefield/containers/transceiver-exporter/Dockerfile
+++ b/bluefield/containers/transceiver-exporter/Dockerfile
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sidecar image for the wobcom transceiver-exporter, scraped by the
+# prometheus/transceiver receiver in the nico-otelcol collector. There is no
+# upstream container image, so we package the published arm64 release binary
+# (the same artifact the forge-dpu .deb installs as a host systemd service).
+#
+# Keep TRANSCEIVER_VERSION in sync with bluefield/transceiver_exporter/version.txt.
+
+ARG TRANSCEIVER_VERSION=1.5.0
+
+# ---------------------------------------------------------------------------
+# Downloader: fetch and extract the release tarball
+# ---------------------------------------------------------------------------
+FROM debian:12-slim AS downloader
+
+ARG TRANSCEIVER_VERSION
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /dl
+# The release tarball holds the binary and LICENSE.md at the top level (no
+# nested directory), matching the download-transceiver-exporter Make task.
+RUN wget -q --tries=5 --timeout=300 \
+        "https://github.com/wobcom/transceiver-exporter/releases/download/v${TRANSCEIVER_VERSION}/transceiver-exporter-v${TRANSCEIVER_VERSION}-linux-arm64.tar.gz" \
+        -O transceiver-exporter.tar.gz \
+    && mkdir -p extract \
+    && tar xzf transceiver-exporter.tar.gz -C extract \
+    && rm transceiver-exporter.tar.gz
+
+# ---------------------------------------------------------------------------
+# Runtime (arm64)
+# ---------------------------------------------------------------------------
+FROM debian:12-slim
+
+COPY --from=downloader --chmod=755 /dl/extract/transceiver-exporter /usr/bin/transceiver-exporter
+COPY --from=downloader /dl/extract/LICENSE.md /usr/share/licenses/transceiver-exporter/LICENSE.md
+
+ENTRYPOINT ["/usr/bin/transceiver-exporter"]

--- a/bluefield/containers/transceiver-exporter/Dockerfile
+++ b/bluefield/containers/transceiver-exporter/Dockerfile
@@ -22,6 +22,15 @@
 
 ARG TRANSCEIVER_VERSION=1.5.0
 
+# Runtime base, matching the other bluefield images (carbide-fmds,
+# forge-dhcp-server, forge-dpu-agent). Declared before the first FROM so the
+# values are in scope for the runtime stage's FROM below.
+ARG CC_VERSION=v3.2.1 # NVIDIA Distroless Container version
+ARG TAG=${CC_VERSION}
+ARG IMG=nvcr.io/nvidia/distroless/cc
+ARG DEBUG_DISTROLESS=true
+ARG DISTROLESS_DEBUG_TAG=${DEBUG_DISTROLESS:+"dev"} # 'dev' provides a busybox shell
+
 # ---------------------------------------------------------------------------
 # Downloader: fetch and extract the release tarball
 # ---------------------------------------------------------------------------
@@ -45,9 +54,10 @@ RUN wget -q --tries=5 --timeout=300 \
     && rm transceiver-exporter.tar.gz
 
 # ---------------------------------------------------------------------------
-# Runtime (arm64)
+# Runtime (arm64) — NVIDIA Distroless Container
 # ---------------------------------------------------------------------------
-FROM debian:12-slim
+# NVIDIA Distroless Container
+FROM --platform=linux/arm64 ${IMG}:${TAG}-${DISTROLESS_DEBUG_TAG}
 
 COPY --from=downloader --chmod=755 /dl/extract/transceiver-exporter /usr/bin/transceiver-exporter
 COPY --from=downloader /dl/extract/LICENSE.md /usr/share/licenses/transceiver-exporter/LICENSE.md


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
Add a transceiver-exporter sidecar mirroring the node-exporter one. There
is no upstream container image, so package the wobcom release binary (the
same artifact the forge-dpu .deb installs) into a new arm64 image built and
pushed by CI alongside otelcol-contrib. The sidecar binds 127.0.0.1:9300
(loopback only), runs as root with just NET_ADMIN/NET_RAW to read module
EEPROM/DOM via ethtool netlink over the host netns, and defaults its image
tag to the otelcol-contrib tag built in the same CI run.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

