### PR TITLE
Revert "refactor(rms-client)!: migrate to updated RMS proto (#1944)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2591,7 +2591,6 @@ dependencies = [
  "mac_address",
  "mqttea",
  "opentelemetry",
- "serde",
  "serde_json",
  "sqlx",
  "state-controller",
@@ -6503,8 +6502,8 @@ dependencies = [
 
 [[package]]
 name = "librms"
-version = "0.0.13"
-source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.0.13#a87f91da04009c62d9133e0ab4820361f3c541d1"
+version = "0.0.12"
+source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.0.12-rc4#a870c06ee1483a46ef3fb01cc4ce7d73470c7d3c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11426,7 +11425,7 @@ dependencies = [
 [[package]]
 name = "tonic-client-wrapper"
 version = "1.0.0"
-source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.0.13#a87f91da04009c62d9133e0ab4820361f3c541d1"
+source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.0.12-rc4#a870c06ee1483a46ef3fb01cc4ce7d73470c7d3c"
 dependencies = [
  "async-trait",
  "heck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.4" }
-librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.13" }
+librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.12-rc4" }
 ansi-to-html = "0.2.2"
 
 tokio = { version = "1", features = ["full", "tracing"] }

--- a/crates/admin-cli/src/rms/args.rs
+++ b/crates/admin-cli/src/rms/args.rs
@@ -57,6 +57,7 @@ pub struct PowerOnSequence {
 impl From<PowerOnSequence> for librms::protos::rack_manager::GetRackPowerOnSequenceRequest {
     fn from(args: PowerOnSequence) -> Self {
         Self {
+            metadata: None,
             rack_id: args.rack_id,
         }
     }
@@ -73,6 +74,7 @@ pub struct PowerState {
 impl From<PowerState> for librms::protos::rack_manager::GetPowerStateRequest {
     fn from(args: PowerState) -> Self {
         Self {
+            metadata: None,
             node_id: args.node_id,
             rack_id: args.rack_id,
         }
@@ -90,6 +92,7 @@ pub struct FirmwareInventory {
 impl From<FirmwareInventory> for librms::protos::rack_manager::GetNodeFirmwareInventoryRequest {
     fn from(args: FirmwareInventory) -> Self {
         Self {
+            metadata: None,
             node_id: args.node_id,
             rack_id: args.rack_id,
         }

--- a/crates/admin-cli/src/rms/cmds.rs
+++ b/crates/admin-cli/src/rms/cmds.rs
@@ -21,9 +21,9 @@ use librms::RmsApi;
 
 use crate::rms::args::{FirmwareInventory, PowerOnSequence, PowerState};
 
-/// Print the RMS node inventory as JSON.
-pub async fn list_node_inventory(rms_client: &Arc<dyn RmsApi>) -> eyre::Result<()> {
-    let response = rms_client.list_node_inventory().await?;
+pub async fn get_all_inventory(rms_client: &Arc<dyn RmsApi>) -> eyre::Result<()> {
+    let cmd = librms::protos::rack_manager::GetAllInventoryRequest::default();
+    let response = rms_client.get_all_inventory(cmd).await?;
     println!("{}", serde_json::to_string_pretty(&response)?);
     Ok(())
 }

--- a/crates/admin-cli/src/rms/mod.rs
+++ b/crates/admin-cli/src/rms/mod.rs
@@ -61,7 +61,7 @@ pub async fn action(action: RmsAction, config: &CliOptions) -> color_eyre::Resul
     let rms_client = rms_client_pool.create_client().await;
 
     match action.command {
-        Cmd::Inventory => cmds::list_node_inventory(&rms_client).await,
+        Cmd::Inventory => cmds::get_all_inventory(&rms_client).await,
         Cmd::PowerOnSequence(args) => cmds::power_on_sequence(args, &rms_client).await,
         Cmd::PowerState(args) => cmds::power_state(args, &rms_client).await,
         Cmd::FirmwareInventory(args) => cmds::get_firmware_inventory(args, &rms_client).await,

--- a/crates/api-core/src/tests/power_shelf_state_controller/maintenance.rs
+++ b/crates/api-core/src/tests/power_shelf_state_controller/maintenance.rs
@@ -108,7 +108,7 @@ async fn enter_maintenance(
 
 /// Set the power shelf's BMC MAC and rack association directly. The
 /// `new_power_shelf` site-explorer fixture leaves both as `None`, but the
-/// handler's `batch_set_power_state` path needs both before it
+/// handler's `set_power_state_by_device_list` path needs both before it
 /// will even attempt the BMC IP lookup.
 ///
 /// `power_shelves.bmc_mac_address` is a FK into `expected_power_shelves`,
@@ -226,14 +226,11 @@ async fn power_on_transitions_to_error_when_bmc_ip_unresolvable(
 
     // Queue a success response so we can assert it was *not* consumed.
     env.rms_sim
-        .queue_batch_set_power_state_response(Ok(rms::BatchSetPowerStateResponse {
+        .queue_set_power_state_by_device_list_response(Ok(rms::SetPowerStateByDeviceListResponse {
             response: Some(rms::NodeBatchResponse {
                 status: rms::ReturnCode::Success as i32,
-                stats: Some(rms::NodeOperationStats {
-                    total_nodes: 1,
-                    successful_nodes: 1,
-                    failed_nodes: 0,
-                }),
+                total_nodes: 1,
+                successful_nodes: 1,
                 ..Default::default()
             }),
         }))
@@ -263,7 +260,10 @@ async fn power_on_transitions_to_error_when_bmc_ip_unresolvable(
         "maintenance request should be cleared on error transition"
     );
 
-    let calls = env.rms_sim.submitted_batch_set_power_state_requests().await;
+    let calls = env
+        .rms_sim
+        .submitted_set_power_state_by_device_list_requests()
+        .await;
     assert!(
         calls.is_empty(),
         "RMS should not be invoked when BMC IP cannot be resolved, got: {} calls",
@@ -329,7 +329,10 @@ async fn power_on_transitions_to_error_when_rack_id_missing(
     let transition = commit_and_extract_transition(outcome).await.unwrap();
     assert_error_with_substring(&transition, "no rack association");
 
-    let calls = env.rms_sim.submitted_batch_set_power_state_requests().await;
+    let calls = env
+        .rms_sim
+        .submitted_set_power_state_by_device_list_requests()
+        .await;
     assert!(calls.is_empty(), "RMS must not be called without a rack_id");
 
     Ok(())
@@ -362,7 +365,10 @@ async fn power_on_transitions_to_error_when_bmc_mac_missing(
     let transition = commit_and_extract_transition(outcome).await.unwrap();
     assert_error_with_substring(&transition, "has no BMC MAC address recorded");
 
-    let calls = env.rms_sim.submitted_batch_set_power_state_requests().await;
+    let calls = env
+        .rms_sim
+        .submitted_set_power_state_by_device_list_requests()
+        .await;
     assert!(
         calls.is_empty(),
         "RMS must not be called without a BMC MAC address"
@@ -440,7 +446,10 @@ async fn power_off_transitions_to_error_when_rack_id_missing(
         assert!(cause.contains("PowerOff"));
     }
 
-    let calls = env.rms_sim.submitted_batch_set_power_state_requests().await;
+    let calls = env
+        .rms_sim
+        .submitted_set_power_state_by_device_list_requests()
+        .await;
     assert!(calls.is_empty());
 
     Ok(())
@@ -472,7 +481,10 @@ async fn power_off_transitions_to_error_when_bmc_mac_missing(
     let transition = commit_and_extract_transition(outcome).await.unwrap();
     assert_error_with_substring(&transition, "has no BMC MAC address recorded");
 
-    let calls = env.rms_sim.submitted_batch_set_power_state_requests().await;
+    let calls = env
+        .rms_sim
+        .submitted_set_power_state_by_device_list_requests()
+        .await;
     assert!(calls.is_empty());
 
     Ok(())
@@ -480,7 +492,7 @@ async fn power_off_transitions_to_error_when_bmc_mac_missing(
 
 // ── Sanity: non-Maintenance state never reaches the by-device-list path ────
 
-/// `Ready` should never invoke `batch_set_power_state`. This guards
+/// `Ready` should never invoke `set_power_state_by_device_list`. This guards
 /// against accidentally wiring the maintenance dispatch into other states.
 #[crate::sqlx_test]
 async fn ready_state_does_not_invoke_rms_set_power_state(
@@ -507,10 +519,13 @@ async fn ready_state_does_not_invoke_rms_set_power_state(
     // call was made.
     let _ = commit_and_extract_transition(outcome).await;
 
-    let calls = env.rms_sim.submitted_batch_set_power_state_requests().await;
+    let calls = env
+        .rms_sim
+        .submitted_set_power_state_by_device_list_requests()
+        .await;
     assert!(
         calls.is_empty(),
-        "Ready state must not call batch_set_power_state"
+        "Ready state must not call set_power_state_by_device_list"
     );
 
     Ok(())

--- a/crates/api-core/src/tests/rack_state_controller/handler.rs
+++ b/crates/api-core/src/tests/rack_state_controller/handler.rs
@@ -1389,16 +1389,13 @@ async fn test_firmware_upgrade_start_submits_json_and_deletes_access_token(
             response: Some(rms::NodeBatchResponse {
                 status: rms::ReturnCode::Success as i32,
                 message: "accepted".to_string(),
+                total_nodes: 1,
+                successful_nodes: 1,
                 job_id: "parent-job".to_string(),
-                stats: Some(rms::NodeOperationStats {
-                    total_nodes: 1,
-                    successful_nodes: 1,
-                    failed_nodes: 0,
-                }),
                 ..Default::default()
             }),
             object_id: "fw-json".to_string(),
-            jobs: vec![rms::NodeFirmwareJobInfo {
+            node_jobs: vec![rms::NodeFirmwareJobInfo {
                 node_id: switch_id_string.clone(),
                 job_id: "child-job".to_string(),
             }],
@@ -1443,13 +1440,16 @@ async fn test_firmware_upgrade_start_submits_json_and_deletes_access_token(
         "expected FirmwareUpgrade(WaitForComplete), got {:?}",
         std::mem::discriminant(&outcome),
     );
-    let requests = env.rms_sim.submitted_apply_firmware_object_requests().await;
+    let requests = env
+        .rms_sim
+        .submitted_apply_firmware_object_from_json_requests()
+        .await;
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0].config_json, r#"{"Id":"fw-json"}"#);
     assert_eq!(requests[0].access_token, "token");
     assert_eq!(requests[0].firmware_type, "prod");
     assert!(requests[0].force_update);
-    assert_eq!(requests[0].nodes.as_ref().unwrap().nodes.len(), 1);
+    assert_eq!(requests[0].nodes.as_ref().unwrap().devices.len(), 1);
 
     let token_after = env
         .test_credential_manager
@@ -1483,7 +1483,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_while_jobs_running(
         .set_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusResponse {
             status: librms::protos::rack_manager::ReturnCode::Success as i32,
             job_id: "child-job-1".to_string(),
-            job_state: rms::FirmwareJobState::Running as i32,
+            job_state: 1,
             state_description: "running".to_string(),
             node_id: host.host_snapshot.id.to_string(),
             ..Default::default()
@@ -1571,7 +1571,7 @@ async fn test_firmware_upgrade_wait_for_complete_transitions_to_error_on_job_fai
         .set_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusResponse {
             status: librms::protos::rack_manager::ReturnCode::Success as i32,
             job_id: "child-job-1".to_string(),
-            job_state: rms::FirmwareJobState::Failed as i32,
+            job_state: 3,
             state_description: "failed".to_string(),
             node_id: host.host_snapshot.id.to_string(),
             error_message: "upgrade failed".to_string(),
@@ -1674,7 +1674,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_termi
         .set_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusResponse {
             status: librms::protos::rack_manager::ReturnCode::Success as i32,
             job_id: "child-job-1".to_string(),
-            job_state: rms::FirmwareJobState::Failed as i32,
+            job_state: 3,
             state_description: "failed".to_string(),
             node_id: host_a.host_snapshot.id.to_string(),
             error_message: "upgrade failed".to_string(),
@@ -1685,7 +1685,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_termi
         .set_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusResponse {
             status: librms::protos::rack_manager::ReturnCode::Success as i32,
             job_id: "child-job-2".to_string(),
-            job_state: rms::FirmwareJobState::Running as i32,
+            job_state: 1,
             state_description: "running".to_string(),
             node_id: host_b.host_snapshot.id.to_string(),
             ..Default::default()
@@ -1783,7 +1783,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_termi
         .set_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusResponse {
             status: librms::protos::rack_manager::ReturnCode::Success as i32,
             job_id: "child-job-2".to_string(),
-            job_state: rms::FirmwareJobState::Completed as i32,
+            job_state: 2,
             state_description: "completed".to_string(),
             node_id: host_b.host_snapshot.id.to_string(),
             ..Default::default()
@@ -1999,7 +1999,7 @@ async fn test_firmware_upgrade_wait_for_complete_retries_on_transient_poll_error
 
 /// test_nvos_update_start_transitions_to_wait_for_complete verifies that
 /// Maintenance::NVOSUpdate(Start) transitions to WaitForComplete when a
-/// NVOS SOT JSON is available for RMS ApplySwitchSystemImage.
+/// NVOS SOT JSON is available for RMS ApplySwitchSystemImageFromJSON.
 #[crate::sqlx_test]
 async fn test_nvos_update_start_transitions_to_wait_for_complete(
     pool: sqlx::PgPool,
@@ -2086,11 +2086,11 @@ async fn test_nvos_update_start_transitions_to_wait_for_complete(
     );
     let requests = env
         .rms_sim
-        .submitted_apply_switch_system_image_requests()
+        .submitted_apply_switch_system_image_from_json_requests()
         .await;
     assert!(
         !requests.is_empty(),
-        "NVOSUpdate(Start) should submit ApplySwitchSystemImage"
+        "NVOSUpdate(Start) should submit ApplySwitchSystemImageFromJSON"
     );
     assert_eq!(requests[0].config_json, r#"{"Id":"fw-nvos-default"}"#);
     assert_eq!(requests[0].access_token, "token");
@@ -2186,13 +2186,13 @@ async fn test_configure_nmx_cluster_start_advances_to_disable_scale_up_fabric_st
 
     assert!(
         env.rms_sim
-            .submitted_batch_set_scale_up_fabric_state_requests()
+            .submitted_set_scale_up_fabric_state_requests()
             .await
             .is_empty()
     );
     assert!(
         env.rms_sim
-            .submitted_batch_get_node_device_info_requests()
+            .submitted_get_device_info_by_device_list_requests()
             .await
             .is_empty()
     );
@@ -2226,19 +2226,14 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_runs_on_all_sw
 
     let switch_ids = attach_switches_with_nvos_credentials(&env, &rack_id, 2).await?;
     env.rms_sim
-        .queue_batch_set_scale_up_fabric_state_response(Ok(
-            rms::BatchSetScaleUpFabricStateResponse {
-                response: Some(rms::NodeBatchResponse {
-                    status: rms::ReturnCode::Success as i32,
-                    stats: Some(rms::NodeOperationStats {
-                        total_nodes: switch_ids.len() as u32,
-                        successful_nodes: switch_ids.len() as u32,
-                        failed_nodes: 0,
-                    }),
-                    ..Default::default()
-                }),
-            },
-        ))
+        .queue_set_scale_up_fabric_state_response(Ok(rms::SetScaleUpFabricStateResponse {
+            response: Some(rms::NodeBatchResponse {
+                status: rms::ReturnCode::Success as i32,
+                successful_nodes: switch_ids.len() as i32,
+                failed_nodes: 0,
+                ..Default::default()
+            }),
+        }))
         .await;
 
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
@@ -2286,27 +2281,18 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_runs_on_all_sw
 
     let requests = env
         .rms_sim
-        .submitted_batch_set_scale_up_fabric_state_requests()
+        .submitted_set_scale_up_fabric_state_requests()
         .await;
     assert_eq!(requests.len(), 1);
     let request = &requests[0];
-    assert!(!request.enabled);
+    assert_eq!(request.enabled, Some(false));
     let devices = request
         .nodes
         .as_ref()
         .expect("disable request should include nodes")
-        .nodes
+        .devices
         .as_slice();
-
     assert_eq!(devices.len(), switch_ids.len());
-    for device in devices {
-        let host_endpoint = device
-            .host_endpoint
-            .as_ref()
-            .ok_or_else(|| eyre::eyre!("disable request should include host endpoints"))?;
-
-        assert!(host_endpoint.dangerously_accept_invalid_certs);
-    }
     let node_ids = devices
         .iter()
         .map(|device| device.node_id.clone())
@@ -2316,7 +2302,7 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_runs_on_all_sw
     }
     assert!(
         env.rms_sim
-            .submitted_batch_get_node_device_info_requests()
+            .submitted_get_device_info_by_device_list_requests()
             .await
             .is_empty()
     );
@@ -2361,9 +2347,9 @@ async fn test_configure_nmx_cluster_configure_selects_persists_and_configures_pr
     let topology_type = RackHardwareTopology::Gb200Nvl72r1C2g4Topology.to_string();
 
     env.rms_sim
-        .queue_batch_get_node_device_info_response(Ok(rms::BatchGetNodeDeviceInfoResponse {
+        .queue_get_device_info_by_device_list_response(Ok(rms::GetDeviceInfoByDeviceListResponse {
             status: rms::ReturnCode::Success as i32,
-            node_device_details: vec![
+            node_device_info: vec![
                 rms::NodeDeviceInfo {
                     node_id: secondary_switch_id.to_string(),
                     tray_index: Some(2),
@@ -2436,21 +2422,21 @@ async fn test_configure_nmx_cluster_configure_selects_persists_and_configures_pr
 
     assert!(
         env.rms_sim
-            .submitted_batch_set_scale_up_fabric_state_requests()
+            .submitted_set_scale_up_fabric_state_requests()
             .await
             .is_empty()
     );
 
     let device_info_requests = env
         .rms_sim
-        .submitted_batch_get_node_device_info_requests()
+        .submitted_get_device_info_by_device_list_requests()
         .await;
     assert_eq!(device_info_requests.len(), 1);
     let device_info_nodes = device_info_requests[0]
         .nodes
         .as_ref()
         .expect("device-info request should include nodes")
-        .nodes
+        .devices
         .as_slice();
     assert_eq!(device_info_nodes.len(), switch_ids.len());
 
@@ -2461,18 +2447,13 @@ async fn test_configure_nmx_cluster_configure_selects_persists_and_configures_pr
     assert_eq!(configure_requests.len(), 1);
     let configure_request = &configure_requests[0];
     assert_eq!(configure_request.topology_type, topology_type);
-    let configure_node = configure_request
-        .node
-        .as_ref()
-        .ok_or_else(|| eyre::eyre!("configure request should include a primary switch"))?;
-
-    assert_eq!(configure_node.node_id, primary_switch_id.to_string());
-    assert!(
-        configure_node
-            .host_endpoint
+    assert_eq!(
+        configure_request
+            .device
             .as_ref()
-            .ok_or_else(|| eyre::eyre!("configure request should include a host endpoint"))?
-            .dangerously_accept_invalid_certs
+            .expect("configure request should include a primary switch")
+            .node_id,
+        primary_switch_id.to_string()
     );
 
     let mut txn = pool.acquire().await?;
@@ -2519,24 +2500,19 @@ async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fab
     let topology_type = RackHardwareTopology::Gb200Nvl72r1C2g4Topology.to_string();
 
     env.rms_sim
-        .queue_batch_set_scale_up_fabric_state_response(Ok(
-            rms::BatchSetScaleUpFabricStateResponse {
-                response: Some(rms::NodeBatchResponse {
-                    status: rms::ReturnCode::Success as i32,
-                    stats: Some(rms::NodeOperationStats {
-                        total_nodes: switch_ids.len() as u32,
-                        successful_nodes: switch_ids.len() as u32,
-                        failed_nodes: 0,
-                    }),
-                    ..Default::default()
-                }),
-            },
-        ))
+        .queue_set_scale_up_fabric_state_response(Ok(rms::SetScaleUpFabricStateResponse {
+            response: Some(rms::NodeBatchResponse {
+                status: rms::ReturnCode::Success as i32,
+                successful_nodes: switch_ids.len() as i32,
+                failed_nodes: 0,
+                ..Default::default()
+            }),
+        }))
         .await;
     env.rms_sim
-        .queue_batch_get_node_device_info_response(Ok(rms::BatchGetNodeDeviceInfoResponse {
+        .queue_get_device_info_by_device_list_response(Ok(rms::GetDeviceInfoByDeviceListResponse {
             status: rms::ReturnCode::Success as i32,
-            node_device_details: vec![
+            node_device_info: vec![
                 rms::NodeDeviceInfo {
                     node_id: secondary_switch_id.to_string(),
                     tray_index: Some(2),
@@ -2610,13 +2586,13 @@ async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fab
 
     assert!(
         env.rms_sim
-            .submitted_batch_set_scale_up_fabric_state_requests()
+            .submitted_set_scale_up_fabric_state_requests()
             .await
             .is_empty()
     );
     assert!(
         env.rms_sim
-            .submitted_batch_get_node_device_info_requests()
+            .submitted_get_device_info_by_device_list_requests()
             .await
             .is_empty()
     );
@@ -2655,27 +2631,18 @@ async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fab
 
     let disable_requests = env
         .rms_sim
-        .submitted_batch_set_scale_up_fabric_state_requests()
+        .submitted_set_scale_up_fabric_state_requests()
         .await;
     assert_eq!(disable_requests.len(), 1);
     let disable_request = &disable_requests[0];
-    assert!(!disable_request.enabled);
+    assert_eq!(disable_request.enabled, Some(false));
     let disable_devices = disable_request
         .nodes
         .as_ref()
         .expect("disable request should include nodes")
-        .nodes
+        .devices
         .as_slice();
-
     assert_eq!(disable_devices.len(), switch_ids.len());
-    for device in disable_devices {
-        let host_endpoint = device
-            .host_endpoint
-            .as_ref()
-            .ok_or_else(|| eyre::eyre!("disable request should include host endpoints"))?;
-
-        assert!(host_endpoint.dangerously_accept_invalid_certs);
-    }
     let disabled_node_ids = disable_devices
         .iter()
         .map(|device| device.node_id.clone())
@@ -2685,7 +2652,7 @@ async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fab
     }
     assert!(
         env.rms_sim
-            .submitted_batch_get_node_device_info_requests()
+            .submitted_get_device_info_by_device_list_requests()
             .await
             .is_empty()
     );
@@ -2723,14 +2690,14 @@ async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fab
 
     let device_info_requests = env
         .rms_sim
-        .submitted_batch_get_node_device_info_requests()
+        .submitted_get_device_info_by_device_list_requests()
         .await;
     assert_eq!(device_info_requests.len(), 1);
     let device_info_devices = device_info_requests[0]
         .nodes
         .as_ref()
         .expect("device-info request should include nodes")
-        .nodes
+        .devices
         .as_slice();
     assert_eq!(device_info_devices.len(), switch_ids.len());
 
@@ -2741,18 +2708,13 @@ async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fab
     assert_eq!(configure_requests.len(), 1);
     let configure_request = &configure_requests[0];
     assert_eq!(configure_request.topology_type, topology_type);
-    let configure_node = configure_request
-        .node
-        .as_ref()
-        .ok_or_else(|| eyre::eyre!("configure request should include a primary switch"))?;
-
-    assert_eq!(configure_node.node_id, primary_switch_id.to_string());
-    assert!(
-        configure_node
-            .host_endpoint
+    assert_eq!(
+        configure_request
+            .device
             .as_ref()
-            .ok_or_else(|| eyre::eyre!("configure request should include a host endpoint"))?
-            .dangerously_accept_invalid_certs
+            .expect("configure request should include a primary switch")
+            .node_id,
+        primary_switch_id.to_string()
     );
 
     let mut txn = pool.acquire().await?;
@@ -2788,20 +2750,15 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_failure_stops_
 
     attach_switches_with_nvos_credentials(&env, &rack_id, 2).await?;
     env.rms_sim
-        .queue_batch_set_scale_up_fabric_state_response(Ok(
-            rms::BatchSetScaleUpFabricStateResponse {
-                response: Some(rms::NodeBatchResponse {
-                    status: rms::ReturnCode::Failure as i32,
-                    message: "disable rejected".to_string(),
-                    stats: Some(rms::NodeOperationStats {
-                        total_nodes: 2,
-                        successful_nodes: 1,
-                        failed_nodes: 1,
-                    }),
-                    ..Default::default()
-                }),
-            },
-        ))
+        .queue_set_scale_up_fabric_state_response(Ok(rms::SetScaleUpFabricStateResponse {
+            response: Some(rms::NodeBatchResponse {
+                status: rms::ReturnCode::Failure as i32,
+                successful_nodes: 1,
+                failed_nodes: 1,
+                message: "disable rejected".to_string(),
+                ..Default::default()
+            }),
+        }))
         .await;
 
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
@@ -2828,7 +2785,7 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_failure_stops_
     match outcome {
         StateHandlerOutcome::Transition { next_state, .. } => match next_state {
             RackState::Error { cause } => {
-                assert!(cause.contains("RMS BatchSetScaleUpFabricState failed"));
+                assert!(cause.contains("RMS SetScaleUpFabricState failed"));
                 assert!(cause.contains("disable rejected"));
             }
             other => panic!("Expected Error state, got {:?}", other),
@@ -2841,14 +2798,14 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_failure_stops_
 
     assert_eq!(
         env.rms_sim
-            .submitted_batch_set_scale_up_fabric_state_requests()
+            .submitted_set_scale_up_fabric_state_requests()
             .await
             .len(),
         1
     );
     assert!(
         env.rms_sim
-            .submitted_batch_get_node_device_info_requests()
+            .submitted_get_device_info_by_device_list_requests()
             .await
             .is_empty()
     );
@@ -2889,9 +2846,9 @@ async fn test_configure_nmx_cluster_configure_selection_failure_stops_before_con
 
     let switch_ids = attach_switches_with_nvos_credentials(&env, &rack_id, 2).await?;
     env.rms_sim
-        .queue_batch_get_node_device_info_response(Ok(rms::BatchGetNodeDeviceInfoResponse {
+        .queue_get_device_info_by_device_list_response(Ok(rms::GetDeviceInfoByDeviceListResponse {
             status: rms::ReturnCode::Success as i32,
-            node_device_details: vec![
+            node_device_info: vec![
                 rms::NodeDeviceInfo {
                     node_id: switch_ids[0].to_string(),
                     tray_index: Some(1),
@@ -2945,13 +2902,13 @@ async fn test_configure_nmx_cluster_configure_selection_failure_stops_before_con
 
     assert!(
         env.rms_sim
-            .submitted_batch_set_scale_up_fabric_state_requests()
+            .submitted_set_scale_up_fabric_state_requests()
             .await
             .is_empty()
     );
     assert_eq!(
         env.rms_sim
-            .submitted_batch_get_node_device_info_requests()
+            .submitted_get_device_info_by_device_list_requests()
             .await
             .len(),
         1
@@ -3004,9 +2961,9 @@ async fn test_configure_nmx_cluster_configure_failure_advances_to_wait_for_fabri
     let topology_type = RackHardwareTopology::Gb200Nvl72r1C2g4Topology.to_string();
 
     env.rms_sim
-        .queue_batch_get_node_device_info_response(Ok(rms::BatchGetNodeDeviceInfoResponse {
+        .queue_get_device_info_by_device_list_response(Ok(rms::GetDeviceInfoByDeviceListResponse {
             status: rms::ReturnCode::Success as i32,
-            node_device_details: vec![
+            node_device_info: vec![
                 rms::NodeDeviceInfo {
                     node_id: primary_switch_id.to_string(),
                     tray_index: Some(1),
@@ -3077,13 +3034,13 @@ async fn test_configure_nmx_cluster_configure_failure_advances_to_wait_for_fabri
 
     assert!(
         env.rms_sim
-            .submitted_batch_set_scale_up_fabric_state_requests()
+            .submitted_set_scale_up_fabric_state_requests()
             .await
             .is_empty()
     );
     assert_eq!(
         env.rms_sim
-            .submitted_batch_get_node_device_info_requests()
+            .submitted_get_device_info_by_device_list_requests()
             .await
             .len(),
         1
@@ -3094,18 +3051,13 @@ async fn test_configure_nmx_cluster_configure_failure_advances_to_wait_for_fabri
         .await;
     assert_eq!(configure_requests.len(), 1);
     assert_eq!(configure_requests[0].topology_type, topology_type);
-    let configure_node = configure_requests[0]
-        .node
-        .as_ref()
-        .ok_or_else(|| eyre::eyre!("configure request should include a primary switch"))?;
-
-    assert_eq!(configure_node.node_id, primary_switch_id.to_string());
-    assert!(
-        configure_node
-            .host_endpoint
+    assert_eq!(
+        configure_requests[0]
+            .device
             .as_ref()
-            .ok_or_else(|| eyre::eyre!("configure request should include a host endpoint"))?
-            .dangerously_accept_invalid_certs
+            .expect("configure request should include a primary switch")
+            .node_id,
+        primary_switch_id.to_string()
     );
 
     let mut txn = pool.acquire().await?;

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -460,7 +460,7 @@ impl Display for RackMaintenanceState {
 /// disables ScaleUpFabric state on all scoped switches before
 /// `ConfigureScaleUpFabricManager` selects, persists, and configures only the
 /// primary switch. `WaitForFabricStatus` polls
-/// `BatchGetScaleUpFabricServiceStatus` and persists the per-switch
+/// `GetScaleUpFabricServicesStatus` and persists the per-switch
 /// `fabric_manager_status` before advancing.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ConfigureNmxClusterState {

--- a/crates/api-test-helper/src/mock_rms.rs
+++ b/crates/api-test-helper/src/mock_rms.rs
@@ -27,13 +27,13 @@
 //!
 //! ```ignore
 //! let mock = MockRmsApi::new();
-//! mock.enqueue_set_power_state(Ok(MockRmsApi::power_ok())).await;
+//! mock.enqueue_power_state(Ok(MockRmsApi::power_ok())).await;
 //!
 //! let backend = RmsPowerShelfBackend::new(Arc::new(mock));
 //! let results = backend.power_control(&endpoints, PowerAction::On).await.unwrap();
 //!
 //! assert!(results[0].success);
-//! let calls = mock.set_power_state_calls().await;
+//! let calls = mock.power_state_calls().await;
 //! assert_eq!(calls[0].node_id, "ps-001");
 //! ```
 
@@ -48,8 +48,8 @@ use tokio::sync::Mutex;
 /// per method and inspect what requests were sent.
 ///
 /// Every `RmsApi` method has a corresponding:
-/// - `enqueue_*()` - push a response to be returned on the next call
-/// - `*_calls()` - retrieve all recorded requests for that method
+/// - `enqueue_*()` — push a response to be returned on the next call
+/// - `*_calls()` — retrieve all recorded requests for that method
 ///
 /// If no response is queued when a method is called, it returns a
 /// clear "no response queued" error so tests fail explicitly.
@@ -59,35 +59,35 @@ pub struct MockRmsApi {
         Mutex<VecDeque<Result<rms::SetPowerStateResponse, RackManagerError>>>,
     set_power_state_calls: Mutex<Vec<rms::SetPowerStateRequest>>,
 
-    batch_set_power_state_responses:
-        Mutex<VecDeque<Result<rms::BatchSetPowerStateResponse, RackManagerError>>>,
-    batch_set_power_state_calls: Mutex<Vec<rms::BatchSetPowerStateRequest>>,
+    set_power_state_by_device_list_responses:
+        Mutex<VecDeque<Result<rms::SetPowerStateByDeviceListResponse, RackManagerError>>>,
+    set_power_state_by_device_list_calls: Mutex<Vec<rms::SetPowerStateByDeviceListRequest>>,
 
     get_power_state_responses:
         Mutex<VecDeque<Result<rms::GetPowerStateResponse, RackManagerError>>>,
     get_power_state_calls: Mutex<Vec<rms::GetPowerStateRequest>>,
 
-    batch_get_power_state_responses:
-        Mutex<VecDeque<Result<rms::BatchGetPowerStateResponse, RackManagerError>>>,
-    batch_get_power_state_calls: Mutex<Vec<rms::BatchGetPowerStateRequest>>,
+    get_power_state_by_device_list_responses:
+        Mutex<VecDeque<Result<rms::GetPowerStateByDeviceListResponse, RackManagerError>>>,
+    get_power_state_by_device_list_calls: Mutex<Vec<rms::GetPowerStateByDeviceListRequest>>,
 
     sequence_rack_power_responses:
         Mutex<VecDeque<Result<rms::SequenceRackPowerResponse, RackManagerError>>>,
     sequence_rack_power_calls: Mutex<Vec<rms::SequenceRackPowerRequest>>,
 
     // Inventory calls.
-    list_node_inventory_responses:
-        Mutex<VecDeque<Result<rms::ListNodeInventoryResponse, RackManagerError>>>,
-    list_node_inventory_calls: Mutex<Vec<rms::ListNodeInventoryRequest>>,
+    get_all_inventory_responses:
+        Mutex<VecDeque<Result<rms::GetAllInventoryResponse, RackManagerError>>>,
+    get_all_inventory_calls: Mutex<Vec<rms::GetAllInventoryRequest>>,
 
-    create_nodes_responses: Mutex<VecDeque<Result<rms::CreateNodesResponse, RackManagerError>>>,
-    create_nodes_calls: Mutex<Vec<rms::CreateNodesRequest>>,
+    add_node_responses: Mutex<VecDeque<Result<rms::AddNodeResponse, RackManagerError>>>,
+    add_node_calls: Mutex<Vec<rms::AddNodeRequest>>,
 
     update_node_responses: Mutex<VecDeque<Result<rms::UpdateNodeResponse, RackManagerError>>>,
     update_node_calls: Mutex<Vec<rms::UpdateNodeRequest>>,
 
-    delete_node_responses: Mutex<VecDeque<Result<rms::DeleteNodeResponse, RackManagerError>>>,
-    delete_node_calls: Mutex<Vec<rms::DeleteNodeRequest>>,
+    remove_node_responses: Mutex<VecDeque<Result<rms::RemoveNodeResponse, RackManagerError>>>,
+    remove_node_calls: Mutex<Vec<rms::RemoveNodeRequest>>,
 
     list_racks_responses: Mutex<VecDeque<Result<rms::ListRacksResponse, RackManagerError>>>,
     list_racks_calls: Mutex<Vec<rms::ListRacksRequest>>,
@@ -97,13 +97,13 @@ pub struct MockRmsApi {
         Mutex<VecDeque<Result<rms::GetNodeDeviceInfoResponse, RackManagerError>>>,
     get_node_device_info_calls: Mutex<Vec<rms::GetNodeDeviceInfoRequest>>,
 
-    list_node_device_info_by_node_type_responses:
-        Mutex<VecDeque<Result<rms::ListNodeDeviceInfoByNodeTypeResponse, RackManagerError>>>,
-    list_node_device_info_by_node_type_calls: Mutex<Vec<rms::ListNodeDeviceInfoByNodeTypeRequest>>,
+    get_device_info_by_node_type_responses:
+        Mutex<VecDeque<Result<rms::GetDeviceInfoByNodeTypeResponse, RackManagerError>>>,
+    get_device_info_by_node_type_calls: Mutex<Vec<rms::GetDeviceInfoByNodeTypeRequest>>,
 
-    batch_get_node_device_info_responses:
-        Mutex<VecDeque<Result<rms::BatchGetNodeDeviceInfoResponse, RackManagerError>>>,
-    batch_get_node_device_info_calls: Mutex<Vec<rms::BatchGetNodeDeviceInfoRequest>>,
+    get_device_info_by_device_list_responses:
+        Mutex<VecDeque<Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError>>>,
+    get_device_info_by_device_list_calls: Mutex<Vec<rms::GetDeviceInfoByDeviceListRequest>>,
 
     // Power-on sequence calls.
     get_rack_power_on_sequence_responses:
@@ -123,12 +123,10 @@ pub struct MockRmsApi {
         Mutex<VecDeque<Result<rms::GetRackFirmwareInventoryResponse, RackManagerError>>>,
     get_rack_firmware_inventory_calls: Mutex<Vec<rms::GetRackFirmwareInventoryRequest>>,
 
-    add_firmware_object_responses:
-        Mutex<VecDeque<Result<rms::AddFirmwareObjectResponse, RackManagerError>>>,
+    add_firmware_object_responses: Mutex<VecDeque<Result<rms::FirmwareObject, RackManagerError>>>,
     add_firmware_object_calls: Mutex<Vec<rms::AddFirmwareObjectRequest>>,
 
-    get_firmware_object_responses:
-        Mutex<VecDeque<Result<rms::GetFirmwareObjectResponse, RackManagerError>>>,
+    get_firmware_object_responses: Mutex<VecDeque<Result<rms::FirmwareObject, RackManagerError>>>,
     get_firmware_object_calls: Mutex<Vec<rms::GetFirmwareObjectRequest>>,
 
     list_firmware_objects_responses:
@@ -136,69 +134,62 @@ pub struct MockRmsApi {
     list_firmware_objects_calls: Mutex<Vec<rms::ListFirmwareObjectsRequest>>,
 
     delete_firmware_object_responses:
-        Mutex<VecDeque<Result<rms::DeleteFirmwareObjectResponse, RackManagerError>>>,
+        Mutex<VecDeque<Result<rms::OperationResponse, RackManagerError>>>,
     delete_firmware_object_calls: Mutex<Vec<rms::DeleteFirmwareObjectRequest>>,
 
     set_default_firmware_object_responses:
-        Mutex<VecDeque<Result<rms::SetDefaultFirmwareObjectResponse, RackManagerError>>>,
+        Mutex<VecDeque<Result<rms::FirmwareObject, RackManagerError>>>,
     set_default_firmware_object_calls: Mutex<Vec<rms::SetDefaultFirmwareObjectRequest>>,
-
-    apply_stored_firmware_object_responses:
-        Mutex<VecDeque<Result<rms::ApplyStoredFirmwareObjectResponse, RackManagerError>>>,
-    apply_stored_firmware_object_calls: Mutex<Vec<rms::ApplyStoredFirmwareObjectRequest>>,
 
     apply_firmware_object_responses:
         Mutex<VecDeque<Result<rms::ApplyFirmwareObjectResponse, RackManagerError>>>,
     apply_firmware_object_calls: Mutex<Vec<rms::ApplyFirmwareObjectRequest>>,
 
+    apply_firmware_object_from_json_responses:
+        Mutex<VecDeque<Result<rms::ApplyFirmwareObjectResponse, RackManagerError>>>,
+    apply_firmware_object_from_json_calls: Mutex<Vec<rms::ApplyFirmwareObjectFromJsonRequest>>,
+
+    apply_switch_system_image_from_json_responses:
+        Mutex<VecDeque<Result<rms::ApplySwitchSystemImageResponse, RackManagerError>>>,
+    apply_switch_system_image_from_json_calls:
+        Mutex<Vec<rms::ApplySwitchSystemImageFromJsonRequest>>,
+
     apply_switch_system_image_responses:
         Mutex<VecDeque<Result<rms::ApplySwitchSystemImageResponse, RackManagerError>>>,
     apply_switch_system_image_calls: Mutex<Vec<rms::ApplySwitchSystemImageRequest>>,
-
-    apply_stored_switch_system_image_responses:
-        Mutex<VecDeque<Result<rms::ApplyStoredSwitchSystemImageResponse, RackManagerError>>>,
-    apply_stored_switch_system_image_calls: Mutex<Vec<rms::ApplyStoredSwitchSystemImageRequest>>,
 
     get_firmware_object_history_responses:
         Mutex<VecDeque<Result<rms::GetFirmwareObjectHistoryResponse, RackManagerError>>>,
     get_firmware_object_history_calls: Mutex<Vec<rms::GetFirmwareObjectHistoryRequest>>,
 
-    update_firmware_responses:
-        Mutex<VecDeque<Result<rms::UpdateFirmwareResponse, RackManagerError>>>,
-    update_firmware_calls: Mutex<Vec<rms::UpdateFirmwareRequest>>,
+    update_node_firmware_async_responses:
+        Mutex<VecDeque<Result<rms::UpdateNodeFirmwareResponse, RackManagerError>>>,
+    update_node_firmware_async_calls: Mutex<Vec<rms::UpdateNodeFirmwareRequest>>,
 
-    batch_update_firmware_by_node_type_responses:
-        Mutex<VecDeque<Result<rms::BatchUpdateFirmwareByNodeTypeResponse, RackManagerError>>>,
-    batch_update_firmware_by_node_type_calls: Mutex<Vec<rms::BatchUpdateFirmwareByNodeTypeRequest>>,
+    update_firmware_by_node_type_async_responses:
+        Mutex<VecDeque<Result<rms::UpdateFirmwareByNodeTypeAsyncResponse, RackManagerError>>>,
+    update_firmware_by_node_type_async_calls: Mutex<Vec<rms::UpdateFirmwareByNodeTypeRequest>>,
 
-    batch_update_firmware_responses:
-        Mutex<VecDeque<Result<rms::BatchUpdateFirmwareResponse, RackManagerError>>>,
-    batch_update_firmware_calls: Mutex<Vec<rms::BatchUpdateFirmwareRequest>>,
-
-    update_switch_system_image_responses:
-        Mutex<VecDeque<Result<rms::UpdateSwitchSystemImageResponse, RackManagerError>>>,
-    update_switch_system_image_calls: Mutex<Vec<rms::UpdateSwitchSystemImageRequest>>,
-
-    update_switch_system_password_responses:
-        Mutex<VecDeque<Result<rms::UpdateSwitchSystemPasswordResponse, RackManagerError>>>,
-    update_switch_system_password_calls: Mutex<Vec<rms::UpdateSwitchSystemPasswordRequest>>,
+    update_firmware_by_device_list_responses:
+        Mutex<VecDeque<Result<rms::UpdateFirmwareByDeviceListResponse, RackManagerError>>>,
+    update_firmware_by_device_list_calls: Mutex<Vec<rms::UpdateFirmwareByDeviceListRequest>>,
 
     get_firmware_job_status_responses:
         Mutex<VecDeque<Result<rms::GetFirmwareJobStatusResponse, RackManagerError>>>,
     get_firmware_job_status_calls: Mutex<Vec<rms::GetFirmwareJobStatusRequest>>,
 
     // Switch firmware calls.
-    list_switch_firmware_responses:
-        Mutex<VecDeque<Result<rms::ListSwitchFirmwareResponse, RackManagerError>>>,
-    list_switch_firmware_calls: Mutex<Vec<rms::ListSwitchFirmwareRequest>>,
+    list_firmware_on_switch_responses:
+        Mutex<VecDeque<Result<rms::ListFirmwareOnSwitchResponse, RackManagerError>>>,
+    list_firmware_on_switch_calls: Mutex<Vec<rms::ListFirmwareOnSwitchCommand>>,
 
-    push_switch_firmware_responses:
-        Mutex<VecDeque<Result<rms::PushSwitchFirmwareResponse, RackManagerError>>>,
-    push_switch_firmware_calls: Mutex<Vec<rms::PushSwitchFirmwareRequest>>,
+    push_firmware_to_switch_responses:
+        Mutex<VecDeque<Result<rms::PushFirmwareToSwitchResponse, RackManagerError>>>,
+    push_firmware_to_switch_calls: Mutex<Vec<rms::PushFirmwareToSwitchCommand>>,
 
-    upgrade_switch_firmware_responses:
-        Mutex<VecDeque<Result<rms::UpgradeSwitchFirmwareResponse, RackManagerError>>>,
-    upgrade_switch_firmware_calls: Mutex<Vec<rms::UpgradeSwitchFirmwareRequest>>,
+    upgrade_firmware_on_switch_responses:
+        Mutex<VecDeque<Result<rms::UpgradeFirmwareOnSwitchResponse, RackManagerError>>>,
+    upgrade_firmware_on_switch_calls: Mutex<Vec<rms::UpgradeFirmwareOnSwitchCommand>>,
 
     // Switch system images calls.
     fetch_switch_system_image_responses:
@@ -213,40 +204,27 @@ pub struct MockRmsApi {
         Mutex<VecDeque<Result<rms::ListSwitchSystemImagesResponse, RackManagerError>>>,
     list_switch_system_images_calls: Mutex<Vec<rms::ListSwitchSystemImagesRequest>>,
 
-    poll_switch_firmware_job_status_responses:
-        Mutex<VecDeque<Result<rms::PollSwitchFirmwareJobStatusResponse, RackManagerError>>>,
-    poll_switch_firmware_job_status_calls: Mutex<Vec<rms::PollSwitchFirmwareJobStatusRequest>>,
-
-    get_switch_system_image_job_status_responses:
-        Mutex<VecDeque<Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError>>>,
-    get_switch_system_image_job_status_calls: Mutex<Vec<rms::GetSwitchSystemImageJobStatusRequest>>,
+    poll_job_status_responses:
+        Mutex<VecDeque<Result<rms::PollJobStatusResponse, RackManagerError>>>,
+    poll_job_status_calls: Mutex<Vec<rms::PollJobStatusCommand>>,
 
     // Scale-up fabric calls.
     configure_scale_up_fabric_manager_responses:
         Mutex<VecDeque<Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError>>>,
     configure_scale_up_fabric_manager_calls: Mutex<Vec<rms::ConfigureScaleUpFabricManagerRequest>>,
 
-    batch_set_scale_up_fabric_state_responses:
-        Mutex<VecDeque<Result<rms::BatchSetScaleUpFabricStateResponse, RackManagerError>>>,
-    batch_set_scale_up_fabric_state_calls: Mutex<Vec<rms::BatchSetScaleUpFabricStateRequest>>,
+    set_scale_up_fabric_state_responses:
+        Mutex<VecDeque<Result<rms::SetScaleUpFabricStateResponse, RackManagerError>>>,
+    set_scale_up_fabric_state_calls: Mutex<Vec<rms::SetScaleUpFabricStateRequest>>,
 
-    batch_get_scale_up_fabric_service_status_responses:
-        Mutex<VecDeque<Result<rms::BatchGetScaleUpFabricServiceStatusResponse, RackManagerError>>>,
-    batch_get_scale_up_fabric_service_status_calls:
-        Mutex<Vec<rms::BatchGetScaleUpFabricServiceStatusRequest>>,
-
-    get_scale_up_fabric_state_responses:
-        Mutex<VecDeque<Result<rms::GetScaleUpFabricStateResponse, RackManagerError>>>,
-    get_scale_up_fabric_state_calls: Mutex<Vec<rms::GetScaleUpFabricStateRequest>>,
-
-    set_scale_up_fabric_telemetry_interface_state_responses: Mutex<
-        VecDeque<Result<rms::SetScaleUpFabricTelemetryInterfaceStateResponse, RackManagerError>>,
+    enable_scale_up_fabric_telemetry_interface_responses: Mutex<
+        VecDeque<Result<rms::EnableScaleUpFabricTelemetryInterfaceResponse, RackManagerError>>,
     >,
-    set_scale_up_fabric_telemetry_interface_state_calls:
-        Mutex<Vec<rms::SetScaleUpFabricTelemetryInterfaceStateRequest>>,
+    enable_scale_up_fabric_telemetry_interface_calls:
+        Mutex<Vec<rms::EnableScaleUpFabricTelemetryInterfaceRequest>>,
 
-    // Version calls.
-    version_responses: Mutex<VecDeque<Result<rms::GetVersionResponse, RackManagerError>>>,
+    // Version (no request type).
+    version_responses: Mutex<VecDeque<Result<(), RackManagerError>>>,
     version_call_count: Mutex<u32>,
 }
 
@@ -268,30 +246,30 @@ impl MockRmsApi {
         Self {
             set_power_state_responses: Default::default(),
             set_power_state_calls: Default::default(),
-            batch_set_power_state_responses: Default::default(),
-            batch_set_power_state_calls: Default::default(),
+            set_power_state_by_device_list_responses: Default::default(),
+            set_power_state_by_device_list_calls: Default::default(),
+            get_power_state_by_device_list_responses: Default::default(),
+            get_power_state_by_device_list_calls: Default::default(),
             get_power_state_responses: Default::default(),
             get_power_state_calls: Default::default(),
-            batch_get_power_state_responses: Default::default(),
-            batch_get_power_state_calls: Default::default(),
             sequence_rack_power_responses: Default::default(),
             sequence_rack_power_calls: Default::default(),
-            list_node_inventory_responses: Default::default(),
-            list_node_inventory_calls: Default::default(),
-            create_nodes_responses: Default::default(),
-            create_nodes_calls: Default::default(),
+            get_all_inventory_responses: Default::default(),
+            get_all_inventory_calls: Default::default(),
+            add_node_responses: Default::default(),
+            add_node_calls: Default::default(),
             update_node_responses: Default::default(),
             update_node_calls: Default::default(),
-            delete_node_responses: Default::default(),
-            delete_node_calls: Default::default(),
+            remove_node_responses: Default::default(),
+            remove_node_calls: Default::default(),
             list_racks_responses: Default::default(),
             list_racks_calls: Default::default(),
             get_node_device_info_responses: Default::default(),
             get_node_device_info_calls: Default::default(),
-            list_node_device_info_by_node_type_responses: Default::default(),
-            list_node_device_info_by_node_type_calls: Default::default(),
-            batch_get_node_device_info_responses: Default::default(),
-            batch_get_node_device_info_calls: Default::default(),
+            get_device_info_by_node_type_responses: Default::default(),
+            get_device_info_by_node_type_calls: Default::default(),
+            get_device_info_by_device_list_responses: Default::default(),
+            get_device_info_by_device_list_calls: Default::default(),
             get_rack_power_on_sequence_responses: Default::default(),
             get_rack_power_on_sequence_calls: Default::default(),
             set_rack_power_on_sequence_responses: Default::default(),
@@ -310,54 +288,44 @@ impl MockRmsApi {
             delete_firmware_object_calls: Default::default(),
             set_default_firmware_object_responses: Default::default(),
             set_default_firmware_object_calls: Default::default(),
-            apply_stored_firmware_object_responses: Default::default(),
-            apply_stored_firmware_object_calls: Default::default(),
             apply_firmware_object_responses: Default::default(),
             apply_firmware_object_calls: Default::default(),
+            apply_firmware_object_from_json_responses: Default::default(),
+            apply_firmware_object_from_json_calls: Default::default(),
+            apply_switch_system_image_from_json_responses: Default::default(),
+            apply_switch_system_image_from_json_calls: Default::default(),
             apply_switch_system_image_responses: Default::default(),
             apply_switch_system_image_calls: Default::default(),
-            apply_stored_switch_system_image_responses: Default::default(),
-            apply_stored_switch_system_image_calls: Default::default(),
             get_firmware_object_history_responses: Default::default(),
             get_firmware_object_history_calls: Default::default(),
-            update_firmware_responses: Default::default(),
-            update_firmware_calls: Default::default(),
-            batch_update_firmware_by_node_type_responses: Default::default(),
-            batch_update_firmware_by_node_type_calls: Default::default(),
-            batch_update_firmware_responses: Default::default(),
-            batch_update_firmware_calls: Default::default(),
-            update_switch_system_image_responses: Default::default(),
-            update_switch_system_image_calls: Default::default(),
-            update_switch_system_password_responses: Default::default(),
-            update_switch_system_password_calls: Default::default(),
+            update_node_firmware_async_responses: Default::default(),
+            update_node_firmware_async_calls: Default::default(),
+            update_firmware_by_node_type_async_responses: Default::default(),
+            update_firmware_by_node_type_async_calls: Default::default(),
+            update_firmware_by_device_list_responses: Default::default(),
+            update_firmware_by_device_list_calls: Default::default(),
             get_firmware_job_status_responses: Default::default(),
             get_firmware_job_status_calls: Default::default(),
-            list_switch_firmware_responses: Default::default(),
-            list_switch_firmware_calls: Default::default(),
-            push_switch_firmware_responses: Default::default(),
-            push_switch_firmware_calls: Default::default(),
-            upgrade_switch_firmware_responses: Default::default(),
-            upgrade_switch_firmware_calls: Default::default(),
+            list_firmware_on_switch_responses: Default::default(),
+            list_firmware_on_switch_calls: Default::default(),
+            push_firmware_to_switch_responses: Default::default(),
+            push_firmware_to_switch_calls: Default::default(),
+            upgrade_firmware_on_switch_responses: Default::default(),
+            upgrade_firmware_on_switch_calls: Default::default(),
             fetch_switch_system_image_responses: Default::default(),
             fetch_switch_system_image_calls: Default::default(),
             install_switch_system_image_responses: Default::default(),
             install_switch_system_image_calls: Default::default(),
             list_switch_system_images_responses: Default::default(),
             list_switch_system_images_calls: Default::default(),
-            poll_switch_firmware_job_status_responses: Default::default(),
-            poll_switch_firmware_job_status_calls: Default::default(),
-            get_switch_system_image_job_status_responses: Default::default(),
-            get_switch_system_image_job_status_calls: Default::default(),
+            poll_job_status_responses: Default::default(),
+            poll_job_status_calls: Default::default(),
             configure_scale_up_fabric_manager_responses: Default::default(),
             configure_scale_up_fabric_manager_calls: Default::default(),
-            batch_set_scale_up_fabric_state_responses: Default::default(),
-            batch_set_scale_up_fabric_state_calls: Default::default(),
-            batch_get_scale_up_fabric_service_status_responses: Default::default(),
-            batch_get_scale_up_fabric_service_status_calls: Default::default(),
-            get_scale_up_fabric_state_responses: Default::default(),
-            get_scale_up_fabric_state_calls: Default::default(),
-            set_scale_up_fabric_telemetry_interface_state_responses: Default::default(),
-            set_scale_up_fabric_telemetry_interface_state_calls: Default::default(),
+            set_scale_up_fabric_state_responses: Default::default(),
+            set_scale_up_fabric_state_calls: Default::default(),
+            enable_scale_up_fabric_telemetry_interface_responses: Default::default(),
+            enable_scale_up_fabric_telemetry_interface_calls: Default::default(),
             version_responses: Default::default(),
             version_call_count: Default::default(),
         }
@@ -378,12 +346,12 @@ impl MockRmsApi {
         rms::SetPowerStateResponse
     );
     impl_enqueue_inspect!(
-        enqueue_batch_set_power_state,
-        batch_set_power_state_calls,
-        batch_set_power_state_responses,
-        batch_set_power_state_calls,
-        rms::BatchSetPowerStateRequest,
-        rms::BatchSetPowerStateResponse
+        enqueue_set_power_state_by_device_list,
+        set_power_state_by_device_list_calls,
+        set_power_state_by_device_list_responses,
+        set_power_state_by_device_list_calls,
+        rms::SetPowerStateByDeviceListRequest,
+        rms::SetPowerStateByDeviceListResponse
     );
     impl_enqueue_inspect!(
         enqueue_get_power_state,
@@ -392,14 +360,6 @@ impl MockRmsApi {
         get_power_state_calls,
         rms::GetPowerStateRequest,
         rms::GetPowerStateResponse
-    );
-    impl_enqueue_inspect!(
-        enqueue_batch_get_power_state,
-        batch_get_power_state_calls,
-        batch_get_power_state_responses,
-        batch_get_power_state_calls,
-        rms::BatchGetPowerStateRequest,
-        rms::BatchGetPowerStateResponse
     );
     impl_enqueue_inspect!(
         enqueue_sequence_rack_power,
@@ -412,20 +372,20 @@ impl MockRmsApi {
 
     // Inventory
     impl_enqueue_inspect!(
-        enqueue_list_node_inventory,
-        list_node_inventory_calls,
-        list_node_inventory_responses,
-        list_node_inventory_calls,
-        rms::ListNodeInventoryRequest,
-        rms::ListNodeInventoryResponse
+        enqueue_get_all_inventory,
+        get_all_inventory_calls,
+        get_all_inventory_responses,
+        get_all_inventory_calls,
+        rms::GetAllInventoryRequest,
+        rms::GetAllInventoryResponse
     );
     impl_enqueue_inspect!(
-        enqueue_create_nodes,
-        create_nodes_calls,
-        create_nodes_responses,
-        create_nodes_calls,
-        rms::CreateNodesRequest,
-        rms::CreateNodesResponse
+        enqueue_add_node,
+        add_node_calls,
+        add_node_responses,
+        add_node_calls,
+        rms::AddNodeRequest,
+        rms::AddNodeResponse
     );
     impl_enqueue_inspect!(
         enqueue_update_node,
@@ -436,12 +396,12 @@ impl MockRmsApi {
         rms::UpdateNodeResponse
     );
     impl_enqueue_inspect!(
-        enqueue_delete_node,
-        delete_node_calls,
-        delete_node_responses,
-        delete_node_calls,
-        rms::DeleteNodeRequest,
-        rms::DeleteNodeResponse
+        enqueue_remove_node,
+        remove_node_calls,
+        remove_node_responses,
+        remove_node_calls,
+        rms::RemoveNodeRequest,
+        rms::RemoveNodeResponse
     );
     impl_enqueue_inspect!(
         enqueue_list_racks,
@@ -462,20 +422,20 @@ impl MockRmsApi {
         rms::GetNodeDeviceInfoResponse
     );
     impl_enqueue_inspect!(
-        enqueue_list_node_device_info_by_node_type,
-        list_node_device_info_by_node_type_calls,
-        list_node_device_info_by_node_type_responses,
-        list_node_device_info_by_node_type_calls,
-        rms::ListNodeDeviceInfoByNodeTypeRequest,
-        rms::ListNodeDeviceInfoByNodeTypeResponse
+        enqueue_get_device_info_by_node_type,
+        get_device_info_by_node_type_calls,
+        get_device_info_by_node_type_responses,
+        get_device_info_by_node_type_calls,
+        rms::GetDeviceInfoByNodeTypeRequest,
+        rms::GetDeviceInfoByNodeTypeResponse
     );
     impl_enqueue_inspect!(
-        enqueue_batch_get_node_device_info,
-        batch_get_node_device_info_calls,
-        batch_get_node_device_info_responses,
-        batch_get_node_device_info_calls,
-        rms::BatchGetNodeDeviceInfoRequest,
-        rms::BatchGetNodeDeviceInfoResponse
+        enqueue_get_device_info_by_device_list,
+        get_device_info_by_device_list_calls,
+        get_device_info_by_device_list_responses,
+        get_device_info_by_device_list_calls,
+        rms::GetDeviceInfoByDeviceListRequest,
+        rms::GetDeviceInfoByDeviceListResponse
     );
 
     // Power-on sequence
@@ -519,7 +479,7 @@ impl MockRmsApi {
         add_firmware_object_responses,
         add_firmware_object_calls,
         rms::AddFirmwareObjectRequest,
-        rms::AddFirmwareObjectResponse
+        rms::FirmwareObject
     );
     impl_enqueue_inspect!(
         enqueue_get_firmware_object,
@@ -527,7 +487,7 @@ impl MockRmsApi {
         get_firmware_object_responses,
         get_firmware_object_calls,
         rms::GetFirmwareObjectRequest,
-        rms::GetFirmwareObjectResponse
+        rms::FirmwareObject
     );
     impl_enqueue_inspect!(
         enqueue_list_firmware_objects,
@@ -543,7 +503,7 @@ impl MockRmsApi {
         delete_firmware_object_responses,
         delete_firmware_object_calls,
         rms::DeleteFirmwareObjectRequest,
-        rms::DeleteFirmwareObjectResponse
+        rms::OperationResponse
     );
     impl_enqueue_inspect!(
         enqueue_set_default_firmware_object,
@@ -551,15 +511,7 @@ impl MockRmsApi {
         set_default_firmware_object_responses,
         set_default_firmware_object_calls,
         rms::SetDefaultFirmwareObjectRequest,
-        rms::SetDefaultFirmwareObjectResponse
-    );
-    impl_enqueue_inspect!(
-        enqueue_apply_stored_firmware_object,
-        apply_stored_firmware_object_calls,
-        apply_stored_firmware_object_responses,
-        apply_stored_firmware_object_calls,
-        rms::ApplyStoredFirmwareObjectRequest,
-        rms::ApplyStoredFirmwareObjectResponse
+        rms::FirmwareObject
     );
     impl_enqueue_inspect!(
         enqueue_apply_firmware_object,
@@ -570,20 +522,28 @@ impl MockRmsApi {
         rms::ApplyFirmwareObjectResponse
     );
     impl_enqueue_inspect!(
+        enqueue_apply_firmware_object_from_json,
+        apply_firmware_object_from_json_calls,
+        apply_firmware_object_from_json_responses,
+        apply_firmware_object_from_json_calls,
+        rms::ApplyFirmwareObjectFromJsonRequest,
+        rms::ApplyFirmwareObjectResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_apply_switch_system_image_from_json,
+        apply_switch_system_image_from_json_calls,
+        apply_switch_system_image_from_json_responses,
+        apply_switch_system_image_from_json_calls,
+        rms::ApplySwitchSystemImageFromJsonRequest,
+        rms::ApplySwitchSystemImageResponse
+    );
+    impl_enqueue_inspect!(
         enqueue_apply_switch_system_image,
         apply_switch_system_image_calls,
         apply_switch_system_image_responses,
         apply_switch_system_image_calls,
         rms::ApplySwitchSystemImageRequest,
         rms::ApplySwitchSystemImageResponse
-    );
-    impl_enqueue_inspect!(
-        enqueue_apply_stored_switch_system_image,
-        apply_stored_switch_system_image_calls,
-        apply_stored_switch_system_image_responses,
-        apply_stored_switch_system_image_calls,
-        rms::ApplyStoredSwitchSystemImageRequest,
-        rms::ApplyStoredSwitchSystemImageResponse
     );
     impl_enqueue_inspect!(
         enqueue_get_firmware_object_history,
@@ -594,44 +554,28 @@ impl MockRmsApi {
         rms::GetFirmwareObjectHistoryResponse
     );
     impl_enqueue_inspect!(
-        enqueue_update_firmware,
-        update_firmware_calls,
-        update_firmware_responses,
-        update_firmware_calls,
-        rms::UpdateFirmwareRequest,
-        rms::UpdateFirmwareResponse
+        enqueue_update_node_firmware_async,
+        update_node_firmware_async_calls,
+        update_node_firmware_async_responses,
+        update_node_firmware_async_calls,
+        rms::UpdateNodeFirmwareRequest,
+        rms::UpdateNodeFirmwareResponse
     );
     impl_enqueue_inspect!(
-        enqueue_batch_update_firmware_by_node_type,
-        batch_update_firmware_by_node_type_calls,
-        batch_update_firmware_by_node_type_responses,
-        batch_update_firmware_by_node_type_calls,
-        rms::BatchUpdateFirmwareByNodeTypeRequest,
-        rms::BatchUpdateFirmwareByNodeTypeResponse
+        enqueue_update_firmware_by_node_type_async,
+        update_firmware_by_node_type_async_calls,
+        update_firmware_by_node_type_async_responses,
+        update_firmware_by_node_type_async_calls,
+        rms::UpdateFirmwareByNodeTypeRequest,
+        rms::UpdateFirmwareByNodeTypeAsyncResponse
     );
     impl_enqueue_inspect!(
-        enqueue_batch_update_firmware,
-        batch_update_firmware_calls,
-        batch_update_firmware_responses,
-        batch_update_firmware_calls,
-        rms::BatchUpdateFirmwareRequest,
-        rms::BatchUpdateFirmwareResponse
-    );
-    impl_enqueue_inspect!(
-        enqueue_update_switch_system_image,
-        update_switch_system_image_calls,
-        update_switch_system_image_responses,
-        update_switch_system_image_calls,
-        rms::UpdateSwitchSystemImageRequest,
-        rms::UpdateSwitchSystemImageResponse
-    );
-    impl_enqueue_inspect!(
-        enqueue_update_switch_system_password,
-        update_switch_system_password_calls,
-        update_switch_system_password_responses,
-        update_switch_system_password_calls,
-        rms::UpdateSwitchSystemPasswordRequest,
-        rms::UpdateSwitchSystemPasswordResponse
+        enqueue_update_firmware_by_device_list,
+        update_firmware_by_device_list_calls,
+        update_firmware_by_device_list_responses,
+        update_firmware_by_device_list_calls,
+        rms::UpdateFirmwareByDeviceListRequest,
+        rms::UpdateFirmwareByDeviceListResponse
     );
     impl_enqueue_inspect!(
         enqueue_get_firmware_job_status,
@@ -644,28 +588,28 @@ impl MockRmsApi {
 
     // Switch firmware
     impl_enqueue_inspect!(
-        enqueue_list_switch_firmware,
-        list_switch_firmware_calls,
-        list_switch_firmware_responses,
-        list_switch_firmware_calls,
-        rms::ListSwitchFirmwareRequest,
-        rms::ListSwitchFirmwareResponse
+        enqueue_list_firmware_on_switch,
+        list_firmware_on_switch_calls,
+        list_firmware_on_switch_responses,
+        list_firmware_on_switch_calls,
+        rms::ListFirmwareOnSwitchCommand,
+        rms::ListFirmwareOnSwitchResponse
     );
     impl_enqueue_inspect!(
-        enqueue_push_switch_firmware,
-        push_switch_firmware_calls,
-        push_switch_firmware_responses,
-        push_switch_firmware_calls,
-        rms::PushSwitchFirmwareRequest,
-        rms::PushSwitchFirmwareResponse
+        enqueue_push_firmware_to_switch,
+        push_firmware_to_switch_calls,
+        push_firmware_to_switch_responses,
+        push_firmware_to_switch_calls,
+        rms::PushFirmwareToSwitchCommand,
+        rms::PushFirmwareToSwitchResponse
     );
     impl_enqueue_inspect!(
-        enqueue_upgrade_switch_firmware,
-        upgrade_switch_firmware_calls,
-        upgrade_switch_firmware_responses,
-        upgrade_switch_firmware_calls,
-        rms::UpgradeSwitchFirmwareRequest,
-        rms::UpgradeSwitchFirmwareResponse
+        enqueue_upgrade_firmware_on_switch,
+        upgrade_firmware_on_switch_calls,
+        upgrade_firmware_on_switch_responses,
+        upgrade_firmware_on_switch_calls,
+        rms::UpgradeFirmwareOnSwitchCommand,
+        rms::UpgradeFirmwareOnSwitchResponse
     );
 
     // Switch system images
@@ -694,20 +638,12 @@ impl MockRmsApi {
         rms::ListSwitchSystemImagesResponse
     );
     impl_enqueue_inspect!(
-        enqueue_poll_switch_firmware_job_status,
-        poll_switch_firmware_job_status_calls,
-        poll_switch_firmware_job_status_responses,
-        poll_switch_firmware_job_status_calls,
-        rms::PollSwitchFirmwareJobStatusRequest,
-        rms::PollSwitchFirmwareJobStatusResponse
-    );
-    impl_enqueue_inspect!(
-        enqueue_get_switch_system_image_job_status,
-        get_switch_system_image_job_status_calls,
-        get_switch_system_image_job_status_responses,
-        get_switch_system_image_job_status_calls,
-        rms::GetSwitchSystemImageJobStatusRequest,
-        rms::GetSwitchSystemImageJobStatusResponse
+        enqueue_poll_job_status,
+        poll_job_status_calls,
+        poll_job_status_responses,
+        poll_job_status_calls,
+        rms::PollJobStatusCommand,
+        rms::PollJobStatusResponse
     );
 
     // Scale-up fabric
@@ -720,40 +656,24 @@ impl MockRmsApi {
         rms::ConfigureScaleUpFabricManagerResponse
     );
     impl_enqueue_inspect!(
-        enqueue_batch_set_scale_up_fabric_state,
-        batch_set_scale_up_fabric_state_calls,
-        batch_set_scale_up_fabric_state_responses,
-        batch_set_scale_up_fabric_state_calls,
-        rms::BatchSetScaleUpFabricStateRequest,
-        rms::BatchSetScaleUpFabricStateResponse
+        enqueue_set_scale_up_fabric_state,
+        set_scale_up_fabric_state_calls,
+        set_scale_up_fabric_state_responses,
+        set_scale_up_fabric_state_calls,
+        rms::SetScaleUpFabricStateRequest,
+        rms::SetScaleUpFabricStateResponse
     );
     impl_enqueue_inspect!(
-        enqueue_batch_get_scale_up_fabric_service_status,
-        batch_get_scale_up_fabric_service_status_calls,
-        batch_get_scale_up_fabric_service_status_responses,
-        batch_get_scale_up_fabric_service_status_calls,
-        rms::BatchGetScaleUpFabricServiceStatusRequest,
-        rms::BatchGetScaleUpFabricServiceStatusResponse
-    );
-    impl_enqueue_inspect!(
-        enqueue_get_scale_up_fabric_state,
-        get_scale_up_fabric_state_calls,
-        get_scale_up_fabric_state_responses,
-        get_scale_up_fabric_state_calls,
-        rms::GetScaleUpFabricStateRequest,
-        rms::GetScaleUpFabricStateResponse
-    );
-    impl_enqueue_inspect!(
-        enqueue_set_scale_up_fabric_telemetry_interface_state,
-        set_scale_up_fabric_telemetry_interface_state_calls,
-        set_scale_up_fabric_telemetry_interface_state_responses,
-        set_scale_up_fabric_telemetry_interface_state_calls,
-        rms::SetScaleUpFabricTelemetryInterfaceStateRequest,
-        rms::SetScaleUpFabricTelemetryInterfaceStateResponse
+        enqueue_enable_scale_up_fabric_telemetry_interface,
+        enable_scale_up_fabric_telemetry_interface_calls,
+        enable_scale_up_fabric_telemetry_interface_responses,
+        enable_scale_up_fabric_telemetry_interface_calls,
+        rms::EnableScaleUpFabricTelemetryInterfaceRequest,
+        rms::EnableScaleUpFabricTelemetryInterfaceResponse
     );
 
-    // The RmsApi wrapper exposes get_version without a request argument.
-    pub async fn enqueue_version(&self, resp: Result<rms::GetVersionResponse, RackManagerError>) {
+    // Version (special — no request type)
+    pub async fn enqueue_version(&self, resp: Result<(), RackManagerError>) {
         self.version_responses.lock().await.push_back(resp);
     }
 
@@ -767,6 +687,7 @@ impl MockRmsApi {
     pub fn power_ok() -> rms::SetPowerStateResponse {
         rms::SetPowerStateResponse {
             status: rms::ReturnCode::Success as i32,
+            ..Default::default()
         }
     }
 
@@ -774,21 +695,20 @@ impl MockRmsApi {
     pub fn power_fail() -> rms::SetPowerStateResponse {
         rms::SetPowerStateResponse {
             status: rms::ReturnCode::Failure as i32,
+            ..Default::default()
         }
     }
 
-    /// Success response for `batch_set_power_state` covering a
+    /// Success response for `set_power_state_by_device_list` covering a
     /// single targeted node.
-    pub fn batch_set_power_state_ok(node_id: &str) -> rms::BatchSetPowerStateResponse {
-        rms::BatchSetPowerStateResponse {
+    pub fn power_by_device_list_ok(node_id: &str) -> rms::SetPowerStateByDeviceListResponse {
+        rms::SetPowerStateByDeviceListResponse {
             response: Some(rms::NodeBatchResponse {
                 status: rms::ReturnCode::Success as i32,
-                stats: Some(rms::NodeOperationStats {
-                    total_nodes: 1,
-                    successful_nodes: 1,
-                    failed_nodes: 0,
-                }),
-                node_results: vec![rms::NodeOperationResult {
+                total_nodes: 1,
+                successful_nodes: 1,
+                failed_nodes: 0,
+                node_results: vec![rms::NodeResult {
                     node_id: node_id.to_owned(),
                     status: rms::ReturnCode::Success as i32,
                     error_message: String::new(),
@@ -798,23 +718,21 @@ impl MockRmsApi {
         }
     }
 
-    /// Failure response for `batch_set_power_state` covering a
+    /// Failure response for `set_power_state_by_device_list` covering a
     /// single targeted node, with an optional batch-level message and
     /// per-node `error_message`.
-    pub fn batch_set_power_state_fail(
+    pub fn power_by_device_list_fail(
         node_id: &str,
         node_error_message: &str,
-    ) -> rms::BatchSetPowerStateResponse {
-        rms::BatchSetPowerStateResponse {
+    ) -> rms::SetPowerStateByDeviceListResponse {
+        rms::SetPowerStateByDeviceListResponse {
             response: Some(rms::NodeBatchResponse {
                 status: rms::ReturnCode::Failure as i32,
+                total_nodes: 1,
+                successful_nodes: 0,
+                failed_nodes: 1,
                 message: String::new(),
-                stats: Some(rms::NodeOperationStats {
-                    total_nodes: 1,
-                    successful_nodes: 0,
-                    failed_nodes: 1,
-                }),
-                node_results: vec![rms::NodeOperationResult {
+                node_results: vec![rms::NodeResult {
                     node_id: node_id.to_owned(),
                     status: rms::ReturnCode::Failure as i32,
                     error_message: node_error_message.to_owned(),
@@ -824,18 +742,18 @@ impl MockRmsApi {
         }
     }
 
-    /// Success response for `update_firmware` with a job ID.
-    pub fn firmware_update_ok(job_id: &str) -> rms::UpdateFirmwareResponse {
-        rms::UpdateFirmwareResponse {
+    /// Success response for `update_node_firmware_async` with a job ID.
+    pub fn firmware_update_ok(job_id: &str) -> rms::UpdateNodeFirmwareResponse {
+        rms::UpdateNodeFirmwareResponse {
             status: rms::ReturnCode::Success as i32,
             job_id: job_id.to_owned(),
             ..Default::default()
         }
     }
 
-    /// Failure response for `update_firmware`.
-    pub fn firmware_update_fail(msg: &str) -> rms::UpdateFirmwareResponse {
-        rms::UpdateFirmwareResponse {
+    /// Failure response for `update_node_firmware_async`.
+    pub fn firmware_update_fail(msg: &str) -> rms::UpdateNodeFirmwareResponse {
+        rms::UpdateNodeFirmwareResponse {
             status: rms::ReturnCode::Failure as i32,
             message: msg.to_owned(),
             ..Default::default()
@@ -867,6 +785,7 @@ impl MockRmsApi {
                     ..Default::default()
                 })
                 .collect(),
+            ..Default::default()
         }
     }
 
@@ -896,6 +815,16 @@ fn pop_or_err<T>(
 
 #[async_trait::async_trait]
 impl RmsApi for MockRmsApi {
+    async fn get_power_state_by_device_list(
+        &self,
+        cmd: rms::GetPowerStateByDeviceListRequest,
+    ) -> Result<rms::GetPowerStateByDeviceListResponse, RackManagerError> {
+        self.get_power_state_by_device_list_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.get_power_state_by_device_list_responses.lock().await)
+    }
     async fn set_power_state(
         &self,
         cmd: rms::SetPowerStateRequest,
@@ -903,22 +832,21 @@ impl RmsApi for MockRmsApi {
         self.set_power_state_calls.lock().await.push(cmd);
         pop_or_err(&mut self.set_power_state_responses.lock().await)
     }
-    async fn batch_set_power_state(
+    async fn set_power_state_by_device_list(
         &self,
-        cmd: rms::BatchSetPowerStateRequest,
-    ) -> Result<rms::BatchSetPowerStateResponse, RackManagerError> {
-        self.batch_set_power_state_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.batch_set_power_state_responses.lock().await)
-    }
-    async fn update_switch_system_password(
-        &self,
-        cmd: rms::UpdateSwitchSystemPasswordRequest,
-    ) -> Result<rms::UpdateSwitchSystemPasswordResponse, RackManagerError> {
-        self.update_switch_system_password_calls
+        cmd: rms::SetPowerStateByDeviceListRequest,
+    ) -> Result<rms::SetPowerStateByDeviceListResponse, RackManagerError> {
+        self.set_power_state_by_device_list_calls
             .lock()
             .await
             .push(cmd);
-        pop_or_err(&mut self.update_switch_system_password_responses.lock().await)
+        pop_or_err(&mut self.set_power_state_by_device_list_responses.lock().await)
+    }
+    async fn update_switch_system_password(
+        &self,
+        _cmd: rms::UpdateSwitchSystemPasswordRequest,
+    ) -> Result<rms::UpdateSwitchSystemPasswordResponse, RackManagerError> {
+        Ok(rms::UpdateSwitchSystemPasswordResponse::default())
     }
     async fn get_power_state(
         &self,
@@ -927,15 +855,6 @@ impl RmsApi for MockRmsApi {
         self.get_power_state_calls.lock().await.push(cmd);
         pop_or_err(&mut self.get_power_state_responses.lock().await)
     }
-
-    async fn batch_get_power_state(
-        &self,
-        cmd: rms::BatchGetPowerStateRequest,
-    ) -> Result<rms::BatchGetPowerStateResponse, RackManagerError> {
-        self.batch_get_power_state_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.batch_get_power_state_responses.lock().await)
-    }
-
     async fn sequence_rack_power(
         &self,
         cmd: rms::SequenceRackPowerRequest,
@@ -943,21 +862,19 @@ impl RmsApi for MockRmsApi {
         self.sequence_rack_power_calls.lock().await.push(cmd);
         pop_or_err(&mut self.sequence_rack_power_responses.lock().await)
     }
-    async fn list_node_inventory(
+    async fn get_all_inventory(
         &self,
-    ) -> Result<rms::ListNodeInventoryResponse, RackManagerError> {
-        self.list_node_inventory_calls
-            .lock()
-            .await
-            .push(rms::ListNodeInventoryRequest::default());
-        pop_or_err(&mut self.list_node_inventory_responses.lock().await)
+        cmd: rms::GetAllInventoryRequest,
+    ) -> Result<rms::GetAllInventoryResponse, RackManagerError> {
+        self.get_all_inventory_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.get_all_inventory_responses.lock().await)
     }
-    async fn create_nodes(
+    async fn add_node(
         &self,
-        cmd: rms::CreateNodesRequest,
-    ) -> Result<rms::CreateNodesResponse, RackManagerError> {
-        self.create_nodes_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.create_nodes_responses.lock().await)
+        cmd: rms::AddNodeRequest,
+    ) -> Result<rms::AddNodeResponse, RackManagerError> {
+        self.add_node_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.add_node_responses.lock().await)
     }
     async fn update_node(
         &self,
@@ -966,18 +883,18 @@ impl RmsApi for MockRmsApi {
         self.update_node_calls.lock().await.push(cmd);
         pop_or_err(&mut self.update_node_responses.lock().await)
     }
-    async fn delete_node(
+    async fn remove_node(
         &self,
-        cmd: rms::DeleteNodeRequest,
-    ) -> Result<rms::DeleteNodeResponse, RackManagerError> {
-        self.delete_node_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.delete_node_responses.lock().await)
+        cmd: rms::RemoveNodeRequest,
+    ) -> Result<rms::RemoveNodeResponse, RackManagerError> {
+        self.remove_node_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.remove_node_responses.lock().await)
     }
-    async fn list_racks(&self) -> Result<rms::ListRacksResponse, RackManagerError> {
-        self.list_racks_calls
-            .lock()
-            .await
-            .push(rms::ListRacksRequest::default());
+    async fn list_racks(
+        &self,
+        cmd: rms::ListRacksRequest,
+    ) -> Result<rms::ListRacksResponse, RackManagerError> {
+        self.list_racks_calls.lock().await.push(cmd);
         pop_or_err(&mut self.list_racks_responses.lock().await)
     }
     async fn get_node_device_info(
@@ -987,27 +904,25 @@ impl RmsApi for MockRmsApi {
         self.get_node_device_info_calls.lock().await.push(cmd);
         pop_or_err(&mut self.get_node_device_info_responses.lock().await)
     }
-    async fn list_node_device_info_by_node_type(
+    async fn get_device_info_by_node_type(
         &self,
-        cmd: rms::ListNodeDeviceInfoByNodeTypeRequest,
-    ) -> Result<rms::ListNodeDeviceInfoByNodeTypeResponse, RackManagerError> {
-        self.list_node_device_info_by_node_type_calls
+        cmd: rms::GetDeviceInfoByNodeTypeRequest,
+    ) -> Result<rms::GetDeviceInfoByNodeTypeResponse, RackManagerError> {
+        self.get_device_info_by_node_type_calls
             .lock()
             .await
             .push(cmd);
-        pop_or_err(
-            &mut self
-                .list_node_device_info_by_node_type_responses
-                .lock()
-                .await,
-        )
+        pop_or_err(&mut self.get_device_info_by_node_type_responses.lock().await)
     }
-    async fn batch_get_node_device_info(
+    async fn get_device_info_by_device_list(
         &self,
-        cmd: rms::BatchGetNodeDeviceInfoRequest,
-    ) -> Result<rms::BatchGetNodeDeviceInfoResponse, RackManagerError> {
-        self.batch_get_node_device_info_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.batch_get_node_device_info_responses.lock().await)
+        cmd: rms::GetDeviceInfoByDeviceListRequest,
+    ) -> Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError> {
+        self.get_device_info_by_device_list_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.get_device_info_by_device_list_responses.lock().await)
     }
     async fn get_rack_power_on_sequence(
         &self,
@@ -1046,19 +961,17 @@ impl RmsApi for MockRmsApi {
     async fn add_firmware_object(
         &self,
         cmd: rms::AddFirmwareObjectRequest,
-    ) -> Result<rms::AddFirmwareObjectResponse, RackManagerError> {
+    ) -> Result<rms::FirmwareObject, RackManagerError> {
         self.add_firmware_object_calls.lock().await.push(cmd);
         pop_or_err(&mut self.add_firmware_object_responses.lock().await)
     }
-
     async fn get_firmware_object(
         &self,
         cmd: rms::GetFirmwareObjectRequest,
-    ) -> Result<rms::GetFirmwareObjectResponse, RackManagerError> {
+    ) -> Result<rms::FirmwareObject, RackManagerError> {
         self.get_firmware_object_calls.lock().await.push(cmd);
         pop_or_err(&mut self.get_firmware_object_responses.lock().await)
     }
-
     async fn list_firmware_objects(
         &self,
         cmd: rms::ListFirmwareObjectsRequest,
@@ -1069,33 +982,20 @@ impl RmsApi for MockRmsApi {
     async fn delete_firmware_object(
         &self,
         cmd: rms::DeleteFirmwareObjectRequest,
-    ) -> Result<rms::DeleteFirmwareObjectResponse, RackManagerError> {
+    ) -> Result<rms::OperationResponse, RackManagerError> {
         self.delete_firmware_object_calls.lock().await.push(cmd);
         pop_or_err(&mut self.delete_firmware_object_responses.lock().await)
     }
-
     async fn set_default_firmware_object(
         &self,
         cmd: rms::SetDefaultFirmwareObjectRequest,
-    ) -> Result<rms::SetDefaultFirmwareObjectResponse, RackManagerError> {
+    ) -> Result<rms::FirmwareObject, RackManagerError> {
         self.set_default_firmware_object_calls
             .lock()
             .await
             .push(cmd);
         pop_or_err(&mut self.set_default_firmware_object_responses.lock().await)
     }
-
-    async fn apply_stored_firmware_object(
-        &self,
-        cmd: rms::ApplyStoredFirmwareObjectRequest,
-    ) -> Result<rms::ApplyStoredFirmwareObjectResponse, RackManagerError> {
-        self.apply_stored_firmware_object_calls
-            .lock()
-            .await
-            .push(cmd);
-        pop_or_err(&mut self.apply_stored_firmware_object_responses.lock().await)
-    }
-
     async fn apply_firmware_object(
         &self,
         cmd: rms::ApplyFirmwareObjectRequest,
@@ -1103,24 +1003,37 @@ impl RmsApi for MockRmsApi {
         self.apply_firmware_object_calls.lock().await.push(cmd);
         pop_or_err(&mut self.apply_firmware_object_responses.lock().await)
     }
-
+    async fn apply_firmware_object_from_json(
+        &self,
+        cmd: rms::ApplyFirmwareObjectFromJsonRequest,
+    ) -> Result<rms::ApplyFirmwareObjectResponse, RackManagerError> {
+        self.apply_firmware_object_from_json_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.apply_firmware_object_from_json_responses.lock().await)
+    }
+    async fn apply_switch_system_image_from_json(
+        &self,
+        cmd: rms::ApplySwitchSystemImageFromJsonRequest,
+    ) -> Result<rms::ApplySwitchSystemImageResponse, RackManagerError> {
+        self.apply_switch_system_image_from_json_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(
+            &mut self
+                .apply_switch_system_image_from_json_responses
+                .lock()
+                .await,
+        )
+    }
     async fn apply_switch_system_image(
         &self,
         cmd: rms::ApplySwitchSystemImageRequest,
     ) -> Result<rms::ApplySwitchSystemImageResponse, RackManagerError> {
         self.apply_switch_system_image_calls.lock().await.push(cmd);
         pop_or_err(&mut self.apply_switch_system_image_responses.lock().await)
-    }
-
-    async fn apply_stored_switch_system_image(
-        &self,
-        cmd: rms::ApplyStoredSwitchSystemImageRequest,
-    ) -> Result<rms::ApplyStoredSwitchSystemImageResponse, RackManagerError> {
-        self.apply_stored_switch_system_image_calls
-            .lock()
-            .await
-            .push(cmd);
-        pop_or_err(&mut self.apply_stored_switch_system_image_responses.lock().await)
     }
     async fn get_firmware_object_history(
         &self,
@@ -1132,44 +1045,38 @@ impl RmsApi for MockRmsApi {
             .push(cmd);
         pop_or_err(&mut self.get_firmware_object_history_responses.lock().await)
     }
-    async fn update_firmware(
+    async fn update_node_firmware_async(
         &self,
-        cmd: rms::UpdateFirmwareRequest,
-    ) -> Result<rms::UpdateFirmwareResponse, RackManagerError> {
-        self.update_firmware_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.update_firmware_responses.lock().await)
+        cmd: rms::UpdateNodeFirmwareRequest,
+    ) -> Result<rms::UpdateNodeFirmwareResponse, RackManagerError> {
+        self.update_node_firmware_async_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.update_node_firmware_async_responses.lock().await)
     }
-    async fn batch_update_firmware_by_node_type(
+    async fn update_firmware_by_node_type_async(
         &self,
-        cmd: rms::BatchUpdateFirmwareByNodeTypeRequest,
-    ) -> Result<rms::BatchUpdateFirmwareByNodeTypeResponse, RackManagerError> {
-        self.batch_update_firmware_by_node_type_calls
+        cmd: rms::UpdateFirmwareByNodeTypeRequest,
+    ) -> Result<rms::UpdateFirmwareByNodeTypeAsyncResponse, RackManagerError> {
+        self.update_firmware_by_node_type_async_calls
             .lock()
             .await
             .push(cmd);
         pop_or_err(
             &mut self
-                .batch_update_firmware_by_node_type_responses
+                .update_firmware_by_node_type_async_responses
                 .lock()
                 .await,
         )
     }
-    async fn batch_update_firmware(
+    async fn update_firmware_by_device_list(
         &self,
-        cmd: rms::BatchUpdateFirmwareRequest,
-    ) -> Result<rms::BatchUpdateFirmwareResponse, RackManagerError> {
-        self.batch_update_firmware_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.batch_update_firmware_responses.lock().await)
+        cmd: rms::UpdateFirmwareByDeviceListRequest,
+    ) -> Result<rms::UpdateFirmwareByDeviceListResponse, RackManagerError> {
+        self.update_firmware_by_device_list_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.update_firmware_by_device_list_responses.lock().await)
     }
-
-    async fn update_switch_system_image(
-        &self,
-        cmd: rms::UpdateSwitchSystemImageRequest,
-    ) -> Result<rms::UpdateSwitchSystemImageResponse, RackManagerError> {
-        self.update_switch_system_image_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.update_switch_system_image_responses.lock().await)
-    }
-
     async fn get_firmware_job_status(
         &self,
         cmd: rms::GetFirmwareJobStatusRequest,
@@ -1177,26 +1084,26 @@ impl RmsApi for MockRmsApi {
         self.get_firmware_job_status_calls.lock().await.push(cmd);
         pop_or_err(&mut self.get_firmware_job_status_responses.lock().await)
     }
-    async fn list_switch_firmware(
+    async fn list_firmware_on_switch(
         &self,
-        cmd: rms::ListSwitchFirmwareRequest,
-    ) -> Result<rms::ListSwitchFirmwareResponse, RackManagerError> {
-        self.list_switch_firmware_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.list_switch_firmware_responses.lock().await)
+        cmd: rms::ListFirmwareOnSwitchCommand,
+    ) -> Result<rms::ListFirmwareOnSwitchResponse, RackManagerError> {
+        self.list_firmware_on_switch_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.list_firmware_on_switch_responses.lock().await)
     }
-    async fn push_switch_firmware(
+    async fn push_firmware_to_switch(
         &self,
-        cmd: rms::PushSwitchFirmwareRequest,
-    ) -> Result<rms::PushSwitchFirmwareResponse, RackManagerError> {
-        self.push_switch_firmware_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.push_switch_firmware_responses.lock().await)
+        cmd: rms::PushFirmwareToSwitchCommand,
+    ) -> Result<rms::PushFirmwareToSwitchResponse, RackManagerError> {
+        self.push_firmware_to_switch_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.push_firmware_to_switch_responses.lock().await)
     }
-    async fn upgrade_switch_firmware(
+    async fn upgrade_firmware_on_switch(
         &self,
-        cmd: rms::UpgradeSwitchFirmwareRequest,
-    ) -> Result<rms::UpgradeSwitchFirmwareResponse, RackManagerError> {
-        self.upgrade_switch_firmware_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.upgrade_switch_firmware_responses.lock().await)
+        cmd: rms::UpgradeFirmwareOnSwitchCommand,
+    ) -> Result<rms::UpgradeFirmwareOnSwitchResponse, RackManagerError> {
+        self.upgrade_firmware_on_switch_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.upgrade_firmware_on_switch_responses.lock().await)
     }
     async fn fetch_switch_system_image(
         &self,
@@ -1222,33 +1129,13 @@ impl RmsApi for MockRmsApi {
         self.list_switch_system_images_calls.lock().await.push(cmd);
         pop_or_err(&mut self.list_switch_system_images_responses.lock().await)
     }
-    async fn poll_switch_firmware_job_status(
+    async fn poll_job_status(
         &self,
-        cmd: rms::PollSwitchFirmwareJobStatusRequest,
-    ) -> Result<rms::PollSwitchFirmwareJobStatusResponse, RackManagerError> {
-        self.poll_switch_firmware_job_status_calls
-            .lock()
-            .await
-            .push(cmd);
-        pop_or_err(&mut self.poll_switch_firmware_job_status_responses.lock().await)
+        cmd: rms::PollJobStatusCommand,
+    ) -> Result<rms::PollJobStatusResponse, RackManagerError> {
+        self.poll_job_status_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.poll_job_status_responses.lock().await)
     }
-
-    async fn get_switch_system_image_job_status(
-        &self,
-        cmd: rms::GetSwitchSystemImageJobStatusRequest,
-    ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError> {
-        self.get_switch_system_image_job_status_calls
-            .lock()
-            .await
-            .push(cmd);
-        pop_or_err(
-            &mut self
-                .get_switch_system_image_job_status_responses
-                .lock()
-                .await,
-        )
-    }
-
     async fn configure_scale_up_fabric_manager(
         &self,
         cmd: rms::ConfigureScaleUpFabricManagerRequest,
@@ -1264,62 +1151,34 @@ impl RmsApi for MockRmsApi {
                 .await,
         )
     }
-    async fn batch_set_scale_up_fabric_state(
+    async fn set_scale_up_fabric_state(
         &self,
-        cmd: rms::BatchSetScaleUpFabricStateRequest,
-    ) -> Result<rms::BatchSetScaleUpFabricStateResponse, RackManagerError> {
-        self.batch_set_scale_up_fabric_state_calls
-            .lock()
-            .await
-            .push(cmd);
-        pop_or_err(&mut self.batch_set_scale_up_fabric_state_responses.lock().await)
+        cmd: rms::SetScaleUpFabricStateRequest,
+    ) -> Result<rms::SetScaleUpFabricStateResponse, RackManagerError> {
+        self.set_scale_up_fabric_state_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.set_scale_up_fabric_state_responses.lock().await)
     }
-
-    async fn batch_get_scale_up_fabric_service_status(
+    async fn enable_scale_up_fabric_telemetry_interface(
         &self,
-        cmd: rms::BatchGetScaleUpFabricServiceStatusRequest,
-    ) -> Result<rms::BatchGetScaleUpFabricServiceStatusResponse, RackManagerError> {
-        self.batch_get_scale_up_fabric_service_status_calls
+        cmd: rms::EnableScaleUpFabricTelemetryInterfaceRequest,
+    ) -> Result<rms::EnableScaleUpFabricTelemetryInterfaceResponse, RackManagerError> {
+        self.enable_scale_up_fabric_telemetry_interface_calls
             .lock()
             .await
             .push(cmd);
         pop_or_err(
             &mut self
-                .batch_get_scale_up_fabric_service_status_responses
+                .enable_scale_up_fabric_telemetry_interface_responses
                 .lock()
                 .await,
         )
     }
-
-    async fn get_scale_up_fabric_state(
-        &self,
-        cmd: rms::GetScaleUpFabricStateRequest,
-    ) -> Result<rms::GetScaleUpFabricStateResponse, RackManagerError> {
-        self.get_scale_up_fabric_state_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.get_scale_up_fabric_state_responses.lock().await)
-    }
-
-    async fn set_scale_up_fabric_telemetry_interface_state(
-        &self,
-        cmd: rms::SetScaleUpFabricTelemetryInterfaceStateRequest,
-    ) -> Result<rms::SetScaleUpFabricTelemetryInterfaceStateResponse, RackManagerError> {
-        self.set_scale_up_fabric_telemetry_interface_state_calls
-            .lock()
-            .await
-            .push(cmd);
-        pop_or_err(
-            &mut self
-                .set_scale_up_fabric_telemetry_interface_state_responses
-                .lock()
-                .await,
-        )
-    }
-    async fn get_version(&self) -> Result<rms::GetVersionResponse, RackManagerError> {
+    async fn version(&self) -> Result<(), RackManagerError> {
         *self.version_call_count.lock().await += 1;
         self.version_responses
             .lock()
             .await
             .pop_front()
-            .unwrap_or(Ok(rms::GetVersionResponse::default()))
+            .unwrap_or(Ok(()))
     }
 }

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -130,20 +130,22 @@ async fn resolve_switch_identities(
 
 fn to_rms_power_operation(action: PowerAction) -> i32 {
     match action {
-        PowerAction::On => rms::PowerOperation::On as i32,
-        PowerAction::GracefulShutdown | PowerAction::ForceOff => rms::PowerOperation::Off as i32,
+        PowerAction::On => rms::PowerOperation::PowerOn as i32,
+        PowerAction::GracefulShutdown | PowerAction::ForceOff => {
+            rms::PowerOperation::PowerOff as i32
+        }
         PowerAction::GracefulRestart | PowerAction::ForceRestart | PowerAction::AcPowercycle => {
-            rms::PowerOperation::Reset as i32
+            rms::PowerOperation::PowerReset as i32
         }
     }
 }
 
 fn map_rms_firmware_job_state(state: i32) -> FirmwareState {
     match rms::FirmwareJobState::try_from(state) {
-        Ok(rms::FirmwareJobState::Queued) => FirmwareState::Queued,
-        Ok(rms::FirmwareJobState::Running) => FirmwareState::InProgress,
-        Ok(rms::FirmwareJobState::Completed) => FirmwareState::Completed,
-        Ok(rms::FirmwareJobState::Failed) => FirmwareState::Failed,
+        Ok(rms::FirmwareJobState::FwJobQueued) => FirmwareState::Queued,
+        Ok(rms::FirmwareJobState::FwJobRunning) => FirmwareState::InProgress,
+        Ok(rms::FirmwareJobState::FwJobCompleted) => FirmwareState::Completed,
+        Ok(rms::FirmwareJobState::FwJobFailed) => FirmwareState::Failed,
         _ => FirmwareState::Unknown,
     }
 }
@@ -156,27 +158,29 @@ fn power_shelf_target_name(c: &PowerShelfComponent) -> &'static str {
     }
 }
 
-/// Default BMC HTTPS port used when populating `rms::Endpoint` for power
+/// Default BMC HTTPS port used when populating `rms::BmcEndpoint` for power
 /// shelves. Mirrors the value used by `crate::power_shelf_controller::maintenance`.
-const POWER_SHELF_BMC_PORT: u32 = 443;
+const POWER_SHELF_BMC_PORT: i32 = 443;
 
-/// Build the `rms::NodeInfo` describing a power shelf for inclusion in a
-/// `BatchSetPowerState` request. The caller-supplied variant of the
+/// Build the `rms::NewNodeInfo` describing a power shelf for inclusion in a
+/// `SetPowerStateByDeviceList` request. The caller-supplied variant of the
 /// RPC requires the BMC connection details inline rather than relying on
 /// RMS's inventory; power shelves do not expose a host endpoint.
-fn build_power_shelf_node_info(ep: &PowerShelfEndpoint, identity: &RmsIdentity) -> rms::NodeInfo {
-    rms::NodeInfo {
+fn build_power_shelf_node_info(
+    ep: &PowerShelfEndpoint,
+    identity: &RmsIdentity,
+) -> rms::NewNodeInfo {
+    rms::NewNodeInfo {
         node_id: identity.node_id.clone(),
         rack_id: identity.rack_id.clone(),
         r#type: Some(rms::NodeType::Powershelf as i32),
-        bmc_endpoint: Some(rms::Endpoint {
+        bmc_endpoint: Some(rms::BmcEndpoint {
             interface: Some(rms::NetworkInterface {
                 ip_address: ep.pmc_ip.to_string(),
                 mac_address: ep.pmc_mac.to_string(),
             }),
             port: POWER_SHELF_BMC_PORT,
             credentials: Some(credentials_to_rms(&ep.pmc_credentials)),
-            dangerously_accept_invalid_certs: true,
         }),
         host_endpoint: None,
     }
@@ -210,14 +214,15 @@ impl PowerShelfManager for RmsBackend {
             };
 
             let device = build_power_shelf_node_info(ep, identity);
-            let request = rms::BatchSetPowerStateRequest {
+            let request = rms::SetPowerStateByDeviceListRequest {
                 nodes: Some(rms::NodeSet {
-                    nodes: vec![device],
+                    devices: vec![device],
                 }),
                 operation,
+                ..Default::default()
             };
 
-            match self.client.batch_set_power_state(request).await {
+            match self.client.set_power_state_by_device_list(request).await {
                 Ok(response) => {
                     let (success, error) =
                         summarize_power_batch(response.response.unwrap_or_default());
@@ -274,14 +279,14 @@ impl PowerShelfManager for RmsBackend {
                 continue;
             };
 
-            let request = rms::UpdateFirmwareRequest {
+            let request = rms::UpdateNodeFirmwareRequest {
                 node_id: identity.node_id.clone(),
                 rack_id: identity.rack_id.clone(),
                 firmware_targets: firmware_targets.clone(),
                 ..Default::default()
             };
 
-            match self.client.update_firmware(request).await {
+            match self.client.update_node_firmware_async(request).await {
                 Ok(response) => {
                     let success = response.status == rms::ReturnCode::Success as i32;
 
@@ -354,6 +359,7 @@ impl PowerShelfManager for RmsBackend {
 
             let request = rms::GetFirmwareJobStatusRequest {
                 job_id: job_id.clone(),
+                ..Default::default()
             };
 
             match self.client.get_firmware_job_status(request).await {
@@ -416,6 +422,7 @@ impl PowerShelfManager for RmsBackend {
             let request = rms::GetNodeFirmwareInventoryRequest {
                 node_id: identity.node_id.clone(),
                 rack_id: identity.rack_id.clone(),
+                ..Default::default()
             };
 
             match self.client.get_node_firmware_inventory(request).await {
@@ -466,6 +473,7 @@ async fn list_firmware_object_ids(
 ) -> Result<Vec<String>, ComponentManagerError> {
     let response = client
         .list_firmware_objects(rms::ListFirmwareObjectsRequest {
+            metadata: None,
             only_available: false,
             hardware_type: String::new(),
         })
@@ -489,9 +497,9 @@ fn switch_target_name(c: &NvSwitchComponent) -> &'static str {
     }
 }
 
-/// Default BMC HTTPS port used when populating `rms::Endpoint` for
+/// Default BMC HTTPS port used when populating `rms::BmcEndpoint` for
 /// switches. Mirrors the value used by `crate::rack::firmware_update`.
-const SWITCH_BMC_PORT: u32 = 443;
+const SWITCH_BMC_PORT: i32 = 443;
 
 fn credentials_to_rms(creds: &Credentials) -> rms::Credentials {
     let Credentials::UsernamePassword { username, password } = creds;
@@ -503,43 +511,39 @@ fn credentials_to_rms(creds: &Credentials) -> rms::Credentials {
     }
 }
 
-/// Build the `rms::NodeInfo` describing a switch for inclusion in a
-/// `BatchSetPowerState` request. The caller-supplied variant of the
+/// Build the `rms::NewNodeInfo` describing a switch for inclusion in a
+/// `SetPowerStateByDeviceList` request. The caller-supplied variant of the
 /// RPC requires the BMC connection details inline rather than relying on
 /// RMS's inventory; the NVOS host endpoint is included for completeness.
-fn build_switch_node_info(ep: &SwitchEndpoint, identity: &RmsIdentity) -> rms::NodeInfo {
-    rms::NodeInfo {
+fn build_switch_node_info(ep: &SwitchEndpoint, identity: &RmsIdentity) -> rms::NewNodeInfo {
+    rms::NewNodeInfo {
         node_id: identity.node_id.clone(),
         rack_id: identity.rack_id.clone(),
         r#type: Some(rms::NodeType::Switch as i32),
-        bmc_endpoint: Some(rms::Endpoint {
+        bmc_endpoint: Some(rms::BmcEndpoint {
             interface: Some(rms::NetworkInterface {
                 ip_address: ep.bmc_ip.to_string(),
                 mac_address: ep.bmc_mac.to_string(),
             }),
             port: SWITCH_BMC_PORT,
             credentials: Some(credentials_to_rms(&ep.bmc_credentials)),
-            dangerously_accept_invalid_certs: true,
         }),
-        host_endpoint: Some(rms::Endpoint {
-            interface: Some(rms::NetworkInterface {
+        host_endpoint: Some(rms::HostEndpoint {
+            interfaces: vec![rms::NetworkInterface {
                 ip_address: ep.nvos_ip.to_string(),
                 mac_address: ep.nvos_mac.to_string(),
-            }),
+            }],
             port: 0,
             credentials: Some(credentials_to_rms(&ep.nvos_credentials)),
-            dangerously_accept_invalid_certs: false,
         }),
     }
 }
 
 /// Summarize a `NodeBatchResponse` into a `(success, error)` pair for a
-/// single-node `BatchSetPowerState` call. Prefers per-node error
+/// single-device `SetPowerStateByDeviceList` call. Prefers per-node error
 /// messages, then the batch-level message, and finally a generic fallback.
 fn summarize_power_batch(batch: rms::NodeBatchResponse) -> (bool, Option<String>) {
-    let stats = batch.stats.unwrap_or_default();
-    let success = batch.status == rms::ReturnCode::Success as i32 && stats.failed_nodes == 0;
-
+    let success = batch.status == rms::ReturnCode::Success as i32 && batch.failed_nodes == 0;
     if success {
         return (true, None);
     }
@@ -597,14 +601,15 @@ impl NvSwitchManager for RmsBackend {
             };
 
             let device = build_switch_node_info(ep, identity);
-            let request = rms::BatchSetPowerStateRequest {
+            let request = rms::SetPowerStateByDeviceListRequest {
                 nodes: Some(rms::NodeSet {
-                    nodes: vec![device],
+                    devices: vec![device],
                 }),
                 operation,
+                ..Default::default()
             };
 
-            match self.client.batch_set_power_state(request).await {
+            match self.client.set_power_state_by_device_list(request).await {
                 Ok(response) => {
                     let (success, error) =
                         summarize_power_batch(response.response.unwrap_or_default());
@@ -661,14 +666,14 @@ impl NvSwitchManager for RmsBackend {
                 continue;
             };
 
-            let request = rms::UpdateFirmwareRequest {
+            let request = rms::UpdateNodeFirmwareRequest {
                 node_id: identity.node_id.clone(),
                 rack_id: identity.rack_id.clone(),
                 firmware_targets: firmware_targets.clone(),
                 ..Default::default()
             };
 
-            match self.client.update_firmware(request).await {
+            match self.client.update_node_firmware_async(request).await {
                 Ok(response) => {
                     let success = response.status == rms::ReturnCode::Success as i32;
 
@@ -739,6 +744,7 @@ impl NvSwitchManager for RmsBackend {
 
             let request = rms::GetFirmwareJobStatusRequest {
                 job_id: job_id.clone(),
+                ..Default::default()
             };
 
             match self.client.get_firmware_job_status(request).await {
@@ -801,31 +807,31 @@ mod tests {
     // ---- Mapping unit tests ----
 
     #[test]
-    fn power_action_on_maps_to_on() {
+    fn power_action_on_maps_to_power_on() {
         assert_eq!(
             to_rms_power_operation(PowerAction::On),
-            rms::PowerOperation::On as i32,
+            rms::PowerOperation::PowerOn as i32,
         );
     }
 
     #[test]
-    fn power_action_shutdown_maps_to_off() {
+    fn power_action_shutdown_maps_to_power_off() {
         assert_eq!(
             to_rms_power_operation(PowerAction::GracefulShutdown),
-            rms::PowerOperation::Off as i32,
+            rms::PowerOperation::PowerOff as i32,
         );
     }
 
     #[test]
-    fn power_action_force_off_maps_to_off() {
+    fn power_action_force_off_maps_to_power_off() {
         assert_eq!(
             to_rms_power_operation(PowerAction::ForceOff),
-            rms::PowerOperation::Off as i32,
+            rms::PowerOperation::PowerOff as i32,
         );
     }
 
     #[test]
-    fn power_action_restart_maps_to_reset() {
+    fn power_action_restart_maps_to_power_reset() {
         for action in [
             PowerAction::GracefulRestart,
             PowerAction::ForceRestart,
@@ -833,8 +839,8 @@ mod tests {
         ] {
             assert_eq!(
                 to_rms_power_operation(action),
-                rms::PowerOperation::Reset as i32,
-                "expected Reset for {action:?}",
+                rms::PowerOperation::PowerReset as i32,
+                "expected PowerReset for {action:?}",
             );
         }
     }
@@ -842,7 +848,7 @@ mod tests {
     #[test]
     fn firmware_job_state_queued() {
         assert_eq!(
-            map_rms_firmware_job_state(rms::FirmwareJobState::Queued as i32),
+            map_rms_firmware_job_state(rms::FirmwareJobState::FwJobQueued as i32),
             FirmwareState::Queued,
         );
     }
@@ -850,7 +856,7 @@ mod tests {
     #[test]
     fn firmware_job_state_running() {
         assert_eq!(
-            map_rms_firmware_job_state(rms::FirmwareJobState::Running as i32),
+            map_rms_firmware_job_state(rms::FirmwareJobState::FwJobRunning as i32),
             FirmwareState::InProgress,
         );
     }
@@ -858,7 +864,7 @@ mod tests {
     #[test]
     fn firmware_job_state_completed() {
         assert_eq!(
-            map_rms_firmware_job_state(rms::FirmwareJobState::Completed as i32),
+            map_rms_firmware_job_state(rms::FirmwareJobState::FwJobCompleted as i32),
             FirmwareState::Completed,
         );
     }
@@ -866,7 +872,7 @@ mod tests {
     #[test]
     fn firmware_job_state_failed() {
         assert_eq!(
-            map_rms_firmware_job_state(rms::FirmwareJobState::Failed as i32),
+            map_rms_firmware_job_state(rms::FirmwareJobState::FwJobFailed as i32),
             FirmwareState::Failed,
         );
     }
@@ -946,11 +952,11 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn ps_power_control_success(pool: sqlx::PgPool) {
         let (mock, backend, rack_id, ps1, ps2, _, _) = make_backend(&pool).await;
-        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
+        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_ok(
             &ps1.to_string(),
         )))
         .await;
-        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
+        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_ok(
             &ps2.to_string(),
         )))
         .await;
@@ -964,27 +970,27 @@ mod tests {
         assert!(results[0].success);
         assert!(results[1].success);
 
-        let calls = mock.batch_set_power_state_calls().await;
+        let calls = mock.set_power_state_by_device_list_calls().await;
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].operation, rms::PowerOperation::On as i32);
-        let dev0 = &calls[0].nodes.as_ref().unwrap().nodes[0];
+        assert_eq!(calls[0].operation, rms::PowerOperation::PowerOn as i32);
+        let dev0 = &calls[0].nodes.as_ref().unwrap().devices[0];
         assert_eq!(dev0.node_id, ps1.to_string());
         assert_eq!(dev0.rack_id, rack_id.to_string());
         assert_eq!(dev0.r#type, Some(rms::NodeType::Powershelf as i32));
         assert!(dev0.bmc_endpoint.is_some());
         assert!(dev0.host_endpoint.is_none());
-        let dev1 = &calls[1].nodes.as_ref().unwrap().nodes[0];
+        let dev1 = &calls[1].nodes.as_ref().unwrap().devices[0];
         assert_eq!(dev1.node_id, ps2.to_string());
     }
 
     #[carbide_macros::sqlx_test]
     async fn ps_power_control_partial_failure(pool: sqlx::PgPool) {
         let (mock, backend, _, ps1, ps2, _, _) = make_backend(&pool).await;
-        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
+        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_ok(
             &ps1.to_string(),
         )))
         .await;
-        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_fail(
+        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_fail(
             &ps2.to_string(),
             "rms reported failure",
         )))
@@ -1003,13 +1009,15 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn ps_power_control_transport_error(pool: sqlx::PgPool) {
         let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
-        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
+        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_ok(
             &ps1.to_string(),
         )))
         .await;
-        mock.enqueue_batch_set_power_state(Err(librms::RackManagerError::ApiInvocationError(
-            tonic::Status::unavailable("connection refused"),
-        )))
+        mock.enqueue_set_power_state_by_device_list(Err(
+            librms::RackManagerError::ApiInvocationError(tonic::Status::unavailable(
+                "connection refused",
+            )),
+        ))
         .await;
 
         let eps = vec![make_ps_endpoint(PS_MAC_1), make_ps_endpoint(PS_MAC_2)];
@@ -1031,7 +1039,7 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn ps_power_control_unknown_mac(pool: sqlx::PgPool) {
         let (mock, backend, _, _, ps2, _, _) = make_backend(&pool).await;
-        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
+        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_ok(
             &ps2.to_string(),
         )))
         .await;
@@ -1045,17 +1053,17 @@ mod tests {
         assert!(!results[0].success);
         assert!(results[1].success);
 
-        let calls = mock.batch_set_power_state_calls().await;
+        let calls = mock.set_power_state_by_device_list_calls().await;
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].operation, rms::PowerOperation::Off as i32);
+        assert_eq!(calls[0].operation, rms::PowerOperation::PowerOff as i32);
     }
 
     #[carbide_macros::sqlx_test]
     async fn ps_update_firmware_success(pool: sqlx::PgPool) {
         let (mock, backend, rack_id, ps1, _ps2, _, _) = make_backend(&pool).await;
-        mock.enqueue_update_firmware(Ok(MockRmsApi::firmware_update_ok("job-aaa")))
+        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-aaa")))
             .await;
-        mock.enqueue_update_firmware(Ok(MockRmsApi::firmware_update_ok("job-bbb")))
+        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-bbb")))
             .await;
 
         let eps = vec![make_ps_endpoint(PS_MAC_1), make_ps_endpoint(PS_MAC_2)];
@@ -1067,7 +1075,7 @@ mod tests {
         assert!(results[0].success);
         assert!(results[1].success);
 
-        let calls = mock.update_firmware_calls().await;
+        let calls = mock.update_node_firmware_async_calls().await;
         assert_eq!(calls[0].firmware_targets[0].target, "pmc");
         assert_eq!(calls[0].node_id, ps1.to_string());
         assert_eq!(calls[0].rack_id, rack_id.to_string());
@@ -1086,7 +1094,7 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn ps_update_firmware_multiple_components(pool: sqlx::PgPool) {
         let (mock, backend, _, _, _, _, _) = make_backend(&pool).await;
-        mock.enqueue_update_firmware(Ok(MockRmsApi::firmware_update_ok("job-1")))
+        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-1")))
             .await;
 
         let eps = vec![make_ps_endpoint(PS_MAC_1)];
@@ -1101,7 +1109,7 @@ mod tests {
 
         assert!(results[0].success);
 
-        let calls = mock.update_firmware_calls().await;
+        let calls = mock.update_node_firmware_async_calls().await;
         assert_eq!(calls[0].firmware_targets.len(), 2);
         assert_eq!(calls[0].firmware_targets[0].target, "pmc");
         assert_eq!(calls[0].firmware_targets[1].target, "psu");
@@ -1110,8 +1118,10 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn ps_update_firmware_failure(pool: sqlx::PgPool) {
         let (mock, backend, _, _, _, _, _) = make_backend(&pool).await;
-        mock.enqueue_update_firmware(Ok(MockRmsApi::firmware_update_fail("bad firmware file")))
-            .await;
+        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_fail(
+            "bad firmware file",
+        )))
+        .await;
 
         let eps = vec![make_ps_endpoint(PS_MAC_1)];
         let results = backend
@@ -1127,7 +1137,7 @@ mod tests {
     async fn ps_firmware_status_running(pool: sqlx::PgPool) {
         let (mock, backend, _, _, _, _, _) = make_backend(&pool).await;
 
-        mock.enqueue_update_firmware(Ok(MockRmsApi::firmware_update_ok("job-xyz")))
+        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-xyz")))
             .await;
         let eps = vec![make_ps_endpoint(PS_MAC_1)];
         backend
@@ -1136,7 +1146,7 @@ mod tests {
             .unwrap();
 
         mock.enqueue_get_firmware_job_status(Ok(MockRmsApi::firmware_job_status_ok(
-            rms::FirmwareJobState::Running,
+            rms::FirmwareJobState::FwJobRunning,
         )))
         .await;
 
@@ -1174,7 +1184,7 @@ mod tests {
     async fn ps_firmware_status_completed(pool: sqlx::PgPool) {
         let (mock, backend, _, _, _, _, _) = make_backend(&pool).await;
 
-        mock.enqueue_update_firmware(Ok(MockRmsApi::firmware_update_ok("job-done")))
+        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-done")))
             .await;
         let eps = vec![make_ps_endpoint(PS_MAC_1)];
         backend
@@ -1183,7 +1193,7 @@ mod tests {
             .unwrap();
 
         mock.enqueue_get_firmware_job_status(Ok(MockRmsApi::firmware_job_status_ok(
-            rms::FirmwareJobState::Completed,
+            rms::FirmwareJobState::FwJobCompleted,
         )))
         .await;
 
@@ -1197,7 +1207,7 @@ mod tests {
     async fn ps_firmware_status_failed(pool: sqlx::PgPool) {
         let (mock, backend, _, _, _, _, _) = make_backend(&pool).await;
 
-        mock.enqueue_update_firmware(Ok(MockRmsApi::firmware_update_ok("job-fail")))
+        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("job-fail")))
             .await;
         let eps = vec![make_ps_endpoint(PS_MAC_1)];
         backend
@@ -1207,7 +1217,7 @@ mod tests {
 
         mock.enqueue_get_firmware_job_status(Ok(rms::GetFirmwareJobStatusResponse {
             status: rms::ReturnCode::Success as i32,
-            job_state: rms::FirmwareJobState::Failed as i32,
+            job_state: rms::FirmwareJobState::FwJobFailed as i32,
             error_message: "checksum mismatch".into(),
             ..Default::default()
         }))
@@ -1287,11 +1297,11 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn sw_power_control_success(pool: sqlx::PgPool) {
         let (mock, backend, rack_id, _, _, sw1, sw2) = make_backend(&pool).await;
-        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
+        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_ok(
             &sw1.to_string(),
         )))
         .await;
-        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
+        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_ok(
             &sw2.to_string(),
         )))
         .await;
@@ -1305,22 +1315,22 @@ mod tests {
         assert!(results[0].success);
         assert!(results[1].success);
 
-        let calls = mock.batch_set_power_state_calls().await;
+        let calls = mock.set_power_state_by_device_list_calls().await;
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].operation, rms::PowerOperation::On as i32);
-        let dev0 = &calls[0].nodes.as_ref().unwrap().nodes[0];
+        assert_eq!(calls[0].operation, rms::PowerOperation::PowerOn as i32);
+        let dev0 = &calls[0].nodes.as_ref().unwrap().devices[0];
         assert_eq!(dev0.node_id, sw1.to_string());
         assert_eq!(dev0.rack_id, rack_id.to_string());
         assert_eq!(dev0.r#type, Some(rms::NodeType::Switch as i32));
         assert!(dev0.bmc_endpoint.is_some());
-        let dev1 = &calls[1].nodes.as_ref().unwrap().nodes[0];
+        let dev1 = &calls[1].nodes.as_ref().unwrap().devices[0];
         assert_eq!(dev1.node_id, sw2.to_string());
     }
 
     #[carbide_macros::sqlx_test]
     async fn sw_power_control_unknown_mac(pool: sqlx::PgPool) {
         let (mock, backend, _, _, _, _, sw2) = make_backend(&pool).await;
-        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
+        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_ok(
             &sw2.to_string(),
         )))
         .await;
@@ -1333,15 +1343,15 @@ mod tests {
         assert!(!results[0].success);
         assert!(results[1].success);
 
-        let calls = mock.batch_set_power_state_calls().await;
+        let calls = mock.set_power_state_by_device_list_calls().await;
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].operation, rms::PowerOperation::Off as i32);
+        assert_eq!(calls[0].operation, rms::PowerOperation::PowerOff as i32);
     }
 
     #[carbide_macros::sqlx_test]
     async fn sw_queue_firmware_updates_success(pool: sqlx::PgPool) {
         let (mock, backend, _, _, _, sw1, _) = make_backend(&pool).await;
-        mock.enqueue_update_firmware(Ok(MockRmsApi::firmware_update_ok("sw-job-1")))
+        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("sw-job-1")))
             .await;
 
         let eps = vec![make_sw_endpoint(SW_MAC_1)];
@@ -1356,7 +1366,7 @@ mod tests {
 
         assert!(results[0].success);
 
-        let calls = mock.update_firmware_calls().await;
+        let calls = mock.update_node_firmware_async_calls().await;
         assert_eq!(calls[0].firmware_targets[0].target, "bmc");
         assert_eq!(calls[0].firmware_targets[1].target, "bios");
         assert_eq!(calls[0].node_id, sw1.to_string());
@@ -1372,7 +1382,7 @@ mod tests {
     async fn sw_firmware_status(pool: sqlx::PgPool) {
         let (mock, backend, _, _, _, _, _) = make_backend(&pool).await;
 
-        mock.enqueue_update_firmware(Ok(MockRmsApi::firmware_update_ok("sw-job-2")))
+        mock.enqueue_update_node_firmware_async(Ok(MockRmsApi::firmware_update_ok("sw-job-2")))
             .await;
         let eps = vec![make_sw_endpoint(SW_MAC_1)];
         backend
@@ -1381,7 +1391,7 @@ mod tests {
             .unwrap();
 
         mock.enqueue_get_firmware_job_status(Ok(MockRmsApi::firmware_job_status_ok(
-            rms::FirmwareJobState::Completed,
+            rms::FirmwareJobState::FwJobCompleted,
         )))
         .await;
 

--- a/crates/power-shelf-controller/src/maintenance.rs
+++ b/crates/power-shelf-controller/src/maintenance.rs
@@ -33,9 +33,9 @@ use state_controller::state_handler::{
 
 use crate::context::PowerShelfStateHandlerContextObjects;
 
-/// Default BMC HTTPS port used when populating `rms::Endpoint` for power
+/// Default BMC HTTPS port used when populating `rms::BmcEndpoint` for power
 /// shelves. Mirrors the value used by `crate::rack::firmware_update`.
-const POWER_SHELF_BMC_PORT: u32 = 443;
+const POWER_SHELF_BMC_PORT: i32 = 443;
 
 /// Handles the Maintenance state for a power shelf, dispatching on the
 /// requested operation (`PowerOn` / `PowerOff`).
@@ -72,7 +72,7 @@ async fn handle_power_on(
         power_shelf_id,
         state,
         ctx,
-        rms::PowerOperation::On,
+        rms::PowerOperation::PowerOn,
         "PowerOn",
     )
     .await
@@ -91,7 +91,7 @@ async fn handle_power_off(
         power_shelf_id,
         state,
         ctx,
-        rms::PowerOperation::Off,
+        rms::PowerOperation::PowerOff,
         "PowerOff",
     )
     .await
@@ -99,7 +99,7 @@ async fn handle_power_off(
 
 /// Common driver for RMS-backed power maintenance operations. Builds a
 /// caller-supplied `NodeSet` with the power shelf's BMC connection details
-/// and dispatches `BatchSetPowerState` against the configured
+/// and dispatches `SetPowerStateByDeviceList` against the configured
 /// `RmsApi` client. Returns to `Ready` on success or transitions to `Error`
 /// on failure. In both terminal cases the `power_shelf_maintenance_requested`
 /// row is cleared so the controller does not re-enter `Maintenance` on the
@@ -158,25 +158,24 @@ async fn invoke_rms_power_operation(
         }
     };
 
-    let request = rms::BatchSetPowerStateRequest {
+    let request = rms::SetPowerStateByDeviceListRequest {
         nodes: Some(rms::NodeSet {
-            nodes: vec![device],
+            devices: vec![device],
         }),
         operation: operation as i32,
+        ..Default::default()
     };
 
-    match rms_client.batch_set_power_state(request).await {
+    match rms_client.set_power_state_by_device_list(request).await {
         Ok(response) => {
             let batch = response.response.unwrap_or_default();
-            let stats = batch.stats.unwrap_or_default();
-
-            if batch.status == rms::ReturnCode::Success as i32 && stats.failed_nodes == 0 {
+            if batch.status == rms::ReturnCode::Success as i32 && batch.failed_nodes == 0 {
                 tracing::info!(
                     power_shelf_id = %power_shelf_id,
                     rack_id = %rack_id,
                     operation = operation_label,
-                    successful_nodes = stats.successful_nodes,
-                    "RMS BatchSetPowerState succeeded; returning PowerShelf to Ready"
+                    successful_nodes = batch.successful_nodes,
+                    "RMS SetPowerStateByDeviceList succeeded; returning PowerShelf to Ready"
                 );
                 let mut txn = ctx.services.db_pool.begin().await?;
                 db_power_shelf::clear_power_shelf_maintenance_requested(&mut txn, *power_shelf_id)
@@ -207,7 +206,7 @@ async fn invoke_rms_power_operation(
             } else {
                 format!(
                     "batch status {}, failed_nodes {}",
-                    batch.status, stats.failed_nodes,
+                    batch.status, batch.failed_nodes,
                 )
             };
 
@@ -216,21 +215,21 @@ async fn invoke_rms_power_operation(
                 rack_id = %rack_id,
                 operation = operation_label,
                 batch_status = batch.status,
-                successful_nodes = stats.successful_nodes,
-                failed_nodes = stats.failed_nodes,
+                successful_nodes = batch.successful_nodes,
+                failed_nodes = batch.failed_nodes,
                 summary = %summary,
-                "RMS BatchSetPowerState returned a non-success result",
+                "RMS SetPowerStateByDeviceList returned a non-success result",
             );
             let cause = format!(
-                "PowerShelf {} maintenance ({}): RMS BatchSetPowerState failed: {}",
+                "PowerShelf {} maintenance ({}): RMS SetPowerStateByDeviceList failed: {}",
                 power_shelf_id, operation_label, summary
             );
             finish_maintenance_with_error(power_shelf_id, ctx, cause).await
         }
         Err(error) => {
-            let error = rack_manager_error("batch_set_power_state", error);
+            let error = rack_manager_error("set_power_state_by_device_list", error);
             let cause = format!(
-                "PowerShelf {} maintenance ({}): RMS BatchSetPowerState failed: {}",
+                "PowerShelf {} maintenance ({}): RMS SetPowerStateByDeviceList failed: {}",
                 power_shelf_id, operation_label, error
             );
             tracing::warn!(
@@ -238,25 +237,26 @@ async fn invoke_rms_power_operation(
                 rack_id = %rack_id,
                 operation = operation_label,
                 error = %error,
-                "RMS BatchSetPowerState transport error",
+                "RMS SetPowerStateByDeviceList transport error",
             );
             finish_maintenance_with_error(power_shelf_id, ctx, cause).await
         }
     }
 }
 
-/// Build the `rms::NodeInfo` describing this power shelf for inclusion
-/// in caller-supplied `NodeSet` requests from `Maintenance` and `Ready`.
-/// Resolves the BMC IP from the database and BMC credentials via the
-/// credential manager, since these RPCs require the BMC connection details
-/// inline rather than relying on RMS's inventory.
+/// Build the `rms::NewNodeInfo` describing this power shelf for inclusion
+/// in any caller-supplied `NodeSet` request (`SetPowerStateByDeviceList`
+/// from `Maintenance`, `GetDeviceInfoByDeviceList` from `Ready`). Resolves
+/// the BMC IP from the database and BMC credentials via the credential
+/// manager, since these RPCs require the BMC connection details inline
+/// rather than relying on RMS's inventory.
 pub(super) async fn build_power_shelf_node_info(
     power_shelf_id: &PowerShelfId,
     state: &PowerShelf,
     rack_id: String,
     db_pool: &PgPool,
     credential_manager: &dyn CredentialManager,
-) -> Result<rms::NodeInfo, String> {
+) -> Result<rms::NewNodeInfo, String> {
     let bmc_mac = state.bmc_mac_address.ok_or_else(|| {
         format!(
             "power shelf {} has no BMC MAC address recorded",
@@ -267,18 +267,17 @@ pub(super) async fn build_power_shelf_node_info(
     let bmc_ip = lookup_power_shelf_bmc_ip(db_pool, power_shelf_id, bmc_mac).await?;
     let credentials = lookup_bmc_credentials(credential_manager, bmc_mac).await?;
 
-    Ok(rms::NodeInfo {
+    Ok(rms::NewNodeInfo {
         node_id: power_shelf_id.to_string(),
         rack_id,
         r#type: Some(rms::NodeType::Powershelf as i32),
-        bmc_endpoint: Some(rms::Endpoint {
+        bmc_endpoint: Some(rms::BmcEndpoint {
             interface: Some(rms::NetworkInterface {
                 ip_address: bmc_ip,
                 mac_address: bmc_mac.to_string(),
             }),
             port: POWER_SHELF_BMC_PORT,
             credentials: Some(credentials),
-            dangerously_accept_invalid_certs: true,
         }),
         host_endpoint: None,
     })

--- a/crates/power-shelf-controller/src/ready.rs
+++ b/crates/power-shelf-controller/src/ready.rs
@@ -83,7 +83,7 @@ async fn poll_rms_power_state(
     let Some(rms_client) = ctx.services.rms_client.as_ref() else {
         tracing::debug!(
             power_shelf_id = %power_shelf_id,
-            "PowerShelf Ready: skipping RMS BatchGetPowerState; RMS client not configured",
+            "PowerShelf Ready: skipping RMS GetPowerStateByDeviceList; RMS client not configured",
         );
         return None;
     };
@@ -91,7 +91,7 @@ async fn poll_rms_power_state(
     let Some(rack_id) = state.rack_id.as_ref() else {
         tracing::debug!(
             power_shelf_id = %power_shelf_id,
-            "PowerShelf Ready: skipping RMS BatchGetPowerState; power shelf has no rack association",
+            "PowerShelf Ready: skipping RMS GetPowerStateByDeviceList; power shelf has no rack association",
         );
         return None;
     };
@@ -111,44 +111,44 @@ async fn poll_rms_power_state(
                 power_shelf_id = %power_shelf_id,
                 rack_id = %rack_id,
                 cause = %cause,
-                "PowerShelf Ready: skipping RMS BatchGetPowerState; unable to build NodeSet",
+                "PowerShelf Ready: skipping RMS GetPowerStateByDeviceList; unable to build NodeSet",
             );
             return None;
         }
     };
 
-    let request = rms::BatchGetPowerStateRequest {
+    let request = rms::GetPowerStateByDeviceListRequest {
         nodes: Some(rms::NodeSet {
-            nodes: vec![device],
+            devices: vec![device],
         }),
+        ..Default::default()
     };
 
     let rack_id_str = rack_id.to_string();
-    let response = match rms_client.batch_get_power_state(request).await {
+    let response = match rms_client.get_power_state_by_device_list(request).await {
         Ok(response) => response,
         Err(error) => {
-            let error = rack_manager_error("batch_get_power_state", error);
+            let error = rack_manager_error("get_power_state_by_device_list", error);
             tracing::warn!(
                 power_shelf_id = %power_shelf_id,
                 rack_id = %rack_id_str,
                 error = %error,
-                "RMS BatchGetPowerState transport error",
+                "RMS GetPowerStateByDeviceList transport error",
             );
             return None;
         }
     };
 
     let batch = response.response.clone().unwrap_or_default();
-    let stats = batch.stats.unwrap_or_default();
-    if !(batch.status == rms::ReturnCode::Success as i32 && stats.failed_nodes == 0) {
+    if !(batch.status == rms::ReturnCode::Success as i32 && batch.failed_nodes == 0) {
         tracing::warn!(
             power_shelf_id = %power_shelf_id,
             rack_id = %rack_id_str,
             batch_status = batch.status,
-            successful_nodes = stats.successful_nodes,
-            failed_nodes = stats.failed_nodes,
+            successful_nodes = batch.successful_nodes,
+            failed_nodes = batch.failed_nodes,
             message = %batch.message,
-            "RMS BatchGetPowerState returned non-Success result",
+            "RMS GetPowerStateByDeviceList returned non-Success result",
         );
         return None;
     }
@@ -156,13 +156,13 @@ async fn poll_rms_power_state(
     tracing::info!(
         power_shelf_id = %power_shelf_id,
         rack_id = %rack_id_str,
-        successful_nodes = stats.successful_nodes,
+        successful_nodes = batch.successful_nodes,
         pstates = ?response
             .node_power_states
             .iter()
             .map(|node| (node.node_id.as_str(), node.pstate.as_str()))
             .collect::<Vec<_>>(),
-        "RMS BatchGetPowerState succeeded",
+        "RMS GetPowerStateByDeviceList succeeded",
     );
 
     persist_observed_power_state(power_shelf_id, state, ctx, &response.node_power_states).await
@@ -189,7 +189,7 @@ async fn persist_observed_power_state(
     else {
         tracing::debug!(
             power_shelf_id = %power_shelf_id,
-            "RMS BatchGetPowerState: no NodePowerState echoed for this power shelf; skipping status update",
+            "RMS GetPowerStateByDeviceList: no NodePowerState echoed for this power shelf; skipping status update",
         );
         return None;
     };

--- a/crates/rack-controller/src/fabric_manager.rs
+++ b/crates/rack-controller/src/fabric_manager.rs
@@ -56,26 +56,30 @@ pub(super) fn validate_switch_inventory_for_nmx_cluster(
 fn build_scale_up_fabric_services_status_request(
     rack_id: &RackId,
     switches: &[FirmwareUpgradeDeviceInfo],
-) -> rms::BatchGetScaleUpFabricServiceStatusRequest {
-    rms::BatchGetScaleUpFabricServiceStatusRequest {
+) -> rms::GetScaleUpFabricServicesStatusRequest {
+    rms::GetScaleUpFabricServicesStatusRequest {
         nodes: Some(rms::NodeSet {
-            nodes: switches
+            devices: switches
                 .iter()
-                .map(|switch| build_new_node_info(rack_id, switch, rms::NodeType::Switch, true))
+                .map(|switch| build_new_node_info(rack_id, switch, rms::NodeType::Switch))
                 .collect(),
         }),
+        verify_ssl: false,
+        ..Default::default()
     }
 }
 
-pub(super) async fn batch_get_scale_up_fabric_service_status(
+pub(super) async fn get_scale_up_fabric_services_status(
     rms_config: &RmsConfig,
     rack_id: &RackId,
     switches: &[FirmwareUpgradeDeviceInfo],
-) -> Result<rms::BatchGetScaleUpFabricServiceStatusResponse, String> {
+) -> Result<rms::GetScaleUpFabricServicesStatusResponse, String> {
     let Some(url) = rms_config.api_url.as_deref().filter(|url| !url.is_empty()) else {
         return Err("RMS client not configured".to_string());
     };
 
+    // The pinned librms::RmsApi trait does not yet expose this RPC, so keep
+    // the direct concrete-client use local to ConfigureNmxCluster.
     let rms_client_config = librms::client_config::RmsClientConfig::new(
         rms_config.root_ca_path.clone(),
         rms_config.client_cert.clone(),
@@ -87,11 +91,11 @@ pub(super) async fn batch_get_scale_up_fabric_service_status(
 
     rms_client
         .client
-        .batch_get_scale_up_fabric_service_status(build_scale_up_fabric_services_status_request(
+        .get_scale_up_fabric_services_status(build_scale_up_fabric_services_status_request(
             rack_id, switches,
         ))
         .await
-        .map_err(|error| format!("RMS BatchGetScaleUpFabricServiceStatus failed: {}", error))
+        .map_err(|error| format!("RMS GetScaleUpFabricServicesStatus failed: {}", error))
 }
 
 #[derive(Debug, Deserialize)]
@@ -161,17 +165,17 @@ pub(super) async fn persist_fabric_manager_statuses(
     txn: &mut PgConnection,
     rack_id: &RackId,
     switches: &[FirmwareUpgradeDeviceInfo],
-    response: &rms::BatchGetScaleUpFabricServiceStatusResponse,
+    response: &rms::GetScaleUpFabricServicesStatusResponse,
 ) -> Result<(), String> {
     if response.status != rms::ReturnCode::Success as i32 {
         return Err(
-            "RMS BatchGetScaleUpFabricServiceStatus returned failure for ConfigureNmxCluster"
+            "RMS GetScaleUpFabricServicesStatus returned failure for ConfigureNmxCluster"
                 .to_string(),
         );
     }
 
     for switch in switches {
-        let Some(entry) = response.service_statuses.get(switch.node_id.as_str()) else {
+        let Some(entry) = response.device_info_result.get(switch.node_id.as_str()) else {
             return Err(format!(
                 "RMS did not return fabric-manager status for switch {}",
                 switch.node_id
@@ -210,13 +214,13 @@ pub(super) async fn persist_fabric_manager_statuses(
 #[derive(Debug, Clone)]
 pub(super) struct SwitchPlacement {
     pub(super) device: FirmwareUpgradeDeviceInfo,
-    pub(super) tray_index: u32,
-    pub(super) slot_number: Option<u32>,
+    pub(super) tray_index: i32,
+    pub(super) slot_number: Option<i32>,
 }
 
 pub(super) fn select_primary_switch(
     switches: &[FirmwareUpgradeDeviceInfo],
-    response: &rms::BatchGetNodeDeviceInfoResponse,
+    response: &rms::GetDeviceInfoByDeviceListResponse,
 ) -> Result<SwitchPlacement, String> {
     if response.status != rms::ReturnCode::Success as i32 {
         let details = if response.message.trim().is_empty() {
@@ -224,17 +228,17 @@ pub(super) fn select_primary_switch(
         } else {
             response.message.clone()
         };
-        return Err(format!("RMS BatchGetNodeDeviceInfo failed: {}", details));
+        return Err(format!("RMS GetDeviceInfoByDeviceList failed: {}", details));
     }
 
     let switches_by_node_id: HashMap<&str, &FirmwareUpgradeDeviceInfo> = switches
         .iter()
         .map(|switch| (switch.node_id.as_str(), switch))
         .collect();
-    let mut placements = Vec::with_capacity(response.node_device_details.len());
-    let mut seen_node_ids = HashSet::with_capacity(response.node_device_details.len());
+    let mut placements = Vec::with_capacity(response.node_device_info.len());
+    let mut seen_node_ids = HashSet::with_capacity(response.node_device_info.len());
 
-    for node_info in &response.node_device_details {
+    for node_info in &response.node_device_info {
         let Some(device) = switches_by_node_id.get(node_info.node_id.as_str()) else {
             return Err(format!(
                 "RMS returned device info for unexpected switch {}",
@@ -290,11 +294,10 @@ pub(super) fn select_primary_switch(
         ));
     }
 
-    let Some(primary) = placements.into_iter().next() else {
-        return Err("RMS returned no switch device info for ConfigureNmxCluster".to_string());
-    };
-
-    Ok(primary)
+    Ok(placements
+        .into_iter()
+        .next()
+        .expect("placements cannot be empty after explicit guard"))
 }
 
 pub(super) async fn persist_primary_switch(
@@ -341,10 +344,10 @@ mod tests {
         }
     }
 
-    fn node_device_details(
+    fn node_device_info(
         node_id: &str,
-        tray_index: u32,
-        slot_number: Option<u32>,
+        tray_index: i32,
+        slot_number: Option<i32>,
     ) -> rms::NodeDeviceInfo {
         rms::NodeDeviceInfo {
             node_id: node_id.to_string(),
@@ -357,20 +360,18 @@ mod tests {
     #[test]
     fn select_primary_switch_picks_lowest_tray_index() {
         let switches = vec![switch("sw-1"), switch("sw-2"), switch("sw-3")];
-        let response = rms::BatchGetNodeDeviceInfoResponse {
+        let response = rms::GetDeviceInfoByDeviceListResponse {
             status: rms::ReturnCode::Success as i32,
-            node_device_details: vec![
-                node_device_details("sw-1", 3, Some(3)),
-                node_device_details("sw-2", 1, Some(1)),
-                node_device_details("sw-3", 2, Some(2)),
+            node_device_info: vec![
+                node_device_info("sw-1", 3, Some(3)),
+                node_device_info("sw-2", 1, Some(1)),
+                node_device_info("sw-3", 2, Some(2)),
             ],
             ..Default::default()
         };
 
-        let primary = match select_primary_switch(&switches, &response) {
-            Ok(primary) => primary,
-            Err(error) => panic!("selection should succeed: {error}"),
-        };
+        let primary =
+            select_primary_switch(&switches, &response).expect("selection should succeed");
 
         assert_eq!(primary.device.node_id, "sw-2");
         assert_eq!(primary.tray_index, 1);
@@ -380,18 +381,16 @@ mod tests {
     #[test]
     fn select_primary_switch_errors_on_duplicate_tray_index() {
         let switches = vec![switch("sw-1"), switch("sw-2")];
-        let response = rms::BatchGetNodeDeviceInfoResponse {
+        let response = rms::GetDeviceInfoByDeviceListResponse {
             status: rms::ReturnCode::Success as i32,
-            node_device_details: vec![
-                node_device_details("sw-1", 1, Some(1)),
-                node_device_details("sw-2", 1, Some(2)),
+            node_device_info: vec![
+                node_device_info("sw-1", 1, Some(1)),
+                node_device_info("sw-2", 1, Some(2)),
             ],
             ..Default::default()
         };
 
-        let Err(error) = select_primary_switch(&switches, &response) else {
-            panic!("selection should fail");
-        };
+        let error = select_primary_switch(&switches, &response).expect_err("selection should fail");
 
         assert!(error.contains("duplicate tray_index 1"));
         assert!(error.contains("sw-1"));

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -29,8 +29,8 @@ use carbide_rack::rms_client::SwitchSystemImageRmsClient;
 use carbide_rack_controller::config::RmsConfig;
 use carbide_rack_controller::context::RackStateHandlerContextObjects;
 use carbide_rack_controller::fabric_manager::{
-    batch_get_scale_up_fabric_service_status, persist_fabric_manager_statuses,
-    persist_primary_switch, select_primary_switch, validate_switch_inventory_for_nmx_cluster,
+    get_scale_up_fabric_services_status, persist_fabric_manager_statuses, persist_primary_switch,
+    select_primary_switch, validate_switch_inventory_for_nmx_cluster,
 };
 use carbide_rack_controller::validating::strip_rv_labels;
 use carbide_uuid::rack::{RackId, RackProfileId};
@@ -438,14 +438,15 @@ fn skip_configure_nmx_cluster_outcome(
 fn build_switch_device_info_request(
     rack_id: &RackId,
     switches: &[FirmwareUpgradeDeviceInfo],
-) -> rms::BatchGetNodeDeviceInfoRequest {
-    rms::BatchGetNodeDeviceInfoRequest {
+) -> rms::GetDeviceInfoByDeviceListRequest {
+    rms::GetDeviceInfoByDeviceListRequest {
         nodes: Some(rms::NodeSet {
-            nodes: switches
+            devices: switches
                 .iter()
-                .map(|switch| build_new_node_info(rack_id, switch, rms::NodeType::Switch, false))
+                .map(|switch| build_new_node_info(rack_id, switch, rms::NodeType::Switch))
                 .collect(),
         }),
+        ..Default::default()
     }
 }
 
@@ -549,26 +550,29 @@ async fn rms_start_firmware_upgrade_from_json(
     let started_at = chrono::Utc::now();
     let machine_count = request.machines.len();
     let switch_count = request.switches.len();
-    let mut nodes = Vec::with_capacity(machine_count + switch_count);
-    nodes.extend(
-        request.machines.iter().map(|device| {
-            build_new_node_info(request.rack_id, device, rms::NodeType::Compute, false)
-        }),
+    let mut devices = Vec::with_capacity(machine_count + switch_count);
+    devices.extend(
+        request
+            .machines
+            .iter()
+            .map(|device| build_new_node_info(request.rack_id, device, rms::NodeType::Compute)),
     );
-    nodes.extend(
-        request.switches.iter().map(|device| {
-            build_new_node_info(request.rack_id, device, rms::NodeType::Switch, false)
-        }),
+    devices.extend(
+        request
+            .switches
+            .iter()
+            .map(|device| build_new_node_info(request.rack_id, device, rms::NodeType::Switch)),
     );
 
     let response = rms_client
-        .apply_firmware_object(rms::ApplyFirmwareObjectRequest {
+        .apply_firmware_object_from_json(rms::ApplyFirmwareObjectFromJsonRequest {
+            metadata: None,
             rack_id: request.rack_id.to_string(),
             config_json: request.config_json.to_string(),
             access_token: request.access_token.to_string(),
             firmware_type: request.firmware_type.to_string(),
             hardware_type: request.hardware_type.to_string(),
-            nodes: Some(rms::NodeSet { nodes }),
+            nodes: Some(rms::NodeSet { devices }),
             force_update: request.force_update,
             component_filters: rms_component_filters_from_components(
                 request.components,
@@ -593,13 +597,13 @@ async fn rms_start_firmware_upgrade_from_json(
         .unwrap_or_default();
     if batch_status != rms::ReturnCode::Success as i32
         && batch_job_id.is_empty()
-        && response.jobs.is_empty()
+        && response.node_jobs.is_empty()
     {
         let message = batch_response
             .map(|batch_response| batch_response.message.as_str())
             .unwrap_or_default();
         let message = if message.is_empty() {
-            "RMS returned failure for ApplyFirmwareObject".to_string()
+            "RMS returned failure for ApplyFirmwareObjectFromJSON".to_string()
         } else {
             message.to_string()
         };
@@ -608,7 +612,7 @@ async fn rms_start_firmware_upgrade_from_json(
 
     let parent_job_id = (!batch_job_id.is_empty()).then(|| batch_job_id.to_string());
     let child_jobs = response
-        .jobs
+        .node_jobs
         .iter()
         .map(|child| (child.node_id.clone(), child.job_id.clone()))
         .collect::<std::collections::HashMap<_, _>>();
@@ -730,6 +734,7 @@ async fn rms_get_firmware_upgrade_status(
         let response = rms_client
             .get_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusRequest {
                 job_id: job_id.clone(),
+                ..Default::default()
             })
             .await;
 
@@ -740,20 +745,20 @@ async fn rms_get_firmware_upgrade_status(
                 if !response.node_id.is_empty() {
                     device.node_id = response.node_id.clone();
                 }
-                match rms::FirmwareJobState::try_from(response.job_state) {
-                    Ok(rms::FirmwareJobState::Queued) => {
+                match response.job_state {
+                    0 => {
                         device.status = "pending".into();
                         device.error_message = None;
                     }
-                    Ok(rms::FirmwareJobState::Running) => {
+                    1 => {
                         device.status = "in_progress".into();
                         device.error_message = None;
                     }
-                    Ok(rms::FirmwareJobState::Completed) => {
+                    2 => {
                         device.status = "completed".into();
                         device.error_message = None;
                     }
-                    Ok(rms::FirmwareJobState::Failed) => {
+                    3 => {
                         device.status = "failed".into();
                         device.error_message = Some(if response.error_message.is_empty() {
                             response.state_description
@@ -761,7 +766,7 @@ async fn rms_get_firmware_upgrade_status(
                             response.error_message
                         });
                     }
-                    Ok(rms::FirmwareJobState::Unspecified) | Err(_) => {
+                    _ => {
                         tracing::warn!(
                             job_id = %job_id,
                             job_state = response.job_state,
@@ -849,17 +854,18 @@ async fn rms_start_nvos_update(
     switches: Vec<FirmwareUpgradeDeviceInfo>,
 ) -> Result<NvosUpdateJob, StateHandlerError> {
     let started_at = chrono::Utc::now();
-    let nodes: Vec<_> = switches
+    let devices: Vec<_> = switches
         .iter()
-        .map(|switch| build_new_node_info(rack_id, switch, rms::NodeType::Switch, false))
+        .map(|switch| build_new_node_info(rack_id, switch, rms::NodeType::Switch))
         .collect();
-    let nodes = Some(rms::NodeSet { nodes });
+    let nodes = Some(rms::NodeSet { devices });
     let NvosUpdateSource {
         config_json,
         access_token,
     } = source;
     let response = rms_client
-        .apply_switch_system_image(rms::ApplySwitchSystemImageRequest {
+        .apply_switch_system_image_from_json(rms::ApplySwitchSystemImageFromJsonRequest {
+            metadata: None,
             rack_id: rack_id.to_string(),
             config_json: config_json.to_string(),
             access_token: access_token.to_string(),
@@ -884,13 +890,13 @@ async fn rms_start_nvos_update(
         .unwrap_or_default();
     if batch_status != rms::ReturnCode::Success as i32
         && batch_job_id.is_empty()
-        && response.jobs.is_empty()
+        && response.node_jobs.is_empty()
     {
         let message = batch_response
             .map(|batch_response| batch_response.message.as_str())
             .unwrap_or_default();
         let message = if message.is_empty() {
-            "RMS returned failure for ApplySwitchSystemImage".to_string()
+            "RMS returned failure for ApplySwitchSystemImageFromJSON".to_string()
         } else {
             message.to_string()
         };
@@ -899,7 +905,7 @@ async fn rms_start_nvos_update(
 
     let parent_job_id = (!batch_job_id.is_empty()).then(|| batch_job_id.to_string());
     let child_jobs = response
-        .jobs
+        .node_jobs
         .iter()
         .map(|child| (child.node_id.clone(), child.job_id.clone()))
         .collect::<std::collections::HashMap<_, _>>();
@@ -989,6 +995,7 @@ async fn rms_get_nvos_update_status(
         let response = rms_client
             .get_switch_system_image_job_status(rms::GetSwitchSystemImageJobStatusRequest {
                 job_id: job_id.clone(),
+                ..Default::default()
             })
             .await;
 
@@ -1794,31 +1801,31 @@ pub async fn handle_maintenance(
                     "Disabling ScaleUpFabric state before selecting ConfigureNmxCluster primary switch"
                 );
                 let response = match rms_client
-                    .batch_set_scale_up_fabric_state(rms::BatchSetScaleUpFabricStateRequest {
+                    .set_scale_up_fabric_state(rms::SetScaleUpFabricStateRequest {
                         nodes: Some(rms::NodeSet {
-                            nodes: switch_inventory
+                            devices: switch_inventory
                                 .switches
                                 .iter()
                                 .map(|switch| {
-                                    build_new_node_info(id, switch, rms::NodeType::Switch, true)
+                                    build_new_node_info(id, switch, rms::NodeType::Switch)
                                 })
                                 .collect(),
                         }),
-                        enabled: false,
+                        enabled: Some(false),
+                        verify_ssl: false,
+                        ..Default::default()
                     })
                     .await
                 {
                     Ok(response) => response,
                     Err(error) => {
-                        let error = rack_manager_error("batch_set_scale_up_fabric_state", error);
+                        let error = rack_manager_error("set_scale_up_fabric_state", error);
                         return transition_to_rack_error(id, state, error.to_string(), ctx).await;
                     }
                 };
 
                 let batch = response.response.unwrap_or_default();
-                let stats = batch.stats.unwrap_or_default();
-
-                if batch.status != rms::ReturnCode::Success as i32 || stats.failed_nodes > 0 {
+                if batch.status != rms::ReturnCode::Success as i32 || batch.failed_nodes > 0 {
                     let node_error = batch
                         .node_results
                         .iter()
@@ -1840,21 +1847,21 @@ pub async fn handle_maintenance(
                     } else {
                         format!(
                             "batch status {}, failed_nodes {}",
-                            batch.status, stats.failed_nodes,
+                            batch.status, batch.failed_nodes,
                         )
                     };
                     tracing::error!(
                         rack_id = %id,
                         batch_status = batch.status,
-                        successful_nodes = stats.successful_nodes,
-                        failed_nodes = stats.failed_nodes,
+                        successful_nodes = batch.successful_nodes,
+                        failed_nodes = batch.failed_nodes,
                         summary = %summary,
-                        "RMS BatchSetScaleUpFabricState failed",
+                        "RMS SetScaleUpFabricState failed",
                     );
                     return transition_to_rack_error(
                         id,
                         state,
-                        format!("RMS BatchSetScaleUpFabricState failed: {}", summary),
+                        format!("RMS SetScaleUpFabricState failed: {}", summary),
                         ctx,
                     )
                     .await;
@@ -1862,7 +1869,7 @@ pub async fn handle_maintenance(
 
                 tracing::info!(
                     rack_id = %id,
-                    successful_nodes = stats.successful_nodes,
+                    successful_nodes = batch.successful_nodes,
                     switch_count = switch_inventory.switches.len(),
                     "ScaleUpFabric state disabled; advancing to ConfigureScaleUpFabricManager"
                 );
@@ -1948,7 +1955,7 @@ pub async fn handle_maintenance(
                 };
 
                 let response = match rms_client
-                    .batch_get_node_device_info(build_switch_device_info_request(
+                    .get_device_info_by_device_list(build_switch_device_info_request(
                         id,
                         &switch_inventory.switches,
                     ))
@@ -1956,7 +1963,7 @@ pub async fn handle_maintenance(
                 {
                     Ok(response) => response,
                     Err(error) => {
-                        let error = rack_manager_error("batch_get_node_device_info", error);
+                        let error = rack_manager_error("get_device_info_by_device_list", error);
                         return transition_to_rack_error(id, state, error.to_string(), ctx).await;
                     }
                 };
@@ -1989,13 +1996,14 @@ pub async fn handle_maintenance(
                 );
                 let response = match rms_client
                     .configure_scale_up_fabric_manager(rms::ConfigureScaleUpFabricManagerRequest {
-                        node: Some(build_new_node_info(
+                        device: Some(build_new_node_info(
                             id,
                             &primary_switch.device,
                             rms::NodeType::Switch,
-                            true,
                         )),
                         topology_type: topology_type.clone(),
+                        verify_ssl: false,
+                        ..Default::default()
                     })
                     .await
                 {
@@ -2080,7 +2088,7 @@ pub async fn handle_maintenance(
                     ));
                 }
 
-                let fabric_status_response = match batch_get_scale_up_fabric_service_status(
+                let fabric_status_response = match get_scale_up_fabric_services_status(
                     &ctx.services.site_config.rms,
                     id,
                     &switch_inventory.switches,

--- a/crates/rack/Cargo.toml
+++ b/crates/rack/Cargo.toml
@@ -42,7 +42,6 @@ eyre = { workspace = true }
 librms = { workspace = true }
 mac_address = { workspace = true }
 opentelemetry = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rack/src/firmware_update.rs
+++ b/crates/rack/src/firmware_update.rs
@@ -210,37 +210,34 @@ pub fn build_new_node_info(
     rack_id: &RackId,
     device: &FirmwareUpgradeDeviceInfo,
     node_type: rms::NodeType,
-    host_endpoint_dangerously_accept_invalid_certs: bool,
-) -> rms::NodeInfo {
+) -> rms::NewNodeInfo {
     let bmc_endpoint = if device.bmc_ip.is_empty() || device.mac.is_empty() {
         None
     } else {
-        Some(rms::Endpoint {
+        Some(rms::BmcEndpoint {
             interface: Some(rms::NetworkInterface {
                 ip_address: device.bmc_ip.clone(),
                 mac_address: device.mac.clone(),
             }),
             port: 443,
             credentials: user_pass_credentials(&device.bmc_username, &device.bmc_password),
-            dangerously_accept_invalid_certs: true,
         })
     };
 
     let host_endpoint = if matches!(node_type, rms::NodeType::Switch) {
-        Some(rms::Endpoint {
-            interface: build_host_interface(device),
+        Some(rms::HostEndpoint {
+            interfaces: build_host_interfaces(device),
             port: 0,
             credentials: user_pass_credentials(
                 device.os_username.as_deref().unwrap_or_default(),
                 device.os_password.as_deref().unwrap_or_default(),
             ),
-            dangerously_accept_invalid_certs: host_endpoint_dangerously_accept_invalid_certs,
         })
     } else {
         None
     };
 
-    rms::NodeInfo {
+    rms::NewNodeInfo {
         node_id: device.node_id.clone(),
         rack_id: rack_id.to_string(),
         r#type: Some(node_type as i32),
@@ -249,15 +246,15 @@ pub fn build_new_node_info(
     }
 }
 
-fn build_host_interface(device: &FirmwareUpgradeDeviceInfo) -> Option<rms::NetworkInterface> {
-    let (Some(ip_address), Some(mac_address)) = (&device.os_ip, &device.os_mac) else {
-        return None;
-    };
+fn build_host_interfaces(device: &FirmwareUpgradeDeviceInfo) -> Vec<rms::NetworkInterface> {
+    if device.os_ip.is_none() && device.os_mac.is_none() {
+        return Vec::new();
+    }
 
-    Some(rms::NetworkInterface {
-        ip_address: ip_address.clone(),
-        mac_address: mac_address.clone(),
-    })
+    vec![rms::NetworkInterface {
+        ip_address: device.os_ip.clone().unwrap_or_default(),
+        mac_address: device.os_mac.clone().unwrap_or_default(),
+    }]
 }
 
 fn user_pass_credentials(username: &str, password: &str) -> Option<rms::Credentials> {

--- a/crates/rack/src/rms_client.rs
+++ b/crates/rack/src/rms_client.rs
@@ -19,9 +19,9 @@ use librms::protos::rack_manager as rms;
 
 #[async_trait::async_trait]
 pub trait SwitchSystemImageRmsClient: Send + Sync {
-    async fn apply_switch_system_image(
+    async fn apply_switch_system_image_from_json(
         &self,
-        cmd: rms::ApplySwitchSystemImageRequest,
+        cmd: rms::ApplySwitchSystemImageFromJsonRequest,
     ) -> Result<rms::ApplySwitchSystemImageResponse, tonic::Status>;
 
     async fn get_switch_system_image_job_status(
@@ -32,11 +32,11 @@ pub trait SwitchSystemImageRmsClient: Send + Sync {
 
 #[async_trait::async_trait]
 impl SwitchSystemImageRmsClient for librms::RackManagerApi {
-    async fn apply_switch_system_image(
+    async fn apply_switch_system_image_from_json(
         &self,
-        cmd: rms::ApplySwitchSystemImageRequest,
+        cmd: rms::ApplySwitchSystemImageFromJsonRequest,
     ) -> Result<rms::ApplySwitchSystemImageResponse, tonic::Status> {
-        self.client.apply_switch_system_image(cmd).await
+        self.client.apply_switch_system_image_from_json(cmd).await
     }
 
     async fn get_switch_system_image_job_status(
@@ -60,96 +60,86 @@ pub mod test_support {
 
     /// RMS simulation for testing, similar to RedfishSim
     pub struct RmsSim {
-        fail_create_nodes: Arc<AtomicBool>,
+        fail_add_node: Arc<AtomicBool>,
         fail_inventory_get: Arc<AtomicBool>,
         registered_nodes: Arc<Mutex<Vec<rms::NodeInventoryInfo>>>,
         firmware_objects: Arc<Mutex<HashMap<String, rms::FirmwareObject>>>,
-        submitted_firmware_requests: Arc<Mutex<Vec<rms::BatchUpdateFirmwareRequest>>>,
-        queued_firmware_responses: Arc<Mutex<VecDeque<rms::BatchUpdateFirmwareResponse>>>,
-        submitted_apply_stored_firmware_object_requests:
-            Arc<Mutex<Vec<rms::ApplyStoredFirmwareObjectRequest>>>,
+        submitted_firmware_requests: Arc<Mutex<Vec<rms::UpdateFirmwareByDeviceListRequest>>>,
+        queued_firmware_responses: Arc<Mutex<VecDeque<rms::UpdateFirmwareByDeviceListResponse>>>,
+        submitted_firmware_object_apply_requests: Arc<Mutex<Vec<rms::ApplyFirmwareObjectRequest>>>,
         queued_firmware_object_apply_responses:
             Arc<Mutex<VecDeque<rms::ApplyFirmwareObjectResponse>>>,
-        submitted_apply_firmware_object_requests: Arc<Mutex<Vec<rms::ApplyFirmwareObjectRequest>>>,
+        submitted_firmware_object_from_json_apply_requests:
+            Arc<Mutex<Vec<rms::ApplyFirmwareObjectFromJsonRequest>>>,
         firmware_job_statuses: Arc<Mutex<HashMap<String, rms::GetFirmwareJobStatusResponse>>>,
         firmware_job_errors: Arc<Mutex<HashMap<String, String>>>,
         submitted_apply_switch_system_image_requests:
             Arc<Mutex<Vec<rms::ApplySwitchSystemImageRequest>>>,
+        submitted_apply_switch_system_image_from_json_requests:
+            Arc<Mutex<Vec<rms::ApplySwitchSystemImageFromJsonRequest>>>,
         queued_apply_switch_system_image_responses:
             Arc<Mutex<VecDeque<rms::ApplySwitchSystemImageResponse>>>,
         switch_system_image_job_statuses:
             Arc<Mutex<HashMap<String, rms::GetSwitchSystemImageJobStatusResponse>>>,
         switch_system_image_job_errors: Arc<Mutex<HashMap<String, String>>>,
-        submitted_batch_get_node_device_info_requests:
-            Arc<Mutex<Vec<rms::BatchGetNodeDeviceInfoRequest>>>,
-        queued_batch_get_node_device_info_responses:
-            Arc<Mutex<VecDeque<Result<rms::BatchGetNodeDeviceInfoResponse, RackManagerError>>>>,
-        submitted_batch_get_power_state_requests: Arc<Mutex<Vec<rms::BatchGetPowerStateRequest>>>,
-        queued_batch_get_power_state_responses:
-            Arc<Mutex<VecDeque<Result<rms::BatchGetPowerStateResponse, RackManagerError>>>>,
+        submitted_get_device_info_by_device_list_requests:
+            Arc<Mutex<Vec<rms::GetDeviceInfoByDeviceListRequest>>>,
+        queued_get_device_info_by_device_list_responses:
+            Arc<Mutex<VecDeque<Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError>>>>,
         submitted_configure_scale_up_fabric_manager_requests:
             Arc<Mutex<Vec<rms::ConfigureScaleUpFabricManagerRequest>>>,
         queued_configure_scale_up_fabric_manager_responses: Arc<
             Mutex<VecDeque<Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError>>>,
         >,
-        submitted_batch_set_scale_up_fabric_state_requests:
-            Arc<Mutex<Vec<rms::BatchSetScaleUpFabricStateRequest>>>,
-        queued_batch_set_scale_up_fabric_state_responses:
-            Arc<Mutex<VecDeque<Result<rms::BatchSetScaleUpFabricStateResponse, RackManagerError>>>>,
-        submitted_batch_get_scale_up_fabric_service_status_requests:
-            Arc<Mutex<Vec<rms::BatchGetScaleUpFabricServiceStatusRequest>>>,
-        queued_batch_get_scale_up_fabric_service_status_responses: Arc<
-            Mutex<
-                VecDeque<Result<rms::BatchGetScaleUpFabricServiceStatusResponse, RackManagerError>>,
-            >,
-        >,
-        submitted_batch_set_power_state_requests: Arc<Mutex<Vec<rms::BatchSetPowerStateRequest>>>,
-        queued_batch_set_power_state_responses:
-            Arc<Mutex<VecDeque<Result<rms::BatchSetPowerStateResponse, RackManagerError>>>>,
+        submitted_set_scale_up_fabric_state_requests:
+            Arc<Mutex<Vec<rms::SetScaleUpFabricStateRequest>>>,
+        queued_set_scale_up_fabric_state_responses:
+            Arc<Mutex<VecDeque<Result<rms::SetScaleUpFabricStateResponse, RackManagerError>>>>,
+        submitted_set_power_state_by_device_list_requests:
+            Arc<Mutex<Vec<rms::SetPowerStateByDeviceListRequest>>>,
+        queued_set_power_state_by_device_list_responses:
+            Arc<Mutex<VecDeque<Result<rms::SetPowerStateByDeviceListResponse, RackManagerError>>>>,
     }
 
     impl Default for RmsSim {
         fn default() -> Self {
             Self {
-                fail_create_nodes: Arc::new(AtomicBool::new(false)),
+                fail_add_node: Arc::new(AtomicBool::new(false)),
                 fail_inventory_get: Arc::new(AtomicBool::new(false)),
                 registered_nodes: Arc::new(Mutex::new(Vec::new())),
                 firmware_objects: Arc::new(Mutex::new(HashMap::new())),
                 submitted_firmware_requests: Arc::new(Mutex::new(Vec::new())),
                 queued_firmware_responses: Arc::new(Mutex::new(VecDeque::new())),
-                submitted_apply_stored_firmware_object_requests: Arc::new(Mutex::new(Vec::new())),
+                submitted_firmware_object_apply_requests: Arc::new(Mutex::new(Vec::new())),
                 queued_firmware_object_apply_responses: Arc::new(Mutex::new(VecDeque::new())),
-                submitted_apply_firmware_object_requests: Arc::new(Mutex::new(Vec::new())),
+                submitted_firmware_object_from_json_apply_requests: Arc::new(
+                    Mutex::new(Vec::new()),
+                ),
                 firmware_job_statuses: Arc::new(Mutex::new(HashMap::new())),
                 firmware_job_errors: Arc::new(Mutex::new(HashMap::new())),
                 submitted_apply_switch_system_image_requests: Arc::new(Mutex::new(Vec::new())),
+                submitted_apply_switch_system_image_from_json_requests: Arc::new(Mutex::new(
+                    Vec::new(),
+                )),
                 queued_apply_switch_system_image_responses: Arc::new(Mutex::new(VecDeque::new())),
                 switch_system_image_job_statuses: Arc::new(Mutex::new(HashMap::new())),
                 switch_system_image_job_errors: Arc::new(Mutex::new(HashMap::new())),
-                submitted_batch_get_node_device_info_requests: Arc::new(Mutex::new(Vec::new())),
-                queued_batch_get_node_device_info_responses: Arc::new(Mutex::new(VecDeque::new())),
-                submitted_batch_get_power_state_requests: Arc::new(Mutex::new(Vec::new())),
-                queued_batch_get_power_state_responses: Arc::new(Mutex::new(VecDeque::new())),
+                submitted_get_device_info_by_device_list_requests: Arc::new(Mutex::new(Vec::new())),
+                queued_get_device_info_by_device_list_responses: Arc::new(Mutex::new(
+                    VecDeque::new(),
+                )),
                 submitted_configure_scale_up_fabric_manager_requests: Arc::new(Mutex::new(
                     Vec::new(),
                 )),
                 queued_configure_scale_up_fabric_manager_responses: Arc::new(Mutex::new(
                     VecDeque::new(),
                 )),
-                submitted_batch_set_scale_up_fabric_state_requests: Arc::new(
-                    Mutex::new(Vec::new()),
-                ),
-                queued_batch_set_scale_up_fabric_state_responses: Arc::new(Mutex::new(
+                submitted_set_scale_up_fabric_state_requests: Arc::new(Mutex::new(Vec::new())),
+                queued_set_scale_up_fabric_state_responses: Arc::new(Mutex::new(VecDeque::new())),
+                submitted_set_power_state_by_device_list_requests: Arc::new(Mutex::new(Vec::new())),
+                queued_set_power_state_by_device_list_responses: Arc::new(Mutex::new(
                     VecDeque::new(),
                 )),
-                submitted_batch_get_scale_up_fabric_service_status_requests: Arc::new(Mutex::new(
-                    Vec::new(),
-                )),
-                queued_batch_get_scale_up_fabric_service_status_responses: Arc::new(Mutex::new(
-                    VecDeque::new(),
-                )),
-                submitted_batch_set_power_state_requests: Arc::new(Mutex::new(Vec::new())),
-                queued_batch_set_power_state_responses: Arc::new(Mutex::new(VecDeque::new())),
             }
         }
     }
@@ -168,42 +158,43 @@ pub mod test_support {
 
         fn build_mock_client(&self) -> MockRmsClient {
             MockRmsClient {
-                fail_create_nodes: self.fail_create_nodes.clone(),
+                submitted_get_power_state_by_device_list_requests: Arc::new(Mutex::new(Vec::new())),
+                queued_get_power_state_by_device_list_responses: Arc::new(Mutex::new(
+                    VecDeque::new(),
+                )),
+                fail_add_node: self.fail_add_node.clone(),
                 fail_inventory_get: self.fail_inventory_get.clone(),
                 registered_nodes: self.registered_nodes.clone(),
                 firmware_objects: self.firmware_objects.clone(),
                 submitted_firmware_requests: self.submitted_firmware_requests.clone(),
                 queued_firmware_responses: self.queued_firmware_responses.clone(),
-                submitted_apply_stored_firmware_object_requests: self
-                    .submitted_apply_stored_firmware_object_requests
+                submitted_firmware_object_apply_requests: self
+                    .submitted_firmware_object_apply_requests
                     .clone(),
                 queued_firmware_object_apply_responses: self
                     .queued_firmware_object_apply_responses
                     .clone(),
-                submitted_apply_firmware_object_requests: self
-                    .submitted_apply_firmware_object_requests
+                submitted_firmware_object_from_json_apply_requests: self
+                    .submitted_firmware_object_from_json_apply_requests
                     .clone(),
                 firmware_job_statuses: self.firmware_job_statuses.clone(),
                 firmware_job_errors: self.firmware_job_errors.clone(),
                 submitted_apply_switch_system_image_requests: self
                     .submitted_apply_switch_system_image_requests
                     .clone(),
+                submitted_apply_switch_system_image_from_json_requests: self
+                    .submitted_apply_switch_system_image_from_json_requests
+                    .clone(),
                 queued_apply_switch_system_image_responses: self
                     .queued_apply_switch_system_image_responses
                     .clone(),
                 switch_system_image_job_statuses: self.switch_system_image_job_statuses.clone(),
                 switch_system_image_job_errors: self.switch_system_image_job_errors.clone(),
-                submitted_batch_get_node_device_info_requests: self
-                    .submitted_batch_get_node_device_info_requests
+                submitted_get_device_info_by_device_list_requests: self
+                    .submitted_get_device_info_by_device_list_requests
                     .clone(),
-                queued_batch_get_node_device_info_responses: self
-                    .queued_batch_get_node_device_info_responses
-                    .clone(),
-                submitted_batch_get_power_state_requests: self
-                    .submitted_batch_get_power_state_requests
-                    .clone(),
-                queued_batch_get_power_state_responses: self
-                    .queued_batch_get_power_state_responses
+                queued_get_device_info_by_device_list_responses: self
+                    .queued_get_device_info_by_device_list_responses
                     .clone(),
                 submitted_configure_scale_up_fabric_manager_requests: self
                     .submitted_configure_scale_up_fabric_manager_requests
@@ -211,31 +202,25 @@ pub mod test_support {
                 queued_configure_scale_up_fabric_manager_responses: self
                     .queued_configure_scale_up_fabric_manager_responses
                     .clone(),
-                submitted_batch_set_scale_up_fabric_state_requests: self
-                    .submitted_batch_set_scale_up_fabric_state_requests
+                submitted_set_scale_up_fabric_state_requests: self
+                    .submitted_set_scale_up_fabric_state_requests
                     .clone(),
-                queued_batch_set_scale_up_fabric_state_responses: self
-                    .queued_batch_set_scale_up_fabric_state_responses
+                queued_set_scale_up_fabric_state_responses: self
+                    .queued_set_scale_up_fabric_state_responses
                     .clone(),
-                submitted_batch_get_scale_up_fabric_service_status_requests: self
-                    .submitted_batch_get_scale_up_fabric_service_status_requests
+                submitted_set_power_state_by_device_list_requests: self
+                    .submitted_set_power_state_by_device_list_requests
                     .clone(),
-                queued_batch_get_scale_up_fabric_service_status_responses: self
-                    .queued_batch_get_scale_up_fabric_service_status_responses
-                    .clone(),
-                submitted_batch_set_power_state_requests: self
-                    .submitted_batch_set_power_state_requests
-                    .clone(),
-                queued_batch_set_power_state_responses: self
-                    .queued_batch_set_power_state_responses
+                queued_set_power_state_by_device_list_responses: self
+                    .queued_set_power_state_by_device_list_responses
                     .clone(),
             }
         }
 
-        /// Set whether `create_nodes` should return an error for testing
+        /// Set whether `add_node` should return an error for testing
         /// if registration attempts are failing (and should retry).
-        pub fn set_fail_create_nodes(&self, fail: bool) {
-            self.fail_create_nodes.store(fail, Ordering::Relaxed);
+        pub fn set_fail_add_node(&self, fail: bool) {
+            self.fail_add_node.store(fail, Ordering::Relaxed);
         }
 
         /// Set whether `inventory_get` should return an error for
@@ -248,7 +233,7 @@ pub mod test_support {
 
         pub async fn queue_update_firmware_response(
             &self,
-            response: rms::BatchUpdateFirmwareResponse,
+            response: rms::UpdateFirmwareByDeviceListResponse,
         ) {
             self.queued_firmware_responses
                 .lock()
@@ -274,7 +259,9 @@ pub mod test_support {
                 .insert(job_id.into(), message.into());
         }
 
-        pub async fn submitted_firmware_requests(&self) -> Vec<rms::BatchUpdateFirmwareRequest> {
+        pub async fn submitted_firmware_requests(
+            &self,
+        ) -> Vec<rms::UpdateFirmwareByDeviceListRequest> {
             self.submitted_firmware_requests.lock().await.clone()
         }
 
@@ -298,16 +285,16 @@ pub mod test_support {
         pub async fn submitted_apply_firmware_object_requests(
             &self,
         ) -> Vec<rms::ApplyFirmwareObjectRequest> {
-            self.submitted_apply_firmware_object_requests
+            self.submitted_firmware_object_apply_requests
                 .lock()
                 .await
                 .clone()
         }
 
-        pub async fn submitted_apply_stored_firmware_object_requests(
+        pub async fn submitted_apply_firmware_object_from_json_requests(
             &self,
-        ) -> Vec<rms::ApplyStoredFirmwareObjectRequest> {
-            self.submitted_apply_stored_firmware_object_requests
+        ) -> Vec<rms::ApplyFirmwareObjectFromJsonRequest> {
+            self.submitted_firmware_object_from_json_apply_requests
                 .lock()
                 .await
                 .clone()
@@ -353,42 +340,29 @@ pub mod test_support {
                 .clone()
         }
 
-        pub async fn queue_batch_get_node_device_info_response(
+        pub async fn submitted_apply_switch_system_image_from_json_requests(
             &self,
-            response: Result<rms::BatchGetNodeDeviceInfoResponse, RackManagerError>,
-        ) {
-            self.queued_batch_get_node_device_info_responses
-                .lock()
-                .await
-                .push_back(response);
-        }
-
-        pub async fn submitted_batch_get_node_device_info_requests(
-            &self,
-        ) -> Vec<rms::BatchGetNodeDeviceInfoRequest> {
-            self.submitted_batch_get_node_device_info_requests
+        ) -> Vec<rms::ApplySwitchSystemImageFromJsonRequest> {
+            self.submitted_apply_switch_system_image_from_json_requests
                 .lock()
                 .await
                 .clone()
         }
 
-        /// Queue a `Result` to be returned on the next call to
-        /// `batch_get_power_state`.
-        pub async fn queue_batch_get_power_state_response(
+        pub async fn queue_get_device_info_by_device_list_response(
             &self,
-            response: Result<rms::BatchGetPowerStateResponse, RackManagerError>,
+            response: Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError>,
         ) {
-            self.queued_batch_get_power_state_responses
+            self.queued_get_device_info_by_device_list_responses
                 .lock()
                 .await
                 .push_back(response);
         }
 
-        /// Snapshot recorded `BatchGetPowerState` requests in call order.
-        pub async fn submitted_batch_get_power_state_requests(
+        pub async fn submitted_get_device_info_by_device_list_requests(
             &self,
-        ) -> Vec<rms::BatchGetPowerStateRequest> {
-            self.submitted_batch_get_power_state_requests
+        ) -> Vec<rms::GetDeviceInfoByDeviceListRequest> {
+            self.submitted_get_device_info_by_device_list_requests
                 .lock()
                 .await
                 .clone()
@@ -413,66 +387,45 @@ pub mod test_support {
                 .clone()
         }
 
-        pub async fn queue_batch_set_scale_up_fabric_state_response(
+        pub async fn queue_set_scale_up_fabric_state_response(
             &self,
-            response: Result<rms::BatchSetScaleUpFabricStateResponse, RackManagerError>,
+            response: Result<rms::SetScaleUpFabricStateResponse, RackManagerError>,
         ) {
-            self.queued_batch_set_scale_up_fabric_state_responses
+            self.queued_set_scale_up_fabric_state_responses
                 .lock()
                 .await
                 .push_back(response);
         }
 
-        pub async fn submitted_batch_set_scale_up_fabric_state_requests(
+        pub async fn submitted_set_scale_up_fabric_state_requests(
             &self,
-        ) -> Vec<rms::BatchSetScaleUpFabricStateRequest> {
-            self.submitted_batch_set_scale_up_fabric_state_requests
-                .lock()
-                .await
-                .clone()
-        }
-
-        /// Queue a response for the next `batch_get_scale_up_fabric_service_status` call.
-        pub async fn queue_batch_get_scale_up_fabric_service_status_response(
-            &self,
-            response: Result<rms::BatchGetScaleUpFabricServiceStatusResponse, RackManagerError>,
-        ) {
-            self.queued_batch_get_scale_up_fabric_service_status_responses
-                .lock()
-                .await
-                .push_back(response);
-        }
-
-        /// Snapshot recorded `BatchGetScaleUpFabricServiceStatus` requests in call order.
-        pub async fn submitted_batch_get_scale_up_fabric_service_status_requests(
-            &self,
-        ) -> Vec<rms::BatchGetScaleUpFabricServiceStatusRequest> {
-            self.submitted_batch_get_scale_up_fabric_service_status_requests
+        ) -> Vec<rms::SetScaleUpFabricStateRequest> {
+            self.submitted_set_scale_up_fabric_state_requests
                 .lock()
                 .await
                 .clone()
         }
 
         /// Queue a `Result` to be returned on the next call to
-        /// `batch_set_power_state`. Used by power-shelf maintenance
+        /// `set_power_state_by_device_list`. Used by power-shelf maintenance
         /// tests to drive both the success and failure paths of the
-        /// caller-supplied `BatchSetPowerState` RPC.
-        pub async fn queue_batch_set_power_state_response(
+        /// caller-supplied `SetPowerStateByDeviceList` RPC.
+        pub async fn queue_set_power_state_by_device_list_response(
             &self,
-            response: Result<rms::BatchSetPowerStateResponse, RackManagerError>,
+            response: Result<rms::SetPowerStateByDeviceListResponse, RackManagerError>,
         ) {
-            self.queued_batch_set_power_state_responses
+            self.queued_set_power_state_by_device_list_responses
                 .lock()
                 .await
                 .push_back(response);
         }
 
-        /// Snapshot the recorded `BatchSetPowerState` requests, in
+        /// Snapshot the recorded `SetPowerStateByDeviceList` requests, in
         /// the order they were received.
-        pub async fn submitted_batch_set_power_state_requests(
+        pub async fn submitted_set_power_state_by_device_list_requests(
             &self,
-        ) -> Vec<rms::BatchSetPowerStateRequest> {
-            self.submitted_batch_set_power_state_requests
+        ) -> Vec<rms::SetPowerStateByDeviceListRequest> {
+            self.submitted_set_power_state_by_device_list_requests
                 .lock()
                 .await
                 .clone()
@@ -481,69 +434,81 @@ pub mod test_support {
 
     #[derive(Debug, Clone)]
     pub struct MockRmsClient {
-        fail_create_nodes: Arc<AtomicBool>,
+        fail_add_node: Arc<AtomicBool>,
         fail_inventory_get: Arc<AtomicBool>,
         registered_nodes: Arc<Mutex<Vec<rms::NodeInventoryInfo>>>,
         firmware_objects: Arc<Mutex<HashMap<String, rms::FirmwareObject>>>,
-        submitted_firmware_requests: Arc<Mutex<Vec<rms::BatchUpdateFirmwareRequest>>>,
-        queued_firmware_responses: Arc<Mutex<VecDeque<rms::BatchUpdateFirmwareResponse>>>,
-        submitted_apply_stored_firmware_object_requests:
-            Arc<Mutex<Vec<rms::ApplyStoredFirmwareObjectRequest>>>,
+        submitted_firmware_requests: Arc<Mutex<Vec<rms::UpdateFirmwareByDeviceListRequest>>>,
+        queued_firmware_responses: Arc<Mutex<VecDeque<rms::UpdateFirmwareByDeviceListResponse>>>,
+        submitted_firmware_object_apply_requests: Arc<Mutex<Vec<rms::ApplyFirmwareObjectRequest>>>,
         queued_firmware_object_apply_responses:
             Arc<Mutex<VecDeque<rms::ApplyFirmwareObjectResponse>>>,
-        submitted_apply_firmware_object_requests: Arc<Mutex<Vec<rms::ApplyFirmwareObjectRequest>>>,
+        submitted_firmware_object_from_json_apply_requests:
+            Arc<Mutex<Vec<rms::ApplyFirmwareObjectFromJsonRequest>>>,
         firmware_job_statuses: Arc<Mutex<HashMap<String, rms::GetFirmwareJobStatusResponse>>>,
         firmware_job_errors: Arc<Mutex<HashMap<String, String>>>,
         submitted_apply_switch_system_image_requests:
             Arc<Mutex<Vec<rms::ApplySwitchSystemImageRequest>>>,
+        submitted_apply_switch_system_image_from_json_requests:
+            Arc<Mutex<Vec<rms::ApplySwitchSystemImageFromJsonRequest>>>,
         queued_apply_switch_system_image_responses:
             Arc<Mutex<VecDeque<rms::ApplySwitchSystemImageResponse>>>,
         switch_system_image_job_statuses:
             Arc<Mutex<HashMap<String, rms::GetSwitchSystemImageJobStatusResponse>>>,
         switch_system_image_job_errors: Arc<Mutex<HashMap<String, String>>>,
-        submitted_batch_get_node_device_info_requests:
-            Arc<Mutex<Vec<rms::BatchGetNodeDeviceInfoRequest>>>,
-        queued_batch_get_node_device_info_responses:
-            Arc<Mutex<VecDeque<Result<rms::BatchGetNodeDeviceInfoResponse, RackManagerError>>>>,
-        submitted_batch_get_power_state_requests: Arc<Mutex<Vec<rms::BatchGetPowerStateRequest>>>,
-        queued_batch_get_power_state_responses:
-            Arc<Mutex<VecDeque<Result<rms::BatchGetPowerStateResponse, RackManagerError>>>>,
+        submitted_get_power_state_by_device_list_requests:
+            Arc<Mutex<Vec<rms::GetPowerStateByDeviceListRequest>>>,
+        queued_get_power_state_by_device_list_responses:
+            Arc<Mutex<VecDeque<Result<rms::GetPowerStateByDeviceListResponse, RackManagerError>>>>,
+        submitted_get_device_info_by_device_list_requests:
+            Arc<Mutex<Vec<rms::GetDeviceInfoByDeviceListRequest>>>,
+        queued_get_device_info_by_device_list_responses:
+            Arc<Mutex<VecDeque<Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError>>>>,
         submitted_configure_scale_up_fabric_manager_requests:
             Arc<Mutex<Vec<rms::ConfigureScaleUpFabricManagerRequest>>>,
         queued_configure_scale_up_fabric_manager_responses: Arc<
             Mutex<VecDeque<Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError>>>,
         >,
-        submitted_batch_set_scale_up_fabric_state_requests:
-            Arc<Mutex<Vec<rms::BatchSetScaleUpFabricStateRequest>>>,
-        queued_batch_set_scale_up_fabric_state_responses:
-            Arc<Mutex<VecDeque<Result<rms::BatchSetScaleUpFabricStateResponse, RackManagerError>>>>,
-        submitted_batch_get_scale_up_fabric_service_status_requests:
-            Arc<Mutex<Vec<rms::BatchGetScaleUpFabricServiceStatusRequest>>>,
-        queued_batch_get_scale_up_fabric_service_status_responses: Arc<
-            Mutex<
-                VecDeque<Result<rms::BatchGetScaleUpFabricServiceStatusResponse, RackManagerError>>,
-            >,
-        >,
-        submitted_batch_set_power_state_requests: Arc<Mutex<Vec<rms::BatchSetPowerStateRequest>>>,
-        queued_batch_set_power_state_responses:
-            Arc<Mutex<VecDeque<Result<rms::BatchSetPowerStateResponse, RackManagerError>>>>,
+        submitted_set_scale_up_fabric_state_requests:
+            Arc<Mutex<Vec<rms::SetScaleUpFabricStateRequest>>>,
+        queued_set_scale_up_fabric_state_responses:
+            Arc<Mutex<VecDeque<Result<rms::SetScaleUpFabricStateResponse, RackManagerError>>>>,
+        submitted_set_power_state_by_device_list_requests:
+            Arc<Mutex<Vec<rms::SetPowerStateByDeviceListRequest>>>,
+        queued_set_power_state_by_device_list_responses:
+            Arc<Mutex<VecDeque<Result<rms::SetPowerStateByDeviceListResponse, RackManagerError>>>>,
     }
 
     #[async_trait::async_trait]
     impl RmsApi for MockRmsClient {
-        async fn batch_get_node_device_info(
+        async fn get_power_state_by_device_list(
             &self,
-            cmd: rms::BatchGetNodeDeviceInfoRequest,
-        ) -> Result<rms::BatchGetNodeDeviceInfoResponse, RackManagerError> {
-            self.submitted_batch_get_node_device_info_requests
+            cmd: rms::GetPowerStateByDeviceListRequest,
+        ) -> Result<rms::GetPowerStateByDeviceListResponse, RackManagerError> {
+            self.submitted_get_power_state_by_device_list_requests
                 .lock()
                 .await
                 .push(cmd);
-            self.queued_batch_get_node_device_info_responses
+            self.queued_get_power_state_by_device_list_responses
                 .lock()
                 .await
                 .pop_front()
-                .unwrap_or(Ok(rms::BatchGetNodeDeviceInfoResponse::default()))
+                .unwrap_or(Ok(rms::GetPowerStateByDeviceListResponse::default()))
+        }
+
+        async fn get_device_info_by_device_list(
+            &self,
+            cmd: rms::GetDeviceInfoByDeviceListRequest,
+        ) -> Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError> {
+            self.submitted_get_device_info_by_device_list_requests
+                .lock()
+                .await
+                .push(cmd);
+            self.queued_get_device_info_by_device_list_responses
+                .lock()
+                .await
+                .pop_front()
+                .unwrap_or(Ok(rms::GetDeviceInfoByDeviceListResponse::default()))
         }
         async fn get_node_device_info(
             &self,
@@ -551,16 +516,16 @@ pub mod test_support {
         ) -> Result<rms::GetNodeDeviceInfoResponse, RackManagerError> {
             Ok(rms::GetNodeDeviceInfoResponse::default())
         }
-        async fn list_node_device_info_by_node_type(
+        async fn get_device_info_by_node_type(
             &self,
-            _cmd: rms::ListNodeDeviceInfoByNodeTypeRequest,
-        ) -> Result<rms::ListNodeDeviceInfoByNodeTypeResponse, RackManagerError> {
-            Ok(rms::ListNodeDeviceInfoByNodeTypeResponse::default())
+            _cmd: rms::GetDeviceInfoByNodeTypeRequest,
+        ) -> Result<rms::GetDeviceInfoByNodeTypeResponse, RackManagerError> {
+            Ok(rms::GetDeviceInfoByNodeTypeResponse::default())
         }
-        async fn batch_update_firmware(
+        async fn update_firmware_by_device_list(
             &self,
-            cmd: rms::BatchUpdateFirmwareRequest,
-        ) -> Result<rms::BatchUpdateFirmwareResponse, RackManagerError> {
+            cmd: rms::UpdateFirmwareByDeviceListRequest,
+        ) -> Result<rms::UpdateFirmwareByDeviceListResponse, RackManagerError> {
             self.submitted_firmware_requests.lock().await.push(cmd);
             Ok(self
                 .queued_firmware_responses
@@ -581,19 +546,19 @@ pub mod test_support {
         ) -> Result<rms::SetPowerStateResponse, RackManagerError> {
             Ok(rms::SetPowerStateResponse::default())
         }
-        async fn batch_set_power_state(
+        async fn set_power_state_by_device_list(
             &self,
-            cmd: rms::BatchSetPowerStateRequest,
-        ) -> Result<rms::BatchSetPowerStateResponse, RackManagerError> {
-            self.submitted_batch_set_power_state_requests
+            cmd: rms::SetPowerStateByDeviceListRequest,
+        ) -> Result<rms::SetPowerStateByDeviceListResponse, RackManagerError> {
+            self.submitted_set_power_state_by_device_list_requests
                 .lock()
                 .await
                 .push(cmd);
-            self.queued_batch_set_power_state_responses
+            self.queued_set_power_state_by_device_list_responses
                 .lock()
                 .await
                 .pop_front()
-                .unwrap_or(Ok(rms::BatchSetPowerStateResponse::default()))
+                .unwrap_or(Ok(rms::SetPowerStateByDeviceListResponse::default()))
         }
         async fn get_power_state(
             &self,
@@ -601,63 +566,48 @@ pub mod test_support {
         ) -> Result<rms::GetPowerStateResponse, RackManagerError> {
             Ok(rms::GetPowerStateResponse::default())
         }
-
-        async fn batch_get_power_state(
-            &self,
-            cmd: rms::BatchGetPowerStateRequest,
-        ) -> Result<rms::BatchGetPowerStateResponse, RackManagerError> {
-            self.submitted_batch_get_power_state_requests
-                .lock()
-                .await
-                .push(cmd);
-            self.queued_batch_get_power_state_responses
-                .lock()
-                .await
-                .pop_front()
-                .unwrap_or(Ok(rms::BatchGetPowerStateResponse::default()))
-        }
-
         async fn sequence_rack_power(
             &self,
             _cmd: rms::SequenceRackPowerRequest,
         ) -> Result<rms::SequenceRackPowerResponse, RackManagerError> {
             Ok(rms::SequenceRackPowerResponse::default())
         }
-        async fn list_node_inventory(
+        async fn get_all_inventory(
             &self,
-        ) -> Result<rms::ListNodeInventoryResponse, RackManagerError> {
+            _cmd: rms::GetAllInventoryRequest,
+        ) -> Result<rms::GetAllInventoryResponse, RackManagerError> {
             if self.fail_inventory_get.load(Ordering::Relaxed) {
                 return Err(RackManagerError::ApiInvocationError(
                     tonic::Status::unavailable("mock RMS inventory_get failure"),
                 ));
             }
             let nodes = self.registered_nodes.lock().await.clone();
-            Ok(rms::ListNodeInventoryResponse { nodes })
+            Ok(rms::GetAllInventoryResponse {
+                nodes,
+                ..Default::default()
+            })
         }
-        async fn create_nodes(
+        async fn add_node(
             &self,
-            cmd: rms::CreateNodesRequest,
-        ) -> Result<rms::CreateNodesResponse, RackManagerError> {
-            if self.fail_create_nodes.load(Ordering::Relaxed) {
+            cmd: rms::AddNodeRequest,
+        ) -> Result<rms::AddNodeResponse, RackManagerError> {
+            if self.fail_add_node.load(Ordering::Relaxed) {
                 return Err(RackManagerError::ApiInvocationError(
-                    tonic::Status::unavailable("mock RMS create_nodes failure"),
+                    tonic::Status::unavailable("mock RMS add_node failure"),
                 ));
             }
             // Track registered nodes so inventory_get can find them,
             // just like a real RMS would.
             let mut registered = self.registered_nodes.lock().await;
-            if let Some(nodes) = cmd.nodes {
-                for node in nodes.nodes {
-                    registered.push(librms::protos::rack_manager::NodeInventoryInfo {
-                        node_id: node.node_id.clone(),
-                        rack_id: node.rack_id.clone(),
-                        r#type: node.r#type.unwrap_or(0),
-                        ..Default::default()
-                    });
-                }
+            for node in cmd.node_info {
+                registered.push(librms::protos::rack_manager::NodeInventoryInfo {
+                    node_id: node.node_id.clone(),
+                    rack_id: node.rack_id.clone(),
+                    r#type: node.r#type.unwrap_or(0),
+                    ..Default::default()
+                });
             }
-
-            Ok(rms::CreateNodesResponse::default())
+            Ok(rms::AddNodeResponse::default())
         }
         async fn update_node(
             &self,
@@ -665,11 +615,11 @@ pub mod test_support {
         ) -> Result<rms::UpdateNodeResponse, RackManagerError> {
             Ok(rms::UpdateNodeResponse::default())
         }
-        async fn delete_node(
+        async fn remove_node(
             &self,
-            _cmd: rms::DeleteNodeRequest,
-        ) -> Result<rms::DeleteNodeResponse, RackManagerError> {
-            Ok(rms::DeleteNodeResponse::default())
+            _cmd: rms::RemoveNodeRequest,
+        ) -> Result<rms::RemoveNodeResponse, RackManagerError> {
+            Ok(rms::RemoveNodeResponse::default())
         }
         async fn get_rack_power_on_sequence(
             &self,
@@ -683,7 +633,10 @@ pub mod test_support {
         ) -> Result<rms::SetRackPowerOnSequenceResponse, RackManagerError> {
             Ok(rms::SetRackPowerOnSequenceResponse::default())
         }
-        async fn list_racks(&self) -> Result<rms::ListRacksResponse, RackManagerError> {
+        async fn list_racks(
+            &self,
+            _cmd: rms::ListRacksRequest,
+        ) -> Result<rms::ListRacksResponse, RackManagerError> {
             Ok(rms::ListRacksResponse::default())
         }
         async fn get_node_firmware_inventory(
@@ -701,26 +654,23 @@ pub mod test_support {
         async fn add_firmware_object(
             &self,
             cmd: rms::AddFirmwareObjectRequest,
-        ) -> Result<rms::AddFirmwareObjectResponse, RackManagerError> {
-            #[derive(serde::Deserialize)]
-            struct FirmwareObjectConfig {
-                #[serde(rename = "Id")]
-                id: String,
-            }
-
-            let config =
-                serde_json::from_str::<FirmwareObjectConfig>(&cmd.config_json).map_err(|e| {
+        ) -> Result<rms::FirmwareObject, RackManagerError> {
+            let value =
+                serde_json::from_str::<serde_json::Value>(&cmd.config_json).map_err(|e| {
                     RackManagerError::ApiInvocationError(tonic::Status::invalid_argument(format!(
                         "invalid config_json: {e}"
                     )))
                 })?;
-            if config.id.is_empty() {
-                return Err(RackManagerError::ApiInvocationError(
-                    tonic::Status::invalid_argument("config_json must contain non-empty Id"),
-                ));
-            }
-            let id = config.id;
-
+            let id = value
+                .get("Id")
+                .and_then(serde_json::Value::as_str)
+                .filter(|id| !id.is_empty())
+                .map(str::to_string)
+                .ok_or_else(|| {
+                    RackManagerError::ApiInvocationError(tonic::Status::invalid_argument(
+                        "config_json must contain non-empty Id",
+                    ))
+                })?;
             let mut objects = self.firmware_objects.lock().await;
             let is_default = cmd.set_default
                 || !objects.values().any(|existing| {
@@ -742,16 +692,13 @@ pub mod test_support {
                 }
             }
             objects.insert(id, object.clone());
-            Ok(rms::AddFirmwareObjectResponse {
-                object: Some(object),
-            })
+            Ok(object)
         }
         async fn get_firmware_object(
             &self,
             cmd: rms::GetFirmwareObjectRequest,
-        ) -> Result<rms::GetFirmwareObjectResponse, RackManagerError> {
-            let object = self
-                .firmware_objects
+        ) -> Result<rms::FirmwareObject, RackManagerError> {
+            self.firmware_objects
                 .lock()
                 .await
                 .get(&cmd.id)
@@ -761,11 +708,7 @@ pub mod test_support {
                         "firmware object {} not found",
                         cmd.id
                     )))
-                })?;
-
-            Ok(rms::GetFirmwareObjectResponse {
-                object: Some(object),
-            })
+                })
         }
         async fn list_firmware_objects(
             &self,
@@ -787,19 +730,17 @@ pub mod test_support {
         async fn delete_firmware_object(
             &self,
             cmd: rms::DeleteFirmwareObjectRequest,
-        ) -> Result<rms::DeleteFirmwareObjectResponse, RackManagerError> {
+        ) -> Result<rms::OperationResponse, RackManagerError> {
             self.firmware_objects.lock().await.remove(&cmd.id);
-            Ok(rms::DeleteFirmwareObjectResponse {
-                response: Some(rms::OperationResponse {
-                    status: rms::ReturnCode::Success as i32,
-                    ..Default::default()
-                }),
+            Ok(rms::OperationResponse {
+                status: rms::ReturnCode::Success as i32,
+                ..Default::default()
             })
         }
         async fn set_default_firmware_object(
             &self,
             cmd: rms::SetDefaultFirmwareObjectRequest,
-        ) -> Result<rms::SetDefaultFirmwareObjectResponse, RackManagerError> {
+        ) -> Result<rms::FirmwareObject, RackManagerError> {
             let mut objects = self.firmware_objects.lock().await;
             let hardware_type = objects
                 .get(&cmd.object_id)
@@ -815,36 +756,16 @@ pub mod test_support {
                     object.is_default = object.id == cmd.object_id;
                 }
             }
-            let Some(object) = objects.get(&cmd.object_id).cloned() else {
-                return Err(RackManagerError::ApiInvocationError(
-                    tonic::Status::not_found(format!(
-                        "firmware object {} not found",
-                        cmd.object_id
-                    )),
-                ));
-            };
-
-            Ok(rms::SetDefaultFirmwareObjectResponse {
-                object: Some(object),
-            })
+            Ok(objects
+                .get(&cmd.object_id)
+                .cloned()
+                .expect("firmware object existence validated above"))
         }
-
-        async fn apply_stored_firmware_object(
-            &self,
-            cmd: rms::ApplyStoredFirmwareObjectRequest,
-        ) -> Result<rms::ApplyStoredFirmwareObjectResponse, RackManagerError> {
-            self.submitted_apply_stored_firmware_object_requests
-                .lock()
-                .await
-                .push(cmd);
-            Ok(rms::ApplyStoredFirmwareObjectResponse::default())
-        }
-
         async fn apply_firmware_object(
             &self,
             cmd: rms::ApplyFirmwareObjectRequest,
         ) -> Result<rms::ApplyFirmwareObjectResponse, RackManagerError> {
-            self.submitted_apply_firmware_object_requests
+            self.submitted_firmware_object_apply_requests
                 .lock()
                 .await
                 .push(cmd);
@@ -855,20 +776,36 @@ pub mod test_support {
                 .pop_front()
                 .unwrap_or_default())
         }
-        async fn update_switch_system_image(
+        async fn apply_firmware_object_from_json(
             &self,
-            _cmd: rms::UpdateSwitchSystemImageRequest,
-        ) -> Result<rms::UpdateSwitchSystemImageResponse, RackManagerError> {
-            Ok(rms::UpdateSwitchSystemImageResponse::default())
+            cmd: rms::ApplyFirmwareObjectFromJsonRequest,
+        ) -> Result<rms::ApplyFirmwareObjectResponse, RackManagerError> {
+            self.submitted_firmware_object_from_json_apply_requests
+                .lock()
+                .await
+                .push(cmd);
+            Ok(self
+                .queued_firmware_object_apply_responses
+                .lock()
+                .await
+                .pop_front()
+                .unwrap_or_default())
         }
-
-        async fn apply_stored_switch_system_image(
+        async fn apply_switch_system_image_from_json(
             &self,
-            _cmd: rms::ApplyStoredSwitchSystemImageRequest,
-        ) -> Result<rms::ApplyStoredSwitchSystemImageResponse, RackManagerError> {
-            Ok(rms::ApplyStoredSwitchSystemImageResponse::default())
+            cmd: rms::ApplySwitchSystemImageFromJsonRequest,
+        ) -> Result<rms::ApplySwitchSystemImageResponse, RackManagerError> {
+            self.submitted_apply_switch_system_image_from_json_requests
+                .lock()
+                .await
+                .push(cmd);
+            Ok(self
+                .queued_apply_switch_system_image_responses
+                .lock()
+                .await
+                .pop_front()
+                .unwrap_or_default())
         }
-
         async fn apply_switch_system_image(
             &self,
             cmd: rms::ApplySwitchSystemImageRequest,
@@ -890,23 +827,23 @@ pub mod test_support {
         ) -> Result<rms::GetFirmwareObjectHistoryResponse, RackManagerError> {
             Ok(rms::GetFirmwareObjectHistoryResponse::default())
         }
-        async fn list_switch_firmware(
+        async fn list_firmware_on_switch(
             &self,
-            _cmd: rms::ListSwitchFirmwareRequest,
-        ) -> Result<rms::ListSwitchFirmwareResponse, RackManagerError> {
-            Ok(rms::ListSwitchFirmwareResponse::default())
+            _cmd: rms::ListFirmwareOnSwitchCommand,
+        ) -> Result<rms::ListFirmwareOnSwitchResponse, RackManagerError> {
+            Ok(rms::ListFirmwareOnSwitchResponse::default())
         }
-        async fn push_switch_firmware(
+        async fn push_firmware_to_switch(
             &self,
-            _cmd: rms::PushSwitchFirmwareRequest,
-        ) -> Result<rms::PushSwitchFirmwareResponse, RackManagerError> {
-            Ok(rms::PushSwitchFirmwareResponse::default())
+            _cmd: rms::PushFirmwareToSwitchCommand,
+        ) -> Result<rms::PushFirmwareToSwitchResponse, RackManagerError> {
+            Ok(rms::PushFirmwareToSwitchResponse::default())
         }
-        async fn upgrade_switch_firmware(
+        async fn upgrade_firmware_on_switch(
             &self,
-            _cmd: rms::UpgradeSwitchFirmwareRequest,
-        ) -> Result<rms::UpgradeSwitchFirmwareResponse, RackManagerError> {
-            Ok(rms::UpgradeSwitchFirmwareResponse::default())
+            _cmd: rms::UpgradeFirmwareOnSwitchCommand,
+        ) -> Result<rms::UpgradeFirmwareOnSwitchResponse, RackManagerError> {
+            Ok(rms::UpgradeFirmwareOnSwitchResponse::default())
         }
         async fn configure_scale_up_fabric_manager(
             &self,
@@ -922,43 +859,19 @@ pub mod test_support {
                 .pop_front()
                 .unwrap_or(Ok(rms::ConfigureScaleUpFabricManagerResponse::default()))
         }
-        async fn batch_set_scale_up_fabric_state(
+        async fn set_scale_up_fabric_state(
             &self,
-            cmd: rms::BatchSetScaleUpFabricStateRequest,
-        ) -> Result<rms::BatchSetScaleUpFabricStateResponse, RackManagerError> {
-            self.submitted_batch_set_scale_up_fabric_state_requests
+            cmd: rms::SetScaleUpFabricStateRequest,
+        ) -> Result<rms::SetScaleUpFabricStateResponse, RackManagerError> {
+            self.submitted_set_scale_up_fabric_state_requests
                 .lock()
                 .await
                 .push(cmd);
-            self.queued_batch_set_scale_up_fabric_state_responses
+            self.queued_set_scale_up_fabric_state_responses
                 .lock()
                 .await
                 .pop_front()
-                .unwrap_or(Ok(rms::BatchSetScaleUpFabricStateResponse::default()))
-        }
-        async fn batch_get_scale_up_fabric_service_status(
-            &self,
-            cmd: rms::BatchGetScaleUpFabricServiceStatusRequest,
-        ) -> Result<rms::BatchGetScaleUpFabricServiceStatusResponse, RackManagerError> {
-            self.submitted_batch_get_scale_up_fabric_service_status_requests
-                .lock()
-                .await
-                .push(cmd);
-
-            self.queued_batch_get_scale_up_fabric_service_status_responses
-                .lock()
-                .await
-                .pop_front()
-                .unwrap_or(Ok(
-                    rms::BatchGetScaleUpFabricServiceStatusResponse::default(),
-                ))
-        }
-
-        async fn get_scale_up_fabric_state(
-            &self,
-            _cmd: rms::GetScaleUpFabricStateRequest,
-        ) -> Result<rms::GetScaleUpFabricStateResponse, RackManagerError> {
-            Ok(rms::GetScaleUpFabricStateResponse::default())
+                .unwrap_or(Ok(rms::SetScaleUpFabricStateResponse::default()))
         }
         async fn fetch_switch_system_image(
             &self,
@@ -978,42 +891,32 @@ pub mod test_support {
         ) -> Result<rms::ListSwitchSystemImagesResponse, RackManagerError> {
             Ok(rms::ListSwitchSystemImagesResponse::default())
         }
-        async fn set_scale_up_fabric_telemetry_interface_state(
+        async fn enable_scale_up_fabric_telemetry_interface(
             &self,
-            _cmd: rms::SetScaleUpFabricTelemetryInterfaceStateRequest,
-        ) -> Result<rms::SetScaleUpFabricTelemetryInterfaceStateResponse, RackManagerError>
-        {
-            Ok(rms::SetScaleUpFabricTelemetryInterfaceStateResponse::default())
+            _cmd: rms::EnableScaleUpFabricTelemetryInterfaceRequest,
+        ) -> Result<rms::EnableScaleUpFabricTelemetryInterfaceResponse, RackManagerError> {
+            Ok(rms::EnableScaleUpFabricTelemetryInterfaceResponse::default())
         }
-        async fn get_switch_system_image_job_status(
+        async fn version(&self) -> Result<(), RackManagerError> {
+            Ok(())
+        }
+        async fn poll_job_status(
             &self,
-            cmd: rms::GetSwitchSystemImageJobStatusRequest,
-        ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError> {
-            self.switch_system_image_job_status(cmd)
-                .await
-                .map_err(RackManagerError::ApiInvocationError)
+            _cmd: rms::PollJobStatusCommand,
+        ) -> Result<rms::PollJobStatusResponse, RackManagerError> {
+            Ok(rms::PollJobStatusResponse::default())
         }
-
-        async fn get_version(&self) -> Result<rms::GetVersionResponse, RackManagerError> {
-            Ok(rms::GetVersionResponse::default())
-        }
-        async fn poll_switch_firmware_job_status(
+        async fn update_node_firmware_async(
             &self,
-            _cmd: rms::PollSwitchFirmwareJobStatusRequest,
-        ) -> Result<rms::PollSwitchFirmwareJobStatusResponse, RackManagerError> {
-            Ok(rms::PollSwitchFirmwareJobStatusResponse::default())
+            _cmd: rms::UpdateNodeFirmwareRequest,
+        ) -> Result<rms::UpdateNodeFirmwareResponse, RackManagerError> {
+            Ok(rms::UpdateNodeFirmwareResponse::default())
         }
-        async fn update_firmware(
+        async fn update_firmware_by_node_type_async(
             &self,
-            _cmd: rms::UpdateFirmwareRequest,
-        ) -> Result<rms::UpdateFirmwareResponse, RackManagerError> {
-            Ok(rms::UpdateFirmwareResponse::default())
-        }
-        async fn batch_update_firmware_by_node_type(
-            &self,
-            _cmd: rms::BatchUpdateFirmwareByNodeTypeRequest,
-        ) -> Result<rms::BatchUpdateFirmwareByNodeTypeResponse, RackManagerError> {
-            Ok(rms::BatchUpdateFirmwareByNodeTypeResponse::default())
+            _cmd: rms::UpdateFirmwareByNodeTypeRequest,
+        ) -> Result<rms::UpdateFirmwareByNodeTypeAsyncResponse, RackManagerError> {
+            Ok(rms::UpdateFirmwareByNodeTypeAsyncResponse::default())
         }
         async fn get_firmware_job_status(
             &self,
@@ -1048,11 +951,11 @@ pub mod test_support {
 
     #[async_trait::async_trait]
     impl SwitchSystemImageRmsClient for MockRmsClient {
-        async fn apply_switch_system_image(
+        async fn apply_switch_system_image_from_json(
             &self,
-            cmd: rms::ApplySwitchSystemImageRequest,
+            cmd: rms::ApplySwitchSystemImageFromJsonRequest,
         ) -> Result<rms::ApplySwitchSystemImageResponse, tonic::Status> {
-            self.submitted_apply_switch_system_image_requests
+            self.submitted_apply_switch_system_image_from_json_requests
                 .lock()
                 .await
                 .push(cmd);
@@ -1065,15 +968,6 @@ pub mod test_support {
         }
 
         async fn get_switch_system_image_job_status(
-            &self,
-            cmd: rms::GetSwitchSystemImageJobStatusRequest,
-        ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, tonic::Status> {
-            self.switch_system_image_job_status(cmd).await
-        }
-    }
-
-    impl MockRmsClient {
-        async fn switch_system_image_job_status(
             &self,
             cmd: rms::GetSwitchSystemImageJobStatusRequest,
         ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, tonic::Status> {

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -196,22 +196,16 @@ pub(crate) async fn ensure_rack_exists(
 /// Returns `(None, None)` on any failure, logging a warning with `entity_label`.
 pub async fn fetch_slot_and_tray(
     rms_client: &dyn librms::RmsApi,
-    request: librms::protos::rack_manager::BatchGetNodeDeviceInfoRequest,
+    request: librms::protos::rack_manager::GetDeviceInfoByDeviceListRequest,
 ) -> (Option<i32>, Option<i32>) {
-    match rms_client.batch_get_node_device_info(request).await {
+    match rms_client.get_device_info_by_device_list(request).await {
         Ok(info) => {
-            let Some(node_device_details) = info.node_device_details.first() else {
-                return (None, None);
-            };
-
-            let slot_number = node_device_details
-                .slot_number
-                .and_then(|value| i32::try_from(value).ok());
-            let tray_index = node_device_details
-                .tray_index
-                .and_then(|value| i32::try_from(value).ok());
-
-            (slot_number, tray_index)
+            if !info.node_device_info.is_empty() {
+                let node_device_info = info.node_device_info.first().unwrap();
+                (node_device_info.slot_number, node_device_info.tray_index)
+            } else {
+                (None, None)
+            }
         }
         Err(e) => {
             tracing::warn!(

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -246,13 +246,13 @@ impl MachineCreator {
         if let (Some(rack_id), Some(rms_client)) =
             (&expected_machine.data.rack_id, &self.rms_client)
         {
-            let request = librms::protos::rack_manager::BatchGetNodeDeviceInfoRequest {
+            let request = librms::protos::rack_manager::GetDeviceInfoByDeviceListRequest {
                 nodes: Some(librms::protos::rack_manager::NodeSet {
-                    nodes: vec![librms::protos::rack_manager::NodeInfo {
+                    devices: vec![librms::protos::rack_manager::NewNodeInfo {
                         node_id: host_machine_id.to_string(),
                         rack_id: rack_id.to_string(),
                         r#type: Some(librms::protos::rack_manager::NodeType::Compute as i32),
-                        bmc_endpoint: Some(librms::protos::rack_manager::Endpoint {
+                        bmc_endpoint: Some(librms::protos::rack_manager::BmcEndpoint {
                             interface: Some(librms::protos::rack_manager::NetworkInterface {
                                 ip_address: explored_host.host_bmc_ip.to_string(),
                                 mac_address: expected_machine.bmc_mac_address.to_string(),
@@ -270,11 +270,11 @@ impl MachineCreator {
                                     ),
                                 }
                             }),
-                            dangerously_accept_invalid_certs: true,
                         }),
                         ..Default::default()
                     }],
                 }),
+                ..Default::default()
             };
             let (slot_number, tray_index) =
                 crate::fetch_slot_and_tray(rms_client.as_ref(), request).await;

--- a/crates/switch-controller/src/initializing.rs
+++ b/crates/switch-controller/src/initializing.rs
@@ -167,25 +167,20 @@ async fn handle_wait_for_os_machine_interface(
     );
     if associated_count >= 1 {
         if let (Some(rack_id), Some(rms_client)) = (&rack_id, &ctx.services.rms_client) {
-            // RMS has always used one host interface for this lookup even though
-            // the previous proto exposed a list, so pick a single interface here.
-            let host_interface = nvos_interfaces
-                .iter()
-                .find(|(_, ip)| ip.is_some())
-                .or_else(|| nvos_interfaces.first())
-                .map(|(mac, ip)| librms::protos::rack_manager::NetworkInterface {
-                    ip_address: ip.as_ref().map(ToString::to_string).unwrap_or_default(),
-                    mac_address: mac.to_string(),
-                });
-
-            let request = librms::protos::rack_manager::BatchGetNodeDeviceInfoRequest {
+            let request = librms::protos::rack_manager::GetDeviceInfoByDeviceListRequest {
                 nodes: Some(librms::protos::rack_manager::NodeSet {
-                    nodes: vec![librms::protos::rack_manager::NodeInfo {
+                    devices: vec![librms::protos::rack_manager::NewNodeInfo {
                         node_id: switch_id.to_string(),
                         rack_id: rack_id.to_string(),
                         r#type: Some(librms::protos::rack_manager::NodeType::Switch as i32),
-                        host_endpoint: Some(librms::protos::rack_manager::Endpoint {
-                            interface: host_interface,
+                        host_endpoint: Some(librms::protos::rack_manager::HostEndpoint {
+                            interfaces: nvos_interfaces
+                                .iter()
+                                .map(|(mac, ip)| librms::protos::rack_manager::NetworkInterface {
+                                    ip_address: ip.map(|a| a.to_string()).unwrap_or_default(),
+                                    mac_address: mac.to_string(),
+                                })
+                                .collect(),
                             port: 0,
                             credentials: nvos_credentials.map(|(username, password)| {
                                 librms::protos::rack_manager::Credentials {
@@ -199,11 +194,11 @@ async fn handle_wait_for_os_machine_interface(
                                     ),
                                 }
                             }),
-                            dangerously_accept_invalid_certs: false,
                         }),
                         ..Default::default()
                     }],
                 }),
+                ..Default::default()
             };
             let (slot_number, tray_index) =
                 carbide_site_explorer::fetch_slot_and_tray(rms_client.as_ref(), request).await;


### PR DESCRIPTION
This reverts commit d2dc5f768f19f8af39e88b015e7e3ea90e8dcbc4.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [x] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

