### PR TITLE
chore(rest-api): Apply FromProto/ToProto modeling to NetworkSecurityGroup

### DIFF
--- a/rest-api/api/pkg/api/handler/networksecuritygroup.go
+++ b/rest-api/api/pkg/api/handler/networksecuritygroup.go
@@ -16,10 +16,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 
+	"go.opentelemetry.io/otel/attribute"
+	temporalClient "go.temporal.io/sdk/client"
+	tp "go.temporal.io/sdk/temporal"
+
 	"github.com/NVIDIA/infra-controller/rest-api/api/internal/config"
 	common "github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/handler/util/common"
 	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/model"
-	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/model/util"
 	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/pagination"
 	sc "github.com/NVIDIA/infra-controller/rest-api/api/pkg/client/site"
 	auth "github.com/NVIDIA/infra-controller/rest-api/auth/pkg/authorization"
@@ -28,11 +31,7 @@ import (
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	cdbp "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	swe "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/error"
-	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/queue"
-	"go.opentelemetry.io/otel/attribute"
-	temporalClient "go.temporal.io/sdk/client"
-	tp "go.temporal.io/sdk/temporal"
 )
 
 // ~~~~~ Create Handler ~~~~~ //
@@ -179,7 +178,9 @@ func (cnsgh CreateNetworkSecurityGroupHandler) Handle(c echo.Context) error {
 	}
 
 	// Convert all the request rules into rules
-	// we can store and send to NICo.
+	// we can store and send to NICo. Per-rule validation has already
+	// run inside apiRequest.Validate, so rule.ToProto is a pure mapper
+	// here; we only check for cross-rule constraints (duplicate names).
 	rules := make([]*cdbm.NetworkSecurityGroupRule, len(apiRequest.Rules))
 
 	names := map[string]bool{}
@@ -193,13 +194,7 @@ func (cnsgh CreateNetworkSecurityGroupHandler) Handle(c echo.Context) error {
 			names[*rule.Name] = true
 		}
 
-		newRule, err := model.ProtobufRuleFromAPINetworkSecurityGroupRule(&rule)
-		if err != nil {
-			logger.Error().Err(err).Msg("unable to convert rules in request to internal rules")
-			return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Unable to process rules in request", err)
-		}
-
-		rules[i] = newRule
+		rules[i] = &cdbm.NetworkSecurityGroupRule{NetworkSecurityGroupRuleAttributes: rule.ToProto()}
 	}
 
 	networkSecurityGroupID := uuid.NewString()
