### PR TITLE
fix: Auto-restart DPU when site explorer hits missing HostPrivilegeLevel

### DIFF
--- a/crates/api-core/src/tests/common/api_fixtures/dpu.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/dpu.rs
@@ -265,6 +265,7 @@ impl From<DpuConfig> for EndpointExplorationReport {
             physical_slot_number: None,
             revision_id: None,
             topology_id: None,
+            remediation_error: None,
         }
     }
 }

--- a/crates/api-core/src/tests/common/api_fixtures/managed_host.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/managed_host.rs
@@ -353,6 +353,7 @@ impl From<ManagedHostConfig> for EndpointExplorationReport {
             compute_tray_index: None,
             revision_id: None,
             topology_id: None,
+            remediation_error: None,
         }
     }
 }

--- a/crates/api-core/src/tests/common/endpoint.rs
+++ b/crates/api-core/src/tests/common/endpoint.rs
@@ -148,5 +148,6 @@ fn build_exploration_report(
         physical_slot_number: None,
         revision_id: None,
         topology_id: None,
+        remediation_error: None,
     }
 }

--- a/crates/api-core/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api-core/src/tests/host_bmc_firmware_test.rs
@@ -438,6 +438,7 @@ fn build_exploration_report(
         physical_slot_number: None,
         revision_id: None,
         topology_id: None,
+        remediation_error: None,
     };
     report.model = report.model();
     report

--- a/crates/api-core/src/tests/site_explorer.rs
+++ b/crates/api-core/src/tests/site_explorer.rs
@@ -552,6 +552,7 @@ async fn test_site_explorer_main(pool: sqlx::PgPool) -> Result<(), Box<dyn std::
                 physical_slot_number: None,
                 revision_id: None,
                 topology_id: None,
+                remediation_error: None,
             }),
         ),
     ]);
@@ -1235,6 +1236,7 @@ async fn test_site_explorer_audit_exploration_results(
                 physical_slot_number: None,
                 revision_id: None,
                 topology_id: None,
+                remediation_error: None,
             },
         ),
         (
@@ -1265,6 +1267,7 @@ async fn test_site_explorer_audit_exploration_results(
                 physical_slot_number: None,
                 revision_id: None,
                 topology_id: None,
+                remediation_error: None,
             },
         ),
         (
@@ -1290,6 +1293,7 @@ async fn test_site_explorer_audit_exploration_results(
                 physical_slot_number: None,
                 revision_id: None,
                 topology_id: None,
+                remediation_error: None,
             },
         ),
         (
@@ -1319,6 +1323,7 @@ async fn test_site_explorer_audit_exploration_results(
                 physical_slot_number: None,
                 revision_id: None,
                 topology_id: None,
+                remediation_error: None,
             },
         ),
         (
@@ -3174,6 +3179,7 @@ async fn test_expected_machine_device_type_metrics(
                 physical_slot_number: None,
                 revision_id: None,
                 topology_id: None,
+                remediation_error: None,
             }),
         ),
         (
@@ -3199,6 +3205,7 @@ async fn test_expected_machine_device_type_metrics(
                 physical_slot_number: None,
                 revision_id: None,
                 topology_id: None,
+                remediation_error: None,
             }),
         ),
         (
@@ -3224,6 +3231,7 @@ async fn test_expected_machine_device_type_metrics(
                 physical_slot_number: None,
                 revision_id: None,
                 topology_id: None,
+                remediation_error: None,
             }),
         ),
     ]);
@@ -3377,6 +3385,7 @@ async fn test_site_explorer_power_shelf_discovery(
             physical_slot_number: None,
             revision_id: None,
             topology_id: None,
+            remediation_error: None,
         }),
     );
 
@@ -3533,6 +3542,7 @@ async fn test_site_explorer_switch_discovery(
             physical_slot_number: None,
             revision_id: None,
             topology_id: None,
+            remediation_error: None,
         }),
     );
 
@@ -3681,6 +3691,7 @@ async fn test_site_explorer_power_shelf_with_expected_config(
             physical_slot_number: None,
             revision_id: None,
             topology_id: None,
+            remediation_error: None,
         }),
     );
 
@@ -3834,6 +3845,7 @@ async fn test_site_explorer_power_shelf_creation_limit(
                 physical_slot_number: None,
                 revision_id: None,
                 topology_id: None,
+                remediation_error: None,
             }),
         );
     }
