### PR TITLE
chore(rest-api): Use Labels.ToProto() in entity ToProto methods

### DIFF
--- a/rest-api/db/pkg/db/model/expectedmachine.go
+++ b/rest-api/db/pkg/db/model/expectedmachine.go
@@ -132,15 +132,8 @@ func (em *ExpectedMachine) ToProto(creds ExpectedMachineCredentials) *cwssaws.Ex
 	}
 
 	if em.Labels != nil {
-		protoLabels := make([]*cwssaws.Label, 0, len(em.Labels))
-		for k, v := range em.Labels {
-			protoLabels = append(protoLabels, &cwssaws.Label{
-				Key:   k,
-				Value: &v,
-			})
-		}
 		proto.Metadata = &cwssaws.Metadata{
-			Labels: protoLabels,
+			Labels: em.Labels.ToProto(),
 		}
 	}
 

--- a/rest-api/db/pkg/db/model/expectedpowershelf.go
+++ b/rest-api/db/pkg/db/model/expectedpowershelf.go
@@ -123,15 +123,8 @@ func (eps *ExpectedPowerShelf) ToProto(creds ExpectedPowerShelfCredentials) *cws
 	}
 
 	if eps.Labels != nil {
-		protoLabels := make([]*cwssaws.Label, 0, len(eps.Labels))
-		for k, v := range eps.Labels {
-			protoLabels = append(protoLabels, &cwssaws.Label{
-				Key:   k,
-				Value: &v,
-			})
-		}
 		proto.Metadata = &cwssaws.Metadata{
-			Labels: protoLabels,
+			Labels: eps.Labels.ToProto(),
 		}
 	}
 

--- a/rest-api/db/pkg/db/model/expectedrack.go
+++ b/rest-api/db/pkg/db/model/expectedrack.go
@@ -105,14 +105,7 @@ func (er *ExpectedRack) ToProto() *cwssaws.ExpectedRack {
 	}
 
 	if len(er.Labels) > 0 {
-		protoLabels := make([]*cwssaws.Label, 0, len(er.Labels))
-		for k, v := range er.Labels {
-			protoLabels = append(protoLabels, &cwssaws.Label{
-				Key:   k,
-				Value: &v,
-			})
-		}
-		proto.Metadata.Labels = protoLabels
+		proto.Metadata.Labels = er.Labels.ToProto()
 	}
 
 	return proto

--- a/rest-api/db/pkg/db/model/expectedswitch.go
+++ b/rest-api/db/pkg/db/model/expectedswitch.go
@@ -130,15 +130,8 @@ func (es *ExpectedSwitch) ToProto(creds ExpectedSwitchCredentials) *cwssaws.Expe
 	}
 
 	if es.Labels != nil {
-		protoLabels := make([]*cwssaws.Label, 0, len(es.Labels))
-		for k, v := range es.Labels {
-			protoLabels = append(protoLabels, &cwssaws.Label{
-				Key:   k,
-				Value: &v,
-			})
-		}
 		proto.Metadata = &cwssaws.Metadata{
-			Labels: protoLabels,
+			Labels: es.Labels.ToProto(),
 		}
 	}
 

--- a/rest-api/db/pkg/db/model/vpc.go
+++ b/rest-api/db/pkg/db/model/vpc.go
@@ -176,11 +176,7 @@ func (vpc *Vpc) toMetadataProto() *cwssaws.Metadata {
 		md.Description = *vpc.Description
 	}
 	if vpc.Labels != nil {
-		labels := make([]*cwssaws.Label, 0, len(vpc.Labels))
-		for k, v := range vpc.Labels {
-			labels = append(labels, &cwssaws.Label{Key: k, Value: &v})
-		}
-		md.Labels = labels
+		md.Labels = vpc.Labels.ToProto()
 	}
 	return md
 }


### PR DESCRIPTION
## Description

Small cleanup of five entities (`Vpc`, `ExpectedMachine`, `ExpectedPowerShelf`, `ExpectedRack`, `ExpectedSwitch`) that built the `[]*cwssaws.Label` slice inline in their `ToProto` methods, instead of delegating to `labels.ToProto()` on the typed `Labels` map -- sorry I missed these!

`InfiniBandPartition` and `InstanceType` already do this correctly -- this unifies the rest with that pattern.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

