### PR TITLE
chore(rest-api): Apply the new FromProto/ToProto modeling to SKU

### DIFF
--- a/rest-api/db/pkg/db/model/sku.go
+++ b/rest-api/db/pkg/db/model/sku.go
@@ -6,6 +6,7 @@ package model
 import (
 	"context"
 	"database/sql"
+	"reflect"
 	"time"
 
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
@@ -43,6 +44,23 @@ type SkuComponents struct {
 	*cwssaws.SkuComponents
 }
 
+// Equal reports whether two `*SkuComponents` wrappers carry the same
+// underlying proto, treating a nil wrapper as carrying a nil proto.
+// Avoids dereferencing a nil wrapper to read `.SkuComponents`. Declared
+// as a method (per the Go convention used by `time.Time.Equal`,
+// `cmp.Equal`, etc.) so callers can write `s.Equal(other)` instead of
+// reaching for a free helper.
+func (s *SkuComponents) Equal(other *SkuComponents) bool {
+	var sp, op *cwssaws.SkuComponents
+	if s != nil {
+		sp = s.SkuComponents
+	}
+	if other != nil {
+		op = other.SkuComponents
+	}
+	return reflect.DeepEqual(sp, op)
+}
+
 func (s *SkuComponents) UnmarshalJSON(b []byte) error {
 	if s.SkuComponents == nil {
 		s.SkuComponents = &cwssaws.SkuComponents{}
@@ -67,6 +85,75 @@ type SKU struct {
 	AssociatedMachineIds []string       `bun:"associated_machines,type:text[],default:'{}'"`
 	Created              time.Time      `bun:"created,nullzero,notnull,default:current_timestamp"`
 	Updated              time.Time      `bun:"updated,nullzero,notnull,default:current_timestamp"`
+}
+
+// ToProto converts this SKU into its workflow proto representation.
+// Used as the canonical entity-to-proto conversion; SKU has no API
+// Create/Update request shapes (the Site is the source of truth for
+// SKU data, so the cloud API exposes read-only handlers), so this
+// receiver is the only `ToProto` the model carries.
+//
+// Fields that exist on the proto but not on the DB row
+// (`Description`, the proto-level `Created` timestamp, `SchemaVersion`)
+// are intentionally omitted — the DB does not carry the data to fill
+// them, and no current caller depends on them. `SiteID` is on the
+// model but not on the proto, so it is also dropped on the wire (the
+// receiving side reconstructs it from context, mirroring `FromProto`).
+func (sk *SKU) ToProto() *cwssaws.Sku {
+	proto := &cwssaws.Sku{
+		Id:         sk.ID,
+		DeviceType: sk.DeviceType,
+	}
+	if sk.Components != nil {
+		proto.Components = sk.Components.SkuComponents
+	}
+	if sk.AssociatedMachineIds != nil {
+		machineIDs := make([]*cwssaws.MachineId, 0, len(sk.AssociatedMachineIds))
+		for _, id := range sk.AssociatedMachineIds {
+			machineIDs = append(machineIDs, &cwssaws.MachineId{Id: id})
+		}
+		proto.AssociatedMachineIds = machineIDs
+	}
+	return proto
+}
+
+// FromProto populates this SKU from a workflow proto reported by a Site.
+// A nil proto is a no-op. This is the inverse of `ToProto`; `siteID`
+// is supplied by the caller because it isn't carried on the proto.
+//
+// Field-level contract:
+//   - `sk.ID` is overwritten with `proto.Id` (callers pre-validate
+//     non-empty IDs at the activity layer).
+//   - `Components` mirrors the proto: stays nil when `proto.Components`
+//     is nil, otherwise wraps it, so the activity layer can distinguish
+//     "not provided" from "explicitly set".
+//   - `AssociatedMachineIds` is built from `proto.AssociatedMachineIds`,
+//     skipping entries with empty IDs. Stays nil when the proto's list
+//     is nil so the activity layer can distinguish "not provided" from
+//     "explicitly empty".
+func (sk *SKU) FromProto(proto *cwssaws.Sku, siteID uuid.UUID) {
+	if proto == nil {
+		return
+	}
+	sk.ID = proto.Id
+	sk.SiteID = siteID
+	sk.DeviceType = proto.DeviceType
+	if proto.Components != nil {
+		sk.Components = &SkuComponents{SkuComponents: proto.Components}
+	} else {
+		sk.Components = nil
+	}
+	if proto.AssociatedMachineIds == nil {
+		sk.AssociatedMachineIds = nil
+	} else {
+		machineIDs := []string{}
+		for _, amid := range proto.AssociatedMachineIds {
+			if strID := amid.GetId(); strID != "" {
+				machineIDs = append(machineIDs, strID)
+			}
+		}
+		sk.AssociatedMachineIds = machineIDs
+	}
 }
 
 // SkuCreateInput input parameters for Create method

--- a/rest-api/db/pkg/db/model/sku_test.go
+++ b/rest-api/db/pkg/db/model/sku_test.go
@@ -19,6 +19,113 @@ import (
 	otrace "go.opentelemetry.io/otel/trace"
 )
 
+func TestSkuComponents_Equal(t *testing.T) {
+	t.Run("nil wrapper equals nil wrapper", func(t *testing.T) {
+		var a, b *SkuComponents
+		assert.True(t, a.Equal(b))
+	})
+	t.Run("nil wrapper equals wrapper with nil inner", func(t *testing.T) {
+		var a *SkuComponents
+		b := &SkuComponents{}
+		assert.True(t, a.Equal(b))
+		assert.True(t, b.Equal(a))
+	})
+	t.Run("two wrappers with nil inner are equal", func(t *testing.T) {
+		assert.True(t, (&SkuComponents{}).Equal(&SkuComponents{}))
+	})
+	t.Run("identical inner protos are equal", func(t *testing.T) {
+		a := &SkuComponents{SkuComponents: &cwssaws.SkuComponents{}}
+		b := &SkuComponents{SkuComponents: &cwssaws.SkuComponents{}}
+		assert.True(t, a.Equal(b))
+	})
+	t.Run("nil inner does not equal non-nil inner", func(t *testing.T) {
+		a := &SkuComponents{}
+		b := &SkuComponents{SkuComponents: &cwssaws.SkuComponents{}}
+		assert.False(t, a.Equal(b))
+		assert.False(t, b.Equal(a))
+	})
+}
+
+func TestSKU_ToProto(t *testing.T) {
+	siteID := uuid.New()
+	deviceType := "GPU"
+
+	t.Run("populates proto from receiver", func(t *testing.T) {
+		sk := &SKU{
+			ID:                   "sku-1",
+			SiteID:               siteID,
+			DeviceType:           &deviceType,
+			Components:           &SkuComponents{SkuComponents: &cwssaws.SkuComponents{}},
+			AssociatedMachineIds: []string{"m-1", "m-2"},
+		}
+		proto := sk.ToProto()
+		require.NotNil(t, proto)
+		assert.Equal(t, "sku-1", proto.Id)
+		assert.Equal(t, &deviceType, proto.DeviceType)
+		require.NotNil(t, proto.Components)
+		require.Len(t, proto.AssociatedMachineIds, 2)
+		assert.Equal(t, "m-1", proto.AssociatedMachineIds[0].Id)
+		assert.Equal(t, "m-2", proto.AssociatedMachineIds[1].Id)
+	})
+
+	t.Run("nil Components yields nil proto.Components", func(t *testing.T) {
+		sk := &SKU{ID: "sku-2"}
+		proto := sk.ToProto()
+		require.NotNil(t, proto)
+		assert.Nil(t, proto.Components)
+	})
+
+	t.Run("nil AssociatedMachineIds yields nil proto.AssociatedMachineIds", func(t *testing.T) {
+		sk := &SKU{ID: "sku-3"}
+		proto := sk.ToProto()
+		require.NotNil(t, proto)
+		assert.Nil(t, proto.AssociatedMachineIds)
+	})
+}
+
+func TestSKU_FromProto(t *testing.T) {
+	siteID := uuid.New()
+	deviceType := "GPU"
+
+	t.Run("nil proto leaves receiver unchanged", func(t *testing.T) {
+		sk := &SKU{ID: "preserved", SiteID: siteID}
+		sk.FromProto(nil, uuid.New())
+		assert.Equal(t, "preserved", sk.ID)
+		assert.Equal(t, siteID, sk.SiteID)
+	})
+
+	t.Run("populates fields from proto", func(t *testing.T) {
+		sk := &SKU{}
+		sk.FromProto(&cwssaws.Sku{
+			Id:         "sku-1",
+			DeviceType: &deviceType,
+			Components: &cwssaws.SkuComponents{},
+			AssociatedMachineIds: []*cwssaws.MachineId{
+				{Id: "m-1"},
+				{Id: ""}, // skipped
+				{Id: "m-2"},
+			},
+		}, siteID)
+		assert.Equal(t, "sku-1", sk.ID)
+		assert.Equal(t, siteID, sk.SiteID)
+		assert.Equal(t, &deviceType, sk.DeviceType)
+		assert.Equal(t, []string{"m-1", "m-2"}, sk.AssociatedMachineIds)
+		require.NotNil(t, sk.Components)
+	})
+
+	t.Run("nil Components yields nil wrapper", func(t *testing.T) {
+		sk := &SKU{Components: &SkuComponents{SkuComponents: &cwssaws.SkuComponents{}}}
+		sk.FromProto(&cwssaws.Sku{Id: "sku-1"}, siteID)
+		assert.Nil(t, sk.Components)
+	})
+
+	t.Run("nil AssociatedMachineIds yields nil slice", func(t *testing.T) {
+		sk := &SKU{}
+		sk.FromProto(&cwssaws.Sku{Id: "sku-1"}, siteID)
+		assert.Nil(t, sk.AssociatedMachineIds)
+	})
+}
+
 // reset the tables needed for SKU tests
 func testSKUSetupSchema(t *testing.T, dbSession *db.Session) {
 	// create User table

--- a/rest-api/workflow/pkg/activity/sku/sku.go
+++ b/rest-api/workflow/pkg/activity/sku/sku.go
@@ -25,19 +25,6 @@ type ManageSku struct {
 	siteClientPool *sc.ClientPool
 }
 
-func getAssociatedMachineIDsFromProto(sku *cwssaws.Sku) []string {
-	if sku == nil || sku.AssociatedMachineIds == nil {
-		return nil
-	}
-	result := []string{}
-	for _, amid := range sku.AssociatedMachineIds {
-		if strId := amid.GetId(); strId != "" {
-			result = append(result, strId)
-		}
-	}
-	return result
-}
-
 // UpdateSkusInDB is a Temporal activity that takes a collection of SKU data pushed by Site Agent and updates the DB
 // NOTE: Initial implementation validates inputs and site existence; DB synchronization will be added iteratively.
 func (ms ManageSku) UpdateSkusInDB(ctx context.Context, siteID uuid.UUID, skuInventory *cwssaws.SkuInventory) error {
@@ -108,20 +95,20 @@ func (ms ManageSku) UpdateSkusInDB(ctx context.Context, siteID uuid.UUID, skuInv
 			continue
 		}
 		reportedIDs[reportedSku.Id] = true
-		reportedAssociatedMachineIDs := getAssociatedMachineIDsFromProto(reportedSku)
+
+		reported := &cdbm.SKU{}
+		reported.FromProto(reportedSku, siteID)
 
 		// Create a new SKU if it doesn't already exist in DB
 		cur, found := existingByID[reportedSku.Id]
 		if !found {
 			// Create new SKU with SiteID
 			sku := cdbm.SkuCreateInput{
-				SkuID:      reportedSku.Id,
-				SiteID:     siteID,
-				DeviceType: reportedSku.DeviceType,
-				Components: &cdbm.SkuComponents{
-					SkuComponents: reportedSku.Components,
-				},
-				AssociatedMachineIds: reportedAssociatedMachineIDs,
+				SkuID:                reported.ID,
+				SiteID:               reported.SiteID,
+				DeviceType:           reported.DeviceType,
+				Components:           reported.Components,
+				AssociatedMachineIds: reported.AssociatedMachineIds,
 			}
 			_, cerr := skuDAO.Create(ctx, nil, sku)
 			if cerr != nil {
@@ -131,19 +118,26 @@ func (ms ManageSku) UpdateSkusInDB(ctx context.Context, siteID uuid.UUID, skuInv
 		}
 
 		// Update existing SKU data in DB
-		if !reflect.DeepEqual(cur.Components.SkuComponents, reportedSku.Components) || cur.DeviceType != reportedSku.DeviceType ||
-			!reflect.DeepEqual(cur.AssociatedMachineIds, reportedAssociatedMachineIDs) {
+		if !cur.Components.Equal(reported.Components) || cur.DeviceType != reported.DeviceType ||
+			!reflect.DeepEqual(cur.AssociatedMachineIds, reported.AssociatedMachineIds) {
 			// nil AssociatedMachineIds in nico can mean we need to clear out existing AssociatedMachineIds in DB
 			// but a nil value will not trigger an update in the DAO layer. We could use `Clear` but an empty map
 			// will save a call to the DB.
-			if cur.AssociatedMachineIds != nil && reportedAssociatedMachineIDs == nil {
-				reportedAssociatedMachineIDs = []string{}
+			associated := reported.AssociatedMachineIds
+			if cur.AssociatedMachineIds != nil && associated == nil {
+				associated = []string{}
+			}
+			// Same nil-clear pattern for Components: a nil from NICo means "clear",
+			// but the DAO skips nil fields, so substitute a non-nil empty wrapper.
+			components := reported.Components
+			if cur.Components != nil && components == nil {
+				components = &cdbm.SkuComponents{SkuComponents: &cwssaws.SkuComponents{}}
 			}
 			sku := cdbm.SkuUpdateInput{
-				SkuID:                reportedSku.Id,
-				Components:           &cdbm.SkuComponents{SkuComponents: reportedSku.Components},
-				DeviceType:           reportedSku.DeviceType,
-				AssociatedMachineIds: reportedAssociatedMachineIDs,
+				SkuID:                reported.ID,
+				Components:           components,
+				DeviceType:           reported.DeviceType,
+				AssociatedMachineIds: associated,
 			}
 			_, uerr := skuDAO.Update(ctx, nil, sku)
 			if uerr != nil {

--- a/rest-api/workflow/pkg/activity/sku/sku_test.go
+++ b/rest-api/workflow/pkg/activity/sku/sku_test.go
@@ -41,7 +41,7 @@ func TestManageSku_Reconcile_CreateUpdateDelete(t *testing.T) {
 	// 1) Create: inventory contains one sku not in DB
 	id1 := "sku-1"
 	inv1 := &cwssaws.SkuInventory{
-		Skus: []*cwssaws.Sku{{Id: id1}},
+		Skus: []*cwssaws.Sku{{Id: id1, Components: &cwssaws.SkuComponents{}}},
 	}
 	assert.NoError(t, ms.UpdateSkusInDB(ctx, site.ID, inv1))
 
@@ -55,7 +55,7 @@ func TestManageSku_Reconcile_CreateUpdateDelete(t *testing.T) {
 	}
 
 	// 2) Update: same id, ensure still one record
-	inv2 := &cwssaws.SkuInventory{Skus: []*cwssaws.Sku{{Id: id1}}}
+	inv2 := &cwssaws.SkuInventory{Skus: []*cwssaws.Sku{{Id: id1, Components: &cwssaws.SkuComponents{}}}}
 	assert.NoError(t, ms.UpdateSkusInDB(ctx, site.ID, inv2))
 
 	_, total, err = ssd.GetAll(ctx, nil, cdbm.SkuFilterInput{SiteIDs: []uuid.UUID{site.ID}}, cdbp.PageInput{Limit: cutil.GetPtr(100)})
@@ -69,6 +69,43 @@ func TestManageSku_Reconcile_CreateUpdateDelete(t *testing.T) {
 	_, total, err = ssd.GetAll(ctx, nil, cdbm.SkuFilterInput{SiteIDs: []uuid.UUID{site.ID}}, cdbp.PageInput{Limit: cutil.GetPtr(100)})
 	assert.NoError(t, err)
 	assert.Equal(t, 0, total)
+}
+
+func TestManageSku_NilComponents_ClearsExisting(t *testing.T) {
+	ctx := context.Background()
+	_ = config.GetTestConfig()
+
+	dbSession := cwu.TestInitDB(t)
+	defer dbSession.Close()
+	cwu.TestSetupSchema(t, dbSession)
+
+	ipOrg := "test-ip-org"
+	ipRoles := []string{"FORGE_PROVIDER_ADMIN"}
+	ipu := cwu.TestBuildUser(t, dbSession, uuid.NewString(), []string{ipOrg}, ipRoles)
+	ip := cwu.TestBuildInfrastructureProvider(t, dbSession, "test-provider", ipOrg, ipu)
+	site := cwu.TestBuildSite(t, dbSession, ip, "test-site", cdbm.SiteStatusRegistered, nil, ipu)
+
+	// Seed a SKU with non-nil Components.
+	id := "sku-clear"
+	_, err := dbSession.DB.NewInsert().Model(&cdbm.SKU{ID: id, SiteID: site.ID, Components: &cdbm.SkuComponents{SkuComponents: &cwssaws.SkuComponents{}}}).Exec(ctx)
+	assert.NoError(t, err)
+
+	ms := NewManageSku(dbSession, cwu.TestTemporalSiteClientPool(t))
+
+	// Send inventory with the same SKU but Components: nil. The activity should
+	// translate nil to a non-nil empty wrapper so the DAO actually writes the
+	// clear (the DAO skips nil Components fields).
+	inv := &cwssaws.SkuInventory{
+		Skus: []*cwssaws.Sku{{Id: id, Components: nil}},
+	}
+	assert.NoError(t, ms.UpdateSkusInDB(ctx, site.ID, inv))
+
+	ssd := cdbm.NewSkuDAO(dbSession)
+	got, gerr := ssd.Get(ctx, nil, id)
+	assert.NoError(t, gerr)
+	if got.Components == nil || got.Components.SkuComponents == nil {
+		t.Fatalf("expected Components to be a non-nil empty wrapper after clear, got %+v", got.Components)
+	}
 }
 
 func TestManageSku_InventoryStatusFailed_Skip(t *testing.T) {


### PR DESCRIPTION
## Description

Brings `SKU` in line with the proto-modeling changes. SKU is read-only at the API (Site is source of truth -- no Create/Update endpoints), so all the conversion work lives on the entity. The proto round-trip moves from the Site Agent's cloud-sync activity onto the DB model.

Primary callouts are:
- New `SKU.FromProto(proto, siteID)` and a symmetric `SKU.ToProto()` on the entity.
- `FromProto` is nil-safe on `proto.Components` -- nil in, nil out. Workflow activity gets a small `skuComponentsEqual` helper to compare safely.
- Workflow activity (`workflow/pkg/activity/sku/sku.go`) simplifies to one-liners through the new receivers.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

