### PR TITLE
feat(api): Introduce VPC prefix lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,6 +1240,7 @@ dependencies = [
  "carbide-utils",
  "carbide-uuid",
  "carbide-version",
+ "carbide-vpc-prefix-controller",
  "casbin",
  "chrono",
  "clap",
@@ -3078,6 +3079,22 @@ dependencies = [
 [[package]]
 name = "carbide-version"
 version = "0.0.0"
+
+[[package]]
+name = "carbide-vpc-prefix-controller"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "carbide-api-db",
+ "carbide-api-model",
+ "carbide-uuid",
+ "chrono",
+ "config-version",
+ "eyre",
+ "sqlx",
+ "state-controller",
+ "tracing",
+]
 
 [[package]]
 name = "cargo_metadata"

--- a/crates/admin-cli/src/devenv/config/apply/cmd.rs
+++ b/crates/admin-cli/src/devenv/config/apply/cmd.rs
@@ -16,7 +16,9 @@
  */
 use carbide_network::ip::prefix::Ipv4Network;
 use carbide_uuid::network::NetworkSegmentId;
-use rpc::forge::{PrefixMatchType, Vpc, VpcPrefixCreationRequest, VpcPrefixSearchQuery};
+use rpc::forge::{
+    DeletedFilter, PrefixMatchType, Vpc, VpcPrefixCreationRequest, VpcPrefixSearchQuery,
+};
 use serde::{Deserialize, Serialize};
 
 use super::args::{Args, NetworkChoice};
@@ -158,6 +160,7 @@ async fn handle_overlay_vpc_prefix_creation(
             name: Some(vpc_prefix_name.clone()),
             prefix_match: Some(network.to_string()),
             prefix_match_type: Some(PrefixMatchType::PrefixExact as i32),
+            deleted: DeletedFilter::Exclude as i32,
         };
         let vpc_prefix_ids = api_client
             .0

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -43,7 +43,7 @@ use carbide_uuid::power_shelf::PowerShelfId;
 use carbide_uuid::rack::RackId;
 use carbide_uuid::spx::SpxPartitionId;
 use carbide_uuid::switch::SwitchId;
-use carbide_uuid::vpc::VpcId;
+use carbide_uuid::vpc::{VpcId, VpcPrefixId};
 use mac_address::MacAddress;
 
 use crate::IntoOnlyOne;
@@ -431,6 +431,27 @@ impl ApiClient {
         Ok(result
             .histories
             .remove(&segment_id.to_string())
+            .map(|h| h.records)
+            .unwrap_or_default())
+    }
+
+    /// Fetches controller state history for a single VPC prefix.
+    pub async fn get_vpc_prefix_state_history(
+        &self,
+        vpc_prefix_id: VpcPrefixId,
+    ) -> CarbideCliResult<Vec<rpc::StateHistoryRecord>> {
+        // Request the history through the generic state-history RPC.
+        let mut result = self
+            .0
+            .find_vpc_prefix_state_histories(rpc::VpcPrefixStateHistoriesRequest {
+                vpc_prefix_ids: vec![vpc_prefix_id],
+            })
+            .await?;
+
+        // Return an empty list when the object has no recorded transitions yet.
+        Ok(result
+            .histories
+            .remove(&vpc_prefix_id.to_string())
             .map(|h| h.records)
             .unwrap_or_default())
     }

--- a/crates/admin-cli/src/vpc_prefix/common.rs
+++ b/crates/admin-cli/src/vpc_prefix/common.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 
 use carbide_uuid::vpc::VpcPrefixId;
 use ipnet::IpNet;
-use rpc::forge::{PrefixMatchType, VpcPrefix, VpcPrefixSearchQuery};
+use rpc::forge::{DeletedFilter, PrefixMatchType, VpcPrefix, VpcPrefixSearchQuery};
 
 use crate::errors::CarbideCliError;
 use crate::errors::CarbideCliError::GenericError;
@@ -32,12 +32,18 @@ pub enum VpcPrefixSelector {
 }
 
 impl VpcPrefixSelector {
-    pub async fn fetch(self, api_client: &ApiClient) -> Result<VpcPrefix, CarbideCliError> {
+    pub async fn fetch(
+        self,
+        api_client: &ApiClient,
+        deleted: DeletedFilter,
+    ) -> Result<VpcPrefix, CarbideCliError> {
         match self {
-            VpcPrefixSelector::Id(id) => get_one_by_id(api_client, id).await,
+            VpcPrefixSelector::Id(id) => get_one_by_id(api_client, id, deleted).await,
             VpcPrefixSelector::Prefix(prefix) => {
                 let id = {
-                    let uuids = search(api_client, prefix_match_exact(&prefix)).await?;
+                    let mut query = prefix_match_exact(&prefix);
+                    query.deleted = deleted as i32;
+                    let uuids = search(api_client, query).await?;
                     let uuid = match Quantity::from(uuids) {
                         Quantity::One(uuid) => Ok(uuid),
                         Quantity::Zero => Err(GenericError(format!(
@@ -54,7 +60,7 @@ impl VpcPrefixSelector {
                         })
                     })
                 }?;
-                get_one_by_id(api_client, id).await
+                get_one_by_id(api_client, id, deleted).await
             }
         }
     }
@@ -105,11 +111,13 @@ pub async fn get_by_ids(
     api_client: &ApiClient,
     batch_size: usize,
     ids: &[VpcPrefixId],
+    deleted: i32,
 ) -> Result<Vec<VpcPrefix>, CarbideCliError> {
     let mut vpc_prefixes = Vec::with_capacity(ids.len());
     for ids in ids.chunks(batch_size) {
         let vpc_id_list = rpc::forge::VpcPrefixGetRequest {
             vpc_prefix_ids: ids.to_owned(),
+            deleted,
         };
         let prefixes_batch = api_client
             .0
@@ -124,8 +132,9 @@ pub async fn get_by_ids(
 pub async fn get_one_by_id(
     api_client: &ApiClient,
     id: VpcPrefixId,
+    deleted: DeletedFilter,
 ) -> Result<VpcPrefix, CarbideCliError> {
-    let mut prefixes = get_by_ids(api_client, 1, &[id]).await?;
+    let mut prefixes = get_by_ids(api_client, 1, &[id], deleted as i32).await?;
     match (prefixes.len(), prefixes.pop()) {
         (1, Some(prefix)) => Ok(prefix),
         (0, None) => Err(CarbideCliError::GenericError(format!(

--- a/crates/admin-cli/src/vpc_prefix/delete/cmd.rs
+++ b/crates/admin-cli/src/vpc_prefix/delete/cmd.rs
@@ -20,6 +20,11 @@ use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
 
 pub async fn delete(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let vpc_prefix_id = args.vpc_prefix_id.to_string();
+
+    // Request asynchronous deletion through the API.
     api_client.0.delete_vpc_prefix(args).await?;
+    eprintln!("Delete requested for VPC prefix {vpc_prefix_id}; final removal is asynchronous.");
+
     Ok(())
 }

--- a/crates/admin-cli/src/vpc_prefix/show/args.rs
+++ b/crates/admin-cli/src/vpc_prefix/show/args.rs
@@ -18,6 +18,7 @@
 use carbide_uuid::vpc::VpcId;
 use clap::Parser;
 use ipnet::IpNet;
+use rpc::forge::DeletedFilter;
 
 use crate::vpc_prefix::common::VpcPrefixSelector;
 
@@ -55,4 +56,8 @@ pub struct Args {
         conflicts_with_all = ["VpcPrefixSelector", "contains"],
     )]
     pub contained_by: Option<IpNet>,
+
+    /// Include soft-deleted VPC prefixes
+    #[clap(long, value_enum, default_value = "exclude")]
+    pub deleted: DeletedFilter,
 }

--- a/crates/admin-cli/src/vpc_prefix/show/cmd.rs
+++ b/crates/admin-cli/src/vpc_prefix/show/cmd.rs
@@ -21,8 +21,8 @@ use std::io::{Write, stdout};
 
 use ::rpc::admin_cli::output::OutputFormat;
 use prettytable::{Row, Table};
-use rpc::forge::{PrefixMatchType, VpcPrefix};
-use serde::Serialize;
+use rpc::forge::{PrefixMatchType, StateHistoryRecord, VpcPrefix};
+use serde::{Deserialize, Serialize};
 
 use super::args::Args;
 use crate::Destination;
@@ -46,19 +46,25 @@ pub async fn show(
 
 #[derive(Debug)]
 enum ShowMethod {
-    Get(VpcPrefixSelector),
+    Get {
+        selector: VpcPrefixSelector,
+        deleted: rpc::forge::DeletedFilter,
+    },
     Search(rpc::forge::VpcPrefixSearchQuery),
 }
 
 pub enum ShowOutput {
-    One(VpcPrefix),
+    One {
+        vpc_prefix: VpcPrefix,
+        history: Vec<StateHistoryRecord>,
+    },
     Many(Vec<VpcPrefix>),
 }
 
 impl ShowOutput {
     pub fn as_slice(&self) -> &[VpcPrefix] {
         match self {
-            ShowOutput::One(vpc_prefix) => std::slice::from_ref(vpc_prefix),
+            ShowOutput::One { vpc_prefix, .. } => std::slice::from_ref(vpc_prefix),
             ShowOutput::Many(vpc_prefixes) => vpc_prefixes.as_slice(),
         }
     }
@@ -67,9 +73,13 @@ impl ShowOutput {
 impl From<Args> for ShowMethod {
     fn from(show_args: Args) -> Self {
         match show_args.prefix_selector {
-            Some(selector) => ShowMethod::Get(selector),
+            Some(selector) => ShowMethod::Get {
+                selector,
+                deleted: show_args.deleted,
+            },
             None => {
                 let mut search = match_all();
+                search.deleted = show_args.deleted as i32;
                 search.vpc_id = show_args.vpc_id;
                 if let Some(prefix) = &show_args.contains {
                     search.prefix_match_type = Some(PrefixMatchType::PrefixContains as i32);
@@ -91,10 +101,26 @@ async fn fetch(
     show_method: ShowMethod,
 ) -> Result<ShowOutput, CarbideCliError> {
     match show_method {
-        ShowMethod::Get(get_one) => get_one.fetch(api_client).await.map(ShowOutput::One),
+        ShowMethod::Get { selector, deleted } => {
+            let vpc_prefix = selector.fetch(api_client, deleted).await?;
+
+            let history = match vpc_prefix.id {
+                Some(id) => api_client
+                    .get_vpc_prefix_state_history(id)
+                    .await
+                    .unwrap_or_default(),
+                None => Vec::new(),
+            };
+
+            Ok(ShowOutput::One {
+                vpc_prefix,
+                history,
+            })
+        }
         ShowMethod::Search(query) => {
+            let deleted = query.deleted;
             let vpc_prefix_ids = search(api_client, query).await?;
-            get_by_ids(api_client, batch_size, vpc_prefix_ids.as_slice())
+            get_by_ids(api_client, batch_size, vpc_prefix_ids.as_slice(), deleted)
                 .await
                 .map(ShowOutput::Many)
         }
@@ -140,6 +166,9 @@ impl ShowOutput {
         let mut out = Vec::new();
         let table = self.make_table();
         table.print(&mut out).expect("Couldn't render ASCII table");
+        if let ShowOutput::One { history, .. } = self {
+            Self::render_state_history(history, &mut out);
+        }
         out
     }
 
@@ -173,10 +202,15 @@ impl Serialize for ShowOutput {
         S: serde::Serializer,
     {
         match self {
-            ShowOutput::One(vpc_prefix) => vpc_prefix.serialize(serializer),
+            ShowOutput::One { vpc_prefix, .. } => vpc_prefix.serialize(serializer),
             ShowOutput::Many(vpc_prefixes) => vpc_prefixes.serialize(serializer),
         }
     }
+}
+
+#[derive(Deserialize)]
+struct LifecycleState {
+    state: String,
 }
 
 impl ShowOutput {
@@ -186,6 +220,8 @@ impl ShowOutput {
             "VpcId",
             "Prefix",
             "Name",
+            "State",
+            "State Version",
             "Total Linknets",
             "Available Linknets",
         ]
@@ -208,7 +244,15 @@ impl ShowOutput {
             .as_ref()
             .map(|x| x.name.as_str())
             .unwrap_or("<no name>");
-        let mut r = vec![vpc_prefix_id, vpc_id, prefix.into(), name.into()];
+        let (state, version) = Self::lifecycle_summary(row);
+        let mut r = vec![
+            vpc_prefix_id,
+            vpc_id,
+            prefix.into(),
+            name.into(),
+            state.into(),
+            version.into(),
+        ];
 
         if let Some(status) = &row.status {
             r.push(status.total_linknet_segments.to_string().into());
@@ -219,5 +263,56 @@ impl ShowOutput {
         }
 
         r
+    }
+
+    /// Extracts a compact lifecycle state and version for table output.
+    fn lifecycle_summary(row: &'_ VpcPrefix) -> (String, String) {
+        // Prefer the structured lifecycle status exposed by new API servers.
+        let Some(lifecycle) = row
+            .status
+            .as_ref()
+            .and_then(|status| status.lifecycle.as_ref())
+        else {
+            return ("NA".to_string(), "NA".to_string());
+        };
+
+        // Collapse the JSON state into its state label when it uses the common shape.
+        let state = serde_json::from_str::<LifecycleState>(&lifecycle.state)
+            .map(|state| state.state)
+            .unwrap_or_else(|_| lifecycle.state.clone());
+
+        (state, lifecycle.version.clone())
+    }
+
+    /// Appends VPC-prefix state history to single-object ASCII output.
+    fn render_state_history(history: &[StateHistoryRecord], out: &mut Vec<u8>) {
+        // Separate the history section from the primary details table.
+        writeln!(out).expect("Couldn't render VPC prefix state-history spacer");
+        writeln!(out, "STATE HISTORY: (Latest 5 only)")
+            .expect("Couldn't render VPC prefix state-history header");
+
+        // Render an explicit empty marker so operators can distinguish no data.
+        if history.is_empty() {
+            writeln!(out, "\tEMPTY").expect("Couldn't render empty VPC prefix state-history");
+            return;
+        }
+
+        writeln!(out, "\tState          Version                      Time")
+            .expect("Couldn't render VPC prefix state-history columns");
+        writeln!(out, "\t---------------------------------------------------")
+            .expect("Couldn't render VPC prefix state-history separator");
+        for record in history.iter().rev().take(5).rev() {
+            let state = serde_json::from_str::<LifecycleState>(&record.state)
+                .map(|state| state.state)
+                .unwrap_or_else(|_| record.state.clone());
+            writeln!(
+                out,
+                "\t{:<15} {:25} {}",
+                state,
+                record.version,
+                record.time.unwrap_or_default()
+            )
+            .expect("Couldn't render VPC prefix state-history record");
+        }
     }
 }

--- a/crates/admin-cli/src/vpc_prefix/tests.rs
+++ b/crates/admin-cli/src/vpc_prefix/tests.rs
@@ -58,6 +58,21 @@ fn parse_show_no_args() {
             assert!(args.vpc_id.is_none());
             assert!(args.contains.is_none());
             assert!(args.contained_by.is_none());
+            assert!(matches!(args.deleted, rpc::forge::DeletedFilter::Exclude));
+        }
+        _ => panic!("expected Show variant"),
+    }
+}
+
+// parse_show_with_deleted ensures show parses deleted filtering.
+#[test]
+fn parse_show_with_deleted() {
+    let cmd = Cmd::try_parse_from(["vpc-prefix", "show", "--deleted", "only"])
+        .expect("should parse show with deleted filter");
+
+    match cmd {
+        Cmd::Show(args) => {
+            assert!(matches!(args.deleted, rpc::forge::DeletedFilter::Only));
         }
         _ => panic!("expected Show variant"),
     }

--- a/crates/api-core/Cargo.toml
+++ b/crates/api-core/Cargo.toml
@@ -64,6 +64,7 @@ carbide-switch-controller = { path = "../switch-controller" }
 carbide-utils = { path = "../utils", features = ["sqlx"] }
 carbide-uuid = { path = "../uuid", features = ["sqlx"] }
 carbide-version = { path = "../version" }
+carbide-vpc-prefix-controller = { path = "../vpc-prefix-controller" }
 component-manager = { path = "../component-manager" }
 config-version = { path = "../config-version", features = ["sqlx"] }
 dns-record = { path = "../dns-record" }

--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -236,6 +236,13 @@ impl Forge for Api {
         crate::handlers::vpc_prefix::delete(self, request).await
     }
 
+    async fn find_vpc_prefix_state_histories(
+        &self,
+        request: Request<rpc::VpcPrefixStateHistoriesRequest>,
+    ) -> Result<Response<rpc::StateHistories>, Status> {
+        crate::handlers::vpc_prefix::find_state_histories(self, request).await
+    }
+
     async fn create_vpc_peering(
         &self,
         request: Request<rpc::VpcPeeringCreationRequest>,

--- a/crates/api-core/src/auth/internal_rbac_rules.rs
+++ b/crates/api-core/src/auth/internal_rbac_rules.rs
@@ -79,6 +79,10 @@ impl InternalRBACRules {
         x.perm("GetVpcPrefixes", vec![ForgeAdminCLI, SiteAgent]);
         x.perm("UpdateVpcPrefix", vec![ForgeAdminCLI, SiteAgent]);
         x.perm("DeleteVpcPrefix", vec![ForgeAdminCLI, SiteAgent]);
+        x.perm(
+            "FindVpcPrefixStateHistories",
+            vec![ForgeAdminCLI, SiteAgent],
+        );
         x.perm("GetAllDpaInterfaceIds", vec![ForgeAdminCLI, SiteAgent]);
         x.perm("FindDpaInterfacesByIds", vec![ForgeAdminCLI, SiteAgent]);
         x.perm("CreateDpaInterface", vec![]);

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -49,6 +49,7 @@ applicable.
 | `tpm_required` | `bool` | `true` | Require TPM module for machine registration. **Testing only** when `false`. |
 | `machine_state_controller` | `MachineStateControllerConfig` | *(see below)* | Machine state controller timing (see [MachineStateControllerConfig](#machinestatecontrollerconfig)). |
 | `network_segment_state_controller` | `NetworkSegmentStateControllerConfig` | *(see below)* | Network segment state controller timing. |
+| `vpc_prefix_state_controller` | `VpcPrefixStateControllerConfig` | *(see below)* | VPC prefix state controller timing. |
 | `ib_partition_state_controller` | `IbPartitionStateControllerConfig` | *(see below)* | IB partition state controller timing. |
 | `dpa_interface_state_controller` | `DpaInterfaceStateControllerConfig` | *(see below)* | DPA interface state controller timing. |
 | `rack_state_controller` | `RackStateControllerConfig` | *(see below)* | Rack state controller timing. |
@@ -169,7 +170,7 @@ applicable.
 
 ### `StateControllerConfig`
 
-Shared by all `*StateControllerConfig` structs (machine, network segment, IB
+Shared by all `*StateControllerConfig` structs (machine, network segment, VPC prefix, IB
 partition, DPA interface, rack, power shelf, switch, SPDM).
 
 | Field | Type | Default | Description |
@@ -204,6 +205,14 @@ Extends `StateControllerConfig` with:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `network_segment_drain_time` | `Duration` | `5m` | Time a network segment must have 0 allocated IPs before release. |
+
+### `VpcPrefixStateControllerConfig`
+
+Extends `StateControllerConfig` with:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `vpc_prefix_drain_time` | `Duration` | `5m` | Time a VPC prefix must have 0 referencing network prefixes before release. |
 
 ### `FirmwareGlobal`
 

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -276,6 +276,10 @@ pub struct CarbideConfig {
     #[serde(default)]
     pub network_segment_state_controller: NetworkSegmentStateControllerConfig,
 
+    /// VpcPrefixStateController related configuration parameter
+    #[serde(default)]
+    pub vpc_prefix_state_controller: VpcPrefixStateControllerConfig,
+
     /// IbPartitionStateController related configuration parameter
     #[serde(default)]
     pub ib_partition_state_controller: IbPartitionStateControllerConfig,
@@ -1428,6 +1432,43 @@ impl Default for NetworkSegmentStateControllerConfig {
     }
 }
 
+/// VpcPrefixStateController related config.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct VpcPrefixStateControllerConfig {
+    /// Common state controller configs
+    #[serde(default = "StateControllerConfig::default")]
+    pub controller: StateControllerConfig,
+    /// The time for which VPC prefixes must have 0 referencing network prefixes,
+    /// before they are actually released.
+    /// This should be set to a duration long enough that ensures no pending
+    /// RPC calls might still use the VPC prefix to avoid race conditions.
+    #[serde(
+        default = "VpcPrefixStateControllerConfig::vpc_prefix_drain_time_default",
+        deserialize_with = "deserialize_duration_chrono",
+        serialize_with = "as_duration"
+    )]
+    pub vpc_prefix_drain_time: chrono::Duration,
+}
+
+impl VpcPrefixStateControllerConfig {
+    /// Returns the default VPC prefix drain time.
+    pub fn vpc_prefix_drain_time_default() -> Duration {
+        // Match the network segment drain default for hierarchical cleanup.
+        Duration::minutes(5)
+    }
+}
+
+impl Default for VpcPrefixStateControllerConfig {
+    /// Builds the default VPC prefix state controller configuration.
+    fn default() -> Self {
+        // Use framework defaults plus the VPC prefix drain grace period.
+        Self {
+            controller: StateControllerConfig::default(),
+            vpc_prefix_drain_time: Self::vpc_prefix_drain_time_default(),
+        }
+    }
+}
+
 /// IbPartitionStateController related config
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct IbPartitionStateControllerConfig {
@@ -2523,6 +2564,10 @@ mod tests {
             NetworkSegmentStateControllerConfig::default()
         );
         assert_eq!(
+            config.vpc_prefix_state_controller,
+            VpcPrefixStateControllerConfig::default()
+        );
+        assert_eq!(
             config.ib_partition_state_controller,
             IbPartitionStateControllerConfig::default()
         );
@@ -2655,6 +2700,21 @@ mod tests {
                     iteration_time: std::time::Duration::from_secs(18 * 60),
                     max_object_handling_time: std::time::Duration::from_secs(188),
                     max_concurrency: 1888,
+                    processor_dispatch_interval: std::time::Duration::from_secs(2),
+                    processor_log_interval: std::time::Duration::from_secs(60),
+                    metric_emission_interval: std::time::Duration::from_secs(60),
+                    metric_hold_time: std::time::Duration::from_secs(5 * 60),
+                },
+            }
+        );
+        assert_eq!(
+            config.vpc_prefix_state_controller,
+            VpcPrefixStateControllerConfig {
+                vpc_prefix_drain_time: Duration::seconds(46),
+                controller: StateControllerConfig {
+                    iteration_time: std::time::Duration::from_secs(19 * 60),
+                    max_object_handling_time: std::time::Duration::from_secs(199),
+                    max_concurrency: 1999,
                     processor_dispatch_interval: std::time::Duration::from_secs(2),
                     processor_log_interval: std::time::Duration::from_secs(60),
                     metric_emission_interval: std::time::Duration::from_secs(60),
@@ -2842,6 +2902,21 @@ mod tests {
                     iteration_time: std::time::Duration::from_secs(8 * 60),
                     max_object_handling_time: std::time::Duration::from_secs(88),
                     max_concurrency: 888,
+                    processor_dispatch_interval: std::time::Duration::from_secs(2),
+                    processor_log_interval: std::time::Duration::from_secs(60),
+                    metric_emission_interval: std::time::Duration::from_secs(60),
+                    metric_hold_time: std::time::Duration::from_secs(5 * 60),
+                },
+            }
+        );
+        assert_eq!(
+            config.vpc_prefix_state_controller,
+            VpcPrefixStateControllerConfig {
+                vpc_prefix_drain_time: Duration::seconds(43),
+                controller: StateControllerConfig {
+                    iteration_time: std::time::Duration::from_secs(6 * 60),
+                    max_object_handling_time: std::time::Duration::from_secs(66),
+                    max_concurrency: 666,
                     processor_dispatch_interval: std::time::Duration::from_secs(2),
                     processor_log_interval: std::time::Duration::from_secs(60),
                     metric_emission_interval: std::time::Duration::from_secs(60),
@@ -3153,6 +3228,21 @@ mod tests {
                     iteration_time: std::time::Duration::from_secs(18 * 60),
                     max_object_handling_time: std::time::Duration::from_secs(188),
                     max_concurrency: 1888,
+                    processor_dispatch_interval: std::time::Duration::from_secs(2),
+                    processor_log_interval: std::time::Duration::from_secs(60),
+                    metric_emission_interval: std::time::Duration::from_secs(60),
+                    metric_hold_time: std::time::Duration::from_secs(5 * 60),
+                },
+            }
+        );
+        assert_eq!(
+            config.vpc_prefix_state_controller,
+            VpcPrefixStateControllerConfig {
+                vpc_prefix_drain_time: Duration::seconds(46),
+                controller: StateControllerConfig {
+                    iteration_time: std::time::Duration::from_secs(19 * 60),
+                    max_object_handling_time: std::time::Duration::from_secs(199),
+                    max_concurrency: 1999,
                     processor_dispatch_interval: std::time::Duration::from_secs(2),
                     processor_log_interval: std::time::Duration::from_secs(60),
                     metric_emission_interval: std::time::Duration::from_secs(60),

--- a/crates/api-core/src/cfg/test_data/full_config.toml
+++ b/crates/api-core/src/cfg/test_data/full_config.toml
@@ -108,6 +108,13 @@ iteration_time = "8m"
 max_object_handling_time = "88s"
 max_concurrency = 888
 
+[vpc_prefix_state_controller]
+vpc_prefix_drain_time = "43s"
+[vpc_prefix_state_controller.controller]
+iteration_time = "6m"
+max_object_handling_time = "66s"
+max_concurrency = 666
+
 [ib_partition_state_controller.controller]
 iteration_time = "7m"
 max_object_handling_time = "77s"

--- a/crates/api-core/src/cfg/test_data/full_config_post_migration.toml
+++ b/crates/api-core/src/cfg/test_data/full_config_post_migration.toml
@@ -74,6 +74,13 @@ iteration_time = "8m"
 max_object_handling_time = "88s"
 max_concurrency = 888
 
+[vpc_prefix_state_controller]
+vpc_prefix_drain_time = "43s"
+[vpc_prefix_state_controller.controller]
+iteration_time = "6m"
+max_object_handling_time = "66s"
+max_concurrency = 666
+
 [ib_partition_state_controller.controller]
 iteration_time = "7m"
 max_object_handling_time = "77s"

--- a/crates/api-core/src/cfg/test_data/site_config.toml
+++ b/crates/api-core/src/cfg/test_data/site_config.toml
@@ -53,6 +53,13 @@ iteration_time = "18m"
 max_object_handling_time = "188s"
 max_concurrency = 1888
 
+[vpc_prefix_state_controller]
+vpc_prefix_drain_time = "46s"
+[vpc_prefix_state_controller.controller]
+iteration_time = "19m"
+max_object_handling_time = "199s"
+max_concurrency = 1999
+
 [ib_partition_state_controller.controller]
 iteration_time = "17m"
 max_object_handling_time = "177s"

--- a/crates/api-core/src/handlers/vpc.rs
+++ b/crates/api-core/src/handlers/vpc.rs
@@ -272,6 +272,20 @@ pub(crate) async fn delete(
         .id
         .ok_or(CarbideError::MissingArgument("id"))?;
 
+    let vpcs = db::vpc::find_by_with_lock(
+        txn.as_mut(),
+        ObjectColumnFilter::One(db::vpc::IdColumn, &vpc_id),
+        db::vpc::VpcRowLock::Mutation,
+    )
+    .await?;
+    if vpcs.is_empty() {
+        return Err(CarbideError::NotFoundError {
+            kind: "vpc",
+            id: vpc_id.to_string(),
+        }
+        .into());
+    }
+
     let vpc = match db::vpc::try_delete(&mut txn, vpc_id).await? {
         Some(vpc) => vpc,
         None => {

--- a/crates/api-core/src/handlers/vpc_prefix.rs
+++ b/crates/api-core/src/handlers/vpc_prefix.rs
@@ -26,6 +26,7 @@ use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
 use crate::api::{Api, log_request_data};
+
 pub async fn create(
     api: &Api,
     request: Request<rpc::VpcPrefixCreationRequest>,
@@ -63,9 +64,10 @@ pub async fn create(
 
     let mut txn = api.txn_begin().await?;
 
-    let vpcs = ::db::vpc::find_by(
-        &mut txn,
+    let vpcs = ::db::vpc::find_by_with_lock(
+        txn.as_mut(),
         ObjectColumnFilter::One(::db::vpc::IdColumn, &new_prefix.vpc_id),
+        ::db::vpc::VpcRowLock::Mutation,
     )
     .await?;
     let vpc = vpcs.first().ok_or_else(|| CarbideError::NotFoundError {
@@ -164,17 +166,31 @@ pub async fn create(
         .map_err(CarbideError::from)?;
 
     let vpc_prefix = db::persist(new_prefix, expected_vpc_version, &mut txn).await?;
+    let vpc_prefix_id = vpc_prefix.id;
+    let vpc_prefix_network = vpc_prefix.config.prefix;
 
     // Associate all of the network segment prefixes with the new VPC prefix.
     for mut segment_prefix in segment_prefixes {
         ::db::network_prefix::set_vpc_prefix(
             &mut segment_prefix,
             &mut txn,
-            &vpc_prefix.id,
-            &vpc_prefix.config.prefix,
+            &vpc_prefix_id,
+            &vpc_prefix_network,
         )
         .await?;
     }
+
+    // Reload through the normal read path so create responses include computed utilization stats.
+    let vpc_prefix = db::get_by_id(
+        &mut txn,
+        ObjectColumnFilter::One(db::IdColumn, &vpc_prefix_id),
+        model::DeletedFilter::Exclude,
+    )
+    .await?
+    .pop()
+    .ok_or_else(|| {
+        CarbideError::internal(format!("Created VPC prefix {vpc_prefix_id} was not found"))
+    })?;
 
     txn.commit().await?;
 
@@ -192,6 +208,7 @@ pub async fn search(
         name,
         prefix_match,
         prefix_match_type,
+        deleted,
     } = request.into_inner();
 
     // We don't have tenant prefixes in this version, so searching against them
@@ -229,7 +246,16 @@ pub async fn search(
 
     let mut txn = api.txn_begin().await?;
 
-    let vpc_prefix_ids = db::search(&mut txn, vpc_id, name, prefix_match).await?;
+    let vpc_prefix_ids = db::search(
+        &mut txn,
+        vpc_prefix::VpcPrefixSearch {
+            vpc_id,
+            name,
+            prefix_match,
+            deleted_filter: model::DeletedFilter::from(deleted),
+        },
+    )
+    .await?;
 
     txn.commit().await?;
 
@@ -244,7 +270,10 @@ pub async fn get(
 ) -> Result<Response<rpc::VpcPrefixList>, Status> {
     log_request_data(&request);
 
-    let rpc::VpcPrefixGetRequest { vpc_prefix_ids } = request.into_inner();
+    let rpc::VpcPrefixGetRequest {
+        vpc_prefix_ids,
+        deleted,
+    } = request.into_inner();
     if vpc_prefix_ids.len() > (api.runtime_config.max_find_by_ids as usize) {
         let msg = format!(
             "Too many VPC prefix IDs were specified (the limit is {maximum})",
@@ -258,6 +287,7 @@ pub async fn get(
     let vpc_prefixes = db::get_by_id(
         &mut txn,
         ObjectColumnFilter::List(db::IdColumn, vpc_prefix_ids.as_slice()),
+        model::DeletedFilter::from(deleted),
     )
     .await?;
 
@@ -265,6 +295,51 @@ pub async fn get(
 
     let vpc_prefixes: Vec<_> = vpc_prefixes.into_iter().map(rpc::VpcPrefix::from).collect();
     Ok(tonic::Response::new(rpc::VpcPrefixList { vpc_prefixes }))
+}
+
+/// Finds controller state-history records for VPC prefixes.
+pub async fn find_state_histories(
+    api: &Api,
+    request: Request<rpc::VpcPrefixStateHistoriesRequest>,
+) -> Result<Response<rpc::StateHistories>, Status> {
+    log_request_data(&request);
+
+    // Extract and validate the requested VPC prefix IDs before querying.
+    let vpc_prefix_ids = request.into_inner().vpc_prefix_ids;
+    let max_find_by_ids = api.runtime_config.max_find_by_ids as usize;
+    if vpc_prefix_ids.len() > max_find_by_ids {
+        return Err(CarbideError::InvalidArgument(format!(
+            "no more than {max_find_by_ids} IDs can be accepted"
+        ))
+        .into());
+    } else if vpc_prefix_ids.is_empty() {
+        return Err(
+            CarbideError::InvalidArgument("at least one ID must be provided".to_string()).into(),
+        );
+    }
+
+    // Fetch state-history rows through the generic state-history DB API.
+    let mut txn = api.txn_begin().await?;
+    let results = ::db::state_history::find_by_object_ids(
+        &mut txn,
+        ::db::state_history::StateHistoryTableId::VpcPrefix,
+        &vpc_prefix_ids,
+    )
+    .await?;
+
+    // Re-key the DB records into the generic RPC response shape.
+    let mut response = rpc::StateHistories::default();
+    for (vpc_prefix_id, records) in results {
+        response.histories.insert(
+            vpc_prefix_id,
+            rpc::StateHistoryRecords {
+                records: records.into_iter().map(Into::into).collect(),
+            },
+        );
+    }
+
+    txn.commit().await?;
+    Ok(tonic::Response::new(response))
 }
 
 pub async fn update(
@@ -299,14 +374,12 @@ pub async fn delete(
 
     let mut txn = api.txn_begin().await?;
 
-    // TODO: We could probably produce some nicer errors here when trying
-    // to delete prefixes that are still being used by network segments, or
-    // whatever else might be pointing at them. For now we're just relying on
-    // the DB constraints and returning whatever error that results in.
-
+    // Load the active prefix so repeat deletes preserve current NotFound
+    // behavior unless the DB layer deliberately makes soft-delete idempotent.
     let vpc_prefixes = db::get_by_id(
         &mut txn,
         ObjectColumnFilter::One(db::IdColumn, &delete_prefix.id),
+        model::DeletedFilter::Exclude,
     )
     .await?;
     let vpc_prefix = vpc_prefixes
@@ -316,9 +389,10 @@ pub async fn delete(
             id: delete_prefix.id.to_string(),
         })?;
 
-    let vpcs = ::db::vpc::find_by(
-        &mut txn,
+    let vpcs = ::db::vpc::find_by_with_lock(
+        txn.as_mut(),
         ObjectColumnFilter::One(::db::vpc::IdColumn, &vpc_prefix.vpc_id),
+        ::db::vpc::VpcRowLock::Mutation,
     )
     .await?;
     let vpc = vpcs.first().ok_or_else(|| CarbideError::NotFoundError {
@@ -326,7 +400,21 @@ pub async fn delete(
         id: vpc_prefix.vpc_id.to_string(),
     })?;
 
-    db::delete(&delete_prefix, vpc.version, &mut txn).await?;
+    // Preserve the hard-delete-era behavior where existing network-prefix
+    // references prevent callers from requesting VPC prefix deletion.
+    let network_prefix_count =
+        db::count_network_prefixes_by_vpc_prefix_id(&mut txn, &delete_prefix.id).await?;
+    if network_prefix_count > 0 {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "VPC prefix {id} cannot be deleted while \
+            {network_prefix_count} network prefix references still exist",
+            id = delete_prefix.id
+        ))
+        .into());
+    }
+
+    // Mark the prefix deleted and keep the existing parent VPC version bump.
+    db::mark_as_deleted(&delete_prefix, vpc.version, &mut txn).await?;
 
     txn.commit().await?;
 

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -60,6 +60,9 @@ use carbide_switch_controller::context::SwitchStateHandlerServices;
 use carbide_switch_controller::handler::SwitchStateHandler;
 use carbide_switch_controller::io::SwitchStateControllerIO;
 use carbide_utils::HostPortPair;
+use carbide_vpc_prefix_controller::context::VpcPrefixStateHandlerServices;
+use carbide_vpc_prefix_controller::handler::VpcPrefixStateHandler;
+use carbide_vpc_prefix_controller::io::VpcPrefixStateControllerIO;
 use db::machine::update_dpu_asns;
 use db::resource_pool::DefineResourcePoolError;
 use db::{Transaction, work_lock_manager};
@@ -1176,6 +1179,25 @@ pub async fn initialize_and_start_controllers<'a>(
         )))
         .build_and_spawn(join_set, cancel_token.clone())
         .expect("Unable to build NetworkSegmentController");
+
+    StateController::<VpcPrefixStateControllerIO>::builder()
+        .database(db_pool.clone(), work_lock_manager_handle.clone())
+        .meter("carbide_vpc_prefixes", meter.clone())
+        .processor_id(state_controller_id.clone())
+        .services(
+            VpcPrefixStateHandlerServices {
+                db_pool: db_pool.clone(),
+            }
+            .into(),
+        )
+        .iteration_config((&carbide_config.vpc_prefix_state_controller.controller).into())
+        .state_handler(Arc::new(VpcPrefixStateHandler::new(
+            carbide_config
+                .vpc_prefix_state_controller
+                .vpc_prefix_drain_time,
+        )))
+        .build_and_spawn(join_set, cancel_token.clone())
+        .expect("Unable to build VpcPrefixStateController");
 
     if carbide_config.spdm.enabled {
         let Some(nras_config) = carbide_config.spdm.nras_config.clone() else {

--- a/crates/api-core/src/test_support/default_config.rs
+++ b/crates/api-core/src/test_support/default_config.rs
@@ -43,7 +43,8 @@ use crate::cfg::file::{
     MeasuredBootMetricsCollectorConfig, MqttAuthConfig, NetworkSecurityGroupConfig,
     NetworkSegmentStateControllerConfig, PowerShelfStateControllerConfig,
     RackStateControllerConfig, SpdmConfig, SpdmStateControllerConfig, SwitchStateControllerConfig,
-    VmaasConfig, VpcPeeringPolicy, default_bmc_session_lockout_threshold, default_max_find_by_ids,
+    VmaasConfig, VpcPeeringPolicy, VpcPrefixStateControllerConfig,
+    default_bmc_session_lockout_threshold, default_max_find_by_ids,
 };
 
 pub fn get() -> CarbideConfig {
@@ -135,6 +136,10 @@ pub fn get() -> CarbideConfig {
         },
         network_segment_state_controller: NetworkSegmentStateControllerConfig {
             network_segment_drain_time: Duration::seconds(2),
+            controller: StateControllerConfig::default(),
+        },
+        vpc_prefix_state_controller: VpcPrefixStateControllerConfig {
+            vpc_prefix_drain_time: Duration::seconds(2),
             controller: StateControllerConfig::default(),
         },
         ib_partition_state_controller: IbPartitionStateControllerConfig {

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -66,6 +66,9 @@ use carbide_uuid::machine::MachineId;
 use carbide_uuid::machine_validation::MachineValidationId;
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::vpc::VpcId;
+use carbide_vpc_prefix_controller::context::VpcPrefixStateHandlerServices;
+use carbide_vpc_prefix_controller::handler::VpcPrefixStateHandler;
+use carbide_vpc_prefix_controller::io::VpcPrefixStateControllerIO;
 use chrono::{DateTime, Duration, Utc};
 use db::db_read::PgPoolReader;
 use db::instance_type::create as create_instance_type;
@@ -172,6 +175,7 @@ pub struct TestEnvOverrides {
     pub nmxc_simulator: Option<bool>,
     pub redfish_overrides: Option<RedfishOverrides>,
     pub nras_should_fail_parsing: Option<Arc<AtomicBool>>,
+    pub vpc_prefixes_drain_period: Option<chrono::Duration>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -271,6 +275,7 @@ pub struct TestEnv {
     spdm_state_controller: Arc<Mutex<StateController<SpdmStateControllerIO>>>,
     pub machine_state_handler: SwapHandler<MachineStateHandler>,
     network_segment_controller: Arc<Mutex<StateController<NetworkSegmentStateControllerIO>>>,
+    vpc_prefix_controller: Arc<Mutex<StateController<VpcPrefixStateControllerIO>>>,
     ib_partition_controller: Arc<Mutex<StateController<IBPartitionStateControllerIO>>>,
     power_shelf_controller: Arc<Mutex<StateController<PowerShelfStateControllerIO>>>,
     rack_controller: Arc<Mutex<StateController<RackStateControllerIO>>>,
@@ -522,6 +527,17 @@ impl TestEnv {
     /// in this test environment
     pub async fn run_network_segment_controller_iteration(&self) {
         self.network_segment_controller
+            .lock()
+            .await
+            .run_single_iteration()
+            .boxed()
+            .await;
+    }
+
+    /// Runs one iteration of the VPC prefix state controller handler with the services
+    /// in this test environment.
+    pub async fn run_vpc_prefix_controller_iteration(&self) {
+        self.vpc_prefix_controller
             .lock()
             .await
             .run_single_iteration()
@@ -1364,6 +1380,28 @@ pub async fn create_test_env_with_overrides(
         .build_for_manual_iterations(cancel_token.clone())
         .expect("Unable to build state controller");
 
+    let vpc_prefix_swap = SwapHandler {
+        inner: Arc::new(Mutex::new(VpcPrefixStateHandler::new(
+            overrides
+                .vpc_prefixes_drain_period
+                .unwrap_or(chrono::Duration::milliseconds(500)),
+        ))),
+    };
+
+    let vpc_prefix_controller = StateController::builder()
+        .database(db_pool.clone(), api.work_lock_manager_handle.clone())
+        .meter("carbide_vpc_prefixes", test_meter.meter())
+        .processor_id(state_controller_id.clone())
+        .services(
+            VpcPrefixStateHandlerServices {
+                db_pool: db_pool.clone(),
+            }
+            .into(),
+        )
+        .state_handler(Arc::new(vpc_prefix_swap.clone()))
+        .build_for_manual_iterations(cancel_token.clone())
+        .expect("Unable to build VpcPrefixStateController");
+
     let test_component_manager = component_manager::component_manager::build_component_manager(
         &component_manager::config::ComponentManagerConfig {
             nv_switch_backend: "rms".into(),
@@ -1561,6 +1599,7 @@ pub async fn create_test_env_with_overrides(
         ib_partition_controller: Arc::new(Mutex::new(ib_controller)),
         switch_controller: Arc::new(Mutex::new(switch_controller)),
         network_segment_controller: Arc::new(Mutex::new(network_controller)),
+        vpc_prefix_controller: Arc::new(Mutex::new(vpc_prefix_controller)),
         power_shelf_controller: Arc::new(Mutex::new(power_shelf_controller)),
         rack_controller: Arc::new(Mutex::new(rack_controller)),
         reachability_params,

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -2498,6 +2498,7 @@ async fn test_allocate_and_release_instance_vpc_prefix_id(
         .api
         .get_vpc_prefixes(tonic::Request::new(rpc::forge::VpcPrefixGetRequest {
             vpc_prefix_ids: vec![vpc_prefix_id],
+            deleted: rpc::forge::DeletedFilter::Exclude as i32,
         }))
         .await
         .unwrap()
@@ -2520,6 +2521,7 @@ async fn test_allocate_and_release_instance_vpc_prefix_id(
         .api
         .get_vpc_prefixes(tonic::Request::new(rpc::forge::VpcPrefixGetRequest {
             vpc_prefix_ids: vec![vpc_prefix_id],
+            deleted: rpc::forge::DeletedFilter::Exclude as i32,
         }))
         .await
         .unwrap()
@@ -2703,6 +2705,7 @@ async fn test_allocate_and_release_instance_vpc_prefix_id(
         .api
         .get_vpc_prefixes(tonic::Request::new(rpc::forge::VpcPrefixGetRequest {
             vpc_prefix_ids: vec![vpc_prefix_id],
+            deleted: rpc::forge::DeletedFilter::Exclude as i32,
         }))
         .await
         .unwrap()

--- a/crates/api-core/src/tests/vpc.rs
+++ b/crates/api-core/src/tests/vpc.rs
@@ -501,6 +501,13 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     assert_eq!(&first.metadata.name, "yet another new name");
     assert_eq!(first.version.version_nr(), 5);
 
+    let vpcs = db::vpc::find_by_with_lock(
+        txn.as_mut(),
+        ObjectColumnFilter::One(vpc::IdColumn, &no_org_vpc_id),
+        db::vpc::VpcRowLock::Mutation,
+    )
+    .await?;
+    assert_eq!(vpcs.len(), 1);
     let vpc = db::vpc::try_delete(&mut txn, no_org_vpc_id).await?.unwrap();
 
     assert!(vpc.deleted.is_some());
@@ -521,6 +528,13 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     let forge_vpc_id: VpcId = forge_vpc.id.expect("should have id");
     assert_eq!(vpcs[0].id, forge_vpc_id);
 
+    let vpcs = db::vpc::find_by_with_lock(
+        txn.as_mut(),
+        ObjectColumnFilter::One(vpc::IdColumn, &forge_vpc_id),
+        db::vpc::VpcRowLock::Mutation,
+    )
+    .await?;
+    assert_eq!(vpcs.len(), 1);
     let vpc = db::vpc::try_delete(&mut txn, forge_vpc_id).await?.unwrap();
     assert!(vpc.deleted.is_some());
     txn.commit().await?;

--- a/crates/api-core/src/tests/vpc_prefix.rs
+++ b/crates/api-core/src/tests/vpc_prefix.rs
@@ -15,18 +15,177 @@
  * limitations under the License.
  */
 
+use carbide_uuid::vpc::{VpcId, VpcPrefixId};
 use rpc::Metadata;
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{
-    PrefixMatchType, VpcPrefixCreationRequest, VpcPrefixDeletionRequest, VpcPrefixSearchQuery,
+    PrefixMatchType, VpcDeletionRequest, VpcPrefixCreationRequest, VpcPrefixDeletionRequest,
+    VpcPrefixSearchQuery,
 };
 use sqlx::PgPool;
 use tonic::Request;
 
-use crate::tests::common::api_fixtures::{
-    self, TEST_SITE_PREFIXES, TestEnvOverrides, create_test_env, create_test_env_with_overrides,
-    get_vpc_fixture_id,
+use crate::tests::common::api_fixtures::instance::{
+    default_os_config, default_tenant_config, single_interface_network_config_with_vpc_prefix,
 };
+use crate::tests::common::api_fixtures::{
+    self, TEST_SITE_PREFIXES, TestEnv, TestEnvOverrides, create_managed_host, create_test_env,
+    create_test_env_with_overrides, get_vpc_fixture_id,
+};
+
+const REFERENCED_VPC_PREFIX: &str = "192.0.4.0/24";
+const UNREFERENCED_VPC_PREFIX: &str = "192.1.4.0/27";
+
+#[derive(serde::Deserialize)]
+struct LifecycleStateJson {
+    state: String,
+}
+
+/// Builds and submits the common structured create request used by lifecycle tests.
+async fn create_vpc_prefix(env: &TestEnv, vpc_id: VpcId, prefix: &str) -> rpc::forge::VpcPrefix {
+    // Send a normal create request so handler validation and response conversion are covered.
+    env.api
+        .create_vpc_prefix(Request::new(VpcPrefixCreationRequest {
+            id: None,
+            prefix: String::new(),
+            vpc_id: Some(vpc_id),
+            config: Some(rpc::forge::VpcPrefixConfig {
+                prefix: prefix.into(),
+            }),
+            metadata: Some(rpc::forge::Metadata {
+                name: format!("VPC prefix {prefix}"),
+                description: String::from("lifecycle test prefix"),
+                labels: vec![rpc::forge::Label {
+                    key: "test".into(),
+                    value: Some("vpc-prefix-lifecycle".into()),
+                }],
+            }),
+        }))
+        .await
+        .expect("Could not create VPC prefix")
+        .into_inner()
+}
+
+/// Returns one VPC prefix from the default get API, if it is visible.
+async fn find_vpc_prefix(env: &TestEnv, id: VpcPrefixId) -> Option<rpc::forge::VpcPrefix> {
+    // Use the default API path because soft-deleted prefixes should be omitted from normal reads.
+    let mut prefixes = env
+        .api
+        .get_vpc_prefixes(Request::new(rpc::forge::VpcPrefixGetRequest {
+            vpc_prefix_ids: vec![id],
+            deleted: rpc::forge::DeletedFilter::Exclude as i32,
+        }))
+        .await
+        .expect("Could not find VPC prefixes")
+        .into_inner()
+        .vpc_prefixes;
+    assert!(
+        prefixes.len() <= 1,
+        "a single VPC prefix ID should return at most one object"
+    );
+    prefixes.pop()
+}
+
+/// Asserts lifecycle fields and family-aware VPC-prefix utilization counters.
+fn assert_status_with_lifecycle_and_linknet_counters(
+    prefix: &rpc::forge::VpcPrefix,
+    expected_state: &str,
+    expected_total_linknets: u64,
+    expected_available_linknets: u64,
+) {
+    let status = prefix
+        .status
+        .as_ref()
+        .expect("VPC prefix status should be populated");
+
+    // Verify lifecycle status is present and points at the expected controller state.
+    let lifecycle_status = status
+        .lifecycle
+        .as_ref()
+        .expect("VPC prefix status should include lifecycle");
+    let lifecycle_state: LifecycleStateJson =
+        serde_json::from_str(&lifecycle_status.state).expect("lifecycle state should be JSON");
+    assert_eq!(lifecycle_state.state, expected_state);
+    assert!(
+        !lifecycle_status.version.is_empty(),
+        "lifecycle version should be populated"
+    );
+    assert!(
+        lifecycle_status.sla.is_some(),
+        "lifecycle SLA should be populated"
+    );
+
+    // Verify the existing utilization counters are still present alongside lifecycle.
+    assert_eq!(status.total_linknet_segments, expected_total_linknets);
+    assert_eq!(
+        status.available_linknet_segments,
+        expected_available_linknets
+    );
+}
+
+/// Returns the number of backing VPC-prefix rows for an ID, including soft-deleted rows.
+async fn stored_vpc_prefix_count(env: &TestEnv, id: VpcPrefixId) -> i64 {
+    // Query the backing table directly because public get intentionally hides deleted prefixes.
+    sqlx::query_scalar("SELECT COUNT(*) FROM network_vpc_prefixes WHERE id = $1")
+        .bind(id)
+        .fetch_one(&env.pool)
+        .await
+        .expect("Could not count stored VPC prefixes")
+}
+
+/// Returns whether a backing VPC-prefix row is marked deleted.
+async fn stored_vpc_prefix_is_deleted(env: &TestEnv, id: VpcPrefixId) -> bool {
+    // Inspect the soft-delete marker that the public get API omits.
+    sqlx::query_scalar("SELECT deleted IS NOT NULL FROM network_vpc_prefixes WHERE id = $1")
+        .bind(id)
+        .fetch_one(&env.pool)
+        .await
+        .expect("Could not read VPC prefix deleted marker")
+}
+
+/// Returns the stored top-level controller state for a VPC prefix row.
+async fn stored_vpc_prefix_controller_state(env: &TestEnv, id: VpcPrefixId) -> Option<String> {
+    // Inspect controller-owned JSON because public get hides deleted rows.
+    sqlx::query_scalar("SELECT controller_state->>'state' FROM network_vpc_prefixes WHERE id = $1")
+        .bind(id)
+        .fetch_optional(&env.pool)
+        .await
+        .expect("Could not read stored VPC prefix controller state")
+        .flatten()
+}
+
+/// Returns the number of network_prefix rows still referencing a VPC prefix.
+async fn network_prefix_ref_count(env: &TestEnv, id: VpcPrefixId) -> i64 {
+    // Count durable prefix references, which are the controller's deletion gate.
+    sqlx::query_scalar("SELECT COUNT(*) FROM network_prefixes WHERE vpc_prefix_id = $1")
+        .bind(id)
+        .fetch_one(&env.pool)
+        .await
+        .expect("Could not count network prefixes for VPC prefix")
+}
+
+/// Drives the manual VPC-prefix controller until the prefix is ready.
+async fn drive_vpc_prefix_to_ready(env: &TestEnv, id: VpcPrefixId) -> rpc::forge::VpcPrefix {
+    // Run the controller once to process the initial Provisioning state.
+    env.run_vpc_prefix_controller_iteration().await;
+
+    // Verify the transition using the public API.
+    let prefix = find_vpc_prefix(env, id)
+        .await
+        .expect("VPC prefix should be visible through the public get API");
+    let status = prefix
+        .status
+        .as_ref()
+        .expect("VPC prefix status should be populated");
+    let lifecycle_status = status
+        .lifecycle
+        .as_ref()
+        .expect("VPC prefix status should include lifecycle");
+    let lifecycle_state: LifecycleStateJson =
+        serde_json::from_str(&lifecycle_status.state).expect("lifecycle state should be JSON");
+    assert_eq!(lifecycle_state.state, "ready");
+    prefix
+}
 
 #[crate::sqlx_test]
 async fn test_create_and_delete_vpc_prefix_deprecated_fields(
@@ -34,8 +193,10 @@ async fn test_create_and_delete_vpc_prefix_deprecated_fields(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool).await;
     env.create_vpc_and_tenant_segment().await;
-    let ip_prefix = "192.0.2.0/25";
+    let ip_prefix = UNREFERENCED_VPC_PREFIX;
     let vpc_id = get_vpc_fixture_id(&env).await;
+
+    // Create with the deprecated flat prefix field to preserve compatibility coverage.
     let new_vpc_prefix = VpcPrefixCreationRequest {
         id: None,
         prefix: ip_prefix.into(),
@@ -50,6 +211,7 @@ async fn test_create_and_delete_vpc_prefix_deprecated_fields(
     let response = env.api.create_vpc_prefix(request).await;
     let vpc_prefix = response.expect("Could not create VPC prefix").into_inner();
 
+    // Assert the create response still mirrors the requested deprecated field.
     assert_eq!(
         vpc_prefix.prefix.as_str(),
         ip_prefix,
@@ -60,10 +222,25 @@ async fn test_create_and_delete_vpc_prefix_deprecated_fields(
         .id
         .expect("The id field on the new VPC prefix is missing (this should be impossible)");
 
+    // Verify persistence through the public get API after checking the create response.
+    let persisted = find_vpc_prefix(&env, id)
+        .await
+        .expect("VPC prefix should be visible through the public get API");
+    assert_eq!(persisted.prefix.as_str(), ip_prefix);
+
+    // Delete marks the prefix deleted; it should no longer be public but should still exist.
     let delete_by_id = VpcPrefixDeletionRequest { id: Some(id) };
     let request = Request::new(delete_by_id);
     let response = env.api.delete_vpc_prefix(request).await;
     let _deletion_result = response.expect("Could not delete VPC prefix").into_inner();
+
+    // Verify public reads hide the soft-deleted prefix.
+    assert!(find_vpc_prefix(&env, id).await.is_none());
+
+    // Verify controller-backed deletion has not hard-deleted the row yet.
+    assert_eq!(stored_vpc_prefix_count(&env, id).await, 1);
+    assert!(stored_vpc_prefix_is_deleted(&env, id).await);
+    assert_eq!(network_prefix_ref_count(&env, id).await, 0);
 
     Ok(())
 }
@@ -72,8 +249,10 @@ async fn test_create_and_delete_vpc_prefix_deprecated_fields(
 async fn test_create_and_delete_vpc_prefix(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool).await;
     env.create_vpc_and_tenant_segment().await;
-    let ip_prefix = "192.0.2.0/25";
+    let ip_prefix = UNREFERENCED_VPC_PREFIX;
     let vpc_id = get_vpc_fixture_id(&env).await;
+
+    // Create with the structured config field used by current clients.
     let new_vpc_prefix = VpcPrefixCreationRequest {
         id: None,
         prefix: String::new(),
@@ -94,6 +273,7 @@ async fn test_create_and_delete_vpc_prefix(pool: PgPool) -> Result<(), Box<dyn s
     let response = env.api.create_vpc_prefix(request).await;
     let vpc_prefix = response.expect("Could not create VPC prefix").into_inner();
 
+    // Assert the create response mirrors the requested prefix.
     assert_eq!(
         vpc_prefix.prefix.as_str(),
         ip_prefix,
@@ -104,10 +284,411 @@ async fn test_create_and_delete_vpc_prefix(pool: PgPool) -> Result<(), Box<dyn s
         .id
         .expect("The id field on the new VPC prefix is missing (this should be impossible)");
 
+    // Verify persistence through the public get API after checking the create response.
+    let persisted = find_vpc_prefix(&env, id)
+        .await
+        .expect("VPC prefix should be visible through the public get API");
+    assert_eq!(persisted.prefix.as_str(), ip_prefix);
+
+    // Delete marks the prefix deleted; it should no longer be public but should still exist.
     let delete_by_id = VpcPrefixDeletionRequest { id: Some(id) };
     let request = Request::new(delete_by_id);
     let response = env.api.delete_vpc_prefix(request).await;
     let _deletion_result = response.expect("Could not delete VPC prefix").into_inner();
+
+    // Verify public reads hide the soft-deleted prefix.
+    assert!(find_vpc_prefix(&env, id).await.is_none());
+
+    // Verify controller-backed deletion has not hard-deleted the row yet.
+    assert_eq!(stored_vpc_prefix_count(&env, id).await, 1);
+    assert!(stored_vpc_prefix_is_deleted(&env, id).await);
+    assert_eq!(network_prefix_ref_count(&env, id).await, 0);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_vpc_prefix_create_returns_initial_lifecycle_state(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    env.create_vpc_and_tenant_segment().await;
+    let vpc_id = get_vpc_fixture_id(&env).await;
+
+    // Create a prefix that has no existing network-prefix references.
+    let created = create_vpc_prefix(&env, vpc_id, UNREFERENCED_VPC_PREFIX).await;
+    let id = created.id.expect("created VPC prefix should include an id");
+
+    // Verify the create response reports the initial controller state and counters.
+    assert_status_with_lifecycle_and_linknet_counters(&created, "provisioning", 16, 16);
+
+    // Verify the same lifecycle state was persisted through the public get API.
+    let persisted = find_vpc_prefix(&env, id)
+        .await
+        .expect("VPC prefix should be visible through the public get API");
+    assert_status_with_lifecycle_and_linknet_counters(&persisted, "provisioning", 16, 16);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_vpc_prefix_controller_transitions_provisioning_to_ready(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    env.create_vpc_and_tenant_segment().await;
+    let vpc_id = get_vpc_fixture_id(&env).await;
+
+    // Create the prefix and capture the initial lifecycle version.
+    let created = create_vpc_prefix(&env, vpc_id, UNREFERENCED_VPC_PREFIX).await;
+    let id = created.id.expect("created VPC prefix should include an id");
+    let created_status = created
+        .status
+        .as_ref()
+        .expect("VPC prefix status should be populated");
+    let initial_version = created_status
+        .lifecycle
+        .as_ref()
+        .expect("VPC prefix status should include lifecycle")
+        .version
+        .clone();
+
+    // Drive the controller and verify the persisted state transitions to Ready.
+    let ready = drive_vpc_prefix_to_ready(&env, id).await;
+    let ready_status = ready
+        .status
+        .as_ref()
+        .expect("VPC prefix status should be populated");
+    let ready_lifecycle = ready_status
+        .lifecycle
+        .as_ref()
+        .expect("VPC prefix status should include lifecycle");
+    assert_ne!(
+        ready_lifecycle.version, initial_version,
+        "controller transition should increment the lifecycle version"
+    );
+    assert!(
+        ready_lifecycle.state_reason.is_some(),
+        "controller outcome should be exposed as lifecycle state_reason"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_vpc_prefix_delete_rejects_network_prefix_refs(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    env.create_vpc_and_tenant_segment().await;
+    let vpc_id = get_vpc_fixture_id(&env).await;
+
+    // Create a VPC prefix covering the tenant segment fixture so a network_prefix row references it.
+    let created = create_vpc_prefix(&env, vpc_id, REFERENCED_VPC_PREFIX).await;
+    let id = created.id.expect("created VPC prefix should include an id");
+    drive_vpc_prefix_to_ready(&env, id).await;
+    assert!(network_prefix_ref_count(&env, id).await > 0);
+
+    // Request deletion while durable network-prefix references still exist.
+    let err = env
+        .api
+        .delete_vpc_prefix(Request::new(VpcPrefixDeletionRequest { id: Some(id) }))
+        .await
+        .expect_err("delete should reject referenced VPC prefixes");
+
+    // Verify the rejected delete leaves the prefix active and visible.
+    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    assert!(find_vpc_prefix(&env, id).await.is_some());
+    let active_search_ids = env
+        .api
+        .search_vpc_prefixes(Request::new(VpcPrefixSearchQuery {
+            vpc_id: Some(vpc_id),
+            deleted: rpc::forge::DeletedFilter::Exclude as i32,
+            ..Default::default()
+        }))
+        .await
+        .expect("active-only search should succeed")
+        .into_inner()
+        .vpc_prefix_ids;
+    assert!(
+        active_search_ids.contains(&id),
+        "default VPC-prefix search should keep rejected deletes visible"
+    );
+    assert_eq!(stored_vpc_prefix_count(&env, id).await, 1);
+    assert!(!stored_vpc_prefix_is_deleted(&env, id).await);
+    assert!(network_prefix_ref_count(&env, id).await > 0);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_deleted_provisioning_vpc_prefix_enters_deleting_on_first_controller_pass(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    env.create_vpc_and_tenant_segment().await;
+    let vpc_id = get_vpc_fixture_id(&env).await;
+
+    // Delete the prefix before the controller has transitioned it out of Provisioning.
+    let created = create_vpc_prefix(&env, vpc_id, UNREFERENCED_VPC_PREFIX).await;
+    let id = created.id.expect("created VPC prefix should include an id");
+    env.api
+        .delete_vpc_prefix(Request::new(VpcPrefixDeletionRequest { id: Some(id) }))
+        .await
+        .expect("delete should mark the VPC prefix deleted");
+
+    assert!(find_vpc_prefix(&env, id).await.is_none());
+    let include_deleted_prefixes = env
+        .api
+        .get_vpc_prefixes(Request::new(rpc::forge::VpcPrefixGetRequest {
+            vpc_prefix_ids: vec![id],
+            deleted: rpc::forge::DeletedFilter::Include as i32,
+        }))
+        .await
+        .expect("Could not find VPC prefix including deleted")
+        .into_inner()
+        .vpc_prefixes;
+    assert_eq!(
+        include_deleted_prefixes.len(),
+        1,
+        "include-deleted get should return the soft-deleted VPC prefix"
+    );
+
+    // The first controller pass should enter Deleting directly rather than recording Ready.
+    env.run_vpc_prefix_controller_iteration().await;
+    assert_eq!(
+        stored_vpc_prefix_controller_state(&env, id)
+            .await
+            .as_deref(),
+        Some("deleting")
+    );
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM vpc_prefix_state_history \
+             WHERE vpc_prefix_id = $1 AND state->>'state' = 'ready'",
+        )
+        .bind(id)
+        .fetch_one(&env.pool)
+        .await
+        .expect("Could not count ready history records"),
+        0
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_deleted_vpc_prefix_cannot_allocate_new_instance_interface(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    env.create_vpc_and_tenant_segment().await;
+    let vpc_id = get_vpc_fixture_id(&env).await;
+
+    // Create and ready a prefix before marking it deleted.
+    let created = create_vpc_prefix(&env, vpc_id, UNREFERENCED_VPC_PREFIX).await;
+    let id = created.id.expect("created VPC prefix should include an id");
+    drive_vpc_prefix_to_ready(&env, id).await;
+    env.api
+        .delete_vpc_prefix(Request::new(VpcPrefixDeletionRequest { id: Some(id) }))
+        .await
+        .expect("delete should mark the VPC prefix deleted");
+
+    // Attempt to allocate a new instance interface from the deleted prefix.
+    let managed_host = create_managed_host(&env).await;
+    let allocation = env
+        .api
+        .allocate_instance(Request::new(rpc::forge::InstanceAllocationRequest {
+            instance_id: None,
+            machine_id: Some(managed_host.host().id),
+            instance_type_id: None,
+            config: Some(rpc::forge::InstanceConfig {
+                tenant: Some(default_tenant_config()),
+                os: Some(default_os_config()),
+                network: Some(single_interface_network_config_with_vpc_prefix(id)),
+                infiniband: None,
+                network_security_group_id: None,
+                dpu_extension_services: None,
+                nvlink: None,
+                spxconfig: None,
+            }),
+            metadata: None,
+            allow_unhealthy_machine: false,
+        }))
+        .await;
+
+    // Verify allocation rejects deleted prefixes instead of generating a new segment.
+    assert!(
+        allocation.is_err(),
+        "deleted VPC prefixes must not be usable for new interface allocation"
+    );
+    assert_eq!(network_prefix_ref_count(&env, id).await, 0);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_vpc_prefix_final_delete_after_generated_segment_cleanup(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides {
+            network_segments_drain_period: Some(chrono::Duration::seconds(0)),
+            vpc_prefixes_drain_period: Some(chrono::Duration::seconds(0)),
+            ..Default::default()
+        },
+    )
+    .await;
+    env.create_vpc_and_tenant_segment().await;
+    let vpc_id = get_vpc_fixture_id(&env).await;
+
+    // Create a ready prefix that instance allocation will use to generate a segment.
+    let created = create_vpc_prefix(&env, vpc_id, UNREFERENCED_VPC_PREFIX).await;
+    let id = created.id.expect("created VPC prefix should include an id");
+    drive_vpc_prefix_to_ready(&env, id).await;
+
+    // Allocate an instance so the generated segment creates network-prefix references.
+    let managed_host = create_managed_host(&env).await;
+    let (instance, rpc_instance) = managed_host
+        .instance_builer(&env)
+        .network(single_interface_network_config_with_vpc_prefix(id))
+        .build_and_return()
+        .await;
+    let generated_segment_id = rpc_instance.config().network().interfaces[0]
+        .network_segment_id
+        .expect("VPC-prefix allocation should assign a generated segment");
+    assert!(network_prefix_ref_count(&env, id).await > 0);
+
+    // Verify the generated segment reference blocks deletion requests.
+    let err = env
+        .api
+        .delete_vpc_prefix(Request::new(VpcPrefixDeletionRequest { id: Some(id) }))
+        .await
+        .expect_err("delete should reject referenced VPC prefixes");
+    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    assert_eq!(stored_vpc_prefix_count(&env, id).await, 1);
+    assert!(!stored_vpc_prefix_is_deleted(&env, id).await);
+    assert!(network_prefix_ref_count(&env, id).await > 0);
+
+    // Release the instance so generated segment cleanup removes the prefix references.
+    instance.delete().await;
+    assert_eq!(network_prefix_ref_count(&env, id).await, 0);
+
+    // Delete the now-unreferenced prefix before running controller cleanup.
+    env.api
+        .delete_vpc_prefix(Request::new(VpcPrefixDeletionRequest { id: Some(id) }))
+        .await
+        .expect("delete should mark the unreferenced VPC prefix deleted");
+
+    // Run VPC-prefix cleanup to advance through DBDelete after dependencies drain.
+    env.run_vpc_prefix_controller_iteration().await;
+    env.run_vpc_prefix_controller_iteration().await;
+    env.run_vpc_prefix_controller_iteration().await;
+
+    // Verify the prefix is finally hard-deleted after generated segment cleanup.
+    assert!(find_vpc_prefix(&env, id).await.is_none());
+    assert_eq!(stored_vpc_prefix_count(&env, id).await, 0);
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM network_segments WHERE id = $1")
+            .bind(generated_segment_id)
+            .fetch_one(&env.pool)
+            .await
+            .expect("Could not count generated network segment rows"),
+        0
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_repeat_vpc_prefix_delete_returns_not_found_while_soft_deleted(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    env.create_vpc_and_tenant_segment().await;
+    let vpc_id = get_vpc_fixture_id(&env).await;
+
+    // Create a prefix and submit the first delete request.
+    let created = create_vpc_prefix(&env, vpc_id, UNREFERENCED_VPC_PREFIX).await;
+    let id = created.id.expect("created VPC prefix should include an id");
+    env.api
+        .delete_vpc_prefix(Request::new(VpcPrefixDeletionRequest { id: Some(id) }))
+        .await
+        .expect("first delete should mark the VPC prefix deleted");
+
+    // Submit the same delete again while the row is still soft-deleted.
+    let err = env
+        .api
+        .delete_vpc_prefix(Request::new(VpcPrefixDeletionRequest { id: Some(id) }))
+        .await
+        .expect_err("repeat delete should return NotFound while soft-deleted");
+
+    // Verify repeat delete follows the active-only public API behavior.
+    assert_eq!(err.code(), tonic::Code::NotFound);
+    assert!(find_vpc_prefix(&env, id).await.is_none());
+    assert_eq!(stored_vpc_prefix_count(&env, id).await, 1);
+    assert!(stored_vpc_prefix_is_deleted(&env, id).await);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_vpc_delete_rejects_existing_vpc_prefix(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    env.create_vpc_and_tenant_segment().await;
+    let vpc_id = get_vpc_fixture_id(&env).await;
+
+    // Any VPC-prefix row, active or soft-deleted, keeps the parent VPC from being deleted.
+    let created = create_vpc_prefix(&env, vpc_id, UNREFERENCED_VPC_PREFIX).await;
+    let id = created.id.expect("created VPC prefix should include an id");
+
+    let err = env
+        .api
+        .delete_vpc(Request::new(VpcDeletionRequest { id: Some(vpc_id) }))
+        .await
+        .expect_err("VPC delete should be rejected while a VPC prefix exists");
+
+    assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        find_vpc_prefix(&env, id).await.is_some(),
+        "rejected parent VPC delete must not remove the VPC prefix"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_vpc_prefix_rpc_status_includes_lifecycle_and_counters(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    env.create_vpc_and_tenant_segment().await;
+    let vpc_id = get_vpc_fixture_id(&env).await;
+
+    // Create and ready a prefix that adopts an existing tenant segment reference.
+    let created = create_vpc_prefix(&env, vpc_id, REFERENCED_VPC_PREFIX).await;
+    let id = created.id.expect("created VPC prefix should include an id");
+    let ready = drive_vpc_prefix_to_ready(&env, id).await;
+
+    // Verify lifecycle fields and existing utilization counters share the RPC status.
+    assert_status_with_lifecycle_and_linknet_counters(&ready, "ready", 128, 127);
+    let status = ready
+        .status
+        .as_ref()
+        .expect("VPC prefix status should be populated");
+    assert_eq!(u64::from(status.total_31_segments), 128);
+    assert_eq!(u64::from(status.available_31_segments), 127);
+    let lifecycle_status = status
+        .lifecycle
+        .as_ref()
+        .expect("VPC prefix status should include lifecycle");
+    assert!(
+        lifecycle_status.state_reason.is_some(),
+        "RPC lifecycle status should expose controller reason"
+    );
 
     Ok(())
 }
@@ -297,6 +878,7 @@ async fn test_vpc_prefix_search(pool: PgPool) -> Result<(), Box<dyn std::error::
             name: None,
             prefix_match: Some(prefix.into()),
             prefix_match_type: Some(PrefixMatchType::PrefixExact as i32),
+            deleted: rpc::forge::DeletedFilter::Exclude as i32,
         };
         let search_request = Request::new(prefix_query);
         let search_response = env.api.search_vpc_prefixes(search_request).await;
@@ -328,6 +910,7 @@ async fn test_vpc_prefix_search(pool: PgPool) -> Result<(), Box<dyn std::error::
             name: None,
             prefix_match: Some(prefix.into()),
             prefix_match_type: Some(PrefixMatchType::PrefixContains as i32),
+            deleted: rpc::forge::DeletedFilter::Exclude as i32,
         };
         let search_request = Request::new(prefix_query);
         let search_response = env.api.search_vpc_prefixes(search_request).await;
@@ -354,6 +937,7 @@ async fn test_vpc_prefix_search(pool: PgPool) -> Result<(), Box<dyn std::error::
         name: None,
         prefix_match: Some(prefix.into()),
         prefix_match_type: Some(PrefixMatchType::PrefixContainedBy as i32),
+        deleted: rpc::forge::DeletedFilter::Exclude as i32,
     };
     let search_request = Request::new(prefix_query);
     let search_response = env.api.search_vpc_prefixes(search_request).await;

--- a/crates/api-db/migrations/20260603202104_vpc_prefix_lifecycle.sql
+++ b/crates/api-db/migrations/20260603202104_vpc_prefix_lifecycle.sql
@@ -1,0 +1,63 @@
+-- Add durable lifecycle state and a soft-delete marker for asynchronous cleanup.
+ALTER TABLE network_vpc_prefixes
+    ADD COLUMN deleted TIMESTAMPTZ DEFAULT NULL,
+    ADD COLUMN controller_state jsonb,
+    ADD COLUMN controller_state_version VARCHAR(64),
+    ADD COLUMN controller_state_outcome jsonb DEFAULT NULL;
+
+-- Keep controller state transitions queryable without overloading the prefix row.
+CREATE TABLE vpc_prefix_state_history (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    vpc_prefix_id uuid NOT NULL,
+    state jsonb NOT NULL,
+    state_version VARCHAR(64) NOT NULL,
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- History intentionally omits a foreign key so records can survive VPC-prefix hard-delete.
+CREATE INDEX vpc_prefix_state_history_vpc_prefix_id_idx
+    ON vpc_prefix_state_history(vpc_prefix_id);
+
+CREATE OR REPLACE FUNCTION vpc_prefix_state_history_keep_limit()
+RETURNS TRIGGER AS
+$body$
+BEGIN
+    DELETE FROM vpc_prefix_state_history WHERE vpc_prefix_id=NEW.vpc_prefix_id AND id NOT IN (SELECT id from vpc_prefix_state_history where vpc_prefix_id=NEW.vpc_prefix_id ORDER BY id DESC LIMIT 250);
+    RETURN NULL;
+END;
+$body$
+LANGUAGE plpgsql;
+
+-- Match the state-controller history retention limit used by other lifecycle tables.
+CREATE TRIGGER t_vpc_prefix_state_history_keep_limit
+  AFTER INSERT ON vpc_prefix_state_history
+  FOR EACH ROW EXECUTE PROCEDURE vpc_prefix_state_history_keep_limit();
+
+-- Existing prefixes were already usable before this controller existed, so backfill them as ready.
+UPDATE network_vpc_prefixes
+SET controller_state = '{"state":"ready"}'::jsonb,
+    controller_state_version = 'V1-T1666644937952268';
+
+-- Seed one history row per upgraded prefix so lifecycle views have an initial state.
+INSERT INTO vpc_prefix_state_history (vpc_prefix_id, state, state_version)
+SELECT id, controller_state, controller_state_version
+FROM network_vpc_prefixes;
+
+-- New prefixes created after the migration start in provisioning until the controller observes them.
+ALTER TABLE network_vpc_prefixes
+    ALTER COLUMN controller_state SET NOT NULL,
+    ALTER COLUMN controller_state SET DEFAULT ('{"state":"provisioning"}'::jsonb),
+    ALTER COLUMN controller_state_version SET NOT NULL,
+    ALTER COLUMN controller_state_version SET DEFAULT ('V1-T1666644937952268');
+
+-- State-controller bookkeeping tables. Names must match VpcPrefixStateControllerIO constants.
+CREATE TABLE network_vpc_prefixes_controller_iteration_ids(
+    id BIGSERIAL PRIMARY KEY,
+    started_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE TABLE network_vpc_prefixes_controller_queued_objects(
+    object_id VARCHAR PRIMARY KEY,
+    processed_by TEXT NULL DEFAULT NULL,
+    processing_started_at timestamptz NOT NULL DEFAULT NOW()
+);

--- a/crates/api-db/src/state_history.rs
+++ b/crates/api-db/src/state_history.rs
@@ -58,6 +58,7 @@ impl From<DbStateHistoryRecord> for StateHistoryRecord {
 pub enum StateHistoryTableId {
     Machine,
     NetworkSegment,
+    VpcPrefix,
     DpaInterface,
     IbPartition,
     PowerShelf,
@@ -70,6 +71,7 @@ impl StateHistoryTableId {
         match self {
             StateHistoryTableId::Machine => "machine_state_history",
             StateHistoryTableId::NetworkSegment => "network_segment_state_history",
+            StateHistoryTableId::VpcPrefix => "vpc_prefix_state_history",
             StateHistoryTableId::DpaInterface => "dpa_interface_state_history",
             StateHistoryTableId::IbPartition => "ib_partition_state_history",
             StateHistoryTableId::PowerShelf => "power_shelf_state_history",
@@ -82,6 +84,7 @@ impl StateHistoryTableId {
         match self {
             StateHistoryTableId::Machine => "machine_id",
             StateHistoryTableId::NetworkSegment => "segment_id",
+            StateHistoryTableId::VpcPrefix => "vpc_prefix_id",
             StateHistoryTableId::DpaInterface => "interface_id",
             StateHistoryTableId::IbPartition => "partition_id",
             StateHistoryTableId::PowerShelf => "power_shelf_id",
@@ -93,6 +96,7 @@ impl StateHistoryTableId {
     fn object_id_sql_type(self) -> &'static str {
         match self {
             StateHistoryTableId::NetworkSegment
+            | StateHistoryTableId::VpcPrefix
             | StateHistoryTableId::DpaInterface
             | StateHistoryTableId::IbPartition => "uuid",
             StateHistoryTableId::Machine

--- a/crates/api-db/src/vpc.rs
+++ b/crates/api-db/src/vpc.rs
@@ -159,20 +159,53 @@ pub async fn find_ids(
     Ok(ids)
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum VpcRowLock {
+    #[default]
+    None,
+    /// Coordinates parent VPC mutations with VPC-attached child mutations.
+    ///
+    /// Callers that need this lock to protect later statements must use a
+    /// connection from an explicit transaction and keep the transaction open until
+    /// the coordinated mutation is committed or rolled back.
+    Mutation,
+}
+
 // Note: Following find function should not be used to search based on vpc labels.
 // Recommended approach to filter by labels is to first find VPC ids.
-pub async fn find_by<'a, C: ColumnInfo<'a, TableType = Vpc>>(
+async fn find_by_inner<'a, C: ColumnInfo<'a, TableType = Vpc>>(
     txn: impl DbReader<'_>,
     filter: ObjectColumnFilter<'a, C>,
+    row_lock: VpcRowLock,
 ) -> Result<Vec<Vpc>, DatabaseError> {
     let mut query = FilterableQueryBuilder::new("SELECT * FROM vpcs").filter(&filter);
 
+    query.push(" AND deleted IS NULL");
+    if matches!(row_lock, VpcRowLock::Mutation) {
+        query.push(" FOR NO KEY UPDATE");
+    }
     query
-        .push(" AND deleted IS NULL")
         .build_query_as()
         .fetch_all(txn)
         .await
         .map_err(|e| DatabaseError::query(query.sql(), e))
+}
+
+// Note: Following find function should not be used to search based on vpc labels.
+// Recommended approach to filter by labels is to first find VPC ids.
+pub async fn find_by_with_lock<'a, C: ColumnInfo<'a, TableType = Vpc>>(
+    txn: &mut PgConnection,
+    filter: ObjectColumnFilter<'a, C>,
+    row_lock: VpcRowLock,
+) -> Result<Vec<Vpc>, DatabaseError> {
+    find_by_inner(&mut *txn, filter, row_lock).await
+}
+
+pub async fn find_by<'a, C: ColumnInfo<'a, TableType = Vpc>>(
+    txn: impl DbReader<'_>,
+    filter: ObjectColumnFilter<'a, C>,
+) -> Result<Vec<Vpc>, DatabaseError> {
+    find_by_inner(txn, filter, VpcRowLock::None).await
 }
 
 pub async fn find_by_vni(txn: &mut PgConnection, vni: i32) -> Result<Vec<Vpc>, DatabaseError> {
@@ -224,14 +257,34 @@ pub async fn find_by_segment(
         .map_err(|e| DatabaseError::query(query.sql(), e))
 }
 
-/// Tries to deletes a VPC
+/// Tries to delete a VPC.
 ///
-/// If the VPC existed at the point of deletion this returns the last known information about the VPC
-/// If the VPC already had been delete, this returns Ok(`None`)
+/// If the VPC existed at the point of deletion, this returns the last known information about the VPC.
+/// If the VPC was already deleted, this returns Ok(`None`), even if historical orphaned
+/// VPC-prefix rows still reference it.
+///
+/// Callers that coordinate VPC-attached child mutations must acquire
+/// [`VpcRowLock::Mutation`] on this VPC before calling this function.
 pub async fn try_delete(txn: &mut PgConnection, id: VpcId) -> Result<Option<Vpc>, DatabaseError> {
-    // TODO: Should this update the version?
+    // Block deletion of active VPCs while any active or soft-deleted prefix row still references
+    // them. The EXISTS clause preserves the existing Ok(None) behavior for already-deleted VPCs,
+    // including legacy cases where old prefix rows may still reference the deleted parent.
+    let vpc_prefix_count_query = "SELECT count(*) FROM network_vpc_prefixes
+        WHERE vpc_id=$1
+        AND EXISTS (SELECT 1 FROM vpcs WHERE id=$1 AND deleted IS NULL)";
+    let (vpc_prefix_count,): (i64,) = sqlx::query_as(vpc_prefix_count_query)
+        .bind(id)
+        .fetch_one(&mut *txn)
+        .await
+        .map_err(|e| DatabaseError::query(vpc_prefix_count_query, e))?;
+    if vpc_prefix_count > 0 {
+        return Err(DatabaseError::FailedPrecondition(format!(
+            "VPC {id} cannot be deleted while {vpc_prefix_count} VPC prefixes still exist or are pending deletion"
+        )));
+    }
+
     let query =
-        "UPDATE vpcs SET updated=NOW(), deleted=NOW() WHERE id=$1 AND deleted is null RETURNING *";
+        "UPDATE vpcs SET updated=NOW(), deleted=NOW() WHERE id=$1 AND deleted IS NULL RETURNING *";
     match sqlx::query_as(query).bind(id).fetch_one(txn).await {
         Ok(vpc) => Ok(Some(vpc)),
         Err(sqlx::Error::RowNotFound) => Ok(None),
@@ -377,8 +430,7 @@ pub async fn increment_vpc_version(
 ) -> Result<ConfigVersion, DatabaseError> {
     let next_version = expected_version.increment();
 
-    let update_query =
-        "UPDATE vpcs SET version = $1 WHERE id = $2 AND version = $3 RETURNING version";
+    let update_query = "UPDATE vpcs SET version = $1 WHERE id = $2 AND version = $3 AND deleted IS NULL RETURNING version";
     let updated: Result<(ConfigVersion,), _> = sqlx::query_as(update_query)
         .bind(next_version)
         .bind(id)

--- a/crates/api-db/src/vpc_prefix.rs
+++ b/crates/api-db/src/vpc_prefix.rs
@@ -19,8 +19,13 @@ pub use carbide_uuid::vpc::{VpcId, VpcPrefixId};
 use config_version::ConfigVersion;
 use ipnetwork::IpNetwork;
 use itertools::Itertools;
+use model::DeletedFilter;
+use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::network_prefix::NetworkPrefix;
-use model::vpc_prefix::{DeleteVpcPrefix, NewVpcPrefix, PrefixMatch, UpdateVpcPrefix, VpcPrefix};
+use model::vpc_prefix::{
+    DeleteVpcPrefix, NewVpcPrefix, UpdateVpcPrefix, VpcPrefix, VpcPrefixControllerState,
+    VpcPrefixSearch,
+};
 use sqlx::{FromRow, PgConnection, QueryBuilder, Row};
 
 use super::{ColumnInfo, DatabaseError, ObjectColumnFilter};
@@ -97,12 +102,22 @@ async fn update_stats(
 pub async fn get_by_id<'a, C>(
     txn: &mut PgConnection,
     filter: ObjectColumnFilter<'a, C>,
+    deleted_filter: DeletedFilter,
 ) -> Result<Vec<VpcPrefix>, DatabaseError>
 where
     C: ColumnInfo<'a, TableType = VpcPrefix>,
 {
     let mut query =
         super::FilterableQueryBuilder::new("SELECT * FROM network_vpc_prefixes").filter(&filter);
+    match deleted_filter {
+        DeletedFilter::Exclude => {
+            query.push(" AND deleted IS NULL");
+        }
+        DeletedFilter::Only => {
+            query.push(" AND deleted IS NOT NULL");
+        }
+        DeletedFilter::Include => {}
+    }
     let mut container = query
         .build_query_as()
         .fetch_all(&mut *txn)
@@ -119,11 +134,21 @@ pub async fn get_by_id_with_row_lock(
     filter: &[VpcPrefixId],
 ) -> Result<Vec<VpcPrefix>, DatabaseError> {
     let query = "SELECT * FROM network_vpc_prefixes WHERE id=ANY($1) FOR NO KEY UPDATE";
-    let mut container = sqlx::query_as(query)
+    let mut container: Vec<VpcPrefix> = sqlx::query_as(query)
         .bind(filter)
         .fetch_all(&mut *txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
+
+    if let Some(vpc_prefix) = container
+        .iter()
+        .find(|prefix| prefix.is_marked_as_deleted())
+    {
+        return Err(DatabaseError::InvalidArgument(format!(
+            "VPC prefix {} is marked for deletion and cannot be used for allocation",
+            vpc_prefix.id
+        )));
+    }
 
     update_stats(&mut container, txn).await?;
     Ok(container)
@@ -135,6 +160,7 @@ pub async fn find_by_vpc(
     vpc_id: VpcId,
 ) -> Result<Vec<VpcPrefix>, DatabaseError> {
     let query = "SELECT * FROM network_vpc_prefixes WHERE vpc_id=$1 \
+            AND deleted IS NULL \
             ORDER BY prefix";
     let mut container = sqlx::query_as(query)
         .bind(vpc_id)
@@ -152,6 +178,7 @@ pub async fn find_by_vpcs(
     vpc_ids: &Vec<VpcId>,
 ) -> Result<Vec<VpcPrefix>, DatabaseError> {
     let query = "SELECT * FROM network_vpc_prefixes WHERE vpc_id=ANY($1) \
+                AND deleted IS NULL \
                 ORDER BY prefix";
     sqlx::query_as(query)
         .bind(vpc_ids)
@@ -166,7 +193,7 @@ pub async fn update_last_used_prefix(
     vpc_prefix_id: &VpcPrefixId,
     last_used_prefix: IpNetwork,
 ) -> Result<(), DatabaseError> {
-    let query = "UPDATE network_vpc_prefixes SET last_used_prefix=$1 WHERE id=$2 RETURNING *";
+    let query = "UPDATE network_vpc_prefixes SET last_used_prefix=$1 WHERE id=$2 AND deleted IS NULL RETURNING *";
     sqlx::query_as::<_, VpcPrefix>(query)
         .bind(last_used_prefix)
         .bind(vpc_prefix_id)
@@ -181,11 +208,26 @@ pub async fn update_last_used_prefix(
 // the prefix (or some combination). Returns just the IDs.
 pub async fn search(
     txn: &mut PgConnection,
-    vpc_id: Option<VpcId>,
-    name: Option<String>,
-    prefix_match: Option<PrefixMatch>,
+    search: VpcPrefixSearch,
 ) -> Result<Vec<VpcPrefixId>, DatabaseError> {
+    let VpcPrefixSearch {
+        vpc_id,
+        name,
+        prefix_match,
+        deleted_filter,
+    } = search;
+
     let mut query = QueryBuilder::new("SELECT id FROM network_vpc_prefixes WHERE true");
+
+    match deleted_filter {
+        DeletedFilter::Exclude => {
+            query.push(" AND deleted IS NULL");
+        }
+        DeletedFilter::Only => {
+            query.push(" AND deleted IS NOT NULL");
+        }
+        DeletedFilter::Include => {}
+    }
 
     if let Some(vpc_id) = vpc_id {
         query.push(" AND vpc_id=");
@@ -238,28 +280,64 @@ pub async fn persist(
     expected_vpc_version: ConfigVersion,
     txn: &mut PgConnection,
 ) -> Result<VpcPrefix, DatabaseError> {
-    let insert_query = "INSERT INTO network_vpc_prefixes (id, prefix, name, labels, description, vpc_id) VALUES ($1, $2, $3, $4::json, $5, $6) RETURNING *";
-    let vpc_prefix: VpcPrefix = sqlx::query_as(insert_query)
+    let initial_version = ConfigVersion::initial();
+    let initial_state = VpcPrefixControllerState::Provisioning;
+
+    let insert_query = "INSERT INTO network_vpc_prefixes (
+                id,
+                prefix,
+                name,
+                labels,
+                description,
+                vpc_id,
+                controller_state,
+                controller_state_version)
+            VALUES ($1, $2, $3, $4::json, $5, $6, $7::json, $8)
+            RETURNING *";
+    let vpc_prefix: VpcPrefix = match sqlx::query_as(insert_query)
         .bind(value.id)
         .bind(value.config.prefix)
         .bind(&value.metadata.name)
         .bind(sqlx::types::Json(&value.metadata.labels))
         .bind(&value.metadata.description)
         .bind(value.vpc_id)
+        .bind(sqlx::types::Json(&initial_state))
+        .bind(initial_version)
         .fetch_one(&mut *txn)
         .await
-        .map_err(|e| DatabaseError::query(insert_query, e))?;
+    {
+        Ok(vpc_prefix) => vpc_prefix,
+        Err(sqlx::Error::Database(error))
+            if error.constraint() == Some("network_vpc_prefixes_globally_unique") =>
+        {
+            return Err(DatabaseError::InvalidArgument(format!(
+                "The requested VPC prefix ({}) overlaps an existing or deleting VPC prefix",
+                value.config.prefix
+            )));
+        }
+        Err(e) => return Err(DatabaseError::query(insert_query, e)),
+    };
+
+    crate::state_history::persist(
+        txn,
+        crate::state_history::StateHistoryTableId::VpcPrefix,
+        &vpc_prefix.id,
+        &initial_state,
+        initial_version,
+    )
+    .await?;
 
     increment_vpc_version(txn, value.vpc_id, expected_vpc_version).await?;
 
     Ok(vpc_prefix)
 }
 
-// Check for existing VPC prefixes using any of our address space.
+/// Checks for existing or deleting VPC prefixes using any of the address space.
 pub async fn probe(
     network: IpNetwork,
     txn: &mut PgConnection,
 ) -> Result<Vec<VpcPrefix>, DatabaseError> {
+    // Include soft-deleted rows because the global exclusion constraint still reserves them.
     let query = "SELECT * FROM network_vpc_prefixes WHERE prefix && $1";
     sqlx::query_as(query)
         .bind(network)
@@ -297,7 +375,7 @@ pub async fn update(
     update: &UpdateVpcPrefix,
     txn: &mut PgConnection,
 ) -> Result<VpcPrefix, DatabaseError> {
-    let query = "UPDATE network_vpc_prefixes SET name=$1, labels=$2::json, description=$3 WHERE id=$4 RETURNING *";
+    let query = "UPDATE network_vpc_prefixes SET name=$1, labels=$2::json, description=$3 WHERE id=$4 AND deleted IS NULL RETURNING *";
     sqlx::query_as(query)
         .bind(&update.metadata.name)
         .bind(sqlx::types::Json(&update.metadata.labels))
@@ -310,19 +388,99 @@ pub async fn update(
     // call increment_vpc_version() here.
 }
 
-pub async fn delete(
+/// Marks an active VPC prefix for asynchronous deletion and bumps the parent VPC version.
+pub async fn mark_as_deleted(
     value: &DeleteVpcPrefix,
     expected_vpc_version: ConfigVersion,
     txn: &mut PgConnection,
 ) -> Result<VpcPrefixId, DatabaseError> {
-    let query = "DELETE FROM network_vpc_prefixes WHERE id=$1 RETURNING *";
+    // Mark the prefix deleted while keeping its address space reserved for the controller.
+    let query =
+        "UPDATE network_vpc_prefixes SET deleted=NOW() WHERE id=$1 AND deleted IS NULL RETURNING *";
     let deleted_prefix: VpcPrefix = sqlx::query_as(query)
         .bind(value.id)
         .fetch_one(&mut *txn)
         .await
-        .map_err(|e| DatabaseError::query(query, e))?;
+        .map_err(|e| match e {
+            sqlx::Error::RowNotFound => DatabaseError::NotFoundError {
+                kind: "vpc_prefix",
+                id: value.id.to_string(),
+            },
+            e => DatabaseError::query(query, e),
+        })?;
 
     increment_vpc_version(txn, deleted_prefix.vpc_id, expected_vpc_version).await?;
 
     Ok(deleted_prefix.id)
+}
+
+/// Hard-deletes a VPC prefix after the controller has drained all dependencies.
+pub async fn final_delete(
+    vpc_prefix_id: VpcPrefixId,
+    txn: &mut PgConnection,
+) -> Result<VpcPrefixId, DatabaseError> {
+    // Remove the terminal row without bumping the parent VPC version again.
+    let query = "DELETE FROM network_vpc_prefixes WHERE id=$1 RETURNING id";
+    let deleted_id = sqlx::query_as::<_, VpcPrefixId>(query)
+        .bind(vpc_prefix_id)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(deleted_id)
+}
+
+/// Updates the controller-owned VPC prefix state if the version still matches.
+pub async fn try_update_controller_state(
+    txn: &mut PgConnection,
+    vpc_prefix_id: VpcPrefixId,
+    expected_version: ConfigVersion,
+    new_version: ConfigVersion,
+    new_state: &VpcPrefixControllerState,
+) -> Result<bool, DatabaseError> {
+    // Use optimistic locking so concurrent controller attempts cannot overwrite each other.
+    let query = "UPDATE network_vpc_prefixes SET controller_state_version=$1, controller_state=$2::json WHERE id=$3 AND controller_state_version=$4 RETURNING id";
+    let result = sqlx::query_as::<_, VpcPrefixId>(query)
+        .bind(new_version)
+        .bind(sqlx::types::Json(new_state))
+        .bind(vpc_prefix_id)
+        .bind(expected_version)
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(result.is_some())
+}
+
+/// Stores the result of the most recent VPC prefix controller handling attempt.
+pub async fn update_controller_state_outcome(
+    txn: &mut PgConnection,
+    vpc_prefix_id: VpcPrefixId,
+    outcome: PersistentStateHandlerOutcome,
+) -> Result<(), DatabaseError> {
+    // Persist the outcome separately from state so waits/errors remain visible.
+    let query = "UPDATE network_vpc_prefixes SET controller_state_outcome=$1::json WHERE id=$2";
+    sqlx::query(query)
+        .bind(sqlx::types::Json(outcome))
+        .bind(vpc_prefix_id)
+        .execute(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+    Ok(())
+}
+
+/// Counts network-prefix rows that still reference a VPC prefix.
+pub async fn count_network_prefixes_by_vpc_prefix_id(
+    txn: &mut PgConnection,
+    vpc_prefix_id: &VpcPrefixId,
+) -> Result<usize, DatabaseError> {
+    // The controller uses this durable dependency as the deletion drain gate.
+    let query = "SELECT count(*) FROM network_prefixes WHERE vpc_prefix_id=$1";
+    let (network_prefix_count,): (i64,) = sqlx::query_as(query)
+        .bind(vpc_prefix_id)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(network_prefix_count.max(0) as usize)
 }

--- a/crates/api-model/src/vpc_prefix.rs
+++ b/crates/api-model/src/vpc_prefix.rs
@@ -15,13 +15,63 @@
  * limitations under the License.
  */
 use std::collections::HashMap;
+use std::time::Duration;
 
 use carbide_uuid::vpc::{VpcId, VpcPrefixId};
+use chrono::{DateTime, Utc};
+use config_version::{ConfigVersion, Versioned};
 use ipnetwork::IpNetwork;
 use sqlx::Row;
 use sqlx::postgres::PgRow;
 
+use crate::controller_outcome::PersistentStateHandlerOutcome;
 use crate::metadata::Metadata;
+use crate::{DeletedFilter, StateSla};
+
+const PROVISIONING_SLA: Duration = Duration::from_secs(15 * 60);
+const DELETING_DBDELETE_SLA: Duration = Duration::from_secs(15 * 60);
+
+/// State of a VPC prefix as tracked by the controller.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "state", rename_all = "lowercase")]
+pub enum VpcPrefixControllerState {
+    Provisioning,
+    Ready,
+    Deleting {
+        deletion_state: VpcPrefixDeletionState,
+    },
+}
+
+/// Possible substates while deleting a VPC prefix.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "state", rename_all = "lowercase")]
+pub enum VpcPrefixDeletionState {
+    DrainNetworkPrefixes { delete_at: DateTime<Utc> },
+    DBDelete,
+}
+
+/// Returns the SLA for the current VPC prefix controller state.
+pub fn state_sla(state: &VpcPrefixControllerState, state_version: &ConfigVersion) -> StateSla {
+    // Compare the controller state's version timestamp against the current time.
+    let time_in_state = chrono::Utc::now()
+        .signed_duration_since(state_version.timestamp())
+        .to_std()
+        .unwrap_or(Duration::from_secs(60 * 60 * 24));
+
+    // Only bounded controller work has an SLA; dependency drains can wait indefinitely.
+    match state {
+        VpcPrefixControllerState::Provisioning => {
+            StateSla::with_sla(PROVISIONING_SLA, time_in_state)
+        }
+        VpcPrefixControllerState::Ready => StateSla::no_sla(),
+        VpcPrefixControllerState::Deleting {
+            deletion_state: VpcPrefixDeletionState::DrainNetworkPrefixes { .. },
+        } => StateSla::no_sla(),
+        VpcPrefixControllerState::Deleting {
+            deletion_state: VpcPrefixDeletionState::DBDelete,
+        } => StateSla::with_sla(DELETING_DBDELETE_SLA, time_in_state),
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct VpcPrefix {
@@ -30,6 +80,15 @@ pub struct VpcPrefix {
     pub config: VpcPrefixConfig,
     pub metadata: Metadata,
     pub status: VpcPrefixStatus,
+    pub deleted: Option<DateTime<Utc>>,
+}
+
+impl VpcPrefix {
+    /// Returns whether the VPC prefix was marked for asynchronous deletion.
+    pub fn is_marked_as_deleted(&self) -> bool {
+        // A non-null deletion timestamp is the durable soft-delete marker.
+        self.deleted.is_some()
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -39,6 +98,8 @@ pub struct VpcPrefixConfig {
 
 #[derive(Clone, Debug)]
 pub struct VpcPrefixStatus {
+    pub controller_state: Versioned<VpcPrefixControllerState>,
+    pub controller_state_outcome: Option<PersistentStateHandlerOutcome>,
     pub last_used_prefix: Option<IpNetwork>,
     pub total_31_segments: u32,
     pub available_31_segments: u32,
@@ -55,6 +116,10 @@ impl<'r> sqlx::FromRow<'r, PgRow> for VpcPrefix {
         let last_used_prefix = row.try_get("last_used_prefix")?;
         let labels: sqlx::types::Json<HashMap<String, String>> = row.try_get("labels")?;
         let description: String = row.try_get("description")?;
+        let controller_state: sqlx::types::Json<VpcPrefixControllerState> =
+            row.try_get("controller_state")?;
+        let controller_state_outcome: Option<sqlx::types::Json<PersistentStateHandlerOutcome>> =
+            row.try_get("controller_state_outcome")?;
 
         Ok(VpcPrefix {
             id,
@@ -66,12 +131,18 @@ impl<'r> sqlx::FromRow<'r, PgRow> for VpcPrefix {
             },
             vpc_id,
             status: VpcPrefixStatus {
+                controller_state: Versioned::new(
+                    controller_state.0,
+                    row.try_get("controller_state_version")?,
+                ),
+                controller_state_outcome: controller_state_outcome.map(|outcome| outcome.0),
                 last_used_prefix,
                 total_31_segments: 0,
                 available_31_segments: 0,
                 total_linknet_segments: 0,
                 available_linknet_segments: 0,
             },
+            deleted: row.try_get("deleted")?,
         })
     }
 }
@@ -81,6 +152,14 @@ pub enum PrefixMatch {
     Exact(IpNetwork),
     Contains(IpNetwork),
     ContainedBy(IpNetwork),
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VpcPrefixSearch {
+    pub vpc_id: Option<VpcId>,
+    pub name: Option<String>,
+    pub prefix_match: Option<PrefixMatch>,
+    pub deleted_filter: DeletedFilter,
 }
 
 /// NewVpcPrefix represents a VPC prefix resource before it's persisted to the

--- a/crates/api-web/src/ipam.rs
+++ b/crates/api-web/src/ipam.rs
@@ -29,7 +29,7 @@ use hyper::http::StatusCode;
 use rpc::forge as forgerpc;
 use rpc::forge::forge_server::Forge;
 
-use super::Base;
+use super::{Base, LifecycleDetail, filters};
 
 #[derive(Template)]
 #[template(path = "ipam_dhcp.html")]
@@ -471,6 +471,7 @@ struct OverlayVpcPrefixDisplay {
     id: String,
     prefix: String,
     name: String,
+    lifecycle_state: String,
 }
 
 /// Overlay Networks -- lists VNIs and their prefixes.
@@ -485,7 +486,10 @@ pub async fn overlay_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     };
 
     // Fetch all VPC prefix IDs, and then the prefixes themselves.
-    let prefix_request = tonic::Request::new(forgerpc::VpcPrefixSearchQuery::default());
+    let prefix_request = tonic::Request::new(forgerpc::VpcPrefixSearchQuery {
+        deleted: forgerpc::DeletedFilter::Include as i32,
+        ..Default::default()
+    });
     let prefix_ids = match state
         .search_vpc_prefixes(prefix_request)
         .await
@@ -508,6 +512,7 @@ pub async fn overlay_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
         match state
             .get_vpc_prefixes(tonic::Request::new(forgerpc::VpcPrefixGetRequest {
                 vpc_prefix_ids: prefix_ids,
+                deleted: forgerpc::DeletedFilter::Include as i32,
             }))
             .await
             .map(|r| r.into_inner().vpc_prefixes)
@@ -553,6 +558,7 @@ pub async fn overlay_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
                 id: p.id.map(|id| id.to_string()).unwrap_or_default(),
                 prefix: prefix_str,
                 name,
+                lifecycle_state: lifecycle_state_label(&p),
             });
     }
 
@@ -582,6 +588,26 @@ pub async fn overlay_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
 
     let tmpl = IpamOverlay { vpcs };
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
+}
+
+fn lifecycle_state_label(prefix: &forgerpc::VpcPrefix) -> String {
+    let Some(lifecycle) = prefix
+        .status
+        .as_ref()
+        .and_then(|status| status.lifecycle.as_ref())
+    else {
+        return "Unavailable".to_string();
+    };
+
+    serde_json::from_str::<serde_json::Value>(&lifecycle.state)
+        .ok()
+        .and_then(|state| {
+            state
+                .get("state")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| lifecycle.state.clone())
 }
 
 async fn fetch_vpcs(api: Arc<Api>) -> Result<Vec<forgerpc::Vpc>, tonic::Status> {
@@ -628,6 +654,9 @@ struct IpamOverlayPrefix {
     vpc_name: String,
     vpc_id: String,
     vni: String,
+    lifecycle_detail: Option<LifecycleDetail>,
+    state_history: Vec<forgerpc::StateHistoryRecord>,
+    state_history_load_error: Option<String>,
     segments: Vec<OverlaySegmentDisplay>,
 }
 
@@ -663,6 +692,7 @@ pub async fn overlay_prefix_html(
     let prefix = match state
         .get_vpc_prefixes(tonic::Request::new(forgerpc::VpcPrefixGetRequest {
             vpc_prefix_ids: vec![vpc_prefix_uuid],
+            deleted: forgerpc::DeletedFilter::Include as i32,
         }))
         .await
         .map(|r| r.into_inner().vpc_prefixes)
@@ -690,6 +720,35 @@ pub async fn overlay_prefix_html(
         .map(|m| m.name.clone())
         .unwrap_or_else(|| "<no name>".to_string());
     let vpc_id = prefix.vpc_id.map(|id| id.to_string()).unwrap_or_default();
+    let lifecycle_detail = prefix
+        .status
+        .as_ref()
+        .and_then(|status| status.lifecycle.clone())
+        .map(Into::into);
+
+    // Fetch the controller state history for this prefix.
+    let (mut state_history, state_history_load_error) = match state
+        .find_vpc_prefix_state_histories(tonic::Request::new(
+            forgerpc::VpcPrefixStateHistoriesRequest {
+                vpc_prefix_ids: vec![vpc_prefix_uuid],
+            },
+        ))
+        .await
+        .map(|r| r.into_inner().histories)
+    {
+        Ok(mut histories) => (
+            histories
+                .remove(&vpc_prefix_uuid.to_string())
+                .map(|history| history.records)
+                .unwrap_or_default(),
+            None,
+        ),
+        Err(err) => {
+            tracing::error!(%err, "find_vpc_prefix_state_histories");
+            (Vec::new(), Some(err.to_string()))
+        }
+    };
+    state_history.reverse();
 
     // Fetch the parent VPC for name/VNI.
     let (vpc_name, vni) = if let Ok(vpc_uuid) = vpc_id.parse() {
@@ -759,6 +818,9 @@ pub async fn overlay_prefix_html(
         vpc_name,
         vpc_id,
         vni,
+        lifecycle_detail,
+        state_history,
+        state_history_load_error,
         segments,
     };
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()

--- a/crates/api-web/templates/ipam_overlay.html
+++ b/crates/api-web/templates/ipam_overlay.html
@@ -13,6 +13,7 @@
 			<th>VNI</th>
 			<th>Tenant</th>
 			<th>Prefixes</th>
+			<th>Prefix States</th>
 		</tr>
 	</thead>
 	<tbody>
@@ -25,6 +26,15 @@
 					{% for p in vpc.prefixes %}
 						<a href="/admin/ipam/overlay/prefix/{{ p.id }}">{{ p.prefix }}</a>
 						{% if !p.name.is_empty() %}({{ p.name }}){% endif %}
+						{% if !loop.last %}<br>{% endif %}
+					{% endfor %}
+					{% if vpc.prefixes.is_empty() %}
+						<span class="muted">None</span>
+					{% endif %}
+				</td>
+				<td>
+					{% for p in vpc.prefixes %}
+						{{ p.lifecycle_state }}
 						{% if !loop.last %}<br>{% endif %}
 					{% endfor %}
 					{% if vpc.prefixes.is_empty() %}

--- a/crates/api-web/templates/ipam_overlay_prefix.html
+++ b/crates/api-web/templates/ipam_overlay_prefix.html
@@ -12,6 +12,39 @@
 	<tr><td>VNI</td><td>{{ vni }}</td></tr>
 </table>
 
+{% if let Some(lifecycle_detail) = lifecycle_detail %}
+{{ lifecycle_detail|safe }}
+{% else %}
+<h2>Lifecycle</h2>
+<table class="detailsview">
+	<tr><th>State</th><td>Unavailable</td></tr>
+</table>
+{% endif %}
+
+<h2>State History</h2>
+{% if let Some(state_history_load_error) = state_history_load_error %}
+<p>Error loading state-history records: {{ state_history_load_error }}</p>
+{% else if state_history.is_empty() %}
+<p>No state-history records.</p>
+{% else %}
+<table class="detailsview">
+	<thead>
+		<tr>
+			<th>Version</th>
+			<th>State</th>
+		</tr>
+	</thead>
+	<tbody>
+	{% for record in state_history %}
+		<tr>
+			<td>{{ record.version|config_version|safe }}</td>
+			<td><div style="overflow: auto;"><pre><code class="prettyjson">{{ record.state }}</code></pre></div></td>
+		</tr>
+	{% endfor %}
+	</tbody>
+</table>
+{% endif %}
+
 <h2>Segments</h2>
 <p>{{ segments.len() }} segment(s) carved from this prefix.</p>
 

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -411,6 +411,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .type_attribute("forge.VpcPrefix", "#[derive(serde::Serialize)]")
         .type_attribute(
+            "forge.VpcPrefixStateHistoriesRequest",
+            "#[derive(serde::Serialize)]",
+        )
+        .type_attribute(
             "forge.VpcPrefixConfig",
             "#[derive(serde::Serialize)]",
         )

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -234,6 +234,7 @@ service Forge {
   rpc FindRackStateHistories(RackStateHistoriesRequest) returns (StateHistories);
   rpc FindSwitchStateHistories(SwitchStateHistoriesRequest) returns (StateHistories);
   rpc FindNetworkSegmentStateHistories(NetworkSegmentStateHistoriesRequest) returns (StateHistories);
+  rpc FindVpcPrefixStateHistories(VpcPrefixStateHistoriesRequest) returns (StateHistories);
   rpc FindTenantOrganizationIds(TenantSearchFilter) returns (TenantOrganizationIdList);
   rpc FindTenantsByOrganizationIds(TenantByOrganizationIdsRequest) returns (TenantList);
   rpc FindConnectedDevicesByDpuMachineIds(common.MachineIdList) returns (ConnectedDeviceList);
@@ -1688,7 +1689,8 @@ message VpcPrefixStatus {
   uint32 total_31_segments = 1;
   uint32 available_31_segments = 2;
   uint64 total_linknet_segments = 3;
-  uint64 available_linknet_segments = 4; 
+  uint64 available_linknet_segments = 4;
+  LifecycleStatus lifecycle = 5;
 }
 
 message VpcPrefixCreationRequest {
@@ -1712,10 +1714,14 @@ message VpcPrefixSearchQuery {
   // for its semantics.)
   optional string prefix_match = 4;
   optional PrefixMatchType prefix_match_type = 5;
+  // Controls whether soft-deleted VPC prefixes are included. Defaults to EXCLUDE.
+  DeletedFilter deleted = 6;
 }
 
 message VpcPrefixGetRequest {
   repeated common.VpcPrefixId vpc_prefix_ids = 1;
+  // Controls whether soft-deleted VPC prefixes are returned. Defaults to EXCLUDE.
+  DeletedFilter deleted = 2;
 }
 
 message VpcPrefixIdList {
@@ -1743,6 +1749,10 @@ message VpcPrefixDeletionRequest {
 }
 
 message VpcPrefixDeletionResult {
+}
+
+message VpcPrefixStateHistoriesRequest {
+  repeated common.VpcPrefixId vpc_prefix_ids = 1;
 }
 
 message VpcPeering {

--- a/crates/rpc/src/model/vpc_prefix.rs
+++ b/crates/rpc/src/model/vpc_prefix.rs
@@ -20,6 +20,7 @@ use ipnetwork::IpNetwork;
 use model::metadata::Metadata;
 use model::vpc_prefix::{
     DeleteVpcPrefix, NewVpcPrefix, UpdateVpcPrefix, VpcPrefix, VpcPrefixConfig, VpcPrefixStatus,
+    state_sla,
 };
 
 use crate as rpc;
@@ -136,19 +137,26 @@ impl TryFrom<rpc::forge::VpcPrefixDeletionRequest> for DeleteVpcPrefix {
 
 impl From<VpcPrefixStatus> for rpc::forge::VpcPrefixStatus {
     fn from(db_status: VpcPrefixStatus) -> Self {
-        let VpcPrefixStatus {
-            total_31_segments,
-            available_31_segments,
-            total_linknet_segments,
-            available_linknet_segments,
-            ..
-        } = db_status;
+        // Lifecycle state is the JSON serialization of the controller's
+        // internal state, matching other state-controller-backed resources.
+        let lifecycle_state =
+            serde_json::to_string(&db_status.controller_state.value).unwrap_or_default();
+        let lifecycle_sla = state_sla(
+            &db_status.controller_state.value,
+            &db_status.controller_state.version,
+        );
 
         Self {
-            total_31_segments,
-            available_31_segments,
-            total_linknet_segments,
-            available_linknet_segments,
+            total_31_segments: db_status.total_31_segments,
+            available_31_segments: db_status.available_31_segments,
+            total_linknet_segments: db_status.total_linknet_segments,
+            available_linknet_segments: db_status.available_linknet_segments,
+            lifecycle: Some(rpc::forge::LifecycleStatus {
+                state: lifecycle_state,
+                version: db_status.controller_state.version.version_string(),
+                state_reason: db_status.controller_state_outcome.map(Into::into),
+                sla: Some(lifecycle_sla.into()),
+            }),
         }
     }
 }

--- a/crates/vpc-prefix-controller/Cargo.toml
+++ b/crates/vpc-prefix-controller/Cargo.toml
@@ -1,0 +1,39 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[package]
+name = "carbide-vpc-prefix-controller"
+version = "0.0.0"
+description = "State controller for VPC prefix lifecycle transitions"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[dependencies]
+carbide-api-db = { path = "../api-db", default-features = false }
+carbide-api-model = { path = "../api-model", default-features = false }
+carbide-uuid = { path = "../uuid", default-features = false }
+config-version = { path = "../config-version", default-features = false }
+state-controller = { path = "../state-controller" }
+
+async-trait = { workspace = true }
+chrono = { workspace = true }
+eyre = { workspace = true }
+sqlx = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/vpc-prefix-controller/src/context.rs
+++ b/crates/vpc-prefix-controller/src/context.rs
@@ -15,28 +15,17 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::output::OutputFormat;
+use sqlx::PgPool;
+use state_controller::state_handler::StateHandlerContextObjects;
 
-use super::args::Args;
-use crate::errors::{CarbideCliError, CarbideCliResult};
-use crate::rpc::ApiClient;
-use crate::vpc_prefix::show::cmd::ShowOutput;
+pub struct VpcPrefixStateHandlerContextObjects {}
 
-pub async fn create(
-    args: Args,
-    output_format: OutputFormat,
-    api_client: &ApiClient,
-) -> CarbideCliResult<()> {
-    let output = api_client
-        .0
-        .create_vpc_prefix(args)
-        .await
-        .map(|vpc_prefix| ShowOutput::One {
-            vpc_prefix,
-            history: Vec::new(),
-        })?;
+#[derive(Clone)]
+pub struct VpcPrefixStateHandlerServices {
+    pub db_pool: PgPool,
+}
 
-    output
-        .write_output(output_format, crate::Destination::Stdout())
-        .map_err(CarbideCliError::from)
+impl StateHandlerContextObjects for VpcPrefixStateHandlerContextObjects {
+    type Services = VpcPrefixStateHandlerServices;
+    type ObjectMetrics = ();
 }

--- a/crates/vpc-prefix-controller/src/handler.rs
+++ b/crates/vpc-prefix-controller/src/handler.rs
@@ -1,0 +1,138 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! State handler implementation for VPC prefixes.
+
+use carbide_uuid::vpc::VpcPrefixId;
+use model::vpc_prefix::{VpcPrefix, VpcPrefixControllerState, VpcPrefixDeletionState};
+use state_controller::state_handler::{
+    StateHandler, StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
+
+use crate::context::VpcPrefixStateHandlerContextObjects;
+
+/// The VPC prefix state handler.
+#[derive(Debug, Clone)]
+pub struct VpcPrefixStateHandler {
+    drain_period: chrono::Duration,
+}
+
+impl VpcPrefixStateHandler {
+    /// Creates a VPC prefix state handler with the configured drain period.
+    pub fn new(drain_period: chrono::Duration) -> Self {
+        // Store the drain period used to re-arm pending prefix deletion.
+        Self { drain_period }
+    }
+
+    fn drain_state(&self) -> VpcPrefixControllerState {
+        let delete_at = chrono::Utc::now()
+            .checked_add_signed(self.drain_period)
+            .unwrap_or_else(chrono::Utc::now);
+        VpcPrefixControllerState::Deleting {
+            deletion_state: VpcPrefixDeletionState::DrainNetworkPrefixes { delete_at },
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl StateHandler for VpcPrefixStateHandler {
+    type ObjectId = VpcPrefixId;
+    type State = VpcPrefix;
+    type ControllerState = VpcPrefixControllerState;
+    type ContextObjects = VpcPrefixStateHandlerContextObjects;
+
+    async fn handle_object_state(
+        &self,
+        vpc_prefix_id: &VpcPrefixId,
+        state: &mut VpcPrefix,
+        controller_state: &Self::ControllerState,
+        ctx: &mut StateHandlerContext<Self::ContextObjects>,
+    ) -> Result<StateHandlerOutcome<VpcPrefixControllerState>, StateHandlerError> {
+        match controller_state {
+            VpcPrefixControllerState::Provisioning => {
+                let new_state = if state.is_marked_as_deleted() {
+                    // Prefixes deleted before their first controller pass should not record a
+                    // spurious Ready transition before entering the deletion lifecycle.
+                    self.drain_state()
+                } else {
+                    // New prefixes are immediately considered ready once persisted.
+                    VpcPrefixControllerState::Ready
+                };
+                tracing::info!(%vpc_prefix_id, state = ?new_state, "VPC Prefix state transition");
+                Ok(StateHandlerOutcome::transition(new_state))
+            }
+            VpcPrefixControllerState::Ready => {
+                if state.is_marked_as_deleted() {
+                    // Start the drain window after the API marks the prefix deleted.
+                    let new_state = self.drain_state();
+                    tracing::info!(%vpc_prefix_id, state = ?new_state, "VPC Prefix state transition");
+                    Ok(StateHandlerOutcome::transition(new_state))
+                } else {
+                    // Ready prefixes have no periodic work until deletion is requested.
+                    Ok(StateHandlerOutcome::do_nothing())
+                }
+            }
+            VpcPrefixControllerState::Deleting { deletion_state } => match deletion_state {
+                VpcPrefixDeletionState::DrainNetworkPrefixes { delete_at } => {
+                    let mut txn = ctx.services.db_pool.begin().await?;
+
+                    // Keep the prefix until generated segment prefixes have released it.
+                    let referenced_prefixes =
+                        db::vpc_prefix::count_network_prefixes_by_vpc_prefix_id(
+                            &mut txn, &state.id,
+                        )
+                        .await?;
+                    if referenced_prefixes > 0 {
+                        let new_state = self.drain_state();
+                        tracing::info!(
+                            referenced_prefixes,
+                            vpc_prefix = %state.id,
+                            "VPC Prefix still has network prefix references",
+                        );
+                        tracing::info!(%vpc_prefix_id, state = ?new_state, "VPC Prefix state transition");
+                        Ok(StateHandlerOutcome::transition(new_state).with_txn(txn))
+                    } else if chrono::Utc::now() >= *delete_at {
+                        // Move to the terminal database delete state after the drain deadline.
+                        let new_state = VpcPrefixControllerState::Deleting {
+                            deletion_state: VpcPrefixDeletionState::DBDelete,
+                        };
+                        tracing::info!(%vpc_prefix_id, state = ?new_state, "VPC Prefix state transition");
+                        Ok(StateHandlerOutcome::transition(new_state).with_txn(txn))
+                    } else {
+                        // The dependency graph is drained, but the grace deadline has not passed.
+                        Ok(StateHandlerOutcome::wait(format!(
+                            "Cannot delete VPC prefix from database until draining completes at {}",
+                            delete_at.to_rfc3339()
+                        ))
+                        .with_txn(txn))
+                    }
+                }
+                VpcPrefixDeletionState::DBDelete => {
+                    let mut txn = ctx.services.db_pool.begin().await?;
+
+                    // Remove the prefix row after all network_prefix references are gone.
+                    tracing::info!(
+                        %vpc_prefix_id,
+                        "VPC Prefix getting removed from the database",
+                    );
+                    db::vpc_prefix::final_delete(*vpc_prefix_id, &mut txn).await?;
+                    Ok(StateHandlerOutcome::deleted().with_txn(txn))
+                }
+            },
+        }
+    }
+}

--- a/crates/vpc-prefix-controller/src/io.rs
+++ b/crates/vpc-prefix-controller/src/io.rs
@@ -1,0 +1,182 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! State controller IO implementation for VPC prefixes.
+
+use carbide_uuid::vpc::VpcPrefixId;
+use config_version::{ConfigVersion, Versioned};
+use db::{self, DatabaseError, ObjectColumnFilter};
+use model::controller_outcome::PersistentStateHandlerOutcome;
+use model::vpc_prefix::{self, VpcPrefix, VpcPrefixControllerState, VpcPrefixDeletionState};
+use model::{DeletedFilter, StateSla};
+use sqlx::PgConnection;
+use state_controller::io::StateControllerIO;
+use state_controller::metrics::NoopMetricsEmitter;
+
+use crate::context::VpcPrefixStateHandlerContextObjects;
+
+/// State controller IO implementation for VPC prefixes.
+#[derive(Default, Debug)]
+pub struct VpcPrefixStateControllerIO {}
+
+#[async_trait::async_trait]
+impl StateControllerIO for VpcPrefixStateControllerIO {
+    type ObjectId = VpcPrefixId;
+    type State = VpcPrefix;
+    type ControllerState = VpcPrefixControllerState;
+    type MetricsEmitter = NoopMetricsEmitter;
+    type ContextObjects = VpcPrefixStateHandlerContextObjects;
+
+    const DB_ITERATION_ID_TABLE_NAME: &'static str =
+        "network_vpc_prefixes_controller_iteration_ids";
+    const DB_QUEUED_OBJECTS_TABLE_NAME: &'static str =
+        "network_vpc_prefixes_controller_queued_objects";
+
+    const LOG_SPAN_CONTROLLER_NAME: &'static str = "vpc_prefix_controller";
+
+    async fn list_objects(
+        &self,
+        txn: &mut PgConnection,
+    ) -> Result<Vec<Self::ObjectId>, DatabaseError> {
+        db::vpc_prefix::search(
+            txn,
+            vpc_prefix::VpcPrefixSearch {
+                deleted_filter: DeletedFilter::Include,
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    async fn load_object_state(
+        &self,
+        txn: &mut PgConnection,
+        vpc_prefix_id: &Self::ObjectId,
+    ) -> Result<Option<Self::State>, DatabaseError> {
+        // Load the controller-visible row, including prefixes marked deleted.
+        let mut prefixes = db::vpc_prefix::get_by_id(
+            txn,
+            ObjectColumnFilter::One(db::vpc_prefix::IdColumn, vpc_prefix_id),
+            DeletedFilter::Include,
+        )
+        .await?;
+        if prefixes.is_empty() {
+            return Ok(None);
+        }
+        if prefixes.len() > 1 {
+            return Err(DatabaseError::new(
+                "db::vpc_prefix::get_by_id()",
+                sqlx::Error::Decode(
+                    eyre::eyre!(
+                        "Searching for VpcPrefix {} returned multiple results",
+                        vpc_prefix_id
+                    )
+                    .into(),
+                ),
+            ));
+        }
+
+        // Return the only matching prefix row to the controller framework.
+        Ok(Some(prefixes.swap_remove(0)))
+    }
+
+    async fn load_controller_state(
+        &self,
+        _txn: &mut PgConnection,
+        _object_id: &Self::ObjectId,
+        state: &Self::State,
+    ) -> Result<Versioned<Self::ControllerState>, DatabaseError> {
+        // Read the versioned controller state from the object snapshot.
+        Ok(state.status.controller_state.clone())
+    }
+
+    async fn persist_controller_state(
+        &self,
+        txn: &mut PgConnection,
+        object_id: &Self::ObjectId,
+        old_version: ConfigVersion,
+        new_version: ConfigVersion,
+        new_state: &Self::ControllerState,
+    ) -> Result<bool, DatabaseError> {
+        // Optimistically update the controller-owned state version and value.
+        db::vpc_prefix::try_update_controller_state(
+            txn,
+            *object_id,
+            old_version,
+            new_version,
+            new_state,
+        )
+        .await
+    }
+
+    async fn persist_state_history(
+        &self,
+        txn: &mut PgConnection,
+        object_id: &Self::ObjectId,
+        new_version: ConfigVersion,
+        new_state: &Self::ControllerState,
+    ) -> Result<(), DatabaseError> {
+        // Record the transition in the VPC prefix state-history table.
+        db::state_history::persist(
+            txn,
+            db::state_history::StateHistoryTableId::VpcPrefix,
+            object_id,
+            new_state,
+            new_version,
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn persist_outcome(
+        &self,
+        txn: &mut PgConnection,
+        object_id: &Self::ObjectId,
+        outcome: PersistentStateHandlerOutcome,
+    ) -> Result<(), DatabaseError> {
+        // Store the latest handler outcome alongside the prefix row.
+        db::vpc_prefix::update_controller_state_outcome(txn, *object_id, outcome).await
+    }
+
+    fn metric_state_names(state: &VpcPrefixControllerState) -> (&'static str, &'static str) {
+        /// Returns the aggregate metric substate name for deletion states.
+        fn deletion_state_name(deletion_state: &VpcPrefixDeletionState) -> &'static str {
+            match deletion_state {
+                VpcPrefixDeletionState::DrainNetworkPrefixes { .. } => "drainnetworkprefixes",
+                VpcPrefixDeletionState::DBDelete => "dbdelete",
+            }
+        }
+
+        // Map the controller state to the labels used by framework metrics.
+        match state {
+            VpcPrefixControllerState::Provisioning => ("provisioning", ""),
+            VpcPrefixControllerState::Ready => ("ready", ""),
+            VpcPrefixControllerState::Deleting { deletion_state } => {
+                ("deleting", deletion_state_name(deletion_state))
+            }
+        }
+    }
+
+    fn state_sla(
+        &self,
+        state: &Versioned<Self::ControllerState>,
+        _object_state: &Self::State,
+    ) -> StateSla {
+        // Delegate SLA calculation to the VPC prefix model helper.
+        vpc_prefix::state_sla(&state.value, &state.version)
+    }
+}

--- a/crates/vpc-prefix-controller/src/lib.rs
+++ b/crates/vpc-prefix-controller/src/lib.rs
@@ -15,28 +15,8 @@
  * limitations under the License.
  */
 
-use ::rpc::admin_cli::output::OutputFormat;
+//! State controller implementation for VPC prefixes.
 
-use super::args::Args;
-use crate::errors::{CarbideCliError, CarbideCliResult};
-use crate::rpc::ApiClient;
-use crate::vpc_prefix::show::cmd::ShowOutput;
-
-pub async fn create(
-    args: Args,
-    output_format: OutputFormat,
-    api_client: &ApiClient,
-) -> CarbideCliResult<()> {
-    let output = api_client
-        .0
-        .create_vpc_prefix(args)
-        .await
-        .map(|vpc_prefix| ShowOutput::One {
-            vpc_prefix,
-            history: Vec::new(),
-        })?;
-
-    output
-        .write_output(output_format, crate::Destination::Stdout())
-        .map_err(CarbideCliError::from)
-}
+pub mod context;
+pub mod handler;
+pub mod io;

--- a/deploy/nico-base/api/config-files/nico-api-config.toml
+++ b/deploy/nico-base/api/config-files/nico-api-config.toml
@@ -64,6 +64,9 @@ casbin_policy_file = "/etc/nico/nico-api/casbin-policy.csv"
 [machine_state_controller]
 failure_retry_time = "90m"
 
+[vpc_prefix_state_controller]
+vpc_prefix_drain_time = "5m"
+
 [network_security_group]
 # Controls whether additional config to support
 # stateful/reflexive ACLs will be inserted into

--- a/dev/deployment/devspace/values.base.yaml
+++ b/dev/deployment/devspace/values.base.yaml
@@ -81,6 +81,9 @@ nico-api:
       iteration_time = "30s"
       max_concurrency = 100
 
+      [vpc_prefix_state_controller]
+      vpc_prefix_drain_time = "5m"
+
       [machine_validation_config]
       enabled = false
 

--- a/dev/docker-env/carbide-api-config.toml
+++ b/dev/docker-env/carbide-api-config.toml
@@ -88,5 +88,10 @@ network_segment_drain_time = "60s"
 [network_segment_state_controller.controller]
 iteration_time = "2s"
 
+[vpc_prefix_state_controller]
+vpc_prefix_drain_time = "60s"
+[vpc_prefix_state_controller.controller]
+iteration_time = "2s"
+
 [ib_partition_state_controller.controller]
 iteration_time = "60s" # Not supported in docker anyway

--- a/dev/mac-local-dev/carbide-api-config.toml
+++ b/dev/mac-local-dev/carbide-api-config.toml
@@ -145,6 +145,11 @@ network_segment_drain_time = "60s"
 [network_segment_state_controller.controller]
 iteration_time = "10s"
 
+[vpc_prefix_state_controller]
+vpc_prefix_drain_time = "60s"
+[vpc_prefix_state_controller.controller]
+iteration_time = "10s"
+
 [ib_partition_state_controller.controller]
 iteration_time = "120s" # Unlikely to be supported for K3S
 

--- a/dev/webdev-env/carbide-api-config.toml
+++ b/dev/webdev-env/carbide-api-config.toml
@@ -74,6 +74,11 @@ network_segment_drain_time = "24h"
 [network_segment_state_controller.controller]
 iteration_time = "24h"
 
+[vpc_prefix_state_controller]
+vpc_prefix_drain_time = "24h"
+[vpc_prefix_state_controller.controller]
+iteration_time = "24h"
+
 [ib_partition_state_controller.controller]
 iteration_time = "24h"
 

--- a/helm/charts/nico-api/files/carbide-api-config.toml
+++ b/helm/charts/nico-api/files/carbide-api-config.toml
@@ -72,6 +72,9 @@ additional_issuer_cns = []
 [machine_state_controller]
 failure_retry_time = "90m"
 
+[vpc_prefix_state_controller]
+vpc_prefix_drain_time = "5m"
+
 [network_security_group]
 # Controls whether additional config to support
 # stateful/reflexive ACLs will be inserted into


### PR DESCRIPTION
## Description
This PR introduces VPC-prefix lifecycles.

VPC prefix deletion is now a soft-delete until it's no longer referenced by any network segments, and then it's hard-deleted.

Two things to note:
- Existing network segment associations still prevent requesting deletion, but it's a clear error message to the caller.  We can also lift the restriction easily.
- VPCs cannot be deleted if any VPC prefixes are still pending clean-up.  I think we'd need VPC life-cycles to allow this, though VPCs are already soft-deleted objects so we could "just do it."

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
NVBUG 5558606
