### PR TITLE
chore(rest-api): Apply the new FromProto/ToProto modeling to SSHKeyGroup

### DIFF
--- a/rest-api/db/pkg/db/model/sshkeygroupsiteassociation.go
+++ b/rest-api/db/pkg/db/model/sshkeygroupsiteassociation.go
@@ -10,13 +10,16 @@ import (
 	"encoding/hex"
 	"time"
 
-	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
-	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
+
 	"github.com/google/uuid"
 	"github.com/uptrace/bun"
 
+	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
+
 	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
+	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 var (
@@ -75,6 +78,110 @@ type SSHKeyGroupSiteAssociation struct {
 	Updated         time.Time    `bun:"updated,nullzero,notnull,default:current_timestamp"`
 	Deleted         *time.Time   `bun:"deleted,soft_delete"`
 	CreatedBy       uuid.UUID    `bun:"created_by,type:uuid,notnull"`
+}
+
+// ToKeysetIdentifierProto builds the workflow proto identifier for this
+// association's SSH Key Group, scoped to the owning organization. The
+// SSHKeyGroup relation must be loaded for Org to be present.
+func (skgsa *SSHKeyGroupSiteAssociation) ToKeysetIdentifierProto() *cwssaws.TenantKeysetIdentifier {
+	var org string
+	if skgsa.SSHKeyGroup != nil {
+		org = skgsa.SSHKeyGroup.Org
+	}
+	return &cwssaws.TenantKeysetIdentifier{
+		KeysetId:       skgsa.SSHKeyGroupID.String(),
+		OrganizationId: org,
+	}
+}
+
+// ToProto builds the canonical workflow proto representation of this
+// SSH Key Group's per-Site association. `content` carries the synced
+// public-key material because it isn't stored on the association
+// record (SSH keys live on `SSHKeyAssociation` rows and are loaded by
+// the caller); a nil `content` is fine and produces a Keyset with no
+// content message.
+//
+// Request-shape protos (create / update / delete) are layered on top
+// of this method and source the canonical wire fields from here so
+// the per-method translations stay focused.
+func (skgsa *SSHKeyGroupSiteAssociation) ToProto(content *cwssaws.TenantKeysetContent) *cwssaws.TenantKeyset {
+	var version string
+	if skgsa.Version != nil {
+		version = *skgsa.Version
+	}
+	return &cwssaws.TenantKeyset{
+		KeysetIdentifier: skgsa.ToKeysetIdentifierProto(),
+		KeysetContent:    content,
+		Version:          version,
+	}
+}
+
+// FromProto populates this association from its workflow proto
+// representation. A nil proto is a no-op. This is the inverse of
+// `ToProto` and exists for convention symmetry — currently no code
+// path on the cloud side reconstructs a full association entity
+// from a `cwssaws.TenantKeyset` (the site is the destination, not
+// the source), but the method is provided so future reconciliation
+// flows have a single canonical entry point.
+//
+// Field-level contract:
+//   - `skgsa.SSHKeyGroupID` is preserved on a missing or unparseable
+//     `proto.KeysetIdentifier.KeysetId`, because callers pre-validate
+//     UUIDs before calling.
+//   - `Version` is cleared when the proto carries an empty value, so
+//     `FromProto` is a clean reset rather than a partial merge.
+//   - SSH key content is intentionally not materialized onto the
+//     association: SSH keys are persisted on `SSHKeyAssociation`
+//     rows, and reconstruction of those rows is the responsibility
+//     of a higher-level reconciliation flow.
+func (skgsa *SSHKeyGroupSiteAssociation) FromProto(proto *cwssaws.TenantKeyset) {
+	if proto == nil {
+		return
+	}
+	if proto.KeysetIdentifier != nil {
+		if id, err := uuid.Parse(proto.KeysetIdentifier.KeysetId); err == nil {
+			skgsa.SSHKeyGroupID = id
+		}
+	}
+	if proto.Version != "" {
+		v := proto.Version
+		skgsa.Version = &v
+	} else {
+		skgsa.Version = nil
+	}
+}
+
+// ToCreateRequestProto builds the workflow request that asks a Site to
+// create this Tenant Keyset. content carries the synced public-key
+// material (built by the caller from SSH Key Associations); the
+// canonical wire fields are sourced from `ToProto`.
+func (skgsa *SSHKeyGroupSiteAssociation) ToCreateRequestProto(content *cwssaws.TenantKeysetContent) *cwssaws.CreateTenantKeysetRequest {
+	tk := skgsa.ToProto(content)
+	return &cwssaws.CreateTenantKeysetRequest{
+		KeysetIdentifier: tk.KeysetIdentifier,
+		KeysetContent:    tk.KeysetContent,
+		Version:          tk.Version,
+	}
+}
+
+// ToUpdateRequestProto builds the workflow request that asks a Site to
+// update this Tenant Keyset. See ToCreateRequestProto for content
+// semantics.
+func (skgsa *SSHKeyGroupSiteAssociation) ToUpdateRequestProto(content *cwssaws.TenantKeysetContent) *cwssaws.UpdateTenantKeysetRequest {
+	tk := skgsa.ToProto(content)
+	return &cwssaws.UpdateTenantKeysetRequest{
+		KeysetIdentifier: tk.KeysetIdentifier,
+		KeysetContent:    tk.KeysetContent,
+		Version:          tk.Version,
+	}
+}
+
+// ToDeletionRequestProto builds the workflow request that asks a Site
+// to delete this Tenant Keyset.
+func (skgsa *SSHKeyGroupSiteAssociation) ToDeletionRequestProto() *cwssaws.DeleteTenantKeysetRequest {
+	return &cwssaws.DeleteTenantKeysetRequest{
+		KeysetIdentifier: skgsa.ToKeysetIdentifierProto(),
+	}
 }
 
 var _ bun.BeforeAppendModelHook = (*SSHKeyGroupSiteAssociation)(nil)

--- a/rest-api/db/pkg/db/model/sshkeygroupsiteassociation_test.go
+++ b/rest-api/db/pkg/db/model/sshkeygroupsiteassociation_test.go
@@ -8,14 +8,174 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	otrace "go.opentelemetry.io/otel/trace"
+
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	otrace "go.opentelemetry.io/otel/trace"
+	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
+
+func TestSSHKeyGroupSiteAssociation_ToKeysetIdentifierProto(t *testing.T) {
+	groupID := uuid.New()
+	skgsa := &SSHKeyGroupSiteAssociation{
+		SSHKeyGroupID: groupID,
+		SSHKeyGroup:   &SSHKeyGroup{Org: "org-1"},
+	}
+	got := skgsa.ToKeysetIdentifierProto()
+	require.NotNil(t, got)
+	assert.Equal(t, groupID.String(), got.KeysetId)
+	assert.Equal(t, "org-1", got.OrganizationId)
+}
+
+func TestSSHKeyGroupSiteAssociation_ToKeysetIdentifierProto_NoSSHKeyGroup(t *testing.T) {
+	groupID := uuid.New()
+	skgsa := &SSHKeyGroupSiteAssociation{SSHKeyGroupID: groupID}
+	got := skgsa.ToKeysetIdentifierProto()
+	require.NotNil(t, got)
+	assert.Equal(t, groupID.String(), got.KeysetId)
+	assert.Equal(t, "", got.OrganizationId)
+}
+
+func TestSSHKeyGroupSiteAssociation_ToProto(t *testing.T) {
+	groupID := uuid.New()
+
+	t.Run("populates identifier, content, and version", func(t *testing.T) {
+		version := "v1"
+		skgsa := &SSHKeyGroupSiteAssociation{
+			SSHKeyGroupID: groupID,
+			SSHKeyGroup:   &SSHKeyGroup{Org: "org-1"},
+			Version:       &version,
+		}
+		content := &cwssaws.TenantKeysetContent{
+			PublicKeys: []*cwssaws.TenantPublicKey{{PublicKey: "ssh-rsa abc"}},
+		}
+		got := skgsa.ToProto(content)
+		require.NotNil(t, got)
+		require.NotNil(t, got.KeysetIdentifier)
+		assert.Equal(t, groupID.String(), got.KeysetIdentifier.KeysetId)
+		assert.Equal(t, "org-1", got.KeysetIdentifier.OrganizationId)
+		assert.Equal(t, content, got.KeysetContent)
+		assert.Equal(t, "v1", got.Version)
+	})
+
+	t.Run("nil version yields empty wire version", func(t *testing.T) {
+		skgsa := &SSHKeyGroupSiteAssociation{
+			SSHKeyGroupID: groupID,
+			SSHKeyGroup:   &SSHKeyGroup{Org: "org-1"},
+		}
+		got := skgsa.ToProto(nil)
+		require.NotNil(t, got)
+		assert.Equal(t, "", got.Version)
+		assert.Nil(t, got.KeysetContent)
+	})
+}
+
+func TestSSHKeyGroupSiteAssociation_FromProto(t *testing.T) {
+	groupID := uuid.New()
+
+	t.Run("nil proto leaves receiver unchanged", func(t *testing.T) {
+		version := "preserved"
+		skgsa := &SSHKeyGroupSiteAssociation{SSHKeyGroupID: groupID, Version: &version}
+		skgsa.FromProto(nil)
+		assert.Equal(t, groupID, skgsa.SSHKeyGroupID)
+		require.NotNil(t, skgsa.Version)
+		assert.Equal(t, "preserved", *skgsa.Version)
+	})
+
+	t.Run("invalid keyset id leaves SSHKeyGroupID unchanged", func(t *testing.T) {
+		skgsa := &SSHKeyGroupSiteAssociation{SSHKeyGroupID: groupID}
+		skgsa.FromProto(&cwssaws.TenantKeyset{
+			KeysetIdentifier: &cwssaws.TenantKeysetIdentifier{KeysetId: "not-a-uuid"},
+			Version:          "v1",
+		})
+		assert.Equal(t, groupID, skgsa.SSHKeyGroupID)
+		require.NotNil(t, skgsa.Version)
+		assert.Equal(t, "v1", *skgsa.Version)
+	})
+
+	t.Run("populates SSHKeyGroupID and Version from proto", func(t *testing.T) {
+		newID := uuid.New()
+		skgsa := &SSHKeyGroupSiteAssociation{}
+		skgsa.FromProto(&cwssaws.TenantKeyset{
+			KeysetIdentifier: &cwssaws.TenantKeysetIdentifier{KeysetId: newID.String()},
+			Version:          "v2",
+		})
+		assert.Equal(t, newID, skgsa.SSHKeyGroupID)
+		require.NotNil(t, skgsa.Version)
+		assert.Equal(t, "v2", *skgsa.Version)
+	})
+
+	t.Run("empty proto version clears Version", func(t *testing.T) {
+		stale := "stale"
+		skgsa := &SSHKeyGroupSiteAssociation{Version: &stale}
+		skgsa.FromProto(&cwssaws.TenantKeyset{
+			KeysetIdentifier: &cwssaws.TenantKeysetIdentifier{KeysetId: groupID.String()},
+			Version:          "",
+		})
+		assert.Nil(t, skgsa.Version)
+	})
+
+	t.Run("nil KeysetIdentifier leaves SSHKeyGroupID unchanged", func(t *testing.T) {
+		skgsa := &SSHKeyGroupSiteAssociation{SSHKeyGroupID: groupID}
+		skgsa.FromProto(&cwssaws.TenantKeyset{Version: "v1"})
+		assert.Equal(t, groupID, skgsa.SSHKeyGroupID)
+		require.NotNil(t, skgsa.Version)
+		assert.Equal(t, "v1", *skgsa.Version)
+	})
+}
+
+func TestSSHKeyGroupSiteAssociation_ToCreateRequestProto(t *testing.T) {
+	groupID := uuid.New()
+	version := "v1"
+	skgsa := &SSHKeyGroupSiteAssociation{
+		SSHKeyGroupID: groupID,
+		SSHKeyGroup:   &SSHKeyGroup{Org: "org-1"},
+		Version:       &version,
+	}
+	content := &cwssaws.TenantKeysetContent{}
+	got := skgsa.ToCreateRequestProto(content)
+	require.NotNil(t, got)
+	require.NotNil(t, got.KeysetIdentifier)
+	assert.Equal(t, groupID.String(), got.KeysetIdentifier.KeysetId)
+	assert.Equal(t, "v1", got.Version)
+	assert.Equal(t, content, got.KeysetContent)
+}
+
+func TestSSHKeyGroupSiteAssociation_ToUpdateRequestProto(t *testing.T) {
+	groupID := uuid.New()
+	version := "v2"
+	skgsa := &SSHKeyGroupSiteAssociation{
+		SSHKeyGroupID: groupID,
+		SSHKeyGroup:   &SSHKeyGroup{Org: "org-1"},
+		Version:       &version,
+	}
+	content := &cwssaws.TenantKeysetContent{}
+	got := skgsa.ToUpdateRequestProto(content)
+	require.NotNil(t, got)
+	require.NotNil(t, got.KeysetIdentifier)
+	assert.Equal(t, groupID.String(), got.KeysetIdentifier.KeysetId)
+	assert.Equal(t, "org-1", got.KeysetIdentifier.OrganizationId)
+	assert.Equal(t, "v2", got.Version)
+	assert.Equal(t, content, got.KeysetContent)
+}
+
+func TestSSHKeyGroupSiteAssociation_ToDeletionRequestProto(t *testing.T) {
+	groupID := uuid.New()
+	skgsa := &SSHKeyGroupSiteAssociation{
+		SSHKeyGroupID: groupID,
+		SSHKeyGroup:   &SSHKeyGroup{Org: "org-1"},
+	}
+	got := skgsa.ToDeletionRequestProto()
+	require.NotNil(t, got)
+	require.NotNil(t, got.KeysetIdentifier)
+	assert.Equal(t, groupID.String(), got.KeysetIdentifier.KeysetId)
+	assert.Equal(t, "org-1", got.KeysetIdentifier.OrganizationId)
+}
 
 // reset the tables needed for SSHKeyGroupSiteAssociation tests
 func testSSHKeyGroupSiteAssociationSetupSchema(t *testing.T, dbSession *db.Session) {

--- a/rest-api/workflow/pkg/activity/sshkeygroup/sshkeygroup.go
+++ b/rest-api/workflow/pkg/activity/sshkeygroup/sshkeygroup.go
@@ -101,10 +101,6 @@ func (mskg ManageSSHKeyGroup) SyncSSHKeyGroupViaSiteAgent(ctx context.Context, s
 	}
 
 	// Sync SSHKeyGroup request
-	keysetIdentifier := &cwssaws.TenantKeysetIdentifier{
-		KeysetId:       skgsa.SSHKeyGroupID.String(),
-		OrganizationId: skgsa.SSHKeyGroup.Org,
-	}
 	keysetContent := &cwssaws.TenantKeysetContent{}
 
 	tx, terr := cdb.BeginTx(ctx, mskg.dbSession, &sql.TxOptions{})
@@ -169,11 +165,7 @@ func (mskg ManageSSHKeyGroup) SyncSSHKeyGroupViaSiteAgent(ctx context.Context, s
 		// Set the workflow ID and KeysetIdentifier for the create request
 		workflowOptions.ID = "site-ssh-key-group-create-" + sshKeyGroupID.String() + "-" + *skgsa.Version
 
-		createSSHKeyGroupRequest := &cwssaws.CreateTenantKeysetRequest{
-			KeysetIdentifier: keysetIdentifier,
-			KeysetContent:    keysetContent,
-			Version:          *skgsa.Version,
-		}
+		createSSHKeyGroupRequest := skgsa.ToCreateRequestProto(keysetContent)
 
 		// Trigger Site create SSHKeyGroup workflow
 		we, err = stc.ExecuteWorkflow(ctx, workflowOptions, "CreateSSHKeyGroupV2", createSSHKeyGroupRequest)
@@ -182,11 +174,7 @@ func (mskg ManageSSHKeyGroup) SyncSSHKeyGroupViaSiteAgent(ctx context.Context, s
 		// Set the workflow ID and KeysetIdentifier for the update request
 		workflowOptions.ID = "site-ssh-key-group-update-" + sshKeyGroupID.String() + "-" + *skgsa.Version
 
-		updateSSHKeyGroupRequest := &cwssaws.UpdateTenantKeysetRequest{
-			KeysetIdentifier: keysetIdentifier,
-			KeysetContent:    keysetContent,
-			Version:          *skgsa.Version,
-		}
+		updateSSHKeyGroupRequest := skgsa.ToUpdateRequestProto(keysetContent)
 
 		// Trigger Site update SSHKeyGroup workflow
 		we, err = stc.ExecuteWorkflow(ctx, workflowOptions, "UpdateSSHKeyGroupV2", updateSSHKeyGroupRequest)
@@ -478,12 +466,10 @@ func (mskg ManageSSHKeyGroup) DeleteSSHKeyGroupViaSiteAgent(ctx context.Context,
 		WorkflowIDReusePolicy: temporalEnums.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
 	}
 
-	deleteSSHKeyGroupRequest := &cwssaws.DeleteTenantKeysetRequest{
-		KeysetIdentifier: &cwssaws.TenantKeysetIdentifier{
-			KeysetId:       sshKeyGroupID.String(),
-			OrganizationId: skgsa.SSHKeyGroup.Org,
-		},
-	}
+	// skgsa.SSHKeyGroupID is authoritative here -- it was loaded above via
+	// GetBySSHKeyGroupIDAndSiteID(sshKeyGroupID, siteID), so the deletion
+	// request keys off the same group we just resolved.
+	deleteSSHKeyGroupRequest := skgsa.ToDeletionRequestProto()
 
 	we, err := stc.ExecuteWorkflow(ctx, workflowOptions, "DeleteSSHKeyGroupV2", deleteSSHKeyGroupRequest)
 	if err != nil {


### PR DESCRIPTION
## Description

Brings the SSH Key Group keyset-sync flow in line with the proto-modeling changes. The proto build used to live inline inside the workflow activity at the create/update/delete RPC sites; it now sits on receiver methods on the DB entity (`SSHKeyGroupSiteAssociation`). No API request `ToProto` here -- the proto build is workflow-internal, the handler doesn't touch it.

Primary callouts are:
- Entity round-trip: `SSHKeyGroupSiteAssociation.ToProto(content)` / `FromProto(proto)`. Per-key content is passed as a side input since public keys live on a sibling table -- same pattern as `ExpectedMachine.ToProto(creds)`.
- Entity request shapes: `ToCreateRequestProto`, `ToUpdateRequestProto`, `ToDeletionRequestProto`, and a shared `ToKeysetIdentifierProto`.
- Workflow activity simplified: the three inline build sites in `workflow/pkg/activity/sshkeygroup/sshkeygroup.go` collapse to one-liners.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

