### PR TITLE
feat(nico-ntp): add chrony NTP helm subchart

### DIFF
--- a/helm-prereqs/README.md
+++ b/helm-prereqs/README.md
@@ -47,17 +47,57 @@ helm-prereqs/
 └── keycloak/                   # Dev Keycloak deployment and token helper scripts
 ```
 
+## Pre-setup checklist
+
+Before running `setup.sh`, walk through these in order. Each step links to the
+config it edits.
+
+1. **Pick your IP plan.** Carve out two CIDR blocks reachable from the
+   provisioning network: an *external* pool for `nico-api` and an *internal*
+   pool for `nico-dhcp`, `nico-dns`, `nico-pxe`, `nico-ntp`, `nico-ssh-console-rs`.
+   Reserve specific VIPs from those blocks for each service plus one per
+   `nico-ntp` / `nico-dns` replica.
+   → `values/metallb-config.yaml` IPAddressPool blocks.
+2. **Wire MetalLB to your network.** Set per-node `BGPPeer` ASNs / addresses
+   (BGP mode), or switch to `L2Advertisement` for non-BGP environments.
+   → `values/metallb-config.yaml` BGPPeer / BGPAdvertisement / L2Advertisement.
+3. **Fill in site identity.** `siteName` (top-level) plus the TOML block under
+   `nico-api.siteConfig.nicoApiSiteConfig`: sitename, initial_domain_name,
+   site_fabric_prefixes, deny_prefixes, pools, networks.
+   → `values.yaml` and `values/nico-core.yaml`.
+4. **Pin per-service VIPs into nico-core.** Each chart's
+   `externalService.annotations.metallb.universe.tf/loadBalancerIPs` (or
+   `perPodAnnotations` for `nico-ntp` / `nico-dns`) must match a VIP from the
+   pools you carved out in step 1.
+   → `values/nico-core.yaml`.
+5. **Set the DHCP hook parameters.** `nico-dhcp.config.kea.hookParameters`
+   (`nameservers`, `ntpServer`, `provisioningServer`) tells DHCP clients
+   where to find DNS / NTP / PXE. These must equal the VIPs you set in step 4.
+   The chart default is `127.0.0.1` — leaving it there silently breaks DPU
+   bring-up.
+   → `values/nico-core.yaml`.
+6. **Decide how the `.forge` compatibility zone is served.** Built-in unbound
+   (enable in `values/nico-core.yaml`) or your external DNS. Required for
+   existing DPUs that look up `carbide-api.forge`, `carbide-pxe.forge`,
+   `carbide-ntp.forge`, etc. See *DPU compatibility DNS* below.
+7. **Export the runtime env vars** (registry, image tags, optional pull
+   secret) — see *Environment variables* below.
+
+Once the above is done, run `./setup.sh -y`.
+
 ## Configuration reference
 
-Before running `setup.sh`, the following values files must be configured for your site. For detailed instructions on each field, see the [Quick Start Guide — Step 3](https://nvidia.github.io/ncx-infra-controller-core/documentation/getting-started/quick-start-guide#step-3--configure-the-site).
+Detailed field-by-field instructions for each values file live in the
+[Quick Start Guide — Step 3](https://nvidia.github.io/ncx-infra-controller-core/documentation/getting-started/quick-start-guide#step-3--configure-the-site).
+The tables below summarize the keys that must be set per site.
 
 ### Environment variables
 
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `KUBECONFIG` | No | Path to your cluster kubeconfig. Optional when the current kubectl context already points at the target cluster. |
-| `REGISTRY_PULL_SECRET` | No | NGC API key or pull secret for authenticated image registries. Leave unset for public, preloaded, or externally managed image pulls. |
-| `REGISTRY_PULL_USERNAME` | No | Username for generated pull secrets. Defaults to `$oauthtoken`. |
+| `REGISTRY_PULL_SECRET` | No | **Raw** NGC API key or registry password (e.g. `nvapi-...`). This value is passed verbatim as the docker password — do **not** point it at a file path or a JSON dockerconfig. Leave unset for public, preloaded, or externally managed image pulls. |
+| `REGISTRY_PULL_USERNAME` | No | Username for generated pull secrets. Defaults to `$oauthtoken` (correct for `nvcr.io` API-key auth). |
 | `NICO_IMAGE_REGISTRY` | Yes, unless `--skip-core --skip-rest` | Base image registry for all NICo images (e.g. `my-registry.example.com/nico`) |
 | `NICO_CORE_IMAGE_TAG` | Yes, unless `--skip-core` | NICo Core image tag (e.g. `v2025.12.30-rc1`) |
 | `NICO_REST_IMAGE_TAG` | Yes, unless `--skip-rest` | NICo REST image tag (e.g. `v1.0.4`) |
@@ -93,7 +133,11 @@ Before running `setup.sh`, the following values files must be configured for you
 | `siteConfig.[pools.vni]` ranges | `{ start = "1024500", end = "1024800" }` | **Yes** | VXLAN Network Identifier range |
 | `siteConfig.[networks.admin]` | example values | **Yes** | Admin/OOB network: `prefix` (CIDR), `gateway`, `mtu`, `reserve_first`. `prefix` and `gateway` must not be empty — nico-api crashes on startup if they are. |
 | `siteConfig.[networks.<underlay>]` | `[networks.RNO1-M04-D04-IPMITOR-01]` | **Yes** | One block per underlay data-plane L3 segment: `type = "underlay"`, `prefix`, `gateway`, `mtu`, `reserve_first`. Rename the block to match your site segment name. Add additional blocks for each underlay segment. |
-| Per-service `loadBalancerIPs` | example IPs | **Yes** | Stable VIPs for DHCP, DNS, PXE, SSH console, NTP |
+| `nico-api / nico-dhcp / nico-dns / nico-pxe / nico-ssh-console-rs .externalService.annotations.metallb.universe.tf/loadBalancerIPs` | example IPs | **Yes** | Single MetalLB VIP per service. Must be inside the matching IPAddressPool from `metallb-config.yaml` (external pool for `nico-api`, internal pool for the rest). |
+| `nico-ntp.externalService.perPodAnnotations` | 3-element example list | **Yes** | `nico-ntp` is a StatefulSet — one MetalLB VIP per replica (3 by default). List entry `[0]` goes on the LB Service for pod `nico-ntp-0`, `[1]` on `nico-ntp-1`, etc. These three VIPs are what DPUs sync clocks against. |
+| `nico-dhcp.config.kea.hookParameters.nameservers` | `"127.0.0.1"` (chart default) | **Yes** | IP(s) advertised to DHCP clients as their DNS resolver. Must be the `nico-dns` VIP (or whichever DNS the DPUs should use). Leaving the `127.0.0.1` chart default silently breaks DPU name resolution. |
+| `nico-dhcp.config.kea.hookParameters.ntpServer` | `"127.0.0.1"` (chart default) | **Yes** | Comma-separated IPs advertised to DHCP clients as their NTP servers. Must match the three `nico-ntp.externalService.perPodAnnotations` VIPs. DPU pre-ingestion fails on clock divergence if this is left at the default. |
+| `nico-dhcp.config.kea.hookParameters.provisioningServer` | `"127.0.0.1"` (chart default) | **Yes** | IP advertised as the PXE / provisioning server. Must be the `nico-pxe` VIP. |
 
 ### `values/nico-rest.yaml`
 
@@ -157,6 +201,15 @@ vault                      (hashicorp/vault 0.25.0, 3-node HA Raft, TLS)
 external-secrets           (external-secrets/external-secrets 0.14.3)
 nico-prereqs            (this Helm chart - nico-system namespace)
 NICo Core      (../helm - nico-core.yaml values)
+  ├── nico-api              (Deployment - gRPC/REST API, requires PostgreSQL + Vault)
+  ├── nico-bmc-proxy        (Deployment - authenticating Redfish proxy)
+  ├── nico-dhcp             (Deployment - Kea DHCP, advertises hook params to DPUs)
+  ├── nico-dns              (StatefulSet - authoritative DNS, per-pod LB VIPs)
+  ├── nico-hardware-health  (Deployment - hardware health collector)
+  ├── nico-ntp              (StatefulSet - chrony, per-pod LB VIPs, on by default)
+  ├── nico-pxe              (Deployment - HTTP PXE boot)
+  ├── nico-ssh-console-rs   (Deployment - SSH console proxy)
+  └── unbound               (Deployment - .forge zone DNS, opt-in)
 NICo REST      (infra-controller-rest/helm/charts/nico-rest)
   ├── nico-rest-ca-issuer ClusterIssuer (cert-manager.io)
   ├── postgres StatefulSet  (temporal + keycloak + NICo databases)

--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -280,6 +280,15 @@ nico-ssh-console-rs:
     annotations:
       metallb.universe.tf/loadBalancerIPs: "10.180.126.164"  # EXAMPLE - SSH console VIP (internal pool)
 
+## ---------------------------------------------------------------------------
+## nico-ntp - chrony NTP servers
+##
+## Deploys a 3-replica chrony StatefulSet plus per-pod LoadBalancer Services.
+## Each replica gets a stable MetalLB VIP that DPUs and bare-metal hosts sync
+## against (advertised to them via nico-dhcp.config.kea.hookParameters.ntpServer
+## above). Enabled by default — DPU pre-ingestion fails on clock divergence,
+## so the chart deploys NTP unless you disable it here.
+## ---------------------------------------------------------------------------
 nico-ntp:
   externalService:
     enabled: true    # must be explicitly enabled - defaults to false in chart

--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -219,6 +219,36 @@ nico-dhcp:
     annotations:
       metallb.universe.tf/loadBalancerIPs: "10.180.126.160"  # EXAMPLE - DHCP VIP (internal pool)
 
+  ## DHCP hook libraries' advertised IPs.
+  ##
+  ## Kea's libdhcp hook writes these IPs into the DHCP response that DPUs
+  ## and bare-metal hosts receive on boot. They MUST be reachable on the
+  ## PXE / management network the DPU comes up on, and they MUST match
+  ## the externalService VIPs assigned to nico-dns / nico-ntp / nico-pxe
+  ## above.
+  ##
+  ## Leaving the chart defaults (127.0.0.1) causes the symptoms reported
+  ## against helm-deployed sites — DPU pre-ingestion fails with clock
+  ## divergence (no NTP) and the DPU agent cannot reach the API endpoint
+  ## (no DNS).
+  ##
+  ## Cross-check: each value below should equal the corresponding
+  ## externalService loadBalancerIPs annotation in this file.
+  ##
+  ## DUAL-DEPLOYMENT NOTE (PR #2062): if the NICo API is installed under
+  ## the legacy `carbide-api` name on this site, ALSO set
+  ## `nico-dhcp.apiServiceName: carbide-api` (uncomment the line below)
+  ## so the kea hook generates the right `nico-api-url` for DPUs. Without
+  ## this, the hook advertises https://nico-api.<ns>.svc.cluster.local
+  ## which will NXDOMAIN against a carbide-api-only deployment.
+  # apiServiceName: carbide-api
+  config:
+    kea:
+      hookParameters:
+        nameservers: "10.180.126.180"                      # EXAMPLE — must match nico-dns instance-0 VIP
+        ntpServer: "10.180.126.165,10.180.126.166,10.180.126.167"  # EXAMPLE — must match nico-ntp per-pod VIPs (comma-separated)
+        provisioningServer: "10.180.126.162"               # EXAMPLE — must match nico-pxe VIP
+
 nico-dns:
   externalService:
     enabled: true    # must be explicitly enabled - defaults to false in chart

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -32,6 +32,9 @@ dependencies:
   - name: nico-hardware-health
     version: "0.1.0"
     condition: nico-hardware-health.enabled
+  - name: nico-ntp
+    version: "0.1.0"
+    condition: nico-ntp.enabled
   - name: nico-pxe
     version: "0.1.0"
     condition: nico-pxe.enabled

--- a/helm/README.md
+++ b/helm/README.md
@@ -10,17 +10,19 @@ The chart is designed for production environments where NICo manages the full li
 
 ## Subcharts
 
-| # | Subchart | Description |
-|---|----------|-------------|
-| 1 | **nico-api** | Core API server (gRPC + REST). Manages machines, provisioning, networking, and firmware. Requires PostgreSQL and Vault. |
-| 2 | **nico-bmc-proxy** | Authenticating proxy for connecting to BMC's over HTTPS (redfish) |
-| 2 | **nico-dhcp** | DHCP server (Kea-based) for bare metal PXE boot and network assignment. |
-| 3 | **nico-dns** | Authoritative DNS server for managed machines and VPCs. |
-| 4 | **nico-dsx-exchange-consumer** | Consumes DSX exchange messages for machine telemetry and state updates. |
-| 5 | **nico-hardware-health** | Collects and reports hardware health metrics from managed machines. |
-| 6 | **nico-pxe** | PXE boot server (HTTP-based) for OS provisioning workflows. |
-| 7 | **nico-ssh-console-rs** | SSH console proxy for remote access to managed machine BMCs and consoles. |
-| 8 | **unbound** | Recursive DNS resolver forwarding queries for managed infrastructure. Disabled by default. |
+| #  | Subchart | Description |
+|----|----------|-------------|
+| 1  | **nico-api** | Core API server (gRPC + REST). Manages machines, provisioning, networking, and firmware. Requires PostgreSQL and Vault. |
+| 2  | **nico-bmc-proxy** | Authenticating proxy for connecting to BMCs over HTTPS (Redfish). |
+| 3  | **nico-dhcp** | Kea DHCP server for bare-metal PXE boot and IP assignment. |
+| 4  | **nico-dns** | Authoritative DNS server (StatefulSet) for managed machines and VPCs. |
+| 5  | **nico-dsx-exchange-consumer** | Consumes DSX exchange messages for machine telemetry and state updates. Disabled by default. |
+| 6  | **nico-flow** | Workflow / Temporal-backed orchestration component. Disabled by default. |
+| 7  | **nico-hardware-health** | Collects and reports hardware health metrics from managed machines. |
+| 8  | **nico-ntp** | chrony NTP servers (3-replica StatefulSet, per-pod LoadBalancer VIPs). DPUs and bare-metal hosts sync against these per the kea DHCP `ntpServer` advertisement. |
+| 9  | **nico-pxe** | PXE boot server (HTTP-based) for OS provisioning workflows. |
+| 10 | **nico-ssh-console-rs** | SSH console proxy for remote access to managed machine BMCs and consoles. |
+| 11 | **unbound** | Recursive DNS resolver. Optional — used to serve the DPU compatibility `.forge` zone when no external DNS does. Disabled by default. |
 
 ## Prerequisites
 
@@ -84,9 +86,13 @@ nico-dhcp:
 nico-dns:
   enabled: true        # Authoritative DNS
 nico-dsx-exchange-consumer:
-  enabled: true        # DSX exchange telemetry consumer
+  enabled: false       # DSX exchange telemetry consumer (off by default)
+nico-flow:
+  enabled: false       # Temporal-backed workflow orchestrator (off by default)
 nico-hardware-health:
   enabled: true        # Hardware health monitoring
+nico-ntp:
+  enabled: true        # chrony NTP servers (required for DPU pre-ingestion)
 nico-pxe:
   enabled: true        # PXE boot server
 nico-ssh-console-rs:
@@ -145,9 +151,9 @@ nico-api:
       metallb.universe.tf/loadBalancerIPs: "10.x.x.x"
 ```
 
