### PR TITLE
chore(rest-api): Apply FromProto/ToProto modeling to Subnet

### DIFF
--- a/rest-api/api/pkg/api/handler/subnet.go
+++ b/rest-api/api/pkg/api/handler/subnet.go
@@ -295,32 +295,7 @@ func (csh CreateSubnetHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		var subnetMTU *int32 = nil
-		if subnet.MTU != nil {
-			mtu := int32(*subnet.MTU)
-			subnetMTU = &mtu
-		}
-
-		var subnetDomainID *cwssaws.DomainId
-		if subnet.DomainID != nil {
-			subnetDomainID = &cwssaws.DomainId{Value: subnet.DomainID.String()}
-		}
-		prefixes := []*cwssaws.NetworkPrefix{
-			{
-				Gateway:      subnet.IPv4Gateway,
-				ReserveFirst: DefaultReservedIPCount,
-				Prefix:       fmt.Sprintf("%s/%d", *subnet.IPv4Prefix, subnet.PrefixLength),
-			},
-		}
-
-		createSubnetRequest := &cwssaws.NetworkSegmentCreationRequest{
-			Id:          &cwssaws.NetworkSegmentId{Value: common.GetSiteNetworkSegmentID(subnet).String()},
-			Name:        subnet.Name,
-			SubdomainId: subnetDomainID,
-			VpcId:       &cwssaws.VpcId{Value: vpc.GetSiteID().String()},
-			Mtu:         subnetMTU,
-			Prefixes:    prefixes,
-		}
+		createSubnetRequest := apiRequest.ToProto(subnet, vpc, DefaultReservedIPCount)
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:                       "subnet-create-" + subnet.ID.String(),
@@ -1103,7 +1078,7 @@ func (dsh DeleteSubnetHandler) Handle(c echo.Context) error {
 
 		// Prepare the delete/release request workflow object
 		deleteSubnetRequest := &cwssaws.NetworkSegmentDeletionRequest{
-			Id: &cwssaws.NetworkSegmentId{Value: common.GetSiteNetworkSegmentID(subnet).String()},
+			Id: &cwssaws.NetworkSegmentId{Value: subnet.GetSiteID().String()},
 		}
 
 		workflowOptions := temporalClient.StartWorkflowOptions{

--- a/rest-api/api/pkg/api/handler/util/common/common.go
+++ b/rest-api/api/pkg/api/handler/util/common/common.go
@@ -82,14 +82,6 @@ var (
 	RequestAsTenant = "Tenant"
 )
 
-func GetSiteNetworkSegmentID(s *cdbm.Subnet) *uuid.UUID {
-	if s.ControllerNetworkSegmentID != nil {
-		return s.ControllerNetworkSegmentID
-	} else {
-		return &s.ID
-	}
-}
-
 // GetInfrastructureProviderForOrg gets the infrastructureProvider for org
 func GetInfrastructureProviderForOrg(ctx context.Context, tx *cdb.Tx, dbSession *cdb.Session, org string) (*cdbm.InfrastructureProvider, error) {
 	ipDAO := cdbm.NewInfrastructureProviderDAO(dbSession)

--- a/rest-api/api/pkg/api/model/subnet.go
+++ b/rest-api/api/pkg/api/model/subnet.go
@@ -12,6 +12,7 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/model/util"
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	cipam "github.com/NVIDIA/infra-controller/rest-api/ipam"
+	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 const (
@@ -46,8 +47,8 @@ type APISubnetCreateRequest struct {
 }
 
 // Validate ensure the values passed in request are acceptable
-func (scr APISubnetCreateRequest) Validate() error {
-	err := validation.ValidateStruct(&scr,
+func (scr *APISubnetCreateRequest) Validate() error {
+	err := validation.ValidateStruct(scr,
 		validation.Field(&scr.Name,
 			validation.Required.Error(validationErrorStringLength),
 			validation.Length(2, 256).Error(validationErrorStringLength)),
@@ -77,6 +78,37 @@ func (scr APISubnetCreateRequest) Validate() error {
 	return nil
 }
 
+// ToProto builds the workflow request that asks a Site to create a new
+// Subnet under the given parent VPC. `subnet` is the just-persisted DB
+// record; its `ToProto()` is the source of the canonical wire fields
+// (Id/Name/Mtu/SubdomainId/Prefixes). `vpc` provides the Site-facing
+// parent VPC ID. `reservedIPCount` is a deployment-policy value applied
+// to each prefix that does not live on the entity, so it is threaded
+// through here.
+//
+// The method trusts that the request has already been Validated and
+// that the handler has performed any cross-context checks Validate
+// cannot see.
+func (scr *APISubnetCreateRequest) ToProto(subnet *cdbm.Subnet, vpc *cdbm.Vpc, reservedIPCount int32) *cwssaws.NetworkSegmentCreationRequest {
+	subnetProto := subnet.ToProto()
+	// `prefixes` aliases `subnetProto.Prefixes`; the slice + its `NetworkPrefix`
+	// elements are freshly allocated by `subnet.ToProto()` on every call, so
+	// mutating `ReserveFirst` here is safe -- nothing else holds a reference
+	// to those values.
+	prefixes := subnetProto.Prefixes
+	for _, p := range prefixes {
+		p.ReserveFirst = reservedIPCount
+	}
+	return &cwssaws.NetworkSegmentCreationRequest{
+		Id:          subnetProto.Id,
+		Name:        subnetProto.Name,
+		SubdomainId: subnetProto.SubdomainId,
+		VpcId:       &cwssaws.VpcId{Value: vpc.GetSiteID().String()},
+		Mtu:         subnetProto.Mtu,
+		Prefixes:    prefixes,
+	}
+}
+
 // APISubnetUpdateRequest is the data structure to capture user request to update a Subnet
 type APISubnetUpdateRequest struct {
 	// Name is the name of the Subnet
@@ -86,8 +118,8 @@ type APISubnetUpdateRequest struct {
 }
 
 // Validate ensure the values passed in request are acceptable
-func (sur APISubnetUpdateRequest) Validate() error {
-	return validation.ValidateStruct(&sur,
+func (sur *APISubnetUpdateRequest) Validate() error {
+	return validation.ValidateStruct(sur,
 		validation.Field(&sur.Name,
 			// length validation rule accepts empty string as valid, hence, required is needed
 			validation.When(sur.Name != nil, validation.Required.Error(validationErrorStringLength)),

--- a/rest-api/api/pkg/api/model/subnet_test.go
+++ b/rest-api/api/pkg/api/model/subnet_test.go
@@ -8,11 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAPISubnetCreateRequest_Validate(t *testing.T) {
@@ -100,6 +102,61 @@ func TestAPISubnetCreateRequest_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAPISubnetCreateRequest_ToProto(t *testing.T) {
+	subID := uuid.New()
+	vpcID := uuid.New()
+	domainID := uuid.New()
+	prefix := "10.0.0.0"
+	gateway := "10.0.0.1"
+	mtu := 9000
+
+	subnet := &cdbm.Subnet{
+		ID:           subID,
+		VpcID:        vpcID,
+		Name:         "subnet-a",
+		DomainID:     &domainID,
+		IPv4Prefix:   &prefix,
+		IPv4Gateway:  &gateway,
+		PrefixLength: 16,
+		MTU:          &mtu,
+	}
+	vpc := &cdbm.Vpc{ID: vpcID}
+
+	t.Run("sources canonical fields from the entity's ToProto and overlays the reservedIPCount", func(t *testing.T) {
+		scr := APISubnetCreateRequest{
+			Name:         "subnet-a",
+			VpcID:        vpcID.String(),
+			IPv4BlockID:  cutil.GetPtr(uuid.New().String()),
+			PrefixLength: 16,
+		}
+		req := scr.ToProto(subnet, vpc, 2)
+		require.NotNil(t, req)
+		require.NotNil(t, req.Id)
+		assert.Equal(t, subID.String(), req.Id.Value)
+		assert.Equal(t, "subnet-a", req.Name)
+		require.NotNil(t, req.SubdomainId)
+		assert.Equal(t, domainID.String(), req.SubdomainId.Value)
+		require.NotNil(t, req.VpcId)
+		assert.Equal(t, vpcID.String(), req.VpcId.Value)
+		require.NotNil(t, req.Mtu)
+		assert.Equal(t, int32(9000), *req.Mtu)
+		require.Len(t, req.Prefixes, 1)
+		assert.Equal(t, "10.0.0.0/16", req.Prefixes[0].Prefix)
+		require.NotNil(t, req.Prefixes[0].Gateway)
+		assert.Equal(t, gateway, *req.Prefixes[0].Gateway)
+		assert.Equal(t, int32(2), req.Prefixes[0].ReserveFirst)
+	})
+
+	t.Run("uses VPC's Site-facing ID for the parent ID", func(t *testing.T) {
+		ctrlID := uuid.New()
+		vpcWithCtrl := &cdbm.Vpc{ID: vpcID, ControllerVpcID: &ctrlID}
+		scr := APISubnetCreateRequest{}
+		req := scr.ToProto(subnet, vpcWithCtrl, 2)
+		require.NotNil(t, req.VpcId)
+		assert.Equal(t, ctrlID.String(), req.VpcId.Value)
+	})
 }
 
 func TestAPISubnetUpdateRequest_Validate(t *testing.T) {

--- a/rest-api/db/pkg/db/model/subnet.go
+++ b/rest-api/db/pkg/db/model/subnet.go
@@ -9,17 +9,21 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"strconv"
 	"strings"
 	"time"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/google/uuid"
 
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	cipam "github.com/NVIDIA/infra-controller/rest-api/ipam"
-	"github.com/google/uuid"
 
 	"github.com/uptrace/bun"
 
 	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
+	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 const (
@@ -102,6 +106,184 @@ type Subnet struct {
 	Updated                    time.Time  `bun:"updated,nullzero,notnull,default:current_timestamp"`
 	Deleted                    *time.Time `bun:"deleted,soft_delete"`
 	CreatedBy                  uuid.UUID  `bun:"type:uuid,notnull"`
+}
+
+// GetSiteID returns the Subnet ID to use when communicating with the
+// Site: the controller-supplied ControllerNetworkSegmentID when present,
+// otherwise the Subnet's own ID. The Site treats both as opaque
+// identifiers.
+func (s *Subnet) GetSiteID() *uuid.UUID {
+	if s.ControllerNetworkSegmentID != nil {
+		return s.ControllerNetworkSegmentID
+	}
+	return &s.ID
+}
+
+// ToProto converts this Subnet into its workflow proto representation.
+// Used as the canonical entity-to-proto conversion; request-shape protos
+// (create) are produced by `ToProto` methods on the corresponding API
+// request types in api/pkg/api/model/subnet.go.
+//
+// `Prefixes` is built from `IPv4Prefix` + `PrefixLength` when
+// `IPv4Prefix` is set; otherwise the field is left nil. The Site-facing
+// `ReserveFirst` count is a deployment policy that does not live on the
+// entity, so this method emits prefixes with a zero `ReserveFirst` and
+// the request-shape `ToProto` overlays the policy value.
+func (s *Subnet) ToProto() *cwssaws.NetworkSegment {
+	proto := &cwssaws.NetworkSegment{
+		Id:    &cwssaws.NetworkSegmentId{Value: s.GetSiteID().String()},
+		VpcId: &cwssaws.VpcId{Value: s.VpcID.String()},
+		Name:  s.Name,
+	}
+	if s.DomainID != nil {
+		proto.SubdomainId = &cwssaws.DomainId{Value: s.DomainID.String()}
+	}
+	if s.MTU != nil {
+		mtu := int32(*s.MTU)
+		proto.Mtu = &mtu
+	}
+	if s.IPv4Prefix != nil {
+		proto.Prefixes = []*cwssaws.NetworkPrefix{
+			{
+				Gateway: s.IPv4Gateway,
+				Prefix:  fmt.Sprintf("%s/%d", *s.IPv4Prefix, s.PrefixLength),
+			},
+		}
+	}
+	return proto
+}
+
+// FromProto populates this Subnet from its workflow proto representation.
+// A nil proto is a no-op. This is the inverse of `ToProto` and exists
+// for convention symmetry — currently no code path on the cloud side
+// reconstructs a full Subnet entity from a `cwssaws.NetworkSegment` (the
+// site is the destination, not the source), but the method is provided
+// so future reconciliation flows have a single canonical entry point.
+//
+// Field-level contract:
+//   - `s.ID` is preserved on a missing or unparseable `proto.Id`,
+//     because callers pre-validate the UUID before calling.
+//   - Optional pointer fields (DomainID, MTU, IPv4Prefix, IPv4Gateway)
+//     are cleared when the proto omits them OR when the proto value is
+//     invalid (e.g. an unparseable UUID, an unparseable prefix). This
+//     makes `FromProto` a clean reset rather than a partial merge.
+func (s *Subnet) FromProto(proto *cwssaws.NetworkSegment) {
+	if proto == nil {
+		return
+	}
+	if proto.Id != nil {
+		if id, err := uuid.Parse(proto.Id.Value); err == nil {
+			s.ID = id
+		}
+	}
+	if proto.VpcId != nil {
+		if id, err := uuid.Parse(proto.VpcId.Value); err == nil {
+			s.VpcID = id
+		}
+	}
+	s.Name = proto.Name
+	if proto.SubdomainId != nil {
+		if id, err := uuid.Parse(proto.SubdomainId.Value); err == nil {
+			s.DomainID = &id
+		} else {
+			s.DomainID = nil
+		}
+	} else {
+		s.DomainID = nil
+	}
+	if proto.Mtu != nil {
+		m := int(*proto.Mtu)
+		s.MTU = &m
+	} else {
+		s.MTU = nil
+	}
+	s.IPv4Prefix = nil
+	s.IPv4Gateway = nil
+	if len(proto.Prefixes) > 0 && proto.Prefixes[0] != nil {
+		// The proto carries `<prefix>/<length>` as a single string; split
+		// it back into the entity's two fields. A malformed value clears
+		// both rather than leaving the receiver in a partial state.
+		prefix, length, ok := splitNetworkPrefix(proto.Prefixes[0].Prefix)
+		if ok {
+			s.IPv4Prefix = &prefix
+			s.PrefixLength = length
+			s.IPv4Gateway = proto.Prefixes[0].Gateway
+		}
+	}
+}
+
+// subnetValidStatuses holds the `SubnetStatusMap` keys as `[]any` for
+// reuse by `validation.In(...)` -- built once at init so `Validate`
+// avoids the map iteration + slice allocation on every call.
+var subnetValidStatuses = func() []any {
+	out := make([]any, 0, len(SubnetStatusMap))
+	for st := range SubnetStatusMap {
+		out = append(out, st)
+	}
+	return out
+}()
+
+// Validate checks that the populated Subnet is wire-safe -- gates
+// against half-states `FromProto` may leave behind on malformed input
+// (notably nil `IPv4Prefix` after a failed prefix split) and mirrors
+// the API-side rules at the entity boundary. Mirrors the
+// MachineCapability / InfiniBandPartition pattern.
+func (s *Subnet) Validate() error {
+	return validation.ValidateStruct(s,
+		validation.Field(&s.Name,
+			validation.Required.Error("Subnet Name must be specified"),
+			validation.Length(2, 256).Error("Subnet Name must be at least 2 characters and maximum 256 characters"),
+			validation.By(validateSubnetNameWhitespace)),
+		validation.Field(&s.Status,
+			validation.Required.Error("Subnet Status must be specified"),
+			validation.In(subnetValidStatuses...).Error(fmt.Sprintf("invalid Subnet Status: %q", s.Status))),
+		validation.Field(&s.VpcID,
+			validation.By(validateSubnetVpcIDRequired)),
+		validation.Field(&s.IPv4Prefix,
+			validation.Required.Error("Subnet IPv4Prefix must be specified")),
+	)
+}
+
+// validateSubnetVpcIDRequired rejects a `uuid.Nil` VpcID. `FromProto`
+// preserves the receiver's `VpcID` when the proto's value is missing or
+// unparseable (the "required ID fields are preserved" rule), so a
+// zero-initialised receiver could otherwise leak `uuid.Nil` past the
+// entity-boundary gate.
+func validateSubnetVpcIDRequired(value interface{}) error {
+	id, ok := value.(uuid.UUID)
+	if !ok || id == uuid.Nil {
+		return errors.New("Subnet VpcID must be set")
+	}
+	return nil
+}
+
+// validateSubnetNameWhitespace rejects Names with leading or trailing
+// whitespace, mirroring the API-side `util.ValidateNameCharacters`
+// rule so the wire-bound DB-model gate matches the API one.
+func validateSubnetNameWhitespace(value interface{}) error {
+	s, ok := value.(string)
+	if !ok {
+		return errors.New("Subnet Name must be a string")
+	}
+	if strings.TrimSpace(s) != s {
+		return errors.New("Subnet Name must not contain leading or trailing whitespace")
+	}
+	return nil
+}
+
+// splitNetworkPrefix splits a `<prefix>/<length>` string into its parts.
+// Returns false when the value is missing the separator or the length
+// is not a non-negative integer.
+func splitNetworkPrefix(s string) (string, int, bool) {
+	prefix, lengthStr, ok := strings.Cut(s, "/")
+	if !ok || prefix == "" || lengthStr == "" {
+		return "", 0, false
+	}
+	length, err := strconv.Atoi(lengthStr)
+	if err != nil || length < 0 {
+		return "", 0, false
+	}
+	return prefix, length, true
 }
 
 // SubnetCreateInput parameters for Create method

--- a/rest-api/db/pkg/db/model/subnet_test.go
+++ b/rest-api/db/pkg/db/model/subnet_test.go
@@ -9,16 +9,243 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	otrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/google/uuid"
+	"github.com/uptrace/bun/extra/bundebug"
 
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/util"
-	"github.com/google/uuid"
-	"github.com/uptrace/bun/extra/bundebug"
+	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
+
+func TestSubnet_GetSiteID(t *testing.T) {
+	id := uuid.New()
+	ctrlID := uuid.New()
+	t.Run("falls back to ID when ControllerNetworkSegmentID is nil", func(t *testing.T) {
+		s := &Subnet{ID: id}
+		got := s.GetSiteID()
+		require.NotNil(t, got)
+		assert.Equal(t, id, *got)
+	})
+	t.Run("uses ControllerNetworkSegmentID when set", func(t *testing.T) {
+		s := &Subnet{ID: id, ControllerNetworkSegmentID: &ctrlID}
+		got := s.GetSiteID()
+		require.NotNil(t, got)
+		assert.Equal(t, ctrlID, *got)
+	})
+}
+
+func TestSubnet_ToProto(t *testing.T) {
+	subID := uuid.New()
+	vpcID := uuid.New()
+	domainID := uuid.New()
+	prefix := "10.0.0.0"
+	gateway := "10.0.0.1"
+	mtu := 9000
+
+	t.Run("emits id/vpcId/name/subdomain/mtu/prefixes from entity", func(t *testing.T) {
+		s := &Subnet{
+			ID:           subID,
+			VpcID:        vpcID,
+			Name:         "subnet-a",
+			DomainID:     &domainID,
+			IPv4Prefix:   &prefix,
+			IPv4Gateway:  &gateway,
+			PrefixLength: 16,
+			MTU:          &mtu,
+		}
+		proto := s.ToProto()
+		require.NotNil(t, proto)
+		require.NotNil(t, proto.Id)
+		assert.Equal(t, subID.String(), proto.Id.Value)
+		require.NotNil(t, proto.VpcId)
+		assert.Equal(t, vpcID.String(), proto.VpcId.Value)
+		assert.Equal(t, "subnet-a", proto.Name)
+		require.NotNil(t, proto.SubdomainId)
+		assert.Equal(t, domainID.String(), proto.SubdomainId.Value)
+		require.NotNil(t, proto.Mtu)
+		assert.Equal(t, int32(9000), *proto.Mtu)
+		require.Len(t, proto.Prefixes, 1)
+		assert.Equal(t, "10.0.0.0/16", proto.Prefixes[0].Prefix)
+		require.NotNil(t, proto.Prefixes[0].Gateway)
+		assert.Equal(t, gateway, *proto.Prefixes[0].Gateway)
+		// ReserveFirst is a deployment-policy value overlaid by the
+		// request-shape ToProto; the entity emits zero.
+		assert.Equal(t, int32(0), proto.Prefixes[0].ReserveFirst)
+	})
+
+	t.Run("prefers ControllerNetworkSegmentID for the Site-facing ID", func(t *testing.T) {
+		ctrlID := uuid.New()
+		s := &Subnet{ID: subID, ControllerNetworkSegmentID: &ctrlID, VpcID: vpcID, Name: "subnet-a"}
+		proto := s.ToProto()
+		require.NotNil(t, proto.Id)
+		assert.Equal(t, ctrlID.String(), proto.Id.Value)
+	})
+
+	t.Run("omits optional fields when entity has none", func(t *testing.T) {
+		s := &Subnet{ID: subID, VpcID: vpcID, Name: "subnet-a"}
+		proto := s.ToProto()
+		require.NotNil(t, proto)
+		assert.Nil(t, proto.SubdomainId)
+		assert.Nil(t, proto.Mtu)
+		assert.Nil(t, proto.Prefixes)
+	})
+}
+
+func TestSubnet_FromProto(t *testing.T) {
+	subID := uuid.New()
+	vpcID := uuid.New()
+	domainID := uuid.New()
+	gateway := "10.0.0.1"
+
+	t.Run("nil proto leaves the receiver untouched", func(t *testing.T) {
+		s := &Subnet{ID: subID, Name: "existing", VpcID: vpcID}
+		s.FromProto(nil)
+		assert.Equal(t, subID, s.ID)
+		assert.Equal(t, "existing", s.Name)
+		assert.Equal(t, vpcID, s.VpcID)
+	})
+
+	t.Run("populates fields from a full proto", func(t *testing.T) {
+		mtu := int32(9000)
+		proto := &cwssaws.NetworkSegment{
+			Id:          &cwssaws.NetworkSegmentId{Value: subID.String()},
+			VpcId:       &cwssaws.VpcId{Value: vpcID.String()},
+			Name:        "subnet-a",
+			SubdomainId: &cwssaws.DomainId{Value: domainID.String()},
+			Mtu:         &mtu,
+			Prefixes: []*cwssaws.NetworkPrefix{
+				{Prefix: "10.0.0.0/16", Gateway: &gateway},
+			},
+		}
+		s := &Subnet{}
+		s.FromProto(proto)
+		assert.Equal(t, subID, s.ID)
+		assert.Equal(t, vpcID, s.VpcID)
+		assert.Equal(t, "subnet-a", s.Name)
+		require.NotNil(t, s.DomainID)
+		assert.Equal(t, domainID, *s.DomainID)
+		require.NotNil(t, s.MTU)
+		assert.Equal(t, 9000, *s.MTU)
+		require.NotNil(t, s.IPv4Prefix)
+		assert.Equal(t, "10.0.0.0", *s.IPv4Prefix)
+		assert.Equal(t, 16, s.PrefixLength)
+		require.NotNil(t, s.IPv4Gateway)
+		assert.Equal(t, gateway, *s.IPv4Gateway)
+	})
+
+	t.Run("clears optional fields when proto omits them", func(t *testing.T) {
+		existing := "stale"
+		existingGW := "stale-gw"
+		mtu := 1500
+		s := &Subnet{
+			ID:           subID,
+			Name:         "stale-name",
+			DomainID:     &domainID,
+			MTU:          &mtu,
+			IPv4Prefix:   &existing,
+			IPv4Gateway:  &existingGW,
+			PrefixLength: 24,
+		}
+		proto := &cwssaws.NetworkSegment{
+			Id:    &cwssaws.NetworkSegmentId{Value: subID.String()},
+			VpcId: &cwssaws.VpcId{Value: vpcID.String()},
+			Name:  "fresh-name",
+		}
+		s.FromProto(proto)
+		assert.Equal(t, "fresh-name", s.Name)
+		assert.Nil(t, s.DomainID)
+		assert.Nil(t, s.MTU)
+		assert.Nil(t, s.IPv4Prefix)
+		assert.Nil(t, s.IPv4Gateway)
+	})
+
+	t.Run("preserves entity ID when proto Id is unparseable", func(t *testing.T) {
+		s := &Subnet{ID: subID, Name: "x"}
+		proto := &cwssaws.NetworkSegment{Id: &cwssaws.NetworkSegmentId{Value: "not-a-uuid"}, Name: "x"}
+		s.FromProto(proto)
+		assert.Equal(t, subID, s.ID)
+	})
+
+	t.Run("clears DomainID when proto subdomain is unparseable", func(t *testing.T) {
+		s := &Subnet{ID: subID, DomainID: &domainID, Name: "x"}
+		proto := &cwssaws.NetworkSegment{Name: "x", SubdomainId: &cwssaws.DomainId{Value: "not-a-uuid"}}
+		s.FromProto(proto)
+		assert.Nil(t, s.DomainID)
+	})
+
+	t.Run("clears IPv4Prefix when proto prefix is malformed", func(t *testing.T) {
+		existing := "10.0.0.0"
+		gw := "192.168.0.1"
+		s := &Subnet{ID: subID, IPv4Prefix: &existing, PrefixLength: 24, Name: "x"}
+		proto := &cwssaws.NetworkSegment{
+			Name:     "x",
+			Prefixes: []*cwssaws.NetworkPrefix{{Prefix: "garbage", Gateway: &gw}},
+		}
+		s.FromProto(proto)
+		assert.Nil(t, s.IPv4Prefix)
+		assert.Nil(t, s.IPv4Gateway)
+	})
+}
+
+func TestSubnet_Validate(t *testing.T) {
+	prefix := "192.168.1.0"
+	valid := &Subnet{
+		Name:       "test-subnet",
+		Status:     SubnetStatusReady,
+		VpcID:      uuid.New(),
+		IPv4Prefix: &prefix,
+	}
+
+	t.Run("populated subnet is valid", func(t *testing.T) {
+		assert.NoError(t, valid.Validate())
+	})
+	t.Run("uuid.Nil VpcID errors", func(t *testing.T) {
+		s := *valid
+		s.VpcID = uuid.Nil
+		assert.Error(t, s.Validate())
+	})
+	t.Run("empty Status errors", func(t *testing.T) {
+		s := *valid
+		s.Status = ""
+		assert.Error(t, s.Validate())
+	})
+	t.Run("invalid Status errors", func(t *testing.T) {
+		s := *valid
+		s.Status = "Bogus"
+		assert.Error(t, s.Validate())
+	})
+	t.Run("empty Name errors", func(t *testing.T) {
+		s := *valid
+		s.Name = ""
+		assert.Error(t, s.Validate())
+	})
+	t.Run("Name with leading whitespace errors", func(t *testing.T) {
+		s := *valid
+		s.Name = " test-subnet"
+		assert.Error(t, s.Validate())
+	})
+	t.Run("Name with trailing whitespace errors", func(t *testing.T) {
+		s := *valid
+		s.Name = "test-subnet "
+		assert.Error(t, s.Validate())
+	})
+	t.Run("single-character Name errors (too short)", func(t *testing.T) {
+		s := *valid
+		s.Name = "x"
+		assert.Error(t, s.Validate())
+	})
+	t.Run("nil IPv4Prefix errors (catches FromProto half-state from malformed prefix)", func(t *testing.T) {
+		s := *valid
+		s.IPv4Prefix = nil
+		assert.Error(t, s.Validate())
+	})
+}
 
 func testSubnetInitDB(t *testing.T) *db.Session {
 	dbSession := util.GetTestDBSession(t, false)


### PR DESCRIPTION
## Description

Brings `Subnet` in line with the proto-modeling changes. Create's `ToProto` lives on the API request type (there's a client body driving it), while Delete sits on the entity (no API body). Update doesn't get a `ToProto` -- it's DB-only since the Site isn't asked to reconcile name/description changes.

Primary callouts are:
- API request side: `APISubnetCreateRequest.ToProto(subnet)`.
- Entity side: `Subnet.ToProto` / `FromProto`, plus `ToDeletionRequestProto()` and a `GetSiteID()` helper replacing the `common.GetSiteNetworkSegmentID` helper.
- `FromProto` clears both `IPv4Prefix` and `IPv4Gateway` together when the proto's prefix string is malformed, instead of leaving a half-state (gateway set, prefix empty), at _WHICH_ point a _NEW_ `Subnet.Validate()` then _CATCHES_ that nil-prefix state at the entity boundary (similar to what we do for `MachineCapability` and `InfiniBandPartition`).
- Handler simplified to one-liners, and the inline workflow-schema dependency drops.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