@@ -3969,6 +3981,7 @@ async fn test_site_explorer_power_shelf_disabled(
             physical_slot_number: None,
             revision_id: None,
             topology_id: None,
+            remediation_error: None,
         }),
     );
 
@@ -4231,6 +4244,7 @@ async fn test_site_explorer_creates_power_shelf(
         physical_slot_number: None,
         revision_id: None,
         topology_id: None,
+        remediation_error: None,
     };
 
     let explored_endpoint = ExploredEndpoint {
@@ -4422,6 +4436,7 @@ async fn test_power_shelf_state_history(
         physical_slot_number: None,
         revision_id: None,
         topology_id: None,
+        remediation_error: None,
     };
 
     let explored_endpoint = ExploredEndpoint {
@@ -4648,6 +4663,7 @@ async fn test_power_shelf_state_history_multiple(
         physical_slot_number: None,
         revision_id: None,
         topology_id: None,
+        remediation_error: None,
     };
 
     let exploration_report2 = EndpointExplorationReport {
@@ -4677,6 +4693,7 @@ async fn test_power_shelf_state_history_multiple(
         physical_slot_number: None,
         revision_id: None,
         topology_id: None,
+        remediation_error: None,
     };
 
     let explored_endpoint1 = ExploredEndpoint {
@@ -4933,6 +4950,7 @@ async fn test_power_shelf_state_history_error_handling(
         physical_slot_number: None,
         revision_id: None,
         topology_id: None,
+        remediation_error: None,
     };
 
     let explored_endpoint = ExploredEndpoint {
@@ -5141,6 +5159,7 @@ async fn test_site_explorer_power_shelf_discovery_with_static_ip(
             physical_slot_number: None,
             revision_id: None,
             topology_id: None,
+            remediation_error: None,
         }),
     );
 

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -117,6 +117,10 @@ pub struct EndpointExplorationReport {
     // Merged from multiple chassis entries
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revision_id: Option<i32>,
+    /// Transient remediation error detected during an otherwise successful exploration.
+    /// Not persisted; used to trigger Site Explorer auto-remediation in the same run.
+    #[serde(skip, default)]
+    pub remediation_error: Option<EndpointExplorationError>,
 }
 
 impl EndpointExplorationReport {
@@ -675,6 +679,7 @@ impl EndpointExplorationReport {
             compute_tray_index: None,
             topology_id: None,
             revision_id: None,
+            remediation_error: None,
         }
     }
 

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -1789,6 +1789,7 @@ mod tests {
             compute_tray_index: None,
             revision_id: None,
             topology_id: None,
+            remediation_error: None,
         };
 
         let inventory_map = report.get_inventory_map();
@@ -1858,6 +1859,7 @@ mod tests {
             compute_tray_index: None,
             revision_id: None,
             topology_id: None,
+            remediation_error: None,
         };
         report
             .generate_machine_id(false)

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -249,6 +249,7 @@ pub async fn nv_generate_exploration_report<B: Bmc>(
         compute_tray_index: None,
         topology_id: None,
         revision_id: None,
+        remediation_error: None,
     })
 }
 

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -3737,10 +3737,10 @@ impl DpuMachineStateHandler {
                         if carbide_redfish::libredfish::dpu_bios::is_dpu_bios_attributes_not_ready(&e) =>
                     {
                         let msg = format!(
-                            "DPU {} BIOS attributes not ready while polling BIOS setup (known UEFI POST/BMC race); issuing force-restart. err: {e}",
+                            "DPU {} BIOS attributes not ready ({e}); issuing a force-restart to mitigate the known UEFI POST/BMC race",
                             dpu_snapshot.id
                         );
-                        tracing::warn!(msg);
+                        tracing::warn!("{msg}");
                         let reboot_status = trigger_reboot_if_needed(
                             dpu_snapshot,
                             state,

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -3733,6 +3733,28 @@ impl DpuMachineStateHandler {
                         "Polling BIOS setup status, waiting for settings to be applied on DPU {}",
                         dpu_snapshot.id
                     ))),
+                    Err(e)
+                        if carbide_redfish::libredfish::dpu_bios::is_dpu_bios_attributes_not_ready(&e) =>
+                    {
+                        let msg = format!(
+                            "DPU {} BIOS attributes not ready while polling BIOS setup (known UEFI POST/BMC race); issuing force-restart. err: {e}",
+                            dpu_snapshot.id
+                        );
+                        tracing::warn!(msg);
+                        let reboot_status = trigger_reboot_if_needed(
+                            dpu_snapshot,
+                            state,
+                            None,
+                            &self.reachability_params,
+                            ctx,
+                        )
+                        .await?;
+
+                        Ok(StateHandlerOutcome::wait(format!(
+                            "{msg};\nWaiting for DPU {} to reboot: {reboot_status:#?}",
+                            dpu_snapshot.id
+                        )))
+                    }
                     Err(e) => {
                         tracing::warn!(
                             dpu_id = %dpu_snapshot.id,

--- a/crates/redfish/src/libredfish/dpu_bios.rs
+++ b/crates/redfish/src/libredfish/dpu_bios.rs
@@ -36,13 +36,6 @@ pub fn is_dpu_bios_attributes_not_ready(error: &RedfishError) -> bool {
     }
 }
 
-pub fn dpu_bios_attributes_not_ready_message(error: &RedfishError) -> String {
-    format!(
-        "DPU BMC BIOS attributes not ready ({error}). \
-         This is a known race between UEFI POST and the BMC; force-restarting the DPU usually resolves it."
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/redfish/src/libredfish/dpu_bios.rs
+++ b/crates/redfish/src/libredfish/dpu_bios.rs
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use libredfish::RedfishError;
+
+const DPU_BIOS_ATTRIBUTE_KEYS: [&str; 4] = [
+    "HostPrivilegeLevel",
+    "Host Privilege Level",
+    "InternalCPUModel",
+    "Internal CPU Model",
+];
+
+/// Returns true when a DPU BMC BIOS response is missing attributes that are expected
+/// once UEFI POST has finished. This is a known race between UEFI POST and the BMC;
+/// force-restarting the DPU usually resolves it.
+pub fn is_dpu_bios_attributes_not_ready(error: &RedfishError) -> bool {
+    match error {
+        RedfishError::MissingKey { key, url } => {
+            url.contains("Bios") && DPU_BIOS_ATTRIBUTE_KEYS.contains(&key.as_str())
+        }
+        _ => false,
+    }
+}
+
+pub fn dpu_bios_attributes_not_ready_message(error: &RedfishError) -> String {
+    format!(
+        "DPU BMC BIOS attributes not ready ({error}). \
+         This is a known race between UEFI POST and the BMC; force-restarting the DPU usually resolves it."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_missing_host_privilege_level() {
+        let error = RedfishError::MissingKey {
+            key: "HostPrivilegeLevel".to_string(),
+            url: "Systems/{}/Bios".to_string(),
+        };
+        assert!(is_dpu_bios_attributes_not_ready(&error));
+    }
+
+    #[test]
+    fn ignores_missing_keys_outside_bios() {
+        let error = RedfishError::MissingKey {
+            key: "HostPrivilegeLevel".to_string(),
+            url: "Systems/{}/BootOptions".to_string(),
+        };
+        assert!(!is_dpu_bios_attributes_not_ready(&error));
+    }
+}

--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -19,6 +19,7 @@ mod implementation;
 
 pub mod auth;
 pub mod conv;
+pub mod dpu_bios;
 pub mod error;
 #[cfg(feature = "test-support")]
 pub mod test_support;

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -1817,7 +1817,12 @@ impl SiteExplorer {
                 .endpoint_exploration_duration
                 .push(exploration_duration);
             match &result {
-                Ok(_) => metrics.endpoint_explorations_success += 1,
+                Ok(report) => {
+                    metrics.endpoint_explorations_success += 1;
+                    if let Some(e) = &report.remediation_error {
+                        redfish_error = Some(e.clone());
+                    }
+                }
                 Err(e) => {
                     *metrics
                         .endpoint_explorations_failures_by_type

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -23,9 +23,7 @@ use std::time::Duration;
 
 use carbide_network::deserialize_input_mac_to_address;
 use carbide_redfish::libredfish::conv::{IntoModel, bmc_vendor};
-use carbide_redfish::libredfish::dpu_bios::{
-    dpu_bios_attributes_not_ready_message, is_dpu_bios_attributes_not_ready,
-};
+use carbide_redfish::libredfish::dpu_bios::is_dpu_bios_attributes_not_ready;
 use carbide_redfish::libredfish::{
     RedfishAuth, RedfishClientCreationError, RedfishClientPool, redact_password,
 };
@@ -319,14 +317,14 @@ impl RedfishClient {
         {
             Ok(status) => (Some(status), None),
             Err(error) if is_dpu && is_dpu_bios_attributes_not_ready(&error) => {
-                tracing::warn!(
-                    %error,
-                    "DPU BMC BIOS attributes not ready while fetching machine setup status; scheduling a force-restart to mitigate the known UEFI POST/BMC race"
+                let details = format!(
+                    "DPU BMC BIOS attributes not ready ({error}); scheduling a force-restart to mitigate the known UEFI POST/BMC race"
                 );
+                tracing::warn!("{details}");
                 (
                     None,
                     Some(EndpointExplorationError::InvalidDpuRedfishBiosResponse {
-                        details: dpu_bios_attributes_not_ready_message(&error),
+                        details,
                         response_body: None,
                         response_code: None,
                     }),

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -311,30 +311,32 @@ impl RedfishClient {
             .await
             .map_err(map_redfish_error)?;
         let is_dpu = system.id.to_lowercase().contains("bluefield");
-        let (machine_setup_status, remediation_error) =
-            match fetch_machine_setup_status(client.as_ref(), boot_interface_mac).await {
-                Ok(status) => (Some(status), None),
-                Err(error)
-                    if is_dpu && is_dpu_bios_attributes_not_ready(&error) =>
-                {
-                    tracing::warn!(
-                        %error,
-                        "DPU BMC BIOS attributes not ready while fetching machine setup status; scheduling a force-restart to mitigate the known UEFI POST/BMC race"
-                    );
-                    (
-                        None,
-                        Some(EndpointExplorationError::InvalidDpuRedfishBiosResponse {
-                            details: dpu_bios_attributes_not_ready_message(&error),
-                            response_body: None,
-                            response_code: None,
-                        }),
-                    )
-                }
-                Err(error) => {
-                    tracing::warn!(%error, "Failed to fetch machine setup status.");
-                    (None, None)
-                }
-            };
+        let (machine_setup_status, remediation_error) = match fetch_machine_setup_status(
+            client.as_ref(),
+            boot_interface_mac,
+        )
+        .await
+        {
+            Ok(status) => (Some(status), None),
+            Err(error) if is_dpu && is_dpu_bios_attributes_not_ready(&error) => {
+                tracing::warn!(
+                    %error,
+                    "DPU BMC BIOS attributes not ready while fetching machine setup status; scheduling a force-restart to mitigate the known UEFI POST/BMC race"
+                );
+                (
+                    None,
+                    Some(EndpointExplorationError::InvalidDpuRedfishBiosResponse {
+                        details: dpu_bios_attributes_not_ready_message(&error),
+                        response_body: None,
+                        response_code: None,
+                    }),
+                )
+            }
+            Err(error) => {
+                tracing::warn!(%error, "Failed to fetch machine setup status.");
+                (None, None)
+            }
+        };
 
         let secure_boot_status = fetch_secure_boot_status(client.as_ref())
             .await

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -23,6 +23,9 @@ use std::time::Duration;
 
 use carbide_network::deserialize_input_mac_to_address;
 use carbide_redfish::libredfish::conv::{IntoModel, bmc_vendor};
+use carbide_redfish::libredfish::dpu_bios::{
+    dpu_bios_attributes_not_ready_message, is_dpu_bios_attributes_not_ready,
+};
 use carbide_redfish::libredfish::{
     RedfishAuth, RedfishClientCreationError, RedfishClientPool, redact_password,
 };
@@ -307,10 +310,31 @@ impl RedfishClient {
         let service = fetch_service(client.as_ref())
             .await
             .map_err(map_redfish_error)?;
-        let machine_setup_status = fetch_machine_setup_status(client.as_ref(), boot_interface_mac)
-            .await
-            .inspect_err(|error| tracing::warn!(%error, "Failed to fetch machine setup status."))
-            .ok();
+        let is_dpu = system.id.to_lowercase().contains("bluefield");
+        let (machine_setup_status, remediation_error) =
+            match fetch_machine_setup_status(client.as_ref(), boot_interface_mac).await {
+                Ok(status) => (Some(status), None),
+                Err(error)
+                    if is_dpu && is_dpu_bios_attributes_not_ready(&error) =>
+                {
+                    tracing::warn!(
+                        %error,
+                        "DPU BMC BIOS attributes not ready while fetching machine setup status; scheduling a force-restart to mitigate the known UEFI POST/BMC race"
+                    );
+                    (
+                        None,
+                        Some(EndpointExplorationError::InvalidDpuRedfishBiosResponse {
+                            details: dpu_bios_attributes_not_ready_message(&error),
+                            response_body: None,
+                            response_code: None,
+                        }),
+                    )
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "Failed to fetch machine setup status.");
+                    (None, None)
+                }
+            };
 
         let secure_boot_status = fetch_secure_boot_status(client.as_ref())
             .await
@@ -349,6 +373,7 @@ impl RedfishClient {
             compute_tray_index: None,
             topology_id: None,
             revision_id: None,
+            remediation_error,
         })
     }
 

--- a/docs/manuals/metrics/core_metrics.md
+++ b/docs/manuals/metrics/core_metrics.md
@@ -40,6 +40,8 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_hosts_health_overrides_count</td><td>gauge</td><td>The amount of health overrides that are configured in the site</td></tr>
 <tr><td>carbide_hosts_health_status_count</td><td>gauge</td><td>The total number of Managed Hosts in the system that have reported either a healthy or not healthy status - based on the presence of health probe alerts</td></tr>
 <tr><td>carbide_hosts_in_use_count</td><td>gauge</td><td>The total number of hosts that are actively used by tenants as instances in the NICo deployment</td></tr>
+<tr><td>carbide_hosts_unhealthy_by_classification_count</td><td>gauge</td><td>The amount of objects which are marked with a certain classification due to being unhealthy</td></tr>
+<tr><td>carbide_hosts_unhealthy_by_probe_id_count</td><td>gauge</td><td>The amount of objects which reported a certain Health Probe Alert</td></tr>
 <tr><td>carbide_hosts_usable_count</td><td>gauge</td><td>The remaining number of hosts in the NICo deployment which are available for immediate instance creation</td></tr>
 <tr><td>carbide_hosts_with_bios_password_set</td><td>gauge</td><td>The total number of Hosts in the system that have their BIOS password set.</td></tr>
 <tr><td>carbide_ib_partitions_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_ib_partitions in the system</td></tr>

--- a/docs/manuals/metrics/core_metrics.md
+++ b/docs/manuals/metrics/core_metrics.md
@@ -40,8 +40,6 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_hosts_health_overrides_count</td><td>gauge</td><td>The amount of health overrides that are configured in the site</td></tr>
 <tr><td>carbide_hosts_health_status_count</td><td>gauge</td><td>The total number of Managed Hosts in the system that have reported either a healthy or not healthy status - based on the presence of health probe alerts</td></tr>
 <tr><td>carbide_hosts_in_use_count</td><td>gauge</td><td>The total number of hosts that are actively used by tenants as instances in the NICo deployment</td></tr>
-<tr><td>carbide_hosts_unhealthy_by_classification_count</td><td>gauge</td><td>The amount of objects which are marked with a certain classification due to being unhealthy</td></tr>
-<tr><td>carbide_hosts_unhealthy_by_probe_id_count</td><td>gauge</td><td>The amount of objects which reported a certain Health Probe Alert</td></tr>
 <tr><td>carbide_hosts_usable_count</td><td>gauge</td><td>The remaining number of hosts in the NICo deployment which are available for immediate instance creation</td></tr>
 <tr><td>carbide_hosts_with_bios_password_set</td><td>gauge</td><td>The total number of Hosts in the system that have their BIOS password set.</td></tr>
 <tr><td>carbide_ib_partitions_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_ib_partitions in the system</td></tr>


### PR DESCRIPTION
## Description
Automates remediation when Site Explorer probes a DPU BMC and `machine_setup_status` fails because the `HostPrivilegeLevel` BIOS attribute is missing (this is a known UEFI POST/BMC race during host ingestion).

Upon detection, Site Explorer logs a clearer message, queues existing DPU BIOS remediation, and then issues a Redfish `ForceRestart` instead of requiring manual `curl`. Also handles the same error in `DpuInit` / `PollingBiosSetup` so ingestion does not retry indefinitely.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
- An auto-restart may be skipped if remediation is paused or credentials are unavailable, as well as if a recent reboot/BMC reset is within the cooldown window.