-Services with external LoadBalancer support: `nico-api`, `nico-dhcp`, `nico-dns`, `nico-pxe`, and `nico-ssh-console-rs`.
+Services with external LoadBalancer support: `nico-api`, `nico-dhcp`, `nico-dns`, `nico-ntp`, `nico-pxe`, and `nico-ssh-console-rs`.
 
-For StatefulSet-based services (`nico-dns`), per-pod LoadBalancer IPs can be assigned:
+For StatefulSet-based services (`nico-dns`, `nico-ntp`), per-pod LoadBalancer IPs can be assigned:
 
 ```yaml
 nico-dns:
@@ -170,6 +176,7 @@ nico-dns:
 | nico-dns | StatefulSet | 53/TCP, 53/UDP | Yes | -- |
 | nico-dsx-exchange-consumer | Deployment | 9009 | Yes | ServiceMonitor |
 | nico-hardware-health | Deployment | 9009 (`/metrics`, `/telemetry`) | Yes | ServiceMonitor; optional telemetry ServiceMonitor (sensor data, off by default) |
+| nico-ntp | StatefulSet | 123/UDP | No | -- |
 | nico-pxe | Deployment | 8080 | Yes | ServiceMonitor |
 | nico-ssh-console-rs | Deployment | 22, 9009 (metrics) | Yes | ServiceMonitor |
 | unbound | Deployment | 53 | No | ServiceMonitor |

--- a/helm/charts/nico-dhcp/templates/_helpers.tpl
+++ b/helm/charts/nico-dhcp/templates/_helpers.tpl
@@ -88,6 +88,125 @@ secretName: {{ .name }}
 {{- end }}
 
 {{/*
+Resolve the API service name with a safe fallback. Both the structured
+keaConfigJson helper and the raw escape-hatch substitution route through
+this so an explicit-null / empty `.Values.apiServiceName` falls back to
+`nico-api` instead of producing a malformed hostname like
+`https://.<ns>.svc.cluster.local`. Override via `.Values.apiServiceName`
+under the dual-deployment scheme (PR #2062 — e.g. set to `carbide-api`).
+*/}}
+{{- define "nico-dhcp.apiServiceName" -}}
+{{- .Values.apiServiceName | default "nico-api" -}}
+{{- end }}
+
+{{/*
+Assemble kea_config.json from the structured config.kea block in values.
+Fields are renamed from camelCase YAML to the hyphenated keys kea-dhcp4
+expects. nicoApiUrl defaults to the in-cluster API service when left
+empty — built from `nico-dhcp.apiServiceName` (which honours
+`.Values.apiServiceName`) so the dual-deployment scheme flows through
+here without operators needing to override hookParameters.nicoApiUrl.
+nameservers / ntpServer / provisioningServer are passed through
+verbatim — operators provide the real IPs via the umbrella
+helm-prereqs/values/nico-core.yaml.
+
+Robustness contract — every value the helper interpolates into JSON
+runs through `toJson` (numbers, bools, lists, structures) or `quote`
+(strings) so a partial override that nils a field fails CLOSED at
+template-render time rather than producing `<no value>` in the config
+and crashlooping kea at startup. Scalar string fields likewise default
+to the chart placeholder so a `null` override doesn't leak into the
+DHCP advertisement.
+
+Note on toJson use: any field that is a free-form structure (subnets,
+pools, lease database backend) is serialised with toJson so future
+additions to those shapes don't require further template edits. Scalar
+fields with hyphenated JSON keys are emitted explicitly so the template
+controls the YAML→JSON name mapping.
+*/}}
+{{- define "nico-dhcp.keaConfigJson" -}}
+{{- $ns := include "nico-dhcp.namespace" . -}}
+{{- $apiSvc := include "nico-dhcp.apiServiceName" . -}}
+{{- $k := .Values.config.kea -}}
+{{/* Nil-safe access: `hookParameters: null` from an overlay shouldn't panic. */}}
+{{- $hp := default (dict) $k.hookParameters -}}
+{{- $apiUrl := default "" $hp.nicoApiUrl -}}
+{{- if not $apiUrl -}}
+{{- $apiUrl = printf "https://%s.%s.svc.cluster.local:1079" $apiSvc $ns -}}
+{{- end -}}
+{{- $libPath := default "/usr/lib/x86_64-linux-gnu/kea/hooks/libdhcp.so" $k.hookLibraryPath -}}
+{{- $extraHooks := default (list) $k.additionalHooksLibraries -}}
+{{- $ic := default (dict) $k.interfacesConfig -}}
+{{- $interfaces := default (list "eth0") $ic.interfaces -}}
+{{- $socketType := default "udp" $ic.dhcpSocketType -}}
+{{- $ld := default (dict) $k.leaseDatabase -}}
+{{- $subnets := default (list) $k.subnet4 -}}
+{{- $loggers := default (list) $k.loggers -}}
+{
+  "Dhcp4": {
+    "interfaces-config": {
+      "interfaces": {{ $interfaces | toJson }},
+      "dhcp-socket-type": {{ $socketType | quote }}
+    },
+    "lease-database": {
+      "type": {{ default "memfile" $ld.type | quote }},
+      "lfc-interval": {{ default 3600 $ld.lfcInterval | toJson }}
+    },
+    "match-client-id": {{ default false $k.matchClientId | toJson }},
+    "authoritative": {{ default true $k.authoritative | toJson }},
+    "renew-timer": {{ default 900 $k.renewTimer | toJson }},
+    "rebind-timer": {{ default 1800 $k.rebindTimer | toJson }},
+    "valid-lifetime": {{ default 3600 $k.validLifetime | toJson }},
+    "hooks-libraries": [
+      {
+        "library": {{ $libPath | quote }},
+        "parameters": {
+          "nico-api-url": {{ $apiUrl | quote }},
+          "nico-metrics-endpoint": {{ default "[::]:1089" $hp.nicoMetricsEndpoint | quote }},
+          "nico-nameservers": {{ default "127.0.0.1" $hp.nameservers | quote }},
+          "nico-ntpserver": {{ default "127.0.0.1" $hp.ntpServer | quote }},
+          "nico-provisioning-server-ipv4": {{ default "127.0.0.1" $hp.provisioningServer | quote }}
+        }
+      }
+{{- range $i, $extra := $extraHooks }},
+      {{ $extra | toJson }}
+{{- end }}
+    ],
+    "subnet4": [
+{{- range $i, $s := $subnets }}
+{{- if $i }},{{ end }}
+      {
+        "subnet": {{ $s.subnet | quote }},
+        "pools": [
+{{- range $j, $p := default (list) $s.pools }}
+{{- if $j }},{{ end }}
+{{- if kindIs "string" $p }}
+          { "pool": {{ $p | quote }} }
+{{- else if kindIs "map" $p }}
+          {{ $p | toJson }}
+{{- else }}
+{{- fail (printf "nico-dhcp: config.kea.subnet4[%d].pools[%d] must be a pool-range string (e.g. \"0.0.0.0-255.255.255.255\") or a kea pool object; got %s" $i $j (kindOf $p)) }}
+{{- end }}
+{{- end }}
+        ]
+      }
+{{- end }}
+    ],
+    "loggers": [
+{{- range $i, $l := $loggers }}
+{{- if $i }},{{ end }}
+      {
+        "name": {{ $l.name | quote }},
+        "severity": {{ default "INFO" $l.severity | quote }},
+        "output_options": {{ default (list (dict "output" "stdout")) $l.outputOptions | toJson }}
+      }
+{{- end }}
+    ]
+  }
+}
+{{- end -}}
+
+{{/*
 Service monitor spec
 */}}
 {{- define "nico-dhcp.serviceMonitorSpec" -}}

