### PR TITLE
test: remove stale sqlx migrator references

### DIFF
--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -239,10 +239,9 @@ mod vpc_prefix;
 // exercise). They build an `Api` via the `tests::common` fixtures, which `carbide-api-web` reaches
 // through this crate's `test-support` feature.
 
-pub use db::migrations::MIGRATOR;
-
-/// Make these symols available as crate::tests::MIGRATOR and crate::tests::sqlx_fixture_from_str,
-/// so that the [`carbide_macros::sqlx_test`] can delegate to them.
+/// Make these symbol available as
+/// crate::tests::sqlx_fixture_from_str, so that the
+/// [`carbide_macros::sqlx_test`] can delegate to them.
 pub use crate::tests::common::sqlx_fixtures::sqlx_fixture_from_str;
 
 /// Setup logging for tests. Only our own test binary needs this global initializer (it depends on

--- a/crates/api-core/src/tests/resource_pool.rs
+++ b/crates/api-core/src/tests/resource_pool.rs
@@ -29,7 +29,6 @@ use rpc::Metadata;
 use rpc::forge::forge_server::Forge;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 
-use crate::tests;
 use crate::tests::common;
 use crate::tests::common::rpc_builder::VpcCreationRequest;
 
@@ -590,7 +589,7 @@ async fn test_parallel() -> Result<(), eyre::Report> {
     let db_pool = PgPoolOptions::new()
         .connect_with(base_options.database(&db_name))
         .await?;
-    tests::MIGRATOR.run(&db_pool).await?;
+    db::migrations::migrate(&db_pool).await?;
 
     let mut txn = db_pool.begin().await?;
     let pool = Arc::new(ResourcePool::new(db_name.clone(), ValueType::Integer));

--- a/crates/api-web/src/lib.rs
+++ b/crates/api-web/src/lib.rs
@@ -215,9 +215,9 @@ fn format_state_sla(sla: Option<&forgerpc::StateSla>) -> String {
         .unwrap_or_default()
 }
 
-// Allow `carbide_macros::sqlx_test` to be referred to as `#[crate::sqlx_test]` in the admin-UI
-// tests (the macro expands to `crate::tests::{MIGRATOR, sqlx_fixture_from_str}`, re-exported in
-// `tests/mod.rs`).
+// Allow `carbide_macros::sqlx_test` to be referred to as
+// `#[crate::sqlx_test]` in the admin-UI tests. These tests do not support
+// `fixtures(...)`; use explicit setup helpers instead.
 #[cfg(test)]
 pub(crate) use carbide_macros::sqlx_test;
 #[cfg(test)]

--- a/crates/api-web/src/tests/mod.rs
+++ b/crates/api-web/src/tests/mod.rs
@@ -21,12 +21,6 @@ use axum::Router;
 // in `carbide-api-core`.
 pub use carbide_api_core::tests::common;
 use carbide_api_core::tests::common::api_fixtures::TestEnv;
-// The `#[crate::sqlx_test]` macro expands to references to `crate::tests::MIGRATOR` and
-// `crate::tests::sqlx_fixture_from_str`; re-export them here so those macro-generated paths resolve
-// in this crate. `#[allow(unused_imports)]` because the only references are in macro output (and
-// `sqlx_fixture_from_str` is only used by tests that declare fixtures), which the lint can't see.
-#[allow(unused_imports)]
-pub use carbide_api_core::tests::{MIGRATOR, sqlx_fixture_from_str};
 use hyper::http::Request;
 use hyper::http::request::Builder;
 

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -124,22 +124,19 @@ fn expand_dispatch(input: DeriveInput) -> syn::Result<TokenStream> {
 /// This ends up blowing up the test executable size tremendously, and causes link times to be very
 /// long, even on incremental builds.
 ///
-/// Using our own test wrapper macro fixes this by declaring fixtures in one static place, and referencing
-/// them on every invocation instead. This is not possible for sqlx to do
-/// natively, since every sqlx::test macro has to stand on its own and not assume any constants
-/// are defined anywhere.
-///
-/// Also, this wrapper uses sqlx_testing library that creates database for all tests from the template
-/// database (initialized using migrations) which is much more faster than migrate database on each
-/// unit test start.
+/// This wrapper delegates database setup to `sqlx_testing::TestFn::run_test`, which creates test
+/// databases from a migrated template database. That avoids re-running migrations for every test.
 ///
 /// # Specifying fixtures
 ///
-/// - Fixtures are specified with `#[carbide_macros::sqlx_test(fixtures("fixture1", ...))]` (or
-///   wherever `crate::tests::sqlx_fixture_from_str` loads them.)
-/// - All fixtures are relative to api/src/tests/fixtures.
+/// - Fixtures are specified with `#[carbide_macros::sqlx_test(fixtures("fixture1", ...))]`.
+/// - For each fixture name, the macro emits a call to `crate::tests::sqlx_fixture_from_str`.
+/// - Crates using fixture arguments must therefore define or re-export
+///   `crate::tests::sqlx_fixture_from_str`.
 ///
-/// This does not support other options from sqlx::test, e.g. `path`, `scripts(...)`, etc.
+/// Tests that do not specify fixtures do not need any `crate::tests` helper items.
+///
+/// This does not support other options from `sqlx::test`, e.g. `path`, `scripts(...)`, etc.
 ///
 /// # Creating new fixtures
 ///
@@ -148,9 +145,11 @@ fn expand_dispatch(input: DeriveInput) -> syn::Result<TokenStream> {
 ///
 /// # How does it work?
 ///
-/// By setting up a sqlx test to run migrations and fixtures the same way `sqlx::test` does, but by
-/// hardcoding calls to our own migrator and fixtures, which can be made static and thus not
-/// duplicated. It will expand to the following:
+/// The macro wraps the async test body in a synchronous `#[test]`, builds a
+/// `::sqlx::testing::TestArgs`, attaches any requested fixtures, and then delegates to
+/// `sqlx_testing::TestFn::run_test`.
+///
+/// With fixtures, it expands roughly to:
 ///
 /// ```ignore
 /// // before:
@@ -162,34 +161,15 @@ fn expand_dispatch(input: DeriveInput) -> syn::Result<TokenStream> {
 /// fn the_test() {
 ///     async fn the_test(pool: sqlx::PgPool) { /* test is "pasted" here */ }
 ///     let mut args = ::sqlx::testing::TestArgs::new("carbide::tests::the_test");
-///     // NOTE: crate::tests::MIGRATOR must exist!
-///     args.migrator(&crate::tests::MIGRATOR);
 ///     args.fixtures(
-///         Box::leak(
-///             Box::new(
-///                 <[_]>::into_vec(
-///                     #[rustc_box]
-///                     ::alloc::boxed::Box::new([
-///                         // NOTE: crate::tests::sqlx_fixture_from_str must exist!
-///                         crate::tests::sqlx_fixture_from_str("create_domain"),
-///                     ]),
-///                 ),
-///             ),
-///         ),
+///         Box::leak(Box::new(vec![
+///             crate::tests::sqlx_fixture_from_str("my_fixture"),
+///         ])),
 ///     );
 ///     let f: fn(_) -> _ = the_test;
-///     ::sqlx::testing::TestFn::run_test(f, args)
-///    }
+///     sqlx_testing::TestFn::run_test(f, args)
 /// }
 /// ```
-///
-/// That is, it will hardcode calls to `crate::tests::sqlx_fixture_from_str` and
-/// `crate::tests::MIGRATOR`. So this macro will only work of those are defined in your crate. The
-/// reason for this is that it can allow defining a single static call to `sqlx::migrate!()` (which
-/// dumps your entire migrations folder as string literals), and a single instance of
-/// `include_str!("fixture.sql")` per fixture, and referencing them repeatedly, rather than dumping
-/// string literals for each on every single test. This reduces the size of our test executable by
-/// 90%.
 #[proc_macro_attribute]
 pub fn sqlx_test(args: TokenStream, input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::ItemFn);


### PR DESCRIPTION
## Description
Remove obsolete `MIGRATOR` re-exports and update tests to call `db::migrations::migrate` directly where needed. Refresh `sqlx_test` macro documentation to reflect that database setup is handled by `sqlx_testing::TestFn::run_test`, and clarify that fixture support requires crates to opt in by providing `sqlx_fixture_from_str`.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

