### PR TITLE
feat(rpc): gate prost builders behind test-support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,7 +1226,6 @@ dependencies = [
  "carbide-nvlink-manager",
  "carbide-power-shelf-controller",
  "carbide-preingestion-manager",
- "carbide-prost-builder",
  "carbide-rack",
  "carbide-rack-controller",
  "carbide-redfish",
@@ -2358,10 +2357,8 @@ dependencies = [
 name = "carbide-macros"
 version = "0.0.0"
 dependencies = [
- "eyre",
  "proc-macro2",
  "quote",
- "sqlx",
  "sqlx-macros-core",
  "syn 2.0.117",
 ]
@@ -2665,6 +2662,7 @@ dependencies = [
  "carbide-libmlx-model",
  "carbide-measured-boot",
  "carbide-network",
+ "carbide-prost-builder",
  "carbide-secrets",
  "carbide-tls",
  "carbide-utils",

--- a/crates/api-core/Cargo.toml
+++ b/crates/api-core/Cargo.toml
@@ -51,8 +51,6 @@ carbide-network-segment-controller = { path = "../network-segment-controller" }
 carbide-nvlink-manager = { path = "../nvlink-manager" }
 carbide-power-shelf-controller = { path = "../power-shelf-controller" }
 carbide-preingestion-manager = { path = "../preingestion-manager" }
-# Optional: only used by the `tests::common` fixtures, gated behind the `test-support` feature.
-carbide-prost-builder = { path = "../prost-builder", optional = true }
 carbide-rack = { path = "../rack" }
 carbide-rack-controller = { path = "../rack-controller" }
 carbide-redfish = { path = "../redfish" }
@@ -126,8 +124,6 @@ opentelemetry_sdk = { workspace = true, features = [
 pkcs1 = { workspace = true }
 p256 = { workspace = true }
 prometheus = { workspace = true }
-# Optional: only used by the `tests::common` fixtures, gated behind the `test-support` feature.
-prost = { workspace = true, optional = true }
 rand = { workspace = true }
 rcgen = { workspace = true, optional = true }
 regex = { workspace = true }
@@ -194,14 +190,13 @@ linux-build = ["tss-esapi"]
 # builds (resolver v2 keeps it out of the production `carbide-api` binary); only `carbide-api-web`'s
 # dev-dependency turns it on.
 test-support = [
-  "dep:carbide-prost-builder",
-  "dep:prost",
   "dep:rcgen",
   "carbide-ib-fabric/test-support",
   "carbide-machine-controller/test-support",
   "carbide-nvlink-manager/test-support",
   "carbide-rack/test-support",
   "carbide-redfish/test-support",
+  "carbide-rpc/test-support",
   "carbide-secrets/test-support",
   "carbide-utils/test-support",
   "state-controller/test-support",
@@ -220,9 +215,9 @@ carbide-macros = { path = "../macros" }
 carbide-nvlink-manager = { path = "../nvlink-manager", features = [
   "test-support",
 ] }
-carbide-prost-builder = { path = "../prost-builder" }
 carbide-rack = { path = "../rack", features = ["test-support"] }
 carbide-redfish = { path = "../redfish", features = ["test-support"] }
+carbide-rpc = { path = "../rpc", features = ["model", "sqlx", "test-support"] }
 carbide-secrets = { path = "../secrets", features = ["test-support"] }
 carbide-sqlx-testing = { path = "../sqlx-testing", default-features = false }
 carbide-utils = { path = "../utils", features = ["test-support"] }

--- a/crates/api-core/src/tests/common/rpc_builder.rs
+++ b/crates/api-core/src/tests/common/rpc_builder.rs
@@ -15,141 +15,21 @@
  * limitations under the License.
  */
 
-use carbide_uuid::compute_allocation::ComputeAllocationId;
+use rpc::forge::InstanceConfigBuilder;
+pub use rpc::forge::{
+    ComputeAllocationAttributes, CreateComputeAllocationRequest, DeleteComputeAllocationRequest,
+    DhcpDiscovery, InstanceAllocationRequest, InstanceConfig, InstanceConfigUpdateRequest,
+    UpdateComputeAllocationRequest, VpcCreationRequest, VpcDeletionRequest, VpcUpdateRequest,
+};
 
-use crate::tests::common::api_fixtures::instance::{default_os_config, default_tenant_config};
-
-// Reflection of rpc::forge::DhcpDiscovery. It should contain exactly
-// the same fields as rpc::forge::DhcpDiscovery. Otherwise it will
-// produce error on carbide_prost_builder::Builder derivation.
-#[derive(carbide_prost_builder::Builder)]
-pub struct DhcpDiscovery {
-    pub mac_address: ::prost::alloc::string::String,
-    pub relay_address: ::prost::alloc::string::String,
-    pub vendor_string: ::core::option::Option<::prost::alloc::string::String>,
-    pub link_address: ::core::option::Option<::prost::alloc::string::String>,
-    pub circuit_id: ::core::option::Option<::prost::alloc::string::String>,
-    pub remote_id: ::core::option::Option<::prost::alloc::string::String>,
-    pub desired_address: ::core::option::Option<::prost::alloc::string::String>,
+pub trait InstanceConfigExt {
+    fn default_tenant_and_os() -> InstanceConfigBuilder;
 }
 
-// Reflection of rpc::forge::VpcCreationRequest. It should contain exactly
-// the same fields as rpc::forge::VpcCreationRequest. Otherwise it will
-// produce error on carbide_prost_builder::Builder derivation.
-#[derive(carbide_prost_builder::Builder)]
-pub struct VpcCreationRequest {
-    pub tenant_organization_id: ::prost::alloc::string::String,
-    pub tenant_keyset_id: ::core::option::Option<::prost::alloc::string::String>,
-    pub network_virtualization_type: ::core::option::Option<i32>,
-    pub id: ::core::option::Option<::carbide_uuid::vpc::VpcId>,
-    pub metadata: ::core::option::Option<rpc::forge::Metadata>,
-    pub network_security_group_id: ::core::option::Option<::prost::alloc::string::String>,
-    pub vni: ::core::option::Option<u32>,
-    pub routing_profile_type: ::core::option::Option<::prost::alloc::string::String>,
-    pub default_nvlink_logical_partition_id:
-        ::core::option::Option<::carbide_uuid::nvlink::NvLinkLogicalPartitionId>,
-}
-
-// Reflection of rpc::forge::VpcUpdateRequest. It should contain exactly
-// the same fields as rpc::forge::VpcUpdateRequest. Otherwise it will
-// produce error on carbide_prost_builder::Builder derivation.
-#[derive(carbide_prost_builder::Builder)]
-pub struct VpcUpdateRequest {
-    pub id: ::core::option::Option<::carbide_uuid::vpc::VpcId>,
-    pub if_version_match: ::core::option::Option<::prost::alloc::string::String>,
-    pub metadata: ::core::option::Option<::rpc::forge::Metadata>,
-    pub network_security_group_id: ::core::option::Option<::prost::alloc::string::String>,
-    pub default_nvlink_logical_partition_id:
-        ::core::option::Option<::carbide_uuid::nvlink::NvLinkLogicalPartitionId>,
-}
-
-// Reflection of rpc::forge::VpcCreationRequest. It should contain exactly
-// the same fields as rpc::forge::VpcDeletionRequest. Otherwise it will
-// produce error on carbide_prost_builder::Builder derivation.
-#[derive(carbide_prost_builder::Builder)]
-pub struct VpcDeletionRequest {
-    pub id: ::core::option::Option<::carbide_uuid::vpc::VpcId>,
-}
-
-// Reflection of rpc::forge::InstanceAllocationRequest. It should contain exactly
-// the same fields as rpc::forge::InstanceAllocationRequest. Otherwise it will
-// produce error on carbide_prost_builder::Builder derivation.
-#[derive(carbide_prost_builder::Builder)]
-pub struct InstanceAllocationRequest {
-    pub machine_id: ::core::option::Option<::carbide_uuid::machine::MachineId>,
-    pub config: ::core::option::Option<::rpc::forge::InstanceConfig>,
-    pub instance_id: ::core::option::Option<::carbide_uuid::instance::InstanceId>,
-    pub instance_type_id: ::core::option::Option<::prost::alloc::string::String>,
-    pub metadata: ::core::option::Option<::rpc::forge::Metadata>,
-    pub allow_unhealthy_machine: bool,
-}
-
-// Reflection of rpc::forge::InstanceConfigUpdateRequest. It should contain exactly
-// the same fields as rpc::forge::InstanceAllocationRequest. Otherwise it will
-// produce error on carbide_prost_builder::Builder derivation.
-#[derive(carbide_prost_builder::Builder)]
-pub struct InstanceConfigUpdateRequest {
-    pub config: ::core::option::Option<::rpc::forge::InstanceConfig>,
-    pub instance_id: ::core::option::Option<::carbide_uuid::instance::InstanceId>,
-    pub metadata: ::core::option::Option<::rpc::forge::Metadata>,
-    pub if_version_match: ::core::option::Option<::prost::alloc::string::String>,
-}
-
-// Reflection of rpc::forge::InstanceConfig. It should contain exactly
-// the same fields as rpc::forge::InstanceConfig. Otherwise it will
-// produce error on carbide_prost_builder::Builder derivation.
-#[derive(carbide_prost_builder::Builder)]
-pub struct InstanceConfig {
-    pub tenant: ::core::option::Option<::rpc::forge::TenantConfig>,
-    pub os: ::core::option::Option<::rpc::forge::InstanceOperatingSystemConfig>,
-    pub network: ::core::option::Option<rpc::forge::InstanceNetworkConfig>,
-    pub infiniband: ::core::option::Option<::rpc::forge::InstanceInfinibandConfig>,
-    pub network_security_group_id: ::core::option::Option<::prost::alloc::string::String>,
-    pub dpu_extension_services:
-        ::core::option::Option<::rpc::forge::InstanceDpuExtensionServicesConfig>,
-    pub nvlink: ::core::option::Option<::rpc::forge::InstanceNvLinkConfig>,
-    pub spxconfig: ::core::option::Option<::rpc::forge::InstanceSpxConfig>,
-}
-
-impl InstanceConfig {
-    pub fn default_tenant_and_os() -> Self {
-        Self::builder()
-            .tenant(default_tenant_config())
-            .os(default_os_config())
+impl InstanceConfigExt for InstanceConfig {
+    fn default_tenant_and_os() -> InstanceConfigBuilder {
+        InstanceConfig::builder()
+            .tenant(crate::tests::common::api_fixtures::instance::default_tenant_config())
+            .os(crate::tests::common::api_fixtures::instance::default_os_config())
     }
-}
-
-// Reflection of rpc::forge::ComputeAllocationAttributes.
-#[derive(carbide_prost_builder::Builder)]
-pub struct ComputeAllocationAttributes {
-    pub instance_type_id: ::prost::alloc::string::String,
-    pub count: u32,
-}
-
-// Reflection of rpc::forge::CreateComputeAllocationRequest.
-#[derive(carbide_prost_builder::Builder)]
-pub struct CreateComputeAllocationRequest {
-    pub id: ::core::option::Option<ComputeAllocationId>,
-    pub tenant_organization_id: ::prost::alloc::string::String,
-    pub created_by: ::core::option::Option<::prost::alloc::string::String>,
-    pub metadata: ::core::option::Option<::rpc::forge::Metadata>,
-    pub attributes: ::core::option::Option<::rpc::forge::ComputeAllocationAttributes>,
-}
-
-// Reflection of rpc::forge::UpdateComputeAllocationRequest.
-#[derive(carbide_prost_builder::Builder)]
-pub struct UpdateComputeAllocationRequest {
-    pub id: ::core::option::Option<ComputeAllocationId>,
-    pub tenant_organization_id: ::prost::alloc::string::String,
-    pub metadata: ::core::option::Option<::rpc::forge::Metadata>,
-    pub attributes: ::core::option::Option<::rpc::forge::ComputeAllocationAttributes>,
-    pub if_version_match: ::core::option::Option<::prost::alloc::string::String>,
-    pub updated_by: ::core::option::Option<::prost::alloc::string::String>,
-}
-
-// Reflection of rpc::forge::DeleteComputeAllocationRequest.
-#[derive(carbide_prost_builder::Builder)]
-pub struct DeleteComputeAllocationRequest {
-    pub id: ::core::option::Option<ComputeAllocationId>,
-    pub tenant_organization_id: ::prost::alloc::string::String,
 }

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -93,7 +93,7 @@ use crate::tests::common::api_fixtures::{
 };
 use crate::tests::common::attestation::spdm_attestation_run_to_failed_then_to_success;
 use crate::tests::common::rpc_builder::{
-    InstanceAllocationRequest, InstanceConfig, VpcCreationRequest,
+    InstanceAllocationRequest, InstanceConfig, InstanceConfigExt, VpcCreationRequest,
 };
 
 pub async fn find_instances_by_label(

--- a/crates/prost-builder/src/lib.rs
+++ b/crates/prost-builder/src/lib.rs
@@ -18,7 +18,7 @@
 //! This proc_macro gives possibility to derive Builder implementation
 //! for prost Message structures.
 //!
-//! To use it you need to copy generated struct and derive the Builder.
+//! To use it, derive `Builder` on a prost-generated message type.
 //! For example:
 //! ```rust,ignore
 //! #[derive(carbide_prost_builder::Builder)]
@@ -85,25 +85,30 @@ pub fn derive_builder(input: TokenStream) -> TokenStream {
             _ => false,
         });
 
+    let builder_name = Ident::new(format!("{name}Builder").as_str(), Span::call_site());
     let mut args = TokenStream2::new();
-    let mut all_fields_move = TokenStream2::new();
-    let mut required_ctor_impl = TokenStream2::new();
+    let mut builder_fields = TokenStream2::new();
+    let mut builder_required_ctor_impl = TokenStream2::new();
+    let mut message_fields_move = TokenStream2::new();
     for (name, tp) in required_fields {
         if is_string(&tp) {
             // Special treatment for String. We want reduce noise in
             // tests...
             args.extend(quote! { #name: impl ::std::fmt::Display, });
-            required_ctor_impl.extend(quote! { #name: #name.to_string(), });
+            builder_required_ctor_impl.extend(quote! { #name: #name.to_string(), });
         } else {
             args.extend(quote! { #name: #tp, });
-            required_ctor_impl.extend(quote! { #name, });
+            builder_required_ctor_impl.extend(quote! { #name, });
         }
-        all_fields_move.extend(quote! { #name: self.#name, })
+        builder_fields.extend(quote! { #name: #tp, });
+        message_fields_move.extend(quote! { #name: self.#name, });
     }
     let mut optional_ctor_impl = TokenStream2::new();
     let mut optional_methods_impl = TokenStream2::new();
     for (name, tp) in optional_fields {
         optional_ctor_impl.extend(quote! { #name: None, });
+        builder_fields.extend(quote! { #name: #tp, });
+        message_fields_move.extend(quote! { #name: self.#name, });
         let tp = match tp {
             Type::Path(typepath) => typepath,
             _ => panic!("Type::Path is expected"),
@@ -146,31 +151,38 @@ pub fn derive_builder(input: TokenStream) -> TokenStream {
                 self
             }
         });
-        all_fields_move.extend(quote! { #name: self.#name, });
     }
 
     TokenStream::from(quote! {
+        pub struct #builder_name {
+            #builder_fields
+        }
+
         impl #name {
-            pub fn builder(#args) -> Self {
-                Self {
-                    #required_ctor_impl
+            pub fn builder(#args) -> #builder_name {
+                #builder_name {
+                    #builder_required_ctor_impl
                     #optional_ctor_impl
                 }
             }
+        }
+
+        impl #builder_name {
             #optional_methods_impl
 
-            pub fn tonic_request(self) -> ::tonic::Request<::rpc::forge::#name> {
+            pub fn tonic_request(self) -> ::tonic::Request<#name> {
                 ::tonic::Request::new(self.rpc())
             }
 
-            pub fn rpc(self) -> ::rpc::forge::#name {
-                ::rpc::forge::#name {
-                    #all_fields_move
+            pub fn rpc(self) -> #name {
+                #name {
+                    #message_fields_move
                 }
             }
         }
-        impl From<#name> for ::rpc::forge::#name {
-            fn from(v: #name) -> Self {
+
+        impl From<#builder_name> for #name {
+            fn from(v: #builder_name) -> Self {
                 v.rpc()
             }
         }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -35,6 +35,7 @@ model = [
   "dep:regex",
   "dep:base64",
 ]
+test-support = ["dep:carbide-prost-builder"]
 
 [dependencies]
 
@@ -46,6 +47,7 @@ carbide-tls = { path = "../tls" }
 carbide-health-report = { path = "../health-report" }
 carbide-libmlx-model = { path = "../libmlx-model" }
 carbide-measured-boot = { path = "../measured-boot", default-features = false }
+carbide-prost-builder = { path = "../prost-builder", optional = true }
 carbide-secrets = { path = "../secrets" }
 carbide-network = { path = "../network" }
 carbide-utils = { path = "../utils" }

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -28,6 +28,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // so that different builds get a different binary file and concurrent builds don't collide
     let reflection = out_dir.join("forge.bin");
 
+    let derive_prost_builder =
+        "#[cfg_attr(feature = \"test-support\", derive(carbide_prost_builder::Builder))]";
+
     tonic_prost_build::configure()
         .file_descriptor_set_path(reflection)
         .type_attribute(
@@ -479,6 +482,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "forge.DhcpDiscovery",
             "#[derive(serde::Deserialize, serde::Serialize)]",
         )
+        .type_attribute("forge.DhcpDiscovery", derive_prost_builder)
         .type_attribute(
             "forge.UserRoles",
             "#[derive(serde::Deserialize, serde::Serialize)]",
@@ -898,6 +902,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "scout_firmware_upgrade.FileArtifact",
             "#[derive(serde::Serialize, serde::Deserialize)]",
         )
+        .type_attribute("forge.VpcCreationRequest", derive_prost_builder)
+        .type_attribute("forge.VpcUpdateRequest", derive_prost_builder)
+        .type_attribute("forge.VpcDeletionRequest", derive_prost_builder)
+        .type_attribute("forge.InstanceAllocationRequest", derive_prost_builder)
+        .type_attribute("forge.InstanceConfigUpdateRequest", derive_prost_builder)
+        .type_attribute("forge.InstanceConfig", derive_prost_builder)
+        .type_attribute("forge.ComputeAllocationAttributes", derive_prost_builder)
+        .type_attribute("forge.CreateComputeAllocationRequest", derive_prost_builder)
+        .type_attribute("forge.UpdateComputeAllocationRequest", derive_prost_builder)
+        .type_attribute("forge.DeleteComputeAllocationRequest", derive_prost_builder)
         .build_server(true)
         .build_client(true)
         .protoc_arg("--experimental_allow_proto3_optional")


### PR DESCRIPTION
## Description
Add a `test-support` feature to `carbide-rpc` that derives `carbide_prost_builder::Builder` for selected generated RPC types via prost `type_attribute`.

Update `carbide-prost-builder` to generate standalone builder types for prost messages, and replace api-core test reflection structs with generated RPC builders plus a small `InstanceConfig` test helper shim.

This is needed for migration of tests that depends on builders from API core crate to specific controllers / managers crates.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

#2001 

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