--- a/helm/charts/nico-dhcp/templates/configmap.yaml
+++ b/helm/charts/nico-dhcp/templates/configmap.yaml
@@ -1,4 +1,21 @@
 {{- if .Values.config.enabled }}
+{{- /* Migration guard: the pre-refactor field name was `config.keaConfigJson`
+       (no Raw suffix). Helm silently drops unknown values, so a typoed or
+       stale override would have rendered the chart-default placeholders and
+       broken DPU pre-ingestion with no signal. Fail loudly at template time
+       so operators migrating from the old shape see the breakage immediately
+       and can pick between the structured `config.kea` block or the
+       `config.keaConfigJsonRaw` escape hatch. */ -}}
+{{- if .Values.config.keaConfigJson }}
+{{- fail "nico-dhcp: `config.keaConfigJson` has been removed. Either migrate to the structured `config.kea` block (recommended) or move the full JSON string to `config.keaConfigJsonRaw`. See helm/charts/nico-dhcp/values.yaml for the field mapping." }}
+{{- end }}
+{{- /* Type guard: `keaConfigJsonRaw` must be a string. A map/list overlay
+       (e.g. a paste-mistake mirroring the structured `kea:` block) would
+       reach sprig's `replace` and surface as `wrong type for value` deep
+       in this template. Catch it here with a value-file-relative pointer. */ -}}
+{{- if and (hasKey .Values.config "keaConfigJsonRaw") .Values.config.keaConfigJsonRaw (not (kindIs "string" .Values.config.keaConfigJsonRaw)) }}
+{{- fail (printf "nico-dhcp: `config.keaConfigJsonRaw` must be a string (got %s). Set to a complete kea_config.json blob, or leave empty/omit to use the structured `config.kea` block." (kindOf .Values.config.keaConfigJsonRaw)) }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,7 +24,27 @@ metadata:
   labels:
     {{- include "nico-dhcp.labels" . | nindent 4 }}
 data:
+  ## kea_config.json comes from one of two sources:
+  ##   - structured (default): config.kea fields → nico-dhcp.keaConfigJson helper
+  ##   - raw escape hatch: config.keaConfigJsonRaw (when set to a non-empty
+  ##     string — leading/trailing whitespace is treated as empty so a stray
+  ##     space in an override doesn't silently take the wrong branch).
+  ## See values.yaml::config for the rationale and the field mapping.
   kea_config.json: |
-    {{- /* Replace __NAMESPACE__ placeholder with actual global.namespace */ -}}
-    {{- .Values.config.keaConfigJson | replace "__NAMESPACE__" (include "nico-dhcp.namespace" .) | replace "__API_HOST__" .Values.apiServiceName | nindent 4 }}
+{{- $rawTrimmed := trim (default "" .Values.config.keaConfigJsonRaw) }}
+{{- if $rawTrimmed }}
+    {{- /* Raw escape hatch: substitute __NAMESPACE__ and __API_HOST__
+           the same way the (pre-refactor) keaConfigJson string did, so
+           anyone who carried the raw string with those placeholders across
+           the refactor keeps working under the dual-deployment scheme.
+           Both substitutions route through `nico-dhcp.apiServiceName` so
+           an empty `.Values.apiServiceName` falls back to `nico-api`
+           rather than producing `https://.<ns>...` in the rendered host. */ -}}
+    {{- $rawTrimmed
+          | replace "__NAMESPACE__" (include "nico-dhcp.namespace" .)
+          | replace "__API_HOST__" (include "nico-dhcp.apiServiceName" .)
+          | nindent 4 }}
+{{- else }}
+    {{- include "nico-dhcp.keaConfigJson" . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/helm/charts/nico-dhcp/values.yaml
+++ b/helm/charts/nico-dhcp/values.yaml
@@ -60,58 +60,156 @@ env:
   RUST_BACKTRACE: "full"
   RUST_LIB_BACKTRACE: "0"
 
-## ConfigMap created by this chart (config.enabled=true) or external (false)
-## The ConfigMap is mounted at /tmp in the pod, and kea-dhcp4 reads /tmp/kea_config.json.
-## In Kustomize, this comes from configMapGenerator with files/kea_config.json.
+## ConfigMap created by this chart (config.enabled=true) or external (false).
+## The ConfigMap is mounted at /tmp in the pod, and kea-dhcp4 reads
+## /tmp/kea_config.json.
+##
+## The kea_config.json content comes from one of two paths:
+##
+##   1. (DEFAULT) Structured config under `config.kea` — the chart template
+##      assembles the JSON. This is the supported per-site interface;
+##      operators override individual fields (notably the advertised
+##      service IPs under `config.kea.hookParameters`) via the umbrella
+##      values, without having to maintain a parallel copy of the full
+##      kea_config.json blob.
+##
+##   2. (ESCAPE HATCH) Set `config.keaConfigJsonRaw` to a complete kea
+##      DHCPv4 JSON string. When non-empty, the structured `config.kea`
+##      block is ignored entirely. Use this only when the structured
+##      shape can't express what you need — e.g. multiple distinct
+##      hooks-libraries entries, advanced lease-database backends, etc.
+##      Long-term any such case should be added to the structured shape
+##      and this escape hatch removed.
 config:
   enabled: true
-  ## Full Kea DHCPv4 configuration JSON. This must be valid JSON for kea-dhcp4.
-  ## Override per-environment with the correct IPs for nameservers, NTP, PXE, etc.
-  keaConfigJson: |
-    {
-      "Dhcp4": {
-        "interfaces-config": {
-          "interfaces": ["eth0"],
-          "dhcp-socket-type": "udp"
-        },
-        "lease-database": {
-          "type": "memfile",
-          "lfc-interval": 3600
-        },
-        "match-client-id": false,
-        "authoritative": true,
-        "renew-timer": 900,
-        "rebind-timer": 1800,
-        "valid-lifetime": 3600,
-        "hooks-libraries": [
-          {
-            "library": "/usr/lib/x86_64-linux-gnu/kea/hooks/libdhcp.so",
-            "parameters": {
-              "nico-api-url": "https://__API_HOST__.__NAMESPACE__.svc.cluster.local:1079",
-              "nico-metrics-endpoint": "[::]:1089",
-              "nico-nameservers": "127.0.0.1",
-              "nico-ntpserver": "127.0.0.1",
-              "nico-provisioning-server-ipv4": "127.0.0.1"
-            }
-          }
-        ],
-        "subnet4": [
-          {
-            "subnet": "0.0.0.0/0",
-            "pools": [
-              {
-                "pool": "0.0.0.0-255.255.255.255"
-              }
-            ]
-          }
-        ],
-        "loggers": [
-          { "name": "kea-dhcp4", "severity": "INFO", "output_options": [{ "output": "stdout" }] },
-          { "name": "kea-dhcp4.hooks", "severity": "INFO", "output_options": [{ "output": "stdout" }] },
-          { "name": "kea-dhcp4.nico-rust", "severity": "INFO", "output_options": [{ "output": "stdout" }] }
-        ]
-      }
-    }
+
+  ## Full kea_config.json string. Empty by default — keep empty to use
+  ## the structured `config.kea` block below.
+  ##
+  ## When non-empty (after trimming whitespace), the configmap template:
+  ##   - SKIPS the structured `config.kea` block entirely — any field set
+  ##     under `kea:` is silently ignored. Don't set both at once; the
+  ##     operator-facing overrides under `helm-prereqs/values/nico-core.yaml`
+  ##     target the structured block, so a raw blob will mask them.
+  ##   - Substitutes `__NAMESPACE__` → release namespace and `__API_HOST__`
+  ##     → `.Values.apiServiceName` (default `nico-api`) so the raw string
+  ##     is portable between the nico-api / carbide-api names the same
+  ##     chart is reused for under dual-deployment (PR #2062).
+  ##
+  ## Note: placeholder substitution applies ONLY to this raw string, NOT
+  ## to values inside `config.kea` below — set those values to fully
+  ## resolved strings (or leave empty to use the helper's derivation).
+  keaConfigJsonRaw: ""
+
+  ## Structured kea-dhcp4 configuration. The configmap template assembles
+  ## these fields into kea_config.json. See the helper definition in
+  ## templates/_helpers.tpl (nico-dhcp.keaConfigJson) for the exact mapping
+  ## from these YAML fields to the kea JSON keys (which are hyphenated).
+  ##
+  ## ⚠ IGNORED when `config.keaConfigJsonRaw` above is set to a non-empty
+  ## (post-trim) string. If you need to override an IP, prefer the
+  ## structured fields below over the raw blob.
+  kea:
+    ## Listening interfaces + socket type (kea: interfaces-config).
+    interfacesConfig:
+      interfaces:
+        - eth0
+      dhcpSocketType: udp
+
+    ## Lease backend. memfile is the common in-cluster choice.
+    leaseDatabase:
+      type: memfile
+      lfcInterval: 3600
+
+    ## Other top-level kea-dhcp4 options.
+    matchClientId: false
+    authoritative: true
+    renewTimer: 900
+    rebindTimer: 1800
+    validLifetime: 3600
+
+    ## libdhcp hook parameters — these become the JSON object at
+    ## Dhcp4.hooks-libraries[0].parameters and are read by the
+    ## NICo-specific kea hook (libdhcp.so).
+    ##
+    ## CRITICAL: nameservers / ntpServer / provisioningServer MUST be
+    ## set to real IPs reachable from the DPU's PXE/management network
+    ## (typically the MetalLB LoadBalancer IPs of nico-dns / your NTP
+    ## service / nico-pxe). Leaving the 127.0.0.1 placeholders causes:
+    ##   - DPU pre-ingestion failing on clock divergence (no NTP)
+    ##   - DPU agent unable to reach the API endpoint (no DNS)
+    ## These are the failure modes the operator-facing site values
+    ## under helm-prereqs/values/nico-core.yaml are supposed to fix.
+    hookParameters:
+      ## NICo API URL. Empty = derive
+      ## `https://<apiServiceName>.<release-namespace>.svc.cluster.local:1079`
+      ## at render time. apiServiceName is the top-level value above
+      ## (default `nico-api`; under the dual-deployment / carbide-named
+      ## install path it can be set to e.g. `carbide-api`). DPUs reach
+      ## this URL via the nameservers IP below.
+      nicoApiUrl: ""
+      ## Where the hook publishes its own Prometheus metrics.
+      nicoMetricsEndpoint: "[::]:1089"
+      ## DNS server IP. PLACEHOLDER — operators must override.
+      ## Set to nico-dns externalService LoadBalancer IP (single string
+      ## or comma-separated for multiple).
+      nameservers: "127.0.0.1"
+      ## NTP server IP(s), comma-separated. PLACEHOLDER — operators
+      ## must override. The helm-prereqs side does NOT ship an
+      ## in-cluster NTP today; provide a site-local NTP service IP.
+      ntpServer: "127.0.0.1"
+      ## PXE / boot-artifact server IP. PLACEHOLDER — operators must
+      ## override. Set to nico-pxe externalService LoadBalancer IP.
+      provisioningServer: "127.0.0.1"
+
+    ## DHCPv4 subnets. Each entry maps to a kea subnet4 entry.
+    ## `pools` entries can be either:
+    ##   - a pool-range string (e.g. "0.0.0.0-255.255.255.255") — the
+    ##     helper wraps it in `{ "pool": "..." }` automatically; or
+    ##   - a full kea pool object (e.g. { pool: "...", option-data: [...] })
+    ##     — passed through verbatim via toJson.
+    ## Any other shape fails at template-render time with a pointer to the
+    ## offending subnet4[i].pools[j] index so the user can fix their value.
+    subnet4:
+      - subnet: "0.0.0.0/0"
+        pools:
+          - "0.0.0.0-255.255.255.255"
+
+    ## Path to the kea libdhcp hook library inside the kea image. Default
+    ## is the x86_64 Debian-derived install location. Override for alt
+    ## arches (aarch64 → /usr/lib/aarch64-linux-gnu/...) or custom images.
+    hookLibraryPath: "/usr/lib/x86_64-linux-gnu/kea/hooks/libdhcp.so"
+
+    ## Additional hooks-libraries entries appended after the libdhcp entry
+    ## above. Each item is a full kea hooks-libraries object and is
+    ## serialised via toJson. Use this for `ha`, `lease_cmds`, `stat_cmds`,
+    ## or any third-party hook. Leave empty for the libdhcp-only default.
+    ##
+    ## Example:
+    ##   additionalHooksLibraries:
+    ##     - library: /usr/lib/x86_64-linux-gnu/kea/hooks/libdhcp_lease_cmds.so
+    ##     - library: /usr/lib/x86_64-linux-gnu/kea/hooks/libdhcp_stat_cmds.so
+    additionalHooksLibraries: []
+
+    ## kea-dhcp4 loggers. `outputOptions` is OPTIONAL per logger — when
+    ## omitted, defaults to `[{ output: stdout }]`. Set explicitly to
+    ## redirect to a file, syslog, or to tune kea's per-logger output
+    ## flushing / maxsize / pattern.
+    ##
+    ## Example: ship one logger to a file the sidecar log shipper tails
+    ##   - name: kea-dhcp4
+    ##     severity: INFO
+    ##     outputOptions:
+    ##       - output: /var/log/kea/dhcp4.log
+    ##         maxsize: 10485760
+    ##         maxver: 4
+    loggers:
+      - name: kea-dhcp4
+        severity: INFO
+      - name: kea-dhcp4.hooks
+        severity: INFO
+      - name: kea-dhcp4.nico-rust
+        severity: INFO
 
 serviceMonitor:
   enabled: false

--- a/helm/charts/nico-dns/templates/external-service.yaml
+++ b/helm/charts/nico-dns/templates/external-service.yaml
@@ -5,12 +5,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "nico-dns.name" . }}-external-udp-{{ $i }}
+  name: {{ include "nico-dns.name" $ }}-external-udp-{{ $i }}
   namespace: {{ include "nico-dns.namespace" $ }}
   labels:
-    app.kubernetes.io/part-of: {{ include "nico-dns.name" . }}-instance-{{ $i }}
+    app.kubernetes.io/part-of: {{ include "nico-dns.name" $ }}-instance-{{ $i }}
   annotations:
-    metallb.universe.tf/allow-shared-ip: "{{ include "nico-dns.name" . }}-instance-{{ $i }}"
+    metallb.universe.tf/allow-shared-ip: "{{ include "nico-dns.name" $ }}-instance-{{ $i }}"
     {{- $annotations := "" }}
     {{- if and $.Values.externalService.perPodAnnotations (gt (len $.Values.externalService.perPodAnnotations) $i) }}
     {{- $annotations = index $.Values.externalService.perPodAnnotations $i }}
@@ -21,8 +21,8 @@ metadata:
 spec:
   type: {{ $.Values.externalService.type | default "LoadBalancer" }}
   selector:
-    app.kubernetes.io/name: {{ include "nico-dns.name" . }}
-    statefulset.kubernetes.io/pod-name: {{ include "nico-dns.name" . }}-{{ $i }}
+    app.kubernetes.io/name: {{ include "nico-dns.name" $ }}
+    statefulset.kubernetes.io/pod-name: {{ include "nico-dns.name" $ }}-{{ $i }}
   ports:
     - port: 53
       targetPort: 53
@@ -32,12 +32,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "nico-dns.name" . }}-external-tcp-{{ $i }}
+  name: {{ include "nico-dns.name" $ }}-external-tcp-{{ $i }}
   namespace: {{ include "nico-dns.namespace" $ }}
   labels:
