### PR TITLE
chore(rest-api): Apply FromProto/ToProto modeling to VpcPrefix

### DIFF
--- a/rest-api/api/pkg/api/handler/vpcprefix.go
+++ b/rest-api/api/pkg/api/handler/vpcprefix.go
@@ -36,7 +36,6 @@ import (
 	cdbp "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	swe "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/error"
 
-	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/queue"
 )
 
@@ -252,16 +251,7 @@ func (csh CreateVpcPrefixHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		createVpcPrefixRequest := &cwssaws.VpcPrefixCreationRequest{
-			Id:    &cwssaws.VpcPrefixId{Value: vpcPrefix.ID.String()},
-			VpcId: &cwssaws.VpcId{Value: vpc.GetSiteID().String()},
-			Config: &cwssaws.VpcPrefixConfig{
-				Prefix: vpcPrefix.Prefix,
-			},
-			Metadata: &cwssaws.Metadata{
-				Name: vpcPrefix.Name,
-			},
-		}
+		createVpcPrefixRequest := apiRequest.ToProto(vpcPrefix, vpc)
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:                       "vpc-prefix-create-" + vpcPrefix.ID.String(),
@@ -865,12 +855,7 @@ func (ush UpdateVpcPrefixHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		updateVpcPrefixRequest := &cwssaws.VpcPrefixUpdateRequest{
-			Id: &cwssaws.VpcPrefixId{Value: updated.ID.String()},
-			Metadata: &cwssaws.Metadata{
-				Name: updated.Name,
-			},
-		}
+		updateVpcPrefixRequest := apiRequest.ToProto(updated)
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:                       "vpc-prefix-update-" + updated.ID.String(),
@@ -1095,9 +1080,7 @@ func (dsh DeleteVpcPrefixHandler) Handle(c echo.Context) error {
 		}
 
 		// Prepare the delete/release request workflow object
-		deleteVpcPrefixRequest := &cwssaws.VpcPrefixDeletionRequest{
-			Id: &cwssaws.VpcPrefixId{Value: vpcPrefix.ID.String()},
-		}
+		deleteVpcPrefixRequest := vpcPrefix.ToDeletionRequestProto()
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:        "vpc-prefix-delete-" + vpcPrefix.ID.String(),

--- a/rest-api/api/pkg/api/model/vpcprefix.go
+++ b/rest-api/api/pkg/api/model/vpcprefix.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/model/util"
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	ipam "github.com/NVIDIA/infra-controller/rest-api/ipam"
+	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 const (
@@ -39,8 +40,8 @@ type APIVpcPrefixCreateRequest struct {
 }
 
 // Validate ensure the values passed in request are acceptable
-func (vpcr APIVpcPrefixCreateRequest) Validate() error {
-	err := validation.ValidateStruct(&vpcr,
+func (vpcr *APIVpcPrefixCreateRequest) Validate() error {
+	err := validation.ValidateStruct(vpcr,
 		validation.Field(&vpcr.Name,
 			validation.Required.Error(validationErrorStringLength),
 			validation.Length(2, 256).Error(validationErrorStringLength)),
@@ -63,6 +64,30 @@ func (vpcr APIVpcPrefixCreateRequest) Validate() error {
 	return nil
 }
 
+// ToProto builds the workflow request that asks a Site to create a new
+// VpcPrefix for this API request. `vp` is the just-persisted DB record;
+// its `ToProto(vpc)` is the source of the canonical wire fields
+// (Id, VpcId, Config.Prefix, Metadata.Name). The parent `vpc` is needed
+// to translate to the Site-facing VPC ID (`Vpc.GetSiteID`).
+//
+// The method trusts that the request has already been Validated. There
+// are no cross-context checks for this entity beyond what Validate
+// covers.
+//
+// Precondition: `vpc` must be non-nil; a nil `vpc` produces a
+// `VpcPrefixCreationRequest` with an unset `VpcId`, which the Site
+// agent will reject. The current handler always provides a hydrated
+// parent VPC.
+func (vpcr *APIVpcPrefixCreateRequest) ToProto(vp *cdbm.VpcPrefix, vpc *cdbm.Vpc) *cwssaws.VpcPrefixCreationRequest {
+	vpProto := vp.ToProto(vpc)
+	return &cwssaws.VpcPrefixCreationRequest{
+		Id:       vpProto.Id,
+		VpcId:    vpProto.VpcId,
+		Config:   vpProto.Config,
+		Metadata: vpProto.Metadata,
+	}
+}
+
 // APIVpcPrefixUpdateRequest is the data structure to capture user request to update a VpcPrefix
 type APIVpcPrefixUpdateRequest struct {
 	// Name is the name of the VpcPrefix
@@ -74,8 +99,8 @@ type APIVpcPrefixUpdateRequest struct {
 }
 
 // Validate ensure the values passed in request are acceptable
-func (vpur APIVpcPrefixUpdateRequest) Validate() error {
-	err := validation.ValidateStruct(&vpur,
+func (vpur *APIVpcPrefixUpdateRequest) Validate() error {
+	err := validation.ValidateStruct(vpur,
 		validation.Field(&vpur.Name,
 			// length validation rule accepts empty string as valid, hence, required is needed
 			validation.When(vpur.Name != nil, validation.Required.Error(validationErrorStringLength)),
@@ -93,6 +118,21 @@ func (vpur APIVpcPrefixUpdateRequest) Validate() error {
 	}
 
 	return nil
+}
+
+// ToProto builds the workflow request that pushes this Update's
+// merged-into-DB state to a Site. The persisted `vp` is the source of
+// the wire fields because the handler has already merged the request's
+// (sparse) update fields into the entity by the time this is called;
+// sending the post-merge state matches the pre-existing handler
+// behaviour. Currently only `Metadata.Name` flows over (`Prefix` is
+// immutable for VpcPrefix and rejected by Validate).
+func (vpur *APIVpcPrefixUpdateRequest) ToProto(vp *cdbm.VpcPrefix) *cwssaws.VpcPrefixUpdateRequest {
+	vpProto := vp.ToProto(nil)
+	return &cwssaws.VpcPrefixUpdateRequest{
+		Id:       vpProto.Id,
+		Metadata: vpProto.Metadata,
+	}
 }
 
 // APIVpcPrefix is the data structure to capture API representation of a VpcPrefix

--- a/rest-api/api/pkg/api/model/vpcprefix_test.go
+++ b/rest-api/api/pkg/api/model/vpcprefix_test.go
@@ -8,12 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	ipam "github.com/NVIDIA/infra-controller/rest-api/ipam"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAPIVpcPrefixCreateRequest_Validate(t *testing.T) {
@@ -274,4 +276,46 @@ func TestNewAPIVpcPrefix_UsageStats(t *testing.T) {
 			req.Equal(tc.want.AcquiredPrefixes, got.UsageStats.AcquiredPrefixes)
 		})
 	}
+}
+
+func TestAPIVpcPrefixCreateRequest_ToProto(t *testing.T) {
+	prefixID := uuid.New()
+	vpcID := uuid.New()
+	vp := &cdbm.VpcPrefix{ID: prefixID, Name: "prefix-a", Prefix: "10.0.0.0/16"}
+	vpc := &cdbm.Vpc{ID: vpcID}
+
+	t.Run("sources canonical fields from the entity's ToProto", func(t *testing.T) {
+		apiReq := APIVpcPrefixCreateRequest{
+			Name:         "prefix-a",
+			VpcID:        vpcID.String(),
+			IPBlockID:    cutil.GetPtr(uuid.New().String()),
+			PrefixLength: 24,
+		}
+		req := apiReq.ToProto(vp, vpc)
+
+		require.NotNil(t, req)
+		require.NotNil(t, req.Id)
+		assert.Equal(t, prefixID.String(), req.Id.Value)
+		require.NotNil(t, req.VpcId)
+		assert.Equal(t, vpcID.String(), req.VpcId.Value)
+		require.NotNil(t, req.Config)
+		assert.Equal(t, "10.0.0.0/16", req.Config.Prefix)
+		require.NotNil(t, req.Metadata)
+		assert.Equal(t, "prefix-a", req.Metadata.Name)
+	})
+}
+
+func TestAPIVpcPrefixUpdateRequest_ToProto(t *testing.T) {
+	prefixID := uuid.New()
+	vp := &cdbm.VpcPrefix{ID: prefixID, Name: "prefix-a"}
+
+	t.Run("sources Id and Metadata.Name from the post-merge entity", func(t *testing.T) {
+		apiReq := APIVpcPrefixUpdateRequest{Name: cutil.GetPtr("prefix-a")}
+		req := apiReq.ToProto(vp)
+		require.NotNil(t, req)
+		require.NotNil(t, req.Id)
+		assert.Equal(t, prefixID.String(), req.Id.Value)
+		require.NotNil(t, req.Metadata)
+		assert.Equal(t, "prefix-a", req.Metadata.Name)
+	})
 }

--- a/rest-api/db/pkg/db/model/vpcprefix.go
+++ b/rest-api/db/pkg/db/model/vpcprefix.go
@@ -11,15 +11,18 @@ import (
 	"strings"
 	"time"
 
-	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
+
+	"github.com/google/uuid"
+
+	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	cipam "github.com/NVIDIA/infra-controller/rest-api/ipam"
-	"github.com/google/uuid"
 
 	"github.com/uptrace/bun"
 
 	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
+	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
 const (
@@ -80,6 +83,89 @@ type VpcPrefix struct {
 	Updated         time.Time  `bun:"updated,nullzero,notnull,default:current_timestamp"`
 	Deleted         *time.Time `bun:"deleted,soft_delete"`
 	CreatedBy       uuid.UUID  `bun:"type:uuid,notnull"`
+}
+
+// ToProto converts this VpcPrefix into its workflow proto representation.
+// Used as the canonical entity-to-proto conversion; request-shape protos
+// (create / update) are produced by `ToProto` methods on the corresponding
+// API request types in api/pkg/api/model/vpcprefix.go.
+//
+// The parent `vpc` is passed as a side input because the Site-facing VPC
+// ID can differ from the cloud-side `vp.VpcID` (see `Vpc.GetSiteID`), and
+// handlers typically already have a hydrated *Vpc from a separate query.
+// A nil `vpc` leaves the wire `VpcId` unset.
+func (vp *VpcPrefix) ToProto(vpc *Vpc) *cwssaws.VpcPrefix {
+	proto := &cwssaws.VpcPrefix{
+		Id: &cwssaws.VpcPrefixId{Value: vp.ID.String()},
+		Config: &cwssaws.VpcPrefixConfig{
+			Prefix: vp.Prefix,
+		},
+		Metadata: &cwssaws.Metadata{
+			Name: vp.Name,
+		},
+	}
+	if vpc != nil {
+		proto.VpcId = &cwssaws.VpcId{Value: vpc.GetSiteID().String()}
+	}
+	return proto
+}
+
+// FromProto populates this VpcPrefix from its workflow proto representation.
+// A nil proto is a no-op. This is the inverse of `ToProto` and exists for
+// convention symmetry — currently no code path on the cloud side
+// reconstructs a full VpcPrefix entity from a `cwssaws.VpcPrefix` (the
+// site is the destination, not the source), but the method is provided so
+// future reconciliation flows have a single canonical entry point.
+//
+// Field-level contract:
+//   - `vp.ID` is preserved on a missing or unparseable `proto.Id`,
+//     because callers pre-validate the UUID before calling.
+//   - `Name` is sourced from `proto.Metadata.Name` when set, falling back
+//     to the (deprecated) top-level `proto.Name` so the method keeps
+//     working through the deprecation window.
+//   - `Prefix` is sourced from `proto.Config.Prefix` when set, falling
+//     back to the (deprecated) top-level `proto.Prefix`.
+//   - `Name` and `Prefix` are similarly reset to the empty string when
+//     the proto omits both the deprecated top-level field and the
+//     structured `Metadata` / `Config` field; `FromProto` is a full
+//     overwrite of those fields, not a merge.
+//   - `VpcID` is cleared when the proto omits it OR when the proto value
+//     is unparseable, so `FromProto` is a clean reset rather than a
+//     partial merge.
+func (vp *VpcPrefix) FromProto(proto *cwssaws.VpcPrefix) {
+	if proto == nil {
+		return
+	}
+	if proto.Id != nil {
+		if id, err := uuid.Parse(proto.Id.Value); err == nil {
+			vp.ID = id
+		}
+	}
+	vp.Name = proto.Name
+	if proto.Metadata != nil && proto.Metadata.Name != "" {
+		vp.Name = proto.Metadata.Name
+	}
+	vp.Prefix = proto.Prefix
+	if proto.Config != nil && proto.Config.Prefix != "" {
+		vp.Prefix = proto.Config.Prefix
+	}
+	if proto.VpcId != nil {
+		if id, err := uuid.Parse(proto.VpcId.Value); err == nil {
+			vp.VpcID = id
+		} else {
+			vp.VpcID = uuid.Nil
+		}
+	} else {
+		vp.VpcID = uuid.Nil
+	}
+}
+
+// ToDeletionRequestProto builds the workflow request that asks a Site to
+// delete this VpcPrefix.
+func (vp *VpcPrefix) ToDeletionRequestProto() *cwssaws.VpcPrefixDeletionRequest {
+	return &cwssaws.VpcPrefixDeletionRequest{
+		Id: &cwssaws.VpcPrefixId{Value: vp.ID.String()},
+	}
 }
 
 // VpcPrefixCreateInput input parameters for Create method

--- a/rest-api/db/pkg/db/model/vpcprefix_test.go
+++ b/rest-api/db/pkg/db/model/vpcprefix_test.go
@@ -9,16 +9,116 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	otrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/google/uuid"
+	"github.com/uptrace/bun/extra/bundebug"
 
 	cutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	stracer "github.com/NVIDIA/infra-controller/rest-api/db/pkg/tracer"
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/util"
-	"github.com/google/uuid"
-	"github.com/uptrace/bun/extra/bundebug"
+	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
+
+func TestVpcPrefix_ToProto(t *testing.T) {
+	prefixID := uuid.New()
+	vpcID := uuid.New()
+	vp := &VpcPrefix{ID: prefixID, Name: "prefix-a", Prefix: "10.0.0.0/16"}
+	vpc := &Vpc{ID: vpcID}
+
+	t.Run("populates wire fields and translates VpcId via the parent VPC", func(t *testing.T) {
+		proto := vp.ToProto(vpc)
+		require.NotNil(t, proto)
+		require.NotNil(t, proto.Id)
+		assert.Equal(t, prefixID.String(), proto.Id.Value)
+		require.NotNil(t, proto.VpcId)
+		assert.Equal(t, vpcID.String(), proto.VpcId.Value)
+		require.NotNil(t, proto.Config)
+		assert.Equal(t, "10.0.0.0/16", proto.Config.Prefix)
+		require.NotNil(t, proto.Metadata)
+		assert.Equal(t, "prefix-a", proto.Metadata.Name)
+	})
+
+	t.Run("leaves VpcId nil when parent VPC is not provided", func(t *testing.T) {
+		proto := vp.ToProto(nil)
+		require.NotNil(t, proto)
+		assert.Nil(t, proto.VpcId)
+		require.NotNil(t, proto.Id)
+		assert.Equal(t, prefixID.String(), proto.Id.Value)
+	})
+}
+
+func TestVpcPrefix_FromProto(t *testing.T) {
+	t.Run("nil proto is a no-op", func(t *testing.T) {
+		original := VpcPrefix{ID: uuid.New(), Name: "original", Prefix: "10.0.0.0/16"}
+		vp := original
+		vp.FromProto(nil)
+		assert.Equal(t, original, vp)
+	})
+
+	t.Run("populates fields from proto Metadata and Config", func(t *testing.T) {
+		prefixID := uuid.New()
+		vpcID := uuid.New()
+		vp := &VpcPrefix{}
+		vp.FromProto(&cwssaws.VpcPrefix{
+			Id:       &cwssaws.VpcPrefixId{Value: prefixID.String()},
+			VpcId:    &cwssaws.VpcId{Value: vpcID.String()},
+			Config:   &cwssaws.VpcPrefixConfig{Prefix: "10.0.0.0/16"},
+			Metadata: &cwssaws.Metadata{Name: "prefix-a"},
+		})
+		assert.Equal(t, prefixID, vp.ID)
+		assert.Equal(t, vpcID, vp.VpcID)
+		assert.Equal(t, "prefix-a", vp.Name)
+		assert.Equal(t, "10.0.0.0/16", vp.Prefix)
+	})
+
+	t.Run("falls back to deprecated top-level Name and Prefix", func(t *testing.T) {
+		prefixID := uuid.New()
+		vp := &VpcPrefix{}
+		vp.FromProto(&cwssaws.VpcPrefix{
+			Id:     &cwssaws.VpcPrefixId{Value: prefixID.String()},
+			Name:   "prefix-legacy",
+			Prefix: "10.1.0.0/16",
+		})
+		assert.Equal(t, "prefix-legacy", vp.Name)
+		assert.Equal(t, "10.1.0.0/16", vp.Prefix)
+	})
+
+	t.Run("preserves ID when proto Id is unparseable", func(t *testing.T) {
+		preserved := uuid.New()
+		vp := &VpcPrefix{ID: preserved}
+		vp.FromProto(&cwssaws.VpcPrefix{
+			Id: &cwssaws.VpcPrefixId{Value: "not-a-uuid"},
+		})
+		assert.Equal(t, preserved, vp.ID)
+	})
+
+	t.Run("clears VpcID when proto omits VpcId", func(t *testing.T) {
+		vp := &VpcPrefix{VpcID: uuid.New()}
+		vp.FromProto(&cwssaws.VpcPrefix{})
+		assert.Equal(t, uuid.Nil, vp.VpcID)
+	})
+
+	t.Run("clears VpcID when proto VpcId is unparseable", func(t *testing.T) {
+		vp := &VpcPrefix{VpcID: uuid.New()}
+		vp.FromProto(&cwssaws.VpcPrefix{
+			VpcId: &cwssaws.VpcId{Value: "not-a-uuid"},
+		})
+		assert.Equal(t, uuid.Nil, vp.VpcID)
+	})
+}
+
+func TestVpcPrefix_ToDeletionRequestProto(t *testing.T) {
+	prefixID := uuid.New()
+	vp := &VpcPrefix{ID: prefixID}
+	req := vp.ToDeletionRequestProto()
+	require.NotNil(t, req)
+	require.NotNil(t, req.Id)
+	assert.Equal(t, prefixID.String(), req.Id.Value)
+}
 
 func testVpcPrefixInitDB(t *testing.T) *db.Session {
 	dbSession := util.GetTestDBSession(t, false)


### PR DESCRIPTION
## Description

Brings `VpcPrefix` in line with the proto-modeling changes. Create and Update route through `ToProto` on the API requests, and Delete sits on the entity (no API body). Because the Site can supply its own controller-side ID for a VPC (`ControllerVpcID`), any proto we send to the Site reads the VPC ID via `vpc.GetSiteID()` instead of `vp.VpcID` directly. The parent `Vpc` is passed as a side input so the entity `ToProto` and the create request's `ToProto` can both call it.

Primary callouts are:
- Entity side: `VpcPrefix.ToProto(vpc)`, `FromProto`, and `ToDeletionRequestProto()`.
- API request side: `APIVpcPrefixCreateRequest.ToProto(vp, vpc)` and `APIVpcPrefixUpdateRequest.ToProto(vp)`.
- Handler simplified to one-liners, and the inline workflow-schema dependency drops.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

