### PR TITLE
refactor(rms-client)!: migrate to updated RMS proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2596,6 +2596,7 @@ dependencies = [
  "mac_address",
  "mqttea",
  "opentelemetry",
+ "serde",
  "serde_json",
  "sqlx",
  "state-controller",
@@ -6572,8 +6573,8 @@ dependencies = [
 
 [[package]]
 name = "librms"
-version = "0.0.12"
-source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.0.12-rc4#a870c06ee1483a46ef3fb01cc4ce7d73470c7d3c"
+version = "0.0.13"
+source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.0.13#a87f91da04009c62d9133e0ab4820361f3c541d1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11483,7 +11484,7 @@ dependencies = [
 [[package]]
 name = "tonic-client-wrapper"
 version = "1.0.0"
-source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.0.12-rc4#a870c06ee1483a46ef3fb01cc4ce7d73470c7d3c"
+source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.0.13#a87f91da04009c62d9133e0ab4820361f3c541d1"
 dependencies = [
  "async-trait",
  "heck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.10" }
-librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.12-rc4" }
+librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.13" }
 ansi-to-html = "0.2.2"
 
 tokio = { version = "1", features = ["full", "tracing"] }

--- a/crates/admin-cli/src/component_manager/update_firmware/args.rs
+++ b/crates/admin-cli/src/component_manager/update_firmware/args.rs
@@ -173,7 +173,7 @@ pub struct FirmwareSourceArgs {
     #[clap(
         long = "sot-json-file",
         value_name = "PATH",
-        help = "SOT JSON file for RMS ApplyFirmwareObjectFromJSON"
+        help = "SOT JSON file for RMS ApplyFirmwareObject"
     )]
     pub sot_json_file: Option<PathBuf>,
 

--- a/crates/admin-cli/src/rack/maintenance/args.rs
+++ b/crates/admin-cli/src/rack/maintenance/args.rs
@@ -87,7 +87,7 @@ pub struct MaintenanceOptions {
     #[clap(
         long = "sot-json-file",
         value_name = "PATH",
-        help = "SOT JSON file for RMS ApplyFirmwareObjectFromJSON"
+        help = "SOT JSON file for RMS ApplyFirmwareObject"
     )]
     pub sot_json_file: Option<PathBuf>,
 