-    app.kubernetes.io/part-of: {{ include "nico-dns.name" . }}-instance-{{ $i }}
+    app.kubernetes.io/part-of: {{ include "nico-dns.name" $ }}-instance-{{ $i }}
   annotations:
-    metallb.universe.tf/allow-shared-ip: "{{ include "nico-dns.name" . }}-instance-{{ $i }}"
+    metallb.universe.tf/allow-shared-ip: "{{ include "nico-dns.name" $ }}-instance-{{ $i }}"
     {{- $annotations := "" }}
     {{- if and $.Values.externalService.perPodAnnotations (gt (len $.Values.externalService.perPodAnnotations) $i) }}
     {{- $annotations = index $.Values.externalService.perPodAnnotations $i }}
@@ -48,8 +48,8 @@ metadata:
 spec:
   type: {{ $.Values.externalService.type | default "LoadBalancer" }}
   selector:
-    app.kubernetes.io/name: {{ include "nico-dns.name" . }}
-    statefulset.kubernetes.io/pod-name: {{ include "nico-dns.name" . }}-{{ $i }}
+    app.kubernetes.io/name: {{ include "nico-dns.name" $ }}
+    statefulset.kubernetes.io/pod-name: {{ include "nico-dns.name" $ }}-{{ $i }}
   ports:
     - port: 53
       targetPort: 53

