### PR TITLE
chore(rest-api): Apply FromProto/ToProto modeling to DpuExtensionService

### DIFF
--- a/rest-api/api/pkg/api/handler/dpuextensionservice.go
+++ b/rest-api/api/pkg/api/handler/dpuextensionservice.go
@@ -218,33 +218,7 @@ func (cdesh CreateDpuExtensionServiceHandler) Handle(c echo.Context) error {
 			statusDetails = append(statusDetails, *statusDetail)
 		}
 
-		createDpuExtensionServiceRequest := &cwssaws.CreateDpuExtensionServiceRequest{
-			ServiceId:            cutil.GetPtr(dpuExtensionService.ID.String()),
-			ServiceName:          apiRequest.Name,
-			Description:          apiRequest.Description,
-			TenantOrganizationId: org,
-			Data:                 apiRequest.Data,
-		}
-
-		if apiRequest.ServiceType == model.DpuExtensionServiceTypeKubernetesPod {
-			createDpuExtensionServiceRequest.ServiceType = cwssaws.DpuExtensionServiceType_KUBERNETES_POD
-		}
-
-		if apiRequest.Credentials != nil {
-			createDpuExtensionServiceRequest.Credential = &cwssaws.DpuExtensionServiceCredential{
-				RegistryUrl: apiRequest.Credentials.RegistryURL,
-				Type: &cwssaws.DpuExtensionServiceCredential_UsernamePassword{
-					UsernamePassword: &cwssaws.UsernamePassword{
-						Username: *apiRequest.Credentials.Username,
-						Password: *apiRequest.Credentials.Password,
-					},
-				},
-			}
-		}
-
-		if apiRequest.Observability != nil {
-			createDpuExtensionServiceRequest.Observability = apiRequest.Observability.ToProto()
-		}
+		createDpuExtensionServiceRequest := apiRequest.ToProto(dpuExtensionService.ID.String(), org)
 
 		logger.Info().Msg("triggering DPU Extension Service create workflow on Site")
 
@@ -833,31 +807,7 @@ func (udesh UpdateDpuExtensionServiceHandler) Handle(c echo.Context) error {
 		updatedDpuExtensionService = udes
 
 		// Trigger workflow to update DPU Extension Service
-		updateDpuExtensionServiceRequest := &cwssaws.UpdateDpuExtensionServiceRequest{
-			ServiceId:   updatedDpuExtensionService.ID.String(),
-			ServiceName: apiRequest.Name,
-			Description: apiRequest.Description,
-		}
-
-		if apiRequest.Data != nil {
-			updateDpuExtensionServiceRequest.Data = *apiRequest.Data
-		}
-
-		if apiRequest.Credentials != nil {
-			updateDpuExtensionServiceRequest.Credential = &cwssaws.DpuExtensionServiceCredential{
-				RegistryUrl: apiRequest.Credentials.RegistryURL,
-				Type: &cwssaws.DpuExtensionServiceCredential_UsernamePassword{
-					UsernamePassword: &cwssaws.UsernamePassword{
-						Username: *apiRequest.Credentials.Username,
-						Password: *apiRequest.Credentials.Password,
-					},
-				},
-			}
-		}
-
-		if apiRequest.Observability != nil {
-			updateDpuExtensionServiceRequest.Observability = apiRequest.Observability.ToProto()
-		}
+		updateDpuExtensionServiceRequest := apiRequest.ToProto(updatedDpuExtensionService.ID.String())
 
 		logger.Info().Msg("triggering DPU Extension Service update workflow on Site")
 
@@ -1102,9 +1052,7 @@ func (ddesh DeleteDpuExtensionServiceHandler) Handle(c echo.Context) error {
 		}
 
 		// Trigger workflow to delete DPU Extension Service
-		deleteDpuExtensionServiceRequest := &cwssaws.DeleteDpuExtensionServiceRequest{
-			ServiceId: dpuExtensionService.ID.String(),
-		}
+		deleteDpuExtensionServiceRequest := dpuExtensionService.ToDeletionRequestProto()
 
 		// Get the temporal client for the site we are working with
 		stc, derr := ddesh.scp.GetClientByID(dpuExtensionService.SiteID)
@@ -1560,10 +1508,7 @@ func (ddesvh DeleteDpuExtensionServiceVersionHandler) Handle(c echo.Context) err
 		}
 
 		// Trigger workflow to delete DPU Extension Service version
