### PR TITLE
chore(macros): remove unused dependencies from crate

### DIFF
--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -26,23 +26,10 @@ name = "carbide_macros"
 proc-macro = true
 
 [dependencies]
-sqlx = { workspace = true, features = [
-  "runtime-tokio",
-  "tls-rustls",
-  "mac_address",
-  "ipnetwork",
-  "uuid",
-  "migrate",
-  "postgres",
-  "chrono",
-  "macros",
-  "json",
-] }
+proc-macro2 = { workspace = true, features = ["proc-macro"] }
+quote = { workspace = true, default-features = false }
 sqlx-macros-core = { workspace = true }
 syn = { workspace = true }
-quote = { default-features = false, workspace = true }
-eyre = { workspace = true }
-proc-macro2 = { features = ["proc-macro"], workspace = true }
 
 [lints]
 workspace = true

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -195,18 +195,11 @@ pub fn sqlx_test(args: TokenStream, input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::ItemFn);
     match expand(args, input) {
         Ok(ts) => ts,
-        Err(e) => {
-            if let Some(parse_err) = e.downcast_ref::<syn::Error>() {
-                parse_err.to_compile_error().into()
-            } else {
-                let msg = e.to_string();
-                quote!(::std::compile_error!(#msg)).into()
-            }
-        }
+        Err(e) => e.to_compile_error().into(),
     }
 }
 
-fn expand(args: TokenStream, input: syn::ItemFn) -> eyre::Result<TokenStream> {
+fn expand(args: TokenStream, input: syn::ItemFn) -> Result<TokenStream, syn::Error> {
     let ret = &input.sig.output;
     let name = &input.sig.ident;
     let inputs = &input.sig.inputs;


### PR DESCRIPTION
## Description
Drop unused `sqlx`, `eyre`, and related direct dependency declarations from `carbide_macros`, and simplify `sqlx_test` macro error handling to use `syn::Error` directly.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