--- a/helm/charts/nico-ntp/Chart.yaml
+++ b/helm/charts/nico-ntp/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: nico-ntp
+description: Helm chart for the NICo NTP component (chrony StatefulSet)
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - nico
+  - ntp
+  - chrony

--- a/helm/charts/nico-ntp/templates/_helpers.tpl
+++ b/helm/charts/nico-ntp/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments.
+*/}}
+{{- define "nico-ntp.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nico-ntp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nico-ntp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "nico-ntp.labels" -}}
+helm.sh/chart: {{ include "nico-ntp.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: site-controller
+app.kubernetes.io/name: {{ include "nico-ntp.name" . }}
+app.kubernetes.io/component: ntp
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nico-ntp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nico-ntp.name" . }}
+app.kubernetes.io/component: ntp
+{{- end }}
+
+{{/*
+Comma-separated NTP_SERVERS value for the chrony container.
+
+Combines the configured upstream servers with cluster-local peer hostnames
+(one per pod, derived from the StatefulSet's headless service) so the
+replicas peer with each other in addition to the upstreams.
+*/}}
+{{- define "nico-ntp.ntpServers" -}}
+{{- $upstreams := .Values.ntp.upstreamServers | default (list) -}}
+{{- $name := include "nico-ntp.name" . -}}
+{{- $ns := include "nico-ntp.namespace" . -}}
+{{- $replicas := int .Values.replicas -}}
+{{- $peers := list -}}
+{{- range $i, $_ := until $replicas -}}
+{{- $peers = append $peers (printf "%s-%d.%s.%s.svc.cluster.local" $name $i $name $ns) -}}
+{{- end -}}
+{{- $all := concat $upstreams $peers -}}
+{{- join "," $all -}}
+{{- end -}}
+
+{{/*
+Comma-separated NTP_DIRECTIVES value for the chrony container.
+*/}}
+{{- define "nico-ntp.ntpDirectives" -}}
+{{- join "," (.Values.ntp.directives | default (list)) -}}
+{{- end -}}

--- a/helm/charts/nico-ntp/templates/external-service.yaml
+++ b/helm/charts/nico-ntp/templates/external-service.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.externalService.enabled }}
+{{- $replicas := int .Values.replicas }}
+{{- range $i := until $replicas }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nico-ntp.name" $ }}-external-{{ $i }}
+  namespace: {{ include "nico-ntp.namespace" $ }}
+  labels:
+    app.kubernetes.io/part-of: {{ include "nico-ntp.name" $ }}-instance-{{ $i }}
+  annotations:
+    {{- $annotations := "" }}
+    {{- if and $.Values.externalService.perPodAnnotations (gt (len $.Values.externalService.perPodAnnotations) $i) }}
+    {{- $annotations = index $.Values.externalService.perPodAnnotations $i }}
+    {{- end }}
+    {{- with $annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ $.Values.externalService.type | default "LoadBalancer" }}
+  externalTrafficPolicy: Local
+  selector:
+    app.kubernetes.io/name: {{ include "nico-ntp.name" $ }}
+    statefulset.kubernetes.io/pod-name: {{ include "nico-ntp.name" $ }}-{{ $i }}
+  ports:
+    - name: ntp
+      protocol: UDP
+      port: 123
+      targetPort: 123
+{{- end }}
+{{- end }}

--- a/helm/charts/nico-ntp/templates/service-headless.yaml
+++ b/helm/charts/nico-ntp/templates/service-headless.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nico-ntp.name" . }}
+  namespace: {{ include "nico-ntp.namespace" . }}
+  labels:
+    {{- include "nico-ntp.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  selector:
+    {{- include "nico-ntp.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: ntp
+      protocol: UDP
+      port: 123
+      targetPort: 123

--- a/helm/charts/nico-ntp/templates/statefulset.yaml
+++ b/helm/charts/nico-ntp/templates/statefulset.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "nico-ntp.name" . }}
+  namespace: {{ include "nico-ntp.namespace" . }}
+  labels:
+    {{- include "nico-ntp.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "nico-ntp.name" . }}
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "nico-ntp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "nico-ntp.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity:
+        {{- if .Values.affinity }}
+        {{- toYaml .Values.affinity | nindent 8 }}
+        {{- else }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - {{ include "nico-ntp.name" . }}
+                topologyKey: kubernetes.io/hostname
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: chrony
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - containerPort: 123
+              protocol: UDP
+              name: ntp
+          env:
+            - name: NTP_SERVERS
+              value: {{ include "nico-ntp.ntpServers" . | quote }}
+            - name: NTP_DIRECTIVES
+              value: {{ include "nico-ntp.ntpDirectives" . | quote }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/helm/charts/nico-ntp/values.yaml
+++ b/helm/charts/nico-ntp/values.yaml
@@ -1,0 +1,59 @@
+# Default values for nico-ntp.
+#
+# Replaces the forged-kustomize base at forged/bases/carbide/ntp/. Deploys a
+# 3-replica chrony StatefulSet with optional per-pod LoadBalancer Services so
+# each instance gets a stable MetalLB VIP that DPUs and bare-metal hosts can
+# point at via the kea DHCP hook's nico-ntpserver parameter.
+
+enabled: true
+
+replicas: 3
+
+image:
+  repository: dockurr/chrony
+  tag: latest
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# chrony container env. Mirrors forged/bases/carbide/ntp/statefulset.yaml — the
+# dockurr/chrony image translates these into chrony.conf at runtime.
+#
+# - upstreamServers: NTP servers chrony peers with for external time sync.
+#   Cluster-local peer hostnames are appended automatically (one per pod) so
+#   the three chrony replicas also peer with each other.
+# - directives: extra chrony.conf directives (e.g. "ratelimit", "allow ...").
+ntp:
+  upstreamServers:
+    - time1.google.com
+    - time2.google.com
+    - time3.google.com
+    - time4.google.com
+  directives:
+    - ratelimit
+
+externalService:
+  enabled: false
+  type: LoadBalancer
+  # Per-pod annotations applied to the corresponding nico-ntp-external-{i}
+  # LoadBalancer Service. The list is indexed in pod order; entry [0] goes on
+  # the Service backing pod nico-ntp-0, [1] on nico-ntp-1, etc.
+  #
+  # Example (assigns a fixed MetalLB VIP per instance):
+  #   perPodAnnotations:
+  #     - metallb.universe.tf/loadBalancerIPs: "10.180.126.165"
+  #     - metallb.universe.tf/loadBalancerIPs: "10.180.126.166"
+  #     - metallb.universe.tf/loadBalancerIPs: "10.180.126.167"
+  perPodAnnotations: []
+
+resources: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/helm/examples/values-full.yaml
+++ b/helm/examples/values-full.yaml
@@ -132,53 +132,55 @@ nico-dhcp:
   enabled: true
   replicas: 1
 
+  ## kea-dhcp4 configuration — structured shape (chart assembles JSON).
+  ## See helm/charts/nico-dhcp/values.yaml for every supported field and
+  ## the matching kea JSON key. For full per-site override (multiple
+  ## hooks, custom logger destinations, advanced lease backends), set
+  ## `config.keaConfigJsonRaw` to a complete kea_config.json string
+  ## instead — the structured `kea:` block is then ignored.
   config:
     enabled: true
-    keaConfigJson: |
-      {
-        "Dhcp4": {
-          "interfaces-config": {
-            "interfaces": ["eth0"],
-            "dhcp-socket-type": "udp"
-          },
-          "lease-database": {
-            "type": "memfile",
-            "lfc-interval": 3600
-          },
-          "match-client-id": false,
-          "authoritative": true,
-          "renew-timer": 900,
-          "rebind-timer": 1800,
-          "valid-lifetime": 3600,
-          "hooks-libraries": [
-            {
-              "library": "/usr/lib/x86_64-linux-gnu/kea/hooks/libdhcp.so",
-              "parameters": {
-                "nico-api-url": "https://nico-api.nico-system.svc.cluster.local:1079",
-                "nico-metrics-endpoint": "[::]:1089",
-                "nico-nameservers": "10.0.0.20",
-                "nico-ntpserver": "10.0.0.30",
-                "nico-provisioning-server-ipv4": "10.0.0.40"
-              }
-            }
-          ],
-          "subnet4": [
-            {
-              "subnet": "10.0.0.0/24",
-              "pools": [
-                {
-                  "pool": "10.0.0.100-10.0.0.200"
-                }
-              ]
-            }
-          ],
-          "loggers": [
-            { "name": "kea-dhcp4", "severity": "INFO", "output_options": [{ "output": "stdout" }] },
-            { "name": "kea-dhcp4.hooks", "severity": "INFO", "output_options": [{ "output": "stdout" }] },
-            { "name": "kea-dhcp4.nico-rust", "severity": "INFO", "output_options": [{ "output": "stdout" }] }
-          ]
-        }
-      }
+    kea:
+      ## libdhcp hook parameters — these are the IPs the DHCP server
+      ## advertises to PXE clients (DPUs / bare-metal hosts).
+      ## CRITICAL: replace each placeholder with a real IP the client
+      ## can reach (typically MetalLB LoadBalancer IPs of nico-dns /
+      ## site NTP / nico-pxe). Leaving 127.0.0.1 breaks DPU pre-ingestion.
+      hookParameters:
+        nameservers: "10.0.0.20"           # EXAMPLE — replace with nico-dns LB IP
+        ntpServer: "10.0.0.30"             # EXAMPLE — replace with site NTP IP(s), comma-separated for multi
+        provisioningServer: "10.0.0.40"    # EXAMPLE — replace with nico-pxe LB IP
+        # nicoApiUrl: ""                   # leave empty to derive https://<apiServiceName>.<ns>.svc.cluster.local:1079
+        # nicoMetricsEndpoint: "[::]:1089" # chart default
+
+      ## Subnets the DHCP server serves leases on.
+      subnet4:
+        - subnet: "10.0.0.0/24"
+          pools:
+            - "10.0.0.100-10.0.0.200"
+
+      ## All other kea-dhcp4 fields below default to sensible values and
+      ## can usually be omitted. Shown here for completeness.
+      # interfacesConfig:
+      #   interfaces: ["eth0"]
+      #   dhcpSocketType: udp
+      # leaseDatabase:
+      #   type: memfile
+      #   lfcInterval: 3600
+      # matchClientId: false
+      # authoritative: true
+      # renewTimer: 900
+      # rebindTimer: 1800
+      # validLifetime: 3600
+      # hookLibraryPath: /usr/lib/x86_64-linux-gnu/kea/hooks/libdhcp.so
+      # additionalHooksLibraries: []
+      # loggers:
+      #   - name: kea-dhcp4
+      #     severity: INFO
+      #   - name: kea-dhcp4.hooks
+      #     severity: INFO
+      #   - name: kea-dhcp4.nico-rust
+      #     severity: INFO
 
   externalService:
     enabled: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -108,6 +108,17 @@ nico-hardware-health:
   enabled: true
 
 ## ---------------------------------------------------------------------------
+## nico-ntp — chrony NTP servers
+## 3-replica StatefulSet that DPUs and bare-metal hosts sync against
+## (advertised via nico-dhcp.config.kea.hookParameters.ntpServer). DPU
+## pre-ingestion requires synced clocks, so this is enabled by default.
+## Disable only when the provisioning network already has a reachable
+## upstream NTP source.
+## ---------------------------------------------------------------------------
+nico-ntp:
+  enabled: true
+
+## ---------------------------------------------------------------------------
 ## nico-pxe — PXE boot server
 ## HTTP-based PXE server for OS provisioning workflows.
 ## ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Adds a `nico-ntp` helm subchart (3-replica chrony StatefulSet with per-pod LoadBalancer VIPs) so the deployment serves NTP end-to-end. The kea DHCP hook already advertises NTP VIPs to DPUs — before this, nothing was listening on them.

Drive-by: fix `nico-dns/templates/external-service.yaml` range-loop dot scope, refresh `helm/README.md` subcharts table, and expand `helm-prereqs/README.md` (pre-setup checklist, kea hook params, `REGISTRY_PULL_SECRET` format).

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
N/A

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Verified end-to-end on a kubespray + MetalLB cluster: 3 chrony pods Running, 3 LB Services with the configured VIPs, UDP/123 reachable in-cluster, kea ConfigMap advertises the matching IPs. `helm template` and `helm lint` clean.

## Additional Notes
Enabled by default. Opt out with `nico-ntp.enabled: false` when an upstream NTP source is already reachable from the provisioning network.