### PR TITLE
fix: Run power manager only when machine is in Ready state.

### DIFF
--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -2218,30 +2218,10 @@ impl StateHandler for MachineStateHandler {
             continue_state_machine,
             msg,
         } = match mh_snapshot.host_snapshot.state.value {
-            ManagedHostState::Assigned {
-                instance_state: InstanceState::Ready,
-            } => {
-                // We can't touch a machine which is in Assigned/Ready state. A tenant owns it.
-                PowerHandlingOutcome::new(None, true, None)
+            ManagedHostState::Ready if self.power_options_config.enabled => {
+                power::handle_power(mh_snapshot, ctx, &self.power_options_config).await?
             }
-            ManagedHostState::HostReprovision { .. }
-            | ManagedHostState::Assigned {
-                instance_state: InstanceState::HostReprovision { .. },
-            } => {
-                // During host reprovisioning (firmware updates), the state controller
-                // manages power directly (ForceOff → ACPowercycle → On). The power
-                // manager must not interfere, otherwise it may power the host back on
-                // between ForceOff and ACPowercycle, causing AuxPowerReset to fail
-                // with ChassisPowerStateOffRequired.
-                PowerHandlingOutcome::new(None, true, None)
-            }
-            _ => {
-                if self.power_options_config.enabled {
-                    power::handle_power(mh_snapshot, ctx, &self.power_options_config).await?
-                } else {
-                    PowerHandlingOutcome::new(None, true, None)
-                }
-            }
+            _ => PowerHandlingOutcome::new(None, true, None),
         };
 
         // Clone the pool before we borrow ctx mutably


### PR DESCRIPTION
## Description
Run power manager only when machine is in Ready state.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

