### PR TITLE
chore(rest-api): Apply the FromProto/ToProto modeling to OperatingSystem

### DIFF
--- a/rest-api/api/pkg/api/handler/operatingsystem.go
+++ b/rest-api/api/pkg/api/handler/operatingsystem.go
@@ -32,8 +32,6 @@ import (
 	cdbp "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	swe "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/error"
 	"github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/queue"
-
-	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 // ~~~~~ Create Handler ~~~~~ //
@@ -362,19 +360,7 @@ func (csh CreateOperatingSystemHandler) Handle(c echo.Context) error {
 					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 				}
 
-				createOsRequest := &cwssaws.OsImageAttributes{
-					Id:                   &cwssaws.UUID{Value: common.GetSiteOperatingSystemtID(os).String()},
-					Name:                 &os.Name,
-					TenantOrganizationId: tenant.Org,
-					Description:          os.Description,
-					SourceUrl:            *os.ImageURL,
-					Digest:               *os.ImageSHA,
-					CreateVolume:         os.EnableBlockStorage,
-					AuthType:             os.ImageAuthType,
-					AuthToken:            os.ImageAuthToken,
-					RootfsId:             os.RootFsID,
-					RootfsLabel:          os.RootFsLabel,
-				}
+				createOsRequest := apiRequest.ToProto(os, tenant.Org)
 
 				workflowOptions := temporalClient.StartWorkflowOptions{
 					ID:                       "image-os-create-" + ossa.SiteID.String() + "-" + os.ID.String() + "-" + *ossa.Version,
@@ -1224,19 +1210,7 @@ func (ush UpdateOperatingSystemHandler) Handle(c echo.Context) error {
 					return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 				}
 
-				updateOsRequest := &cwssaws.OsImageAttributes{
-					Id:                   &cwssaws.UUID{Value: common.GetSiteOperatingSystemtID(uos).String()},
-					Name:                 &uos.Name,
-					Description:          uos.Description,
-					TenantOrganizationId: tenant.Org,
-					SourceUrl:            *uos.ImageURL,
-					Digest:               *uos.ImageSHA,
-					CreateVolume:         uos.EnableBlockStorage,
-					AuthType:             uos.ImageAuthType,
-					AuthToken:            uos.ImageAuthToken,
-					RootfsId:             uos.RootFsID,
-					RootfsLabel:          uos.RootFsLabel,
-				}
+				updateOsRequest := apiRequest.ToProto(uos, tenant.Org)
 
 				workflowOptions := temporalClient.StartWorkflowOptions{
 					ID:                       "image-os-update-" + updatedOssa.SiteID.String() + "-" + uos.ID.String() + "-" + *updatedOssa.Version,
@@ -1537,10 +1511,7 @@ func (dsh DeleteOperatingSystemHandler) Handle(c echo.Context) error {
 					}
 
 					// Prepare the delete/release request workflow object
-					deleteOsRequest := &cwssaws.DeleteOsImageRequest{
-						Id:                   &cwssaws.UUID{Value: common.GetSiteOperatingSystemtID(os).String()},
-						TenantOrganizationId: tenant.Org,
-					}
+					deleteOsRequest := os.ToDeletionRequestProto(tenant.Org)
 
 					workflowOptions := temporalClient.StartWorkflowOptions{
 						ID:                       "image-os-delete-" + ossa.SiteID.String() + "-" + os.ID.String() + "-" + *ossa.Version,

--- a/rest-api/api/pkg/api/handler/util/common/common.go
+++ b/rest-api/api/pkg/api/handler/util/common/common.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"sync"
 
-	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel/attribute"
@@ -26,6 +25,8 @@ import (
 	tp "go.temporal.io/sdk/temporal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
@@ -86,14 +87,6 @@ func GetSiteNetworkSegmentID(s *cdbm.Subnet) *uuid.UUID {
 		return s.ControllerNetworkSegmentID
 	} else {
 		return &s.ID
-	}
-}
-
-func GetSiteOperatingSystemtID(o *cdbm.OperatingSystem) *uuid.UUID {
-	if o.ControllerOperatingSystemID != nil {
-		return o.ControllerOperatingSystemID
-	} else {
-		return &o.ID
 	}
 }
 

--- a/rest-api/api/pkg/api/model/operatingsystem.go
+++ b/rest-api/api/pkg/api/model/operatingsystem.go
@@ -7,13 +7,15 @@ import (
 	"errors"
 	"time"
 
-	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/model/util"
-	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
-	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/go-ozzo/ozzo-validation/v4/is"
 	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
+
+	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/model/util"
+	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
+	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
+	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 const (
@@ -66,9 +68,9 @@ type APIOperatingSystemCreateRequest struct {
 }
 
 // Validate ensure the values passed in request are acceptable
-func (oscr APIOperatingSystemCreateRequest) Validate() error {
+func (oscr *APIOperatingSystemCreateRequest) Validate() error {
 	var err error
-	err = validation.ValidateStruct(&oscr,
+	err = validation.ValidateStruct(oscr,
 		validation.Field(&oscr.Name,
 			validation.Required.Error(validationErrorStringLength),
 			validation.By(util.ValidateNameCharacters),
@@ -105,7 +107,7 @@ func (oscr APIOperatingSystemCreateRequest) Validate() error {
 	}
 
 	if oscr.ImageURL != nil {
-		err = validation.ValidateStruct(&oscr,
+		err = validation.ValidateStruct(oscr,
 			validation.Field(&oscr.ImageURL, is.URL),
 			validation.Field(&oscr.ImageSHA,
 				validation.Required.Error(validationErrorValueRequired),
@@ -137,7 +139,7 @@ func (oscr APIOperatingSystemCreateRequest) Validate() error {
 			}
 		}
 	} else {
-		err = validation.ValidateStruct(&oscr,
+		err = validation.ValidateStruct(oscr,
 			validation.Field(&oscr.SiteIDs,
 				validation.Nil.Error("siteIds cannot be specified if imageURL is not specified")),
 			validation.Field(&oscr.ImageSHA,
@@ -156,7 +158,7 @@ func (oscr APIOperatingSystemCreateRequest) Validate() error {
 	}
 
 	if oscr.IpxeScript != nil {
-		err = validation.ValidateStruct(&oscr,
+		err = validation.ValidateStruct(oscr,
 			validation.Field(&oscr.IpxeScript,
 				validation.Required.Error(validationErrorValueRequired)),
 			validation.Field(&oscr.EnableBlockStorage,
@@ -224,6 +226,25 @@ func (oscr *APIOperatingSystemCreateRequest) ValidateAndSetUserData(phonehomeUrl
 	return nil
 }
 
+// ToProto builds the workflow request that asks a Site to create the
+// OS image for this API request. `os` is the just-persisted DB record;
+// its `ToImageAttributesProto(tenantOrg)` is the source of every wire
+// field because the handler has already merged the request fields into
+// the entity via the DAO before this method runs. `tenantOrg` is a
+// side input — it lives on the request's resolved Tenant rather than
+// on the entity, and the handler passes it through.
+//
+// The method trusts that the request has already been Validated (and
+// that ValidateAndSetUserData has run) and that the handler has
+// performed the cross-context checks Validate cannot see — most
+// importantly that the OS is image-typed, since
+// `ToImageAttributesProto` dereferences `ImageURL` and `ImageSHA`.
+// For iPXE-typed records there is no Site-side image workflow, so
+// this method should not be called.
+func (oscr *APIOperatingSystemCreateRequest) ToProto(os *cdbm.OperatingSystem, tenantOrg string) *cwssaws.OsImageAttributes {
+	return os.ToImageAttributesProto(tenantOrg)
+}
+
 // APIOperatingSystemUpdateRequest is the data structure to capture user request to update an OperatingSystem
 type APIOperatingSystemUpdateRequest struct {
 	// Name is the name of the OperatingSystem
@@ -261,8 +282,8 @@ type APIOperatingSystemUpdateRequest struct {
 }
 
 // Validate ensure the values passed in request are acceptable
-func (osur APIOperatingSystemUpdateRequest) Validate(existingOS *cdbm.OperatingSystem) error {
-	err := validation.ValidateStruct(&osur,
+func (osur *APIOperatingSystemUpdateRequest) Validate(existingOS *cdbm.OperatingSystem) error {
+	err := validation.ValidateStruct(osur,
 		validation.Field(&osur.Name,
 			validation.When(osur.Name != nil, validation.Required.Error(validationErrorStringLength)),
 			validation.When(osur.Name != nil, validation.By(util.ValidateNameCharacters)),
@@ -331,7 +352,7 @@ func (osur APIOperatingSystemUpdateRequest) Validate(existingOS *cdbm.OperatingS
 	}
 
 	if osur.ImageURL != nil {
-		err = validation.ValidateStruct(&osur,
+		err = validation.ValidateStruct(osur,
 			validation.Field(&osur.ImageURL, is.URL),
 			validation.Field(&osur.ImageSHA,
 				validation.Required.Error(validationErrorValueRequired),
@@ -351,7 +372,7 @@ func (osur APIOperatingSystemUpdateRequest) Validate(existingOS *cdbm.OperatingS
 				validation.When(!(util.IsNilOrEmptyStrPtr(osur.RootFsID)), validation.Empty.Error(errMsgOnlyOneRootFsField))),
 		)
 	} else {
-		err = validation.ValidateStruct(&osur,
+		err = validation.ValidateStruct(osur,
 			validation.Field(&osur.ImageSHA,
 				validation.Nil.Error("imageSHA cannot be specified if imageURL is not specified")),
 			validation.Field(&osur.ImageAuthType,
@@ -368,7 +389,7 @@ func (osur APIOperatingSystemUpdateRequest) Validate(existingOS *cdbm.OperatingS
 	}
 
 	if osur.IpxeScript != nil {
-		err = validation.ValidateStruct(&osur,
+		err = validation.ValidateStruct(osur,
 			validation.Field(&osur.IpxeScript,
 				validation.Required.Error(validationErrorValueRequired)),
 		)
@@ -483,6 +504,29 @@ func (osur *APIOperatingSystemUpdateRequest) ValidateAndSetUserData(phonehomeUrl
 	osur.UserData = cutil.GetPtr(string(byteUserData))
 
 	return nil
+}
+
+// ToProto builds the workflow request that asks a Site to update the
+// OS image for this API request. `uos` is the post-update DB record;
+// its `ToImageAttributesProto(tenantOrg)` is the source of every wire
+// field, so unchanged fields stay populated and updated fields reflect
+// the just-persisted state. `tenantOrg` is a side input — it lives on
+// the request's resolved Tenant rather than on the entity, and the
+// handler passes it through.
+//
+// The same `OsImageAttributes` proto is used for both create and
+// update workflows on the Site side, so this method delegates to the
+// entity-level method rather than building a distinct wire shape. The
+// request-level method exists so call sites stay uniform with the
+// rest of the layered convention (handlers always invoke
+// `apiRequest.ToProto(entity, ...)`).
+//
+// As with the create variant, the method trusts that the request has
+// been Validated (Validate + ValidateAndSetUserData) and that the
+// handler has confirmed the OS is image-typed before this is called;
+// `ToImageAttributesProto` dereferences `ImageURL` and `ImageSHA`.
+func (osur *APIOperatingSystemUpdateRequest) ToProto(uos *cdbm.OperatingSystem, tenantOrg string) *cwssaws.OsImageAttributes {
+	return uos.ToImageAttributesProto(tenantOrg)
 }
 
 // APIOperatingSystem is the data structure to capture API representation of an OS

--- a/rest-api/api/pkg/api/model/operatingsystem_test.go
+++ b/rest-api/api/pkg/api/model/operatingsystem_test.go
@@ -10,14 +10,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/model/util"
 	cdmu "github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/model/util"
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAPIOperatingSystemCreateRequest_Validate(t *testing.T) {
@@ -888,4 +889,79 @@ func TestAPIOperatingSystemNew(t *testing.T) {
 			assert.Equal(t, *tc.dbObj.Description, *got.Description)
 		})
 	}
+}
+
+func TestAPIOperatingSystemCreateRequest_ToProto(t *testing.T) {
+	id := uuid.New()
+	url := "https://image"
+	sha := "deadbeef"
+	rootFsID := "fs-1"
+	os := &cdbm.OperatingSystem{
+		ID:                 id,
+		Name:               "ubuntu",
+		ImageURL:           &url,
+		ImageSHA:           &sha,
+		RootFsID:           &rootFsID,
+		EnableBlockStorage: false,
+	}
+	t.Run("delegates to ToImageAttributesProto with tenantOrg", func(t *testing.T) {
+		req := APIOperatingSystemCreateRequest{}
+		got := req.ToProto(os, "org-1")
+		require.NotNil(t, got)
+		require.NotNil(t, got.Id)
+		assert.Equal(t, id.String(), got.Id.Value)
+		require.NotNil(t, got.Name)
+		assert.Equal(t, "ubuntu", *got.Name)
+		assert.Equal(t, "org-1", got.TenantOrganizationId)
+		assert.Equal(t, "https://image", got.SourceUrl)
+		assert.Equal(t, "deadbeef", got.Digest)
+		require.NotNil(t, got.RootfsId)
+		assert.Equal(t, "fs-1", *got.RootfsId)
+	})
+	t.Run("uses ControllerOperatingSystemID when set", func(t *testing.T) {
+		ctrlID := uuid.New()
+		osWithCtrl := &cdbm.OperatingSystem{
+			ID:                          id,
+			ControllerOperatingSystemID: &ctrlID,
+			Name:                        "ubuntu",
+			ImageURL:                    &url,
+			ImageSHA:                    &sha,
+			RootFsID:                    &rootFsID,
+		}
+		req := APIOperatingSystemCreateRequest{}
+		got := req.ToProto(osWithCtrl, "org-1")
+		require.NotNil(t, got)
+		require.NotNil(t, got.Id)
+		assert.Equal(t, ctrlID.String(), got.Id.Value)
+	})
+}
+
+func TestAPIOperatingSystemUpdateRequest_ToProto(t *testing.T) {
+	id := uuid.New()
+	url := "https://image-new"
+	sha := "cafebabe"
+	rootFsLabel := "lbl"
+	uos := &cdbm.OperatingSystem{
+		ID:                 id,
+		Name:               "ubuntu-22",
+		ImageURL:           &url,
+		ImageSHA:           &sha,
+		RootFsLabel:        &rootFsLabel,
+		EnableBlockStorage: true,
+	}
+	t.Run("delegates to ToImageAttributesProto with tenantOrg", func(t *testing.T) {
+		req := APIOperatingSystemUpdateRequest{}
+		got := req.ToProto(uos, "org-2")
+		require.NotNil(t, got)
+		require.NotNil(t, got.Id)
+		assert.Equal(t, id.String(), got.Id.Value)
+		require.NotNil(t, got.Name)
+		assert.Equal(t, "ubuntu-22", *got.Name)
+		assert.Equal(t, "org-2", got.TenantOrganizationId)
+		assert.Equal(t, "https://image-new", got.SourceUrl)
+		assert.Equal(t, "cafebabe", got.Digest)
+		assert.True(t, got.CreateVolume)
+		require.NotNil(t, got.RootfsLabel)
+		assert.Equal(t, "lbl", *got.RootfsLabel)
+	})
 }

--- a/rest-api/db/pkg/db/model/operatingsystem.go
+++ b/rest-api/db/pkg/db/model/operatingsystem.go
@@ -8,13 +8,15 @@ import (
 	"database/sql"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
-	"github.com/google/uuid"
 
 	"github.com/uptrace/bun"
 
 	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
+	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 const (
@@ -110,6 +112,56 @@ type OperatingSystem struct {
 	Updated                     time.Time               `bun:"updated,nullzero,notnull,default:current_timestamp"`
 	Deleted                     *time.Time              `bun:"deleted,soft_delete"`
 	CreatedBy                   uuid.UUID               `bun:"type:uuid,notnull"`
+}
+
+// GetSiteID returns the OperatingSystem ID to use when communicating
+// with the Site: ControllerOperatingSystemID when present, otherwise
+// the OS's own ID. The Site treats both as opaque identifiers.
+func (os *OperatingSystem) GetSiteID() *uuid.UUID {
+	if os.ControllerOperatingSystemID != nil {
+		return os.ControllerOperatingSystemID
+	}
+	return &os.ID
+}
+
+// ToImageAttributesProto builds the OsImageAttributes proto used by
+// both the create and update workflows. tenantOrg is the owning
+// tenant's organization id (not stored on the entity directly).
+//
+// The same proto shape is sent for both create and update flows, so
+// this entity-level method is the canonical entity-to-proto for OS
+// image data; the request-shape ToProto methods on
+// APIOperatingSystemCreateRequest and APIOperatingSystemUpdateRequest
+// layer on top of it without altering the wire fields.
+//
+// Per the proto-conversion convention, the method trusts the caller:
+// the request must have been Validated and the handler must have
+// performed the cross-context check that the OS is image-typed (the
+// dereferences below assume ImageURL and ImageSHA are non-nil, which
+// holds for image-typed records after validation).
+func (os *OperatingSystem) ToImageAttributesProto(tenantOrg string) *cwssaws.OsImageAttributes {
+	return &cwssaws.OsImageAttributes{
+		Id:                   &cwssaws.UUID{Value: os.GetSiteID().String()},
+		Name:                 &os.Name,
+		TenantOrganizationId: tenantOrg,
+		Description:          os.Description,
+		SourceUrl:            *os.ImageURL,
+		Digest:               *os.ImageSHA,
+		CreateVolume:         os.EnableBlockStorage,
+		AuthType:             os.ImageAuthType,
+		AuthToken:            os.ImageAuthToken,
+		RootfsId:             os.RootFsID,
+		RootfsLabel:          os.RootFsLabel,
+	}
+}
+
+// ToDeletionRequestProto builds the workflow request that asks a Site
+// to delete this OS image.
+func (os *OperatingSystem) ToDeletionRequestProto(tenantOrg string) *cwssaws.DeleteOsImageRequest {
+	return &cwssaws.DeleteOsImageRequest{
+		Id:                   &cwssaws.UUID{Value: os.GetSiteID().String()},
+		TenantOrganizationId: tenantOrg,
+	}
 }
 
 // OperatingSystemCreateInput input parameters for Create method

--- a/rest-api/db/pkg/db/model/operatingsystem_test.go
+++ b/rest-api/db/pkg/db/model/operatingsystem_test.go
@@ -9,16 +9,83 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	otrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/google/uuid"
+	"github.com/uptrace/bun/extra/bundebug"
 
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/util"
-	"github.com/google/uuid"
-	"github.com/uptrace/bun/extra/bundebug"
 )
+
+func TestOperatingSystem_GetSiteID(t *testing.T) {
+	id := uuid.New()
+	ctrlID := uuid.New()
+	t.Run("falls back to ID when ControllerOperatingSystemID is nil", func(t *testing.T) {
+		os := &OperatingSystem{ID: id}
+		got := os.GetSiteID()
+		require.NotNil(t, got)
+		assert.Equal(t, id, *got)
+	})
+	t.Run("uses ControllerOperatingSystemID when set", func(t *testing.T) {
+		os := &OperatingSystem{ID: id, ControllerOperatingSystemID: &ctrlID}
+		got := os.GetSiteID()
+		require.NotNil(t, got)
+		assert.Equal(t, ctrlID, *got)
+	})
+}
+
+func TestOperatingSystem_ToImageAttributesProto(t *testing.T) {
+	id := uuid.New()
+	desc := "primary"
+	url := "https://image"
+	sha := "deadbeef"
+	authType := "Basic"
+	authToken := "token"
+	rootFsID := "fs-1"
+	rootFsLabel := "label"
+	os := &OperatingSystem{
+		ID:                 id,
+		Name:               "ubuntu",
+		Description:        &desc,
+		ImageURL:           &url,
+		ImageSHA:           &sha,
+		ImageAuthType:      &authType,
+		ImageAuthToken:     &authToken,
+		RootFsID:           &rootFsID,
+		RootFsLabel:        &rootFsLabel,
+		EnableBlockStorage: true,
+	}
+	got := os.ToImageAttributesProto("org-1")
+	require.NotNil(t, got)
+	require.NotNil(t, got.Id)
+	assert.Equal(t, id.String(), got.Id.Value)
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "ubuntu", *got.Name)
+	assert.Equal(t, "org-1", got.TenantOrganizationId)
+	assert.Equal(t, &desc, got.Description)
+	assert.Equal(t, "https://image", got.SourceUrl)
+	assert.Equal(t, "deadbeef", got.Digest)
+	assert.True(t, got.CreateVolume)
+	assert.Equal(t, &authType, got.AuthType)
+	assert.Equal(t, &authToken, got.AuthToken)
+	assert.Equal(t, &rootFsID, got.RootfsId)
+	assert.Equal(t, &rootFsLabel, got.RootfsLabel)
+}
+
+func TestOperatingSystem_ToDeletionRequestProto(t *testing.T) {
+	id := uuid.New()
+	os := &OperatingSystem{ID: id}
+	got := os.ToDeletionRequestProto("org-1")
+	require.NotNil(t, got)
+	require.NotNil(t, got.Id)
+	assert.Equal(t, id.String(), got.Id.Value)
+	assert.Equal(t, "org-1", got.TenantOrganizationId)
+}
 
 func testOperatingSystemInitDB(t *testing.T) *db.Session {
 	dbSession := util.GetTestDBSession(t, false)


### PR DESCRIPTION
## Description

Brings `OperatingSystem` in line with the proto-modeling changes. Create and Update route through `ToProto` on the API request types, while Delete sits on the entity (no API body).

`tenantOrg` is introduced in as argument, since it's sourced from the resolved `Tenant` and not the entity.

Primary callouts are:
- API request side: `APIOperatingSystemCreateRequest.ToProto(os, tenantOrg)` and `APIOperatingSystemUpdateRequest.ToProto(os, tenantOrg)`. Both delegate to an entity-level `ToImageAttributesProto(tenantOrg)`.
- Entity side: `OperatingSystem.GetSiteID()`, `ToImageAttributesProto(tenantOrg)`, and `ToDeletionRequestProto(tenantOrg)`. The `common.GetSiteOperatingSystemtID` helper is removed.
- Handler simplified to one-liners, and the inline `cwssaws` import drops.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

