### PR TITLE
Support for setting multicast group limits on nvlink partitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,10 +2358,8 @@ dependencies = [
 name = "carbide-macros"
 version = "0.0.0"
 dependencies = [
- "eyre",
  "proc-macro2",
  "quote",
- "sqlx",
  "sqlx-macros-core",
  "syn 2.0.117",
 ]
@@ -2730,6 +2728,35 @@ dependencies = [
  "thiserror 2.0.18",
  "tonic",
  "tracing",
+]
+
+[[package]]
+name = "carbide-rvs"
+version = "0.0.1"
+dependencies = [
+ "axum",
+ "carbide-rpc",
+ "carbide-tls",
+ "carbide-uuid",
+ "clap",
+ "figment",
+ "futures",
+ "hex",
+ "jsonpath-rust",
+ "logfmt",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "toml 1.1.2+spec-1.1.0",
+ "tonic",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2733,26 +2733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "carbide-rvs"
-version = "0.0.1"
-dependencies = [
- "carbide-rpc",
- "carbide-tls",
- "carbide-uuid",
- "figment",
- "logfmt",
- "serde",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "toml 1.1.2+spec-1.1.0",
- "tonic",
- "tracing",
- "tracing-subscriber",
- "uuid",
-]
-
-[[package]]
 name = "carbide-scout"
 version = "0.0.1"
 dependencies = [

--- a/crates/api-core/src/tests/common/api_fixtures/host.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/host.rs
@@ -49,6 +49,9 @@ pub const GB200_COMPUTE_TRAY_3_INFO_JSON: &[u8] = include_bytes!(
 pub const GB200_COMPUTE_TRAY_4_INFO_JSON: &[u8] = include_bytes!(
     "../../../../../api-model/src/hardware_info/test_data/gb200_compute_tray_4_info.json"
 );
+pub const GB200_COMPUTE_TRAY_5_INFO_JSON: &[u8] = include_bytes!(
+    "../../../../../api-model/src/hardware_info/test_data/gb200_compute_tray_5_info.json"
+);
 /// Uses the `discover_dhcp` API to discover a Host with a certain MAC address
 ///
 /// Returns the created `machine_interface_id`

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -280,6 +280,8 @@ pub struct TestEnv {
     pub attestation_enabled: bool,
     pub site_explorer: SiteExplorer,
     pub nmxc_sim: Arc<dyn NmxcPool>,
+    /// True when the test env uses [`NmxcSimClient::simulator_for_nvlink_config`] (gRPC proxy to a local simulator).
+    pub nmxc_grpc_simulator: bool,
     pub endpoint_explorer: MockEndpointExplorer,
     pub admin_segments: Vec<NetworkSegmentId>,
     pub underlay_segment: Option<NetworkSegmentId>,
@@ -1114,7 +1116,8 @@ pub async fn create_test_env_with_overrides(
         .cloned()
         .unwrap_or_default();
 
-    let nmxc_sim: Arc<dyn NmxcPool> = if overrides.nmxc_simulator == Some(true) {
+    let nmxc_grpc_simulator = overrides.nmxc_simulator == Some(true);
+    let nmxc_sim: Arc<dyn NmxcPool> = if nmxc_grpc_simulator {
         Arc::new(NmxcSimClient::simulator_for_nvlink_config(
             &nvlink_for_nmxc_sim,
         ))
@@ -1548,6 +1551,7 @@ pub async fn create_test_env_with_overrides(
         test_meter,
         site_explorer,
         nmxc_sim,
+        nmxc_grpc_simulator,
         endpoint_explorer: fake_endpoint_explorer,
         admin_segments,
         underlay_segment,
@@ -2223,21 +2227,26 @@ fn hardware_info_from_hardware_info_template(
     serde_json::from_slice::<HardwareInfo>(json_bytes).ok()
 }
 
-/// Inserts `nvlink_nmxc_endpoints` with a random `http://<ipv4>:<port>` endpoint when the template's
-/// `dmi_data.product_name` contains `"GB200"` and a non-empty `gpus[].platform_info.chassis_serial`
-/// exists. Skips if the row already exists or on DB errors.
+/// Inserts `nvlink_nmxc_endpoints` with the NMX-C gRPC simulator default URL when the test env
+/// uses the gRPC simulator, otherwise a random `http://<ipv4>:<port>` endpoint, when the
+/// template's `dmi_data.product_name` contains `"GB200"` and a non-empty
+/// `gpus[].platform_info.chassis_serial` exists. Skips if the row already exists or on DB errors.
 pub async fn insert_nvlink_nmxc_endpoint_from_managed_host(
     env: &TestEnv,
     hardware_info_template: &managed_host::HardwareInfoTemplate,
 ) {
-    let endpoint = format!(
-        "http://{}.{}.{}.{}:{}",
-        rand::random::<u8>(),
-        rand::random::<u8>(),
-        rand::random::<u8>(),
-        rand::random::<u8>(),
-        rand::random::<u16>() % 40_000 + 10_000,
-    );
+    let endpoint = if env.nmxc_grpc_simulator {
+        NmxcSimClient::SIMULATOR_URL.to_string()
+    } else {
+        format!(
+            "http://{}.{}.{}.{}:{}",
+            rand::random::<u8>(),
+            rand::random::<u8>(),
+            rand::random::<u8>(),
+            rand::random::<u8>(),
+            rand::random::<u16>() % 40_000 + 10_000,
+        )
+    };
     let Some(hi) = hardware_info_from_hardware_info_template(hardware_info_template) else {
         return;
     };
@@ -2285,6 +2294,27 @@ pub async fn insert_nvlink_nmxc_endpoint_from_managed_host(
         return;
     }
     txn.commit().await.ok();
+}
+
+pub async fn set_nvlink_nmxc_endpoint(env: &TestEnv, chassis_serial: &str, endpoint: &str) {
+    let mut txn = db::Transaction::begin(&env.pool)
+        .await
+        .expect("begin txn for nvlink_nmxc_endpoint");
+    match db::nvlink_nmxc_endpoints::find_by_chassis_serial(&mut txn, chassis_serial).await {
+        Ok(None) => {
+            db::nvlink_nmxc_endpoints::create(&mut txn, chassis_serial, endpoint)
+                .await
+                .expect("create nvlink_nmxc_endpoint");
+        }
+        Ok(Some(_)) => {
+            db::nvlink_nmxc_endpoints::update(&mut txn, chassis_serial, endpoint)
+                .await
+                .expect("update nvlink_nmxc_endpoint")
+                .expect("nvlink_nmxc_endpoint row missing after find");
+        }
+        Err(e) => panic!("find nvlink_nmxc_endpoint: {e}"),
+    }
+    txn.commit().await.expect("commit nvlink_nmxc_endpoint");
 }
 
 pub async fn update_time_params(

--- a/crates/api-core/src/tests/nvl_instance.rs
+++ b/crates/api-core/src/tests/nvl_instance.rs
@@ -2230,6 +2230,10 @@ async fn test_create_instance_with_nvl_config_mtls_use_nmxc_simulator(pool: sqlx
     run_create_instance_with_nvl_config_nmxc_simulator_scenario(pool, true).await;
 }
 
+// This test creates two instances in the same logical partition but on different domains.
+// This test relies on having two NMX-C simulator instances running on ports 9601 and 9602.
+// Simulator running on port 9601 simulates a tray as defined in GB200_COMPUTE_TRAY_4_INFO_JSON.
+// Simulator running on port 9602 simulates a tray as defined in GB200_COMPUTE_TRAY_5_INFO_JSON.
 #[crate::sqlx_test]
 async fn test_create_instance_multiple_domains_use_nmxc_simulator(pool: sqlx::PgPool) {
     if !nmxc_simulator_tests_enabled() {

--- a/crates/api-core/src/tests/nvl_instance.rs
+++ b/crates/api-core/src/tests/nvl_instance.rs
@@ -2601,9 +2601,10 @@ async fn test_instance_delete_with_nvl_config_use_nmxc_simulator(pool: sqlx::PgP
     assert_eq!(ids_all.partition_ids.len(), 0);
 }
 
-
 #[crate::sqlx_test]
-async fn test_managed_host_creation_with_tray_default_partition_use_nmxc_simulator(pool: sqlx::PgPool) {
+async fn test_managed_host_creation_with_tray_default_partition_use_nmxc_simulator(
+    pool: sqlx::PgPool,
+) {
     if !nmxc_simulator_tests_enabled() {
         println!(
             "skipping test_instance_delete_with_nvl_config_use_nmxc_simulator as nmxc simulator tests are not enabled"
@@ -2624,7 +2625,6 @@ async fn test_managed_host_creation_with_tray_default_partition_use_nmxc_simulat
 
     let _segment_id = env.create_vpc_and_tenant_segment().await;
 
-
     let mh = create_managed_host_with_hardware_info_template(
         &env,
         HardwareInfoTemplate::Custom(
@@ -2642,7 +2642,6 @@ async fn test_managed_host_creation_with_tray_default_partition_use_nmxc_simulat
     let gpus: Vec<Gpu> = discovery_info.gpus.to_vec();
 
     println!("{gpus:?}");
-
 
     // Run twice to record observation.
     env.run_nvl_partition_monitor_iteration().await;

--- a/crates/api-core/src/tests/nvl_instance.rs
+++ b/crates/api-core/src/tests/nvl_instance.rs
@@ -16,20 +16,17 @@
  */
 
 use ::rpc::machine_discovery::Gpu;
-use carbide_uuid::nvlink::NvLinkPartitionId;
 use common::api_fixtures::create_managed_host_with_hardware_info_template;
 use common::api_fixtures::instance::{
     create_instance_with_nvlink_config, update_instance_nvlink_config,
 };
-use libnmxc::nmxc_model::{
-    CreatePartitionRequest, GetPartitionInfoListRequest, UpdatePartitionRequest,
-};
-
 use common::api_fixtures::managed_host::HardwareInfoTemplate;
 use common::api_fixtures::nvl_logical_partition::create_nvl_logical_partition;
-use db::{self, nvl_partition as db_nvl_partition};
+use libnmxc::nmxc_model::{
+    CreatePartitionRequest, GetGpuInfoListRequest, GetPartitionInfoListRequest, GpuAttr,
+    UpdatePartitionRequest,
+};
 use model::instance::config::nvlink::InstanceNvLinkConfig;
-use model::nvl_partition::{NewNvlPartition, NvlPartitionName};
 use rpc::forge::TenantState;
 use rpc::forge::forge_server::Forge;
 
@@ -2234,12 +2231,10 @@ async fn test_create_instance_with_nvl_config_mtls_use_nmxc_simulator(pool: sqlx
 }
 
 #[crate::sqlx_test]
-async fn test_update_nvlink_config_nmxm_existing_partitions_with_nmxc_simulator(
-    pool: sqlx::PgPool,
-) {
+async fn test_create_instance_multiple_domains_use_nmxc_simulator(pool: sqlx::PgPool) {
     if !nmxc_simulator_tests_enabled() {
         println!(
-            "skipping test_update_nvlink_config_nmxm_existing_partitions_with_nmxc_simulator as nmxc simulator tests are not enabled"
+            "skipping test_create_instance_multiple_domains_use_nmxc_simulator as nmxc simulator tests are not enabled"
         );
         return;
     }
@@ -2273,141 +2268,85 @@ async fn test_update_nvlink_config_nmxm_existing_partitions_with_nmxc_simulator(
         .unwrap();
     assert_eq!(logical_ids_list.partition_ids.len(), 1);
 
-    let mh = create_managed_host_with_hardware_info_template(
+    common::api_fixtures::set_nvlink_nmxc_endpoint(&env, "27XYX27000001", "http://localhost:9601")
+        .await;
+    let mh4 = create_managed_host_with_hardware_info_template(
         &env,
         HardwareInfoTemplate::Custom(
             crate::tests::common::api_fixtures::host::GB200_COMPUTE_TRAY_4_INFO_JSON,
         ),
     )
     .await;
-    let machine = mh.host().rpc_machine().await;
+    common::api_fixtures::set_nvlink_nmxc_endpoint(&env, "27ZYX27000001", "http://localhost:9602")
+        .await;
+    let mh5 = create_managed_host_with_hardware_info_template(
+        &env,
+        HardwareInfoTemplate::Custom(
+            crate::tests::common::api_fixtures::host::GB200_COMPUTE_TRAY_5_INFO_JSON,
+        ),
+    )
+    .await;
 
-    assert_eq!(&machine.state, "Ready");
-    let discovery_info = machine.discovery_info.as_ref().unwrap();
+    env.run_nvl_partition_monitor_iteration().await;
+    env.run_nvl_partition_monitor_iteration().await;
 
-    assert_eq!(discovery_info.gpus.len(), 4);
-
-    let gpus: Vec<Gpu> = discovery_info.gpus.to_vec();
-
-    let gpu_uids: Vec<u64> = gpus
-        .iter()
-        .filter_map(|gpu| {
-            gpu.platform_info.as_ref().map(|platform_info| {
-                let s = platform_info.fabric_guid.trim();
-                if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
-                    u64::from_str_radix(hex, 16).unwrap_or(0)
-                } else {
-                    s.parse::<u64>().unwrap_or(0)
-                }
-            })
-        })
-        .collect();
-    assert_eq!(gpu_uids.len(), 4);
-
-    let mut nmxc_sim_client = env
+    let mut nmxc_client_9601 = env
         .nmxc_sim
         .create_client(libnmxc::Endpoint::new("http://localhost:9601").expect("NMX-C endpoint URI"))
         .await
-        .unwrap();
-
-    const NMXC_DEFAULT_PARTITION_ID: u32 = 32766;
-    nmxc_sim_client
-        .remove_gpus_from_partition(UpdatePartitionRequest {
-            context: None,
-            partition_id: Some(libnmxc::nmxc_model::PartitionId {
-                partition_id: NMXC_DEFAULT_PARTITION_ID,
+        .expect("create NMX-C client for domain :9601");
+    let _nmxc_gpus_9601 = nmxc_client_9601
+        .get_gpu_info_list(GetGpuInfoListRequest {
+            context: Some(libnmxc::nmxc_model::Context {
+                context: String::new(),
             }),
-            location_list: vec![],
-            gpu_uid: gpu_uids.clone(),
-            gateway_id: libnmxc::NMX_C_GATEWAY_ID.into(),
-            name: String::new(),
-            reroute: true,
-        })
-        .await
-        .expect("remove host GPUs from default NMX-C partition");
-    // create a NMX-C partition with all the GPUs from the managed host. This is used to simulate the case
-    // as if NMX-M created the partition
-    nmxc_sim_client
-        .create_partition(CreatePartitionRequest {
-            context: None,
-            name: "test-existing-nmxc-partition".to_string(),
-            gpu_resource_id: gpu_uids
-                .iter()
-                .map(|&uid| libnmxc::nmxc_model::GpuResourceId {
-                    resource_id: Some(libnmxc::nmxc_model::gpu_resource_id::ResourceId::GpuUid(
-                        uid,
-                    )),
-                })
-                .collect(),
-            attr: None,
+            attr: GpuAttr::NmxGpuAttrAll as i32,
+            num_gpus: 0,
+            loc: None,
             partition_id: None,
             gateway_id: libnmxc::NMX_C_GATEWAY_ID.into(),
+            gpu_health: 0,
         })
         .await
-        .expect("create NMX-C partition for managed host GPUs");
-
-    // Now create a NMX-M db nvlink partition entry. This should simulate the case where core had
-    // a pre-exisiting NMX-M partition
-    const NMXC_PARTITION_ID: u32 = 666_666;
-    let nmxc_partition_id = NMXC_PARTITION_ID;
-    let nmx_c_partition_id = i32::try_from(u64::from(nmxc_partition_id) + 10_000_000).unwrap();
-    let domain_uuid = machine
-        .nvlink_info
-        .as_ref()
-        .and_then(|info| info.domain_uuid)
-        .expect("domain_uuid from machine discovery nvlink_info");
-
-    let mut txn = db::Transaction::begin(&env.pool).await.unwrap();
-    db_nvl_partition::create(
-        &NewNvlPartition {
-            id: NvLinkPartitionId::new(),
-            nmx_c_partition_id,
-            domain_uuid,
-            name: NvlPartitionName::try_from("test_partition".to_string()).unwrap(),
-            logical_partition_id,
-        },
-        &mut txn,
-    )
-    .await
-    .unwrap();
-    txn.commit().await.unwrap();
-
-    let nvl_config = rpc::forge::InstanceNvLinkConfig {
-        gpu_configs: gpus
-            .iter()
-            .filter_map(|gpu| {
-                gpu.platform_info.as_ref().map(|platform_info| {
-                    rpc::forge::InstanceNvLinkGpuConfig {
-                        device_instance: platform_info.module_id - 1,
-                        logical_partition_id: None,
-                    }
-                })
-            })
-            .collect(),
-    };
-
-    let (_tinstance, instance) =
-        create_instance_with_nvlink_config(&env, &mh, nvl_config, segment_id).await;
-
-    let machine = mh.host().rpc_machine().await;
-    assert_eq!(&machine.state, "Assigned/Ready");
-
-    env.run_nvl_partition_monitor_iteration().await;
-
-    let request_all = tonic::Request::new(rpc::forge::NvLinkPartitionSearchFilter {
-        name: None,
-        tenant_organization_id: None,
-    });
-    let ids_before_update = env
-        .api
-        .find_nv_link_partition_ids(request_all)
+        .expect("GetGpuInfoList on :9601")
+        .gpu_info_list;
+    let mut nmxc_client_9602 = env
+        .nmxc_sim
+        .create_client(libnmxc::Endpoint::new("http://localhost:9602").expect("NMX-C endpoint URI"))
         .await
-        .map(|response| response.into_inner())
-        .unwrap();
-    assert_eq!(ids_before_update.partition_ids.len(), 1);
+        .expect("create NMX-C client for domain :9602");
+    let _nmxc_gpus_9602 = nmxc_client_9602
+        .get_gpu_info_list(GetGpuInfoListRequest {
+            context: Some(libnmxc::nmxc_model::Context {
+                context: String::new(),
+            }),
+            attr: GpuAttr::NmxGpuAttrAll as i32,
+            num_gpus: 0,
+            loc: None,
+            partition_id: None,
+            gateway_id: libnmxc::NMX_C_GATEWAY_ID.into(),
+            gpu_health: 0,
+        })
+        .await
+        .expect("GetGpuInfoList on :9602")
+        .gpu_info_list;
 
-    let new_nvl_config = rpc::forge::InstanceNvLinkConfig {
-        gpu_configs: gpus
+    let machine4 = mh4.host().rpc_machine().await;
+    let machine5 = mh5.host().rpc_machine().await;
+
+    assert_eq!(&machine4.state, "Ready");
+    assert_eq!(&machine5.state, "Ready");
+
+    let discovery_info4 = machine4.discovery_info.as_ref().unwrap();
+    let discovery_info5 = machine5.discovery_info.as_ref().unwrap();
+    assert_eq!(discovery_info4.gpus.len(), 4);
+    assert_eq!(discovery_info5.gpus.len(), 4);
+
+    let gpus4: Vec<Gpu> = discovery_info4.gpus.to_vec();
+    let gpus5: Vec<Gpu> = discovery_info5.gpus.to_vec();
+
+    let nvl_config5 = rpc::forge::InstanceNvLinkConfig {
+        gpu_configs: gpus5
             .iter()
             .filter_map(|gpu| {
                 gpu.platform_info.as_ref().map(|platform_info| {
@@ -2420,66 +2359,48 @@ async fn test_update_nvlink_config_nmxm_existing_partitions_with_nmxc_simulator(
             .collect(),
     };
 
-    let mut new_config = instance.config().inner().clone();
-    new_config.nvlink = Some(new_nvl_config);
-    let instance = env
-        .api
-        .update_instance_config(tonic::Request::new(
-            rpc::forge::InstanceConfigUpdateRequest {
-                instance_id: instance.id().into(),
-                if_version_match: None,
-                config: Some(new_config),
-                metadata: Some(instance.metadata().clone()),
-            },
-        ))
-        .await
-        .unwrap()
-        .into_inner();
-    let instance_status = instance.status.as_ref().unwrap();
-    assert_eq!(instance_status.configs_synced(), rpc::SyncState::Pending);
-    assert_eq!(
-        instance_status.tenant.as_ref().unwrap().state(),
-        rpc::TenantState::Configuring
-    );
+    let nvl_config4 = rpc::forge::InstanceNvLinkConfig {
+        gpu_configs: gpus4
+            .iter()
+            .filter_map(|gpu| {
+                gpu.platform_info.as_ref().map(|platform_info| {
+                    rpc::forge::InstanceNvLinkGpuConfig {
+                        device_instance: platform_info.module_id - 1,
+                        logical_partition_id: Some(logical_partition_id),
+                    }
+                })
+            })
+            .collect(),
+    };
 
-    env.run_nvl_partition_monitor_iteration().await;
-    env.run_nvl_partition_monitor_iteration().await;
+    let (tinstance4, instance4) =
+        create_instance_with_nvlink_config(&env, &mh4, nvl_config4.clone(), segment_id).await;
+    let (tinstance5, instance5) =
+        create_instance_with_nvlink_config(&env, &mh5, nvl_config5.clone(), segment_id).await;
 
-    let instance = env.one_instance(instance.id.unwrap()).await;
-    let instance_status = instance.status();
-    let nvl_status = instance_status.inner().nvlink.as_ref().unwrap();
-    assert_eq!(nvl_status.configs_synced(), rpc::SyncState::Synced);
+    let machine4 = mh4.host().rpc_machine().await;
+    let machine5 = mh5.host().rpc_machine().await;
+    assert_eq!(&machine4.state, "Assigned/Ready");
+    assert_eq!(&machine5.state, "Assigned/Ready");
 
-    // After partition monitor has run, it should delete the old partition created by NMX-M
-    // and create a new one with the GPUs.
+    let check_instance4 = tinstance4.rpc_instance().await;
+    let check_instance5 = tinstance5.rpc_instance().await;
+    assert_eq!(instance4.status().tenant(), rpc::TenantState::Ready);
+    assert_eq!(instance5.status().tenant(), rpc::TenantState::Ready);
+    assert_eq!(instance4, check_instance4);
+    assert_eq!(instance5, check_instance5);
     let request_all = tonic::Request::new(rpc::forge::NvLinkPartitionSearchFilter {
         name: None,
         tenant_organization_id: None,
     });
-    let ids_after_update = env
+
+    let ids_all = env
         .api
         .find_nv_link_partition_ids(request_all)
         .await
         .map(|response| response.into_inner())
         .unwrap();
-    assert_eq!(ids_after_update.partition_ids.len(), 2);
-
-    let nmxc_partitions = nmxc_sim_client
-        .get_partition_info_list(GetPartitionInfoListRequest {
-            context: Some(libnmxc::nmxc_model::Context {
-                context: String::new(),
-            }),
-            partition_id_list: vec![],
-            partition_name_list: vec![],
-            gateway_id: libnmxc::NMX_C_GATEWAY_ID.into(),
-        })
-        .await
-        .unwrap()
-        .partition_info_list;
-    assert!(
-        nmxc_partitions.iter().any(|p| p.gpu_uid_list.len() == 4),
-        "expected a Carbide-managed NMX-C partition with four GPUs after instance update, got: {nmxc_partitions:?}"
-    );
+    assert_eq!(ids_all.partition_ids.len(), 2);
 }
 
 #[crate::sqlx_test]
@@ -2666,4 +2587,141 @@ async fn test_managed_host_creation_with_tray_default_partition_use_nmxc_simulat
         .partition_info_list;
     assert_eq!(nmxc_partitions.len(), 1);
     assert_eq!(nmxc_partitions[0].name, "tray_partition_1");
+}
+
+#[crate::sqlx_test]
+async fn test_update_nvlink_config_nmxm_existing_partitions_with_nmxc_simulator(
+    pool: sqlx::PgPool,
+) {
+    if !nmxc_simulator_tests_enabled() {
+        println!(
+            "skipping test_update_nvlink_config_nmxm_existing_partitions_with_nmxc_simulator as nmxc simulator tests are not enabled"
+        );
+        return;
+    }
+
+    let mut config = common::api_fixtures::get_config();
+    if let Some(nvlink_config) = config.nvlink_config.as_mut() {
+        nvlink_config.enabled = true;
+    }
+
+    let mut test_overrides = TestEnvOverrides::with_config(config);
+    test_overrides.nmxc_simulator = Some(true);
+
+    let env =
+        common::api_fixtures::create_test_env_with_overrides(pool.clone(), test_overrides).await;
+
+    let _segment_id = env.create_vpc_and_tenant_segment().await;
+
+    let NvlLogicalPartitionFixture {
+        id: _logical_partition_id,
+        logical_partition: _logical_partition,
+    } = create_nvl_logical_partition(&env, "test_partition".to_string()).await;
+
+    let request_logical_ids =
+        tonic::Request::new(rpc::forge::NvLinkLogicalPartitionSearchFilter { name: None });
+
+    let logical_ids_list = env
+        .api
+        .find_nv_link_logical_partition_ids(request_logical_ids)
+        .await
+        .map(|response| response.into_inner())
+        .unwrap();
+    assert_eq!(logical_ids_list.partition_ids.len(), 1);
+
+    let mh = create_managed_host_with_hardware_info_template(
+        &env,
+        HardwareInfoTemplate::Custom(
+            crate::tests::common::api_fixtures::host::GB200_COMPUTE_TRAY_4_INFO_JSON,
+        ),
+    )
+    .await;
+    let machine = mh.host().rpc_machine().await;
+
+    assert_eq!(&machine.state, "Ready");
+    let discovery_info = machine.discovery_info.as_ref().unwrap();
+
+    assert_eq!(discovery_info.gpus.len(), 4);
+
+    let gpus: Vec<Gpu> = discovery_info.gpus.to_vec();
+
+    let gpu_uids: Vec<u64> = gpus
+        .iter()
+        .filter_map(|gpu| {
+            gpu.platform_info.as_ref().map(|platform_info| {
+                let s = platform_info.fabric_guid.trim();
+                if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+                    u64::from_str_radix(hex, 16).unwrap_or(0)
+                } else {
+                    s.parse::<u64>().unwrap_or(0)
+                }
+            })
+        })
+        .collect();
+    assert_eq!(gpu_uids.len(), 4);
+
+    let mut nmxc_sim_client = env
+        .nmxc_sim
+        .create_client(libnmxc::Endpoint::new("http://localhost:9601").expect("NMX-C endpoint URI"))
+        .await
+        .unwrap();
+
+    const NMXC_DEFAULT_PARTITION_ID: u32 = 32766;
+    nmxc_sim_client
+        .remove_gpus_from_partition(UpdatePartitionRequest {
+            context: None,
+            partition_id: Some(libnmxc::nmxc_model::PartitionId {
+                partition_id: NMXC_DEFAULT_PARTITION_ID,
+            }),
+            location_list: vec![],
+            gpu_uid: gpu_uids.clone(),
+            gateway_id: libnmxc::NMX_C_GATEWAY_ID.into(),
+            name: String::new(),
+            reroute: true,
+        })
+        .await
+        .expect("remove host GPUs from default NMX-C partition");
+
+    println!("\n\n\n\n\n\n\n creating 1\n");
+    // create a NMX-C partition with all the GPUs from the managed host. This is used to simulate the case
+    // as if NMX-M created the partition
+    nmxc_sim_client
+        .create_partition(CreatePartitionRequest {
+            context: None,
+            name: "test-existing-nmxc-partition".to_string(),
+            gpu_resource_id: gpu_uids
+                .iter()
+                .map(|&uid| libnmxc::nmxc_model::GpuResourceId {
+                    resource_id: Some(libnmxc::nmxc_model::gpu_resource_id::ResourceId::GpuUid(
+                        uid,
+                    )),
+                })
+                .collect(),
+            attr: None,
+            partition_id: None,
+            gateway_id: libnmxc::NMX_C_GATEWAY_ID.into(),
+        })
+        .await
+        .expect("create NMX-C partition for managed host GPUs");
+
+    println!("\n\n\n\n\n\n\n creating 2\n");
+
+    nmxc_sim_client
+        .create_partition(CreatePartitionRequest {
+            context: None,
+            name: "test-existing-nmxc-partition".to_string(),
+            gpu_resource_id: gpu_uids
+                .iter()
+                .map(|&uid| libnmxc::nmxc_model::GpuResourceId {
+                    resource_id: Some(libnmxc::nmxc_model::gpu_resource_id::ResourceId::GpuUid(
+                        uid,
+                    )),
+                })
+                .collect(),
+            attr: None,
+            partition_id: None,
+            gateway_id: libnmxc::NMX_C_GATEWAY_ID.into(),
+        })
+        .await
+        .expect("create NMX-C partition for managed host GPUs");
 }

--- a/crates/api-core/src/tests/nvl_instance.rs
+++ b/crates/api-core/src/tests/nvl_instance.rs
@@ -15,25 +15,24 @@
  * limitations under the License.
  */
 
-//use rpc::forge::NvlPartitionSearchFilter;
 use ::rpc::machine_discovery::Gpu;
 use carbide_uuid::nvlink::NvLinkPartitionId;
 use common::api_fixtures::create_managed_host_with_hardware_info_template;
 use common::api_fixtures::instance::{
     create_instance_with_nvlink_config, update_instance_nvlink_config,
 };
-use common::api_fixtures::managed_host::HardwareInfoTemplate;
-use common::api_fixtures::nvl_logical_partition::create_nvl_logical_partition;
-use db::{self, nvl_partition as db_nvl_partition};
 use libnmxc::nmxc_model::{
     CreatePartitionRequest, GetPartitionInfoListRequest, UpdatePartitionRequest,
 };
+
+use common::api_fixtures::managed_host::HardwareInfoTemplate;
+use common::api_fixtures::nvl_logical_partition::create_nvl_logical_partition;
+use db::{self, nvl_partition as db_nvl_partition};
 use model::instance::config::nvlink::InstanceNvLinkConfig;
 use model::nvl_partition::{NewNvlPartition, NvlPartitionName};
 use rpc::forge::TenantState;
 use rpc::forge::forge_server::Forge;
 
-// model::instance::config::nvlink::{InstanceNvLinkConfig, InstanceNvLinkGpuConfig},
 use crate::tests::common;
 use crate::tests::common::api_fixtures::TestEnvOverrides;
 use crate::tests::common::api_fixtures::nvl_logical_partition::NvlLogicalPartitionFixture;

--- a/crates/api-core/src/tests/nvl_instance.rs
+++ b/crates/api-core/src/tests/nvl_instance.rs
@@ -1498,16 +1498,8 @@ async fn test_create_instance_remove_from_default_partition(pool: sqlx::PgPool) 
         .await
         .unwrap()
         .partition_info_list;
-    assert_eq!(nmxc_partitions.len(), 2);
-    let default_partition = nmxc_partitions
-        .iter()
-        .find(|p| {
-            p.partition_id
-                .as_ref()
-                .is_some_and(|id| id.partition_id == 32766)
-        })
-        .expect("default partition");
-    assert_eq!(default_partition.gpu_uid_list.len(), 8);
+    // only the tenant partition should be present. The default partition should be removed.
+    assert_eq!(nmxc_partitions.len(), 1);
 }
 
 #[crate::sqlx_test]

--- a/crates/api-core/src/tests/nvl_instance.rs
+++ b/crates/api-core/src/tests/nvl_instance.rs
@@ -2585,6 +2585,8 @@ async fn test_instance_delete_with_nvl_config_use_nmxc_simulator(pool: sqlx::PgP
     env.run_nvl_partition_monitor_iteration().await;
     env.run_nvl_partition_monitor_iteration().await;
 
+    env.run_nvl_partition_monitor_iteration().await;
+
     let request_all = tonic::Request::new(rpc::forge::NvLinkPartitionSearchFilter {
         name: None,
         tenant_organization_id: None,
@@ -2597,4 +2599,73 @@ async fn test_instance_delete_with_nvl_config_use_nmxc_simulator(pool: sqlx::PgP
         .map(|response| response.into_inner())
         .unwrap();
     assert_eq!(ids_all.partition_ids.len(), 0);
+}
+
+
+#[crate::sqlx_test]
+async fn test_managed_host_creation_with_tray_default_partition_use_nmxc_simulator(pool: sqlx::PgPool) {
+    if !nmxc_simulator_tests_enabled() {
+        println!(
+            "skipping test_instance_delete_with_nvl_config_use_nmxc_simulator as nmxc simulator tests are not enabled"
+        );
+        return;
+    }
+
+    let mut config = common::api_fixtures::get_config();
+    if let Some(nvlink_config) = config.nvlink_config.as_mut() {
+        nvlink_config.enabled = true;
+    }
+
+    let mut test_overrides = TestEnvOverrides::with_config(config);
+    test_overrides.nmxc_simulator = Some(true);
+
+    let env =
+        common::api_fixtures::create_test_env_with_overrides(pool.clone(), test_overrides).await;
+
+    let _segment_id = env.create_vpc_and_tenant_segment().await;
+
+
+    let mh = create_managed_host_with_hardware_info_template(
+        &env,
+        HardwareInfoTemplate::Custom(
+            crate::tests::common::api_fixtures::host::GB200_COMPUTE_TRAY_4_INFO_JSON,
+        ),
+    )
+    .await;
+    let machine = mh.host().rpc_machine().await;
+
+    assert_eq!(&machine.state, "Ready");
+    let discovery_info = machine.discovery_info.as_ref().unwrap();
+
+    assert_eq!(discovery_info.gpus.len(), 4);
+
+    let gpus: Vec<Gpu> = discovery_info.gpus.to_vec();
+
+    println!("{gpus:?}");
+
+
+    // Run twice to record observation.
+    env.run_nvl_partition_monitor_iteration().await;
+    env.run_nvl_partition_monitor_iteration().await;
+    env.run_nvl_partition_monitor_iteration().await;
+
+    let mut nmxc_sim_client = env
+        .nmxc_sim
+        .create_client(libnmxc::Endpoint::new("http://localhost:9601").expect("NMX-C endpoint URI"))
+        .await
+        .unwrap();
+    let nmxc_partitions = nmxc_sim_client
+        .get_partition_info_list(GetPartitionInfoListRequest {
+            context: Some(libnmxc::nmxc_model::Context {
+                context: String::new(),
+            }),
+            partition_id_list: vec![],
+            partition_name_list: vec![],
+            gateway_id: libnmxc::NMX_C_GATEWAY_ID.into(),
+        })
+        .await
+        .unwrap()
+        .partition_info_list;
+    assert_eq!(nmxc_partitions.len(), 1);
+    assert_eq!(nmxc_partitions[0].name, "tray_partition_1");
 }

--- a/crates/api-model/src/hardware_info/test_data/gb200_compute_tray_5_info.json
+++ b/crates/api-model/src/hardware_info/test_data/gb200_compute_tray_5_info.json
@@ -1,0 +1,319 @@
+{
+    "cpu_info": [
+        {
+            "model": "Intel(R) Xeon(R) Gold 6354 CPU @ 3.00GHz",
+            "vendor": "GenuineIntel",
+            "sockets": 1,
+            "cores": 18,
+            "threads": 72
+        }
+    ],
+    "machine_type": "x86_64",
+    "nvme_devices": [
+        {
+            "model": "Dell Ent NVMe CM6 RI 1.92TB",
+            "serial": "61M0A0D2TCD8",
+            "firmware_rev": "2.1.3"
+        }
+    ],
+    "dmi_data": {
+        "board_name": "",
+        "board_version": "",
+        "bios_version": "1.13.0",
+        "bios_date": "01/01/1971",
+        "product_serial": "Host12346",
+        "board_serial": "HostBoard12346",
+        "chassis_serial": "HostChassis12346",
+        "product_name": "DGX GB200 Compute Tray",
+        "sys_vendor": "Dell Inc."
+    },
+    "block_devices": [
+        {
+            "model": "DELLBOSS_VD",
+            "serial": "e932d5c34b090010",
+            "revision": "MV.R00-0",
+            "device_type": "disk"
+        },
+        {
+            "model": "DELLBOSS_VD",
+            "serial": "e932d5c34b090010",
+            "revision": "MV.R00-0",
+            "device_type": "partition"
+        },
+        {
+            "model": "DELLBOSS_VD",
+            "serial": "e932d5c34b090010",
+            "revision": "MV.R00-0",
+            "device_type": "partition"
+        },
+        {
+            "model": "Dell Ent NVMe CM6 RI 1.92TB",
+            "serial": "61M0A0D2TCD8",
+            "revision": "2.1.3",
+            "device_type": "disk"
+        },
+        {
+            "model": "Dell Ent NVMe CM6 RI 1.92TB",
+            "serial": "61M0A0D2TCD8",
+            "revision": "2.1.3",
+            "device_type": "partition"
+        },
+        {
+            "model": "Dell Ent NVMe CM6 RI 1.92TB",
+            "serial": "61M0A0D2TCD8",
+            "revision": "2.1.3",
+            "device_type": "partition"
+        },
+        {
+            "model": "Dell Ent NVMe CM6 RI 1.92TB",
+            "serial": "61M0A098TCD8",
+            "revision": "2.1.3",
+            "device_type": "partition"
+        },
+        {
+            "model": "Dell Ent NVMe CM6 RI 1.92TB",
+            "serial": "61M0A098TCD8",
+            "revision": "2.1.3",
+            "device_type": "partition"
+        },
+        {
+            "model": "Dell Ent NVMe CM6 RI 1.92TB",
+            "serial": "61M0A098TCD8",
+            "revision": "2.1.3",
+            "device_type": "partition"
+        },
+        {
+            "model": "Dell Ent NVMe CM6 RI 1.92TB",
+            "serial": "61M0A0B8TCD8",
+            "revision": "2.1.3",
+            "device_type": "partition"
+        },
+        {
+            "model": "Dell Ent NVMe CM6 RI 1.92TB",
+            "serial": "61M0A0B8TCD8",
+            "revision": "2.1.3",
+            "device_type": "partition"
+        },
+        {
+            "model": "Dell Ent NVMe CM6 RI 1.92TB",
+            "serial": "61M0A0B8TCD8",
+            "revision": "2.1.3",
+            "device_type": "partition"
+        }
+    ],
+    "network_interfaces": [
+        {
+            "mac_address": "70:b5:e8:f0:50:28",
+            "pci_properties": {
+                "path": "/devices/pci0000:00/0000:00:1c.5/0000:04:00.0/net/eno8303",
+                "device": "0x165f",
+                "vendor": "0x14e4",
+                "numa_node": 0,
+                "description": "NetXtreme BCM5720 2-port Gigabit Ethernet PCIe (PowerEdge Rx5xx LOM Board)"
+            }
+        },
+        {
+            "mac_address": "70:b5:e8:f0:50:29",
+            "pci_properties": {
+                "path": "/devices/pci0000:00/0000:00:1c.5/0000:04:00.1/net/eno8403",
+                "device": "0x165f",
+                "vendor": "0x14e4",
+                "numa_node": 0,
+                "description": "NetXtreme BCM5720 2-port Gigabit Ethernet PCIe (PowerEdge Rx5xx LOM Board)"
+            }
+        },
+        {
+            "mac_address": "e4:3d:1a:15:3e:d0",
+            "pci_properties": {
+                "path": "/devices/pci0000:30/0000:30:04.0/0000:31:00.0/net/eno12399np0",
+                "device": "0x16d7",
+                "vendor": "0x14e4",
+                "numa_node": 0,
+                "description": "BCM57414 NetXtreme-E 10Gb/25Gb RDMA Ethernet Controller"
+            }
+        },
+        {
+            "mac_address": "e4:3d:1a:15:3e:d1",
+            "pci_properties": {
+                "path": "/devices/pci0000:30/0000:30:04.0/0000:31:00.1/net/eno12409np1",
+                "device": "0x16d7",
+                "vendor": "0x14e4",
+                "numa_node": 0,
+                "description": "BCM57414 NetXtreme-E 10Gb/25Gb RDMA Ethernet Controller"
+            }
+        },
+        {
+            "mac_address": "08:c0:eb:cb:0e:96",
+            "pci_properties": {
+                "path": "/devices/pci0000:b0/0000:b0:04.0/0000:b1:00.0/net/enp177s0f0np0",
+                "device": "BlueField SoC",
+                "vendor": "mellanox",
+                "numa_node": 1,
+                "description": "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller"
+            }
+        },
+        {
+            "mac_address": "08:c0:eb:cb:0e:97",
+            "pci_properties": {
+                "path": "/devices/pci0000:b0/0000:b0:04.0/0000:b1:00.1/net/enp177s0f1np1",
+                "device": "BlueField SoC",
+                "vendor": "mellanox",
+                "numa_node": 1,
+                "description": "MT42822 BlueField-2 integrated ConnectX-6 Dx network controller"
+            }
+        }
+    ],
+    "infiniband_interfaces": [
+        {
+            "pci_properties": {
+                "vendor": "0x15b3",
+                "device": "0x1021",
+                "path": "/devices/pci0000:b0/0000:c0:02.0/0000:c1:00.1/infiniband/ibp178s0f1",
+                "numaNode": 1,
+                "description": "MT2910 Family [ConnectX-7]",
+                "slot": "0000:c1:00.1"
+            },
+            "guid": "946dae03002ac100"
+        },
+        {
+            "pci_properties": {
+                "vendor": "0x15b3",
+                "device": "0x1021",
+                "path": "/devices/pci0000:b0/0000:c0:02.0/0000:c1:00.0/infiniband/ibp178s0f0",
+                "numaNode": 1,
+                "description": "MT2910 Family [ConnectX-7]",
+                "slot": "0000:c1:00.0"
+            },
+            "guid": "946dae03002ac101"
+        },
+        {
+            "pci_properties": {
+                "vendor": "0x15b3",
+                "device": "0x1021",
+                "path": "/devices/pci0000:b0/0000:b0:02.0/0000:b1:00.1/infiniband/ibp177s0f1",
+                "numaNode": 1,
+                "description": "MT2910 Family [ConnectX-7]",
+                "slot": "0000:b1:00.1"
+            },
+            "guid": "946dae03002ac102"
+        },
+        {
+            "pci_properties": {
+                "vendor": "0x15b3",
+                "device": "0x1021",
+                "path": "/devices/pci0000:b0/0000:b0:02.0/0000:b1:00.0/infiniband/ibp177s0f0",
+                "numaNode": 1,
+                "description": "MT2910 Family [ConnectX-7]",
+                "slot": "0000:b1:00.0"
+            },
+            "guid": "946dae03002ac103"
+        },
+        {
+            "pci_properties": {
+                "vendor": "0x15b3",
+                "device": "0x1017",
+                "path": "/devices/pci0000:97/0000:97:02.0/0000:98:00.0/infiniband/ibp152s0f0",
+                "numaNode": 1,
+                "description": "MT27800 Family [ConnectX-5]",
+                "slot": "0000:98:00.0"
+            },
+            "guid": "946dae03002ac752"
+        },
+        {
+            "pci_properties": {
+                "vendor": "0x15b3",
+                "device": "0x1017",
+                "path": "/devices/pci0000:97/0000:97:02.0/0000:98:00.1/infiniband/ibp152s0f1",
+                "numaNode": 1,
+                "description": "MT27800 Family [ConnectX-5]",
+                "slot": "0000:98:00.1"
+            },
+            "guid": "946dae03002ac753"
+        }
+    ],
+    "tpm_ek_certificate": "U29tZSBhcmJpdHJhcnkgYmFzZTY0",
+    "gpus": [
+        {
+            "name": "NVIDIA H100 PCIe",
+            "serial": "2054422005699",
+            "driver_version": "530.30.02",
+            "vbios_version": "96.00.30.00.01",
+            "inforom_version": "1010.0200.00.02",
+            "total_memory": "81559 MiB",
+            "frequency": "1755 MHz",
+            "pci_bus_id": "00000000:17:00.0",
+            "platform_info": {
+                "chassis_serial": "27ZYX27000001",
+                "slot_number": 1,
+                "tray_index": 1,
+                "host_id": 1,
+                "module_id": 1,
+                "fabric_guid": "2001"
+            }
+        },
+        {
+            "name": "NVIDIA H100 PCIe",
+            "serial": "2154422005699",
+            "driver_version": "530.30.02",
+            "vbios_version": "96.00.30.00.01",
+            "inforom_version": "1010.0200.00.02",
+            "total_memory": "81559 MiB",
+            "frequency": "1755 MHz",
+            "pci_bus_id": "00000000:17:00.1",
+            "platform_info": {
+                "chassis_serial": "27ZYX27000001",
+                "slot_number": 1,
+                "tray_index": 1,
+                "host_id": 1,
+                "module_id": 2,
+                "fabric_guid": "2002"
+            }
+        },
+        {
+            "name": "NVIDIA H100 PCIe",
+            "serial": "2254422005699",
+            "driver_version": "530.30.02",
+            "vbios_version": "96.00.30.00.01",
+            "inforom_version": "1010.0200.00.02",
+            "total_memory": "81559 MiB",
+            "frequency": "1755 MHz",
+            "pci_bus_id": "00000000:17:00.2",
+            "platform_info": {
+                "chassis_serial": "27ZYX27000001",
+                "slot_number": 1,
+                "tray_index": 1,
+                "host_id": 1,
+                "module_id": 3,
+                "fabric_guid": "2003"
+            }
+        },
+        {
+            "name": "NVIDIA H100 PCIe",
+            "serial": "2354422005699",
+            "driver_version": "530.30.02",
+            "vbios_version": "96.00.30.00.01",
+            "inforom_version": "1010.0200.00.02",
+            "total_memory": "81559 MiB",
+            "frequency": "1755 MHz",
+            "pci_bus_id": "00000000:17:00.3",
+            "platform_info": {
+                "chassis_serial": "27ZYX27000001",
+                "slot_number": 1,
+                "tray_index": 1,
+                "host_id": 1,
+                "module_id": 4,
+                "fabric_guid": "2004"
+            }
+        }
+    ],
+    "memory_devices": [
+        {
+            "size_mb": 1024,
+            "mem_type": "DDR4"
+        },
+        {
+            "size_mb": 1024,
+            "mem_type": "DDR4"
+        }
+    ]
+}

--- a/crates/api-model/src/machine/nvlink.rs
+++ b/crates/api-model/src/machine/nvlink.rs
@@ -81,9 +81,10 @@ pub fn nvlink_config_synced(
             ));
         };
         if gpu_config.logical_partition_id != gpu_observation.logical_partition_id {
-            return Err(NvLinkConfigNotSyncedReason(
-                "Logical partition ID mismatch between config and observation".to_string(),
-            ));
+            return Err(NvLinkConfigNotSyncedReason(format!(
+                "Logical partition ID mismatch between config and observation (gpu_config.logical_partition_id={:?}, gpu_observation.logical_partition_id={:?})",
+                gpu_config.logical_partition_id, gpu_observation.logical_partition_id,
+            )));
         }
         if gpu_config.logical_partition_id.is_some() && gpu_observation.partition_id.is_none() {
             return Err(NvLinkConfigNotSyncedReason(

--- a/crates/libnmxc/src/lib.rs
+++ b/crates/libnmxc/src/lib.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 mod nmxc_api;
+mod response;
 
 // Generated gRPC types and client from nmx_c.proto
 pub mod nmxc_model {
@@ -50,12 +51,35 @@ pub enum NmxcError {
 
     #[error("Connection not initialized")]
     Uninitialized,
+
+    #[error("NMX-C {operation} response missing server_header")]
+    MissingServerHeader { operation: &'static str },
+
+    #[error("NMX-C {operation} returned status code {return_code}")]
+    NmxReturnCode {
+        return_code: i32,
+        operation: &'static str,
+    },
 }
 
 impl NmxcError {
     /// Creates an error for invalid or missing response from the server.
     pub fn invalid_response(msg: impl Into<String>) -> Self {
         NmxcError::Status(tonic::Status::unknown(msg.into()))
+    }
+
+    /// NMX-C `server_header.return_code` when this error is [`NmxcError::NmxReturnCode`].
+    pub fn nmx_return_code(&self) -> Option<i32> {
+        match self {
+            NmxcError::NmxReturnCode { return_code, .. } => Some(*return_code),
+            _ => None,
+        }
+    }
+
+    /// True when NMX-C returned `NMX_ST_RESOURCE_EXHAUSTED`.
+    pub fn is_nmx_resource_exhausted(&self) -> bool {
+        self.nmx_return_code()
+            == Some(nmxc_model::StReturnCode::NmxStResourceExhausted as i32)
     }
 }
 

--- a/crates/libnmxc/src/lib.rs
+++ b/crates/libnmxc/src/lib.rs
@@ -78,8 +78,7 @@ impl NmxcError {
 
     /// True when NMX-C returned `NMX_ST_RESOURCE_EXHAUSTED`.
     pub fn is_nmx_resource_exhausted(&self) -> bool {
-        self.nmx_return_code()
-            == Some(nmxc_model::StReturnCode::NmxStResourceExhausted as i32)
+        self.nmx_return_code() == Some(nmxc_model::StReturnCode::NmxStResourceExhausted as i32)
     }
 }
 

--- a/crates/libnmxc/src/nmxc_api.rs
+++ b/crates/libnmxc/src/nmxc_api.rs
@@ -17,7 +17,16 @@
 use tonic::transport::Channel;
 
 use crate::nmxc_model::nmx_controller_client::NmxControllerClient;
+use crate::response::check_server_header_success;
 use crate::{Nmxc, NmxcError, nmxc_model};
+
+macro_rules! nmx_c_checked {
+    ($operation:literal, $future:expr) => {{
+        let response = $future.await?.into_inner();
+        check_server_header_success(response.server_header.as_ref(), $operation)?;
+        response
+    }};
+}
 
 fn default_context() -> nmxc_model::Context {
     nmxc_model::Context {
@@ -43,8 +52,7 @@ impl Nmxc for NmxcApi {
             major_version: nmxc_model::ProtoMsgMajorVersion::ProtoMsgMajorVersion as i32,
             minor_version: nmxc_model::ProtoMsgMinorVersion::ProtoMsgMinorVersion as i32,
         };
-        let res = self.client.hello(tonic::Request::new(req)).await?;
-        Ok(res.into_inner())
+        Ok(nmx_c_checked!("Hello", self.client.hello(tonic::Request::new(req))))
     }
 
     async fn get_domain_properties(
@@ -56,11 +64,10 @@ impl Nmxc for NmxcApi {
             context: Some(context.unwrap_or_else(default_context)),
             gateway_id: gateway_id.to_string(),
         };
-        let res = self
-            .client
-            .get_domain_properties(tonic::Request::new(req))
-            .await?;
-        Ok(res.into_inner())
+        Ok(nmx_c_checked!(
+            "GetDomainProperties",
+            self.client.get_domain_properties(tonic::Request::new(req))
+        ))
     }
 
     async fn get_domain_state_info(
@@ -72,11 +79,10 @@ impl Nmxc for NmxcApi {
             context: Some(context.unwrap_or_else(default_context)),
             gateway_id: gateway_id.to_string(),
         };
-        let res = self
-            .client
-            .get_domain_state_info(tonic::Request::new(req))
-            .await?;
-        Ok(res.into_inner())
+        Ok(nmx_c_checked!(
+            "GetDomainStateInfo",
+            self.client.get_domain_state_info(tonic::Request::new(req))
+        ))
     }
 
     async fn get_topology_info(
@@ -88,142 +94,133 @@ impl Nmxc for NmxcApi {
             context: Some(context.unwrap_or_else(default_context)),
             gateway_id: gateway_id.to_string(),
         };
-        let res = self
-            .client
-            .get_topology_info(tonic::Request::new(req))
-            .await?;
-        Ok(res.into_inner())
+        Ok(nmx_c_checked!(
+            "GetTopologyInfo",
+            self.client.get_topology_info(tonic::Request::new(req))
+        ))
     }
 
     async fn get_compute_node_count(
         &mut self,
         req: nmxc_model::GetComputeNodeCountRequest,
     ) -> Result<nmxc_model::GetComputeNodeCountResponse, NmxcError> {
-        let res = self
-            .client
-            .get_compute_node_count(tonic::Request::new(req))
-            .await?;
-        Ok(res.into_inner())
+        Ok(nmx_c_checked!(
+            "GetComputeNodeCount",
+            self.client.get_compute_node_count(tonic::Request::new(req))
+        ))
     }
 
     async fn get_compute_node_info_list(
         &mut self,
         req: nmxc_model::GetComputeNodeInfoListRequest,
     ) -> Result<nmxc_model::GetComputeNodeInfoListResponse, NmxcError> {
-        let res = self
-            .client
-            .get_compute_node_info_list(tonic::Request::new(req))
-            .await?;
-        Ok(res.into_inner())
+        Ok(nmx_c_checked!(
+            "GetComputeNodeInfoList",
+            self.client
+                .get_compute_node_info_list(tonic::Request::new(req))
+        ))
     }
 
     async fn get_gpu_info_list(
         &mut self,
         req: nmxc_model::GetGpuInfoListRequest,
     ) -> Result<nmxc_model::GetGpuInfoListResponse, NmxcError> {
-        let res = self
-            .client
-            .get_gpu_info_list(tonic::Request::new(req))
-            .await?;
-        Ok(res.into_inner())
+        Ok(nmx_c_checked!(
+            "GetGpuInfoList",
+            self.client.get_gpu_info_list(tonic::Request::new(req))
+        ))
     }
 
     async fn get_switch_node_count(
         &mut self,
         req: nmxc_model::GetSwitchNodeCountRequest,
     ) -> Result<nmxc_model::GetSwitchNodeCountResponse, NmxcError> {
-        let res = self
-            .client
-            .get_switch_node_count(tonic::Request::new(req))
-            .await?;
-        Ok(res.into_inner())
+        Ok(nmx_c_checked!(
+            "GetSwitchNodeCount",
+            self.client.get_switch_node_count(tonic::Request::new(req))
+        ))
     }
 
     async fn get_switch_node_info_list(
         &mut self,
         req: nmxc_model::GetSwitchNodeInfoListRequest,
     ) -> Result<nmxc_model::GetSwitchNodeInfoListResponse, NmxcError> {
-        let res = self
-            .client
-            .get_switch_node_info_list(tonic::Request::new(req))
-            .await?;
-        Ok(res.into_inner())
+        Ok(nmx_c_checked!(
+            "GetSwitchNodeInfoList",
+            self.client
+                .get_switch_node_info_list(tonic::Request::new(req))
+        ))
     }
 
     async fn get_partition_count(
         &mut self,
         req: nmxc_model::GetPartitionCountRequest,
     ) -> Result<nmxc_model::GetPartitionCountResponse, NmxcError> {
-        let res = self
-            .client
-            .get_partition_count(tonic::Request::new(req))
-            .await?;
-        Ok(res.into_inner())
+        Ok(nmx_c_checked!(
+            "GetPartitionCount",
+            self.client.get_partition_count(tonic::Request::new(req))
+        ))
     }
 
     async fn get_partition_id_list(
         &mut self,
         req: nmxc_model::GetPartitionIdListRequest,
     ) -> Result<nmxc_model::GetPartitionIdListResponse, NmxcError> {
-        let res = self
-            .client
-            .get_partition_id_list(tonic::Request::new(req))
-            .await?;
-        Ok(res.into_inner())
+        Ok(nmx_c_checked!(
+            "GetPartitionIdList",
+            self.client.get_partition_id_list(tonic::Request::new(req))
+        ))
     }
 
     async fn get_partition_info_list(
         &mut self,
         req: nmxc_model::GetPartitionInfoListRequest,
     ) -> Result<nmxc_model::GetPartitionInfoListResponse, NmxcError> {
-        let res = self
-            .client
-            .get_partition_info_list(tonic::Request::new(req))
-            .await?;
-        Ok(res.into_inner())
+        Ok(nmx_c_checked!(
+            "GetPartitionInfoList",
+            self.client
+                .get_partition_info_list(tonic::Request::new(req))
+        ))
     }
 
     async fn create_partition(
         &mut self,
         req: nmxc_model::CreatePartitionRequest,
     ) -> Result<nmxc_model::CreatePartitionResponse, NmxcError> {
-        let res = self
-            .client
-            .create_partition(tonic::Request::new(req))
-            .await?;
-        Ok(res.into_inner())
+        Ok(nmx_c_checked!(
+            "CreatePartition",
+            self.client.create_partition(tonic::Request::new(req))
+        ))
     }
 
     async fn delete_partition(
         &mut self,
         req: nmxc_model::DeletePartitionRequest,
     ) -> Result<nmxc_model::DeletePartitionResponse, NmxcError> {
-        let res = self
-            .client
-            .delete_partition(tonic::Request::new(req))
-            .await?;
-        Ok(res.into_inner())
+        Ok(nmx_c_checked!(
+            "DeletePartition",
+            self.client.delete_partition(tonic::Request::new(req))
+        ))
     }
 
     async fn add_gpus_to_partition(
         &mut self,
         req: nmxc_model::UpdatePartitionRequest,
     ) -> Result<nmxc_model::UpdatePartitionResponse, NmxcError> {
-        let res = self
-            .client
-            .add_gpus_to_partition(tonic::Request::new(req))
-            .await?;
-        Ok(res.into_inner())
+        Ok(nmx_c_checked!(
+            "AddGpusToPartition",
+            self.client.add_gpus_to_partition(tonic::Request::new(req))
+        ))
     }
 
     async fn remove_gpus_from_partition(
         &mut self,
         req: nmxc_model::UpdatePartitionRequest,
     ) -> Result<nmxc_model::UpdatePartitionResponse, NmxcError> {
-        let res = self
-            .client
-            .remove_gpus_from_partition(tonic::Request::new(req))
-            .await?;
-        Ok(res.into_inner())
+        Ok(nmx_c_checked!(
+            "RemoveGpusFromPartition",
+            self.client
+                .remove_gpus_from_partition(tonic::Request::new(req))
+        ))
     }
 }

--- a/crates/libnmxc/src/nmxc_api.rs
+++ b/crates/libnmxc/src/nmxc_api.rs
@@ -52,7 +52,10 @@ impl Nmxc for NmxcApi {
             major_version: nmxc_model::ProtoMsgMajorVersion::ProtoMsgMajorVersion as i32,
             minor_version: nmxc_model::ProtoMsgMinorVersion::ProtoMsgMinorVersion as i32,
         };
-        Ok(nmx_c_checked!("Hello", self.client.hello(tonic::Request::new(req))))
+        Ok(nmx_c_checked!(
+            "Hello",
+            self.client.hello(tonic::Request::new(req))
+        ))
     }
 
     async fn get_domain_properties(

--- a/crates/libnmxc/src/response.rs
+++ b/crates/libnmxc/src/response.rs
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::{NmxcError, nmxc_model};
+
+pub(crate) fn check_server_header_success(
+    header: Option<&nmxc_model::ServerHeader>,
+    operation: &'static str,
+) -> Result<(), NmxcError> {
+    let Some(header) = header else {
+        return Err(NmxcError::MissingServerHeader { operation });
+    };
+    if header.return_code == nmxc_model::StReturnCode::NmxStSuccess as i32 {
+        Ok(())
+    } else {
+        Err(NmxcError::NmxReturnCode {
+            return_code: header.return_code,
+            operation,
+        })
+    }
+}

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -41,7 +41,7 @@ use errors::{NvLinkManagerError, NvLinkManagerResult};
 use libnmxc::nmxc_model::{GetPartitionInfoListRequest, PartitionInfo};
 use libnmxc::{Endpoint, NMX_C_GATEWAY_ID, Nmxc, NmxcPool};
 use metrics::{AppliedChange, NmxcMetricOperationStatus, NvlPartitionMonitorMetrics};
-use model::hardware_info::MachineNvLinkInfo;
+use model::hardware_info::{MachineNvLinkInfo, NvLinkGpu};
 use model::instance::status::SyncState;
 use model::instance::status::nvlink::InstanceNvLinkStatus;
 use model::machine::machine_search_config::MachineSearchConfig;
@@ -56,6 +56,16 @@ use tracing::Instrument;
 
 /// Default NMX-M instance identifier for credentials and client lookup when none is specified.
 pub const DEFAULT_NMX_M_NAME: &str = "default";
+
+/// Multicast groups limit for new NMX-C partitions: floor(1024 / 36).
+const NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT: u32 = 1024 / 36;
+
+fn nmx_c_partition_create_attr() -> libnmxc::nmxc_model::PartitionAttr {
+    libnmxc::nmxc_model::PartitionAttr {
+        resiliency_mode: libnmxc::nmxc_model::ResiliencyMode::NmxResiliencyModeUndefined as i32,
+        multicast_groups_limit: NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT,
+    }
+}
 
 #[derive(Debug, Clone)]
 struct NmxcPartitionOperation {
@@ -115,6 +125,10 @@ pub struct PartitionProcessingContext {
     nmx_c_operations: HashMap<NvLinkLogicalPartitionId, Vec<NmxcPartitionOperation>>,
     unknown_partition_removal_operations: HashMap<u32, Vec<NmxcPartitionOperation>>,
     unknown_partition_addition_operations: HashMap<u32, NmxcPartitionOperation>,
+    /// Pending NMX-C `Create` for tray default partitions (key: GPU `slot_id`), merged after scanning hosts.
+    pending_tray_partition_creates_by_slot: HashMap<i32, NmxcPartitionOperation>,
+    /// At most one `RemoveUnknownPartition` for the NMX-C default partition this monitor pass (e.g. admin-network cleanup).
+    pending_delete_nmx_c_default_partition_once: Option<u32>,
 }
 
 fn nmx_c_partition_id_string(pi: &PartitionInfo) -> String {
@@ -130,6 +144,10 @@ fn is_nmx_c_default_partition(partition: &PartitionInfo) -> bool {
         .as_ref()
         .is_some_and(|id| id.partition_id == 32766);
     id_is_default || partition.name.contains("Default")
+}
+
+fn tray_default_partition_name(slot_id: i32) -> String {
+    format!("tray_partition_{slot_id}")
 }
 
 impl PartitionProcessingContext {
@@ -161,8 +179,110 @@ impl PartitionProcessingContext {
             nmx_c_operations: HashMap::new(),
             unknown_partition_removal_operations: HashMap::new(),
             unknown_partition_addition_operations: HashMap::new(),
+            pending_tray_partition_creates_by_slot: HashMap::new(),
+            pending_delete_nmx_c_default_partition_once: None,
         }
     }
+
+    /// If an NMX-C default partition exists, schedule deleting it at most once this monitor pass.
+    /// Returns `true` when a removal was already scheduled or this call newly scheduled it.
+    fn delete_nmx_c_default_partition_if_present(&mut self) -> bool {
+        if self.pending_delete_nmx_c_default_partition_once.is_some() {
+            return true;
+        }
+        let Some(default_pi) = self
+            .nmx_c_partitions
+            .values()
+            .find(|p| is_nmx_c_default_partition(p))
+        else {
+            return false;
+        };
+        let Some(pid) = default_pi.partition_id else {
+            return false;
+        };
+        self.pending_delete_nmx_c_default_partition_once = Some(pid.partition_id);
+        true
+    }
+
+    /// Coalesce one `Create` per `slot_id` for GPUs that need a new tray default partition in the same monitor pass.
+    fn enqueue_tray_default_partition_create(
+        &mut self,
+        slot_id: i32,
+        domain_uuid: NvLinkDomainId,
+        gpu_guid: u64,
+        partition_name: String,
+    ) {
+        self.pending_tray_partition_creates_by_slot
+            .entry(slot_id)
+            .and_modify(|op| {
+                if !op.gpu_uids.contains(&gpu_guid) {
+                    op.gpu_uids.push(gpu_guid);
+                }
+            })
+            .or_insert(NmxcPartitionOperation {
+                domain_uuid: Some(domain_uuid),
+                operation_type: NmxcPartitionOperationType::Create,
+                gpu_uids: vec![gpu_guid],
+                name: partition_name,
+                db_partition_id: None,
+            });
+    }
+
+    /// Queue NMX-C work so `gpu` is added to `tray_partition_{slot_id}` (existing partition or `Create`).
+    fn ensure_gpu_enqueued_into_tray_partition(
+        &mut self,
+        machine_id: &MachineId,
+        domain_uuid: NvLinkDomainId,
+        gpu: &NvLinkGpu,
+    ) -> NvLinkManagerResult<()> {
+        let tray_partition_nm = tray_default_partition_name(gpu.slot_id);
+
+        if let Some(tray_nmxc) = self
+            .nmx_c_partitions
+            .values()
+            .find(|p| p.name == tray_partition_nm)
+        {
+            let Some(partition_id_struct) = tray_nmxc.partition_id else {
+                tracing::warn!(
+                    machine_id = %machine_id,
+                    gpu_guid = %gpu.guid,
+                    tray_partition = %tray_partition_nm,
+                    "Tray default NMX-C partition has no partition_id; skipping"
+                );
+                return Ok(());
+            };
+            let nmx_c_id = partition_id_struct.partition_id;
+            let gpus_in_partition = tray_nmxc.gpu_uid_list.clone();
+
+            tracing::info!(
+                machine_id = %machine_id,
+                gpu_guid = %gpu.guid,
+                nmx_c_id,
+                tray_partition = %tray_partition_nm,
+                "Enqueueing add to tray default partition"
+            );
+            self.handle_gpu_addition_to_unknown_partition(
+                &partition_id_struct,
+                gpu.guid,
+                gpus_in_partition,
+            )?;
+        } else {
+            tracing::info!(
+                machine_id = %machine_id,
+                gpu_guid = %gpu.guid,
+                tray_partition = %tray_partition_nm,
+                "Enqueueing create of tray default partition"
+            );
+            self.enqueue_tray_default_partition_create(
+                gpu.slot_id,
+                domain_uuid,
+                gpu.guid,
+                tray_partition_nm,
+            );
+        }
+        Ok(())
+    }
+
     // Build a map from GPU UIDs (as string) to partition from NMX-C partition info list.
     fn build_gpu_to_partition_map(
         nmx_c_partitions: &[PartitionInfo],
@@ -1269,6 +1389,24 @@ impl NvlPartitionMonitor {
                     .or_insert(vec![operation.clone()]);
             }
         }
+        if let Some(default_nmx_c_id) =
+            std::mem::take(&mut partition_ctx.pending_delete_nmx_c_default_partition_once)
+        {
+            let operation = NmxcPartitionOperation {
+                domain_uuid: None,
+                operation_type: NmxcPartitionOperationType::RemoveUnknownPartition(default_nmx_c_id),
+                gpu_uids: vec![],
+                name: String::new(),
+                db_partition_id: None,
+            };
+            partition_ctx
+                .nmx_c_operations
+                .entry(NvLinkLogicalPartitionId::default())
+                .and_modify(|ops| {
+                    ops.push(operation.clone());
+                })
+                .or_insert(vec![operation]);
+        }
         for (_partition_nmx_c_id, operation) in
             partition_ctx.unknown_partition_addition_operations.iter()
         {
@@ -1279,6 +1417,14 @@ impl NvlPartitionMonitor {
                     ops.push(operation.clone());
                 })
                 .or_insert(vec![operation.clone()]);
+        }
+        for (_, operation) in std::mem::take(&mut partition_ctx.pending_tray_partition_creates_by_slot)
+        {
+            partition_ctx
+                .nmx_c_operations
+                .entry(NvLinkLogicalPartitionId::default())
+                .or_default()
+                .push(operation);
         }
         Ok(machine_gpu_statuses)
     }
@@ -1313,8 +1459,8 @@ impl NvlPartitionMonitor {
         }
     }
 
-    // Managed hosts that are no longer an instance should not have GPUs in any logical partitions.
-    // GPUs should be removed from the tenant partition and move to the default partition.
+    // Managed hosts that are no longer an instance should not have GPUs in tenant or NMX-C default
+    // partitions: move every GPU into its tray default partition (`tray_partition_{slot_id}`).
     pub fn check_machine_and_handle_gpu_removals(
         &self,
         mh: &ManagedHostStateSnapshot,
@@ -1329,100 +1475,116 @@ impl NvlPartitionMonitor {
             return Ok(());
         }
 
+        if partition_ctx.delete_nmx_c_default_partition_if_present() {
+            tracing::info!(
+                machine_id = %mh.host_snapshot.id,
+                "Deleting NMX-C default partition for admin-network machine without instance"
+            );
+            return Ok(());
+        }
+
         if let Some(nvlink_info) = &mh.host_snapshot.nvlink_info {
             for gpu in &nvlink_info.gpus {
                 let nmxc_partition = match partition_ctx.gpu_to_partition_map.get(&gpu.guid) {
                     // GPU is in a partition, so we need to remove it from the partition.
                     Some(p) => p,
                     None => {
-                        // GPU has been removed from  the partition it was previously in, now add it to the default partition.
-                        let Some(default_nmxc) = partition_ctx
-                            .nmx_c_partitions
-                            .values()
-                            .find(|p| is_nmx_c_default_partition(p))
-                        else {
-                            tracing::warn!(
-                                machine_id = %mh.host_snapshot.id,
-                                gpu_guid = %gpu.guid,
-                                "GPU not in any NMX-C partition and no default partition found; skipping"
-                            );
-                            continue;
-                        };
-                        let Some(partition_id_struct) = default_nmxc.partition_id else {
-                            tracing::warn!(
-                                machine_id = %mh.host_snapshot.id,
-                                gpu_guid = %gpu.guid,
-                                "Default NMX-C partition has no partition_id; skipping"
-                            );
-                            continue;
-                        };
-                        let nmx_c_id = partition_id_struct.partition_id;
-
-                        let gpus_in_partition = default_nmxc.gpu_uid_list.clone();
-
-                        tracing::info!(
-                            machine_id = %mh.host_snapshot.id,
-                            gpu_guid = %gpu.guid,
-                            nmx_c_id,
-                            "GPU not in any partition; enqueueing add to default partition"
-                        );
-                        partition_ctx.handle_gpu_addition_to_unknown_partition(
-                            &partition_id_struct,
-                            gpu.guid,
-                            gpus_in_partition,
+                        // GPU is not in any NMX-C partition; place it in the tray default partition
+                        // (named from this GPU's slot id), creating that partition if needed.
+                        partition_ctx.ensure_gpu_enqueued_into_tray_partition(
+                            &mh.host_snapshot.id,
+                            nvlink_info.domain_uuid,
+                            gpu,
                         )?;
                         continue;
                     }
                 };
 
+                let tray_nm = tray_default_partition_name(gpu.slot_id);
+                if nmxc_partition.name == tray_nm {
+                    continue;
+                }
+
                 let partition_id = nmxc_partition
                     .partition_id
                     .map(|id| id.partition_id)
                     .unwrap_or_default();
-                let Some((
+
+                if let Some((
                     db_partition_id,
                     db_logical_partition_id,
                     db_partition_name,
                     db_partition_nmx_c_id,
                 )) = partition_ctx.get_db_partition_info(partition_id)
-                else {
-                    if !is_nmx_c_default_partition(nmxc_partition) {
-                        tracing::error!(
-                            "No partition found with NMX-C ID = {} while processing removal of GPU {gpu:?} in admin network",
-                            partition_id,
+                {
+                    let gpu_ctx = GpuProcessingContext {
+                        gpu_guid: gpu.guid,
+                        domain_uuid: nvlink_info.domain_uuid,
+                        partition_id: db_partition_id,
+                        partition_name: db_partition_name.clone(),
+                        logical_partition_id: db_logical_partition_id,
+                        partition_nmx_c_id: db_partition_nmx_c_id,
+                    };
+
+                    let Some(gpus_to_keep) = partition_ctx.get_gpus_to_keep_after_removal(
+                        db_logical_partition_id,
+                        &gpu_ctx.partition_nmx_c_id,
+                        gpu.guid,
+                        &mh.host_snapshot.id,
+                        gpu.device_id.try_into().unwrap(),
+                    ) else {
+                        continue;
+                    };
+
+                    let logical_id = db_logical_partition_id.unwrap_or_default();
+                    tracing::info!(
+                        machine_id = %mh.host_snapshot.id,
+                        gpu_guid = %gpu.guid,
+                        logical_partition_id = %logical_id,
+                        gpus_to_keep = ?gpus_to_keep,
+                        "Handling GPU removal from partition for machine in admin network"
+                    );
+                    partition_ctx.handle_gpu_removal(&gpu_ctx, gpus_to_keep)?;
+                } else {
+                    let Some(pid_struct) = nmxc_partition.partition_id else {
+                        tracing::warn!(
+                            machine_id = %mh.host_snapshot.id,
+                            gpu_guid = %gpu.guid,
+                            nmx_c_partition_id = partition_id,
+                            "NMX-C partition has no partition_id; cannot remove GPU before tray move"
                         );
-                    }
-                    continue;
-                };
-
-                let gpu_ctx = GpuProcessingContext {
-                    gpu_guid: gpu.guid,
-                    domain_uuid: nvlink_info.domain_uuid,
-                    partition_id: db_partition_id,
-                    partition_name: db_partition_name.clone(),
-                    logical_partition_id: db_logical_partition_id,
-                    partition_nmx_c_id: db_partition_nmx_c_id,
-                };
-
-                let Some(gpus_to_keep) = partition_ctx.get_gpus_to_keep_after_removal(
-                    db_logical_partition_id,
-                    &gpu_ctx.partition_nmx_c_id,
-                    gpu.guid,
+                        continue;
+                    };
+                    let Some(gpus_to_keep) = partition_ctx
+                        .get_gpus_to_keep_in_unknown_partition_after_removal(
+                            &pid_struct,
+                            gpu.guid,
+                            &mh.host_snapshot.id,
+                            gpu.device_id.try_into().unwrap(),
+                        )
+                    else {
+                        continue;
+                    };
+                    tracing::info!(
+                        machine_id = %mh.host_snapshot.id,
+                        gpu_guid = %gpu.guid,
+                        nmx_c_partition_id = pid_struct.partition_id,
+                        gpus_to_keep = ?gpus_to_keep,
+                        "Handling GPU removal from NMX-C partition without DB row (admin network)"
+                    );
+                    partition_ctx.handle_gpu_removal_from_unknown_partition(
+                        &pid_struct,
+                        gpu.guid,
+                        gpus_to_keep,
+                    )?;
+                }
+/*
+                partition_ctx.ensure_gpu_enqueued_into_tray_partition(
                     &mh.host_snapshot.id,
-                    gpu.device_id.try_into().unwrap(),
-                ) else {
-                    continue;
-                };
-
-                let logical_id = db_logical_partition_id.unwrap_or_default();
-                tracing::info!(
-                    machine_id = %mh.host_snapshot.id,
-                    gpu_guid = %gpu.guid,
-                    logical_partition_id = %logical_id,
-                    gpus_to_keep = ?gpus_to_keep,
-                    "Handling GPU removal for machine in admin network"
-                );
-                partition_ctx.handle_gpu_removal(&gpu_ctx, gpus_to_keep)?;
+                    nvlink_info.domain_uuid,
+                    gpu,
+                )?;
+                */
             }
         }
         Ok(())
@@ -1466,17 +1628,21 @@ impl NvlPartitionMonitor {
                 let start_time = std::time::Instant::now();
                 let success = match &operation.operation_type {
                     NmxcPartitionOperationType::Create => {
-                        let name = format!(
-                            "{}{}",
-                            logical_partition_id,
-                            operation
-                                .gpu_uids
-                                .iter()
-                                .map(|u| u.to_string())
-                                .collect::<Vec<_>>()
-                                .join(",")
-                        );
-                        let name: String = name.chars().take(240).collect();
+                        let name = if operation.name.starts_with("tray_partition_") {
+                            operation.name.chars().take(240).collect::<String>()
+                        } else {
+                            let name = format!(
+                                "{}{}",
+                                logical_partition_id,
+                                operation
+                                    .gpu_uids
+                                    .iter()
+                                    .map(|u| u.to_string())
+                                    .collect::<Vec<_>>()
+                                    .join(",")
+                            );
+                            name.chars().take(240).collect::<String>()
+                        };
                         let request = libnmxc::nmxc_model::CreatePartitionRequest {
                             context: None,
                             name,
@@ -1491,7 +1657,7 @@ impl NvlPartitionMonitor {
                                     ),
                                 })
                                 .collect(),
-                            attr: None,
+                            attr: Some(nmx_c_partition_create_attr()),
                             partition_id: None,
                             gateway_id: NMX_C_GATEWAY_ID.into(),
                         };
@@ -1704,6 +1870,14 @@ impl NvlPartitionMonitor {
                             continue;
                         };
 
+                        if operation.name.starts_with("tray_partition_") {
+                            tracing::debug!(
+                                logical_partition_id = %logical_partition_id,
+                                name = %operation.name,
+                                "Skipping nvl_partition DB insert for tray partition"
+                            );
+                            continue;
+                        }
                         // Create the nvl partition in the database
                         let new_partition = model::nvl_partition::NewNvlPartition {
                             id: NvLinkPartitionId::new(),

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -154,8 +154,6 @@ pub struct PartitionProcessingContext {
     unknown_partition_addition_operations: HashMap<u32, NmxcPartitionOperation>,
     /// Pending NMX-C `Create` for tray default partitions (key: GPU `slot_id`), merged after scanning hosts.
     pending_tray_partition_creates_by_slot: HashMap<i32, NmxcPartitionOperation>,
-    /// At most one `RemoveUnknownPartition` for the NMX-C default partition this monitor pass (e.g. admin-network cleanup).
-    pending_delete_nmx_c_default_partition_once: Option<u32>,
 }
 
 fn nmx_c_partition_id_string(pi: &PartitionInfo) -> String {
@@ -207,27 +205,31 @@ impl PartitionProcessingContext {
             unknown_partition_removal_operations: HashMap::new(),
             unknown_partition_addition_operations: HashMap::new(),
             pending_tray_partition_creates_by_slot: HashMap::new(),
-            pending_delete_nmx_c_default_partition_once: None,
         }
     }
 
-    /// If an NMX-C default partition exists, schedule deleting it at most once this monitor pass.
-    /// Returns `true` when a removal was already scheduled or this call newly scheduled it.
-    fn delete_nmx_c_default_partition_if_present(&mut self) -> bool {
-        if self.pending_delete_nmx_c_default_partition_once.is_some() {
-            return true;
-        }
-        let Some(default_pi) = self
+    /// If the NMX-C default partition exists, enqueue its removal and return true.
+    fn enqueue_nmx_c_default_partition_removal_if_present(&mut self) -> bool {
+        let Some(default_nmx_c_id) = self
             .nmx_c_partitions
             .values()
             .find(|p| is_nmx_c_default_partition(p))
+            .and_then(|p| p.partition_id.map(|id| id.partition_id))
         else {
             return false;
         };
-        let Some(pid) = default_pi.partition_id else {
-            return false;
-        };
-        self.pending_delete_nmx_c_default_partition_once = Some(pid.partition_id);
+        self.nmx_c_operations
+            .entry(NvLinkLogicalPartitionId::default())
+            .or_default()
+            .push(NmxcPartitionOperation {
+                domain_uuid: None,
+                operation_type: NmxcPartitionOperationType::RemoveUnknownPartition(
+                    default_nmx_c_id,
+                ),
+                gpu_uids: vec![],
+                name: String::new(),
+                db_partition_id: None,
+            });
         true
     }
 
@@ -1120,6 +1122,12 @@ impl NvlPartitionMonitor {
     ) -> NvLinkManagerResult<HashMap<MachineId, MachineNvLinkStatusObservation>> {
         let mut machine_gpu_statuses = HashMap::new();
 
+        // If the default partition is present, enqueue a removal operation and return early.
+        // no observations will be generated
+        if partition_ctx.enqueue_nmx_c_default_partition_removal_if_present() {
+            return Ok(machine_gpu_statuses);
+        }
+
         for mh in mh_snapshots.values() {
             metrics.num_machines_scanned += 1;
             let Some(instance) = &mh.instance else {
@@ -1416,26 +1424,6 @@ impl NvlPartitionMonitor {
                     .or_insert(vec![operation.clone()]);
             }
         }
-        if let Some(default_nmx_c_id) =
-            std::mem::take(&mut partition_ctx.pending_delete_nmx_c_default_partition_once)
-        {
-            let operation = NmxcPartitionOperation {
-                domain_uuid: None,
-                operation_type: NmxcPartitionOperationType::RemoveUnknownPartition(
-                    default_nmx_c_id,
-                ),
-                gpu_uids: vec![],
-                name: String::new(),
-                db_partition_id: None,
-            };
-            partition_ctx
-                .nmx_c_operations
-                .entry(NvLinkLogicalPartitionId::default())
-                .and_modify(|ops| {
-                    ops.push(operation.clone());
-                })
-                .or_insert(vec![operation]);
-        }
         for (_partition_nmx_c_id, operation) in
             partition_ctx.unknown_partition_addition_operations.iter()
         {
@@ -1504,13 +1492,6 @@ impl NvlPartitionMonitor {
         if !mh.use_admin_network() {
             return Ok(());
         }
-
-        if partition_ctx.delete_nmx_c_default_partition_if_present() {
-            println!("\n\n\n\n\nDeleting NMX-C default partition");
-            return Ok(());
-        }
-
-        println!("\n\n\n\n\nNot deleting NMX-C default partition");
 
         if let Some(nvlink_info) = &mh.host_snapshot.nvlink_info {
             for gpu in &nvlink_info.gpus {

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -1588,13 +1588,6 @@ impl NvlPartitionMonitor {
                         gpus_to_keep,
                     )?;
                 }
-                /*
-                partition_ctx.ensure_gpu_enqueued_into_tray_partition(
-                    &mh.host_snapshot.id,
-                    nvlink_info.domain_uuid,
-                    gpu,
-                )?;
-                */
             }
         }
         Ok(())

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -57,7 +57,7 @@ use tracing::Instrument;
 /// Default NMX-M instance identifier for credentials and client lookup when none is specified.
 pub const DEFAULT_NMX_M_NAME: &str = "default";
 
-/// Multicast groups limit for new NMX-C partitions. Assuming at most 2 partitions per tray and 
+/// Multicast groups limit for new NMX-C partitions. Assuming at most 2 partitions per tray and
 // 18 tray default partitions, this is set to floor(1024 / (36+18)).
 const NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT: u32 = 1024 / (36 + 18);
 
@@ -81,9 +81,9 @@ fn nmx_c_create_partition_request(
         gpu_resource_id: gpu_uids
             .iter()
             .map(|&uid| libnmxc::nmxc_model::GpuResourceId {
-                resource_id: Some(
-                    libnmxc::nmxc_model::gpu_resource_id::ResourceId::GpuUid(uid),
-                ),
+                resource_id: Some(libnmxc::nmxc_model::gpu_resource_id::ResourceId::GpuUid(
+                    uid,
+                )),
             })
             .collect(),
         attr: Some(nmx_c_partition_create_attr_with_multicast_groups_limit(
@@ -1421,7 +1421,9 @@ impl NvlPartitionMonitor {
         {
             let operation = NmxcPartitionOperation {
                 domain_uuid: None,
-                operation_type: NmxcPartitionOperationType::RemoveUnknownPartition(default_nmx_c_id),
+                operation_type: NmxcPartitionOperationType::RemoveUnknownPartition(
+                    default_nmx_c_id,
+                ),
                 gpu_uids: vec![],
                 name: String::new(),
                 db_partition_id: None,
@@ -1445,7 +1447,8 @@ impl NvlPartitionMonitor {
                 })
                 .or_insert(vec![operation.clone()]);
         }
-        for (_, operation) in std::mem::take(&mut partition_ctx.pending_tray_partition_creates_by_slot)
+        for (_, operation) in
+            std::mem::take(&mut partition_ctx.pending_tray_partition_creates_by_slot)
         {
             partition_ctx
                 .nmx_c_operations
@@ -1503,8 +1506,11 @@ impl NvlPartitionMonitor {
         }
 
         if partition_ctx.delete_nmx_c_default_partition_if_present() {
+            println!("\n\n\n\n\nDeleting NMX-C default partition");
             return Ok(());
         }
+
+        println!("\n\n\n\n\nNot deleting NMX-C default partition");
 
         if let Some(nvlink_info) = &mh.host_snapshot.nvlink_info {
             for gpu in &nvlink_info.gpus {
@@ -1601,7 +1607,7 @@ impl NvlPartitionMonitor {
                         gpus_to_keep,
                     )?;
                 }
-/*
+                /*
                 partition_ctx.ensure_gpu_enqueued_into_tray_partition(
                     &mh.host_snapshot.id,
                     nvlink_info.domain_uuid,
@@ -1671,11 +1677,12 @@ impl NvlPartitionMonitor {
                             &operation.gpu_uids,
                             NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT,
                         );
-                        match nmxc_client.create_partition(request).await {
+                        match nmxc_client.create_partition(request.clone()).await {
                             Err(e) if e.is_nmx_resource_exhausted() => {
                                 tracing::info!(
                                     %logical_partition_id,
                                     partition_name = %name,
+                                    create_partition_request = ?request,
                                     "NMX-C create partition returned NMX_ST_RESOURCE_EXHAUSTED; retrying with multicast_groups_limit=0"
                                 );
                                 let retry_request =
@@ -1695,6 +1702,7 @@ impl NvlPartitionMonitor {
                             Err(e) => {
                                 tracing::warn!(
                                     %logical_partition_id,
+                                    create_partition_request = ?request,
                                     "Failed to issue create partition to NMX-C, continuing with other operations: {e}"
                                 );
                                 false

--- a/crates/nvlink-manager/src/lib.rs
+++ b/crates/nvlink-manager/src/lib.rs
@@ -57,13 +57,40 @@ use tracing::Instrument;
 /// Default NMX-M instance identifier for credentials and client lookup when none is specified.
 pub const DEFAULT_NMX_M_NAME: &str = "default";
 
-/// Multicast groups limit for new NMX-C partitions: floor(1024 / 36).
-const NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT: u32 = 1024 / 36;
+/// Multicast groups limit for new NMX-C partitions. Assuming at most 2 partitions per tray and 
+// 18 tray default partitions, this is set to floor(1024 / (36+18)).
+const NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT: u32 = 1024 / (36 + 18);
 
-fn nmx_c_partition_create_attr() -> libnmxc::nmxc_model::PartitionAttr {
+fn nmx_c_partition_create_attr_with_multicast_groups_limit(
+    multicast_groups_limit: u32,
+) -> libnmxc::nmxc_model::PartitionAttr {
     libnmxc::nmxc_model::PartitionAttr {
         resiliency_mode: libnmxc::nmxc_model::ResiliencyMode::NmxResiliencyModeUndefined as i32,
-        multicast_groups_limit: NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT,
+        multicast_groups_limit,
+    }
+}
+
+fn nmx_c_create_partition_request(
+    name: String,
+    gpu_uids: &[u64],
+    multicast_groups_limit: u32,
+) -> libnmxc::nmxc_model::CreatePartitionRequest {
+    libnmxc::nmxc_model::CreatePartitionRequest {
+        context: None,
+        name,
+        gpu_resource_id: gpu_uids
+            .iter()
+            .map(|&uid| libnmxc::nmxc_model::GpuResourceId {
+                resource_id: Some(
+                    libnmxc::nmxc_model::gpu_resource_id::ResourceId::GpuUid(uid),
+                ),
+            })
+            .collect(),
+        attr: Some(nmx_c_partition_create_attr_with_multicast_groups_limit(
+            multicast_groups_limit,
+        )),
+        partition_id: None,
+        gateway_id: NMX_C_GATEWAY_ID.into(),
     }
 }
 
@@ -1476,10 +1503,6 @@ impl NvlPartitionMonitor {
         }
 
         if partition_ctx.delete_nmx_c_default_partition_if_present() {
-            tracing::info!(
-                machine_id = %mh.host_snapshot.id,
-                "Deleting NMX-C default partition for admin-network machine without instance"
-            );
             return Ok(());
         }
 
@@ -1643,25 +1666,31 @@ impl NvlPartitionMonitor {
                             );
                             name.chars().take(240).collect::<String>()
                         };
-                        let request = libnmxc::nmxc_model::CreatePartitionRequest {
-                            context: None,
-                            name,
-                            gpu_resource_id: operation
-                                .gpu_uids
-                                .iter()
-                                .map(|&uid| libnmxc::nmxc_model::GpuResourceId {
-                                    resource_id: Some(
-                                        libnmxc::nmxc_model::gpu_resource_id::ResourceId::GpuUid(
-                                            uid,
-                                        ),
-                                    ),
-                                })
-                                .collect(),
-                            attr: Some(nmx_c_partition_create_attr()),
-                            partition_id: None,
-                            gateway_id: NMX_C_GATEWAY_ID.into(),
-                        };
+                        let request = nmx_c_create_partition_request(
+                            name.clone(),
+                            &operation.gpu_uids,
+                            NMX_C_PARTITION_MULTICAST_GROUPS_LIMIT,
+                        );
                         match nmxc_client.create_partition(request).await {
+                            Err(e) if e.is_nmx_resource_exhausted() => {
+                                tracing::info!(
+                                    %logical_partition_id,
+                                    partition_name = %name,
+                                    "NMX-C create partition returned NMX_ST_RESOURCE_EXHAUSTED; retrying with multicast_groups_limit=0"
+                                );
+                                let retry_request =
+                                    nmx_c_create_partition_request(name, &operation.gpu_uids, 0);
+                                match nmxc_client.create_partition(retry_request).await {
+                                    Ok(_) => true,
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            %logical_partition_id,
+                                            "Failed to retry create partition on NMX-C with multicast_groups_limit=0: {e}"
+                                        );
+                                        false
+                                    }
+                                }
+                            }
                             Ok(_) => true,
                             Err(e) => {
                                 tracing::warn!(
@@ -1762,15 +1791,16 @@ impl NvlPartitionMonitor {
                                         name: String::new(),
                                         reroute: true,
                                     };
-                                    if let Err(e) =
-                                        nmxc_client.remove_gpus_from_partition(req).await
-                                    {
-                                        tracing::warn!(
-                                            %logical_partition_id,
-                                            %nmx_c_partition_id,
-                                            "Failed to remove GPUs from partition on NMX-C: {e}"
-                                        );
-                                        ok = false;
+                                    match nmxc_client.remove_gpus_from_partition(req).await {
+                                        Ok(_) => {}
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                %logical_partition_id,
+                                                %nmx_c_partition_id,
+                                                "Failed to remove GPUs from partition on NMX-C: {e}"
+                                            );
+                                            ok = false;
+                                        }
                                     }
                                 }
                                 if ok && !to_add.is_empty() {
@@ -1783,13 +1813,16 @@ impl NvlPartitionMonitor {
                                         name: String::new(),
                                         reroute: true,
                                     };
-                                    if let Err(e) = nmxc_client.add_gpus_to_partition(req).await {
-                                        tracing::warn!(
-                                            %logical_partition_id,
-                                            %nmx_c_partition_id,
-                                            "Failed to add GPUs to partition on NMX-C: {e}"
-                                        );
-                                        ok = false;
+                                    match nmxc_client.add_gpus_to_partition(req).await {
+                                        Ok(_) => {}
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                %logical_partition_id,
+                                                %nmx_c_partition_id,
+                                                "Failed to add GPUs to partition on NMX-C: {e}"
+                                            );
+                                            ok = false;
+                                        }
                                     }
                                 }
                                 ok

--- a/crates/nvlink-manager/src/nvlink.rs
+++ b/crates/nvlink-manager/src/nvlink.rs
@@ -225,6 +225,11 @@ pub mod test_support {
                 ..Default::default()
             }
         }
+
+        /// True when `endpoint` carries a URL from `nvlink_nmxc_endpoints` (non-empty host).
+        fn nvlink_nmxc_endpoint_is_set(endpoint: &Endpoint) -> bool {
+            endpoint.uri.host().is_some_and(|host| !host.is_empty())
+        }
     }
 
     #[::async_trait::async_trait]
@@ -512,13 +517,15 @@ pub mod test_support {
 
     #[::async_trait::async_trait]
     impl NmxcPool for NmxcSimClient {
-        async fn create_client(&self, _endpoint: Endpoint) -> Result<Box<dyn Nmxc>, NmxcError> {
+        async fn create_client(&self, endpoint: Endpoint) -> Result<Box<dyn Nmxc>, NmxcError> {
             if let Some(pool) = &self._grpc_pool {
-                let ep = self
-                    ._simulator_endpoint
-                    .as_ref()
-                    .expect("simulator mode must set _simulator_endpoint")
-                    .clone();
+                let ep = if Self::nvlink_nmxc_endpoint_is_set(&endpoint) {
+                    endpoint
+                } else {
+                    self._simulator_endpoint
+                        .clone()
+                        .expect("simulator mode must set _simulator_endpoint")
+                };
                 return pool.create_client(ep).await;
             }
             Ok(Box::new(NmxcSimClient {

--- a/crates/nvlink-manager/src/nvlink.rs
+++ b/crates/nvlink-manager/src/nvlink.rs
@@ -218,15 +218,23 @@ pub mod test_support {
                 })
                 .collect()
         }
+
+        fn success_server_header() -> nmxc_model::ServerHeader {
+            nmxc_model::ServerHeader {
+                return_code: nmxc_model::StReturnCode::NmxStSuccess as i32,
+                ..Default::default()
+            }
+        }
     }
 
     #[::async_trait::async_trait]
     impl Nmxc for NmxcSimClient {
         async fn hello(&mut self, _gateway_id: &str) -> Result<nmxc_model::ServerHello, NmxcError> {
             Ok(nmxc_model::ServerHello {
-                server_header: Some(nmxc_model::ServerHeader {
-                    domain_uuid: "ffffffff-ffff-ffff-ffff-ffffffffffff".to_string(),
-                    ..Default::default()
+                server_header: Some({
+                    let mut header = Self::success_server_header();
+                    header.domain_uuid = "ffffffff-ffff-ffff-ffff-ffffffffffff".to_string();
+                    header
                 }),
                 components_ver: vec![],
                 capabilities: vec![],
@@ -243,7 +251,7 @@ pub mod test_support {
             _gateway_id: &str,
         ) -> Result<nmxc_model::DomainProperties, NmxcError> {
             Ok(nmxc_model::DomainProperties {
-                server_header: None,
+                server_header: Some(Self::success_server_header()),
                 context: None,
                 max_compute_nodes: 0,
                 max_compute_nodes_per_chassis: 0,
@@ -268,7 +276,7 @@ pub mod test_support {
             _gateway_id: &str,
         ) -> Result<nmxc_model::DomainStateInfo, NmxcError> {
             Ok(nmxc_model::DomainStateInfo {
-                server_header: None,
+                server_header: Some(Self::success_server_header()),
                 context: None,
                 control_plane_state: 0,
                 available_multicast_groups: 0,
@@ -283,7 +291,7 @@ pub mod test_support {
             _gateway_id: &str,
         ) -> Result<nmxc_model::FmTopologyInfo, NmxcError> {
             Ok(nmxc_model::FmTopologyInfo {
-                server_header: None,
+                server_header: Some(Self::success_server_header()),
                 context: None,
                 device_topo_info: vec![],
             })
@@ -294,7 +302,7 @@ pub mod test_support {
             _req: nmxc_model::GetComputeNodeCountRequest,
         ) -> Result<GetComputeNodeCountResponse, NmxcError> {
             Ok(GetComputeNodeCountResponse {
-                server_header: None,
+                server_header: Some(Self::success_server_header()),
                 context: None,
                 num_nodes: 0,
             })
@@ -305,7 +313,7 @@ pub mod test_support {
             _req: nmxc_model::GetComputeNodeInfoListRequest,
         ) -> Result<GetComputeNodeInfoListResponse, NmxcError> {
             Ok(GetComputeNodeInfoListResponse {
-                server_header: None,
+                server_header: Some(Self::success_server_header()),
                 context: None,
                 node_info_list: vec![],
             })
@@ -316,7 +324,7 @@ pub mod test_support {
             _req: nmxc_model::GetGpuInfoListRequest,
         ) -> Result<GetGpuInfoListResponse, NmxcError> {
             Ok(GetGpuInfoListResponse {
-                server_header: None,
+                server_header: Some(Self::success_server_header()),
                 context: None,
                 gpu_info_list: vec![],
             })
@@ -327,7 +335,7 @@ pub mod test_support {
             _req: nmxc_model::GetSwitchNodeCountRequest,
         ) -> Result<GetSwitchNodeCountResponse, NmxcError> {
             Ok(GetSwitchNodeCountResponse {
-                server_header: None,
+                server_header: Some(Self::success_server_header()),
                 context: None,
                 num_nodes: 0,
             })
@@ -338,7 +346,7 @@ pub mod test_support {
             _req: nmxc_model::GetSwitchNodeInfoListRequest,
         ) -> Result<GetSwitchNodeInfoListResponse, NmxcError> {
             Ok(GetSwitchNodeInfoListResponse {
-                server_header: None,
+                server_header: Some(Self::success_server_header()),
                 context: None,
                 node_info_list: vec![],
             })
@@ -350,7 +358,7 @@ pub mod test_support {
         ) -> Result<GetPartitionCountResponse, NmxcError> {
             let n = self._partitions.lock().unwrap().len() as u32;
             Ok(GetPartitionCountResponse {
-                server_header: None,
+                server_header: Some(Self::success_server_header()),
                 context: None,
                 num_partitions: n,
             })
@@ -371,7 +379,7 @@ pub mod test_support {
                 })
                 .collect();
             Ok(GetPartitionIdListResponse {
-                server_header: None,
+                server_header: Some(Self::success_server_header()),
                 context: None,
                 partition_list,
             })
@@ -398,7 +406,7 @@ pub mod test_support {
                         .collect()
                 };
             Ok(GetPartitionInfoListResponse {
-                server_header: None,
+                server_header: Some(Self::success_server_header()),
                 context: None,
                 partition_info_list,
             })
@@ -430,7 +438,7 @@ pub mod test_support {
                 gpu_uids,
             });
             Ok(nmxc_model::CreatePartitionResponse {
-                server_header: None,
+                server_header: Some(Self::success_server_header()),
                 context: None,
                 partition_id: Some(nmxc_model::PartitionId { partition_id }),
             })
@@ -446,7 +454,7 @@ pub mod test_support {
                 .unwrap()
                 .retain(|p| p.partition_id != pid);
             Ok(nmxc_model::DeletePartitionResponse {
-                server_header: None,
+                server_header: Some(Self::success_server_header()),
                 context: None,
                 partition_id: Some(nmxc_model::PartitionId { partition_id: pid }),
             })
@@ -472,7 +480,7 @@ pub mod test_support {
                 }
             }
             Ok(nmxc_model::UpdatePartitionResponse {
-                server_header: None,
+                server_header: Some(Self::success_server_header()),
                 context: None,
                 partition_id: Some(nmxc_model::PartitionId { partition_id: pid }),
             })
@@ -495,7 +503,7 @@ pub mod test_support {
                 .ok_or_else(|| NmxcError::invalid_response("partition not found"))?;
             partition.gpu_uids.retain(|u| !remove.contains(u));
             Ok(nmxc_model::UpdatePartitionResponse {
-                server_header: None,
+                server_header: Some(Self::success_server_header()),
                 context: None,
                 partition_id: Some(nmxc_model::PartitionId { partition_id: pid }),
             })


### PR DESCRIPTION
## Description
To help with multicast group limit attribute settings on nvlink partitions, domain default partitions are deleted and all GPUs of a tray are moved to tray default partitions (TDPs) after discovery.
TDP implementation details:
* Use of TDPs and multicast group limit settings will require domain default partitions to be deleted
* TDPs are identified by their name ("tray_partition_" + "$(slot_id)", so we will have tray_partition_1, tray_partition_2 and so on)
* TDPs are not added to the nvlink partitions db, and are only present on the NMX-C
* As soon as a managed host with no instance is seen by our partition_monitor, any GPUs belonging to it will be moved to TDP.
* On instance creation, if no nvlink_config has been provided, GPUs continue to exist in TDP.
* On instance deletion, GPUs that are not in TDP will be moved back to TDP.
* If tenant applies subset nvlink config, only GPUs with config will be moved to tenant partition, other GPUs in the tray will remain TDP.
* When tenant clears nvlink config in an instnce, GPUs that do not have a nvlink config will end up isolated.
* All partitions are created with mutlicast group limit attribute set to 18.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ X] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://github.com/NVIDIA/infra-controller/issues/1559

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [X] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