--- a/crates/admin-cli/src/rms/args.rs
+++ b/crates/admin-cli/src/rms/args.rs
@@ -82,7 +82,6 @@ pub struct PowerOnSequence {
 impl From<PowerOnSequence> for librms::protos::rack_manager::GetRackPowerOnSequenceRequest {
     fn from(args: PowerOnSequence) -> Self {
         Self {
-            metadata: None,
             rack_id: args.rack_id,
         }
     }
@@ -106,7 +105,6 @@ pub struct PowerState {
 impl From<PowerState> for librms::protos::rack_manager::GetPowerStateRequest {
     fn from(args: PowerState) -> Self {
         Self {
-            metadata: None,
             node_id: args.node_id,
             rack_id: args.rack_id,
         }
@@ -131,7 +129,6 @@ pub struct FirmwareInventory {
 impl From<FirmwareInventory> for librms::protos::rack_manager::GetNodeFirmwareInventoryRequest {
     fn from(args: FirmwareInventory) -> Self {
         Self {
-            metadata: None,
             node_id: args.node_id,
             rack_id: args.rack_id,
         }

--- a/crates/admin-cli/src/rms/cmds.rs
+++ b/crates/admin-cli/src/rms/cmds.rs
@@ -21,9 +21,9 @@ use librms::RmsApi;
 
 use crate::rms::args::{FirmwareInventory, PowerOnSequence, PowerState};
 
-pub async fn get_all_inventory(rms_client: &Arc<dyn RmsApi>) -> eyre::Result<()> {
-    let cmd = librms::protos::rack_manager::GetAllInventoryRequest::default();
-    let response = rms_client.get_all_inventory(cmd).await?;
+/// Print the RMS node inventory as JSON.
+pub async fn list_node_inventory(rms_client: &Arc<dyn RmsApi>) -> eyre::Result<()> {
+    let response = rms_client.list_node_inventory().await?;
     println!("{}", serde_json::to_string_pretty(&response)?);
     Ok(())
 }

--- a/crates/admin-cli/src/rms/mod.rs
+++ b/crates/admin-cli/src/rms/mod.rs
@@ -61,7 +61,7 @@ pub async fn action(action: RmsAction, config: &CliOptions) -> color_eyre::Resul
     let rms_client = rms_client_pool.create_client().await;
 
     match action.command {
-        Cmd::Inventory => cmds::get_all_inventory(&rms_client).await,
+        Cmd::Inventory => cmds::list_node_inventory(&rms_client).await,
         Cmd::PowerOnSequence(args) => cmds::power_on_sequence(args, &rms_client).await,
         Cmd::PowerState(args) => cmds::power_state(args, &rms_client).await,
         Cmd::FirmwareInventory(args) => cmds::get_firmware_inventory(args, &rms_client).await,

--- a/crates/api-core/src/tests/power_shelf_state_controller/maintenance.rs
+++ b/crates/api-core/src/tests/power_shelf_state_controller/maintenance.rs
@@ -136,7 +136,7 @@ async fn enter_maintenance(
 
 /// Set the power shelf's BMC MAC and rack association directly. The
 /// `new_power_shelf` site-explorer fixture leaves both as `None`, but the
-/// handler's `set_power_state_by_device_list` path needs both before it
+/// handler's `batch_set_power_state` path needs both before it
 /// will even attempt the BMC IP lookup.
 ///
 /// `power_shelves.bmc_mac_address` is a FK into `expected_power_shelves`,
@@ -254,11 +254,14 @@ async fn power_on_transitions_to_error_when_bmc_ip_unresolvable(
 
     // Queue a success response so we can assert it was *not* consumed.
     env.rms_sim
-        .queue_set_power_state_by_device_list_response(Ok(rms::SetPowerStateByDeviceListResponse {
+        .queue_batch_set_power_state_response(Ok(rms::BatchSetPowerStateResponse {
             response: Some(rms::NodeBatchResponse {
                 status: rms::ReturnCode::Success as i32,
-                total_nodes: 1,
-                successful_nodes: 1,
+                stats: Some(rms::NodeOperationStats {
+                    total_nodes: 1,
+                    successful_nodes: 1,
+                    failed_nodes: 0,
+                }),
                 ..Default::default()
             }),
         }))
@@ -291,10 +294,7 @@ async fn power_on_transitions_to_error_when_bmc_ip_unresolvable(
         "maintenance request should be cleared on error transition"
     );
 
-    let calls = env
-        .rms_sim
-        .submitted_set_power_state_by_device_list_requests()
-        .await;
+    let calls = env.rms_sim.submitted_batch_set_power_state_requests().await;
     assert!(
         calls.is_empty(),
         "RMS should not be invoked when BMC IP cannot be resolved, got: {} calls",
@@ -363,10 +363,7 @@ async fn power_on_transitions_to_error_when_rack_id_missing(
     let transition = commit_and_extract_transition(outcome).await.unwrap();
     assert_error_with_substring(&transition, "no rack association");
 
-    let calls = env
-        .rms_sim
-        .submitted_set_power_state_by_device_list_requests()
-        .await;
+    let calls = env.rms_sim.submitted_batch_set_power_state_requests().await;
     assert!(calls.is_empty(), "RMS must not be called without a rack_id");
 
     Ok(())
@@ -402,10 +399,7 @@ async fn power_on_transitions_to_error_when_bmc_mac_missing(
     let transition = commit_and_extract_transition(outcome).await.unwrap();
     assert_error_with_substring(&transition, "has no BMC MAC address recorded");
 
-    let calls = env
-        .rms_sim
-        .submitted_set_power_state_by_device_list_requests()
-        .await;
+    let calls = env.rms_sim.submitted_batch_set_power_state_requests().await;
     assert!(
         calls.is_empty(),
         "RMS must not be called without a BMC MAC address"
@@ -486,10 +480,7 @@ async fn power_off_transitions_to_error_when_rack_id_missing(
         assert!(cause.contains("PowerOff"));
     }
 
-    let calls = env
-        .rms_sim
-        .submitted_set_power_state_by_device_list_requests()
-        .await;
+    let calls = env.rms_sim.submitted_batch_set_power_state_requests().await;
     assert!(calls.is_empty());
 
     Ok(())
@@ -524,10 +515,7 @@ async fn power_off_transitions_to_error_when_bmc_mac_missing(
     let transition = commit_and_extract_transition(outcome).await.unwrap();
     assert_error_with_substring(&transition, "has no BMC MAC address recorded");
 
-    let calls = env
-        .rms_sim
-        .submitted_set_power_state_by_device_list_requests()
-        .await;
+    let calls = env.rms_sim.submitted_batch_set_power_state_requests().await;
     assert!(calls.is_empty());
 
     Ok(())
@@ -535,7 +523,7 @@ async fn power_off_transitions_to_error_when_bmc_mac_missing(
 
 // ── Sanity: non-Maintenance state never reaches the by-device-list path ────
 
-/// `Ready` should never invoke `set_power_state_by_device_list`. This guards
+/// `Ready` should never invoke `batch_set_power_state`. This guards
 /// against accidentally wiring the maintenance dispatch into other states.
 #[crate::sqlx_test]
 async fn ready_state_does_not_invoke_rms_set_power_state(
@@ -565,13 +553,10 @@ async fn ready_state_does_not_invoke_rms_set_power_state(
     // call was made.
     let _ = commit_and_extract_transition(outcome).await;
 
-    let calls = env
-        .rms_sim
-        .submitted_set_power_state_by_device_list_requests()
-        .await;
+    let calls = env.rms_sim.submitted_batch_set_power_state_requests().await;
     assert!(
         calls.is_empty(),
-        "Ready state must not call set_power_state_by_device_list"
+        "Ready state must not call batch_set_power_state"
     );
 
     Ok(())

--- a/crates/api-core/src/tests/rack_state_controller/handler.rs
+++ b/crates/api-core/src/tests/rack_state_controller/handler.rs
@@ -1401,13 +1401,16 @@ async fn test_firmware_upgrade_start_submits_json_and_deletes_access_token(
             response: Some(rms::NodeBatchResponse {
                 status: rms::ReturnCode::Success as i32,
                 message: "accepted".to_string(),
-                total_nodes: 1,
-                successful_nodes: 1,
                 job_id: "parent-job".to_string(),
+                stats: Some(rms::NodeOperationStats {
+                    total_nodes: 1,
+                    successful_nodes: 1,
+                    failed_nodes: 0,
+                }),
                 ..Default::default()
             }),
             object_id: "fw-json".to_string(),
-            node_jobs: vec![rms::NodeFirmwareJobInfo {
+            jobs: vec![rms::NodeFirmwareJobInfo {
                 node_id: switch_id_string.clone(),
                 job_id: "child-job".to_string(),
             }],
@@ -1452,16 +1455,13 @@ async fn test_firmware_upgrade_start_submits_json_and_deletes_access_token(
         "expected FirmwareUpgrade(WaitForComplete), got {:?}",
         std::mem::discriminant(&outcome),
     );
-    let requests = env
-        .rms_sim
-        .submitted_apply_firmware_object_from_json_requests()
-        .await;
+    let requests = env.rms_sim.submitted_apply_firmware_object_requests().await;
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0].config_json, r#"{"Id":"fw-json"}"#);
     assert_eq!(requests[0].access_token, "token");
     assert_eq!(requests[0].firmware_type, "prod");
     assert!(requests[0].force_update);
-    assert_eq!(requests[0].nodes.as_ref().unwrap().devices.len(), 1);
+    assert_eq!(requests[0].nodes.as_ref().unwrap().nodes.len(), 1);
 
     let token_after = env
         .test_credential_manager
@@ -1495,7 +1495,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_while_jobs_running(
         .set_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusResponse {
             status: librms::protos::rack_manager::ReturnCode::Success as i32,
             job_id: "child-job-1".to_string(),
-            job_state: 1,
+            job_state: rms::FirmwareJobState::Running as i32,
             state_description: "running".to_string(),
             node_id: host.host_snapshot.id.to_string(),
             ..Default::default()
@@ -1583,7 +1583,7 @@ async fn test_firmware_upgrade_wait_for_complete_transitions_to_error_on_job_fai
         .set_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusResponse {
             status: librms::protos::rack_manager::ReturnCode::Success as i32,
             job_id: "child-job-1".to_string(),
-            job_state: 3,
+            job_state: rms::FirmwareJobState::Failed as i32,
             state_description: "failed".to_string(),
             node_id: host.host_snapshot.id.to_string(),
             error_message: "upgrade failed".to_string(),
@@ -1686,7 +1686,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_termi
         .set_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusResponse {
             status: librms::protos::rack_manager::ReturnCode::Success as i32,
             job_id: "child-job-1".to_string(),
-            job_state: 3,
+            job_state: rms::FirmwareJobState::Failed as i32,
             state_description: "failed".to_string(),
             node_id: host_a.host_snapshot.id.to_string(),
             error_message: "upgrade failed".to_string(),
@@ -1697,7 +1697,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_termi
         .set_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusResponse {
             status: librms::protos::rack_manager::ReturnCode::Success as i32,
             job_id: "child-job-2".to_string(),
-            job_state: 1,
+            job_state: rms::FirmwareJobState::Running as i32,
             state_description: "running".to_string(),
             node_id: host_b.host_snapshot.id.to_string(),
             ..Default::default()
@@ -1795,7 +1795,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_termi
         .set_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusResponse {
             status: librms::protos::rack_manager::ReturnCode::Success as i32,
             job_id: "child-job-2".to_string(),
-            job_state: 2,
+            job_state: rms::FirmwareJobState::Completed as i32,
             state_description: "completed".to_string(),
             node_id: host_b.host_snapshot.id.to_string(),
             ..Default::default()
@@ -2011,7 +2011,7 @@ async fn test_firmware_upgrade_wait_for_complete_retries_on_transient_poll_error
 
 /// test_nvos_update_start_transitions_to_wait_for_complete verifies that
 /// Maintenance::NVOSUpdate(Start) transitions to WaitForComplete when a
-/// NVOS SOT JSON is available for RMS ApplySwitchSystemImageFromJSON.
+/// NVOS SOT JSON is available for RMS ApplySwitchSystemImage.
 #[crate::sqlx_test]
 async fn test_nvos_update_start_transitions_to_wait_for_complete(
     pool: sqlx::PgPool,
@@ -2098,11 +2098,11 @@ async fn test_nvos_update_start_transitions_to_wait_for_complete(
     );
     let requests = env
         .rms_sim
-        .submitted_apply_switch_system_image_from_json_requests()
+        .submitted_apply_switch_system_image_requests()
         .await;
     assert!(
         !requests.is_empty(),
-        "NVOSUpdate(Start) should submit ApplySwitchSystemImageFromJSON"
+        "NVOSUpdate(Start) should submit ApplySwitchSystemImage"
     );
     assert_eq!(requests[0].config_json, r#"{"Id":"fw-nvos-default"}"#);
     assert_eq!(requests[0].access_token, "token");
@@ -2198,13 +2198,13 @@ async fn test_configure_nmx_cluster_start_advances_to_disable_scale_up_fabric_st
 
     assert!(
         env.rms_sim
-            .submitted_set_scale_up_fabric_state_requests()
+            .submitted_batch_set_scale_up_fabric_state_requests()
             .await
             .is_empty()
     );
     assert!(
         env.rms_sim
-            .submitted_get_device_info_by_device_list_requests()
+            .submitted_batch_get_node_device_info_requests()
             .await
             .is_empty()
     );
@@ -2238,14 +2238,19 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_runs_on_all_sw
 
     let switch_ids = attach_switches_with_nvos_credentials(&env, &rack_id, 2).await?;
     env.rms_sim
-        .queue_set_scale_up_fabric_state_response(Ok(rms::SetScaleUpFabricStateResponse {
-            response: Some(rms::NodeBatchResponse {
-                status: rms::ReturnCode::Success as i32,
-                successful_nodes: switch_ids.len() as i32,
-                failed_nodes: 0,
-                ..Default::default()
-            }),
-        }))
+        .queue_batch_set_scale_up_fabric_state_response(Ok(
+            rms::BatchSetScaleUpFabricStateResponse {
+                response: Some(rms::NodeBatchResponse {
+                    status: rms::ReturnCode::Success as i32,
+                    stats: Some(rms::NodeOperationStats {
+                        total_nodes: switch_ids.len() as u32,
+                        successful_nodes: switch_ids.len() as u32,
+                        failed_nodes: 0,
+                    }),
+                    ..Default::default()
+                }),
+            },
+        ))
         .await;
 
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
@@ -2293,18 +2298,27 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_runs_on_all_sw
 
     let requests = env
         .rms_sim
-        .submitted_set_scale_up_fabric_state_requests()
+        .submitted_batch_set_scale_up_fabric_state_requests()
         .await;
     assert_eq!(requests.len(), 1);
     let request = &requests[0];
-    assert_eq!(request.enabled, Some(false));
+    assert!(!request.enabled);
     let devices = request
         .nodes
         .as_ref()
         .expect("disable request should include nodes")
-        .devices
+        .nodes
         .as_slice();
+
     assert_eq!(devices.len(), switch_ids.len());
+    for device in devices {
+        let host_endpoint = device
+            .host_endpoint
+            .as_ref()
+            .ok_or_else(|| eyre::eyre!("disable request should include host endpoints"))?;
+
+        assert!(host_endpoint.dangerously_accept_invalid_certs);
+    }
     let node_ids = devices
         .iter()
         .map(|device| device.node_id.clone())
@@ -2314,7 +2328,7 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_runs_on_all_sw
     }
     assert!(
         env.rms_sim
-            .submitted_get_device_info_by_device_list_requests()
+            .submitted_batch_get_node_device_info_requests()
             .await
             .is_empty()
     );
@@ -2359,9 +2373,9 @@ async fn test_configure_nmx_cluster_configure_selects_persists_and_configures_pr
     let topology_type = RackHardwareTopology::Gb200Nvl72r1C2g4Topology.to_string();
 
     env.rms_sim
-        .queue_get_device_info_by_device_list_response(Ok(rms::GetDeviceInfoByDeviceListResponse {
+        .queue_batch_get_node_device_info_response(Ok(rms::BatchGetNodeDeviceInfoResponse {
             status: rms::ReturnCode::Success as i32,
-            node_device_info: vec![
+            node_device_details: vec![
                 rms::NodeDeviceInfo {
                     node_id: secondary_switch_id.to_string(),
                     tray_index: Some(2),
@@ -2434,21 +2448,21 @@ async fn test_configure_nmx_cluster_configure_selects_persists_and_configures_pr
 
     assert!(
         env.rms_sim
-            .submitted_set_scale_up_fabric_state_requests()
+            .submitted_batch_set_scale_up_fabric_state_requests()
             .await
             .is_empty()
     );
 
     let device_info_requests = env
         .rms_sim
-        .submitted_get_device_info_by_device_list_requests()
+        .submitted_batch_get_node_device_info_requests()
         .await;
     assert_eq!(device_info_requests.len(), 1);
     let device_info_nodes = device_info_requests[0]
         .nodes
         .as_ref()
         .expect("device-info request should include nodes")
-        .devices
+        .nodes
         .as_slice();
     assert_eq!(device_info_nodes.len(), switch_ids.len());
 
@@ -2459,13 +2473,18 @@ async fn test_configure_nmx_cluster_configure_selects_persists_and_configures_pr
     assert_eq!(configure_requests.len(), 1);
     let configure_request = &configure_requests[0];
     assert_eq!(configure_request.topology_type, topology_type);
-    assert_eq!(
-        configure_request
-            .device
+    let configure_node = configure_request
+        .node
+        .as_ref()
+        .ok_or_else(|| eyre::eyre!("configure request should include a primary switch"))?;
+
+    assert_eq!(configure_node.node_id, primary_switch_id.to_string());
+    assert!(
+        configure_node
+            .host_endpoint
             .as_ref()
-            .expect("configure request should include a primary switch")
-            .node_id,
-        primary_switch_id.to_string()
+            .ok_or_else(|| eyre::eyre!("configure request should include a host endpoint"))?
+            .dangerously_accept_invalid_certs
     );
 
     let mut txn = pool.acquire().await?;
@@ -2512,19 +2531,24 @@ async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fab
     let topology_type = RackHardwareTopology::Gb200Nvl72r1C2g4Topology.to_string();
 
     env.rms_sim
-        .queue_set_scale_up_fabric_state_response(Ok(rms::SetScaleUpFabricStateResponse {
-            response: Some(rms::NodeBatchResponse {
-                status: rms::ReturnCode::Success as i32,
-                successful_nodes: switch_ids.len() as i32,
-                failed_nodes: 0,
-                ..Default::default()
-            }),
-        }))
+        .queue_batch_set_scale_up_fabric_state_response(Ok(
+            rms::BatchSetScaleUpFabricStateResponse {
+                response: Some(rms::NodeBatchResponse {
+                    status: rms::ReturnCode::Success as i32,
+                    stats: Some(rms::NodeOperationStats {
+                        total_nodes: switch_ids.len() as u32,
+                        successful_nodes: switch_ids.len() as u32,
+                        failed_nodes: 0,
+                    }),
+                    ..Default::default()
+                }),
+            },
+        ))
         .await;
     env.rms_sim
-        .queue_get_device_info_by_device_list_response(Ok(rms::GetDeviceInfoByDeviceListResponse {
+        .queue_batch_get_node_device_info_response(Ok(rms::BatchGetNodeDeviceInfoResponse {
             status: rms::ReturnCode::Success as i32,
-            node_device_info: vec![
+            node_device_details: vec![
                 rms::NodeDeviceInfo {
                     node_id: secondary_switch_id.to_string(),
                     tray_index: Some(2),
@@ -2598,13 +2622,13 @@ async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fab
 
     assert!(
         env.rms_sim
-            .submitted_set_scale_up_fabric_state_requests()
+            .submitted_batch_set_scale_up_fabric_state_requests()
             .await
             .is_empty()
     );
     assert!(
         env.rms_sim
-            .submitted_get_device_info_by_device_list_requests()
+            .submitted_batch_get_node_device_info_requests()
             .await
             .is_empty()
     );
@@ -2643,18 +2667,27 @@ async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fab
 
     let disable_requests = env
         .rms_sim
-        .submitted_set_scale_up_fabric_state_requests()
+        .submitted_batch_set_scale_up_fabric_state_requests()
         .await;
     assert_eq!(disable_requests.len(), 1);
     let disable_request = &disable_requests[0];
-    assert_eq!(disable_request.enabled, Some(false));
+    assert!(!disable_request.enabled);
     let disable_devices = disable_request
         .nodes
         .as_ref()
         .expect("disable request should include nodes")
-        .devices
+        .nodes
         .as_slice();
+
     assert_eq!(disable_devices.len(), switch_ids.len());
+    for device in disable_devices {
+        let host_endpoint = device
+            .host_endpoint
+            .as_ref()
+            .ok_or_else(|| eyre::eyre!("disable request should include host endpoints"))?;
+
+        assert!(host_endpoint.dangerously_accept_invalid_certs);
+    }
     let disabled_node_ids = disable_devices
         .iter()
         .map(|device| device.node_id.clone())
@@ -2664,7 +2697,7 @@ async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fab
     }
     assert!(
         env.rms_sim
-            .submitted_get_device_info_by_device_list_requests()
+            .submitted_batch_get_node_device_info_requests()
             .await
             .is_empty()
     );
@@ -2702,14 +2735,14 @@ async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fab
 
     let device_info_requests = env
         .rms_sim
-        .submitted_get_device_info_by_device_list_requests()
+        .submitted_batch_get_node_device_info_requests()
         .await;
     assert_eq!(device_info_requests.len(), 1);
     let device_info_devices = device_info_requests[0]
         .nodes
         .as_ref()
         .expect("device-info request should include nodes")
-        .devices
+        .nodes
         .as_slice();
     assert_eq!(device_info_devices.len(), switch_ids.len());
 
@@ -2720,13 +2753,18 @@ async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fab
     assert_eq!(configure_requests.len(), 1);
     let configure_request = &configure_requests[0];
     assert_eq!(configure_request.topology_type, topology_type);
-    assert_eq!(
-        configure_request
-            .device
+    let configure_node = configure_request
+        .node
+        .as_ref()
+        .ok_or_else(|| eyre::eyre!("configure request should include a primary switch"))?;
+
+    assert_eq!(configure_node.node_id, primary_switch_id.to_string());
+    assert!(
+        configure_node
+            .host_endpoint
             .as_ref()
-            .expect("configure request should include a primary switch")
-            .node_id,
-        primary_switch_id.to_string()
+            .ok_or_else(|| eyre::eyre!("configure request should include a host endpoint"))?
+            .dangerously_accept_invalid_certs
     );
 
     let mut txn = pool.acquire().await?;
@@ -2762,15 +2800,20 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_failure_stops_
 
     attach_switches_with_nvos_credentials(&env, &rack_id, 2).await?;
     env.rms_sim
-        .queue_set_scale_up_fabric_state_response(Ok(rms::SetScaleUpFabricStateResponse {
-            response: Some(rms::NodeBatchResponse {
-                status: rms::ReturnCode::Failure as i32,
-                successful_nodes: 1,
-                failed_nodes: 1,
-                message: "disable rejected".to_string(),
-                ..Default::default()
-            }),
-        }))
+        .queue_batch_set_scale_up_fabric_state_response(Ok(
+            rms::BatchSetScaleUpFabricStateResponse {
+                response: Some(rms::NodeBatchResponse {
+                    status: rms::ReturnCode::Failure as i32,
+                    message: "disable rejected".to_string(),
+                    stats: Some(rms::NodeOperationStats {
+                        total_nodes: 2,
+                        successful_nodes: 1,
+                        failed_nodes: 1,
+                    }),
+                    ..Default::default()
+                }),
+            },
+        ))
         .await;
 
     let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
@@ -2797,7 +2840,7 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_failure_stops_
     match outcome {
         StateHandlerOutcome::Transition { next_state, .. } => match next_state {
             RackState::Error { cause } => {
-                assert!(cause.contains("RMS SetScaleUpFabricState failed"));
+                assert!(cause.contains("RMS BatchSetScaleUpFabricState failed"));
                 assert!(cause.contains("disable rejected"));
             }
             other => panic!("Expected Error state, got {:?}", other),
@@ -2810,14 +2853,14 @@ async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_failure_stops_
 
     assert_eq!(
         env.rms_sim
-            .submitted_set_scale_up_fabric_state_requests()
+            .submitted_batch_set_scale_up_fabric_state_requests()
             .await
             .len(),
         1
     );
     assert!(
         env.rms_sim
-            .submitted_get_device_info_by_device_list_requests()
+            .submitted_batch_get_node_device_info_requests()
             .await
             .is_empty()
     );
@@ -2858,9 +2901,9 @@ async fn test_configure_nmx_cluster_configure_selection_failure_stops_before_con
 
     let switch_ids = attach_switches_with_nvos_credentials(&env, &rack_id, 2).await?;
     env.rms_sim
-        .queue_get_device_info_by_device_list_response(Ok(rms::GetDeviceInfoByDeviceListResponse {
+        .queue_batch_get_node_device_info_response(Ok(rms::BatchGetNodeDeviceInfoResponse {
             status: rms::ReturnCode::Success as i32,
-            node_device_info: vec![
+            node_device_details: vec![
                 rms::NodeDeviceInfo {
                     node_id: switch_ids[0].to_string(),
                     tray_index: Some(1),
@@ -2914,13 +2957,13 @@ async fn test_configure_nmx_cluster_configure_selection_failure_stops_before_con
 
     assert!(
         env.rms_sim
-            .submitted_set_scale_up_fabric_state_requests()
+            .submitted_batch_set_scale_up_fabric_state_requests()
             .await
             .is_empty()
     );
     assert_eq!(
         env.rms_sim
-            .submitted_get_device_info_by_device_list_requests()
+            .submitted_batch_get_node_device_info_requests()
             .await
             .len(),
         1
@@ -2973,9 +3016,9 @@ async fn test_configure_nmx_cluster_configure_failure_advances_to_wait_for_fabri
     let topology_type = RackHardwareTopology::Gb200Nvl72r1C2g4Topology.to_string();
 
     env.rms_sim
-        .queue_get_device_info_by_device_list_response(Ok(rms::GetDeviceInfoByDeviceListResponse {
+        .queue_batch_get_node_device_info_response(Ok(rms::BatchGetNodeDeviceInfoResponse {
             status: rms::ReturnCode::Success as i32,
-            node_device_info: vec![
+            node_device_details: vec![
                 rms::NodeDeviceInfo {
                     node_id: primary_switch_id.to_string(),
                     tray_index: Some(1),
@@ -3046,13 +3089,13 @@ async fn test_configure_nmx_cluster_configure_failure_advances_to_wait_for_fabri
 
     assert!(
         env.rms_sim
-            .submitted_set_scale_up_fabric_state_requests()
+            .submitted_batch_set_scale_up_fabric_state_requests()
             .await
             .is_empty()
     );
     assert_eq!(
         env.rms_sim
-            .submitted_get_device_info_by_device_list_requests()
+            .submitted_batch_get_node_device_info_requests()
             .await
             .len(),
         1
@@ -3063,13 +3106,18 @@ async fn test_configure_nmx_cluster_configure_failure_advances_to_wait_for_fabri
         .await;
     assert_eq!(configure_requests.len(), 1);
     assert_eq!(configure_requests[0].topology_type, topology_type);
-    assert_eq!(
-        configure_requests[0]
-            .device
+    let configure_node = configure_requests[0]
+        .node
+        .as_ref()
+        .ok_or_else(|| eyre::eyre!("configure request should include a primary switch"))?;
+
+    assert_eq!(configure_node.node_id, primary_switch_id.to_string());
+    assert!(
+        configure_node
+            .host_endpoint
             .as_ref()
-            .expect("configure request should include a primary switch")
-            .node_id,
-        primary_switch_id.to_string()
+            .ok_or_else(|| eyre::eyre!("configure request should include a host endpoint"))?
+            .dangerously_accept_invalid_certs
     );
 
     let mut txn = pool.acquire().await?;

--- a/crates/api-core/src/tests/switch_state_controller/maintenance.rs
+++ b/crates/api-core/src/tests/switch_state_controller/maintenance.rs
@@ -181,13 +181,10 @@ async fn ready_state_does_not_invoke_power_control(
     let outcome = run_handler(&mut services, &mut switch).await;
     let _ = commit_and_extract_transition(outcome).await;
 
-    let calls = env
-        .rms_sim
-        .submitted_set_power_state_by_device_list_requests()
-        .await;
+    let calls = env.rms_sim.submitted_batch_set_power_state_requests().await;
     assert!(
         calls.is_empty(),
-        "Ready state must not call set_power_state_by_device_list"
+        "Ready state must not call batch_set_power_state"
     );
 
     Ok(())

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -460,7 +460,7 @@ impl Display for RackMaintenanceState {
 /// disables ScaleUpFabric state on all scoped switches before
 /// `ConfigureScaleUpFabricManager` selects, persists, and configures only the
 /// primary switch. `WaitForFabricStatus` polls
-/// `GetScaleUpFabricServicesStatus` and persists the per-switch
+/// `BatchGetScaleUpFabricServiceStatus` and persists the per-switch
 /// `fabric_manager_status` before advancing.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ConfigureNmxClusterState {
@@ -656,7 +656,7 @@ impl MachineRvLabels {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MaintenanceActivity {
     FirmwareUpgrade {
-        /// SOT JSON for RMS ApplyFirmwareObjectFromJSON.
+        /// SOT JSON for RMS ApplyFirmwareObject.
         /// `None` is only valid for implicit all-activity maintenance skips.
         #[serde(default)]
         firmware_version: Option<String>,
@@ -668,7 +668,7 @@ pub enum MaintenanceActivity {
         force_update: bool,
     },
     NvosUpdate {
-        /// Ephemeral SOT JSON used with RMS ApplySwitchSystemImageFromJSON.
+        /// Ephemeral SOT JSON used with RMS ApplySwitchSystemImage.
         /// The access token is stored separately as a maintenance credential.
         config_json: String,
     },

--- a/crates/api-test-helper/src/mock_rms.rs
+++ b/crates/api-test-helper/src/mock_rms.rs
@@ -27,13 +27,13 @@
 //!
 //! ```ignore
 //! let mock = MockRmsApi::new();
-//! mock.enqueue_power_state(Ok(MockRmsApi::power_ok())).await;
+//! mock.enqueue_set_power_state(Ok(MockRmsApi::power_ok())).await;
 //!
 //! let backend = RmsPowerShelfBackend::new(Arc::new(mock));
 //! let results = backend.power_control(&endpoints, PowerAction::On).await.unwrap();
 //!
 //! assert!(results[0].success);
-//! let calls = mock.power_state_calls().await;
+//! let calls = mock.set_power_state_calls().await;
 //! assert_eq!(calls[0].node_id, "ps-001");
 //! ```
 
@@ -48,8 +48,8 @@ use tokio::sync::Mutex;
 /// per method and inspect what requests were sent.
 ///
 /// Every `RmsApi` method has a corresponding:
-/// - `enqueue_*()` — push a response to be returned on the next call
-/// - `*_calls()` — retrieve all recorded requests for that method
+/// - `enqueue_*()` - push a response to be returned on the next call
+/// - `*_calls()` - retrieve all recorded requests for that method
 ///
 /// If no response is queued when a method is called, it returns a
 /// clear "no response queued" error so tests fail explicitly.
@@ -59,35 +59,35 @@ pub struct MockRmsApi {
         Mutex<VecDeque<Result<rms::SetPowerStateResponse, RackManagerError>>>,
     set_power_state_calls: Mutex<Vec<rms::SetPowerStateRequest>>,
 
-    set_power_state_by_device_list_responses:
-        Mutex<VecDeque<Result<rms::SetPowerStateByDeviceListResponse, RackManagerError>>>,
-    set_power_state_by_device_list_calls: Mutex<Vec<rms::SetPowerStateByDeviceListRequest>>,
+    batch_set_power_state_responses:
+        Mutex<VecDeque<Result<rms::BatchSetPowerStateResponse, RackManagerError>>>,
+    batch_set_power_state_calls: Mutex<Vec<rms::BatchSetPowerStateRequest>>,
 
     get_power_state_responses:
         Mutex<VecDeque<Result<rms::GetPowerStateResponse, RackManagerError>>>,
     get_power_state_calls: Mutex<Vec<rms::GetPowerStateRequest>>,
 
-    get_power_state_by_device_list_responses:
-        Mutex<VecDeque<Result<rms::GetPowerStateByDeviceListResponse, RackManagerError>>>,
-    get_power_state_by_device_list_calls: Mutex<Vec<rms::GetPowerStateByDeviceListRequest>>,
+    batch_get_power_state_responses:
+        Mutex<VecDeque<Result<rms::BatchGetPowerStateResponse, RackManagerError>>>,
+    batch_get_power_state_calls: Mutex<Vec<rms::BatchGetPowerStateRequest>>,
 
     sequence_rack_power_responses:
         Mutex<VecDeque<Result<rms::SequenceRackPowerResponse, RackManagerError>>>,
     sequence_rack_power_calls: Mutex<Vec<rms::SequenceRackPowerRequest>>,
 
     // Inventory calls.
-    get_all_inventory_responses:
-        Mutex<VecDeque<Result<rms::GetAllInventoryResponse, RackManagerError>>>,
-    get_all_inventory_calls: Mutex<Vec<rms::GetAllInventoryRequest>>,
+    list_node_inventory_responses:
+        Mutex<VecDeque<Result<rms::ListNodeInventoryResponse, RackManagerError>>>,
+    list_node_inventory_calls: Mutex<Vec<rms::ListNodeInventoryRequest>>,
 
-    add_node_responses: Mutex<VecDeque<Result<rms::AddNodeResponse, RackManagerError>>>,
-    add_node_calls: Mutex<Vec<rms::AddNodeRequest>>,
+    create_nodes_responses: Mutex<VecDeque<Result<rms::CreateNodesResponse, RackManagerError>>>,
+    create_nodes_calls: Mutex<Vec<rms::CreateNodesRequest>>,
 
     update_node_responses: Mutex<VecDeque<Result<rms::UpdateNodeResponse, RackManagerError>>>,
     update_node_calls: Mutex<Vec<rms::UpdateNodeRequest>>,
 
-    remove_node_responses: Mutex<VecDeque<Result<rms::RemoveNodeResponse, RackManagerError>>>,
-    remove_node_calls: Mutex<Vec<rms::RemoveNodeRequest>>,
+    delete_node_responses: Mutex<VecDeque<Result<rms::DeleteNodeResponse, RackManagerError>>>,
+    delete_node_calls: Mutex<Vec<rms::DeleteNodeRequest>>,
 
     list_racks_responses: Mutex<VecDeque<Result<rms::ListRacksResponse, RackManagerError>>>,
     list_racks_calls: Mutex<Vec<rms::ListRacksRequest>>,
@@ -97,13 +97,13 @@ pub struct MockRmsApi {
         Mutex<VecDeque<Result<rms::GetNodeDeviceInfoResponse, RackManagerError>>>,
     get_node_device_info_calls: Mutex<Vec<rms::GetNodeDeviceInfoRequest>>,
 
-    get_device_info_by_node_type_responses:
-        Mutex<VecDeque<Result<rms::GetDeviceInfoByNodeTypeResponse, RackManagerError>>>,
-    get_device_info_by_node_type_calls: Mutex<Vec<rms::GetDeviceInfoByNodeTypeRequest>>,
+    list_node_device_info_by_node_type_responses:
+        Mutex<VecDeque<Result<rms::ListNodeDeviceInfoByNodeTypeResponse, RackManagerError>>>,
+    list_node_device_info_by_node_type_calls: Mutex<Vec<rms::ListNodeDeviceInfoByNodeTypeRequest>>,
 
-    get_device_info_by_device_list_responses:
-        Mutex<VecDeque<Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError>>>,
-    get_device_info_by_device_list_calls: Mutex<Vec<rms::GetDeviceInfoByDeviceListRequest>>,
+    batch_get_node_device_info_responses:
+        Mutex<VecDeque<Result<rms::BatchGetNodeDeviceInfoResponse, RackManagerError>>>,
+    batch_get_node_device_info_calls: Mutex<Vec<rms::BatchGetNodeDeviceInfoRequest>>,
 
     // Power-on sequence calls.
     get_rack_power_on_sequence_responses:
@@ -123,10 +123,12 @@ pub struct MockRmsApi {
         Mutex<VecDeque<Result<rms::GetRackFirmwareInventoryResponse, RackManagerError>>>,
     get_rack_firmware_inventory_calls: Mutex<Vec<rms::GetRackFirmwareInventoryRequest>>,
 
-    add_firmware_object_responses: Mutex<VecDeque<Result<rms::FirmwareObject, RackManagerError>>>,
+    add_firmware_object_responses:
+        Mutex<VecDeque<Result<rms::AddFirmwareObjectResponse, RackManagerError>>>,
     add_firmware_object_calls: Mutex<Vec<rms::AddFirmwareObjectRequest>>,
 
-    get_firmware_object_responses: Mutex<VecDeque<Result<rms::FirmwareObject, RackManagerError>>>,
+    get_firmware_object_responses:
+        Mutex<VecDeque<Result<rms::GetFirmwareObjectResponse, RackManagerError>>>,
     get_firmware_object_calls: Mutex<Vec<rms::GetFirmwareObjectRequest>>,
 
     list_firmware_objects_responses:
@@ -134,66 +136,69 @@ pub struct MockRmsApi {
     list_firmware_objects_calls: Mutex<Vec<rms::ListFirmwareObjectsRequest>>,
 
     delete_firmware_object_responses:
-        Mutex<VecDeque<Result<rms::OperationResponse, RackManagerError>>>,
+        Mutex<VecDeque<Result<rms::DeleteFirmwareObjectResponse, RackManagerError>>>,
     delete_firmware_object_calls: Mutex<Vec<rms::DeleteFirmwareObjectRequest>>,
 
     set_default_firmware_object_responses:
-        Mutex<VecDeque<Result<rms::FirmwareObject, RackManagerError>>>,
+        Mutex<VecDeque<Result<rms::SetDefaultFirmwareObjectResponse, RackManagerError>>>,
     set_default_firmware_object_calls: Mutex<Vec<rms::SetDefaultFirmwareObjectRequest>>,
+
+    apply_stored_firmware_object_responses:
+        Mutex<VecDeque<Result<rms::ApplyStoredFirmwareObjectResponse, RackManagerError>>>,
+    apply_stored_firmware_object_calls: Mutex<Vec<rms::ApplyStoredFirmwareObjectRequest>>,
 
     apply_firmware_object_responses:
         Mutex<VecDeque<Result<rms::ApplyFirmwareObjectResponse, RackManagerError>>>,
     apply_firmware_object_calls: Mutex<Vec<rms::ApplyFirmwareObjectRequest>>,
 
-    apply_firmware_object_from_json_responses:
-        Mutex<VecDeque<Result<rms::ApplyFirmwareObjectResponse, RackManagerError>>>,
-    apply_firmware_object_from_json_calls: Mutex<Vec<rms::ApplyFirmwareObjectFromJsonRequest>>,
-
-    apply_switch_system_image_from_json_responses:
-        Mutex<VecDeque<Result<rms::ApplySwitchSystemImageResponse, RackManagerError>>>,
-    apply_switch_system_image_from_json_calls:
-        Mutex<Vec<rms::ApplySwitchSystemImageFromJsonRequest>>,
-
     apply_switch_system_image_responses:
         Mutex<VecDeque<Result<rms::ApplySwitchSystemImageResponse, RackManagerError>>>,
     apply_switch_system_image_calls: Mutex<Vec<rms::ApplySwitchSystemImageRequest>>,
 
-    get_switch_system_image_job_status_responses:
-        Mutex<VecDeque<Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError>>>,
-    get_switch_system_image_job_status_calls: Mutex<Vec<rms::GetSwitchSystemImageJobStatusRequest>>,
+    apply_stored_switch_system_image_responses:
+        Mutex<VecDeque<Result<rms::ApplyStoredSwitchSystemImageResponse, RackManagerError>>>,
+    apply_stored_switch_system_image_calls: Mutex<Vec<rms::ApplyStoredSwitchSystemImageRequest>>,
 
     get_firmware_object_history_responses:
         Mutex<VecDeque<Result<rms::GetFirmwareObjectHistoryResponse, RackManagerError>>>,
     get_firmware_object_history_calls: Mutex<Vec<rms::GetFirmwareObjectHistoryRequest>>,
 
-    update_node_firmware_async_responses:
-        Mutex<VecDeque<Result<rms::UpdateNodeFirmwareResponse, RackManagerError>>>,
-    update_node_firmware_async_calls: Mutex<Vec<rms::UpdateNodeFirmwareRequest>>,
+    update_firmware_responses:
+        Mutex<VecDeque<Result<rms::UpdateFirmwareResponse, RackManagerError>>>,
+    update_firmware_calls: Mutex<Vec<rms::UpdateFirmwareRequest>>,
 
-    update_firmware_by_node_type_async_responses:
-        Mutex<VecDeque<Result<rms::UpdateFirmwareByNodeTypeAsyncResponse, RackManagerError>>>,
-    update_firmware_by_node_type_async_calls: Mutex<Vec<rms::UpdateFirmwareByNodeTypeRequest>>,
+    batch_update_firmware_by_node_type_responses:
+        Mutex<VecDeque<Result<rms::BatchUpdateFirmwareByNodeTypeResponse, RackManagerError>>>,
+    batch_update_firmware_by_node_type_calls: Mutex<Vec<rms::BatchUpdateFirmwareByNodeTypeRequest>>,
 
-    update_firmware_by_device_list_responses:
-        Mutex<VecDeque<Result<rms::UpdateFirmwareByDeviceListResponse, RackManagerError>>>,
-    update_firmware_by_device_list_calls: Mutex<Vec<rms::UpdateFirmwareByDeviceListRequest>>,
+    batch_update_firmware_responses:
+        Mutex<VecDeque<Result<rms::BatchUpdateFirmwareResponse, RackManagerError>>>,
+    batch_update_firmware_calls: Mutex<Vec<rms::BatchUpdateFirmwareRequest>>,
+
+    update_switch_system_image_responses:
+        Mutex<VecDeque<Result<rms::UpdateSwitchSystemImageResponse, RackManagerError>>>,
+    update_switch_system_image_calls: Mutex<Vec<rms::UpdateSwitchSystemImageRequest>>,
+
+    update_switch_system_password_responses:
+        Mutex<VecDeque<Result<rms::UpdateSwitchSystemPasswordResponse, RackManagerError>>>,
+    update_switch_system_password_calls: Mutex<Vec<rms::UpdateSwitchSystemPasswordRequest>>,
 
     get_firmware_job_status_responses:
         Mutex<VecDeque<Result<rms::GetFirmwareJobStatusResponse, RackManagerError>>>,
     get_firmware_job_status_calls: Mutex<Vec<rms::GetFirmwareJobStatusRequest>>,
 
     // Switch firmware calls.
-    list_firmware_on_switch_responses:
-        Mutex<VecDeque<Result<rms::ListFirmwareOnSwitchResponse, RackManagerError>>>,
-    list_firmware_on_switch_calls: Mutex<Vec<rms::ListFirmwareOnSwitchCommand>>,
+    list_switch_firmware_responses:
+        Mutex<VecDeque<Result<rms::ListSwitchFirmwareResponse, RackManagerError>>>,
+    list_switch_firmware_calls: Mutex<Vec<rms::ListSwitchFirmwareRequest>>,
 
-    push_firmware_to_switch_responses:
-        Mutex<VecDeque<Result<rms::PushFirmwareToSwitchResponse, RackManagerError>>>,
-    push_firmware_to_switch_calls: Mutex<Vec<rms::PushFirmwareToSwitchCommand>>,
+    push_switch_firmware_responses:
+        Mutex<VecDeque<Result<rms::PushSwitchFirmwareResponse, RackManagerError>>>,
+    push_switch_firmware_calls: Mutex<Vec<rms::PushSwitchFirmwareRequest>>,
 
-    upgrade_firmware_on_switch_responses:
-        Mutex<VecDeque<Result<rms::UpgradeFirmwareOnSwitchResponse, RackManagerError>>>,
-    upgrade_firmware_on_switch_calls: Mutex<Vec<rms::UpgradeFirmwareOnSwitchCommand>>,
+    upgrade_switch_firmware_responses:
+        Mutex<VecDeque<Result<rms::UpgradeSwitchFirmwareResponse, RackManagerError>>>,
+    upgrade_switch_firmware_calls: Mutex<Vec<rms::UpgradeSwitchFirmwareRequest>>,
 
     // Switch system images calls.
     fetch_switch_system_image_responses:
@@ -208,27 +213,40 @@ pub struct MockRmsApi {
         Mutex<VecDeque<Result<rms::ListSwitchSystemImagesResponse, RackManagerError>>>,
     list_switch_system_images_calls: Mutex<Vec<rms::ListSwitchSystemImagesRequest>>,
 
-    poll_job_status_responses:
-        Mutex<VecDeque<Result<rms::PollJobStatusResponse, RackManagerError>>>,
-    poll_job_status_calls: Mutex<Vec<rms::PollJobStatusCommand>>,
+    poll_switch_firmware_job_status_responses:
+        Mutex<VecDeque<Result<rms::PollSwitchFirmwareJobStatusResponse, RackManagerError>>>,
+    poll_switch_firmware_job_status_calls: Mutex<Vec<rms::PollSwitchFirmwareJobStatusRequest>>,
+
+    get_switch_system_image_job_status_responses:
+        Mutex<VecDeque<Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError>>>,
+    get_switch_system_image_job_status_calls: Mutex<Vec<rms::GetSwitchSystemImageJobStatusRequest>>,
 
     // Scale-up fabric calls.
     configure_scale_up_fabric_manager_responses:
         Mutex<VecDeque<Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError>>>,
     configure_scale_up_fabric_manager_calls: Mutex<Vec<rms::ConfigureScaleUpFabricManagerRequest>>,
 
-    set_scale_up_fabric_state_responses:
-        Mutex<VecDeque<Result<rms::SetScaleUpFabricStateResponse, RackManagerError>>>,
-    set_scale_up_fabric_state_calls: Mutex<Vec<rms::SetScaleUpFabricStateRequest>>,
+    batch_set_scale_up_fabric_state_responses:
+        Mutex<VecDeque<Result<rms::BatchSetScaleUpFabricStateResponse, RackManagerError>>>,
+    batch_set_scale_up_fabric_state_calls: Mutex<Vec<rms::BatchSetScaleUpFabricStateRequest>>,
 
-    enable_scale_up_fabric_telemetry_interface_responses: Mutex<
-        VecDeque<Result<rms::EnableScaleUpFabricTelemetryInterfaceResponse, RackManagerError>>,
+    batch_get_scale_up_fabric_service_status_responses:
+        Mutex<VecDeque<Result<rms::BatchGetScaleUpFabricServiceStatusResponse, RackManagerError>>>,
+    batch_get_scale_up_fabric_service_status_calls:
+        Mutex<Vec<rms::BatchGetScaleUpFabricServiceStatusRequest>>,
+
+    get_scale_up_fabric_state_responses:
+        Mutex<VecDeque<Result<rms::GetScaleUpFabricStateResponse, RackManagerError>>>,
+    get_scale_up_fabric_state_calls: Mutex<Vec<rms::GetScaleUpFabricStateRequest>>,
+
+    set_scale_up_fabric_telemetry_interface_state_responses: Mutex<
+        VecDeque<Result<rms::SetScaleUpFabricTelemetryInterfaceStateResponse, RackManagerError>>,
     >,
-    enable_scale_up_fabric_telemetry_interface_calls:
-        Mutex<Vec<rms::EnableScaleUpFabricTelemetryInterfaceRequest>>,
+    set_scale_up_fabric_telemetry_interface_state_calls:
+        Mutex<Vec<rms::SetScaleUpFabricTelemetryInterfaceStateRequest>>,
 
-    // Version (no request type).
-    version_responses: Mutex<VecDeque<Result<(), RackManagerError>>>,
+    // Version calls.
+    version_responses: Mutex<VecDeque<Result<rms::GetVersionResponse, RackManagerError>>>,
     version_call_count: Mutex<u32>,
 }
 
@@ -250,30 +268,30 @@ impl MockRmsApi {
         Self {
             set_power_state_responses: Default::default(),
             set_power_state_calls: Default::default(),
-            set_power_state_by_device_list_responses: Default::default(),
-            set_power_state_by_device_list_calls: Default::default(),
-            get_power_state_by_device_list_responses: Default::default(),
-            get_power_state_by_device_list_calls: Default::default(),
+            batch_set_power_state_responses: Default::default(),
+            batch_set_power_state_calls: Default::default(),
             get_power_state_responses: Default::default(),
             get_power_state_calls: Default::default(),
+            batch_get_power_state_responses: Default::default(),
+            batch_get_power_state_calls: Default::default(),
             sequence_rack_power_responses: Default::default(),
             sequence_rack_power_calls: Default::default(),
-            get_all_inventory_responses: Default::default(),
-            get_all_inventory_calls: Default::default(),
-            add_node_responses: Default::default(),
-            add_node_calls: Default::default(),
+            list_node_inventory_responses: Default::default(),
+            list_node_inventory_calls: Default::default(),
+            create_nodes_responses: Default::default(),
+            create_nodes_calls: Default::default(),
             update_node_responses: Default::default(),
             update_node_calls: Default::default(),
-            remove_node_responses: Default::default(),
-            remove_node_calls: Default::default(),
+            delete_node_responses: Default::default(),
+            delete_node_calls: Default::default(),
             list_racks_responses: Default::default(),
             list_racks_calls: Default::default(),
             get_node_device_info_responses: Default::default(),
             get_node_device_info_calls: Default::default(),
-            get_device_info_by_node_type_responses: Default::default(),
-            get_device_info_by_node_type_calls: Default::default(),
-            get_device_info_by_device_list_responses: Default::default(),
-            get_device_info_by_device_list_calls: Default::default(),
+            list_node_device_info_by_node_type_responses: Default::default(),
+            list_node_device_info_by_node_type_calls: Default::default(),
+            batch_get_node_device_info_responses: Default::default(),
+            batch_get_node_device_info_calls: Default::default(),
             get_rack_power_on_sequence_responses: Default::default(),
             get_rack_power_on_sequence_calls: Default::default(),
             set_rack_power_on_sequence_responses: Default::default(),
@@ -292,46 +310,54 @@ impl MockRmsApi {
             delete_firmware_object_calls: Default::default(),
             set_default_firmware_object_responses: Default::default(),
             set_default_firmware_object_calls: Default::default(),
+            apply_stored_firmware_object_responses: Default::default(),
+            apply_stored_firmware_object_calls: Default::default(),
             apply_firmware_object_responses: Default::default(),
             apply_firmware_object_calls: Default::default(),
-            apply_firmware_object_from_json_responses: Default::default(),
-            apply_firmware_object_from_json_calls: Default::default(),
-            apply_switch_system_image_from_json_responses: Default::default(),
-            apply_switch_system_image_from_json_calls: Default::default(),
             apply_switch_system_image_responses: Default::default(),
             apply_switch_system_image_calls: Default::default(),
-            get_switch_system_image_job_status_responses: Default::default(),
-            get_switch_system_image_job_status_calls: Default::default(),
+            apply_stored_switch_system_image_responses: Default::default(),
+            apply_stored_switch_system_image_calls: Default::default(),
             get_firmware_object_history_responses: Default::default(),
             get_firmware_object_history_calls: Default::default(),
-            update_node_firmware_async_responses: Default::default(),
-            update_node_firmware_async_calls: Default::default(),
-            update_firmware_by_node_type_async_responses: Default::default(),
-            update_firmware_by_node_type_async_calls: Default::default(),
-            update_firmware_by_device_list_responses: Default::default(),
-            update_firmware_by_device_list_calls: Default::default(),
+            update_firmware_responses: Default::default(),
+            update_firmware_calls: Default::default(),
+            batch_update_firmware_by_node_type_responses: Default::default(),
+            batch_update_firmware_by_node_type_calls: Default::default(),
+            batch_update_firmware_responses: Default::default(),
+            batch_update_firmware_calls: Default::default(),
+            update_switch_system_image_responses: Default::default(),
+            update_switch_system_image_calls: Default::default(),
+            update_switch_system_password_responses: Default::default(),
+            update_switch_system_password_calls: Default::default(),
             get_firmware_job_status_responses: Default::default(),
             get_firmware_job_status_calls: Default::default(),
-            list_firmware_on_switch_responses: Default::default(),
-            list_firmware_on_switch_calls: Default::default(),
-            push_firmware_to_switch_responses: Default::default(),
-            push_firmware_to_switch_calls: Default::default(),
-            upgrade_firmware_on_switch_responses: Default::default(),
-            upgrade_firmware_on_switch_calls: Default::default(),
+            list_switch_firmware_responses: Default::default(),
+            list_switch_firmware_calls: Default::default(),
+            push_switch_firmware_responses: Default::default(),
+            push_switch_firmware_calls: Default::default(),
+            upgrade_switch_firmware_responses: Default::default(),
+            upgrade_switch_firmware_calls: Default::default(),
             fetch_switch_system_image_responses: Default::default(),
             fetch_switch_system_image_calls: Default::default(),
             install_switch_system_image_responses: Default::default(),
             install_switch_system_image_calls: Default::default(),
             list_switch_system_images_responses: Default::default(),
             list_switch_system_images_calls: Default::default(),
-            poll_job_status_responses: Default::default(),
-            poll_job_status_calls: Default::default(),
+            poll_switch_firmware_job_status_responses: Default::default(),
+            poll_switch_firmware_job_status_calls: Default::default(),
+            get_switch_system_image_job_status_responses: Default::default(),
+            get_switch_system_image_job_status_calls: Default::default(),
             configure_scale_up_fabric_manager_responses: Default::default(),
             configure_scale_up_fabric_manager_calls: Default::default(),
-            set_scale_up_fabric_state_responses: Default::default(),
-            set_scale_up_fabric_state_calls: Default::default(),
-            enable_scale_up_fabric_telemetry_interface_responses: Default::default(),
-            enable_scale_up_fabric_telemetry_interface_calls: Default::default(),
+            batch_set_scale_up_fabric_state_responses: Default::default(),
+            batch_set_scale_up_fabric_state_calls: Default::default(),
+            batch_get_scale_up_fabric_service_status_responses: Default::default(),
+            batch_get_scale_up_fabric_service_status_calls: Default::default(),
+            get_scale_up_fabric_state_responses: Default::default(),
+            get_scale_up_fabric_state_calls: Default::default(),
+            set_scale_up_fabric_telemetry_interface_state_responses: Default::default(),
+            set_scale_up_fabric_telemetry_interface_state_calls: Default::default(),
             version_responses: Default::default(),
             version_call_count: Default::default(),
         }
@@ -352,12 +378,12 @@ impl MockRmsApi {
         rms::SetPowerStateResponse
     );
     impl_enqueue_inspect!(
-        enqueue_set_power_state_by_device_list,
-        set_power_state_by_device_list_calls,
-        set_power_state_by_device_list_responses,
-        set_power_state_by_device_list_calls,
-        rms::SetPowerStateByDeviceListRequest,
-        rms::SetPowerStateByDeviceListResponse
+        enqueue_batch_set_power_state,
+        batch_set_power_state_calls,
+        batch_set_power_state_responses,
+        batch_set_power_state_calls,
+        rms::BatchSetPowerStateRequest,
+        rms::BatchSetPowerStateResponse
     );
     impl_enqueue_inspect!(
         enqueue_get_power_state,
@@ -366,6 +392,14 @@ impl MockRmsApi {
         get_power_state_calls,
         rms::GetPowerStateRequest,
         rms::GetPowerStateResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_batch_get_power_state,
+        batch_get_power_state_calls,
+        batch_get_power_state_responses,
+        batch_get_power_state_calls,
+        rms::BatchGetPowerStateRequest,
+        rms::BatchGetPowerStateResponse
     );
     impl_enqueue_inspect!(
         enqueue_sequence_rack_power,
@@ -378,20 +412,20 @@ impl MockRmsApi {
 
     // Inventory
     impl_enqueue_inspect!(
-        enqueue_get_all_inventory,
-        get_all_inventory_calls,
-        get_all_inventory_responses,
-        get_all_inventory_calls,
-        rms::GetAllInventoryRequest,
-        rms::GetAllInventoryResponse
+        enqueue_list_node_inventory,
+        list_node_inventory_calls,
+        list_node_inventory_responses,
+        list_node_inventory_calls,
+        rms::ListNodeInventoryRequest,
+        rms::ListNodeInventoryResponse
     );
     impl_enqueue_inspect!(
-        enqueue_add_node,
-        add_node_calls,
-        add_node_responses,
-        add_node_calls,
-        rms::AddNodeRequest,
-        rms::AddNodeResponse
+        enqueue_create_nodes,
+        create_nodes_calls,
+        create_nodes_responses,
+        create_nodes_calls,
+        rms::CreateNodesRequest,
+        rms::CreateNodesResponse
     );
     impl_enqueue_inspect!(
         enqueue_update_node,
@@ -402,12 +436,12 @@ impl MockRmsApi {
         rms::UpdateNodeResponse
     );
     impl_enqueue_inspect!(
-        enqueue_remove_node,
-        remove_node_calls,
-        remove_node_responses,
-        remove_node_calls,
-        rms::RemoveNodeRequest,
-        rms::RemoveNodeResponse
+        enqueue_delete_node,
+        delete_node_calls,
+        delete_node_responses,
+        delete_node_calls,
+        rms::DeleteNodeRequest,
+        rms::DeleteNodeResponse
     );
     impl_enqueue_inspect!(
         enqueue_list_racks,
@@ -428,20 +462,20 @@ impl MockRmsApi {
         rms::GetNodeDeviceInfoResponse
     );
     impl_enqueue_inspect!(
-        enqueue_get_device_info_by_node_type,
-        get_device_info_by_node_type_calls,
-        get_device_info_by_node_type_responses,
-        get_device_info_by_node_type_calls,
-        rms::GetDeviceInfoByNodeTypeRequest,
-        rms::GetDeviceInfoByNodeTypeResponse
+        enqueue_list_node_device_info_by_node_type,
+        list_node_device_info_by_node_type_calls,
+        list_node_device_info_by_node_type_responses,
+        list_node_device_info_by_node_type_calls,
+        rms::ListNodeDeviceInfoByNodeTypeRequest,
+        rms::ListNodeDeviceInfoByNodeTypeResponse
     );
     impl_enqueue_inspect!(
-        enqueue_get_device_info_by_device_list,
-        get_device_info_by_device_list_calls,
-        get_device_info_by_device_list_responses,
-        get_device_info_by_device_list_calls,
-        rms::GetDeviceInfoByDeviceListRequest,
-        rms::GetDeviceInfoByDeviceListResponse
+        enqueue_batch_get_node_device_info,
+        batch_get_node_device_info_calls,
+        batch_get_node_device_info_responses,
+        batch_get_node_device_info_calls,
+        rms::BatchGetNodeDeviceInfoRequest,
+        rms::BatchGetNodeDeviceInfoResponse
     );
 
     // Power-on sequence
@@ -485,7 +519,7 @@ impl MockRmsApi {
         add_firmware_object_responses,
         add_firmware_object_calls,
         rms::AddFirmwareObjectRequest,
-        rms::FirmwareObject
+        rms::AddFirmwareObjectResponse
     );
     impl_enqueue_inspect!(
         enqueue_get_firmware_object,
@@ -493,7 +527,7 @@ impl MockRmsApi {
         get_firmware_object_responses,
         get_firmware_object_calls,
         rms::GetFirmwareObjectRequest,
-        rms::FirmwareObject
+        rms::GetFirmwareObjectResponse
     );
     impl_enqueue_inspect!(
         enqueue_list_firmware_objects,
@@ -509,7 +543,7 @@ impl MockRmsApi {
         delete_firmware_object_responses,
         delete_firmware_object_calls,
         rms::DeleteFirmwareObjectRequest,
-        rms::OperationResponse
+        rms::DeleteFirmwareObjectResponse
     );
     impl_enqueue_inspect!(
         enqueue_set_default_firmware_object,
@@ -517,7 +551,15 @@ impl MockRmsApi {
         set_default_firmware_object_responses,
         set_default_firmware_object_calls,
         rms::SetDefaultFirmwareObjectRequest,
-        rms::FirmwareObject
+        rms::SetDefaultFirmwareObjectResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_apply_stored_firmware_object,
+        apply_stored_firmware_object_calls,
+        apply_stored_firmware_object_responses,
+        apply_stored_firmware_object_calls,
+        rms::ApplyStoredFirmwareObjectRequest,
+        rms::ApplyStoredFirmwareObjectResponse
     );
     impl_enqueue_inspect!(
         enqueue_apply_firmware_object,
@@ -528,22 +570,6 @@ impl MockRmsApi {
         rms::ApplyFirmwareObjectResponse
     );
     impl_enqueue_inspect!(
-        enqueue_apply_firmware_object_from_json,
-        apply_firmware_object_from_json_calls,
-        apply_firmware_object_from_json_responses,
-        apply_firmware_object_from_json_calls,
-        rms::ApplyFirmwareObjectFromJsonRequest,
-        rms::ApplyFirmwareObjectResponse
-    );
-    impl_enqueue_inspect!(
-        enqueue_apply_switch_system_image_from_json,
-        apply_switch_system_image_from_json_calls,
-        apply_switch_system_image_from_json_responses,
-        apply_switch_system_image_from_json_calls,
-        rms::ApplySwitchSystemImageFromJsonRequest,
-        rms::ApplySwitchSystemImageResponse
-    );
-    impl_enqueue_inspect!(
         enqueue_apply_switch_system_image,
         apply_switch_system_image_calls,
         apply_switch_system_image_responses,
@@ -552,12 +578,12 @@ impl MockRmsApi {
         rms::ApplySwitchSystemImageResponse
     );
     impl_enqueue_inspect!(
-        enqueue_get_switch_system_image_job_status,
-        get_switch_system_image_job_status_calls,
-        get_switch_system_image_job_status_responses,
-        get_switch_system_image_job_status_calls,
-        rms::GetSwitchSystemImageJobStatusRequest,
-        rms::GetSwitchSystemImageJobStatusResponse
+        enqueue_apply_stored_switch_system_image,
+        apply_stored_switch_system_image_calls,
+        apply_stored_switch_system_image_responses,
+        apply_stored_switch_system_image_calls,
+        rms::ApplyStoredSwitchSystemImageRequest,
+        rms::ApplyStoredSwitchSystemImageResponse
     );
     impl_enqueue_inspect!(
         enqueue_get_firmware_object_history,
@@ -568,28 +594,44 @@ impl MockRmsApi {
         rms::GetFirmwareObjectHistoryResponse
     );
     impl_enqueue_inspect!(
-        enqueue_update_node_firmware_async,
-        update_node_firmware_async_calls,
-        update_node_firmware_async_responses,
-        update_node_firmware_async_calls,
-        rms::UpdateNodeFirmwareRequest,
-        rms::UpdateNodeFirmwareResponse
+        enqueue_update_firmware,
+        update_firmware_calls,
+        update_firmware_responses,
+        update_firmware_calls,
+        rms::UpdateFirmwareRequest,
+        rms::UpdateFirmwareResponse
     );
     impl_enqueue_inspect!(
-        enqueue_update_firmware_by_node_type_async,
-        update_firmware_by_node_type_async_calls,
-        update_firmware_by_node_type_async_responses,
-        update_firmware_by_node_type_async_calls,
-        rms::UpdateFirmwareByNodeTypeRequest,
-        rms::UpdateFirmwareByNodeTypeAsyncResponse
+        enqueue_batch_update_firmware_by_node_type,
+        batch_update_firmware_by_node_type_calls,
+        batch_update_firmware_by_node_type_responses,
+        batch_update_firmware_by_node_type_calls,
+        rms::BatchUpdateFirmwareByNodeTypeRequest,
+        rms::BatchUpdateFirmwareByNodeTypeResponse
     );
     impl_enqueue_inspect!(
-        enqueue_update_firmware_by_device_list,
-        update_firmware_by_device_list_calls,
-        update_firmware_by_device_list_responses,
-        update_firmware_by_device_list_calls,
-        rms::UpdateFirmwareByDeviceListRequest,
-        rms::UpdateFirmwareByDeviceListResponse
+        enqueue_batch_update_firmware,
+        batch_update_firmware_calls,
+        batch_update_firmware_responses,
+        batch_update_firmware_calls,
+        rms::BatchUpdateFirmwareRequest,
+        rms::BatchUpdateFirmwareResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_update_switch_system_image,
+        update_switch_system_image_calls,
+        update_switch_system_image_responses,
+        update_switch_system_image_calls,
+        rms::UpdateSwitchSystemImageRequest,
+        rms::UpdateSwitchSystemImageResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_update_switch_system_password,
+        update_switch_system_password_calls,
+        update_switch_system_password_responses,
+        update_switch_system_password_calls,
+        rms::UpdateSwitchSystemPasswordRequest,
+        rms::UpdateSwitchSystemPasswordResponse
     );
     impl_enqueue_inspect!(
         enqueue_get_firmware_job_status,
@@ -602,28 +644,28 @@ impl MockRmsApi {
 
     // Switch firmware
     impl_enqueue_inspect!(
-        enqueue_list_firmware_on_switch,
-        list_firmware_on_switch_calls,
-        list_firmware_on_switch_responses,
-        list_firmware_on_switch_calls,
-        rms::ListFirmwareOnSwitchCommand,
-        rms::ListFirmwareOnSwitchResponse
+        enqueue_list_switch_firmware,
+        list_switch_firmware_calls,
+        list_switch_firmware_responses,
+        list_switch_firmware_calls,
+        rms::ListSwitchFirmwareRequest,
+        rms::ListSwitchFirmwareResponse
     );
     impl_enqueue_inspect!(
-        enqueue_push_firmware_to_switch,
-        push_firmware_to_switch_calls,
-        push_firmware_to_switch_responses,
-        push_firmware_to_switch_calls,
-        rms::PushFirmwareToSwitchCommand,
-        rms::PushFirmwareToSwitchResponse
+        enqueue_push_switch_firmware,
+        push_switch_firmware_calls,
+        push_switch_firmware_responses,
+        push_switch_firmware_calls,
+        rms::PushSwitchFirmwareRequest,
+        rms::PushSwitchFirmwareResponse
     );
     impl_enqueue_inspect!(
-        enqueue_upgrade_firmware_on_switch,
-        upgrade_firmware_on_switch_calls,
-        upgrade_firmware_on_switch_responses,
-        upgrade_firmware_on_switch_calls,
-        rms::UpgradeFirmwareOnSwitchCommand,
-        rms::UpgradeFirmwareOnSwitchResponse
+        enqueue_upgrade_switch_firmware,
+        upgrade_switch_firmware_calls,
+        upgrade_switch_firmware_responses,
+        upgrade_switch_firmware_calls,
+        rms::UpgradeSwitchFirmwareRequest,
+        rms::UpgradeSwitchFirmwareResponse
     );
 
     // Switch system images
@@ -652,12 +694,20 @@ impl MockRmsApi {
         rms::ListSwitchSystemImagesResponse
     );
     impl_enqueue_inspect!(
-        enqueue_poll_job_status,
-        poll_job_status_calls,
-        poll_job_status_responses,
-        poll_job_status_calls,
-        rms::PollJobStatusCommand,
-        rms::PollJobStatusResponse
+        enqueue_poll_switch_firmware_job_status,
+        poll_switch_firmware_job_status_calls,
+        poll_switch_firmware_job_status_responses,
+        poll_switch_firmware_job_status_calls,
+        rms::PollSwitchFirmwareJobStatusRequest,
+        rms::PollSwitchFirmwareJobStatusResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_get_switch_system_image_job_status,
+        get_switch_system_image_job_status_calls,
+        get_switch_system_image_job_status_responses,
+        get_switch_system_image_job_status_calls,
+        rms::GetSwitchSystemImageJobStatusRequest,
+        rms::GetSwitchSystemImageJobStatusResponse
     );
 
     // Scale-up fabric
@@ -670,24 +720,40 @@ impl MockRmsApi {
         rms::ConfigureScaleUpFabricManagerResponse
     );
     impl_enqueue_inspect!(
-        enqueue_set_scale_up_fabric_state,
-        set_scale_up_fabric_state_calls,
-        set_scale_up_fabric_state_responses,
-        set_scale_up_fabric_state_calls,
-        rms::SetScaleUpFabricStateRequest,
-        rms::SetScaleUpFabricStateResponse
+        enqueue_batch_set_scale_up_fabric_state,
+        batch_set_scale_up_fabric_state_calls,
+        batch_set_scale_up_fabric_state_responses,
+        batch_set_scale_up_fabric_state_calls,
+        rms::BatchSetScaleUpFabricStateRequest,
+        rms::BatchSetScaleUpFabricStateResponse
     );
     impl_enqueue_inspect!(
-        enqueue_enable_scale_up_fabric_telemetry_interface,
-        enable_scale_up_fabric_telemetry_interface_calls,
-        enable_scale_up_fabric_telemetry_interface_responses,
-        enable_scale_up_fabric_telemetry_interface_calls,
-        rms::EnableScaleUpFabricTelemetryInterfaceRequest,
-        rms::EnableScaleUpFabricTelemetryInterfaceResponse
+        enqueue_batch_get_scale_up_fabric_service_status,
+        batch_get_scale_up_fabric_service_status_calls,
+        batch_get_scale_up_fabric_service_status_responses,
+        batch_get_scale_up_fabric_service_status_calls,
+        rms::BatchGetScaleUpFabricServiceStatusRequest,
+        rms::BatchGetScaleUpFabricServiceStatusResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_get_scale_up_fabric_state,
+        get_scale_up_fabric_state_calls,
+        get_scale_up_fabric_state_responses,
+        get_scale_up_fabric_state_calls,
+        rms::GetScaleUpFabricStateRequest,
+        rms::GetScaleUpFabricStateResponse
+    );
+    impl_enqueue_inspect!(
+        enqueue_set_scale_up_fabric_telemetry_interface_state,
+        set_scale_up_fabric_telemetry_interface_state_calls,
+        set_scale_up_fabric_telemetry_interface_state_responses,
+        set_scale_up_fabric_telemetry_interface_state_calls,
+        rms::SetScaleUpFabricTelemetryInterfaceStateRequest,
+        rms::SetScaleUpFabricTelemetryInterfaceStateResponse
     );
 
-    // Version (special — no request type)
-    pub async fn enqueue_version(&self, resp: Result<(), RackManagerError>) {
+    // The RmsApi wrapper exposes get_version without a request argument.
+    pub async fn enqueue_version(&self, resp: Result<rms::GetVersionResponse, RackManagerError>) {
         self.version_responses.lock().await.push_back(resp);
     }
 
@@ -701,7 +767,6 @@ impl MockRmsApi {
     pub fn power_ok() -> rms::SetPowerStateResponse {
         rms::SetPowerStateResponse {
             status: rms::ReturnCode::Success as i32,
-            ..Default::default()
         }
     }
 
@@ -709,20 +774,21 @@ impl MockRmsApi {
     pub fn power_fail() -> rms::SetPowerStateResponse {
         rms::SetPowerStateResponse {
             status: rms::ReturnCode::Failure as i32,
-            ..Default::default()
         }
     }
 
-    /// Success response for `set_power_state_by_device_list` covering a
+    /// Success response for `batch_set_power_state` covering a
     /// single targeted node.
-    pub fn power_by_device_list_ok(node_id: &str) -> rms::SetPowerStateByDeviceListResponse {
-        rms::SetPowerStateByDeviceListResponse {
+    pub fn batch_set_power_state_ok(node_id: &str) -> rms::BatchSetPowerStateResponse {
+        rms::BatchSetPowerStateResponse {
             response: Some(rms::NodeBatchResponse {
                 status: rms::ReturnCode::Success as i32,
-                total_nodes: 1,
-                successful_nodes: 1,
-                failed_nodes: 0,
-                node_results: vec![rms::NodeResult {
+                stats: Some(rms::NodeOperationStats {
+                    total_nodes: 1,
+                    successful_nodes: 1,
+                    failed_nodes: 0,
+                }),
+                node_results: vec![rms::NodeOperationResult {
                     node_id: node_id.to_owned(),
                     status: rms::ReturnCode::Success as i32,
                     error_message: String::new(),
@@ -732,21 +798,23 @@ impl MockRmsApi {
         }
     }
 
-    /// Failure response for `set_power_state_by_device_list` covering a
+    /// Failure response for `batch_set_power_state` covering a
     /// single targeted node, with an optional batch-level message and
     /// per-node `error_message`.
-    pub fn power_by_device_list_fail(
+    pub fn batch_set_power_state_fail(
         node_id: &str,
         node_error_message: &str,
-    ) -> rms::SetPowerStateByDeviceListResponse {
-        rms::SetPowerStateByDeviceListResponse {
+    ) -> rms::BatchSetPowerStateResponse {
+        rms::BatchSetPowerStateResponse {
             response: Some(rms::NodeBatchResponse {
                 status: rms::ReturnCode::Failure as i32,
-                total_nodes: 1,
-                successful_nodes: 0,
-                failed_nodes: 1,
                 message: String::new(),
-                node_results: vec![rms::NodeResult {
+                stats: Some(rms::NodeOperationStats {
+                    total_nodes: 1,
+                    successful_nodes: 0,
+                    failed_nodes: 1,
+                }),
+                node_results: vec![rms::NodeOperationResult {
                     node_id: node_id.to_owned(),
                     status: rms::ReturnCode::Failure as i32,
                     error_message: node_error_message.to_owned(),
@@ -756,25 +824,25 @@ impl MockRmsApi {
         }
     }
 
-    /// Success response for `update_node_firmware_async` with a job ID.
-    pub fn firmware_update_ok(job_id: &str) -> rms::UpdateNodeFirmwareResponse {
-        rms::UpdateNodeFirmwareResponse {
+    /// Success response for `update_firmware` with a job ID.
+    pub fn firmware_update_ok(job_id: &str) -> rms::UpdateFirmwareResponse {
+        rms::UpdateFirmwareResponse {
             status: rms::ReturnCode::Success as i32,
             job_id: job_id.to_owned(),
             ..Default::default()
         }
     }
 
-    /// Failure response for `update_node_firmware_async`.
-    pub fn firmware_update_fail(msg: &str) -> rms::UpdateNodeFirmwareResponse {
-        rms::UpdateNodeFirmwareResponse {
+    /// Failure response for `update_firmware`.
+    pub fn firmware_update_fail(msg: &str) -> rms::UpdateFirmwareResponse {
+        rms::UpdateFirmwareResponse {
             status: rms::ReturnCode::Failure as i32,
             message: msg.to_owned(),
             ..Default::default()
         }
     }
 
-    /// Success response for `apply_firmware_object_from_json` with a child job ID.
+    /// Success response for `apply_firmware_object` with a child job ID.
     pub fn firmware_object_apply_ok(
         node_id: &str,
         job_id: &str,
@@ -782,17 +850,19 @@ impl MockRmsApi {
         rms::ApplyFirmwareObjectResponse {
             response: Some(rms::NodeBatchResponse {
                 status: rms::ReturnCode::Success as i32,
-                total_nodes: 1,
-                successful_nodes: 1,
-                failed_nodes: 0,
-                node_results: vec![rms::NodeResult {
+                stats: Some(rms::NodeOperationStats {
+                    total_nodes: 1,
+                    successful_nodes: 1,
+                    failed_nodes: 0,
+                }),
+                node_results: vec![rms::NodeOperationResult {
                     node_id: node_id.to_owned(),
                     status: rms::ReturnCode::Success as i32,
                     error_message: String::new(),
                 }],
                 ..Default::default()
             }),
-            node_jobs: vec![rms::NodeFirmwareJobInfo {
+            jobs: vec![rms::NodeFirmwareJobInfo {
                 node_id: node_id.to_owned(),
                 job_id: job_id.to_owned(),
             }],
@@ -800,7 +870,7 @@ impl MockRmsApi {
         }
     }
 
-    /// Failure response for `apply_firmware_object_from_json`.
+    /// Failure response for `apply_firmware_object`.
     pub fn firmware_object_apply_fail(
         node_id: &str,
         msg: &str,
@@ -808,22 +878,24 @@ impl MockRmsApi {
         rms::ApplyFirmwareObjectResponse {
             response: Some(rms::NodeBatchResponse {
                 status: rms::ReturnCode::Failure as i32,
-                total_nodes: 1,
-                successful_nodes: 0,
-                failed_nodes: 1,
-                node_results: vec![rms::NodeResult {
+                stats: Some(rms::NodeOperationStats {
+                    total_nodes: 1,
+                    successful_nodes: 0,
+                    failed_nodes: 1,
+                }),
+                node_results: vec![rms::NodeOperationResult {
                     node_id: node_id.to_owned(),
                     status: rms::ReturnCode::Failure as i32,
                     error_message: msg.to_owned(),
                 }],
                 ..Default::default()
             }),
-            node_jobs: Vec::new(),
+            jobs: Vec::new(),
             object_id: "fw-json".to_owned(),
         }
     }
 
-    /// Success response for `apply_switch_system_image_from_json` with a child job ID.
+    /// Success response for `apply_switch_system_image` with a child job ID.
     pub fn switch_system_image_apply_ok(
         node_id: &str,
         job_id: &str,
@@ -831,17 +903,19 @@ impl MockRmsApi {
         rms::ApplySwitchSystemImageResponse {
             response: Some(rms::NodeBatchResponse {
                 status: rms::ReturnCode::Success as i32,
-                total_nodes: 1,
-                successful_nodes: 1,
-                failed_nodes: 0,
-                node_results: vec![rms::NodeResult {
+                stats: Some(rms::NodeOperationStats {
+                    total_nodes: 1,
+                    successful_nodes: 1,
+                    failed_nodes: 0,
+                }),
+                node_results: vec![rms::NodeOperationResult {
                     node_id: node_id.to_owned(),
                     status: rms::ReturnCode::Success as i32,
                     error_message: String::new(),
                 }],
                 ..Default::default()
             }),
-            node_jobs: vec![rms::SwitchSystemImageUpdateJobInfo {
+            jobs: vec![rms::SwitchSystemImageUpdateJobInfo {
                 node_id: node_id.to_owned(),
                 job_id: job_id.to_owned(),
             }],
@@ -850,7 +924,7 @@ impl MockRmsApi {
         }
     }
 
-    /// Failure response for `apply_switch_system_image_from_json`.
+    /// Failure response for `apply_switch_system_image`.
     pub fn switch_system_image_apply_fail(
         node_id: &str,
         msg: &str,
@@ -858,17 +932,19 @@ impl MockRmsApi {
         rms::ApplySwitchSystemImageResponse {
             response: Some(rms::NodeBatchResponse {
                 status: rms::ReturnCode::Failure as i32,
-                total_nodes: 1,
-                successful_nodes: 0,
-                failed_nodes: 1,
-                node_results: vec![rms::NodeResult {
+                stats: Some(rms::NodeOperationStats {
+                    total_nodes: 1,
+                    successful_nodes: 0,
+                    failed_nodes: 1,
+                }),
+                node_results: vec![rms::NodeOperationResult {
                     node_id: node_id.to_owned(),
                     status: rms::ReturnCode::Failure as i32,
                     error_message: msg.to_owned(),
                 }],
                 ..Default::default()
             }),
-            node_jobs: Vec::new(),
+            jobs: Vec::new(),
             object_id: "fw-json".to_owned(),
             image_filename: "nvos.img".to_owned(),
         }
@@ -885,9 +961,11 @@ impl MockRmsApi {
         }
     }
 
-    /// Success response for `poll_job_status`.
-    pub fn poll_job_status_ok(state: &str) -> rms::PollJobStatusResponse {
-        rms::PollJobStatusResponse {
+    /// Success response for `poll_switch_firmware_job_status`.
+    pub fn poll_switch_firmware_job_status_ok(
+        state: &str,
+    ) -> rms::PollSwitchFirmwareJobStatusResponse {
+        rms::PollSwitchFirmwareJobStatusResponse {
             status: rms::ReturnCode::Success as i32,
             state: state.to_owned(),
             ..Default::default()
@@ -935,7 +1013,6 @@ impl MockRmsApi {
                     ..Default::default()
                 })
                 .collect(),
-            ..Default::default()
         }
     }
 
@@ -965,16 +1042,6 @@ fn pop_or_err<T>(
 
 #[async_trait::async_trait]
 impl RmsApi for MockRmsApi {
-    async fn get_power_state_by_device_list(
-        &self,
-        cmd: rms::GetPowerStateByDeviceListRequest,
-    ) -> Result<rms::GetPowerStateByDeviceListResponse, RackManagerError> {
-        self.get_power_state_by_device_list_calls
-            .lock()
-            .await
-            .push(cmd);
-        pop_or_err(&mut self.get_power_state_by_device_list_responses.lock().await)
-    }
     async fn set_power_state(
         &self,
         cmd: rms::SetPowerStateRequest,
@@ -982,21 +1049,22 @@ impl RmsApi for MockRmsApi {
         self.set_power_state_calls.lock().await.push(cmd);
         pop_or_err(&mut self.set_power_state_responses.lock().await)
     }
-    async fn set_power_state_by_device_list(
+    async fn batch_set_power_state(
         &self,
-        cmd: rms::SetPowerStateByDeviceListRequest,
-    ) -> Result<rms::SetPowerStateByDeviceListResponse, RackManagerError> {
-        self.set_power_state_by_device_list_calls
-            .lock()
-            .await
-            .push(cmd);
-        pop_or_err(&mut self.set_power_state_by_device_list_responses.lock().await)
+        cmd: rms::BatchSetPowerStateRequest,
+    ) -> Result<rms::BatchSetPowerStateResponse, RackManagerError> {
+        self.batch_set_power_state_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.batch_set_power_state_responses.lock().await)
     }
     async fn update_switch_system_password(
         &self,
-        _cmd: rms::UpdateSwitchSystemPasswordRequest,
+        cmd: rms::UpdateSwitchSystemPasswordRequest,
     ) -> Result<rms::UpdateSwitchSystemPasswordResponse, RackManagerError> {
-        Ok(rms::UpdateSwitchSystemPasswordResponse::default())
+        self.update_switch_system_password_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.update_switch_system_password_responses.lock().await)
     }
     async fn get_power_state(
         &self,
@@ -1005,6 +1073,15 @@ impl RmsApi for MockRmsApi {
         self.get_power_state_calls.lock().await.push(cmd);
         pop_or_err(&mut self.get_power_state_responses.lock().await)
     }
+
+    async fn batch_get_power_state(
+        &self,
+        cmd: rms::BatchGetPowerStateRequest,
+    ) -> Result<rms::BatchGetPowerStateResponse, RackManagerError> {
+        self.batch_get_power_state_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.batch_get_power_state_responses.lock().await)
+    }
+
     async fn sequence_rack_power(
         &self,
         cmd: rms::SequenceRackPowerRequest,
@@ -1012,19 +1089,21 @@ impl RmsApi for MockRmsApi {
         self.sequence_rack_power_calls.lock().await.push(cmd);
         pop_or_err(&mut self.sequence_rack_power_responses.lock().await)
     }
-    async fn get_all_inventory(
+    async fn list_node_inventory(
         &self,
-        cmd: rms::GetAllInventoryRequest,
-    ) -> Result<rms::GetAllInventoryResponse, RackManagerError> {
-        self.get_all_inventory_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.get_all_inventory_responses.lock().await)
+    ) -> Result<rms::ListNodeInventoryResponse, RackManagerError> {
+        self.list_node_inventory_calls
+            .lock()
+            .await
+            .push(rms::ListNodeInventoryRequest::default());
+        pop_or_err(&mut self.list_node_inventory_responses.lock().await)
     }
-    async fn add_node(
+    async fn create_nodes(
         &self,
-        cmd: rms::AddNodeRequest,
-    ) -> Result<rms::AddNodeResponse, RackManagerError> {
-        self.add_node_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.add_node_responses.lock().await)
+        cmd: rms::CreateNodesRequest,
+    ) -> Result<rms::CreateNodesResponse, RackManagerError> {
+        self.create_nodes_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.create_nodes_responses.lock().await)
     }
     async fn update_node(
         &self,
@@ -1033,18 +1112,18 @@ impl RmsApi for MockRmsApi {
         self.update_node_calls.lock().await.push(cmd);
         pop_or_err(&mut self.update_node_responses.lock().await)
     }
-    async fn remove_node(
+    async fn delete_node(
         &self,
-        cmd: rms::RemoveNodeRequest,
-    ) -> Result<rms::RemoveNodeResponse, RackManagerError> {
-        self.remove_node_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.remove_node_responses.lock().await)
+        cmd: rms::DeleteNodeRequest,
+    ) -> Result<rms::DeleteNodeResponse, RackManagerError> {
+        self.delete_node_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.delete_node_responses.lock().await)
     }
-    async fn list_racks(
-        &self,
-        cmd: rms::ListRacksRequest,
-    ) -> Result<rms::ListRacksResponse, RackManagerError> {
-        self.list_racks_calls.lock().await.push(cmd);
+    async fn list_racks(&self) -> Result<rms::ListRacksResponse, RackManagerError> {
+        self.list_racks_calls
+            .lock()
+            .await
+            .push(rms::ListRacksRequest::default());
         pop_or_err(&mut self.list_racks_responses.lock().await)
     }
     async fn get_node_device_info(
@@ -1054,25 +1133,27 @@ impl RmsApi for MockRmsApi {
         self.get_node_device_info_calls.lock().await.push(cmd);
         pop_or_err(&mut self.get_node_device_info_responses.lock().await)
     }
-    async fn get_device_info_by_node_type(
+    async fn list_node_device_info_by_node_type(
         &self,
-        cmd: rms::GetDeviceInfoByNodeTypeRequest,
-    ) -> Result<rms::GetDeviceInfoByNodeTypeResponse, RackManagerError> {
-        self.get_device_info_by_node_type_calls
+        cmd: rms::ListNodeDeviceInfoByNodeTypeRequest,
+    ) -> Result<rms::ListNodeDeviceInfoByNodeTypeResponse, RackManagerError> {
+        self.list_node_device_info_by_node_type_calls
             .lock()
             .await
             .push(cmd);
-        pop_or_err(&mut self.get_device_info_by_node_type_responses.lock().await)
+        pop_or_err(
+            &mut self
+                .list_node_device_info_by_node_type_responses
+                .lock()
+                .await,
+        )
     }
-    async fn get_device_info_by_device_list(
+    async fn batch_get_node_device_info(
         &self,
-        cmd: rms::GetDeviceInfoByDeviceListRequest,
-    ) -> Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError> {
-        self.get_device_info_by_device_list_calls
-            .lock()
-            .await
-            .push(cmd);
-        pop_or_err(&mut self.get_device_info_by_device_list_responses.lock().await)
+        cmd: rms::BatchGetNodeDeviceInfoRequest,
+    ) -> Result<rms::BatchGetNodeDeviceInfoResponse, RackManagerError> {
+        self.batch_get_node_device_info_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.batch_get_node_device_info_responses.lock().await)
     }
     async fn get_rack_power_on_sequence(
         &self,
@@ -1111,17 +1192,19 @@ impl RmsApi for MockRmsApi {
     async fn add_firmware_object(
         &self,
         cmd: rms::AddFirmwareObjectRequest,
-    ) -> Result<rms::FirmwareObject, RackManagerError> {
+    ) -> Result<rms::AddFirmwareObjectResponse, RackManagerError> {
         self.add_firmware_object_calls.lock().await.push(cmd);
         pop_or_err(&mut self.add_firmware_object_responses.lock().await)
     }
+
     async fn get_firmware_object(
         &self,
         cmd: rms::GetFirmwareObjectRequest,
-    ) -> Result<rms::FirmwareObject, RackManagerError> {
+    ) -> Result<rms::GetFirmwareObjectResponse, RackManagerError> {
         self.get_firmware_object_calls.lock().await.push(cmd);
         pop_or_err(&mut self.get_firmware_object_responses.lock().await)
     }
+
     async fn list_firmware_objects(
         &self,
         cmd: rms::ListFirmwareObjectsRequest,
@@ -1132,20 +1215,33 @@ impl RmsApi for MockRmsApi {
     async fn delete_firmware_object(
         &self,
         cmd: rms::DeleteFirmwareObjectRequest,
-    ) -> Result<rms::OperationResponse, RackManagerError> {
+    ) -> Result<rms::DeleteFirmwareObjectResponse, RackManagerError> {
         self.delete_firmware_object_calls.lock().await.push(cmd);
         pop_or_err(&mut self.delete_firmware_object_responses.lock().await)
     }
+
     async fn set_default_firmware_object(
         &self,
         cmd: rms::SetDefaultFirmwareObjectRequest,
-    ) -> Result<rms::FirmwareObject, RackManagerError> {
+    ) -> Result<rms::SetDefaultFirmwareObjectResponse, RackManagerError> {
         self.set_default_firmware_object_calls
             .lock()
             .await
             .push(cmd);
         pop_or_err(&mut self.set_default_firmware_object_responses.lock().await)
     }
+
+    async fn apply_stored_firmware_object(
+        &self,
+        cmd: rms::ApplyStoredFirmwareObjectRequest,
+    ) -> Result<rms::ApplyStoredFirmwareObjectResponse, RackManagerError> {
+        self.apply_stored_firmware_object_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.apply_stored_firmware_object_responses.lock().await)
+    }
+
     async fn apply_firmware_object(
         &self,
         cmd: rms::ApplyFirmwareObjectRequest,
@@ -1153,37 +1249,24 @@ impl RmsApi for MockRmsApi {
         self.apply_firmware_object_calls.lock().await.push(cmd);
         pop_or_err(&mut self.apply_firmware_object_responses.lock().await)
     }
-    async fn apply_firmware_object_from_json(
-        &self,
-        cmd: rms::ApplyFirmwareObjectFromJsonRequest,
-    ) -> Result<rms::ApplyFirmwareObjectResponse, RackManagerError> {
-        self.apply_firmware_object_from_json_calls
-            .lock()
-            .await
-            .push(cmd);
-        pop_or_err(&mut self.apply_firmware_object_from_json_responses.lock().await)
-    }
-    async fn apply_switch_system_image_from_json(
-        &self,
-        cmd: rms::ApplySwitchSystemImageFromJsonRequest,
-    ) -> Result<rms::ApplySwitchSystemImageResponse, RackManagerError> {
-        self.apply_switch_system_image_from_json_calls
-            .lock()
-            .await
-            .push(cmd);
-        pop_or_err(
-            &mut self
-                .apply_switch_system_image_from_json_responses
-                .lock()
-                .await,
-        )
-    }
+
     async fn apply_switch_system_image(
         &self,
         cmd: rms::ApplySwitchSystemImageRequest,
     ) -> Result<rms::ApplySwitchSystemImageResponse, RackManagerError> {
         self.apply_switch_system_image_calls.lock().await.push(cmd);
         pop_or_err(&mut self.apply_switch_system_image_responses.lock().await)
+    }
+
+    async fn apply_stored_switch_system_image(
+        &self,
+        cmd: rms::ApplyStoredSwitchSystemImageRequest,
+    ) -> Result<rms::ApplyStoredSwitchSystemImageResponse, RackManagerError> {
+        self.apply_stored_switch_system_image_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.apply_stored_switch_system_image_responses.lock().await)
     }
     async fn get_firmware_object_history(
         &self,
@@ -1195,38 +1278,44 @@ impl RmsApi for MockRmsApi {
             .push(cmd);
         pop_or_err(&mut self.get_firmware_object_history_responses.lock().await)
     }
-    async fn update_node_firmware_async(
+    async fn update_firmware(
         &self,
-        cmd: rms::UpdateNodeFirmwareRequest,
-    ) -> Result<rms::UpdateNodeFirmwareResponse, RackManagerError> {
-        self.update_node_firmware_async_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.update_node_firmware_async_responses.lock().await)
+        cmd: rms::UpdateFirmwareRequest,
+    ) -> Result<rms::UpdateFirmwareResponse, RackManagerError> {
+        self.update_firmware_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.update_firmware_responses.lock().await)
     }
-    async fn update_firmware_by_node_type_async(
+    async fn batch_update_firmware_by_node_type(
         &self,
-        cmd: rms::UpdateFirmwareByNodeTypeRequest,
-    ) -> Result<rms::UpdateFirmwareByNodeTypeAsyncResponse, RackManagerError> {
-        self.update_firmware_by_node_type_async_calls
+        cmd: rms::BatchUpdateFirmwareByNodeTypeRequest,
+    ) -> Result<rms::BatchUpdateFirmwareByNodeTypeResponse, RackManagerError> {
+        self.batch_update_firmware_by_node_type_calls
             .lock()
             .await
             .push(cmd);
         pop_or_err(
             &mut self
-                .update_firmware_by_node_type_async_responses
+                .batch_update_firmware_by_node_type_responses
                 .lock()
                 .await,
         )
     }
-    async fn update_firmware_by_device_list(
+    async fn batch_update_firmware(
         &self,
-        cmd: rms::UpdateFirmwareByDeviceListRequest,
-    ) -> Result<rms::UpdateFirmwareByDeviceListResponse, RackManagerError> {
-        self.update_firmware_by_device_list_calls
-            .lock()
-            .await
-            .push(cmd);
-        pop_or_err(&mut self.update_firmware_by_device_list_responses.lock().await)
+        cmd: rms::BatchUpdateFirmwareRequest,
+    ) -> Result<rms::BatchUpdateFirmwareResponse, RackManagerError> {
+        self.batch_update_firmware_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.batch_update_firmware_responses.lock().await)
     }
+
+    async fn update_switch_system_image(
+        &self,
+        cmd: rms::UpdateSwitchSystemImageRequest,
+    ) -> Result<rms::UpdateSwitchSystemImageResponse, RackManagerError> {
+        self.update_switch_system_image_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.update_switch_system_image_responses.lock().await)
+    }
+
     async fn get_firmware_job_status(
         &self,
         cmd: rms::GetFirmwareJobStatusRequest,
@@ -1234,26 +1323,26 @@ impl RmsApi for MockRmsApi {
         self.get_firmware_job_status_calls.lock().await.push(cmd);
         pop_or_err(&mut self.get_firmware_job_status_responses.lock().await)
     }
-    async fn list_firmware_on_switch(
+    async fn list_switch_firmware(
         &self,
-        cmd: rms::ListFirmwareOnSwitchCommand,
-    ) -> Result<rms::ListFirmwareOnSwitchResponse, RackManagerError> {
-        self.list_firmware_on_switch_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.list_firmware_on_switch_responses.lock().await)
+        cmd: rms::ListSwitchFirmwareRequest,
+    ) -> Result<rms::ListSwitchFirmwareResponse, RackManagerError> {
+        self.list_switch_firmware_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.list_switch_firmware_responses.lock().await)
     }
-    async fn push_firmware_to_switch(
+    async fn push_switch_firmware(
         &self,
-        cmd: rms::PushFirmwareToSwitchCommand,
-    ) -> Result<rms::PushFirmwareToSwitchResponse, RackManagerError> {
-        self.push_firmware_to_switch_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.push_firmware_to_switch_responses.lock().await)
+        cmd: rms::PushSwitchFirmwareRequest,
+    ) -> Result<rms::PushSwitchFirmwareResponse, RackManagerError> {
+        self.push_switch_firmware_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.push_switch_firmware_responses.lock().await)
     }
-    async fn upgrade_firmware_on_switch(
+    async fn upgrade_switch_firmware(
         &self,
-        cmd: rms::UpgradeFirmwareOnSwitchCommand,
-    ) -> Result<rms::UpgradeFirmwareOnSwitchResponse, RackManagerError> {
-        self.upgrade_firmware_on_switch_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.upgrade_firmware_on_switch_responses.lock().await)
+        cmd: rms::UpgradeSwitchFirmwareRequest,
+    ) -> Result<rms::UpgradeSwitchFirmwareResponse, RackManagerError> {
+        self.upgrade_switch_firmware_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.upgrade_switch_firmware_responses.lock().await)
     }
     async fn fetch_switch_system_image(
         &self,
@@ -1279,13 +1368,33 @@ impl RmsApi for MockRmsApi {
         self.list_switch_system_images_calls.lock().await.push(cmd);
         pop_or_err(&mut self.list_switch_system_images_responses.lock().await)
     }
-    async fn poll_job_status(
+    async fn poll_switch_firmware_job_status(
         &self,
-        cmd: rms::PollJobStatusCommand,
-    ) -> Result<rms::PollJobStatusResponse, RackManagerError> {
-        self.poll_job_status_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.poll_job_status_responses.lock().await)
+        cmd: rms::PollSwitchFirmwareJobStatusRequest,
+    ) -> Result<rms::PollSwitchFirmwareJobStatusResponse, RackManagerError> {
+        self.poll_switch_firmware_job_status_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.poll_switch_firmware_job_status_responses.lock().await)
     }
+
+    async fn get_switch_system_image_job_status(
+        &self,
+        cmd: rms::GetSwitchSystemImageJobStatusRequest,
+    ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError> {
+        self.get_switch_system_image_job_status_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(
+            &mut self
+                .get_switch_system_image_job_status_responses
+                .lock()
+                .await,
+        )
+    }
+
     async fn configure_scale_up_fabric_manager(
         &self,
         cmd: rms::ConfigureScaleUpFabricManagerRequest,
@@ -1301,34 +1410,62 @@ impl RmsApi for MockRmsApi {
                 .await,
         )
     }
-    async fn set_scale_up_fabric_state(
+    async fn batch_set_scale_up_fabric_state(
         &self,
-        cmd: rms::SetScaleUpFabricStateRequest,
-    ) -> Result<rms::SetScaleUpFabricStateResponse, RackManagerError> {
-        self.set_scale_up_fabric_state_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.set_scale_up_fabric_state_responses.lock().await)
+        cmd: rms::BatchSetScaleUpFabricStateRequest,
+    ) -> Result<rms::BatchSetScaleUpFabricStateResponse, RackManagerError> {
+        self.batch_set_scale_up_fabric_state_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(&mut self.batch_set_scale_up_fabric_state_responses.lock().await)
     }
-    async fn enable_scale_up_fabric_telemetry_interface(
+
+    async fn batch_get_scale_up_fabric_service_status(
         &self,
-        cmd: rms::EnableScaleUpFabricTelemetryInterfaceRequest,
-    ) -> Result<rms::EnableScaleUpFabricTelemetryInterfaceResponse, RackManagerError> {
-        self.enable_scale_up_fabric_telemetry_interface_calls
+        cmd: rms::BatchGetScaleUpFabricServiceStatusRequest,
+    ) -> Result<rms::BatchGetScaleUpFabricServiceStatusResponse, RackManagerError> {
+        self.batch_get_scale_up_fabric_service_status_calls
             .lock()
             .await
             .push(cmd);
         pop_or_err(
             &mut self
-                .enable_scale_up_fabric_telemetry_interface_responses
+                .batch_get_scale_up_fabric_service_status_responses
                 .lock()
                 .await,
         )
     }
-    async fn version(&self) -> Result<(), RackManagerError> {
+
+    async fn get_scale_up_fabric_state(
+        &self,
+        cmd: rms::GetScaleUpFabricStateRequest,
+    ) -> Result<rms::GetScaleUpFabricStateResponse, RackManagerError> {
+        self.get_scale_up_fabric_state_calls.lock().await.push(cmd);
+        pop_or_err(&mut self.get_scale_up_fabric_state_responses.lock().await)
+    }
+
+    async fn set_scale_up_fabric_telemetry_interface_state(
+        &self,
+        cmd: rms::SetScaleUpFabricTelemetryInterfaceStateRequest,
+    ) -> Result<rms::SetScaleUpFabricTelemetryInterfaceStateResponse, RackManagerError> {
+        self.set_scale_up_fabric_telemetry_interface_state_calls
+            .lock()
+            .await
+            .push(cmd);
+        pop_or_err(
+            &mut self
+                .set_scale_up_fabric_telemetry_interface_state_responses
+                .lock()
+                .await,
+        )
+    }
+    async fn get_version(&self) -> Result<rms::GetVersionResponse, RackManagerError> {
         *self.version_call_count.lock().await += 1;
         self.version_responses
             .lock()
             .await
             .pop_front()
-            .unwrap_or(Ok(()))
+            .unwrap_or(Ok(rms::GetVersionResponse::default()))
     }
 }

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -63,6 +63,7 @@ const RMS_FIRMWARE_OBJECT_FIRMWARE_TYPE: &str = "prod";
 const RMS_SWITCH_SYSTEM_IMAGE_SOFTWARE_TYPE: &str = "prod";
 const RMS_FIRMWARE_OBJECT_HARDWARE_TYPE: &str = "any";
 const RMS_NOAUTH_ACCESS_TOKEN: &str = "NOAUTH";
+const RMS_SWITCH_NODE_TYPE: rms::NodeType = rms::NodeType::Switch;
 
 pub struct RmsBackend {
     client: Arc<dyn RmsApi>,
@@ -173,22 +174,20 @@ async fn resolve_switch_identities(
 
 fn to_rms_power_operation(action: PowerAction) -> i32 {
     match action {
-        PowerAction::On => rms::PowerOperation::PowerOn as i32,
-        PowerAction::GracefulShutdown | PowerAction::ForceOff => {
-            rms::PowerOperation::PowerOff as i32
-        }
+        PowerAction::On => rms::PowerOperation::On as i32,
+        PowerAction::GracefulShutdown | PowerAction::ForceOff => rms::PowerOperation::Off as i32,
         PowerAction::GracefulRestart | PowerAction::ForceRestart | PowerAction::AcPowercycle => {
-            rms::PowerOperation::PowerReset as i32
+            rms::PowerOperation::Reset as i32
         }
     }
 }
 
 fn map_rms_firmware_job_state(state: i32) -> FirmwareState {
     match rms::FirmwareJobState::try_from(state) {
-        Ok(rms::FirmwareJobState::FwJobQueued) => FirmwareState::Queued,
-        Ok(rms::FirmwareJobState::FwJobRunning) => FirmwareState::InProgress,
-        Ok(rms::FirmwareJobState::FwJobCompleted) => FirmwareState::Completed,
-        Ok(rms::FirmwareJobState::FwJobFailed) => FirmwareState::Failed,
+        Ok(rms::FirmwareJobState::Queued) => FirmwareState::Queued,
+        Ok(rms::FirmwareJobState::Running) => FirmwareState::InProgress,
+        Ok(rms::FirmwareJobState::Completed) => FirmwareState::Completed,
+        Ok(rms::FirmwareJobState::Failed) => FirmwareState::Failed,
         _ => FirmwareState::Unknown,
     }
 }
@@ -237,29 +236,27 @@ fn aggregate_firmware_job_states(states: &[FirmwareState]) -> FirmwareState {
     }
 }
 
-/// Default BMC HTTPS port used when populating `rms::BmcEndpoint` for power
+/// Default BMC HTTPS port used when populating `rms::Endpoint` for power
 /// shelves. Mirrors the value used by `crate::power_shelf_controller::maintenance`.
-const POWER_SHELF_BMC_PORT: i32 = 443;
+const POWER_SHELF_BMC_PORT: u32 = 443;
 
-/// Build the `rms::NewNodeInfo` describing a power shelf for inclusion in a
-/// `SetPowerStateByDeviceList` request. The caller-supplied variant of the
+/// Build the `rms::NodeInfo` describing a power shelf for inclusion in a
+/// `BatchSetPowerState` request. The caller-supplied variant of the
 /// RPC requires the BMC connection details inline rather than relying on
 /// RMS's inventory; power shelves do not expose a host endpoint.
-fn build_power_shelf_node_info(
-    ep: &PowerShelfEndpoint,
-    identity: &RmsIdentity,
-) -> rms::NewNodeInfo {
-    rms::NewNodeInfo {
+fn build_power_shelf_node_info(ep: &PowerShelfEndpoint, identity: &RmsIdentity) -> rms::NodeInfo {
+    rms::NodeInfo {
         node_id: identity.node_id.clone(),
         rack_id: identity.rack_id.clone(),
         r#type: Some(rms::NodeType::Powershelf as i32),
-        bmc_endpoint: Some(rms::BmcEndpoint {
+        bmc_endpoint: Some(rms::Endpoint {
             interface: Some(rms::NetworkInterface {
                 ip_address: ep.pmc_ip.to_string(),
                 mac_address: ep.pmc_mac.to_string(),
             }),
             port: POWER_SHELF_BMC_PORT,
             credentials: Some(credentials_to_rms(&ep.pmc_credentials)),
+            dangerously_accept_invalid_certs: true,
         }),
         host_endpoint: None,
     }
@@ -297,15 +294,14 @@ impl PowerShelfManager for RmsBackend {
             };
 
             let device = build_power_shelf_node_info(ep, identity);
-            let request = rms::SetPowerStateByDeviceListRequest {
+            let request = rms::BatchSetPowerStateRequest {
                 nodes: Some(rms::NodeSet {
-                    devices: vec![device],
+                    nodes: vec![device],
                 }),
                 operation,
-                ..Default::default()
             };
 
-            match self.client.set_power_state_by_device_list(request).await {
+            match self.client.batch_set_power_state(request).await {
                 Ok(response) => {
                     let (success, error) =
                         summarize_power_batch(response.response.unwrap_or_default());
@@ -358,7 +354,7 @@ impl PowerShelfManager for RmsBackend {
             };
 
             let device = build_power_shelf_node_info(ep, identity);
-            let request = match apply_firmware_object_from_json_request(
+            let request = match apply_firmware_object_request(
                 device,
                 identity,
                 target_version,
@@ -377,7 +373,7 @@ impl PowerShelfManager for RmsBackend {
                 }
             };
 
-            match self.client.apply_firmware_object_from_json(request).await {
+            match self.client.apply_firmware_object(request).await {
                 Ok(response) => {
                     let (success, error, job_id) =
                         summarize_firmware_object_apply_response(response, &identity.node_id);
@@ -457,7 +453,6 @@ impl PowerShelfManager for RmsBackend {
 
             let request = rms::GetFirmwareJobStatusRequest {
                 job_id: job_id.clone(),
-                ..Default::default()
             };
 
             match self.client.get_firmware_job_status(request).await {
@@ -524,7 +519,6 @@ impl PowerShelfManager for RmsBackend {
             let request = rms::GetNodeFirmwareInventoryRequest {
                 node_id: identity.node_id.clone(),
                 rack_id: identity.rack_id.clone(),
-                ..Default::default()
             };
 
             match self.client.get_node_firmware_inventory(request).await {
@@ -613,7 +607,6 @@ async fn list_firmware_object_ids(
 ) -> Result<Vec<String>, ComponentManagerError> {
     let response = client
         .list_firmware_objects(rms::ListFirmwareObjectsRequest {
-            metadata: None,
             only_available: false,
             hardware_type: String::new(),
         })
@@ -627,9 +620,9 @@ async fn list_firmware_object_ids(
     Ok(response.objects.into_iter().map(|fw| fw.id).collect())
 }
 
-/// Default BMC HTTPS port used when populating `rms::BmcEndpoint` for
+/// Default BMC HTTPS port used when populating `rms::Endpoint` for
 /// switches. Mirrors the value used by `crate::rack::firmware_update`.
-const SWITCH_BMC_PORT: i32 = 443;
+const SWITCH_BMC_PORT: u32 = 443;
 
 fn credentials_to_rms(creds: &Credentials) -> rms::Credentials {
     let Credentials::UsernamePassword { username, password } = creds;
@@ -641,39 +634,43 @@ fn credentials_to_rms(creds: &Credentials) -> rms::Credentials {
     }
 }
 
-/// Build the `rms::NewNodeInfo` describing a switch for inclusion in a
-/// `SetPowerStateByDeviceList` request. The caller-supplied variant of the
+/// Build the `rms::NodeInfo` describing a switch for inclusion in a
+/// `BatchSetPowerState` request. The caller-supplied variant of the
 /// RPC requires the BMC connection details inline rather than relying on
 /// RMS's inventory; the NVOS host endpoint is included for completeness.
-fn build_switch_node_info(ep: &SwitchEndpoint, identity: &RmsIdentity) -> rms::NewNodeInfo {
-    rms::NewNodeInfo {
+fn build_switch_node_info(ep: &SwitchEndpoint, identity: &RmsIdentity) -> rms::NodeInfo {
+    rms::NodeInfo {
         node_id: identity.node_id.clone(),
         rack_id: identity.rack_id.clone(),
-        r#type: Some(rms::NodeType::Switch as i32),
-        bmc_endpoint: Some(rms::BmcEndpoint {
+        r#type: Some(RMS_SWITCH_NODE_TYPE as i32),
+        bmc_endpoint: Some(rms::Endpoint {
             interface: Some(rms::NetworkInterface {
                 ip_address: ep.bmc_ip.to_string(),
                 mac_address: ep.bmc_mac.to_string(),
             }),
             port: SWITCH_BMC_PORT,
             credentials: Some(credentials_to_rms(&ep.bmc_credentials)),
+            dangerously_accept_invalid_certs: true,
         }),
-        host_endpoint: Some(rms::HostEndpoint {
-            interfaces: vec![rms::NetworkInterface {
+        host_endpoint: Some(rms::Endpoint {
+            interface: Some(rms::NetworkInterface {
                 ip_address: ep.nvos_ip.to_string(),
                 mac_address: ep.nvos_mac.to_string(),
-            }],
+            }),
             port: 0,
             credentials: Some(credentials_to_rms(&ep.nvos_credentials)),
+            dangerously_accept_invalid_certs: true,
         }),
     }
 }
 
 /// Summarize a `NodeBatchResponse` into a `(success, error)` pair for a
-/// single-device `SetPowerStateByDeviceList` call. Prefers per-node error
+/// single-node `BatchSetPowerState` call. Prefers per-node error
 /// messages, then the batch-level message, and finally a generic fallback.
 fn summarize_power_batch(batch: rms::NodeBatchResponse) -> (bool, Option<String>) {
-    let success = batch.status == rms::ReturnCode::Success as i32 && batch.failed_nodes == 0;
+    let stats = batch.stats.unwrap_or_default();
+    let success = batch.status == rms::ReturnCode::Success as i32 && stats.failed_nodes == 0;
+
     if success {
         return (true, None);
     }
@@ -711,26 +708,27 @@ struct RmsObservedPowerState {
 
 async fn query_rms_power_state(
     client: &dyn RmsApi,
-    device: rms::NewNodeInfo,
+    device: rms::NodeInfo,
     node_id: &str,
     device_mac: MacAddress,
     device_kind: &str,
 ) -> RmsObservedPowerState {
-    let request = rms::GetPowerStateByDeviceListRequest {
+    let request = rms::BatchGetPowerStateRequest {
         nodes: Some(rms::NodeSet {
-            devices: vec![device],
+            nodes: vec![device],
         }),
-        ..Default::default()
     };
 
-    match client.get_power_state_by_device_list(request).await {
+    match client.batch_get_power_state(request).await {
         Ok(response) => {
             let batch = response.response.clone().unwrap_or_default();
-            if batch.status != rms::ReturnCode::Success as i32 || batch.failed_nodes != 0 {
+            let stats = batch.stats.unwrap_or_default();
+
+            if batch.status != rms::ReturnCode::Success as i32 || stats.failed_nodes != 0 {
                 let summary = if batch.message.is_empty() {
                     format!(
                         "batch status {}, failed_nodes {}",
-                        batch.status, batch.failed_nodes
+                        batch.status, stats.failed_nodes
                     )
                 } else {
                     batch.message
@@ -774,14 +772,14 @@ fn rms_access_token_or_noauth(access_token: Option<&str>) -> String {
         .to_string()
 }
 
-fn apply_firmware_object_from_json_request(
-    device: rms::NewNodeInfo,
+fn apply_firmware_object_request(
+    device: rms::NodeInfo,
     identity: &RmsIdentity,
     config_json: &str,
     options: &FirmwareUpdateOptions,
     node_type: rms::NodeType,
     components: Vec<String>,
-) -> Result<rms::ApplyFirmwareObjectFromJsonRequest, ComponentManagerError> {
+) -> Result<rms::ApplyFirmwareObjectRequest, ComponentManagerError> {
     let access_token = rms_access_token_or_noauth(options.access_token.as_deref());
 
     if config_json.trim().is_empty() {
@@ -796,27 +794,26 @@ fn apply_firmware_object_from_json_request(
         rms::FirmwareObjectComponentFilter { components },
     );
 
-    Ok(rms::ApplyFirmwareObjectFromJsonRequest {
-        metadata: None,
+    Ok(rms::ApplyFirmwareObjectRequest {
         rack_id: identity.rack_id.clone(),
         config_json: config_json.to_owned(),
         access_token,
         firmware_type: RMS_FIRMWARE_OBJECT_FIRMWARE_TYPE.to_owned(),
         hardware_type: RMS_FIRMWARE_OBJECT_HARDWARE_TYPE.to_owned(),
         nodes: Some(rms::NodeSet {
-            devices: vec![device],
+            nodes: vec![device],
         }),
         force_update: options.force_update,
         component_filters,
     })
 }
 
-fn apply_switch_system_image_from_json_request(
-    device: rms::NewNodeInfo,
+fn apply_switch_system_image_request(
+    device: rms::NodeInfo,
     identity: &RmsIdentity,
     config_json: &str,
     options: &FirmwareUpdateOptions,
-) -> Result<rms::ApplySwitchSystemImageFromJsonRequest, ComponentManagerError> {
+) -> Result<rms::ApplySwitchSystemImageRequest, ComponentManagerError> {
     let access_token = rms_access_token_or_noauth(options.access_token.as_deref());
 
     if config_json.trim().is_empty() {
@@ -825,15 +822,14 @@ fn apply_switch_system_image_from_json_request(
         ));
     }
 
-    Ok(rms::ApplySwitchSystemImageFromJsonRequest {
-        metadata: None,
+    Ok(rms::ApplySwitchSystemImageRequest {
         rack_id: identity.rack_id.clone(),
         config_json: config_json.to_owned(),
         access_token,
         software_type: RMS_SWITCH_SYSTEM_IMAGE_SOFTWARE_TYPE.to_owned(),
         hardware_type: RMS_FIRMWARE_OBJECT_HARDWARE_TYPE.to_owned(),
         nodes: Some(rms::NodeSet {
-            devices: vec![device],
+            nodes: vec![device],
         }),
         // RMS does not expose force_update on switch system-image JSON updates.
     })
@@ -880,7 +876,7 @@ fn summarize_firmware_object_apply_response(
     node_id: &str,
 ) -> (bool, Option<String>, Option<String>) {
     let node_job_id = response
-        .node_jobs
+        .jobs
         .iter()
         .find(|j| j.node_id == node_id && !j.job_id.is_empty())
         .map(|j| j.job_id.clone());
@@ -898,7 +894,7 @@ fn summarize_switch_system_image_apply_response(
     node_id: &str,
 ) -> (bool, Option<String>, Option<String>) {
     let node_job_id = response
-        .node_jobs
+        .jobs
         .iter()
         .find(|j| j.node_id == node_id && !j.job_id.is_empty())
         .map(|j| j.job_id.clone());
@@ -930,8 +926,9 @@ fn summarize_firmware_batch(
                 .iter()
                 .find(|r| r.status != rms::ReturnCode::Success as i32)
         });
+    let stats = batch.stats.unwrap_or_default();
     let success = batch.status == rms::ReturnCode::Success as i32
-        && batch.failed_nodes == 0
+        && stats.failed_nodes == 0
         && node_failure.is_none();
     let job_id = node_job_id.or_else(|| (!batch.job_id.is_empty()).then_some(batch.job_id.clone()));
 
@@ -968,7 +965,6 @@ async fn query_tracked_firmware_job_status(
         RmsTrackedFirmwareJob::FirmwareObject(job_id) => {
             let request = rms::GetFirmwareJobStatusRequest {
                 job_id: job_id.clone(),
-                ..Default::default()
             };
 
             match client.get_firmware_job_status(request).await {
@@ -1004,7 +1000,6 @@ async fn query_tracked_firmware_job_status(
             };
             let request = rms::GetSwitchSystemImageJobStatusRequest {
                 job_id: job_id.clone(),
-                ..Default::default()
             };
 
             match client.get_switch_system_image_job_status(request).await {
@@ -1071,15 +1066,14 @@ impl NvSwitchManager for RmsBackend {
             };
 
             let device = build_switch_node_info(ep, identity);
-            let request = rms::SetPowerStateByDeviceListRequest {
+            let request = rms::BatchSetPowerStateRequest {
                 nodes: Some(rms::NodeSet {
-                    devices: vec![device],
+                    nodes: vec![device],
                 }),
                 operation,
-                ..Default::default()
             };
 
-            match self.client.set_power_state_by_device_list(request).await {
+            match self.client.batch_set_power_state(request).await {
                 Ok(response) => {
                     let (success, error) =
                         summarize_power_batch(response.response.unwrap_or_default());
@@ -1139,7 +1133,7 @@ impl NvSwitchManager for RmsBackend {
 
             if include_firmware_object {
                 let device = build_switch_node_info(ep, identity);
-                match apply_firmware_object_from_json_request(
+                match apply_firmware_object_request(
                     device,
                     identity,
                     bundle_version,
@@ -1147,8 +1141,7 @@ impl NvSwitchManager for RmsBackend {
                     rms::NodeType::Switch,
                     component_filters.clone(),
                 ) {
-                    Ok(request) => match self.client.apply_firmware_object_from_json(request).await
-                    {
+                    Ok(request) => match self.client.apply_firmware_object(request).await {
                         Ok(response) => {
                             let (operation_success, error, job_id) =
                                 summarize_firmware_object_apply_response(
@@ -1193,59 +1186,46 @@ impl NvSwitchManager for RmsBackend {
 
             if include_system_image {
                 let device = build_switch_node_info(ep, identity);
-                match apply_switch_system_image_from_json_request(
-                    device,
-                    identity,
-                    bundle_version,
-                    options,
-                ) {
-                    Ok(request) => {
-                        match self
-                            .client
-                            .apply_switch_system_image_from_json(request)
-                            .await
-                        {
-                            Ok(response) => {
-                                let (operation_success, error, job_id) =
-                                    summarize_switch_system_image_apply_response(
-                                        response,
-                                        &identity.node_id,
-                                    );
-
-                                if !operation_success {
-                                    success = false;
-                                }
-                                if let Some(error) = error {
-                                    errors.push(error);
-                                }
-                                if operation_success {
-                                    if let Some(job_id) = job_id {
-                                        tracked_jobs.push(
-                                            RmsTrackedFirmwareJob::SwitchSystemImage {
-                                                job_id,
-                                                rack_id: identity.rack_id.clone(),
-                                                node_id: identity.node_id.clone(),
-                                            },
-                                        );
-                                    }
-                                } else if job_id.is_some() {
-                                    tracing::debug!(
-                                        bmc_mac = %ep.bmc_mac,
-                                        "RMS returned a switch system-image job id for a failed switch update; not tracking it"
-                                    );
-                                }
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    bmc_mac = %ep.bmc_mac,
-                                    error = %e,
-                                    "RMS switch system-image update failed for switch"
+                match apply_switch_system_image_request(device, identity, bundle_version, options) {
+                    Ok(request) => match self.client.apply_switch_system_image(request).await {
+                        Ok(response) => {
+                            let (operation_success, error, job_id) =
+                                summarize_switch_system_image_apply_response(
+                                    response,
+                                    &identity.node_id,
                                 );
+
+                            if !operation_success {
                                 success = false;
-                                errors.push(e.to_string());
+                            }
+                            if let Some(error) = error {
+                                errors.push(error);
+                            }
+                            if operation_success {
+                                if let Some(job_id) = job_id {
+                                    tracked_jobs.push(RmsTrackedFirmwareJob::SwitchSystemImage {
+                                        job_id,
+                                        rack_id: identity.rack_id.clone(),
+                                        node_id: identity.node_id.clone(),
+                                    });
+                                }
+                            } else if job_id.is_some() {
+                                tracing::debug!(
+                                    bmc_mac = %ep.bmc_mac,
+                                    "RMS returned a switch system-image job id for a failed switch update; not tracking it"
+                                );
                             }
                         }
-                    }
+                        Err(e) => {
+                            tracing::warn!(
+                                bmc_mac = %ep.bmc_mac,
+                                error = %e,
+                                "RMS switch system-image update failed for switch"
+                            );
+                            success = false;
+                            errors.push(e.to_string());
+                        }
+                    },
                     Err(e) => {
                         success = false;
                         errors.push(e.to_string());
@@ -1393,14 +1373,13 @@ impl NvSwitchManager for RmsBackend {
             };
 
             let device = build_switch_node_info(ep, identity);
-            let request = rms::GetDeviceInfoByDeviceListRequest {
+            let request = rms::BatchGetNodeDeviceInfoRequest {
                 nodes: Some(rms::NodeSet {
-                    devices: vec![device],
+                    nodes: vec![device],
                 }),
-                ..Default::default()
             };
 
-            match self.client.get_device_info_by_device_list(request).await {
+            match self.client.batch_get_node_device_info(request).await {
                 Ok(info) => {
                     if info.status != rms::ReturnCode::Success as i32 {
                         let summary = if info.message.is_empty() {
@@ -1417,7 +1396,7 @@ impl NvSwitchManager for RmsBackend {
                         continue;
                     }
 
-                    let Some(node_device_info) = info.node_device_info.first() else {
+                    let Some(node_device_details) = info.node_device_details.first() else {
                         results.push(SwitchSlotAndTrayResult {
                             bmc_mac: ep.bmc_mac,
                             slot_number: None,
@@ -1429,8 +1408,12 @@ impl NvSwitchManager for RmsBackend {
 
                     results.push(SwitchSlotAndTrayResult {
                         bmc_mac: ep.bmc_mac,
-                        slot_number: node_device_info.slot_number,
-                        tray_index: node_device_info.tray_index,
+                        slot_number: node_device_details
+                            .slot_number
+                            .and_then(|value| i32::try_from(value).ok()),
+                        tray_index: node_device_details
+                            .tray_index
+                            .and_then(|value| i32::try_from(value).ok()),
                         error: None,
                     });
                 }
@@ -1483,7 +1466,7 @@ mod tests {
     fn power_action_on_maps_to_power_on() {
         assert_eq!(
             to_rms_power_operation(PowerAction::On),
-            rms::PowerOperation::PowerOn as i32,
+            rms::PowerOperation::On as i32,
         );
     }
 
@@ -1491,7 +1474,7 @@ mod tests {
     fn power_action_shutdown_maps_to_power_off() {
         assert_eq!(
             to_rms_power_operation(PowerAction::GracefulShutdown),
-            rms::PowerOperation::PowerOff as i32,
+            rms::PowerOperation::Off as i32,
         );
     }
 
@@ -1499,7 +1482,7 @@ mod tests {
     fn power_action_force_off_maps_to_power_off() {
         assert_eq!(
             to_rms_power_operation(PowerAction::ForceOff),
-            rms::PowerOperation::PowerOff as i32,
+            rms::PowerOperation::Off as i32,
         );
     }
 
@@ -1512,7 +1495,7 @@ mod tests {
         ] {
             assert_eq!(
                 to_rms_power_operation(action),
-                rms::PowerOperation::PowerReset as i32,
+                rms::PowerOperation::Reset as i32,
                 "expected PowerReset for {action:?}",
             );
         }
@@ -1521,7 +1504,7 @@ mod tests {
     #[test]
     fn firmware_job_state_queued() {
         assert_eq!(
-            map_rms_firmware_job_state(rms::FirmwareJobState::FwJobQueued as i32),
+            map_rms_firmware_job_state(rms::FirmwareJobState::Queued as i32),
             FirmwareState::Queued,
         );
     }
@@ -1529,7 +1512,7 @@ mod tests {
     #[test]
     fn firmware_job_state_running() {
         assert_eq!(
-            map_rms_firmware_job_state(rms::FirmwareJobState::FwJobRunning as i32),
+            map_rms_firmware_job_state(rms::FirmwareJobState::Running as i32),
             FirmwareState::InProgress,
         );
     }
@@ -1537,7 +1520,7 @@ mod tests {
     #[test]
     fn firmware_job_state_completed() {
         assert_eq!(
-            map_rms_firmware_job_state(rms::FirmwareJobState::FwJobCompleted as i32),
+            map_rms_firmware_job_state(rms::FirmwareJobState::Completed as i32),
             FirmwareState::Completed,
         );
     }
@@ -1545,7 +1528,7 @@ mod tests {
     #[test]
     fn firmware_job_state_failed() {
         assert_eq!(
-            map_rms_firmware_job_state(rms::FirmwareJobState::FwJobFailed as i32),
+            map_rms_firmware_job_state(rms::FirmwareJobState::Failed as i32),
             FirmwareState::Failed,
         );
     }
@@ -1658,7 +1641,7 @@ mod tests {
         let response = rms::ApplyFirmwareObjectResponse {
             response: None,
             object_id: "fw-json".to_owned(),
-            node_jobs: vec![rms::NodeFirmwareJobInfo {
+            jobs: vec![rms::NodeFirmwareJobInfo {
                 node_id: "node-1".to_owned(),
                 job_id: "job-1".to_owned(),
             }],
@@ -1730,7 +1713,7 @@ mod tests {
     }
 
     fn component_filters_for(
-        request: &rms::ApplyFirmwareObjectFromJsonRequest,
+        request: &rms::ApplyFirmwareObjectRequest,
         node_type: rms::NodeType,
     ) -> &[String] {
         &request
@@ -1742,8 +1725,8 @@ mod tests {
 
     #[test]
     fn direct_rms_firmware_object_json_request_defaults_missing_access_token_to_noauth() {
-        let request = apply_firmware_object_from_json_request(
-            rms::NewNodeInfo::default(),
+        let request = apply_firmware_object_request(
+            rms::NodeInfo::default(),
             &RmsIdentity {
                 node_id: "node-1".to_string(),
                 rack_id: "rack-1".to_string(),
@@ -1763,8 +1746,8 @@ mod tests {
 
     #[test]
     fn direct_rms_switch_system_image_request_defaults_empty_access_token_to_noauth() {
-        let request = apply_switch_system_image_from_json_request(
-            rms::NewNodeInfo::default(),
+        let request = apply_switch_system_image_request(
+            rms::NodeInfo::default(),
             &RmsIdentity {
                 node_id: "node-1".to_string(),
                 rack_id: "rack-1".to_string(),
@@ -1785,11 +1768,11 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn ps_power_control_success(pool: sqlx::PgPool) {
         let (mock, backend, rack_id, ps1, ps2, _, _) = make_backend(&pool).await;
-        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_ok(
+        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
             &ps1.to_string(),
         )))
         .await;
-        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_ok(
+        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
             &ps2.to_string(),
         )))
         .await;
@@ -1803,27 +1786,27 @@ mod tests {
         assert!(results[0].success);
         assert!(results[1].success);
 
-        let calls = mock.set_power_state_by_device_list_calls().await;
+        let calls = mock.batch_set_power_state_calls().await;
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].operation, rms::PowerOperation::PowerOn as i32);
-        let dev0 = &calls[0].nodes.as_ref().unwrap().devices[0];
+        assert_eq!(calls[0].operation, rms::PowerOperation::On as i32);
+        let dev0 = &calls[0].nodes.as_ref().unwrap().nodes[0];
         assert_eq!(dev0.node_id, ps1.to_string());
         assert_eq!(dev0.rack_id, rack_id.to_string());
         assert_eq!(dev0.r#type, Some(rms::NodeType::Powershelf as i32));
         assert!(dev0.bmc_endpoint.is_some());
         assert!(dev0.host_endpoint.is_none());
-        let dev1 = &calls[1].nodes.as_ref().unwrap().devices[0];
+        let dev1 = &calls[1].nodes.as_ref().unwrap().nodes[0];
         assert_eq!(dev1.node_id, ps2.to_string());
     }
 
     #[carbide_macros::sqlx_test]
     async fn ps_power_control_partial_failure(pool: sqlx::PgPool) {
         let (mock, backend, _, ps1, ps2, _, _) = make_backend(&pool).await;
-        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_ok(
+        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
             &ps1.to_string(),
         )))
         .await;
-        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_fail(
+        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_fail(
             &ps2.to_string(),
             "rms reported failure",
         )))
@@ -1842,15 +1825,13 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn ps_power_control_transport_error(pool: sqlx::PgPool) {
         let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
-        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_ok(
+        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
             &ps1.to_string(),
         )))
         .await;
-        mock.enqueue_set_power_state_by_device_list(Err(
-            librms::RackManagerError::ApiInvocationError(tonic::Status::unavailable(
-                "connection refused",
-            )),
-        ))
+        mock.enqueue_batch_set_power_state(Err(librms::RackManagerError::ApiInvocationError(
+            tonic::Status::unavailable("connection refused"),
+        )))
         .await;
 
         let eps = vec![make_ps_endpoint(PS_MAC_1), make_ps_endpoint(PS_MAC_2)];
@@ -1872,7 +1853,7 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn ps_power_control_unknown_mac(pool: sqlx::PgPool) {
         let (mock, backend, _, _, ps2, _, _) = make_backend(&pool).await;
-        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_ok(
+        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
             &ps2.to_string(),
         )))
         .await;
@@ -1886,20 +1867,20 @@ mod tests {
         assert!(!results[0].success);
         assert!(results[1].success);
 
-        let calls = mock.set_power_state_by_device_list_calls().await;
+        let calls = mock.batch_set_power_state_calls().await;
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].operation, rms::PowerOperation::PowerOff as i32);
+        assert_eq!(calls[0].operation, rms::PowerOperation::Off as i32);
     }
 
     #[carbide_macros::sqlx_test]
     async fn ps_update_firmware_success(pool: sqlx::PgPool) {
         let (mock, backend, rack_id, ps1, _ps2, _, _) = make_backend(&pool).await;
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_ok(
             &ps1.to_string(),
             "job-aaa",
         )))
         .await;
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_ok(
             &_ps2.to_string(),
             "job-bbb",
         )))
@@ -1919,7 +1900,7 @@ mod tests {
         assert!(results[0].success);
         assert!(results[1].success);
 
-        let calls = mock.apply_firmware_object_from_json_calls().await;
+        let calls = mock.apply_firmware_object_calls().await;
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].config_json, r#"{"Id":"fw-json"}"#);
         assert_eq!(calls[0].access_token, "token");
@@ -1928,7 +1909,7 @@ mod tests {
         assert!(calls[0].force_update);
         let filters = component_filters_for(&calls[0], rms::NodeType::Powershelf);
         assert_eq!(filters, ["PowerShelfFW"]);
-        let dev0 = &calls[0].nodes.as_ref().unwrap().devices[0];
+        let dev0 = &calls[0].nodes.as_ref().unwrap().nodes[0];
         assert_eq!(dev0.node_id, ps1.to_string());
         assert_eq!(dev0.rack_id, rack_id.to_string());
         assert_eq!(dev0.r#type, Some(rms::NodeType::Powershelf as i32));
@@ -1952,7 +1933,7 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn ps_update_firmware_multiple_components(pool: sqlx::PgPool) {
         let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_ok(
             &ps1.to_string(),
             "job-1",
         )))
@@ -1971,7 +1952,7 @@ mod tests {
 
         assert!(results[0].success);
 
-        let calls = mock.apply_firmware_object_from_json_calls().await;
+        let calls = mock.apply_firmware_object_calls().await;
         let filters = component_filters_for(&calls[0], rms::NodeType::Powershelf);
         assert_eq!(filters, ["PowerShelfFW"]);
     }
@@ -1979,7 +1960,7 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn ps_update_firmware_failure(pool: sqlx::PgPool) {
         let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_fail(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_fail(
             &ps1.to_string(),
             "bad firmware file",
         )))
@@ -2005,7 +1986,7 @@ mod tests {
         let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
         let eps = vec![make_ps_endpoint(PS_MAC_1)];
 
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_ok(
             &ps1.to_string(),
             "job-old",
         )))
@@ -2020,7 +2001,7 @@ mod tests {
             .await
             .unwrap();
 
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_fail(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_fail(
             &ps1.to_string(),
             "bad firmware file",
         )))
@@ -2043,7 +2024,7 @@ mod tests {
     async fn ps_firmware_status_running(pool: sqlx::PgPool) {
         let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
 
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_ok(
             &ps1.to_string(),
             "job-xyz",
         )))
@@ -2060,7 +2041,7 @@ mod tests {
             .unwrap();
 
         mock.enqueue_get_firmware_job_status(Ok(MockRmsApi::firmware_job_status_ok(
-            rms::FirmwareJobState::FwJobRunning,
+            rms::FirmwareJobState::Running,
         )))
         .await;
 
@@ -2098,7 +2079,7 @@ mod tests {
     async fn ps_firmware_status_completed(pool: sqlx::PgPool) {
         let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
 
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_ok(
             &ps1.to_string(),
             "job-done",
         )))
@@ -2115,7 +2096,7 @@ mod tests {
             .unwrap();
 
         mock.enqueue_get_firmware_job_status(Ok(MockRmsApi::firmware_job_status_ok(
-            rms::FirmwareJobState::FwJobCompleted,
+            rms::FirmwareJobState::Completed,
         )))
         .await;
 
@@ -2129,7 +2110,7 @@ mod tests {
     async fn ps_firmware_status_failed(pool: sqlx::PgPool) {
         let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
 
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_ok(
             &ps1.to_string(),
             "job-fail",
         )))
@@ -2147,7 +2128,7 @@ mod tests {
 
         mock.enqueue_get_firmware_job_status(Ok(rms::GetFirmwareJobStatusResponse {
             status: rms::ReturnCode::Success as i32,
-            job_state: rms::FirmwareJobState::FwJobFailed as i32,
+            job_state: rms::FirmwareJobState::Failed as i32,
             error_message: "checksum mismatch".into(),
             ..Default::default()
         }))
@@ -2164,7 +2145,7 @@ mod tests {
     async fn ps_firmware_status_non_success_without_error_has_diagnostic(pool: sqlx::PgPool) {
         let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
 
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_ok(
             &ps1.to_string(),
             "job-status-error",
         )))
@@ -2266,11 +2247,11 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn sw_power_control_success(pool: sqlx::PgPool) {
         let (mock, backend, rack_id, _, _, sw1, sw2) = make_backend(&pool).await;
-        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_ok(
+        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
             &sw1.to_string(),
         )))
         .await;
-        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_ok(
+        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
             &sw2.to_string(),
         )))
         .await;
@@ -2284,22 +2265,22 @@ mod tests {
         assert!(results[0].success);
         assert!(results[1].success);
 
-        let calls = mock.set_power_state_by_device_list_calls().await;
+        let calls = mock.batch_set_power_state_calls().await;
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].operation, rms::PowerOperation::PowerOn as i32);
-        let dev0 = &calls[0].nodes.as_ref().unwrap().devices[0];
+        assert_eq!(calls[0].operation, rms::PowerOperation::On as i32);
+        let dev0 = &calls[0].nodes.as_ref().unwrap().nodes[0];
         assert_eq!(dev0.node_id, sw1.to_string());
         assert_eq!(dev0.rack_id, rack_id.to_string());
         assert_eq!(dev0.r#type, Some(rms::NodeType::Switch as i32));
         assert!(dev0.bmc_endpoint.is_some());
-        let dev1 = &calls[1].nodes.as_ref().unwrap().devices[0];
+        let dev1 = &calls[1].nodes.as_ref().unwrap().nodes[0];
         assert_eq!(dev1.node_id, sw2.to_string());
     }
 
     #[carbide_macros::sqlx_test]
     async fn sw_power_control_unknown_mac(pool: sqlx::PgPool) {
         let (mock, backend, _, _, _, _, sw2) = make_backend(&pool).await;
-        mock.enqueue_set_power_state_by_device_list(Ok(MockRmsApi::power_by_device_list_ok(
+        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
             &sw2.to_string(),
         )))
         .await;
@@ -2312,15 +2293,15 @@ mod tests {
         assert!(!results[0].success);
         assert!(results[1].success);
 
-        let calls = mock.set_power_state_by_device_list_calls().await;
+        let calls = mock.batch_set_power_state_calls().await;
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].operation, rms::PowerOperation::PowerOff as i32);
+        assert_eq!(calls[0].operation, rms::PowerOperation::Off as i32);
     }
 
     #[carbide_macros::sqlx_test]
     async fn sw_queue_firmware_updates_success(pool: sqlx::PgPool) {
         let (mock, backend, _, _, _, sw1, _) = make_backend(&pool).await;
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_ok(
             &sw1.to_string(),
             "sw-job-1",
         )))
@@ -2339,13 +2320,13 @@ mod tests {
 
         assert!(results[0].success);
 
-        let calls = mock.apply_firmware_object_from_json_calls().await;
+        let calls = mock.apply_firmware_object_calls().await;
         assert_eq!(calls[0].config_json, r#"{"Id":"fw-json"}"#);
         assert_eq!(calls[0].access_token, "token");
         assert!(calls[0].force_update);
         let filters = component_filters_for(&calls[0], rms::NodeType::Switch);
         assert_eq!(filters, ["BMC", "BIOS"]);
-        let dev0 = &calls[0].nodes.as_ref().unwrap().devices[0];
+        let dev0 = &calls[0].nodes.as_ref().unwrap().nodes[0];
         assert_eq!(dev0.node_id, sw1.to_string());
         assert_eq!(dev0.r#type, Some(rms::NodeType::Switch as i32));
         assert!(dev0.bmc_endpoint.is_some());
@@ -2365,7 +2346,7 @@ mod tests {
         let (mock, backend, _, _, _, sw1, _) = make_backend(&pool).await;
         let eps = vec![make_sw_endpoint(SW_MAC_1)];
 
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_ok(
             &sw1.to_string(),
             "sw-job-old",
         )))
@@ -2380,7 +2361,7 @@ mod tests {
             .await
             .unwrap();
 
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_fail(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_fail(
             &sw1.to_string(),
             "bad firmware file",
         )))
@@ -2403,9 +2384,10 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn sw_queue_firmware_updates_nvos_uses_switch_system_image_json(pool: sqlx::PgPool) {
         let (mock, backend, rack_id, _, _, sw1, _) = make_backend(&pool).await;
-        mock.enqueue_apply_switch_system_image_from_json(Ok(
-            MockRmsApi::switch_system_image_apply_ok(&sw1.to_string(), "nvos-job-1"),
-        ))
+        mock.enqueue_apply_switch_system_image(Ok(MockRmsApi::switch_system_image_apply_ok(
+            &sw1.to_string(),
+            "nvos-job-1",
+        )))
         .await;
 
         let eps = vec![make_sw_endpoint(SW_MAC_1)];
@@ -2420,20 +2402,16 @@ mod tests {
             .unwrap();
 
         assert!(results[0].success);
-        assert!(
-            mock.apply_firmware_object_from_json_calls()
-                .await
-                .is_empty()
-        );
+        assert!(mock.apply_firmware_object_calls().await.is_empty());
 
-        let calls = mock.apply_switch_system_image_from_json_calls().await;
+        let calls = mock.apply_switch_system_image_calls().await;
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].config_json, r#"{"Id":"fw-json"}"#);
         assert_eq!(calls[0].access_token, "token");
         assert_eq!(calls[0].software_type, "prod");
         assert_eq!(calls[0].hardware_type, "any");
         assert_eq!(calls[0].rack_id, rack_id.to_string());
-        let dev0 = &calls[0].nodes.as_ref().unwrap().devices[0];
+        let dev0 = &calls[0].nodes.as_ref().unwrap().nodes[0];
         assert_eq!(dev0.node_id, sw1.to_string());
         assert_eq!(dev0.r#type, Some(rms::NodeType::Switch as i32));
         assert!(dev0.bmc_endpoint.is_some());
@@ -2453,14 +2431,15 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn sw_queue_firmware_updates_mixed_tracks_both_jobs(pool: sqlx::PgPool) {
         let (mock, backend, rack_id, _, _, sw1, _) = make_backend(&pool).await;
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_ok(
             &sw1.to_string(),
             "sw-fw-job",
         )))
         .await;
-        mock.enqueue_apply_switch_system_image_from_json(Ok(
-            MockRmsApi::switch_system_image_apply_ok(&sw1.to_string(), "sw-nvos-job"),
-        ))
+        mock.enqueue_apply_switch_system_image(Ok(MockRmsApi::switch_system_image_apply_ok(
+            &sw1.to_string(),
+            "sw-nvos-job",
+        )))
         .await;
 
         let eps = vec![make_sw_endpoint(SW_MAC_1)];
@@ -2475,11 +2454,8 @@ mod tests {
             .unwrap();
 
         assert!(results[0].success);
-        assert_eq!(mock.apply_firmware_object_from_json_calls().await.len(), 1);
-        assert_eq!(
-            mock.apply_switch_system_image_from_json_calls().await.len(),
-            1
-        );
+        assert_eq!(mock.apply_firmware_object_calls().await.len(), 1);
+        assert_eq!(mock.apply_switch_system_image_calls().await.len(), 1);
 
         {
             let jobs = backend.firmware_jobs.lock().unwrap();
@@ -2497,7 +2473,7 @@ mod tests {
         }
 
         mock.enqueue_get_firmware_job_status(Ok(MockRmsApi::firmware_job_status_ok(
-            rms::FirmwareJobState::FwJobCompleted,
+            rms::FirmwareJobState::Completed,
         )))
         .await;
         mock.enqueue_get_switch_system_image_job_status(Ok(
@@ -2521,14 +2497,15 @@ mod tests {
     #[carbide_macros::sqlx_test]
     async fn sw_queue_firmware_updates_mixed_failure_keeps_submitted_job(pool: sqlx::PgPool) {
         let (mock, backend, _, _, _, sw1, _) = make_backend(&pool).await;
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_ok(
             &sw1.to_string(),
             "sw-fw-job",
         )))
         .await;
-        mock.enqueue_apply_switch_system_image_from_json(Ok(
-            MockRmsApi::switch_system_image_apply_fail(&sw1.to_string(), "bad system image"),
-        ))
+        mock.enqueue_apply_switch_system_image(Ok(MockRmsApi::switch_system_image_apply_fail(
+            &sw1.to_string(),
+            "bad system image",
+        )))
         .await;
 
         let eps = vec![make_sw_endpoint(SW_MAC_1)];
@@ -2557,7 +2534,7 @@ mod tests {
     async fn sw_firmware_status(pool: sqlx::PgPool) {
         let (mock, backend, _, _, _, sw1, _) = make_backend(&pool).await;
 
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_ok(
             &sw1.to_string(),
             "sw-job-2",
         )))
@@ -2574,7 +2551,7 @@ mod tests {
             .unwrap();
 
         mock.enqueue_get_firmware_job_status(Ok(MockRmsApi::firmware_job_status_ok(
-            rms::FirmwareJobState::FwJobCompleted,
+            rms::FirmwareJobState::Completed,
         )))
         .await;
 
@@ -2594,7 +2571,7 @@ mod tests {
     ) {
         let (mock, backend, _, _, _, sw1, _) = make_backend(&pool).await;
 
-        mock.enqueue_apply_firmware_object_from_json(Ok(MockRmsApi::firmware_object_apply_ok(
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_ok(
             &sw1.to_string(),
             "sw-job-status-error",
         )))

--- a/crates/rack-controller/src/fabric_manager.rs
+++ b/crates/rack-controller/src/fabric_manager.rs
@@ -56,30 +56,26 @@ pub(super) fn validate_switch_inventory_for_nmx_cluster(
 fn build_scale_up_fabric_services_status_request(
     rack_id: &RackId,
     switches: &[FirmwareUpgradeDeviceInfo],
-) -> rms::GetScaleUpFabricServicesStatusRequest {
-    rms::GetScaleUpFabricServicesStatusRequest {
+) -> rms::BatchGetScaleUpFabricServiceStatusRequest {
+    rms::BatchGetScaleUpFabricServiceStatusRequest {
         nodes: Some(rms::NodeSet {
-            devices: switches
+            nodes: switches
                 .iter()
                 .map(|switch| build_new_node_info(rack_id, switch, rms::NodeType::Switch))
                 .collect(),
         }),
-        verify_ssl: false,
-        ..Default::default()
     }
 }
 
-pub(super) async fn get_scale_up_fabric_services_status(
+pub(super) async fn batch_get_scale_up_fabric_service_status(
     rms_config: &RmsConfig,
     rack_id: &RackId,
     switches: &[FirmwareUpgradeDeviceInfo],
-) -> Result<rms::GetScaleUpFabricServicesStatusResponse, String> {
+) -> Result<rms::BatchGetScaleUpFabricServiceStatusResponse, String> {
     let Some(url) = rms_config.api_url.as_deref().filter(|url| !url.is_empty()) else {
         return Err("RMS client not configured".to_string());
     };
 
-    // The pinned librms::RmsApi trait does not yet expose this RPC, so keep
-    // the direct concrete-client use local to ConfigureNmxCluster.
     let rms_client_config = librms::client_config::RmsClientConfig::new(
         rms_config.root_ca_path.clone(),
         rms_config.client_cert.clone(),
@@ -91,11 +87,11 @@ pub(super) async fn get_scale_up_fabric_services_status(
 
     rms_client
         .client
-        .get_scale_up_fabric_services_status(build_scale_up_fabric_services_status_request(
+        .batch_get_scale_up_fabric_service_status(build_scale_up_fabric_services_status_request(
             rack_id, switches,
         ))
         .await
-        .map_err(|error| format!("RMS GetScaleUpFabricServicesStatus failed: {}", error))
+        .map_err(|error| format!("RMS BatchGetScaleUpFabricServiceStatus failed: {}", error))
 }
 
 #[derive(Debug, Deserialize)]
@@ -165,17 +161,17 @@ pub(super) async fn persist_fabric_manager_statuses(
     txn: &mut PgConnection,
     rack_id: &RackId,
     switches: &[FirmwareUpgradeDeviceInfo],
-    response: &rms::GetScaleUpFabricServicesStatusResponse,
+    response: &rms::BatchGetScaleUpFabricServiceStatusResponse,
 ) -> Result<(), String> {
     if response.status != rms::ReturnCode::Success as i32 {
         return Err(
-            "RMS GetScaleUpFabricServicesStatus returned failure for ConfigureNmxCluster"
+            "RMS BatchGetScaleUpFabricServiceStatus returned failure for ConfigureNmxCluster"
                 .to_string(),
         );
     }
 
     for switch in switches {
-        let Some(entry) = response.device_info_result.get(switch.node_id.as_str()) else {
+        let Some(entry) = response.service_statuses.get(switch.node_id.as_str()) else {
             return Err(format!(
                 "RMS did not return fabric-manager status for switch {}",
                 switch.node_id
@@ -214,13 +210,13 @@ pub(super) async fn persist_fabric_manager_statuses(
 #[derive(Debug, Clone)]
 pub(super) struct SwitchPlacement {
     pub(super) device: FirmwareUpgradeDeviceInfo,
-    pub(super) tray_index: i32,
-    pub(super) slot_number: Option<i32>,
+    pub(super) tray_index: u32,
+    pub(super) slot_number: Option<u32>,
 }
 
 pub(super) fn select_primary_switch(
     switches: &[FirmwareUpgradeDeviceInfo],
-    response: &rms::GetDeviceInfoByDeviceListResponse,
+    response: &rms::BatchGetNodeDeviceInfoResponse,
 ) -> Result<SwitchPlacement, String> {
     if response.status != rms::ReturnCode::Success as i32 {
         let details = if response.message.trim().is_empty() {
@@ -228,17 +224,17 @@ pub(super) fn select_primary_switch(
         } else {
             response.message.clone()
         };
-        return Err(format!("RMS GetDeviceInfoByDeviceList failed: {}", details));
+        return Err(format!("RMS BatchGetNodeDeviceInfo failed: {}", details));
     }
 
     let switches_by_node_id: HashMap<&str, &FirmwareUpgradeDeviceInfo> = switches
         .iter()
         .map(|switch| (switch.node_id.as_str(), switch))
         .collect();
-    let mut placements = Vec::with_capacity(response.node_device_info.len());
-    let mut seen_node_ids = HashSet::with_capacity(response.node_device_info.len());
+    let mut placements = Vec::with_capacity(response.node_device_details.len());
+    let mut seen_node_ids = HashSet::with_capacity(response.node_device_details.len());
 
-    for node_info in &response.node_device_info {
+    for node_info in &response.node_device_details {
         let Some(device) = switches_by_node_id.get(node_info.node_id.as_str()) else {
             return Err(format!(
                 "RMS returned device info for unexpected switch {}",
@@ -294,10 +290,11 @@ pub(super) fn select_primary_switch(
         ));
     }
 
-    Ok(placements
-        .into_iter()
-        .next()
-        .expect("placements cannot be empty after explicit guard"))
+    let Some(primary) = placements.into_iter().next() else {
+        return Err("RMS returned no switch device info for ConfigureNmxCluster".to_string());
+    };
+
+    Ok(primary)
 }
 
 pub(super) async fn persist_primary_switch(
@@ -344,10 +341,10 @@ mod tests {
         }
     }
 
-    fn node_device_info(
+    fn node_device_details(
         node_id: &str,
-        tray_index: i32,
-        slot_number: Option<i32>,
+        tray_index: u32,
+        slot_number: Option<u32>,
     ) -> rms::NodeDeviceInfo {
         rms::NodeDeviceInfo {
             node_id: node_id.to_string(),
@@ -358,43 +355,48 @@ mod tests {
     }
 
     #[test]
-    fn select_primary_switch_picks_lowest_tray_index() {
+    fn select_primary_switch_picks_lowest_tray_index() -> Result<(), String> {
         let switches = vec![switch("sw-1"), switch("sw-2"), switch("sw-3")];
-        let response = rms::GetDeviceInfoByDeviceListResponse {
+        let response = rms::BatchGetNodeDeviceInfoResponse {
             status: rms::ReturnCode::Success as i32,
-            node_device_info: vec![
-                node_device_info("sw-1", 3, Some(3)),
-                node_device_info("sw-2", 1, Some(1)),
-                node_device_info("sw-3", 2, Some(2)),
+            node_device_details: vec![
+                node_device_details("sw-1", 3, Some(3)),
+                node_device_details("sw-2", 1, Some(1)),
+                node_device_details("sw-3", 2, Some(2)),
             ],
             ..Default::default()
         };
 
-        let primary =
-            select_primary_switch(&switches, &response).expect("selection should succeed");
+        let primary = select_primary_switch(&switches, &response)?;
 
         assert_eq!(primary.device.node_id, "sw-2");
         assert_eq!(primary.tray_index, 1);
         assert_eq!(primary.slot_number, Some(1));
+
+        Ok(())
     }
 
     #[test]
-    fn select_primary_switch_errors_on_duplicate_tray_index() {
+    fn select_primary_switch_errors_on_duplicate_tray_index() -> Result<(), String> {
         let switches = vec![switch("sw-1"), switch("sw-2")];
-        let response = rms::GetDeviceInfoByDeviceListResponse {
+        let response = rms::BatchGetNodeDeviceInfoResponse {
             status: rms::ReturnCode::Success as i32,
-            node_device_info: vec![
-                node_device_info("sw-1", 1, Some(1)),
-                node_device_info("sw-2", 1, Some(2)),
+            node_device_details: vec![
+                node_device_details("sw-1", 1, Some(1)),
+                node_device_details("sw-2", 1, Some(2)),
             ],
             ..Default::default()
         };
 
-        let error = select_primary_switch(&switches, &response).expect_err("selection should fail");
+        let Err(error) = select_primary_switch(&switches, &response) else {
+            return Err("selection should fail".to_string());
+        };
 
         assert!(error.contains("duplicate tray_index 1"));
         assert!(error.contains("sw-1"));
         assert!(error.contains("sw-2"));
+
+        Ok(())
     }
 
     #[test]

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -29,8 +29,8 @@ use carbide_rack::rms_client::SwitchSystemImageRmsClient;
 use carbide_rack_controller::config::RmsConfig;
 use carbide_rack_controller::context::RackStateHandlerContextObjects;
 use carbide_rack_controller::fabric_manager::{
-    get_scale_up_fabric_services_status, persist_fabric_manager_statuses, persist_primary_switch,
-    select_primary_switch, validate_switch_inventory_for_nmx_cluster,
+    batch_get_scale_up_fabric_service_status, persist_fabric_manager_statuses,
+    persist_primary_switch, select_primary_switch, validate_switch_inventory_for_nmx_cluster,
 };
 use carbide_rack_controller::validating::strip_rv_labels;
 use carbide_uuid::rack::{RackId, RackProfileId};
@@ -438,15 +438,14 @@ fn skip_configure_nmx_cluster_outcome(
 fn build_switch_device_info_request(
     rack_id: &RackId,
     switches: &[FirmwareUpgradeDeviceInfo],
-) -> rms::GetDeviceInfoByDeviceListRequest {
-    rms::GetDeviceInfoByDeviceListRequest {
+) -> rms::BatchGetNodeDeviceInfoRequest {
+    rms::BatchGetNodeDeviceInfoRequest {
         nodes: Some(rms::NodeSet {
-            devices: switches
+            nodes: switches
                 .iter()
                 .map(|switch| build_new_node_info(rack_id, switch, rms::NodeType::Switch))
                 .collect(),
         }),
-        ..Default::default()
     }
 }
 
@@ -550,14 +549,14 @@ async fn rms_start_firmware_upgrade_from_json(
     let started_at = chrono::Utc::now();
     let machine_count = request.machines.len();
     let switch_count = request.switches.len();
-    let mut devices = Vec::with_capacity(machine_count + switch_count);
-    devices.extend(
+    let mut nodes = Vec::with_capacity(machine_count + switch_count);
+    nodes.extend(
         request
             .machines
             .iter()
             .map(|device| build_new_node_info(request.rack_id, device, rms::NodeType::Compute)),
     );
-    devices.extend(
+    nodes.extend(
         request
             .switches
             .iter()
@@ -565,14 +564,13 @@ async fn rms_start_firmware_upgrade_from_json(
     );
 
     let response = rms_client
-        .apply_firmware_object_from_json(rms::ApplyFirmwareObjectFromJsonRequest {
-            metadata: None,
+        .apply_firmware_object(rms::ApplyFirmwareObjectRequest {
             rack_id: request.rack_id.to_string(),
             config_json: request.config_json.to_string(),
             access_token: request.access_token.to_string(),
             firmware_type: request.firmware_type.to_string(),
             hardware_type: request.hardware_type.to_string(),
-            nodes: Some(rms::NodeSet { devices }),
+            nodes: Some(rms::NodeSet { nodes }),
             force_update: request.force_update,
             component_filters: rms_component_filters_from_components(
                 request.components,
@@ -597,13 +595,13 @@ async fn rms_start_firmware_upgrade_from_json(
         .unwrap_or_default();
     if batch_status != rms::ReturnCode::Success as i32
         && batch_job_id.is_empty()
-        && response.node_jobs.is_empty()
+        && response.jobs.is_empty()
     {
         let message = batch_response
             .map(|batch_response| batch_response.message.as_str())
             .unwrap_or_default();
         let message = if message.is_empty() {
-            "RMS returned failure for ApplyFirmwareObjectFromJSON".to_string()
+            "RMS returned failure for ApplyFirmwareObject".to_string()
         } else {
             message.to_string()
         };
@@ -612,7 +610,7 @@ async fn rms_start_firmware_upgrade_from_json(
 
     let parent_job_id = (!batch_job_id.is_empty()).then(|| batch_job_id.to_string());
     let child_jobs = response
-        .node_jobs
+        .jobs
         .iter()
         .map(|child| (child.node_id.clone(), child.job_id.clone()))
         .collect::<std::collections::HashMap<_, _>>();
@@ -734,7 +732,6 @@ async fn rms_get_firmware_upgrade_status(
         let response = rms_client
             .get_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusRequest {
                 job_id: job_id.clone(),
-                ..Default::default()
             })
             .await;
 
@@ -745,20 +742,20 @@ async fn rms_get_firmware_upgrade_status(
                 if !response.node_id.is_empty() {
                     device.node_id = response.node_id.clone();
                 }
-                match response.job_state {
-                    0 => {
+                match rms::FirmwareJobState::try_from(response.job_state) {
+                    Ok(rms::FirmwareJobState::Queued) => {
                         device.status = "pending".into();
                         device.error_message = None;
                     }
-                    1 => {
+                    Ok(rms::FirmwareJobState::Running) => {
                         device.status = "in_progress".into();
                         device.error_message = None;
                     }
-                    2 => {
+                    Ok(rms::FirmwareJobState::Completed) => {
                         device.status = "completed".into();
                         device.error_message = None;
                     }
-                    3 => {
+                    Ok(rms::FirmwareJobState::Failed) => {
                         device.status = "failed".into();
                         device.error_message = Some(if response.error_message.is_empty() {
                             response.state_description
@@ -766,7 +763,7 @@ async fn rms_get_firmware_upgrade_status(
                             response.error_message
                         });
                     }
-                    _ => {
+                    Ok(rms::FirmwareJobState::Unspecified) | Err(_) => {
                         tracing::warn!(
                             job_id = %job_id,
                             job_state = response.job_state,
@@ -854,18 +851,17 @@ async fn rms_start_nvos_update(
     switches: Vec<FirmwareUpgradeDeviceInfo>,
 ) -> Result<NvosUpdateJob, StateHandlerError> {
     let started_at = chrono::Utc::now();
-    let devices: Vec<_> = switches
+    let nodes: Vec<_> = switches
         .iter()
         .map(|switch| build_new_node_info(rack_id, switch, rms::NodeType::Switch))
         .collect();
-    let nodes = Some(rms::NodeSet { devices });
+    let nodes = Some(rms::NodeSet { nodes });
     let NvosUpdateSource {
         config_json,
         access_token,
     } = source;
     let response = rms_client
-        .apply_switch_system_image_from_json(rms::ApplySwitchSystemImageFromJsonRequest {
-            metadata: None,
+        .apply_switch_system_image(rms::ApplySwitchSystemImageRequest {
             rack_id: rack_id.to_string(),
             config_json: config_json.to_string(),
             access_token: access_token.to_string(),
@@ -890,13 +886,13 @@ async fn rms_start_nvos_update(
         .unwrap_or_default();
     if batch_status != rms::ReturnCode::Success as i32
         && batch_job_id.is_empty()
-        && response.node_jobs.is_empty()
+        && response.jobs.is_empty()
     {
         let message = batch_response
             .map(|batch_response| batch_response.message.as_str())
             .unwrap_or_default();
         let message = if message.is_empty() {
-            "RMS returned failure for ApplySwitchSystemImageFromJSON".to_string()
+            "RMS returned failure for ApplySwitchSystemImage".to_string()
         } else {
             message.to_string()
         };
@@ -905,7 +901,7 @@ async fn rms_start_nvos_update(
 
     let parent_job_id = (!batch_job_id.is_empty()).then(|| batch_job_id.to_string());
     let child_jobs = response
-        .node_jobs
+        .jobs
         .iter()
         .map(|child| (child.node_id.clone(), child.job_id.clone()))
         .collect::<std::collections::HashMap<_, _>>();
@@ -995,7 +991,6 @@ async fn rms_get_nvos_update_status(
         let response = rms_client
             .get_switch_system_image_job_status(rms::GetSwitchSystemImageJobStatusRequest {
                 job_id: job_id.clone(),
-                ..Default::default()
             })
             .await;
 
@@ -1801,9 +1796,9 @@ pub async fn handle_maintenance(
                     "Disabling ScaleUpFabric state before selecting ConfigureNmxCluster primary switch"
                 );
                 let response = match rms_client
-                    .set_scale_up_fabric_state(rms::SetScaleUpFabricStateRequest {
+                    .batch_set_scale_up_fabric_state(rms::BatchSetScaleUpFabricStateRequest {
                         nodes: Some(rms::NodeSet {
-                            devices: switch_inventory
+                            nodes: switch_inventory
                                 .switches
                                 .iter()
                                 .map(|switch| {
@@ -1811,21 +1806,21 @@ pub async fn handle_maintenance(
                                 })
                                 .collect(),
                         }),
-                        enabled: Some(false),
-                        verify_ssl: false,
-                        ..Default::default()
+                        enabled: false,
                     })
                     .await
                 {
                     Ok(response) => response,
                     Err(error) => {
-                        let error = rack_manager_error("set_scale_up_fabric_state", error);
+                        let error = rack_manager_error("batch_set_scale_up_fabric_state", error);
                         return transition_to_rack_error(id, state, error.to_string(), ctx).await;
                     }
                 };
 
                 let batch = response.response.unwrap_or_default();
-                if batch.status != rms::ReturnCode::Success as i32 || batch.failed_nodes > 0 {
+                let stats = batch.stats.unwrap_or_default();
+
+                if batch.status != rms::ReturnCode::Success as i32 || stats.failed_nodes > 0 {
                     let node_error = batch
                         .node_results
                         .iter()
@@ -1847,21 +1842,21 @@ pub async fn handle_maintenance(
                     } else {
                         format!(
                             "batch status {}, failed_nodes {}",
-                            batch.status, batch.failed_nodes,
+                            batch.status, stats.failed_nodes,
                         )
                     };
                     tracing::error!(
                         rack_id = %id,
                         batch_status = batch.status,
-                        successful_nodes = batch.successful_nodes,
-                        failed_nodes = batch.failed_nodes,
+                        successful_nodes = stats.successful_nodes,
+                        failed_nodes = stats.failed_nodes,
                         summary = %summary,
-                        "RMS SetScaleUpFabricState failed",
+                        "RMS BatchSetScaleUpFabricState failed",
                     );
                     return transition_to_rack_error(
                         id,
                         state,
-                        format!("RMS SetScaleUpFabricState failed: {}", summary),
+                        format!("RMS BatchSetScaleUpFabricState failed: {}", summary),
                         ctx,
                     )
                     .await;
@@ -1869,7 +1864,7 @@ pub async fn handle_maintenance(
 
                 tracing::info!(
                     rack_id = %id,
-                    successful_nodes = batch.successful_nodes,
+                    successful_nodes = stats.successful_nodes,
                     switch_count = switch_inventory.switches.len(),
                     "ScaleUpFabric state disabled; advancing to ConfigureScaleUpFabricManager"
                 );
@@ -1955,7 +1950,7 @@ pub async fn handle_maintenance(
                 };
 
                 let response = match rms_client
-                    .get_device_info_by_device_list(build_switch_device_info_request(
+                    .batch_get_node_device_info(build_switch_device_info_request(
                         id,
                         &switch_inventory.switches,
                     ))
@@ -1963,7 +1958,7 @@ pub async fn handle_maintenance(
                 {
                     Ok(response) => response,
                     Err(error) => {
-                        let error = rack_manager_error("get_device_info_by_device_list", error);
+                        let error = rack_manager_error("batch_get_node_device_info", error);
                         return transition_to_rack_error(id, state, error.to_string(), ctx).await;
                     }
                 };
@@ -1996,14 +1991,12 @@ pub async fn handle_maintenance(
                 );
                 let response = match rms_client
                     .configure_scale_up_fabric_manager(rms::ConfigureScaleUpFabricManagerRequest {
-                        device: Some(build_new_node_info(
+                        node: Some(build_new_node_info(
                             id,
                             &primary_switch.device,
                             rms::NodeType::Switch,
                         )),
                         topology_type: topology_type.clone(),
-                        verify_ssl: false,
-                        ..Default::default()
                     })
                     .await
                 {
@@ -2088,7 +2081,7 @@ pub async fn handle_maintenance(
                     ));
                 }
 
-                let fabric_status_response = match get_scale_up_fabric_services_status(
+                let fabric_status_response = match batch_get_scale_up_fabric_service_status(
                     &ctx.services.site_config.rms,
                     id,
                     &switch_inventory.switches,

--- a/crates/rack/Cargo.toml
+++ b/crates/rack/Cargo.toml
@@ -42,6 +42,7 @@ eyre = { workspace = true }
 librms = { workspace = true }
 mac_address = { workspace = true }
 opentelemetry = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rack/src/firmware_update.rs
+++ b/crates/rack/src/firmware_update.rs
@@ -210,34 +210,40 @@ pub fn build_new_node_info(
     rack_id: &RackId,
     device: &FirmwareUpgradeDeviceInfo,
     node_type: rms::NodeType,
-) -> rms::NewNodeInfo {
+) -> rms::NodeInfo {
     let bmc_endpoint = if device.bmc_ip.is_empty() || device.mac.is_empty() {
         None
     } else {
-        Some(rms::BmcEndpoint {
+        Some(rms::Endpoint {
             interface: Some(rms::NetworkInterface {
                 ip_address: device.bmc_ip.clone(),
                 mac_address: device.mac.clone(),
             }),
             port: 443,
             credentials: user_pass_credentials(&device.bmc_username, &device.bmc_password),
+            // TODO: we'll need to remove this from the RMS proto `Endpoint` field. This field
+            // should not be set by the caller, and should be owned by the RMS.
+            dangerously_accept_invalid_certs: true,
         })
     };
 
     let host_endpoint = if matches!(node_type, rms::NodeType::Switch) {
-        Some(rms::HostEndpoint {
-            interfaces: build_host_interfaces(device),
+        Some(rms::Endpoint {
+            interface: build_host_interface(device),
             port: 0,
             credentials: user_pass_credentials(
                 device.os_username.as_deref().unwrap_or_default(),
                 device.os_password.as_deref().unwrap_or_default(),
             ),
+            // TODO: we'll need to remove this from the RMS proto `Endpoint` field. This field
+            // should not be set by the caller, and should be owned by the RMS.
+            dangerously_accept_invalid_certs: true,
         })
     } else {
         None
     };
 
-    rms::NewNodeInfo {
+    rms::NodeInfo {
         node_id: device.node_id.clone(),
         rack_id: rack_id.to_string(),
         r#type: Some(node_type as i32),
@@ -246,15 +252,15 @@ pub fn build_new_node_info(
     }
 }
 
-fn build_host_interfaces(device: &FirmwareUpgradeDeviceInfo) -> Vec<rms::NetworkInterface> {
-    if device.os_ip.is_none() && device.os_mac.is_none() {
-        return Vec::new();
-    }
+fn build_host_interface(device: &FirmwareUpgradeDeviceInfo) -> Option<rms::NetworkInterface> {
+    let (Some(ip_address), Some(mac_address)) = (&device.os_ip, &device.os_mac) else {
+        return None;
+    };
 
-    vec![rms::NetworkInterface {
-        ip_address: device.os_ip.clone().unwrap_or_default(),
-        mac_address: device.os_mac.clone().unwrap_or_default(),
-    }]
+    Some(rms::NetworkInterface {
+        ip_address: ip_address.clone(),
+        mac_address: mac_address.clone(),
+    })
 }
 
 fn user_pass_credentials(username: &str, password: &str) -> Option<rms::Credentials> {

--- a/crates/rack/src/rms_client.rs
+++ b/crates/rack/src/rms_client.rs
@@ -19,9 +19,9 @@ use librms::protos::rack_manager as rms;
 
 #[async_trait::async_trait]
 pub trait SwitchSystemImageRmsClient: Send + Sync {
-    async fn apply_switch_system_image_from_json(
+    async fn apply_switch_system_image(
         &self,
-        cmd: rms::ApplySwitchSystemImageFromJsonRequest,
+        cmd: rms::ApplySwitchSystemImageRequest,
     ) -> Result<rms::ApplySwitchSystemImageResponse, tonic::Status>;
 
     async fn get_switch_system_image_job_status(
@@ -32,11 +32,11 @@ pub trait SwitchSystemImageRmsClient: Send + Sync {
 
 #[async_trait::async_trait]
 impl SwitchSystemImageRmsClient for librms::RackManagerApi {
-    async fn apply_switch_system_image_from_json(
+    async fn apply_switch_system_image(
         &self,
-        cmd: rms::ApplySwitchSystemImageFromJsonRequest,
+        cmd: rms::ApplySwitchSystemImageRequest,
     ) -> Result<rms::ApplySwitchSystemImageResponse, tonic::Status> {
-        self.client.apply_switch_system_image_from_json(cmd).await
+        self.client.apply_switch_system_image(cmd).await
     }
 
     async fn get_switch_system_image_job_status(
@@ -60,86 +60,96 @@ pub mod test_support {
 
     /// RMS simulation for testing, similar to RedfishSim
     pub struct RmsSim {
-        fail_add_node: Arc<AtomicBool>,
+        fail_create_nodes: Arc<AtomicBool>,
         fail_inventory_get: Arc<AtomicBool>,
         registered_nodes: Arc<Mutex<Vec<rms::NodeInventoryInfo>>>,
         firmware_objects: Arc<Mutex<HashMap<String, rms::FirmwareObject>>>,
-        submitted_firmware_requests: Arc<Mutex<Vec<rms::UpdateFirmwareByDeviceListRequest>>>,
-        queued_firmware_responses: Arc<Mutex<VecDeque<rms::UpdateFirmwareByDeviceListResponse>>>,
-        submitted_firmware_object_apply_requests: Arc<Mutex<Vec<rms::ApplyFirmwareObjectRequest>>>,
+        submitted_firmware_requests: Arc<Mutex<Vec<rms::BatchUpdateFirmwareRequest>>>,
+        queued_firmware_responses: Arc<Mutex<VecDeque<rms::BatchUpdateFirmwareResponse>>>,
+        submitted_apply_stored_firmware_object_requests:
+            Arc<Mutex<Vec<rms::ApplyStoredFirmwareObjectRequest>>>,
         queued_firmware_object_apply_responses:
             Arc<Mutex<VecDeque<rms::ApplyFirmwareObjectResponse>>>,
-        submitted_firmware_object_from_json_apply_requests:
-            Arc<Mutex<Vec<rms::ApplyFirmwareObjectFromJsonRequest>>>,
+        submitted_apply_firmware_object_requests: Arc<Mutex<Vec<rms::ApplyFirmwareObjectRequest>>>,
         firmware_job_statuses: Arc<Mutex<HashMap<String, rms::GetFirmwareJobStatusResponse>>>,
         firmware_job_errors: Arc<Mutex<HashMap<String, String>>>,
         submitted_apply_switch_system_image_requests:
             Arc<Mutex<Vec<rms::ApplySwitchSystemImageRequest>>>,
-        submitted_apply_switch_system_image_from_json_requests:
-            Arc<Mutex<Vec<rms::ApplySwitchSystemImageFromJsonRequest>>>,
         queued_apply_switch_system_image_responses:
             Arc<Mutex<VecDeque<rms::ApplySwitchSystemImageResponse>>>,
         switch_system_image_job_statuses:
             Arc<Mutex<HashMap<String, rms::GetSwitchSystemImageJobStatusResponse>>>,
         switch_system_image_job_errors: Arc<Mutex<HashMap<String, String>>>,
-        submitted_get_device_info_by_device_list_requests:
-            Arc<Mutex<Vec<rms::GetDeviceInfoByDeviceListRequest>>>,
-        queued_get_device_info_by_device_list_responses:
-            Arc<Mutex<VecDeque<Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError>>>>,
+        submitted_batch_get_node_device_info_requests:
+            Arc<Mutex<Vec<rms::BatchGetNodeDeviceInfoRequest>>>,
+        queued_batch_get_node_device_info_responses:
+            Arc<Mutex<VecDeque<Result<rms::BatchGetNodeDeviceInfoResponse, RackManagerError>>>>,
+        submitted_batch_get_power_state_requests: Arc<Mutex<Vec<rms::BatchGetPowerStateRequest>>>,
+        queued_batch_get_power_state_responses:
+            Arc<Mutex<VecDeque<Result<rms::BatchGetPowerStateResponse, RackManagerError>>>>,
         submitted_configure_scale_up_fabric_manager_requests:
             Arc<Mutex<Vec<rms::ConfigureScaleUpFabricManagerRequest>>>,
         queued_configure_scale_up_fabric_manager_responses: Arc<
             Mutex<VecDeque<Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError>>>,
         >,
-        submitted_set_scale_up_fabric_state_requests:
-            Arc<Mutex<Vec<rms::SetScaleUpFabricStateRequest>>>,
-        queued_set_scale_up_fabric_state_responses:
-            Arc<Mutex<VecDeque<Result<rms::SetScaleUpFabricStateResponse, RackManagerError>>>>,
-        submitted_set_power_state_by_device_list_requests:
-            Arc<Mutex<Vec<rms::SetPowerStateByDeviceListRequest>>>,
-        queued_set_power_state_by_device_list_responses:
-            Arc<Mutex<VecDeque<Result<rms::SetPowerStateByDeviceListResponse, RackManagerError>>>>,
+        submitted_batch_set_scale_up_fabric_state_requests:
+            Arc<Mutex<Vec<rms::BatchSetScaleUpFabricStateRequest>>>,
+        queued_batch_set_scale_up_fabric_state_responses:
+            Arc<Mutex<VecDeque<Result<rms::BatchSetScaleUpFabricStateResponse, RackManagerError>>>>,
+        submitted_batch_get_scale_up_fabric_service_status_requests:
+            Arc<Mutex<Vec<rms::BatchGetScaleUpFabricServiceStatusRequest>>>,
+        queued_batch_get_scale_up_fabric_service_status_responses: Arc<
+            Mutex<
+                VecDeque<Result<rms::BatchGetScaleUpFabricServiceStatusResponse, RackManagerError>>,
+            >,
+        >,
+        submitted_batch_set_power_state_requests: Arc<Mutex<Vec<rms::BatchSetPowerStateRequest>>>,
+        queued_batch_set_power_state_responses:
+            Arc<Mutex<VecDeque<Result<rms::BatchSetPowerStateResponse, RackManagerError>>>>,
     }
 
     impl Default for RmsSim {
         fn default() -> Self {
             Self {
-                fail_add_node: Arc::new(AtomicBool::new(false)),
+                fail_create_nodes: Arc::new(AtomicBool::new(false)),
                 fail_inventory_get: Arc::new(AtomicBool::new(false)),
                 registered_nodes: Arc::new(Mutex::new(Vec::new())),
                 firmware_objects: Arc::new(Mutex::new(HashMap::new())),
                 submitted_firmware_requests: Arc::new(Mutex::new(Vec::new())),
                 queued_firmware_responses: Arc::new(Mutex::new(VecDeque::new())),
-                submitted_firmware_object_apply_requests: Arc::new(Mutex::new(Vec::new())),
+                submitted_apply_stored_firmware_object_requests: Arc::new(Mutex::new(Vec::new())),
                 queued_firmware_object_apply_responses: Arc::new(Mutex::new(VecDeque::new())),
-                submitted_firmware_object_from_json_apply_requests: Arc::new(
-                    Mutex::new(Vec::new()),
-                ),
+                submitted_apply_firmware_object_requests: Arc::new(Mutex::new(Vec::new())),
                 firmware_job_statuses: Arc::new(Mutex::new(HashMap::new())),
                 firmware_job_errors: Arc::new(Mutex::new(HashMap::new())),
                 submitted_apply_switch_system_image_requests: Arc::new(Mutex::new(Vec::new())),
-                submitted_apply_switch_system_image_from_json_requests: Arc::new(Mutex::new(
-                    Vec::new(),
-                )),
                 queued_apply_switch_system_image_responses: Arc::new(Mutex::new(VecDeque::new())),
                 switch_system_image_job_statuses: Arc::new(Mutex::new(HashMap::new())),
                 switch_system_image_job_errors: Arc::new(Mutex::new(HashMap::new())),
-                submitted_get_device_info_by_device_list_requests: Arc::new(Mutex::new(Vec::new())),
-                queued_get_device_info_by_device_list_responses: Arc::new(Mutex::new(
-                    VecDeque::new(),
-                )),
+                submitted_batch_get_node_device_info_requests: Arc::new(Mutex::new(Vec::new())),
+                queued_batch_get_node_device_info_responses: Arc::new(Mutex::new(VecDeque::new())),
+                submitted_batch_get_power_state_requests: Arc::new(Mutex::new(Vec::new())),
+                queued_batch_get_power_state_responses: Arc::new(Mutex::new(VecDeque::new())),
                 submitted_configure_scale_up_fabric_manager_requests: Arc::new(Mutex::new(
                     Vec::new(),
                 )),
                 queued_configure_scale_up_fabric_manager_responses: Arc::new(Mutex::new(
                     VecDeque::new(),
                 )),
-                submitted_set_scale_up_fabric_state_requests: Arc::new(Mutex::new(Vec::new())),
-                queued_set_scale_up_fabric_state_responses: Arc::new(Mutex::new(VecDeque::new())),
-                submitted_set_power_state_by_device_list_requests: Arc::new(Mutex::new(Vec::new())),
-                queued_set_power_state_by_device_list_responses: Arc::new(Mutex::new(
+                submitted_batch_set_scale_up_fabric_state_requests: Arc::new(
+                    Mutex::new(Vec::new()),
+                ),
+                queued_batch_set_scale_up_fabric_state_responses: Arc::new(Mutex::new(
                     VecDeque::new(),
                 )),
+                submitted_batch_get_scale_up_fabric_service_status_requests: Arc::new(Mutex::new(
+                    Vec::new(),
+                )),
+                queued_batch_get_scale_up_fabric_service_status_responses: Arc::new(Mutex::new(
+                    VecDeque::new(),
+                )),
+                submitted_batch_set_power_state_requests: Arc::new(Mutex::new(Vec::new())),
+                queued_batch_set_power_state_responses: Arc::new(Mutex::new(VecDeque::new())),
             }
         }
     }
@@ -158,43 +168,42 @@ pub mod test_support {
 
         fn build_mock_client(&self) -> MockRmsClient {
             MockRmsClient {
-                submitted_get_power_state_by_device_list_requests: Arc::new(Mutex::new(Vec::new())),
-                queued_get_power_state_by_device_list_responses: Arc::new(Mutex::new(
-                    VecDeque::new(),
-                )),
-                fail_add_node: self.fail_add_node.clone(),
+                fail_create_nodes: self.fail_create_nodes.clone(),
                 fail_inventory_get: self.fail_inventory_get.clone(),
                 registered_nodes: self.registered_nodes.clone(),
                 firmware_objects: self.firmware_objects.clone(),
                 submitted_firmware_requests: self.submitted_firmware_requests.clone(),
                 queued_firmware_responses: self.queued_firmware_responses.clone(),
-                submitted_firmware_object_apply_requests: self
-                    .submitted_firmware_object_apply_requests
+                submitted_apply_stored_firmware_object_requests: self
+                    .submitted_apply_stored_firmware_object_requests
                     .clone(),
                 queued_firmware_object_apply_responses: self
                     .queued_firmware_object_apply_responses
                     .clone(),
-                submitted_firmware_object_from_json_apply_requests: self
-                    .submitted_firmware_object_from_json_apply_requests
+                submitted_apply_firmware_object_requests: self
+                    .submitted_apply_firmware_object_requests
                     .clone(),
                 firmware_job_statuses: self.firmware_job_statuses.clone(),
                 firmware_job_errors: self.firmware_job_errors.clone(),
                 submitted_apply_switch_system_image_requests: self
                     .submitted_apply_switch_system_image_requests
                     .clone(),
-                submitted_apply_switch_system_image_from_json_requests: self
-                    .submitted_apply_switch_system_image_from_json_requests
-                    .clone(),
                 queued_apply_switch_system_image_responses: self
                     .queued_apply_switch_system_image_responses
                     .clone(),
                 switch_system_image_job_statuses: self.switch_system_image_job_statuses.clone(),
                 switch_system_image_job_errors: self.switch_system_image_job_errors.clone(),
-                submitted_get_device_info_by_device_list_requests: self
-                    .submitted_get_device_info_by_device_list_requests
+                submitted_batch_get_node_device_info_requests: self
+                    .submitted_batch_get_node_device_info_requests
                     .clone(),
-                queued_get_device_info_by_device_list_responses: self
-                    .queued_get_device_info_by_device_list_responses
+                queued_batch_get_node_device_info_responses: self
+                    .queued_batch_get_node_device_info_responses
+                    .clone(),
+                submitted_batch_get_power_state_requests: self
+                    .submitted_batch_get_power_state_requests
+                    .clone(),
+                queued_batch_get_power_state_responses: self
+                    .queued_batch_get_power_state_responses
                     .clone(),
                 submitted_configure_scale_up_fabric_manager_requests: self
                     .submitted_configure_scale_up_fabric_manager_requests
@@ -202,25 +211,31 @@ pub mod test_support {
                 queued_configure_scale_up_fabric_manager_responses: self
                     .queued_configure_scale_up_fabric_manager_responses
                     .clone(),
-                submitted_set_scale_up_fabric_state_requests: self
-                    .submitted_set_scale_up_fabric_state_requests
+                submitted_batch_set_scale_up_fabric_state_requests: self
+                    .submitted_batch_set_scale_up_fabric_state_requests
                     .clone(),
-                queued_set_scale_up_fabric_state_responses: self
-                    .queued_set_scale_up_fabric_state_responses
+                queued_batch_set_scale_up_fabric_state_responses: self
+                    .queued_batch_set_scale_up_fabric_state_responses
                     .clone(),
-                submitted_set_power_state_by_device_list_requests: self
-                    .submitted_set_power_state_by_device_list_requests
+                submitted_batch_get_scale_up_fabric_service_status_requests: self
+                    .submitted_batch_get_scale_up_fabric_service_status_requests
                     .clone(),
-                queued_set_power_state_by_device_list_responses: self
-                    .queued_set_power_state_by_device_list_responses
+                queued_batch_get_scale_up_fabric_service_status_responses: self
+                    .queued_batch_get_scale_up_fabric_service_status_responses
+                    .clone(),
+                submitted_batch_set_power_state_requests: self
+                    .submitted_batch_set_power_state_requests
+                    .clone(),
+                queued_batch_set_power_state_responses: self
+                    .queued_batch_set_power_state_responses
                     .clone(),
             }
         }
 
-        /// Set whether `add_node` should return an error for testing
+        /// Set whether `create_nodes` should return an error for testing
         /// if registration attempts are failing (and should retry).
-        pub fn set_fail_add_node(&self, fail: bool) {
-            self.fail_add_node.store(fail, Ordering::Relaxed);
+        pub fn set_fail_create_nodes(&self, fail: bool) {
+            self.fail_create_nodes.store(fail, Ordering::Relaxed);
         }
 
         /// Set whether `inventory_get` should return an error for
@@ -233,7 +248,7 @@ pub mod test_support {
 
         pub async fn queue_update_firmware_response(
             &self,
-            response: rms::UpdateFirmwareByDeviceListResponse,
+            response: rms::BatchUpdateFirmwareResponse,
         ) {
             self.queued_firmware_responses
                 .lock()
@@ -259,9 +274,7 @@ pub mod test_support {
                 .insert(job_id.into(), message.into());
         }
 
-        pub async fn submitted_firmware_requests(
-            &self,
-        ) -> Vec<rms::UpdateFirmwareByDeviceListRequest> {
+        pub async fn submitted_firmware_requests(&self) -> Vec<rms::BatchUpdateFirmwareRequest> {
             self.submitted_firmware_requests.lock().await.clone()
         }
 
@@ -285,16 +298,16 @@ pub mod test_support {
         pub async fn submitted_apply_firmware_object_requests(
             &self,
         ) -> Vec<rms::ApplyFirmwareObjectRequest> {
-            self.submitted_firmware_object_apply_requests
+            self.submitted_apply_firmware_object_requests
                 .lock()
                 .await
                 .clone()
         }
 
-        pub async fn submitted_apply_firmware_object_from_json_requests(
+        pub async fn submitted_apply_stored_firmware_object_requests(
             &self,
-        ) -> Vec<rms::ApplyFirmwareObjectFromJsonRequest> {
-            self.submitted_firmware_object_from_json_apply_requests
+        ) -> Vec<rms::ApplyStoredFirmwareObjectRequest> {
+            self.submitted_apply_stored_firmware_object_requests
                 .lock()
                 .await
                 .clone()
@@ -340,29 +353,42 @@ pub mod test_support {
                 .clone()
         }
 
-        pub async fn submitted_apply_switch_system_image_from_json_requests(
+        pub async fn queue_batch_get_node_device_info_response(
             &self,
-        ) -> Vec<rms::ApplySwitchSystemImageFromJsonRequest> {
-            self.submitted_apply_switch_system_image_from_json_requests
-                .lock()
-                .await
-                .clone()
-        }
-
-        pub async fn queue_get_device_info_by_device_list_response(
-            &self,
-            response: Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError>,
+            response: Result<rms::BatchGetNodeDeviceInfoResponse, RackManagerError>,
         ) {
-            self.queued_get_device_info_by_device_list_responses
+            self.queued_batch_get_node_device_info_responses
                 .lock()
                 .await
                 .push_back(response);
         }
 
-        pub async fn submitted_get_device_info_by_device_list_requests(
+        pub async fn submitted_batch_get_node_device_info_requests(
             &self,
-        ) -> Vec<rms::GetDeviceInfoByDeviceListRequest> {
-            self.submitted_get_device_info_by_device_list_requests
+        ) -> Vec<rms::BatchGetNodeDeviceInfoRequest> {
+            self.submitted_batch_get_node_device_info_requests
+                .lock()
+                .await
+                .clone()
+        }
+
+        /// Queue a `Result` to be returned on the next call to
+        /// `batch_get_power_state`.
+        pub async fn queue_batch_get_power_state_response(
+            &self,
+            response: Result<rms::BatchGetPowerStateResponse, RackManagerError>,
+        ) {
+            self.queued_batch_get_power_state_responses
+                .lock()
+                .await
+                .push_back(response);
+        }
+
+        /// Snapshot recorded `BatchGetPowerState` requests in call order.
+        pub async fn submitted_batch_get_power_state_requests(
+            &self,
+        ) -> Vec<rms::BatchGetPowerStateRequest> {
+            self.submitted_batch_get_power_state_requests
                 .lock()
                 .await
                 .clone()
@@ -387,45 +413,66 @@ pub mod test_support {
                 .clone()
         }
 
-        pub async fn queue_set_scale_up_fabric_state_response(
+        pub async fn queue_batch_set_scale_up_fabric_state_response(
             &self,
-            response: Result<rms::SetScaleUpFabricStateResponse, RackManagerError>,
+            response: Result<rms::BatchSetScaleUpFabricStateResponse, RackManagerError>,
         ) {
-            self.queued_set_scale_up_fabric_state_responses
+            self.queued_batch_set_scale_up_fabric_state_responses
                 .lock()
                 .await
                 .push_back(response);
         }
 
-        pub async fn submitted_set_scale_up_fabric_state_requests(
+        pub async fn submitted_batch_set_scale_up_fabric_state_requests(
             &self,
-        ) -> Vec<rms::SetScaleUpFabricStateRequest> {
-            self.submitted_set_scale_up_fabric_state_requests
+        ) -> Vec<rms::BatchSetScaleUpFabricStateRequest> {
+            self.submitted_batch_set_scale_up_fabric_state_requests
+                .lock()
+                .await
+                .clone()
+        }
+
+        /// Queue a response for the next `batch_get_scale_up_fabric_service_status` call.
+        pub async fn queue_batch_get_scale_up_fabric_service_status_response(
+            &self,
+            response: Result<rms::BatchGetScaleUpFabricServiceStatusResponse, RackManagerError>,
+        ) {
+            self.queued_batch_get_scale_up_fabric_service_status_responses
+                .lock()
+                .await
+                .push_back(response);
+        }
+
+        /// Snapshot recorded `BatchGetScaleUpFabricServiceStatus` requests in call order.
+        pub async fn submitted_batch_get_scale_up_fabric_service_status_requests(
+            &self,
+        ) -> Vec<rms::BatchGetScaleUpFabricServiceStatusRequest> {
+            self.submitted_batch_get_scale_up_fabric_service_status_requests
                 .lock()
                 .await
                 .clone()
         }
 
         /// Queue a `Result` to be returned on the next call to
-        /// `set_power_state_by_device_list`. Used by power-shelf maintenance
+        /// `batch_set_power_state`. Used by power-shelf maintenance
         /// tests to drive both the success and failure paths of the
-        /// caller-supplied `SetPowerStateByDeviceList` RPC.
-        pub async fn queue_set_power_state_by_device_list_response(
+        /// caller-supplied `BatchSetPowerState` RPC.
+        pub async fn queue_batch_set_power_state_response(
             &self,
-            response: Result<rms::SetPowerStateByDeviceListResponse, RackManagerError>,
+            response: Result<rms::BatchSetPowerStateResponse, RackManagerError>,
         ) {
-            self.queued_set_power_state_by_device_list_responses
+            self.queued_batch_set_power_state_responses
                 .lock()
                 .await
                 .push_back(response);
         }
 
-        /// Snapshot the recorded `SetPowerStateByDeviceList` requests, in
+        /// Snapshot the recorded `BatchSetPowerState` requests, in
         /// the order they were received.
-        pub async fn submitted_set_power_state_by_device_list_requests(
+        pub async fn submitted_batch_set_power_state_requests(
             &self,
-        ) -> Vec<rms::SetPowerStateByDeviceListRequest> {
-            self.submitted_set_power_state_by_device_list_requests
+        ) -> Vec<rms::BatchSetPowerStateRequest> {
+            self.submitted_batch_set_power_state_requests
                 .lock()
                 .await
                 .clone()
@@ -434,81 +481,69 @@ pub mod test_support {
 
     #[derive(Debug, Clone)]
     pub struct MockRmsClient {
-        fail_add_node: Arc<AtomicBool>,
+        fail_create_nodes: Arc<AtomicBool>,
         fail_inventory_get: Arc<AtomicBool>,
         registered_nodes: Arc<Mutex<Vec<rms::NodeInventoryInfo>>>,
         firmware_objects: Arc<Mutex<HashMap<String, rms::FirmwareObject>>>,
-        submitted_firmware_requests: Arc<Mutex<Vec<rms::UpdateFirmwareByDeviceListRequest>>>,
-        queued_firmware_responses: Arc<Mutex<VecDeque<rms::UpdateFirmwareByDeviceListResponse>>>,
-        submitted_firmware_object_apply_requests: Arc<Mutex<Vec<rms::ApplyFirmwareObjectRequest>>>,
+        submitted_firmware_requests: Arc<Mutex<Vec<rms::BatchUpdateFirmwareRequest>>>,
+        queued_firmware_responses: Arc<Mutex<VecDeque<rms::BatchUpdateFirmwareResponse>>>,
+        submitted_apply_stored_firmware_object_requests:
+            Arc<Mutex<Vec<rms::ApplyStoredFirmwareObjectRequest>>>,
         queued_firmware_object_apply_responses:
             Arc<Mutex<VecDeque<rms::ApplyFirmwareObjectResponse>>>,
-        submitted_firmware_object_from_json_apply_requests:
-            Arc<Mutex<Vec<rms::ApplyFirmwareObjectFromJsonRequest>>>,
+        submitted_apply_firmware_object_requests: Arc<Mutex<Vec<rms::ApplyFirmwareObjectRequest>>>,
         firmware_job_statuses: Arc<Mutex<HashMap<String, rms::GetFirmwareJobStatusResponse>>>,
         firmware_job_errors: Arc<Mutex<HashMap<String, String>>>,
         submitted_apply_switch_system_image_requests:
             Arc<Mutex<Vec<rms::ApplySwitchSystemImageRequest>>>,
-        submitted_apply_switch_system_image_from_json_requests:
-            Arc<Mutex<Vec<rms::ApplySwitchSystemImageFromJsonRequest>>>,
         queued_apply_switch_system_image_responses:
             Arc<Mutex<VecDeque<rms::ApplySwitchSystemImageResponse>>>,
         switch_system_image_job_statuses:
             Arc<Mutex<HashMap<String, rms::GetSwitchSystemImageJobStatusResponse>>>,
         switch_system_image_job_errors: Arc<Mutex<HashMap<String, String>>>,
-        submitted_get_power_state_by_device_list_requests:
-            Arc<Mutex<Vec<rms::GetPowerStateByDeviceListRequest>>>,
-        queued_get_power_state_by_device_list_responses:
-            Arc<Mutex<VecDeque<Result<rms::GetPowerStateByDeviceListResponse, RackManagerError>>>>,
-        submitted_get_device_info_by_device_list_requests:
-            Arc<Mutex<Vec<rms::GetDeviceInfoByDeviceListRequest>>>,
-        queued_get_device_info_by_device_list_responses:
-            Arc<Mutex<VecDeque<Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError>>>>,
+        submitted_batch_get_node_device_info_requests:
+            Arc<Mutex<Vec<rms::BatchGetNodeDeviceInfoRequest>>>,
+        queued_batch_get_node_device_info_responses:
+            Arc<Mutex<VecDeque<Result<rms::BatchGetNodeDeviceInfoResponse, RackManagerError>>>>,
+        submitted_batch_get_power_state_requests: Arc<Mutex<Vec<rms::BatchGetPowerStateRequest>>>,
+        queued_batch_get_power_state_responses:
+            Arc<Mutex<VecDeque<Result<rms::BatchGetPowerStateResponse, RackManagerError>>>>,
         submitted_configure_scale_up_fabric_manager_requests:
             Arc<Mutex<Vec<rms::ConfigureScaleUpFabricManagerRequest>>>,
         queued_configure_scale_up_fabric_manager_responses: Arc<
             Mutex<VecDeque<Result<rms::ConfigureScaleUpFabricManagerResponse, RackManagerError>>>,
         >,
-        submitted_set_scale_up_fabric_state_requests:
-            Arc<Mutex<Vec<rms::SetScaleUpFabricStateRequest>>>,
-        queued_set_scale_up_fabric_state_responses:
-            Arc<Mutex<VecDeque<Result<rms::SetScaleUpFabricStateResponse, RackManagerError>>>>,
-        submitted_set_power_state_by_device_list_requests:
-            Arc<Mutex<Vec<rms::SetPowerStateByDeviceListRequest>>>,
-        queued_set_power_state_by_device_list_responses:
-            Arc<Mutex<VecDeque<Result<rms::SetPowerStateByDeviceListResponse, RackManagerError>>>>,
+        submitted_batch_set_scale_up_fabric_state_requests:
+            Arc<Mutex<Vec<rms::BatchSetScaleUpFabricStateRequest>>>,
+        queued_batch_set_scale_up_fabric_state_responses:
+            Arc<Mutex<VecDeque<Result<rms::BatchSetScaleUpFabricStateResponse, RackManagerError>>>>,
+        submitted_batch_get_scale_up_fabric_service_status_requests:
+            Arc<Mutex<Vec<rms::BatchGetScaleUpFabricServiceStatusRequest>>>,
+        queued_batch_get_scale_up_fabric_service_status_responses: Arc<
+            Mutex<
+                VecDeque<Result<rms::BatchGetScaleUpFabricServiceStatusResponse, RackManagerError>>,
+            >,
+        >,
+        submitted_batch_set_power_state_requests: Arc<Mutex<Vec<rms::BatchSetPowerStateRequest>>>,
+        queued_batch_set_power_state_responses:
+            Arc<Mutex<VecDeque<Result<rms::BatchSetPowerStateResponse, RackManagerError>>>>,
     }
 
     #[async_trait::async_trait]
     impl RmsApi for MockRmsClient {
-        async fn get_power_state_by_device_list(
+        async fn batch_get_node_device_info(
             &self,
-            cmd: rms::GetPowerStateByDeviceListRequest,
-        ) -> Result<rms::GetPowerStateByDeviceListResponse, RackManagerError> {
-            self.submitted_get_power_state_by_device_list_requests
+            cmd: rms::BatchGetNodeDeviceInfoRequest,
+        ) -> Result<rms::BatchGetNodeDeviceInfoResponse, RackManagerError> {
+            self.submitted_batch_get_node_device_info_requests
                 .lock()
                 .await
                 .push(cmd);
-            self.queued_get_power_state_by_device_list_responses
+            self.queued_batch_get_node_device_info_responses
                 .lock()
                 .await
                 .pop_front()
-                .unwrap_or(Ok(rms::GetPowerStateByDeviceListResponse::default()))
-        }
-
-        async fn get_device_info_by_device_list(
-            &self,
-            cmd: rms::GetDeviceInfoByDeviceListRequest,
-        ) -> Result<rms::GetDeviceInfoByDeviceListResponse, RackManagerError> {
-            self.submitted_get_device_info_by_device_list_requests
-                .lock()
-                .await
-                .push(cmd);
-            self.queued_get_device_info_by_device_list_responses
-                .lock()
-                .await
-                .pop_front()
-                .unwrap_or(Ok(rms::GetDeviceInfoByDeviceListResponse::default()))
+                .unwrap_or(Ok(rms::BatchGetNodeDeviceInfoResponse::default()))
         }
         async fn get_node_device_info(
             &self,
@@ -516,16 +551,16 @@ pub mod test_support {
         ) -> Result<rms::GetNodeDeviceInfoResponse, RackManagerError> {
             Ok(rms::GetNodeDeviceInfoResponse::default())
         }
-        async fn get_device_info_by_node_type(
+        async fn list_node_device_info_by_node_type(
             &self,
-            _cmd: rms::GetDeviceInfoByNodeTypeRequest,
-        ) -> Result<rms::GetDeviceInfoByNodeTypeResponse, RackManagerError> {
-            Ok(rms::GetDeviceInfoByNodeTypeResponse::default())
+            _cmd: rms::ListNodeDeviceInfoByNodeTypeRequest,
+        ) -> Result<rms::ListNodeDeviceInfoByNodeTypeResponse, RackManagerError> {
+            Ok(rms::ListNodeDeviceInfoByNodeTypeResponse::default())
         }
-        async fn update_firmware_by_device_list(
+        async fn batch_update_firmware(
             &self,
-            cmd: rms::UpdateFirmwareByDeviceListRequest,
-        ) -> Result<rms::UpdateFirmwareByDeviceListResponse, RackManagerError> {
+            cmd: rms::BatchUpdateFirmwareRequest,
+        ) -> Result<rms::BatchUpdateFirmwareResponse, RackManagerError> {
             self.submitted_firmware_requests.lock().await.push(cmd);
             Ok(self
                 .queued_firmware_responses
@@ -546,19 +581,19 @@ pub mod test_support {
         ) -> Result<rms::SetPowerStateResponse, RackManagerError> {
             Ok(rms::SetPowerStateResponse::default())
         }
-        async fn set_power_state_by_device_list(
+        async fn batch_set_power_state(
             &self,
-            cmd: rms::SetPowerStateByDeviceListRequest,
-        ) -> Result<rms::SetPowerStateByDeviceListResponse, RackManagerError> {
-            self.submitted_set_power_state_by_device_list_requests
+            cmd: rms::BatchSetPowerStateRequest,
+        ) -> Result<rms::BatchSetPowerStateResponse, RackManagerError> {
+            self.submitted_batch_set_power_state_requests
                 .lock()
                 .await
                 .push(cmd);
-            self.queued_set_power_state_by_device_list_responses
+            self.queued_batch_set_power_state_responses
                 .lock()
                 .await
                 .pop_front()
-                .unwrap_or(Ok(rms::SetPowerStateByDeviceListResponse::default()))
+                .unwrap_or(Ok(rms::BatchSetPowerStateResponse::default()))
         }
         async fn get_power_state(
             &self,
@@ -566,48 +601,63 @@ pub mod test_support {
         ) -> Result<rms::GetPowerStateResponse, RackManagerError> {
             Ok(rms::GetPowerStateResponse::default())
         }
+
+        async fn batch_get_power_state(
+            &self,
+            cmd: rms::BatchGetPowerStateRequest,
+        ) -> Result<rms::BatchGetPowerStateResponse, RackManagerError> {
+            self.submitted_batch_get_power_state_requests
+                .lock()
+                .await
+                .push(cmd);
+            self.queued_batch_get_power_state_responses
+                .lock()
+                .await
+                .pop_front()
+                .unwrap_or(Ok(rms::BatchGetPowerStateResponse::default()))
+        }
+
         async fn sequence_rack_power(
             &self,
             _cmd: rms::SequenceRackPowerRequest,
         ) -> Result<rms::SequenceRackPowerResponse, RackManagerError> {
             Ok(rms::SequenceRackPowerResponse::default())
         }
-        async fn get_all_inventory(
+        async fn list_node_inventory(
             &self,
-            _cmd: rms::GetAllInventoryRequest,
-        ) -> Result<rms::GetAllInventoryResponse, RackManagerError> {
+        ) -> Result<rms::ListNodeInventoryResponse, RackManagerError> {
             if self.fail_inventory_get.load(Ordering::Relaxed) {
                 return Err(RackManagerError::ApiInvocationError(
                     tonic::Status::unavailable("mock RMS inventory_get failure"),
                 ));
             }
             let nodes = self.registered_nodes.lock().await.clone();
-            Ok(rms::GetAllInventoryResponse {
-                nodes,
-                ..Default::default()
-            })
+            Ok(rms::ListNodeInventoryResponse { nodes })
         }
-        async fn add_node(
+        async fn create_nodes(
             &self,
-            cmd: rms::AddNodeRequest,
-        ) -> Result<rms::AddNodeResponse, RackManagerError> {
-            if self.fail_add_node.load(Ordering::Relaxed) {
+            cmd: rms::CreateNodesRequest,
+        ) -> Result<rms::CreateNodesResponse, RackManagerError> {
+            if self.fail_create_nodes.load(Ordering::Relaxed) {
                 return Err(RackManagerError::ApiInvocationError(
-                    tonic::Status::unavailable("mock RMS add_node failure"),
+                    tonic::Status::unavailable("mock RMS create_nodes failure"),
                 ));
             }
             // Track registered nodes so inventory_get can find them,
             // just like a real RMS would.
             let mut registered = self.registered_nodes.lock().await;
-            for node in cmd.node_info {
-                registered.push(librms::protos::rack_manager::NodeInventoryInfo {
-                    node_id: node.node_id.clone(),
-                    rack_id: node.rack_id.clone(),
-                    r#type: node.r#type.unwrap_or(0),
-                    ..Default::default()
-                });
+            if let Some(nodes) = cmd.nodes {
+                for node in nodes.nodes {
+                    registered.push(librms::protos::rack_manager::NodeInventoryInfo {
+                        node_id: node.node_id.clone(),
+                        rack_id: node.rack_id.clone(),
+                        r#type: node.r#type.unwrap_or(0),
+                        ..Default::default()
+                    });
+                }
             }
-            Ok(rms::AddNodeResponse::default())
+
+            Ok(rms::CreateNodesResponse::default())
         }
         async fn update_node(
             &self,
@@ -615,11 +665,11 @@ pub mod test_support {
         ) -> Result<rms::UpdateNodeResponse, RackManagerError> {
             Ok(rms::UpdateNodeResponse::default())
         }
-        async fn remove_node(
+        async fn delete_node(
             &self,
-            _cmd: rms::RemoveNodeRequest,
-        ) -> Result<rms::RemoveNodeResponse, RackManagerError> {
-            Ok(rms::RemoveNodeResponse::default())
+            _cmd: rms::DeleteNodeRequest,
+        ) -> Result<rms::DeleteNodeResponse, RackManagerError> {
+            Ok(rms::DeleteNodeResponse::default())
         }
         async fn get_rack_power_on_sequence(
             &self,
@@ -633,10 +683,7 @@ pub mod test_support {
         ) -> Result<rms::SetRackPowerOnSequenceResponse, RackManagerError> {
             Ok(rms::SetRackPowerOnSequenceResponse::default())
         }
-        async fn list_racks(
-            &self,
-            _cmd: rms::ListRacksRequest,
-        ) -> Result<rms::ListRacksResponse, RackManagerError> {
+        async fn list_racks(&self) -> Result<rms::ListRacksResponse, RackManagerError> {
             Ok(rms::ListRacksResponse::default())
         }
         async fn get_node_firmware_inventory(
@@ -654,23 +701,26 @@ pub mod test_support {
         async fn add_firmware_object(
             &self,
             cmd: rms::AddFirmwareObjectRequest,
-        ) -> Result<rms::FirmwareObject, RackManagerError> {
-            let value =
-                serde_json::from_str::<serde_json::Value>(&cmd.config_json).map_err(|e| {
+        ) -> Result<rms::AddFirmwareObjectResponse, RackManagerError> {
+            #[derive(serde::Deserialize)]
+            struct FirmwareObjectConfig {
+                #[serde(rename = "Id")]
+                id: String,
+            }
+
+            let config =
+                serde_json::from_str::<FirmwareObjectConfig>(&cmd.config_json).map_err(|e| {
                     RackManagerError::ApiInvocationError(tonic::Status::invalid_argument(format!(
                         "invalid config_json: {e}"
                     )))
                 })?;
-            let id = value
-                .get("Id")
-                .and_then(serde_json::Value::as_str)
-                .filter(|id| !id.is_empty())
-                .map(str::to_string)
-                .ok_or_else(|| {
-                    RackManagerError::ApiInvocationError(tonic::Status::invalid_argument(
-                        "config_json must contain non-empty Id",
-                    ))
-                })?;
+            if config.id.is_empty() {
+                return Err(RackManagerError::ApiInvocationError(
+                    tonic::Status::invalid_argument("config_json must contain non-empty Id"),
+                ));
+            }
+            let id = config.id;
+
             let mut objects = self.firmware_objects.lock().await;
             let is_default = cmd.set_default
                 || !objects.values().any(|existing| {
@@ -692,13 +742,16 @@ pub mod test_support {
                 }
             }
             objects.insert(id, object.clone());
-            Ok(object)
+            Ok(rms::AddFirmwareObjectResponse {
+                object: Some(object),
+            })
         }
         async fn get_firmware_object(
             &self,
             cmd: rms::GetFirmwareObjectRequest,
-        ) -> Result<rms::FirmwareObject, RackManagerError> {
-            self.firmware_objects
+        ) -> Result<rms::GetFirmwareObjectResponse, RackManagerError> {
+            let object = self
+                .firmware_objects
                 .lock()
                 .await
                 .get(&cmd.id)
@@ -708,7 +761,11 @@ pub mod test_support {
                         "firmware object {} not found",
                         cmd.id
                     )))
-                })
+                })?;
+
+            Ok(rms::GetFirmwareObjectResponse {
+                object: Some(object),
+            })
         }
         async fn list_firmware_objects(
             &self,
@@ -730,17 +787,19 @@ pub mod test_support {
         async fn delete_firmware_object(
             &self,
             cmd: rms::DeleteFirmwareObjectRequest,
-        ) -> Result<rms::OperationResponse, RackManagerError> {
+        ) -> Result<rms::DeleteFirmwareObjectResponse, RackManagerError> {
             self.firmware_objects.lock().await.remove(&cmd.id);
-            Ok(rms::OperationResponse {
-                status: rms::ReturnCode::Success as i32,
-                ..Default::default()
+            Ok(rms::DeleteFirmwareObjectResponse {
+                response: Some(rms::OperationResponse {
+                    status: rms::ReturnCode::Success as i32,
+                    ..Default::default()
+                }),
             })
         }
         async fn set_default_firmware_object(
             &self,
             cmd: rms::SetDefaultFirmwareObjectRequest,
-        ) -> Result<rms::FirmwareObject, RackManagerError> {
+        ) -> Result<rms::SetDefaultFirmwareObjectResponse, RackManagerError> {
             let mut objects = self.firmware_objects.lock().await;
             let hardware_type = objects
                 .get(&cmd.object_id)
@@ -756,16 +815,36 @@ pub mod test_support {
                     object.is_default = object.id == cmd.object_id;
                 }
             }
-            Ok(objects
-                .get(&cmd.object_id)
-                .cloned()
-                .expect("firmware object existence validated above"))
+            let Some(object) = objects.get(&cmd.object_id).cloned() else {
+                return Err(RackManagerError::ApiInvocationError(
+                    tonic::Status::not_found(format!(
+                        "firmware object {} not found",
+                        cmd.object_id
+                    )),
+                ));
+            };
+
+            Ok(rms::SetDefaultFirmwareObjectResponse {
+                object: Some(object),
+            })
         }
+
+        async fn apply_stored_firmware_object(
+            &self,
+            cmd: rms::ApplyStoredFirmwareObjectRequest,
+        ) -> Result<rms::ApplyStoredFirmwareObjectResponse, RackManagerError> {
+            self.submitted_apply_stored_firmware_object_requests
+                .lock()
+                .await
+                .push(cmd);
+            Ok(rms::ApplyStoredFirmwareObjectResponse::default())
+        }
+
         async fn apply_firmware_object(
             &self,
             cmd: rms::ApplyFirmwareObjectRequest,
         ) -> Result<rms::ApplyFirmwareObjectResponse, RackManagerError> {
-            self.submitted_firmware_object_apply_requests
+            self.submitted_apply_firmware_object_requests
                 .lock()
                 .await
                 .push(cmd);
@@ -776,36 +855,20 @@ pub mod test_support {
                 .pop_front()
                 .unwrap_or_default())
         }
-        async fn apply_firmware_object_from_json(
+        async fn update_switch_system_image(
             &self,
-            cmd: rms::ApplyFirmwareObjectFromJsonRequest,
-        ) -> Result<rms::ApplyFirmwareObjectResponse, RackManagerError> {
-            self.submitted_firmware_object_from_json_apply_requests
-                .lock()
-                .await
-                .push(cmd);
-            Ok(self
-                .queued_firmware_object_apply_responses
-                .lock()
-                .await
-                .pop_front()
-                .unwrap_or_default())
+            _cmd: rms::UpdateSwitchSystemImageRequest,
+        ) -> Result<rms::UpdateSwitchSystemImageResponse, RackManagerError> {
+            Ok(rms::UpdateSwitchSystemImageResponse::default())
         }
-        async fn apply_switch_system_image_from_json(
+
+        async fn apply_stored_switch_system_image(
             &self,
-            cmd: rms::ApplySwitchSystemImageFromJsonRequest,
-        ) -> Result<rms::ApplySwitchSystemImageResponse, RackManagerError> {
-            self.submitted_apply_switch_system_image_from_json_requests
-                .lock()
-                .await
-                .push(cmd);
-            Ok(self
-                .queued_apply_switch_system_image_responses
-                .lock()
-                .await
-                .pop_front()
-                .unwrap_or_default())
+            _cmd: rms::ApplyStoredSwitchSystemImageRequest,
+        ) -> Result<rms::ApplyStoredSwitchSystemImageResponse, RackManagerError> {
+            Ok(rms::ApplyStoredSwitchSystemImageResponse::default())
         }
+
         async fn apply_switch_system_image(
             &self,
             cmd: rms::ApplySwitchSystemImageRequest,
@@ -827,23 +890,23 @@ pub mod test_support {
         ) -> Result<rms::GetFirmwareObjectHistoryResponse, RackManagerError> {
             Ok(rms::GetFirmwareObjectHistoryResponse::default())
         }
-        async fn list_firmware_on_switch(
+        async fn list_switch_firmware(
             &self,
-            _cmd: rms::ListFirmwareOnSwitchCommand,
-        ) -> Result<rms::ListFirmwareOnSwitchResponse, RackManagerError> {
-            Ok(rms::ListFirmwareOnSwitchResponse::default())
+            _cmd: rms::ListSwitchFirmwareRequest,
+        ) -> Result<rms::ListSwitchFirmwareResponse, RackManagerError> {
+            Ok(rms::ListSwitchFirmwareResponse::default())
         }
-        async fn push_firmware_to_switch(
+        async fn push_switch_firmware(
             &self,
-            _cmd: rms::PushFirmwareToSwitchCommand,
-        ) -> Result<rms::PushFirmwareToSwitchResponse, RackManagerError> {
-            Ok(rms::PushFirmwareToSwitchResponse::default())
+            _cmd: rms::PushSwitchFirmwareRequest,
+        ) -> Result<rms::PushSwitchFirmwareResponse, RackManagerError> {
+            Ok(rms::PushSwitchFirmwareResponse::default())
         }
-        async fn upgrade_firmware_on_switch(
+        async fn upgrade_switch_firmware(
             &self,
-            _cmd: rms::UpgradeFirmwareOnSwitchCommand,
-        ) -> Result<rms::UpgradeFirmwareOnSwitchResponse, RackManagerError> {
-            Ok(rms::UpgradeFirmwareOnSwitchResponse::default())
+            _cmd: rms::UpgradeSwitchFirmwareRequest,
+        ) -> Result<rms::UpgradeSwitchFirmwareResponse, RackManagerError> {
+            Ok(rms::UpgradeSwitchFirmwareResponse::default())
         }
         async fn configure_scale_up_fabric_manager(
             &self,
@@ -859,19 +922,43 @@ pub mod test_support {
                 .pop_front()
                 .unwrap_or(Ok(rms::ConfigureScaleUpFabricManagerResponse::default()))
         }
-        async fn set_scale_up_fabric_state(
+        async fn batch_set_scale_up_fabric_state(
             &self,
-            cmd: rms::SetScaleUpFabricStateRequest,
-        ) -> Result<rms::SetScaleUpFabricStateResponse, RackManagerError> {
-            self.submitted_set_scale_up_fabric_state_requests
+            cmd: rms::BatchSetScaleUpFabricStateRequest,
+        ) -> Result<rms::BatchSetScaleUpFabricStateResponse, RackManagerError> {
+            self.submitted_batch_set_scale_up_fabric_state_requests
                 .lock()
                 .await
                 .push(cmd);
-            self.queued_set_scale_up_fabric_state_responses
+            self.queued_batch_set_scale_up_fabric_state_responses
                 .lock()
                 .await
                 .pop_front()
-                .unwrap_or(Ok(rms::SetScaleUpFabricStateResponse::default()))
+                .unwrap_or(Ok(rms::BatchSetScaleUpFabricStateResponse::default()))
+        }
+        async fn batch_get_scale_up_fabric_service_status(
+            &self,
+            cmd: rms::BatchGetScaleUpFabricServiceStatusRequest,
+        ) -> Result<rms::BatchGetScaleUpFabricServiceStatusResponse, RackManagerError> {
+            self.submitted_batch_get_scale_up_fabric_service_status_requests
+                .lock()
+                .await
+                .push(cmd);
+
+            self.queued_batch_get_scale_up_fabric_service_status_responses
+                .lock()
+                .await
+                .pop_front()
+                .unwrap_or(Ok(
+                    rms::BatchGetScaleUpFabricServiceStatusResponse::default(),
+                ))
+        }
+
+        async fn get_scale_up_fabric_state(
+            &self,
+            _cmd: rms::GetScaleUpFabricStateRequest,
+        ) -> Result<rms::GetScaleUpFabricStateResponse, RackManagerError> {
+            Ok(rms::GetScaleUpFabricStateResponse::default())
         }
         async fn fetch_switch_system_image(
             &self,
@@ -891,32 +978,42 @@ pub mod test_support {
         ) -> Result<rms::ListSwitchSystemImagesResponse, RackManagerError> {
             Ok(rms::ListSwitchSystemImagesResponse::default())
         }
-        async fn enable_scale_up_fabric_telemetry_interface(
+        async fn set_scale_up_fabric_telemetry_interface_state(
             &self,
-            _cmd: rms::EnableScaleUpFabricTelemetryInterfaceRequest,
-        ) -> Result<rms::EnableScaleUpFabricTelemetryInterfaceResponse, RackManagerError> {
-            Ok(rms::EnableScaleUpFabricTelemetryInterfaceResponse::default())
+            _cmd: rms::SetScaleUpFabricTelemetryInterfaceStateRequest,
+        ) -> Result<rms::SetScaleUpFabricTelemetryInterfaceStateResponse, RackManagerError>
+        {
+            Ok(rms::SetScaleUpFabricTelemetryInterfaceStateResponse::default())
         }
-        async fn version(&self) -> Result<(), RackManagerError> {
-            Ok(())
-        }
-        async fn poll_job_status(
+        async fn get_switch_system_image_job_status(
             &self,
-            _cmd: rms::PollJobStatusCommand,
-        ) -> Result<rms::PollJobStatusResponse, RackManagerError> {
-            Ok(rms::PollJobStatusResponse::default())
+            cmd: rms::GetSwitchSystemImageJobStatusRequest,
+        ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError> {
+            self.switch_system_image_job_status(cmd)
+                .await
+                .map_err(RackManagerError::ApiInvocationError)
         }
-        async fn update_node_firmware_async(
-            &self,
-            _cmd: rms::UpdateNodeFirmwareRequest,
-        ) -> Result<rms::UpdateNodeFirmwareResponse, RackManagerError> {
-            Ok(rms::UpdateNodeFirmwareResponse::default())
+
+        async fn get_version(&self) -> Result<rms::GetVersionResponse, RackManagerError> {
+            Ok(rms::GetVersionResponse::default())
         }
-        async fn update_firmware_by_node_type_async(
+        async fn poll_switch_firmware_job_status(
             &self,
-            _cmd: rms::UpdateFirmwareByNodeTypeRequest,
-        ) -> Result<rms::UpdateFirmwareByNodeTypeAsyncResponse, RackManagerError> {
-            Ok(rms::UpdateFirmwareByNodeTypeAsyncResponse::default())
+            _cmd: rms::PollSwitchFirmwareJobStatusRequest,
+        ) -> Result<rms::PollSwitchFirmwareJobStatusResponse, RackManagerError> {
+            Ok(rms::PollSwitchFirmwareJobStatusResponse::default())
+        }
+        async fn update_firmware(
+            &self,
+            _cmd: rms::UpdateFirmwareRequest,
+        ) -> Result<rms::UpdateFirmwareResponse, RackManagerError> {
+            Ok(rms::UpdateFirmwareResponse::default())
+        }
+        async fn batch_update_firmware_by_node_type(
+            &self,
+            _cmd: rms::BatchUpdateFirmwareByNodeTypeRequest,
+        ) -> Result<rms::BatchUpdateFirmwareByNodeTypeResponse, RackManagerError> {
+            Ok(rms::BatchUpdateFirmwareByNodeTypeResponse::default())
         }
         async fn get_firmware_job_status(
             &self,
@@ -951,11 +1048,11 @@ pub mod test_support {
 
     #[async_trait::async_trait]
     impl SwitchSystemImageRmsClient for MockRmsClient {
-        async fn apply_switch_system_image_from_json(
+        async fn apply_switch_system_image(
             &self,
-            cmd: rms::ApplySwitchSystemImageFromJsonRequest,
+            cmd: rms::ApplySwitchSystemImageRequest,
         ) -> Result<rms::ApplySwitchSystemImageResponse, tonic::Status> {
-            self.submitted_apply_switch_system_image_from_json_requests
+            self.submitted_apply_switch_system_image_requests
                 .lock()
                 .await
                 .push(cmd);
@@ -968,6 +1065,15 @@ pub mod test_support {
         }
 
         async fn get_switch_system_image_job_status(
+            &self,
+            cmd: rms::GetSwitchSystemImageJobStatusRequest,
+        ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, tonic::Status> {
+            self.switch_system_image_job_status(cmd).await
+        }
+    }
+
+    impl MockRmsClient {
+        async fn switch_system_image_job_status(
             &self,
             cmd: rms::GetSwitchSystemImageJobStatusRequest,
         ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, tonic::Status> {

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -6022,7 +6022,7 @@ message FirmwareUpgradeActivity {
 message NvosUpdateActivity {
   reserved 1;
   reserved "firmware_object_id";
-  // SOT JSON string passed to RMS ApplySwitchSystemImageFromJSON.
+  // SOT JSON string passed to RMS ApplySwitchSystemImage.
   // Required for nvos-update activity.
   string config_json = 2;
   // Used only by the backend for artifact download when config_json is set.

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -197,16 +197,22 @@ pub(crate) async fn ensure_rack_exists(
 /// Returns `(None, None)` on any failure, logging a warning with `entity_label`.
 pub async fn fetch_slot_and_tray(
     rms_client: &dyn librms::RmsApi,
-    request: librms::protos::rack_manager::GetDeviceInfoByDeviceListRequest,
+    request: librms::protos::rack_manager::BatchGetNodeDeviceInfoRequest,
 ) -> (Option<i32>, Option<i32>) {
-    match rms_client.get_device_info_by_device_list(request).await {
+    match rms_client.batch_get_node_device_info(request).await {
         Ok(info) => {
-            if !info.node_device_info.is_empty() {
-                let node_device_info = info.node_device_info.first().unwrap();
-                (node_device_info.slot_number, node_device_info.tray_index)
-            } else {
-                (None, None)
-            }
+            let Some(node_device_details) = info.node_device_details.first() else {
+                return (None, None);
+            };
+
+            let slot_number = node_device_details
+                .slot_number
+                .and_then(|value| i32::try_from(value).ok());
+            let tray_index = node_device_details
+                .tray_index
+                .and_then(|value| i32::try_from(value).ok());
+
+            (slot_number, tray_index)
         }
         Err(e) => {
             tracing::warn!(

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -246,13 +246,13 @@ impl MachineCreator {
         if let (Some(rack_id), Some(rms_client)) =
             (&expected_machine.data.rack_id, &self.rms_client)
         {
-            let request = librms::protos::rack_manager::GetDeviceInfoByDeviceListRequest {
+            let request = librms::protos::rack_manager::BatchGetNodeDeviceInfoRequest {
                 nodes: Some(librms::protos::rack_manager::NodeSet {
-                    devices: vec![librms::protos::rack_manager::NewNodeInfo {
+                    nodes: vec![librms::protos::rack_manager::NodeInfo {
                         node_id: host_machine_id.to_string(),
                         rack_id: rack_id.to_string(),
                         r#type: Some(librms::protos::rack_manager::NodeType::Compute as i32),
-                        bmc_endpoint: Some(librms::protos::rack_manager::BmcEndpoint {
+                        bmc_endpoint: Some(librms::protos::rack_manager::Endpoint {
                             interface: Some(librms::protos::rack_manager::NetworkInterface {
                                 ip_address: explored_host.host_bmc_ip.to_string(),
                                 mac_address: expected_machine.bmc_mac_address.to_string(),
@@ -270,11 +270,11 @@ impl MachineCreator {
                                     ),
                                 }
                             }),
+                            dangerously_accept_invalid_certs: true,
                         }),
                         ..Default::default()
                     }],
                 }),
-                ..Default::default()
             };
             let (slot_number, tray_index) =
                 crate::fetch_slot_and_tray(rms_client.as_ref(), request).await;


### PR DESCRIPTION
## Description
Migrates NICo to the updated `nv-rms-client` proto.

This covers the RMS RPC/type renames, enum updates, node/job field changes, and the related mock/test updates. It also preserves the old TLS behavior by mapping `verify_ssl: false` to endpoint-level `dangerously_accept_invalid_certs: true` where the proto refactor moved that setting.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues
Closes #2174

## Breaking Changes
- [x] This PR contains breaking changes

Updates the pinned `nv-rms-client` proto version, so downstream RMS needs to be updated to be compatible.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)