### PR TITLE
chore(rest-api): Apply FromProto/ToProto modeling to VpcPeering

### DIFF
--- a/rest-api/api/pkg/api/handler/vpcpeering.go
+++ b/rest-api/api/pkg/api/handler/vpcpeering.go
@@ -30,8 +30,6 @@ import (
 	cdbp "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	swe "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/error"
 	"github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/queue"
-
-	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 // ~~~~~ Create VPC Peering Handler ~~~~~ //
@@ -312,12 +310,11 @@ func (cvph CreateVpcPeeringHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to update VPC Peering status to Configuring", nil)
 		}
 
-		// Create the VPC Peering creation request
-		createVpcPeeringRequest := &cwssaws.VpcPeeringCreationRequest{
-			VpcId:     &cwssaws.VpcId{Value: vpcPeering.Vpc1ID.String()},
-			PeerVpcId: &cwssaws.VpcId{Value: vpcPeering.Vpc2ID.String()},
-			Id:        &cwssaws.VpcPeeringId{Value: vpcPeering.ID.String()},
-		}
+		// Create the VPC Peering creation request. The entity's
+		// `ToProto()` is the source of the canonical wire fields; the API
+		// request's `ToProto` produces the request-shape envelope around
+		// it.
+		createVpcPeeringRequest := apiRequest.ToProto(vpcPeering)
 
 		logger.Info().Msg("triggering VPC Peering create workflow on Site")
 
@@ -867,9 +864,7 @@ func (dvph DeleteVpcPeeringHandler) Handle(c echo.Context) error {
 		}
 
 		// Create the VPC Peering deletion request
-		deleteVpcPeeringRequest := &cwssaws.VpcPeeringDeletionRequest{
-			Id: &cwssaws.VpcPeeringId{Value: vpcPeering.ID.String()},
-		}
+		deleteVpcPeeringRequest := vpcPeering.ToDeletionRequestProto()
 
 		// Get the site temporal client
 		stc, derr := dvph.scp.GetClientByID(vpcPeering.SiteID)

--- a/rest-api/api/pkg/api/model/vpcpeering.go
+++ b/rest-api/api/pkg/api/model/vpcpeering.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"time"
 
-	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	validationis "github.com/go-ozzo/ozzo-validation/v4/is"
+
+	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
+	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 // APIVpcPeeringCreateRequest captures the request data for creating a new VPC peering
@@ -24,8 +26,8 @@ type APIVpcPeeringCreateRequest struct {
 }
 
 // Validate ensures the values passed in create request are acceptable
-func (vpcr APIVpcPeeringCreateRequest) Validate() error {
-	err := validation.ValidateStruct(&vpcr,
+func (vpcr *APIVpcPeeringCreateRequest) Validate() error {
+	err := validation.ValidateStruct(vpcr,
 		validation.Field(&vpcr.Vpc1ID,
 			validation.Required.Error(validationErrorValueRequired),
 			validationis.UUID.Error(validationErrorInvalidUUID)),
@@ -47,6 +49,26 @@ func (vpcr APIVpcPeeringCreateRequest) Validate() error {
 		}
 	}
 	return nil
+}
+
+// ToProto builds the workflow request that asks a Site to create a new
+// VPC peering for this API request. `vp` is the just-persisted DB
+// record; its `ToProto()` is the source of the canonical wire fields
+// (peering ID, VpcId, PeerVpcId).
+//
+// The method trusts that the request has already been Validated and
+// that the handler has performed any cross-context checks Validate
+// cannot see (Site existence, VPC existence, RBAC). There is no
+// request-only data layered on top of the entity for the peering
+// create flow: the API request just carries the same VPC IDs that end
+// up on the entity, so this is a thin wrapper around `vp.ToProto()`.
+func (vpcr *APIVpcPeeringCreateRequest) ToProto(vp *cdbm.VpcPeering) *cwssaws.VpcPeeringCreationRequest {
+	vpProto := vp.ToProto()
+	return &cwssaws.VpcPeeringCreationRequest{
+		Id:        vpProto.Id,
+		VpcId:     vpProto.VpcId,
+		PeerVpcId: vpProto.PeerVpcId,
+	}
 }
 
 // APIVpcPeering represents a VPC peering connection

--- a/rest-api/api/pkg/api/model/vpcpeering_test.go
+++ b/rest-api/api/pkg/api/model/vpcpeering_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 	"time"
 
-	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 )
 
 func TestAPIVpcPeeringCreateRequest_Validate(t *testing.T) {
@@ -105,6 +107,27 @@ func TestAPIVpcPeeringCreateRequest_Validate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAPIVpcPeeringCreateRequest_ToProto(t *testing.T) {
+	id := uuid.New()
+	v1 := uuid.New()
+	v2 := uuid.New()
+	vp := &cdbm.VpcPeering{ID: id, Vpc1ID: v1, Vpc2ID: v2}
+
+	req := APIVpcPeeringCreateRequest{
+		Vpc1ID: v1.String(),
+		Vpc2ID: v2.String(),
+		SiteID: uuid.New().String(),
+	}
+	got := req.ToProto(vp)
+	require.NotNil(t, got)
+	require.NotNil(t, got.Id)
+	assert.Equal(t, id.String(), got.Id.Value)
+	require.NotNil(t, got.VpcId)
+	assert.Equal(t, v1.String(), got.VpcId.Value)
+	require.NotNil(t, got.PeerVpcId)
+	assert.Equal(t, v2.String(), got.PeerVpcId.Value)
 }
 
 func TestNewAPIVpcPeering(t *testing.T) {

--- a/rest-api/db/pkg/db/model/vpcpeering.go
+++ b/rest-api/db/pkg/db/model/vpcpeering.go
@@ -11,9 +11,11 @@ import (
 
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 
+	"github.com/google/uuid"
+
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
-	"github.com/google/uuid"
+	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 
 	"github.com/uptrace/bun"
 )
@@ -88,6 +90,69 @@ type VpcPeering struct {
 	Updated   time.Time  `bun:"updated,nullzero,notnull,default:current_timestamp"`
 	Deleted   *time.Time `bun:"deleted,soft_delete"`
 	CreatedBy uuid.UUID  `bun:"type:uuid,notnull"`
+}
+
+// ToProto converts this VpcPeering into its workflow proto representation.
+// Used as the canonical entity-to-proto conversion; the request-shape
+// proto for create is produced by `APIVpcPeeringCreateRequest.ToProto`
+// in api/pkg/api/model/vpcpeering.go, which sources its canonical wire
+// fields from this method.
+//
+// The peering's Vpc1ID/Vpc2ID are sent through directly: the Site
+// treats them as opaque identifiers, and any ControllerVpcID
+// indirection has already been applied by the time the peering rows
+// reference these UUIDs.
+func (vp *VpcPeering) ToProto() *cwssaws.VpcPeering {
+	return &cwssaws.VpcPeering{
+		Id:        &cwssaws.VpcPeeringId{Value: vp.ID.String()},
+		VpcId:     &cwssaws.VpcId{Value: vp.Vpc1ID.String()},
+		PeerVpcId: &cwssaws.VpcId{Value: vp.Vpc2ID.String()},
+	}
+}
+
+// FromProto populates this VpcPeering from its workflow proto
+// representation. A nil proto is a no-op. This is the inverse of
+// `ToProto` and exists for convention symmetry — currently no code
+// path on the cloud side reconstructs a full VpcPeering entity from a
+// `cwssaws.VpcPeering` (the site is the destination, not the source),
+// but the method is provided so future reconciliation flows have a
+// single canonical entry point.
+//
+// Field-level contract:
+//   - `vp.ID` is preserved on a missing or unparseable `proto.Id`,
+//     because callers pre-validate the UUID before calling.
+//   - `vp.Vpc1ID` / `vp.Vpc2ID` are likewise preserved when the proto
+//     omits the matching `VpcId` / `PeerVpcId` or carries an
+//     unparseable value, so `FromProto` cannot silently zero out a
+//     required foreign key.
+func (vp *VpcPeering) FromProto(proto *cwssaws.VpcPeering) {
+	if proto == nil {
+		return
+	}
+	if proto.Id != nil {
+		if id, err := uuid.Parse(proto.Id.Value); err == nil {
+			vp.ID = id
+		}
+	}
+	if proto.VpcId != nil {
+		if id, err := uuid.Parse(proto.VpcId.Value); err == nil {
+			vp.Vpc1ID = id
+		}
+	}
+	if proto.PeerVpcId != nil {
+		if id, err := uuid.Parse(proto.PeerVpcId.Value); err == nil {
+			vp.Vpc2ID = id
+		}
+	}
+}
+
+// ToDeletionRequestProto builds the workflow request that asks a Site to
+// delete this VpcPeering. Stays on the entity because the delete-by-id
+// flow has no API request body.
+func (vp *VpcPeering) ToDeletionRequestProto() *cwssaws.VpcPeeringDeletionRequest {
+	return &cwssaws.VpcPeeringDeletionRequest{
+		Id: &cwssaws.VpcPeeringId{Value: vp.ID.String()},
+	}
 }
 
 type VpcPeeringCreateInput struct {

--- a/rest-api/db/pkg/db/model/vpcpeering_test.go
+++ b/rest-api/db/pkg/db/model/vpcpeering_test.go
@@ -7,18 +7,101 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	otrace "go.opentelemetry.io/otel/trace"
+
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	otrace "go.opentelemetry.io/otel/trace"
+	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 var (
 	mockID = uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
 )
+
+func TestVpcPeering_ToProto(t *testing.T) {
+	id := uuid.New()
+	v1 := uuid.New()
+	v2 := uuid.New()
+	vp := &VpcPeering{ID: id, Vpc1ID: v1, Vpc2ID: v2}
+	got := vp.ToProto()
+	require.NotNil(t, got)
+	require.NotNil(t, got.Id)
+	assert.Equal(t, id.String(), got.Id.Value)
+	require.NotNil(t, got.VpcId)
+	assert.Equal(t, v1.String(), got.VpcId.Value)
+	require.NotNil(t, got.PeerVpcId)
+	assert.Equal(t, v2.String(), got.PeerVpcId.Value)
+}
+
+func TestVpcPeering_FromProto(t *testing.T) {
+	t.Run("nil proto is a no-op", func(t *testing.T) {
+		origID := uuid.New()
+		origV1 := uuid.New()
+		origV2 := uuid.New()
+		vp := &VpcPeering{ID: origID, Vpc1ID: origV1, Vpc2ID: origV2}
+		vp.FromProto(nil)
+		assert.Equal(t, origID, vp.ID)
+		assert.Equal(t, origV1, vp.Vpc1ID)
+		assert.Equal(t, origV2, vp.Vpc2ID)
+	})
+
+	t.Run("populates all fields from a complete proto", func(t *testing.T) {
+		id := uuid.New()
+		v1 := uuid.New()
+		v2 := uuid.New()
+		vp := &VpcPeering{}
+		vp.FromProto(&cwssaws.VpcPeering{
+			Id:        &cwssaws.VpcPeeringId{Value: id.String()},
+			VpcId:     &cwssaws.VpcId{Value: v1.String()},
+			PeerVpcId: &cwssaws.VpcId{Value: v2.String()},
+		})
+		assert.Equal(t, id, vp.ID)
+		assert.Equal(t, v1, vp.Vpc1ID)
+		assert.Equal(t, v2, vp.Vpc2ID)
+	})
+
+	t.Run("preserves required IDs when proto omits or carries unparseable values", func(t *testing.T) {
+		origID := uuid.New()
+		origV1 := uuid.New()
+		origV2 := uuid.New()
+		vp := &VpcPeering{ID: origID, Vpc1ID: origV1, Vpc2ID: origV2}
+		vp.FromProto(&cwssaws.VpcPeering{
+			Id:        &cwssaws.VpcPeeringId{Value: "not-a-uuid"},
+			VpcId:     nil,
+			PeerVpcId: &cwssaws.VpcId{Value: "also-bad"},
+		})
+		assert.Equal(t, origID, vp.ID)
+		assert.Equal(t, origV1, vp.Vpc1ID)
+		assert.Equal(t, origV2, vp.Vpc2ID)
+	})
+
+	t.Run("round-trips through ToProto/FromProto", func(t *testing.T) {
+		orig := &VpcPeering{
+			ID:     uuid.New(),
+			Vpc1ID: uuid.New(),
+			Vpc2ID: uuid.New(),
+		}
+		round := &VpcPeering{}
+		round.FromProto(orig.ToProto())
+		assert.Equal(t, orig.ID, round.ID)
+		assert.Equal(t, orig.Vpc1ID, round.Vpc1ID)
+		assert.Equal(t, orig.Vpc2ID, round.Vpc2ID)
+	})
+}
+
+func TestVpcPeering_ToDeletionRequestProto(t *testing.T) {
+	id := uuid.New()
+	vp := &VpcPeering{ID: id}
+	req := vp.ToDeletionRequestProto()
+	require.NotNil(t, req)
+	require.NotNil(t, req.Id)
+	assert.Equal(t, id.String(), req.Id.Value)
+}
 
 func testVpcPeeringSetupSchema(t *testing.T, dbSession *db.Session) {
 	testInterfaceSetupSchema(t, dbSession)


### PR DESCRIPTION
## Description

Brings `VpcPeering` in line with the proto-modeling changes. Create routes through `ToProto` on the API request; the entity owns both the round-trip and the deletion request. This is create-only at the API layer -- no Update endpoint exists.

Primary callouts are:
- API request side: `APIVpcPeeringCreateRequest.ToProto(vpcPeering)`, sourcing `Id` / `VpcId` / `PeerVpcId` from the entity's `ToProto()`.
- Entity side: `VpcPeering.ToProto` / `FromProto` (replacing the old `ToCreationRequestProto`), and `ToDeletionRequestProto` for the delete flow.
- Handler simplified to one-liners, and the inline `cwssaws` import drops.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