-		deleteDpuExtensionServiceVersionRequest := &cwssaws.DeleteDpuExtensionServiceRequest{
-			ServiceId: dpuExtensionService.ID.String(),
-			Versions:  []string{versionID},
-		}
+		deleteDpuExtensionServiceVersionRequest := dpuExtensionService.ToVersionDeletionRequestProto(versionID)
 
 		// Get the temporal client for the site we are working with
 		siteClient, derr := ddesvh.scp.GetClientByID(dpuExtensionService.SiteID)

--- a/rest-api/api/pkg/api/model/dpuextensionservice.go
+++ b/rest-api/api/pkg/api/model/dpuextensionservice.go
@@ -9,10 +9,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/model/util"
-	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	validationis "github.com/go-ozzo/ozzo-validation/v4/is"
+
+	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/model/util"
+	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
@@ -52,8 +53,8 @@ type APIDpuExtensionServiceCreateRequest struct {
 }
 
 // Validate ensures that the values passed in request are acceptable
-func (descr APIDpuExtensionServiceCreateRequest) Validate() error {
-	err := validation.ValidateStruct(&descr,
+func (descr *APIDpuExtensionServiceCreateRequest) Validate() error {
+	err := validation.ValidateStruct(descr,
 		validation.Field(&descr.Name,
 			validation.Required.Error(validationErrorStringLength),
 			validation.By(util.ValidateNameCharacters),
@@ -104,8 +105,8 @@ type APIDpuExtensionServiceUpdateRequest struct {
 }
 
 // Validate ensures that the values passed in request are acceptable
-func (desur APIDpuExtensionServiceUpdateRequest) Validate() error {
-	err := validation.ValidateStruct(&desur,
+func (desur *APIDpuExtensionServiceUpdateRequest) Validate() error {
+	err := validation.ValidateStruct(desur,
 		validation.Field(&desur.Name,
 			validation.When(desur.Name != nil, validation.Required.Error(validationErrorStringLength)),
 			validation.When(desur.Name != nil, validation.By(util.ValidateNameCharacters)),
@@ -154,6 +155,75 @@ func (desc APIDpuExtensionServiceCredentials) Validate() error {
 		validation.Field(&desc.Password,
 			validation.When(desc.RegistryURL != "", validation.Required.Error("`password` must be specified if `registryUrl` is specified"))),
 	)
+}
+
+// ToProto converts the API credentials into the workflow proto
+// representation. Returns nil for a nil receiver. Validation should
+// have already established that Username and Password are non-nil
+// when RegistryURL is non-empty; the nil guards below are defensive
+// so a misuse panics with a clear shape failure rather than an opaque
+// nil-deref.
+func (desc *APIDpuExtensionServiceCredentials) ToProto() *cwssaws.DpuExtensionServiceCredential {
+	if desc == nil {
+		return nil
+	}
+	cred := &cwssaws.DpuExtensionServiceCredential{
+		RegistryUrl: desc.RegistryURL,
+	}
+	if desc.Username != nil && desc.Password != nil {
+		cred.Type = &cwssaws.DpuExtensionServiceCredential_UsernamePassword{
+			UsernamePassword: &cwssaws.UsernamePassword{
+				Username: *desc.Username,
+				Password: *desc.Password,
+			},
+		}
+	}
+	return cred
+}
+
+// ToProto converts a validated APIDpuExtensionServiceCreateRequest into
+// the workflow proto request. serviceID is the DB-generated ID for the
+// new service and tenantOrg is the owning tenant's organization ID;
+// neither is on the request body.
+//
+// The method trusts that the request has already been Validated. The
+// nested `Credentials.ToProto()` and `Observability.ToProto()` calls
+// each handle a nil receiver, so no outer guard is needed here.
+func (descr *APIDpuExtensionServiceCreateRequest) ToProto(serviceID, tenantOrg string) *cwssaws.CreateDpuExtensionServiceRequest {
+	req := &cwssaws.CreateDpuExtensionServiceRequest{
+		ServiceId:            &serviceID,
+		ServiceName:          descr.Name,
+		Description:          descr.Description,
+		TenantOrganizationId: tenantOrg,
+		Data:                 descr.Data,
+		Credential:           descr.Credentials.ToProto(),
+		Observability:        descr.Observability.ToProto(),
+	}
+	if descr.ServiceType == DpuExtensionServiceTypeKubernetesPod {
+		req.ServiceType = cwssaws.DpuExtensionServiceType_KUBERNETES_POD
+	}
+	return req
+}
+
+// ToProto converts a validated APIDpuExtensionServiceUpdateRequest into
+// the workflow proto request. serviceID identifies the service being
+// updated.
+//
+// The method trusts that the request has already been Validated. The
+// nested `Credentials.ToProto()` and `Observability.ToProto()` calls
+// each handle a nil receiver, so no outer guard is needed here.
+func (desur *APIDpuExtensionServiceUpdateRequest) ToProto(serviceID string) *cwssaws.UpdateDpuExtensionServiceRequest {
+	req := &cwssaws.UpdateDpuExtensionServiceRequest{
+		ServiceId:     serviceID,
+		ServiceName:   desur.Name,
+		Description:   desur.Description,
+		Credential:    desur.Credentials.ToProto(),
+		Observability: desur.Observability.ToProto(),
+	}
+	if desur.Data != nil {
+		req.Data = *desur.Data
+	}
+	return req
 }
 
 // APIDpuExtensionService is the data structure to capture API representation of a DpuExtensionService
@@ -406,43 +476,66 @@ func (desol APIDpuExtensionServiceObservabilityConfigLogging) Validate() error {
 	return nil
 }
 
+// ToProto converts the Prometheus sub-config to its protobuf
+// representation. Trusts that `Validate` has already been run.
+func (desop *APIDpuExtensionServiceObservabilityConfigPrometheus) ToProto() *cwssaws.DpuExtensionServiceObservabilityConfigPrometheus {
+	if desop == nil {
+		return nil
+	}
+	return &cwssaws.DpuExtensionServiceObservabilityConfigPrometheus{
+		ScrapeIntervalSeconds: desop.ScrapeIntervalSeconds,
+		Endpoint:              desop.Endpoint,
+	}
+}
+
+// ToProto converts the Logging sub-config to its protobuf
+// representation. Trusts that `Validate` has already been run.
+func (desol *APIDpuExtensionServiceObservabilityConfigLogging) ToProto() *cwssaws.DpuExtensionServiceObservabilityConfigLogging {
+	if desol == nil {
+		return nil
+	}
+	return &cwssaws.DpuExtensionServiceObservabilityConfigLogging{
+		Path: desol.Path,
+	}
+}
+
+// ToProto converts a single observability config (Name plus exactly one
+// of Prometheus / Logging) to its protobuf representation. The two
+// sub-configs are modeled as a proto oneof; `Validate` enforces that
+// exactly one is set.
+func (desoc *APIDpuExtensionServiceObservabilityConfig) ToProto() *cwssaws.DpuExtensionServiceObservabilityConfig {
+	if desoc == nil {
+		return nil
+	}
+	proto := &cwssaws.DpuExtensionServiceObservabilityConfig{
+		Name: desoc.Name,
+	}
+	switch {
+	case desoc.Prometheus != nil:
+		proto.Config = &cwssaws.DpuExtensionServiceObservabilityConfig_Prometheus{
+			Prometheus: desoc.Prometheus.ToProto(),
+		}
+	case desoc.Logging != nil:
+		proto.Config = &cwssaws.DpuExtensionServiceObservabilityConfig_Logging{
+			Logging: desoc.Logging.ToProto(),
+		}
+	}
+	return proto
+}
+
 // ToProto converts an API observability definition to the protobuf
-// representation passed to NICo.
+// representation passed to NICo. Delegates per-config conversion to
+// `APIDpuExtensionServiceObservabilityConfig.ToProto`.
 func (apiObservability *APIDpuExtensionServiceObservability) ToProto() *cwssaws.DpuExtensionServiceObservability {
 	if apiObservability == nil {
 		return nil
 	}
-
 	protoObservability := &cwssaws.DpuExtensionServiceObservability{
 		Configs: make([]*cwssaws.DpuExtensionServiceObservabilityConfig, 0, len(apiObservability.Configs)),
 	}
-
 	for _, cfg := range apiObservability.Configs {
-		protoCfg := &cwssaws.DpuExtensionServiceObservabilityConfig{
-			Name: cfg.Name,
-		}
-
-		// A single observability config is modeled as a proto oneof,
-		// so exactly one of these options should be populated.
-		switch {
-		case cfg.Prometheus != nil:
-			protoCfg.Config = &cwssaws.DpuExtensionServiceObservabilityConfig_Prometheus{
-				Prometheus: &cwssaws.DpuExtensionServiceObservabilityConfigPrometheus{
-					ScrapeIntervalSeconds: cfg.Prometheus.ScrapeIntervalSeconds,
-					Endpoint:              cfg.Prometheus.Endpoint,
-				},
-			}
-		case cfg.Logging != nil:
-			protoCfg.Config = &cwssaws.DpuExtensionServiceObservabilityConfig_Logging{
-				Logging: &cwssaws.DpuExtensionServiceObservabilityConfigLogging{
-					Path: cfg.Logging.Path,
-				},
-			}
-		}
-
-		protoObservability.Configs = append(protoObservability.Configs, protoCfg)
+		protoObservability.Configs = append(protoObservability.Configs, cfg.ToProto())
 	}
-
 	return protoObservability
 }
 

--- a/rest-api/api/pkg/api/model/dpuextensionservice_test.go
+++ b/rest-api/api/pkg/api/model/dpuextensionservice_test.go
@@ -9,9 +9,11 @@ import (
 	"testing"
 	"time"
 
-	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
@@ -712,4 +714,101 @@ func TestNewAPIDpuExtensionService(t *testing.T) {
 			assert.Equal(t, len(tc.dbdesds), len(ades.StatusHistory))
 		})
 	}
+}
+
+func TestAPIDpuExtensionServiceCredentials_ToProto(t *testing.T) {
+	t.Run("nil receiver yields nil", func(t *testing.T) {
+		var c *APIDpuExtensionServiceCredentials
+		assert.Nil(t, c.ToProto())
+	})
+	t.Run("populates UsernamePassword type", func(t *testing.T) {
+		user := "u"
+		pass := "p"
+		c := &APIDpuExtensionServiceCredentials{RegistryURL: "https://reg/", Username: &user, Password: &pass}
+		got := c.ToProto()
+		require.NotNil(t, got)
+		assert.Equal(t, "https://reg/", got.RegistryUrl)
+		up, ok := got.Type.(*cwssaws.DpuExtensionServiceCredential_UsernamePassword)
+		require.True(t, ok)
+		require.NotNil(t, up.UsernamePassword)
+		assert.Equal(t, "u", up.UsernamePassword.Username)
+		assert.Equal(t, "p", up.UsernamePassword.Password)
+	})
+	t.Run("nil username/password yields no Type", func(t *testing.T) {
+		c := &APIDpuExtensionServiceCredentials{RegistryURL: "https://reg/"}
+		got := c.ToProto()
+		require.NotNil(t, got)
+		assert.Equal(t, "https://reg/", got.RegistryUrl)
+		assert.Nil(t, got.Type)
+	})
+}
+
+func TestAPIDpuExtensionServiceCreateRequest_ToProto(t *testing.T) {
+	t.Run("populated request maps fields through", func(t *testing.T) {
+		desc := "primary"
+		user := "u"
+		pass := "p"
+		descr := APIDpuExtensionServiceCreateRequest{
+			Name:        "svc-a",
+			Description: &desc,
+			ServiceType: DpuExtensionServiceTypeKubernetesPod,
+			SiteID:      uuid.NewString(),
+			Data:        "kind: Pod",
+			Credentials: &APIDpuExtensionServiceCredentials{
+				RegistryURL: "https://reg/",
+				Username:    &user,
+				Password:    &pass,
+			},
+		}
+		req := descr.ToProto("svc-id-1", "org-1")
+		assert.NotNil(t, req)
+		assert.Equal(t, "svc-id-1", *req.ServiceId)
+		assert.Equal(t, "svc-a", req.ServiceName)
+		assert.Equal(t, &desc, req.Description)
+		assert.Equal(t, "org-1", req.TenantOrganizationId)
+		assert.Equal(t, "kind: Pod", req.Data)
+		assert.Equal(t, cwssaws.DpuExtensionServiceType_KUBERNETES_POD, req.ServiceType)
+		assert.NotNil(t, req.Credential)
+	})
+	t.Run("nil Credentials and Observability yield nil proto fields", func(t *testing.T) {
+		// Confirms the nested ToProto calls' nil-receiver behavior is
+		// what keeps the request mapper clean.
+		descr := APIDpuExtensionServiceCreateRequest{
+			Name:        "svc-c",
+			ServiceType: DpuExtensionServiceTypeKubernetesPod,
+			Data:        "kind: Pod",
+		}
+		req := descr.ToProto("svc-id-3", "org-1")
+		assert.NotNil(t, req)
+		assert.Nil(t, req.Credential)
+		assert.Nil(t, req.Observability)
+	})
+}
+
+func TestAPIDpuExtensionServiceUpdateRequest_ToProto(t *testing.T) {
+	t.Run("populated request maps fields through", func(t *testing.T) {
+		name := "svc-b"
+		data := "kind: Pod V2"
+		desur := APIDpuExtensionServiceUpdateRequest{
+			Name: &name,
+			Data: &data,
+		}
+		req := desur.ToProto("svc-id-2")
+		assert.NotNil(t, req)
+		assert.Equal(t, "svc-id-2", req.ServiceId)
+		assert.Equal(t, &name, req.ServiceName)
+		assert.Equal(t, "kind: Pod V2", req.Data)
+		assert.Nil(t, req.Credential)
+		assert.Nil(t, req.Observability)
+	})
+	t.Run("nil Data leaves proto Data at the zero value", func(t *testing.T) {
+		// Update's Data is *string on the request, but a required
+		// string on the wire; nil request Data maps to "".
+		desur := APIDpuExtensionServiceUpdateRequest{}
+		req := desur.ToProto("svc-id-4")
+		assert.NotNil(t, req)
+		assert.Equal(t, "", req.Data)
+		assert.Nil(t, req.Credential)
+		assert.Nil(t, req.Observability)
+	})
 }

--- a/rest-api/db/pkg/db/model/dpuextensionservice.go
+++ b/rest-api/db/pkg/db/model/dpuextensionservice.go
@@ -8,12 +8,13 @@ import (
 	"database/sql"
 	"time"
 
-	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
-	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
-	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
 	"github.com/google/uuid"
 	"github.com/uptrace/bun"
 	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
+	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
 
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
@@ -154,6 +155,25 @@ type DpuExtensionService struct {
 	Updated         time.Time                       `bun:"updated,nullzero,notnull,default:current_timestamp"`
 	Deleted         time.Time                       `bun:"deleted,nullzero,default:null"`
 	CreatedBy       uuid.UUID                       `bun:"created_by,type:uuid,notnull"`
+}
+
+// ToDeletionRequestProto builds the workflow request that asks a Site to
+// delete this DPU Extension Service.
+func (des *DpuExtensionService) ToDeletionRequestProto() *cwssaws.DeleteDpuExtensionServiceRequest {
+	return &cwssaws.DeleteDpuExtensionServiceRequest{
+		ServiceId: des.ID.String(),
+	}
+}
+
+// ToVersionDeletionRequestProto builds the workflow request that asks a
+// Site to delete a single version of this DPU Extension Service. Shares
+// the `DeleteDpuExtensionServiceRequest` proto with the whole-service
+// delete; the populated `Versions` field is what scopes the request.
+func (des *DpuExtensionService) ToVersionDeletionRequestProto(versionID string) *cwssaws.DeleteDpuExtensionServiceRequest {
+	return &cwssaws.DeleteDpuExtensionServiceRequest{
+		ServiceId: des.ID.String(),
+		Versions:  []string{versionID},
+	}
 }
 
 var _ bun.BeforeAppendModelHook = (*DpuExtensionService)(nil)

--- a/rest-api/db/pkg/db/model/dpuextensionservice_test.go
+++ b/rest-api/db/pkg/db/model/dpuextensionservice_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	otrace "go.opentelemetry.io/otel/trace"
+
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	otrace "go.opentelemetry.io/otel/trace"
 
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
@@ -935,4 +936,22 @@ func TestDpuExtensionServiceSQLDAO_Delete(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDpuExtensionService_ToDeletionRequestProto(t *testing.T) {
+	id := uuid.New()
+	des := &DpuExtensionService{ID: id}
+	req := des.ToDeletionRequestProto()
+	assert.NotNil(t, req)
+	assert.Equal(t, id.String(), req.ServiceId)
+	assert.Empty(t, req.Versions)
+}
+
+func TestDpuExtensionService_ToVersionDeletionRequestProto(t *testing.T) {
+	id := uuid.New()
+	des := &DpuExtensionService{ID: id}
+	req := des.ToVersionDeletionRequestProto("v1.2.3")
+	assert.NotNil(t, req)
+	assert.Equal(t, id.String(), req.ServiceId)
+	assert.Equal(t, []string{"v1.2.3"}, req.Versions)
 }


### PR DESCRIPTION
## Description

Brings `DpuExtensionService` in line with the proto-modeling changes. Create and Update build their workflow requests through `ToProto` on the API requests, and the entity owns both the service and per-version deletion requests.

Primary callouts are:
- API request side: `APIDpuExtensionServiceCreateRequest.ToProto(serviceID, tenantOrg)` and `APIDpuExtensionServiceUpdateRequest.ToProto(serviceID)`. A shared `APIDpuExtensionServiceCredentials.ToProto()` keeps the credential mapping in one place.
- Entity side: `DpuExtensionService.ToDeletionRequestProto()` for the service delete, and `DpuExtensionService.ToVersionDeletionRequestProto(versionID)` for the per-version delete. They share a proto type -- the populated `Versions` field is what scopes the version variant.
- Handler simplified to one-liners at all four request-build sites.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