@@ -255,35 +250,10 @@ func (cnsgh CreateNetworkSecurityGroupHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		createLabels := util.ProtobufLabelsFromAPILabels(nsg.Labels)
-
-		description := ""
-		if nsg.Description != nil {
-			description = *nsg.Description
-		}
-
-		// Convert the DB rule wrappers into rules
-		// we can send to NICo.
-		nicoRules := make([]*cwssaws.NetworkSecurityGroupRuleAttributes, len(rules))
-
-		for i, rule := range rules {
-			nicoRules[i] = rule.NetworkSecurityGroupRuleAttributes
-		}
-
-		// Prepare the create request workflow object
-		createNetworkSecurityGroupRequest := &cwssaws.CreateNetworkSecurityGroupRequest{
-			Id:                   &networkSecurityGroupID,
-			TenantOrganizationId: tenant.Org,
-			Metadata: &cwssaws.Metadata{
-				Name:        apiRequest.Name,
-				Description: description,
-				Labels:      createLabels,
-			},
-			NetworkSecurityGroupAttributes: &cwssaws.NetworkSecurityGroupAttributes{
-				StatefulEgress: apiRequest.StatefulEgress,
-				Rules:          nicoRules,
-			},
-		}
+		// The DB record is the canonical source for Metadata and the
+		// assigned ID; request-shape fields (rules, statefulEgress)
+		// come from the validated apiRequest.
+		createNetworkSecurityGroupRequest := apiRequest.ToProto(nsg)
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:                       "network-security-group-create-" + nsg.ID,
@@ -348,11 +318,7 @@ func (cnsgh CreateNetworkSecurityGroupHandler) Handle(c echo.Context) error {
 	}
 
 	// Create response
-	apiNetworkSecurityGroup, err := model.NewAPINetworkSecurityGroup(networkSecurityGroup, []cdbm.StatusDetail{*ssd})
-	if err != nil {
-		logger.Error().Err(err).Msg("failed to convert NetworkSecurityGroup database record to API response")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to convert Network Security Group database record to API response", nil)
-	}
+	apiNetworkSecurityGroup := model.NewAPINetworkSecurityGroup(networkSecurityGroup, []cdbm.StatusDetail{*ssd})
 
 	logger.Info().Msg("finishing API handler")
 	return c.JSON(http.StatusCreated, apiNetworkSecurityGroup)
@@ -589,11 +555,7 @@ func (gansgh GetAllNetworkSecurityGroupHandler) Handle(c echo.Context) error {
 
 	// Loop through the NSGs, create the API response, and attach the statsMap data.
 	for i, nsg := range nsgs {
-		apiNSG, err := model.NewAPINetworkSecurityGroup(&nsg, ssdMap[nsg.ID])
-		if err != nil {
-			logger.Error().Err(err).Msg("error converting NetworkSecurityGroup to APINetworkSecurityGroup")
-			return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to prepare Network Security Group for response", nil)
-		}
+		apiNSG := model.NewAPINetworkSecurityGroup(&nsg, ssdMap[nsg.ID])
 
 		aits[i] = apiNSG
 		apiNSG.AttachmentStats = statsMap[nsg.ID]
@@ -757,11 +719,7 @@ func (gansgh GetNetworkSecurityGroupHandler) Handle(c echo.Context) error {
 	}
 
 	// Create response
-	apiNetworkSecurityGroup, err := model.NewAPINetworkSecurityGroup(nsg, ssds)
-	if err != nil {
-		logger.Error().Err(err).Msg("error converting NetworkSecurityGroup to APINetworkSecurityGroup")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to prepare Network Security Group for response", nil)
-	}
+	apiNetworkSecurityGroup := model.NewAPINetworkSecurityGroup(nsg, ssds)
 
 	// Attach stats if requested
 	if includeAttachmentStats {
@@ -947,10 +905,7 @@ func (dnsgh DeleteNetworkSecurityGroupHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		deleteNetworkSecurityGroupRequest := &cwssaws.DeleteNetworkSecurityGroupRequest{
-			Id:                   nsg.ID,
-			TenantOrganizationId: nsg.TenantOrg,
-		}
+		deleteNetworkSecurityGroupRequest := nsg.ToDeletionRequestProto()
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:                       "network-security-group-delete-" + nsg.ID,
@@ -1169,10 +1124,10 @@ func (dnsgh UpdateNetworkSecurityGroupHandler) Handle(c echo.Context) error {
 
 	var rules []*cdbm.NetworkSecurityGroupRule
 
-	// Override rules if requested.
+	// Override rules if requested. Per-rule validation has already run
+	// inside apiRequest.Validate, so rule.ToProto is a pure mapper
+	// here; we only check for cross-rule constraints (duplicate names).
 	if apiRequest.Rules != nil {
-		// Convert all the request rules into rules
-		// we can store and send to NICo.
 		rules = make([]*cdbm.NetworkSecurityGroupRule, len(apiRequest.Rules))
 
 		names := map[string]bool{}
@@ -1188,13 +1143,7 @@ func (dnsgh UpdateNetworkSecurityGroupHandler) Handle(c echo.Context) error {
 				names[*rule.Name] = true
 			}
 
-			newRule, err := model.ProtobufRuleFromAPINetworkSecurityGroupRule(&rule)
-			if err != nil {
-				logger.Error().Err(err).Msg("unable to convert rules in request to internal rules")
-				return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Unable to process rules in request", err)
-			}
-
-			rules[i] = newRule
+			rules[i] = &cdbm.NetworkSecurityGroupRule{NetworkSecurityGroupRuleAttributes: rule.ToProto()}
 		}
 	}
 
@@ -1239,35 +1188,11 @@ func (dnsgh UpdateNetworkSecurityGroupHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		labels := util.ProtobufLabelsFromAPILabels(updated.Labels)
-
-		description := ""
-		if updated.Description != nil {
-			description = *updated.Description
-		}
-
-		// Convert the DB rule wrappers into rules
-		// we can send to NICo.
-		nicoRules := make([]*cwssaws.NetworkSecurityGroupRuleAttributes, len(updated.Rules))
-
-		for i, rule := range updated.Rules {
-			nicoRules[i] = rule.NetworkSecurityGroupRuleAttributes
-		}
-
-		// Prepare the create request workflow object
-		updateNetworkSecurityGroupRequest := &cwssaws.UpdateNetworkSecurityGroupRequest{
-			Id:                   updated.ID,
-			TenantOrganizationId: updated.TenantOrg,
-			Metadata: &cwssaws.Metadata{
-				Name:        updated.Name,
-				Description: description,
-				Labels:      labels,
-			},
-			NetworkSecurityGroupAttributes: &cwssaws.NetworkSecurityGroupAttributes{
-				StatefulEgress: updated.StatefulEgress,
-				Rules:          nicoRules,
-			},
-		}
+		// The DB record has already been updated with the request
+		// data, so its `ToProto()` is the canonical wire form for
+		// both Metadata and the post-merge Attributes (rule list +
+		// statefulEgress).
+		updateNetworkSecurityGroupRequest := apiRequest.ToProto(updated)
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:                       "network-security-group-update-" + updated.ID,
@@ -1332,11 +1257,7 @@ func (dnsgh UpdateNetworkSecurityGroupHandler) Handle(c echo.Context) error {
 	}
 
 	// Create response
-	apiNetworkSecurityGroup, err := model.NewAPINetworkSecurityGroup(updatedNSG, ssds)
-	if err != nil {
-		logger.Error().Err(err).Msg("failed to convert NetworkSecurityGroup database record to API response")
-		return cutil.NewAPIErrorResponse(c, http.StatusInternalServerError, "Failed to convert Network Security Group database record to API response", nil)
-	}
+	apiNetworkSecurityGroup := model.NewAPINetworkSecurityGroup(updatedNSG, ssds)
 
 	logger.Info().Msg("finishing API handler")
 	return c.JSON(http.StatusOK, apiNetworkSecurityGroup)

--- a/rest-api/api/pkg/api/handler/networksecuritygroup_test.go
+++ b/rest-api/api/pkg/api/handler/networksecuritygroup_test.go
@@ -16,6 +16,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/NVIDIA/infra-controller/rest-api/api/internal/config"
 	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/handler/util/common"
 	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/model"
@@ -23,22 +28,19 @@ import (
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	sutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	swe "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/error"
-	"github.com/google/uuid"
-	"github.com/labstack/echo/v4"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	sc "github.com/NVIDIA/infra-controller/rest-api/api/pkg/client/site"
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 
-	authz "github.com/NVIDIA/infra-controller/rest-api/auth/pkg/authorization"
 	"github.com/stretchr/testify/mock"
 	"go.temporal.io/api/enums/v1"
 	temporalClient "go.temporal.io/sdk/client"
 	tmocks "go.temporal.io/sdk/mocks"
 	tp "go.temporal.io/sdk/temporal"
+
+	authz "github.com/NVIDIA/infra-controller/rest-api/auth/pkg/authorization"
 )
 
 func getIntPtrToUint32Ptr(i *int) *uint32 {
@@ -1878,8 +1880,7 @@ func TestNetworkSecurityGroupHandler_Update(t *testing.T) {
 	rules := []model.APINetworkSecurityGroupRule{}
 
 	for _, rule := range dbRules {
-		r, err := model.APINetworkSecurityGroupRuleFromProtobufRule(rule)
-		assert.Nil(t, err, err)
+		r := model.NewAPINetworkSecurityGroupRule(rule.NetworkSecurityGroupRuleAttributes)
 		rules = append(rules, *r)
 	}
 

--- a/rest-api/api/pkg/api/handler/task_test.go
+++ b/rest-api/api/pkg/api/handler/task_test.go
@@ -14,13 +14,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/handler/util/common"
-	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/model"
-	sc "github.com/NVIDIA/infra-controller/rest-api/api/pkg/client/site"
-	authz "github.com/NVIDIA/infra-controller/rest-api/auth/pkg/authorization"
-	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/otelecho"
-	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
-	flowv1 "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/flow/protobuf/v1"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +21,14 @@ import (
 	"github.com/stretchr/testify/require"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	tmocks "go.temporal.io/sdk/mocks"
+
+	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/handler/util/common"
+	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/model"
+	sc "github.com/NVIDIA/infra-controller/rest-api/api/pkg/client/site"
+	authz "github.com/NVIDIA/infra-controller/rest-api/auth/pkg/authorization"
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/otelecho"
+	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
+	flowv1 "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/flow/protobuf/v1"
 )
 
 func TestGetTaskHandler_Handle(t *testing.T) {

--- a/rest-api/api/pkg/api/model/networksecuritygroup.go
+++ b/rest-api/api/pkg/api/model/networksecuritygroup.go
@@ -4,19 +4,19 @@
 package model
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"strings"
 	"time"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	validationis "github.com/go-ozzo/ozzo-validation/v4/is"
 
 	hutil "github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/handler/util"
 	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/model/util"
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
-	validation "github.com/go-ozzo/ozzo-validation/v4"
-	validationis "github.com/go-ozzo/ozzo-validation/v4/is"
 )
 
 const MaxNetworkSecurityGroupRules = 200
@@ -121,9 +121,12 @@ type APINetworkSecurityGroupCreateRequest struct {
 	Labels map[string]string `json:"labels"`
 }
 
-// Validate ensures the values in the request are acceptable
-func (req APINetworkSecurityGroupCreateRequest) Validate(siteConfig *cdbm.SiteConfig) error {
-	err := validation.ValidateStruct(&req,
+// Validate ensures the values in the request are acceptable.
+// Per the proto-conversion convention, this is the universal
+// pre-`ToProto` step: each rule is validated here so the request-shape
+// `ToProto` can be a focused mapper that trusts its input.
+func (req *APINetworkSecurityGroupCreateRequest) Validate(siteConfig *cdbm.SiteConfig) error {
+	err := validation.ValidateStruct(req,
 		validation.Field(&req.Name,
 			validation.Required.Error(validationErrorStringLength),
 			validation.By(util.ValidateNameCharacters),
@@ -150,9 +153,13 @@ func (req APINetworkSecurityGroupCreateRequest) Validate(siteConfig *cdbm.SiteCo
 		}
 	}
 
-	// Individual rule validation happens later during
-	// processing when we convert from request rules to
-	// the protobuf representation.
+	// Validate (and normalize) each rule up-front so the request-shape
+	// `ToProto` can rely on the request being safe to translate.
+	for i := range req.Rules {
+		if err := req.Rules[i].Validate(); err != nil {
+			return err
+		}
+	}
 
 	if err := util.ValidateLabels(req.Labels); err != nil {
 		return err
@@ -175,9 +182,12 @@ type APINetworkSecurityGroupUpdateRequest struct {
 	Labels map[string]string `json:"labels"`
 }
 
-// Validate ensures the values in the request are acceptable
-func (req APINetworkSecurityGroupUpdateRequest) Validate(siteConfig *cdbm.SiteConfig) error {
-	err := validation.ValidateStruct(&req,
+// Validate ensures the values in the request are acceptable.
+// Per the proto-conversion convention, this is the universal
+// pre-`ToProto` step: each rule is validated here so the request-shape
+// `ToProto` can be a focused mapper that trusts its input.
+func (req *APINetworkSecurityGroupUpdateRequest) Validate(siteConfig *cdbm.SiteConfig) error {
+	err := validation.ValidateStruct(req,
 		validation.Field(&req.Name,
 			validation.When(req.Name != nil, validation.Required.Error(validationErrorStringLength)),
 			validation.When(req.Name != nil, validation.By(util.ValidateNameCharacters)),
@@ -202,9 +212,13 @@ func (req APINetworkSecurityGroupUpdateRequest) Validate(siteConfig *cdbm.SiteCo
 		}
 	}
 
-	// Individual rule validation happens later during
-	// processing when we convert from request rules to
-	// the protobuf representation.
+	// Validate (and normalize) each rule up-front so the request-shape
+	// `ToProto` can rely on the request being safe to translate.
+	for i := range req.Rules {
+		if err := req.Rules[i].Validate(); err != nil {
+			return err
+		}
+	}
 
 	if err := util.ValidateLabels(req.Labels); err != nil {
 		return err
@@ -250,227 +264,218 @@ type APINetworkSecurityGroup struct {
 	RuleCount int `json:"ruleCount"`
 }
 
-// Accepts a rule definition from an API request and converts
-// it to the proto representation that will be stored and passed
-// to NICo
-func ProtobufRuleFromAPINetworkSecurityGroupRule(rule *APINetworkSecurityGroupRule) (*cdbm.NetworkSecurityGroupRule, error) {
+// ruleErr wraps a formatted message in the `validation.Errors{"rules": ...}`
+// envelope that every rule-level failure uses. Keeping this here lets the
+// individual validate* helpers (and the Validate body itself) stay
+// one-liners while still producing the exact error shape callers expect.
+func ruleErr(format string, args ...any) error {
+	return validation.Errors{"rules": fmt.Errorf(format, args...)}
+}
 
-	if rule.Priority < NetworkSecurityGroupRulePriorityMin || rule.Priority > NetworkSecurityGroupRulePriorityMax {
-		return nil, validation.Errors{"rules": fmt.Errorf("priority `%d` must be between 0 and 60000", rule.Priority)}
+// validateRuleEnumValue uppercases *value in place and looks the result
+// up in the provided enum map, returning a `ruleErr` with the field
+// name interpolated if the value is not recognised. Used for the three
+// near-identical Direction / Action / Protocol checks. `T any` is fine
+// because we only care that the map key (the API string) is present.
+func validateRuleEnumValue[T any](value *string, lookup map[string]T, fieldName string) error {
+	*value = strings.ToUpper(*value)
+	if _, found := lookup[*value]; !found {
+		return ruleErr("unknown %s `%s`", fieldName, *value)
 	}
+	return nil
+}
 
-	// Process rule direction
-	rule.Direction = strings.ToUpper(rule.Direction)
-	direction, found := NetworkSecurityGroupRuleProtobufDirectionFromAPIDirection[rule.Direction]
-	if !found {
-		return nil, validation.Errors{"rules": fmt.Errorf("unknown direction `%s`", rule.Direction)}
+// validateRulePortRange runs the shared port-range parser against one
+// side of a rule and wraps any parser error in the matching
+// `unable to parse <label> port range` message. `label` is "source" or
+// "destination". The parsed values themselves are reproduced in
+// `ToProto`; this helper only gates well-formedness.
+func validateRulePortRange(value *string, label string) error {
+	if _, _, err := hutil.StringPtrToPortRangeUint32PtrPair(value); err != nil {
+		return ruleErr("unable to parse %s port range in API request: %w", label, err)
 	}
+	return nil
+}
 
-	// Process rule action
-	rule.Action = strings.ToUpper(rule.Action)
-	action, found := NetworkSecurityGroupRuleProtobufActionFromAPIAction[rule.Action]
-	if !found {
-		return nil, validation.Errors{"rules": fmt.Errorf("unknown action `%s`", rule.Action)}
+// validateRulePrefix enforces that the source / destination prefix is
+// both present (the only network option modelled today, so it's
+// required) and a parseable CIDR. `label` is "source" or "destination"
+// and is interpolated into both the missing-option and invalid-CIDR
+// messages so the caller's error funnel keeps a consistent shape.
+func validateRulePrefix(value *string, label string) error {
+	if value == nil {
+		return ruleErr("required %s network option not found in API request", label)
 	}
-
-	// Process rule protocol
-	rule.Protocol = strings.ToUpper(rule.Protocol)
-	protocol, found := NetworkSecurityGroupRuleProtobufProtocolFromAPIProtocol[rule.Protocol]
-	if !found {
-		return nil, validation.Errors{"rules": fmt.Errorf("unknown protocol `%s`", rule.Protocol)}
+	if _, _, err := net.ParseCIDR(*value); err != nil {
+		return ruleErr("%s prefix `%s` is not valid", label, *value)
 	}
+	return nil
+}
 
-	// Some protocols don't allow ports, so let's check for that.
+// validateRuleProtocolPortCompat rejects rules that pair a port-less
+// protocol (Any / Icmp / Icmp6) with a source or destination port
+// range. Pulled out of `Validate` so the high-level outline stays
+// flat; the switch is small but the inline form drowned in the
+// surrounding sequential checks.
+func validateRuleProtocolPortCompat(rule *APINetworkSecurityGroupRule) error {
 	switch rule.Protocol {
 	case APINetworkSecurityGroupRuleProtocolAny, APINetworkSecurityGroupRuleProtocolIcmp, APINetworkSecurityGroupRuleProtocolIcmp6:
 		if rule.SourcePortRange != nil || rule.DestinationPortRange != nil {
-			return nil, validation.Errors{"rules": fmt.Errorf("ports cannot be specified with protocol `%s`", rule.Protocol)}
+			return ruleErr("ports cannot be specified with protocol `%s`", rule.Protocol)
 		}
 	}
+	return nil
+}
 
-	// Process src/dst port ranges
-
-	srcPortStart, srcPortEnd, err := hutil.StringPtrToPortRangeUint32PtrPair(rule.SourcePortRange)
-	if err != nil {
-		return nil, validation.Errors{"rules": fmt.Errorf("unable to parse source port range in API request: %w", err)}
+// Validate checks the request-side fields of this rule and normalizes
+// case for the enum-style fields (Direction / Action / Protocol).
+// Per the proto-conversion convention this is the pre-`ToProto`
+// validation step: it covers priority bounds, recognised enum values,
+// protocol/port compatibility, port-range parseability, prefix CIDR
+// shape, and the presence of source / destination network options.
+// Once Validate has succeeded `ToProto` can act as a focused mapper.
+func (rule *APINetworkSecurityGroupRule) Validate() error {
+	if rule.Priority < NetworkSecurityGroupRulePriorityMin || rule.Priority > NetworkSecurityGroupRulePriorityMax {
+		return ruleErr("priority `%d` must be between 0 and 60000", rule.Priority)
 	}
-
-	dstPortStart, dstPortEnd, err := hutil.StringPtrToPortRangeUint32PtrPair(rule.DestinationPortRange)
-	if err != nil {
-		return nil, validation.Errors{"rules": fmt.Errorf("unable to parse destination port range in API request: %w", err)}
+	if err := validateRuleEnumValue(&rule.Direction, NetworkSecurityGroupRuleProtobufDirectionFromAPIDirection, "direction"); err != nil {
+		return err
 	}
-
-	newRule := &cdbm.NetworkSecurityGroupRule{
-		NetworkSecurityGroupRuleAttributes: &cwssaws.NetworkSecurityGroupRuleAttributes{
-			Id:        rule.Name,
-			Direction: direction,
-			Protocol:  protocol,
-			Action:    action,
-			Priority:  uint32(rule.Priority),
-			Ipv6:      false, // We have support for it in ACLs but pretty much nowhere else, so hide this for now.
-
-			SrcPortStart: srcPortStart,
-			SrcPortEnd:   srcPortEnd,
-			DstPortStart: dstPortStart,
-			DstPortEnd:   dstPortEnd,
-		},
+	if err := validateRuleEnumValue(&rule.Action, NetworkSecurityGroupRuleProtobufActionFromAPIAction, "action"); err != nil {
+		return err
 	}
+	if err := validateRuleEnumValue(&rule.Protocol, NetworkSecurityGroupRuleProtobufProtocolFromAPIProtocol, "protocol"); err != nil {
+		return err
+	}
+	if err := validateRuleProtocolPortCompat(rule); err != nil {
+		return err
+	}
+	if err := validateRulePortRange(rule.SourcePortRange, "source"); err != nil {
+		return err
+	}
+	if err := validateRulePortRange(rule.DestinationPortRange, "destination"); err != nil {
+		return err
+	}
+	if err := validateRulePrefix(rule.SourcePrefix, "source"); err != nil {
+		return err
+	}
+	if err := validateRulePrefix(rule.DestinationPrefix, "destination"); err != nil {
+		return err
+	}
+	return nil
+}
 
-	// Process src/dst prefixes
+// ToProto converts an API rule into the workflow proto attributes that
+// the DB record wraps and that get sent to NICo. It trusts that
+// `Validate` has run first — enum lookups, port ranges, and prefixes
+// are assumed safe — so this method is a focused mapper and does not
+// return errors.
+func (rule *APINetworkSecurityGroupRule) ToProto() *cwssaws.NetworkSecurityGroupRuleAttributes {
+	// Validate has normalized casing and proven these lookups succeed,
+	// so we don't re-check the `found` results here.
+	direction := NetworkSecurityGroupRuleProtobufDirectionFromAPIDirection[rule.Direction]
+	action := NetworkSecurityGroupRuleProtobufActionFromAPIAction[rule.Action]
+	protocol := NetworkSecurityGroupRuleProtobufProtocolFromAPIProtocol[rule.Protocol]
 
-	// We currently only have a single source network
-	// option supported.
-	// As/If we add more, add more if-blocks
-	// and checking the final count will be a
-	// pretty cheap way to make sure we have only
-	// one.
+	// Validate already parsed both ranges successfully; the parse
+	// helpers are total over well-formed input and a nil pointer
+	// produces nil starts/ends.
+	srcPortStart, srcPortEnd, _ := hutil.StringPtrToPortRangeUint32PtrPair(rule.SourcePortRange)
+	dstPortStart, dstPortEnd, _ := hutil.StringPtrToPortRangeUint32PtrPair(rule.DestinationPortRange)
 
-	// Process source net
+	attrs := &cwssaws.NetworkSecurityGroupRuleAttributes{
+		Id:        rule.Name,
+		Direction: direction,
+		Protocol:  protocol,
+		Action:    action,
+		Priority:  uint32(rule.Priority),
+		Ipv6:      false, // We have support for it in ACLs but pretty much nowhere else, so hide this for now.
 
-	sourceNetOptionCount := 0
+		SrcPortStart: srcPortStart,
+		SrcPortEnd:   srcPortEnd,
+		DstPortStart: dstPortStart,
+		DstPortEnd:   dstPortEnd,
+	}
 
 	if rule.SourcePrefix != nil {
-
-		if _, _, err := net.ParseCIDR(*rule.SourcePrefix); err != nil {
-			return nil, validation.Errors{"rules": fmt.Errorf("source prefix `%s` is not valid", *rule.SourcePrefix)}
-		}
-
-		newRule.SourceNet = &cwssaws.NetworkSecurityGroupRuleAttributes_SrcPrefix{SrcPrefix: *rule.SourcePrefix}
-		sourceNetOptionCount++
+		attrs.SourceNet = &cwssaws.NetworkSecurityGroupRuleAttributes_SrcPrefix{SrcPrefix: *rule.SourcePrefix}
 	}
-
-	if sourceNetOptionCount > 1 {
-		return nil, validation.Errors{"rules": fmt.Errorf("too many source network options found in API request")}
-	}
-
-	if sourceNetOptionCount == 0 {
-		return nil, validation.Errors{"rules": fmt.Errorf("required source network option not found in API request")}
-	}
-
-	// Process destination net
-
-	destinationNetOptionCount := 0
-
 	if rule.DestinationPrefix != nil {
-
-		if _, _, err := net.ParseCIDR(*rule.DestinationPrefix); err != nil {
-			return nil, validation.Errors{"rules": fmt.Errorf("destination prefix `%s` is not valid", *rule.DestinationPrefix)}
-		}
-
-		newRule.DestinationNet = &cwssaws.NetworkSecurityGroupRuleAttributes_DstPrefix{DstPrefix: *rule.DestinationPrefix}
-		destinationNetOptionCount++
+		attrs.DestinationNet = &cwssaws.NetworkSecurityGroupRuleAttributes_DstPrefix{DstPrefix: *rule.DestinationPrefix}
 	}
 
-	if destinationNetOptionCount > 1 {
-		return nil, validation.Errors{"rules": fmt.Errorf("too many destination network options found in API request")}
-	}
-
-	if destinationNetOptionCount == 0 {
-		return nil, validation.Errors{"rules": fmt.Errorf("required destination network option not found in API request")}
-	}
-
-	return newRule, nil
+	return attrs
 }
 
-// Accepts a NICo rule definition and converts
-// it to the nico-rest-api request representation that will be
-// returned to users
-func APINetworkSecurityGroupRuleFromProtobufRule(rule *cdbm.NetworkSecurityGroupRule) (*APINetworkSecurityGroupRule, error) {
-
-	if rule.Priority > NetworkSecurityGroupRulePriorityMax {
-		return nil, validation.Errors{"rules": fmt.Errorf("priority `%d` must be between 0 and 60000", rule.Priority)}
+// FromProto populates this rule from workflow proto attributes
+// (typically the embedded value on a stored
+// `cdbm.NetworkSecurityGroupRule`). A nil attrs is a no-op.
+//
+// Per the proto-conversion convention this method does not return
+// errors. Unknown enum values leave the corresponding string field
+// empty; half-defined port ranges and unrecognized network options
+// leave the matching fields nil. Anything more aggressive belongs in
+// a DB-integrity check before the data reaches this method.
+func (rule *APINetworkSecurityGroupRule) FromProto(attrs *cwssaws.NetworkSecurityGroupRuleAttributes) {
+	if attrs == nil {
+		return
 	}
 
-	// Process rule direction
-	direction, found := NetworkSecurityGroupRuleAPIDirectionFromProtobufDirection[rule.Direction]
-	if !found {
-		return nil, validation.Errors{"rules": fmt.Errorf("unknown direction in database record, %s (%d)", rule.Direction.String(), rule.Direction.Number())}
+	rule.Name = attrs.Id
+	rule.Priority = int(attrs.Priority)
+
+	// Unknown enum values fall through to the zero string. Callers
+	// that need stricter handling should reject the entity at the DB
+	// layer rather than the conversion layer.
+	rule.Direction = NetworkSecurityGroupRuleAPIDirectionFromProtobufDirection[attrs.Direction]
+	rule.Action = NetworkSecurityGroupRuleAPIActionFromProtobufAction[attrs.Action]
+	rule.Protocol = NetworkSecurityGroupRuleAPIProtocolFromProtobufProtocol[attrs.Protocol]
+
+	// Source / destination prefixes — currently the only network
+	// options modelled on the API side. Anything else leaves the
+	// matching field nil.
+	rule.SourcePrefix = nil
+	if src, ok := attrs.GetSourceNet().(*cwssaws.NetworkSecurityGroupRuleAttributes_SrcPrefix); ok {
+		prefix := src.SrcPrefix
+		rule.SourcePrefix = &prefix
+	}
+	rule.DestinationPrefix = nil
+	if dst, ok := attrs.GetDestinationNet().(*cwssaws.NetworkSecurityGroupRuleAttributes_DstPrefix); ok {
+		prefix := dst.DstPrefix
+		rule.DestinationPrefix = &prefix
 	}
 
-	// Process rule action
-	action, found := NetworkSecurityGroupRuleAPIActionFromProtobufAction[rule.Action]
-	if !found {
-		return nil, validation.Errors{"rules": fmt.Errorf("unknown action in database record, %s (%d)", rule.Action.String(), rule.Action.Number())}
+	// Port ranges round-trip only when both halves are present. A
+	// half-defined range comes back as a nil API range; the rest of
+	// the rule still loads.
+	rule.SourcePortRange = nil
+	if attrs.SrcPortStart != nil && attrs.SrcPortEnd != nil {
+		s := fmt.Sprintf("%d-%d", *attrs.SrcPortStart, *attrs.SrcPortEnd)
+		rule.SourcePortRange = &s
 	}
-
-	// Process rule protocol
-	protocol, found := NetworkSecurityGroupRuleAPIProtocolFromProtobufProtocol[rule.Protocol]
-	if !found {
-		return nil, validation.Errors{"rules": fmt.Errorf("unknown protocol in database record, %s (%d)", rule.Protocol.String(), rule.Protocol.Number())}
+	rule.DestinationPortRange = nil
+	if attrs.DstPortStart != nil && attrs.DstPortEnd != nil {
+		s := fmt.Sprintf("%d-%d", *attrs.DstPortStart, *attrs.DstPortEnd)
+		rule.DestinationPortRange = &s
 	}
-
-	// Some protocols don't allow ports, so let's check for that.
-	switch protocol {
-	case APINetworkSecurityGroupRuleProtocolAny, APINetworkSecurityGroupRuleProtocolIcmp, APINetworkSecurityGroupRuleProtocolIcmp6:
-		if rule.SrcPortStart != nil || rule.DstPortStart != nil {
-			return nil, validation.Errors{"rules": fmt.Errorf("found ports incorrectly specified with protocol `%s` in database record", protocol)}
-		}
-	}
-
-	// Process rule source and destination networks
-
-	var srcPrefix *string
-	var dstPrefix *string
-
-	switch srcNet := rule.GetSourceNet().(type) {
-	case *cwssaws.NetworkSecurityGroupRuleAttributes_SrcPrefix:
-		if _, _, err := net.ParseCIDR(srcNet.SrcPrefix); err != nil {
-			return nil, validation.Errors{"rules": fmt.Errorf("found invalid source prefix `%s` in database record", srcNet.SrcPrefix)}
-		}
-		srcPrefix = &srcNet.SrcPrefix
-	default:
-		return nil, validation.Errors{"rules": fmt.Errorf("encountered unknown source network option in database record")}
-	}
-
-	switch dstNet := rule.GetDestinationNet().(type) {
-	case *cwssaws.NetworkSecurityGroupRuleAttributes_DstPrefix:
-		if _, _, err := net.ParseCIDR(dstNet.DstPrefix); err != nil {
-			return nil, validation.Errors{"rules": fmt.Errorf("found invalid destination prefix `%s` in database record", dstNet.DstPrefix)}
-		}
-		dstPrefix = &dstNet.DstPrefix
-	default:
-		return nil, fmt.Errorf("encountered unknown source network option in database record")
-	}
-
-	// Process rule port ranges
-	var srcPortRange *string
-	var dstPortRange *string
-
-	// Whether nico-rest-api validates ranges or not,
-	// NICo will reject half-defined port ranges.
-	// If we see a half-defined range, it means DB
-	// corruption.
-	if rule.SrcPortStart != nil || rule.SrcPortEnd != nil {
-		if rule.SrcPortStart == nil || rule.SrcPortEnd == nil {
-			return nil, errors.New("encountered half-defined source port range in database record")
-		}
-		srcPortRangeStr := fmt.Sprintf("%d-%d", *rule.SrcPortStart, *rule.SrcPortEnd)
-		srcPortRange = &srcPortRangeStr
-	}
-
-	if rule.DstPortStart != nil || rule.DstPortEnd != nil {
-		if rule.DstPortStart == nil || rule.DstPortEnd == nil {
-			return nil, errors.New("encountered half-defined destination port range in database record")
-		}
-		dstPortRangeStr := fmt.Sprintf("%d-%d", *rule.DstPortStart, *rule.DstPortEnd)
-		dstPortRange = &dstPortRangeStr
-	}
-
-	return &APINetworkSecurityGroupRule{
-		Name:                 rule.Id,
-		Direction:            direction,
-		SourcePortRange:      srcPortRange,
-		DestinationPortRange: dstPortRange,
-		Protocol:             protocol,
-		Action:               action,
-		Priority:             int(rule.Priority),
-		SourcePrefix:         srcPrefix,
-		DestinationPrefix:    dstPrefix,
-	}, nil
 }
 
-// NewAPINetworkSecurityGroup accepts a DB layer NetworkSecurityGroup object and returns an API object
-func NewAPINetworkSecurityGroup(dsg *cdbm.NetworkSecurityGroup, dbsds []cdbm.StatusDetail) (*APINetworkSecurityGroup, error) {
+// NewAPINetworkSecurityGroupRule constructs an APINetworkSecurityGroupRule
+// from workflow proto attributes by calling FromProto. Returns nil for a
+// nil attrs argument.
+func NewAPINetworkSecurityGroupRule(attrs *cwssaws.NetworkSecurityGroupRuleAttributes) *APINetworkSecurityGroupRule {
+	if attrs == nil {
+		return nil
+	}
+	rule := &APINetworkSecurityGroupRule{}
+	rule.FromProto(attrs)
+	return rule
+}
+
+// NewAPINetworkSecurityGroup accepts a DB layer NetworkSecurityGroup object and returns an API object.
+// Rule reconstruction is defensive (see (*APINetworkSecurityGroupRule).FromProto),
+// so this constructor does not return an error.
+func NewAPINetworkSecurityGroup(dsg *cdbm.NetworkSecurityGroup, dbsds []cdbm.StatusDetail) *APINetworkSecurityGroup {
 	apisg := &APINetworkSecurityGroup{
 		ID:             dsg.ID,
 		Name:           dsg.Name,
@@ -500,18 +505,65 @@ func NewAPINetworkSecurityGroup(dsg *cdbm.NetworkSecurityGroup, dbsds []cdbm.Sta
 	rules := make([]*APINetworkSecurityGroupRule, len(dsg.Rules))
 
 	for i, rule := range dsg.Rules {
-		newRule, err := APINetworkSecurityGroupRuleFromProtobufRule(rule)
-		if err != nil {
-			return nil, err
-		}
-
-		rules[i] = newRule
+		rules[i] = NewAPINetworkSecurityGroupRule(rule.NetworkSecurityGroupRuleAttributes)
 	}
 
 	apisg.Rules = rules
 	apisg.RuleCount = len(rules)
 
-	return apisg, nil
+	return apisg
+}
+
+// ToProto builds the workflow request that asks a Site to create a new
+// NetworkSecurityGroup for this API request. `nsg` is the just-persisted
+// DB record; its `ToProto()` is the source of the canonical Metadata
+// (Name, Description, Labels) and the assigned ID. The request-shape
+// fields (rule list, statefulEgress) are taken directly from the
+// request because they're the caller's authoritative input for this
+// create.
+//
+// The method trusts that the request has already been Validated and
+// that the handler has performed any cross-context checks Validate
+// cannot see; in particular, every rule has been Validated, so each
+// `rule.ToProto()` is safe to call without checking errors.
+func (req *APINetworkSecurityGroupCreateRequest) ToProto(nsg *cdbm.NetworkSecurityGroup) *cwssaws.CreateNetworkSecurityGroupRequest {
+	nsgProto := nsg.ToProto()
+	// The DB record has already been built from the request, so the
+	// Metadata it produces (Name / Description / Labels) is the
+	// canonical wire form. Re-use it here rather than rebuilding from
+	// the request struct.
+	rules := make([]*cwssaws.NetworkSecurityGroupRuleAttributes, len(req.Rules))
+	for i := range req.Rules {
+		rules[i] = req.Rules[i].ToProto()
+	}
+	return &cwssaws.CreateNetworkSecurityGroupRequest{
+		Id:                   &nsg.ID,
+		TenantOrganizationId: nsgProto.TenantOrganizationId,
+		Metadata:             nsgProto.Metadata,
+		NetworkSecurityGroupAttributes: &cwssaws.NetworkSecurityGroupAttributes{
+			StatefulEgress: req.StatefulEgress,
+			Rules:          rules,
+		},
+	}
+}
+
+// ToProto builds the workflow request that pushes this update's
+// post-merge state to the Site. `nsg` is the already-updated DB
+// record; its `ToProto()` provides the canonical Metadata and the
+// post-merge rule list (the handler writes the request rules into the
+// DB before calling this), keeping the wire payload aligned with what
+// the database now holds.
+//
+// As with the create variant, this method trusts that `Validate` has
+// run and any cross-context checks have been performed in the handler.
+func (req *APINetworkSecurityGroupUpdateRequest) ToProto(nsg *cdbm.NetworkSecurityGroup) *cwssaws.UpdateNetworkSecurityGroupRequest {
+	nsgProto := nsg.ToProto()
+	return &cwssaws.UpdateNetworkSecurityGroupRequest{
+		Id:                             nsgProto.Id,
+		TenantOrganizationId:           nsgProto.TenantOrganizationId,
+		Metadata:                       nsgProto.Metadata,
+		NetworkSecurityGroupAttributes: nsgProto.Attributes,
+	}
 }
 
 type APINetworkSecurityGroupRule struct {

--- a/rest-api/api/pkg/api/model/networksecuritygroup_test.go
+++ b/rest-api/api/pkg/api/model/networksecuritygroup_test.go
@@ -8,14 +8,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
-	validation "github.com/go-ozzo/ozzo-validation/v4"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/proto"
 )
 
 // A helper only for tests.  Ignores potential conversion errors.
@@ -120,55 +121,31 @@ func TestAPINetworkSecurityGroupRuleConversions(t *testing.T) {
 	// as the set of all the generated rules.
 	assert.True(t, len(allRules) > len(validRules))
 
-	// Convert to API rules
-	// We'll loop through all rules, but we expect errors for the
-	// invalid ones and a final count that contains only the valid ones.
-	i := 0
-	for _, rule := range allRules {
+	// Round-trip the valid rules through FromProto and ToProto. After
+	// the layered-proto-conversion refactor, FromProto / ToProto no
+	// longer return errors: they trust their input. The valid set
+	// here is exactly the set of inputs the previous-stage validation
+	// (Validate) would have allowed through.
+	for i, rule := range validRules {
+		apiRule := NewAPINetworkSecurityGroupRule(rule.NetworkSecurityGroupRuleAttributes)
 
-		apiRule, err := APINetworkSecurityGroupRuleFromProtobufRule(rule)
+		assert.NotNil(t, apiRule, "expected non-nil API rule for valid proto attrs")
 
-		failMsg := fmt.Sprintf("\nNICo Rule\n\n%+v\n\nAPI Rule\n\n%+v\n\n", rule, apiRule)
+		newAttrs := apiRule.ToProto()
 
-		// Here, we're doing the inverse of what we did during rule generation where we
-		// excluded matching rules from the set of validRules.
-		// Now, we want to match on the _invalid_ rules and make sure they generate an error.
-		if rule.Direction == cwssaws.NetworkSecurityGroupRuleDirection_NSG_RULE_DIRECTION_INVALID ||
-			rule.Protocol == cwssaws.NetworkSecurityGroupRuleProtocol_NSG_RULE_PROTO_INVALID ||
-			rule.Action == cwssaws.NetworkSecurityGroupRuleAction_NSG_RULE_ACTION_INVALID ||
-			((rule.SrcPortStart == nil) != (rule.SrcPortEnd == nil)) ||
-			((rule.DstPortStart == nil) != (rule.DstPortEnd == nil)) ||
-			(rule.SrcPortStart != nil || rule.DstPortStart != nil) &&
-				(rule.Protocol == cwssaws.NetworkSecurityGroupRuleProtocol_NSG_RULE_PROTO_ANY ||
-					rule.Protocol == cwssaws.NetworkSecurityGroupRuleProtocol_NSG_RULE_PROTO_ICMP ||
-					rule.Protocol == cwssaws.NetworkSecurityGroupRuleProtocol_NSG_RULE_PROTO_ICMP6) {
-
-			assert.NotNil(t, err, failMsg)
-			continue
-		}
-
-		assert.Nil(t, err, failMsg)
-
-		// Convert back again
-		newRule, err := ProtobufRuleFromAPINetworkSecurityGroupRule(apiRule)
-
-		if !assert.Nil(t, err, failMsg) {
-			if e, ok := err.(validation.Errors); ok {
-				msg, _ := e.MarshalJSON()
-				t.Fatalf("API validation failure: %s", msg)
-			}
-		}
-
-		// Compare the double-conversion to the original of rule
-		assert.True(t, proto.Equal(validRules[i], newRule), fmt.Sprintf("\nNICo Rule\n\n%+v\n\nAPI Rule\n\n%+v\n\nNew NICo Rule\n\n%+v\n", rule, apiRule, newRule))
-
-		// Track the valid rule index
-		i++
+		assert.True(t,
+			proto.Equal(validRules[i].NetworkSecurityGroupRuleAttributes, newAttrs),
+			fmt.Sprintf("\nNICo Rule\n\n%+v\n\nAPI Rule\n\n%+v\n\nNew NICo Rule\n\n%+v\n", rule, apiRule, newAttrs),
+		)
 	}
 
-	// Test some invalid API request cases
-	// The first entry is a known good one.
-	// The rest are invalid
+	// Test some invalid API request cases.
+	// The first entry of each axis is a known-good value; the rest
+	// are invalid. With Validate now owning request validation, we
+	// drive each rule through `Validate()` instead of `ToProto()`,
+	// and assert that any non-zero index along any axis produces an
+	// error. The "known good" combo (all axes at index 0) must
+	// round-trip cleanly through ToProto and FromProto.
 	directions := []string{APINetworkSecurityGroupRuleDirectionIngress, "outer space", ""}
 	protocol := []string{APINetworkSecurityGroupRuleProtocolTcp, "MPLS", ""}
 	actions := []string{APINetworkSecurityGroupRuleActionPermit, "explode", ""}
@@ -201,29 +178,27 @@ func TestAPINetworkSecurityGroupRuleConversions(t *testing.T) {
 
 									failMsg := fmt.Sprintf("\n%v\n%v\n%v\n%v\n%v\n%v\n%v\n%d\n\n%+v\n", d, p, a, sr, dr, sp, dp, prio, rule)
 
-									// Now, convert to a NICo/proto rule
-									nicoRule, err := ProtobufRuleFromAPINetworkSecurityGroupRule(rule)
+									err := rule.Validate()
 
 									// If this rule has all the known good entries,
-									// it should have passed (converted successfully).
+									// it should have passed (validated successfully)
+									// and ToProto/FromProto should be symmetric.
 									if dI == 0 && pI == 0 && aI == 0 && srI == 0 && drI == 0 && spI == 0 && dpI == 0 && prioI == 0 {
 										assert.Nil(t, err, failMsg)
 
-										// Now, convert back again so we can confirm that all conversions
-										// are symmetric.
-										apiRule, err := APINetworkSecurityGroupRuleFromProtobufRule(nicoRule)
+										nicoAttrs := rule.ToProto()
 
-										assert.Nil(t, err, failMsg)
+										apiRule := NewAPINetworkSecurityGroupRule(nicoAttrs)
 
 										// Compare the original rule to the one that
 										// came out of the double-conversion.
 										assert.Equal(t, rule, apiRule, failMsg)
 
 									} else {
-										// For every other case it should fail.
-										// The combos ensure that each bad property gets
-										// tested with every other property set to a known
-										// good value.
+										// For every other case Validate should fail.
+										// The combos ensure that each bad property
+										// gets tested with every other property set to
+										// a known good value.
 										assert.NotNil(t, err, failMsg)
 									}
 								}
@@ -238,8 +213,18 @@ func TestAPINetworkSecurityGroupRuleConversions(t *testing.T) {
 
 func TestAPINetworkSecurityGroupCreateRequest_Validate(t *testing.T) {
 
+	// Rule-level validation now runs inside the parent Validate, so
+	// the fixture rule must itself be valid for the "ok" cases below
+	// to pass.
 	rules := []APINetworkSecurityGroupRule{
-		{Direction: APINetworkSecurityGroupRuleProtocolTcp, SourcePortRange: cutil.GetPtr("80-81"), Protocol: APINetworkSecurityGroupRuleProtocolTcp, Action: APINetworkSecurityGroupRuleActionPermit},
+		{
+			Direction:         APINetworkSecurityGroupRuleDirectionIngress,
+			SourcePortRange:   cutil.GetPtr("80-81"),
+			Protocol:          APINetworkSecurityGroupRuleProtocolTcp,
+			Action:            APINetworkSecurityGroupRuleActionPermit,
+			SourcePrefix:      cutil.GetPtr("0.0.0.0/0"),
+			DestinationPrefix: cutil.GetPtr("0.0.0.0/0"),
+		},
 	}
 
 	tests := []struct {
@@ -283,8 +268,18 @@ func TestAPINetworkSecurityGroupCreateRequest_Validate(t *testing.T) {
 
 func TestAPINetworkSecurityGroupUpdateRequest_Validate(t *testing.T) {
 
+	// Rule-level validation now runs inside the parent Validate, so
+	// the fixture rule must itself be valid for the "ok" cases below
+	// to pass.
 	rules := []APINetworkSecurityGroupRule{
-		{Direction: APINetworkSecurityGroupRuleProtocolTcp, SourcePortRange: cutil.GetPtr("80-81"), Protocol: APINetworkSecurityGroupRuleProtocolTcp, Action: APINetworkSecurityGroupRuleActionPermit},
+		{
+			Direction:         APINetworkSecurityGroupRuleDirectionIngress,
+			SourcePortRange:   cutil.GetPtr("80-81"),
+			Protocol:          APINetworkSecurityGroupRuleProtocolTcp,
+			Action:            APINetworkSecurityGroupRuleActionPermit,
+			SourcePrefix:      cutil.GetPtr("0.0.0.0/0"),
+			DestinationPrefix: cutil.GetPtr("0.0.0.0/0"),
+		},
 	}
 
 	tests := []struct {
@@ -371,8 +366,7 @@ func TestAPINetworkSecurityGroupNew(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			got, err := NewAPINetworkSecurityGroup(tc.dbObj, tc.dbSds)
-			assert.Nil(t, err)
+			got := NewAPINetworkSecurityGroup(tc.dbObj, tc.dbSds)
 			assert.Equal(t, tc.dbObj.ID, got.ID)
 		})
 	}
@@ -424,4 +418,150 @@ func TestAPINetworkSecurityGroupNewSummary(t *testing.T) {
 			assert.Equal(t, len(tc.dbObj.Rules), got.RuleCount)
 		})
 	}
+}
+
+func TestNewAPINetworkSecurityGroupRule(t *testing.T) {
+	t.Run("nil attrs returns nil rule", func(t *testing.T) {
+		rule := NewAPINetworkSecurityGroupRule(nil)
+		assert.Nil(t, rule)
+	})
+
+	t.Run("unknown enum produces an empty enum field but a non-nil rule", func(t *testing.T) {
+		// FromProto is defensive: an unrecognized direction enum
+		// leaves the corresponding API field empty rather than
+		// erroring. Any stricter handling belongs in a DB-integrity
+		// check, not in the conversion layer.
+		attrs := &cwssaws.NetworkSecurityGroupRuleAttributes{
+			Direction: cwssaws.NetworkSecurityGroupRuleDirection_NSG_RULE_DIRECTION_INVALID,
+		}
+		rule := NewAPINetworkSecurityGroupRule(attrs)
+		assert.NotNil(t, rule)
+		assert.Equal(t, "", rule.Direction)
+	})
+
+	t.Run("valid attrs produce a populated rule", func(t *testing.T) {
+		ruleID := cutil.GetPtr("rule-id")
+		attrs := &cwssaws.NetworkSecurityGroupRuleAttributes{
+			Id:             ruleID,
+			Direction:      cwssaws.NetworkSecurityGroupRuleDirection_NSG_RULE_DIRECTION_INGRESS,
+			Action:         cwssaws.NetworkSecurityGroupRuleAction_NSG_RULE_ACTION_PERMIT,
+			Protocol:       cwssaws.NetworkSecurityGroupRuleProtocol_NSG_RULE_PROTO_TCP,
+			Priority:       55,
+			SourceNet:      &cwssaws.NetworkSecurityGroupRuleAttributes_SrcPrefix{SrcPrefix: "0.0.0.0/0"},
+			DestinationNet: &cwssaws.NetworkSecurityGroupRuleAttributes_DstPrefix{DstPrefix: "1.1.1.1/0"},
+		}
+		rule := NewAPINetworkSecurityGroupRule(attrs)
+		assert.NotNil(t, rule)
+		assert.Equal(t, APINetworkSecurityGroupRuleDirectionIngress, rule.Direction)
+		assert.Equal(t, APINetworkSecurityGroupRuleActionPermit, rule.Action)
+		assert.Equal(t, APINetworkSecurityGroupRuleProtocolTcp, rule.Protocol)
+		assert.Equal(t, 55, rule.Priority)
+	})
+}
+
+func TestAPINetworkSecurityGroupCreateRequest_Validate_RuleErrors(t *testing.T) {
+	// The parent Validate must surface rule-level validation failures
+	// so that callers never reach a request-shape ToProto with a bad
+	// rule. The simplest signal is a known-bad direction.
+	rules := []APINetworkSecurityGroupRule{
+		{Direction: "nope", Protocol: APINetworkSecurityGroupRuleProtocolTcp, Action: APINetworkSecurityGroupRuleActionPermit, SourcePrefix: cutil.GetPtr("0.0.0.0/0"), DestinationPrefix: cutil.GetPtr("0.0.0.0/0")},
+	}
+	req := APINetworkSecurityGroupCreateRequest{Name: "test", SiteID: uuid.New().String(), Rules: rules}
+	err := req.Validate(nil)
+	assert.Error(t, err)
+}
+
+func TestAPINetworkSecurityGroupCreateRequest_ToProto(t *testing.T) {
+	// Build a request and the corresponding (just-persisted) DB
+	// record. The DB record provides the canonical Metadata; the
+	// request-shape ToProto sources rules / statefulEgress / id from
+	// the request and the wire envelope (Metadata) from the entity.
+	siteID := uuid.New()
+	tenantID := uuid.New()
+	req := APINetworkSecurityGroupCreateRequest{
+		Name:           "test-nsg",
+		Description:    cutil.GetPtr("desc"),
+		SiteID:         siteID.String(),
+		StatefulEgress: true,
+		Rules: []APINetworkSecurityGroupRule{
+			{
+				Direction:         APINetworkSecurityGroupRuleDirectionIngress,
+				Protocol:          APINetworkSecurityGroupRuleProtocolTcp,
+				Action:            APINetworkSecurityGroupRuleActionPermit,
+				SourcePrefix:      cutil.GetPtr("0.0.0.0/0"),
+				DestinationPrefix: cutil.GetPtr("1.1.1.1/0"),
+			},
+		},
+		Labels: map[string]string{"env": "test"},
+	}
+
+	require.NoError(t, req.Validate(nil))
+
+	nsg := &cdbm.NetworkSecurityGroup{
+		ID:             uuid.NewString(),
+		Name:           req.Name,
+		Description:    req.Description,
+		SiteID:         siteID,
+		TenantID:       tenantID,
+		TenantOrg:      "tenant-org",
+		Labels:         req.Labels,
+		StatefulEgress: req.StatefulEgress,
+	}
+
+	got := req.ToProto(nsg)
+	require.NotNil(t, got)
+	assert.Equal(t, nsg.ID, *got.Id)
+	assert.Equal(t, "tenant-org", got.TenantOrganizationId)
+	require.NotNil(t, got.Metadata)
+	assert.Equal(t, req.Name, got.Metadata.Name)
+	assert.Equal(t, *req.Description, got.Metadata.Description)
+	require.NotNil(t, got.NetworkSecurityGroupAttributes)
+	assert.Equal(t, req.StatefulEgress, got.NetworkSecurityGroupAttributes.StatefulEgress)
+	assert.Equal(t, 1, len(got.NetworkSecurityGroupAttributes.Rules))
+}
+
+func TestAPINetworkSecurityGroupUpdateRequest_ToProto(t *testing.T) {
+	// The update flow writes the request data into the DB record
+	// before calling ToProto, so the DB record's `ToProto()` is the
+	// canonical wire form for both Metadata and Attributes. We mimic
+	// that here by setting the post-merge fields directly on the
+	// `nsg` argument.
+	siteID := uuid.New()
+	tenantID := uuid.New()
+	nsg := &cdbm.NetworkSecurityGroup{
+		ID:             uuid.NewString(),
+		Name:           "updated-name",
+		Description:    cutil.GetPtr("updated-desc"),
+		SiteID:         siteID,
+		TenantID:       tenantID,
+		TenantOrg:      "tenant-org",
+		Labels:         map[string]string{"env": "prod"},
+		StatefulEgress: true,
+		Rules: []*cdbm.NetworkSecurityGroupRule{
+			{
+				NetworkSecurityGroupRuleAttributes: &cwssaws.NetworkSecurityGroupRuleAttributes{
+					Direction: cwssaws.NetworkSecurityGroupRuleDirection_NSG_RULE_DIRECTION_INGRESS,
+					Action:    cwssaws.NetworkSecurityGroupRuleAction_NSG_RULE_ACTION_PERMIT,
+					Protocol:  cwssaws.NetworkSecurityGroupRuleProtocol_NSG_RULE_PROTO_TCP,
+				},
+			},
+		},
+	}
+
+	req := APINetworkSecurityGroupUpdateRequest{
+		Name:           cutil.GetPtr("updated-name"),
+		Description:    cutil.GetPtr("updated-desc"),
+		StatefulEgress: cutil.GetPtr(true),
+	}
+
+	got := req.ToProto(nsg)
+	assert.NotNil(t, got)
+	assert.Equal(t, nsg.ID, got.Id)
+	assert.Equal(t, "tenant-org", got.TenantOrganizationId)
+	assert.NotNil(t, got.Metadata)
+	assert.Equal(t, nsg.Name, got.Metadata.Name)
+	assert.Equal(t, *nsg.Description, got.Metadata.Description)
+	assert.NotNil(t, got.NetworkSecurityGroupAttributes)
+	assert.Equal(t, nsg.StatefulEgress, got.NetworkSecurityGroupAttributes.StatefulEgress)
+	assert.Equal(t, 1, len(got.NetworkSecurityGroupAttributes.Rules))
 }

--- a/rest-api/db/pkg/db/model/networksecuritygroup.go
+++ b/rest-api/db/pkg/db/model/networksecuritygroup.go
@@ -9,13 +9,15 @@ import (
 	"errors"
 	"time"
 
-	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
-	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	"github.com/google/uuid"
 
-	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
+	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
+
 	"github.com/uptrace/bun"
 	"google.golang.org/protobuf/encoding/protojson"
+
+	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 
 	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
 )
@@ -77,7 +79,7 @@ type NetworkSecurityGroup struct {
 	CreatedBy      uuid.UUID                   `bun:"type:uuid,notnull"`
 	UpdatedBy      uuid.UUID                   `bun:"type:uuid,notnull"`
 	Version        string                      `bun:"version"`
-	Labels         map[string]string           `bun:"labels,type:jsonb"`
+	Labels         Labels                      `bun:"labels,type:jsonb"`
 	StatefulEgress bool                        `bun:"stateful_egress,notnull"`
 	Rules          []*NetworkSecurityGroupRule `bun:"rules,type:jsonb"`
 }
@@ -98,6 +100,122 @@ func (s *NetworkSecurityGroup) GetRulesAsProtoRefs() []*cwssaws.NetworkSecurityG
 	}
 
 	return rules
+}
+
+// toMetadataProto builds a workflow Metadata proto from the
+// NetworkSecurityGroup's Name, Description, and Labels. Description
+// defaults to the empty string when the receiver's pointer is nil to
+// match the previous inline handler behaviour. Labels conversion is
+// delegated to the typed `Labels.ToProto()` helper per the
+// "Named types own their proto behavior" convention.
+func (s *NetworkSecurityGroup) toMetadataProto() *cwssaws.Metadata {
+	md := &cwssaws.Metadata{
+		Name:        s.Name,
+		Description: "",
+		Labels:      s.Labels.ToProto(),
+	}
+	if s.Description != nil {
+		md.Description = *s.Description
+	}
+	return md
+}
+
+// ToProto converts this NetworkSecurityGroup into its workflow proto
+// representation. Used as the canonical entity-to-proto conversion;
+// request-shape protos (create / update) are produced by `ToProto`
+// methods on the corresponding API request types in
+// api/pkg/api/model/networksecuritygroup.go.
+//
+// The proto's Attributes carry the rule list rebuilt from the embedded
+// proto attributes on each persisted rule wrapper.
+func (s *NetworkSecurityGroup) ToProto() *cwssaws.NetworkSecurityGroup {
+	return &cwssaws.NetworkSecurityGroup{
+		Id:                   s.ID,
+		TenantOrganizationId: s.TenantOrg,
+		Metadata:             s.toMetadataProto(),
+		Version:              s.Version,
+		Attributes: &cwssaws.NetworkSecurityGroupAttributes{
+			StatefulEgress: s.StatefulEgress,
+			Rules:          s.GetRulesAsProtoRefs(),
+		},
+	}
+}
+
+// FromProto populates this NetworkSecurityGroup from its workflow proto
+// representation. A nil proto is a no-op. This is the inverse of
+// `ToProto` and exists for convention symmetry — currently no code
+// path on the cloud side reconstructs a full NSG entity from a
+// `cwssaws.NetworkSecurityGroup` (the site is the destination, not the
+// source), but the method is provided so future reconciliation flows
+// have a single canonical entry point.
+//
+// Field-level contract:
+//   - `s.ID` is preserved when `proto.Id` is empty.
+//   - `Name` is sourced from `proto.Metadata.Name` when set, falling
+//     back to leaving the receiver's name untouched if the proto has
+//     no metadata.
+//   - Description / Labels are reset from `proto.Metadata` so the
+//     receiver ends up as a clean replacement rather than a partial
+//     merge.
+//   - Rule attributes are rewrapped from `proto.Attributes.Rules`;
+//     a nil Attributes leaves the rule list nil.
+func (s *NetworkSecurityGroup) FromProto(proto *cwssaws.NetworkSecurityGroup) {
+	if proto == nil {
+		return
+	}
+	if proto.Id != "" {
+		s.ID = proto.Id
+	}
+	s.TenantOrg = proto.TenantOrganizationId
+	if proto.Version != "" {
+		s.Version = proto.Version
+	}
+	// Reset metadata-derived fields up front so the `clean reset rather
+	// than a partial merge` contract holds when proto.Metadata is nil
+	// or omits a field.
+	s.Name = ""
+	s.Description = nil
+	s.Labels = nil
+	if proto.Metadata != nil {
+		if proto.Metadata.Name != "" {
+			s.Name = proto.Metadata.Name
+		}
+		if proto.Metadata.Description != "" {
+			desc := proto.Metadata.Description
+			s.Description = &desc
+		}
+		s.Labels.FromProto(proto.Metadata.GetLabels())
+	}
+	// Attributes fields are reset before the conditional populate so the
+	// "clean replacement" contract holds even when proto.Attributes is nil
+	// (otherwise StatefulEgress / Rules would silently keep stale values).
+	s.StatefulEgress = false
+	s.Rules = nil
+	if proto.Attributes != nil {
+		s.StatefulEgress = proto.Attributes.StatefulEgress
+		if proto.Attributes.Rules != nil {
+			rules := make([]*NetworkSecurityGroupRule, len(proto.Attributes.Rules))
+			for i, r := range proto.Attributes.Rules {
+				if r == nil {
+					rules[i] = nil
+				} else {
+					rules[i] = &NetworkSecurityGroupRule{NetworkSecurityGroupRuleAttributes: r}
+				}
+			}
+			s.Rules = rules
+		} else {
+			s.Rules = nil
+		}
+	}
+}
+
+// ToDeletionRequestProto builds the workflow request that asks a Site
+// to delete this NetworkSecurityGroup.
+func (s *NetworkSecurityGroup) ToDeletionRequestProto() *cwssaws.DeleteNetworkSecurityGroupRequest {
+	return &cwssaws.DeleteNetworkSecurityGroupRequest{
+		Id:                   s.ID,
+		TenantOrganizationId: s.TenantOrg,
+	}
 }
 
 // A light wrapper around the protobuf so

--- a/rest-api/db/pkg/db/model/networksecuritygroup_test.go
+++ b/rest-api/db/pkg/db/model/networksecuritygroup_test.go
@@ -8,15 +8,16 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	otrace "go.opentelemetry.io/otel/trace"
+	"google.golang.org/protobuf/proto"
+
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	otrace "go.opentelemetry.io/otel/trace"
-	"google.golang.org/protobuf/proto"
 )
 
 func getIntPtrToUint32Ptr(i *int) *uint32 {
@@ -541,7 +542,7 @@ func TestNetworkSecurityGroupSQLDAO_Update(t *testing.T) {
 		expectedStatus         *string
 		expectedStatefulEgress *bool
 		expectedRules          []*NetworkSecurityGroupRule
-		expectedLabels         map[string]string
+		expectedLabels         Labels
 
 		expectError        bool
 		verifyChildSpanner bool
@@ -563,7 +564,7 @@ func TestNetworkSecurityGroupSQLDAO_Update(t *testing.T) {
 			expectedDescription:    cutil.GetPtr("updatedDesc"),
 			expectedStatus:         cutil.GetPtr(NetworkSecurityGroupStatusReady),
 			expectedVersion:        cutil.GetPtr("555555"),
-			expectedLabels:         map[string]string{"key": "value"},
+			expectedLabels:         Labels{"key": "value"},
 			expectedUpdatedByID:    &user2.ID,
 			expectedTenantID:       &sg1.TenantID,
 			expectedTenantOrg:      &sg1.TenantOrg,


### PR DESCRIPTION
## Description

Brings `NetworkSecurityGroup` in line with the proto-modeling changes. Create and Update route through `ToProto` on the API request types, the entity gets `ToProto` / `FromProto` plus `ToDeletionRequestProto`, and a new rule-level `Validate` gates every request before any `ToProto` runs. Also picks up the typed `Labels` field per the `InstanceType` reference (which we did in https://github.com/NVIDIA/infra-controller-rest/pull/540).

Primary callouts are:
- API request side: `APINetworkSecurityGroupCreateRequest.ToProto(nsg, id)` and `APINetworkSecurityGroupUpdateRequest.ToProto(nsg)`, plus `APINetworkSecurityGroupRule.ToProto` / `FromProto` as pure mappers.
- Entity side: `NetworkSecurityGroup.ToProto()`, `FromProto`, and `ToDeletionRequestProto()`.
- New `APINetworkSecurityGroupRule.Validate()` lifts the priority / enum / port-protocol / CIDR / required-prefix checks out of `ToProto`. Both Create and Update request validators call it per rule.
- Handler simplified to one-liners through the new receivers, and the corresponding error-handling branches drop.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

