### PR TITLE
chore(rest-api): Move entity equality checks onto the entities themselves

### DIFF
--- a/rest-api/api/pkg/api/handler/instancetype.go
+++ b/rest-api/api/pkg/api/handler/instancetype.go
@@ -28,7 +28,6 @@ import (
 	swe "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/error"
 
 	cwma "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/activity/machine"
-	cwu "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
 
 	"github.com/NVIDIA/infra-controller/rest-api/api/internal/config"
 	"github.com/NVIDIA/infra-controller/rest-api/api/pkg/api/handler/util/common"
@@ -1066,7 +1065,7 @@ func (uith UpdateInstanceTypeHandler) Handle(c echo.Context) error {
 				existingCap := existingMacCapMap[capKey]
 				// The incoming requested capability doesn't exist at all currently,
 				// so it's brand new.
-				if existingCap != nil && cwu.MachineCapabilitiesEqual(existingCap, &cdbm.MachineCapability{
+				if existingCap != nil && existingCap.Equal(&cdbm.MachineCapability{
 					Type:             reqMacCap.Type,
 					Name:             reqMacCap.Name,
 					Frequency:        reqMacCap.Frequency,

--- a/rest-api/db/pkg/db/model/machinecapability.go
+++ b/rest-api/db/pkg/db/model/machinecapability.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -238,6 +239,48 @@ type MachineCapability struct {
 	ValueStr    *string `bun:"value_str"`
 	ValueInt    *int    `bun:"value_int"`
 	Description *string `bun:"description"`
+}
+
+// Equal reports whether two `*MachineCapability` records carry the same
+// proto-relevant fields. Used by the cloud-sync activity to skip
+// no-op DAO updates when the cloud copy matches what the Site
+// reported. Declared as a method (per the Go convention used by
+// `time.Time.Equal`, `cmp.Equal`, etc.) so callers can write
+// `mc.Equal(other)` instead of reaching for a free helper.
+//
+// Compares the wire-relevant fields only: `MachineID`, `InstanceTypeID`,
+// `ID`, `Created`/`Updated`/`Deleted` and the deprecated `ValueStr` /
+// `ValueInt` / `Description` are deliberately excluded.
+func (mc *MachineCapability) Equal(other *MachineCapability) bool {
+	if mc == nil || other == nil {
+		return mc == other
+	}
+	return mcPtrsEqual(mc.Cores, other.Cores) &&
+		mcPtrsEqual(mc.Threads, other.Threads) &&
+		mcPtrsEqual(mc.Count, other.Count) &&
+		mcPtrsEqual(mc.DeviceType, other.DeviceType) &&
+		mc.Name == other.Name &&
+		mc.Type == other.Type &&
+		mcPtrsEqual(mc.Capacity, other.Capacity) &&
+		mcPtrsEqual(mc.Frequency, other.Frequency) &&
+		mcPtrsEqual(mc.HardwareRevision, other.HardwareRevision) &&
+		mcPtrsEqual(mc.Vendor, other.Vendor) &&
+		slices.Equal(mc.InactiveDevices, other.InactiveDevices) &&
+		mc.Index == other.Index
+}
+
+// mcPtrsEqual is a file-local copy of the workflow util `PtrsEqual`
+// helper, declared here so `(*MachineCapability).Equal` can compare
+// pointer-typed fields without taking a dependency on the workflow
+// layer. The signature mirrors `util.PtrsEqual` exactly.
+func mcPtrsEqual[T comparable](a, b *T) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	return *a == *b
 }
 
 // ToProto converts this MachineCapability to its workflow proto

--- a/rest-api/db/pkg/db/model/machinecapability_test.go
+++ b/rest-api/db/pkg/db/model/machinecapability_test.go
@@ -22,6 +22,56 @@ import (
 	otrace "go.opentelemetry.io/otel/trace"
 )
 
+func TestMachineCapability_Equal(t *testing.T) {
+	makeCap := func() *MachineCapability {
+		return &MachineCapability{
+			Type:             MachineCapabilityTypeCPU,
+			Name:             "cap-1",
+			Cores:            cutil.GetPtr(8),
+			Threads:          cutil.GetPtr(16),
+			Count:            cutil.GetPtr(1),
+			Vendor:           cutil.GetPtr("Intel"),
+			Capacity:         cutil.GetPtr("64GB"),
+			Frequency:        cutil.GetPtr("3.0GHz"),
+			HardwareRevision: cutil.GetPtr("rev-1"),
+			InactiveDevices:  []int{1, 2},
+			Index:            0,
+		}
+	}
+
+	t.Run("nil equals nil", func(t *testing.T) {
+		var a, b *MachineCapability
+		assert.True(t, a.Equal(b))
+	})
+	t.Run("nil does not equal non-nil", func(t *testing.T) {
+		var a *MachineCapability
+		b := makeCap()
+		assert.False(t, a.Equal(b))
+		assert.False(t, b.Equal(a))
+	})
+	t.Run("identical caps are equal", func(t *testing.T) {
+		assert.True(t, makeCap().Equal(makeCap()))
+	})
+	t.Run("differing Name returns false", func(t *testing.T) {
+		a := makeCap()
+		b := makeCap()
+		b.Name = "cap-2"
+		assert.False(t, a.Equal(b))
+	})
+	t.Run("differing pointer field returns false", func(t *testing.T) {
+		a := makeCap()
+		b := makeCap()
+		b.Cores = cutil.GetPtr(4)
+		assert.False(t, a.Equal(b))
+	})
+	t.Run("differing InactiveDevices slice returns false", func(t *testing.T) {
+		a := makeCap()
+		b := makeCap()
+		b.InactiveDevices = []int{1, 3}
+		assert.False(t, a.Equal(b))
+	})
+}
+
 func TestMachineCapabilitySQLDAO_Create(t *testing.T) {
 	ctx := context.Background()
 

--- a/rest-api/db/pkg/db/model/networksecuritygroup.go
+++ b/rest-api/db/pkg/db/model/networksecuritygroup.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"slices"
 	"time"
 
 	"github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
@@ -146,6 +147,28 @@ func (s *NetworkSecurityGroupPropagationDetails) UnmarshalJSON(b []byte) error {
 
 func (s *NetworkSecurityGroupPropagationDetails) MarshalJSON() ([]byte, error) {
 	return protojson.Marshal(s)
+}
+
+// Equal reports whether two `*NetworkSecurityGroupPropagationDetails`
+// wrappers carry the same wire-relevant state. Used by the cloud-sync
+// activity to skip no-op DAO updates when the cloud copy already
+// matches what the Site reported. Treats two nil receivers as equal.
+// Declared as a method (per the Go convention used by `time.Time.Equal`,
+// `cmp.Equal`, etc.) so callers can write `pd.Equal(other)` instead of
+// reaching for a free helper.
+func (s *NetworkSecurityGroupPropagationDetails) Equal(other *NetworkSecurityGroupPropagationDetails) bool {
+	if s == nil || other == nil {
+		return s == other
+	}
+	// `Details` is the only pointer-typed field we compare; inline the
+	// nil-aware check so this method doesn't depend on the workflow util
+	// layer.
+	detailsEqual := (s.Details == nil) == (other.Details == nil) &&
+		(s.Details == nil || *s.Details == *other.Details)
+	return s.Status.Number() == other.Status.Number() &&
+		detailsEqual &&
+		slices.Equal(s.UnpropagatedInstanceIds, other.UnpropagatedInstanceIds) &&
+		slices.Equal(s.RelatedInstanceIds, other.RelatedInstanceIds)
 }
 
 // NetworkSecurityGroupCreateInput input parameters for Create method

--- a/rest-api/db/pkg/db/model/networksecuritygroup_test.go
+++ b/rest-api/db/pkg/db/model/networksecuritygroup_test.go
@@ -38,6 +38,58 @@ func testNetworkSecurityGroupSetupSchema(t *testing.T, dbSession *db.Session) {
 	assert.Nil(t, err)
 }
 
+func TestNetworkSecurityGroupPropagationDetails_Equal(t *testing.T) {
+	mk := func() *NetworkSecurityGroupPropagationDetails {
+		return &NetworkSecurityGroupPropagationDetails{
+			FriendlyStatus: "Propagated",
+			NetworkSecurityGroupPropagationObjectStatus: &cwssaws.NetworkSecurityGroupPropagationObjectStatus{
+				Status:                  cwssaws.NetworkSecurityGroupPropagationStatus_NSG_PROP_STATUS_FULL,
+				Details:                 cutil.GetPtr("ok"),
+				UnpropagatedInstanceIds: []string{"i-1"},
+				RelatedInstanceIds:      []string{"i-2"},
+			},
+		}
+	}
+
+	t.Run("nil equals nil", func(t *testing.T) {
+		var a, b *NetworkSecurityGroupPropagationDetails
+		assert.True(t, a.Equal(b))
+	})
+	t.Run("nil does not equal non-nil", func(t *testing.T) {
+		var a *NetworkSecurityGroupPropagationDetails
+		b := mk()
+		assert.False(t, a.Equal(b))
+		assert.False(t, b.Equal(a))
+	})
+	t.Run("identical wrappers are equal", func(t *testing.T) {
+		assert.True(t, mk().Equal(mk()))
+	})
+	t.Run("differing Status returns false", func(t *testing.T) {
+		a := mk()
+		b := mk()
+		b.Status = cwssaws.NetworkSecurityGroupPropagationStatus_NSG_PROP_STATUS_ERROR
+		assert.False(t, a.Equal(b))
+	})
+	t.Run("differing Details returns false", func(t *testing.T) {
+		a := mk()
+		b := mk()
+		b.Details = cutil.GetPtr("changed")
+		assert.False(t, a.Equal(b))
+	})
+	t.Run("nil-vs-set Details returns false", func(t *testing.T) {
+		a := mk()
+		b := mk()
+		b.Details = nil
+		assert.False(t, a.Equal(b))
+	})
+	t.Run("differing UnpropagatedInstanceIds returns false", func(t *testing.T) {
+		a := mk()
+		b := mk()
+		b.UnpropagatedInstanceIds = []string{"i-9"}
+		assert.False(t, a.Equal(b))
+	})
+}
+
 func TestNetworkSecurityGroupSQLDAO_Create(t *testing.T) {
 	ctx := context.Background()
 	dbSession := testInstanceInitDB(t)

--- a/rest-api/workflow/pkg/activity/instance/instance.go
+++ b/rest-api/workflow/pkg/activity/instance/instance.go
@@ -229,7 +229,7 @@ func (mi ManageInstance) UpdateInstancesInDB(ctx context.Context, siteID uuid.UU
 			controllerInstanceID != nil ||
 			isUpdatePending != nil ||
 			tpmEkCertificateUpdated != nil ||
-			!util.NetworkSecurityGroupPropagationDetailsEqual(instance.NetworkSecurityGroupPropagationDetails, sitePropagationStatus)
+			!instance.NetworkSecurityGroupPropagationDetails.Equal(sitePropagationStatus)
 
 		if needsUpdate {
 			// If the Instance in the DB has propagation details but the site reported no propagation details

--- a/rest-api/workflow/pkg/activity/instancetype/instancetype.go
+++ b/rest-api/workflow/pkg/activity/instancetype/instancetype.go
@@ -17,7 +17,6 @@ import (
 	cdbp "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 
 	sc "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/client/site"
-	"github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
 
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 
@@ -224,7 +223,7 @@ func (mv ManageInstanceType) UpdateInstanceTypeInCloud(ctx context.Context, site
 
 		cloudCap := cloudCapMap[macCapName]
 
-		if cloudCap == nil || !util.MachineCapabilitiesEqual(cloudCap, controllerCap) {
+		if cloudCap == nil || !cloudCap.Equal(controllerCap) {
 
 			if cloudCap != nil {
 				// If cloud and site knew about it but they have mismatched properties,

--- a/rest-api/workflow/pkg/activity/machine/machine.go
+++ b/rest-api/workflow/pkg/activity/machine/machine.go
@@ -934,7 +934,7 @@ func processMachineCapabilities(ctx context.Context, logger zerolog.Logger, dbSe
 			}
 		} else {
 			// Compare the orignal with the current and update if there's a diff.
-			if !util.MachineCapabilitiesEqual(cloudCap, controllerCap) {
+			if !cloudCap.Equal(controllerCap) {
 				_, serr := mcDAO.Update(ctx, nil, cdbm.MachineCapabilityUpdateInput{
 					ID:               cloudCap.ID,
 					Frequency:        controllerCap.Frequency,

--- a/rest-api/workflow/pkg/activity/vpc/vpc.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc.go
@@ -177,7 +177,7 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 			controllerVpcID != nil ||
 			networkVirtualizationType != nil ||
 			!util.PtrsEqual(vpc.RoutingProfile, controllerVpc.RoutingProfileType) ||
-			!util.NetworkSecurityGroupPropagationDetailsEqual(vpc.NetworkSecurityGroupPropagationDetails, sitePropagationStatus) ||
+			!vpc.NetworkSecurityGroupPropagationDetails.Equal(sitePropagationStatus) ||
 			// Changing VNI isn't allowed after creation, and it should never go back to nil - that would be a bug.
 			// We should assume status _could start_ as null and then update to the active VPC VNI.
 			// Status should never go back to nil - that would be a bug.

--- a/rest-api/workflow/pkg/util/common.go
+++ b/rest-api/workflow/pkg/util/common.go
@@ -5,7 +5,6 @@ package util
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	cwutil "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
@@ -43,40 +42,6 @@ func PtrsEqual[T comparable](i1 *T, i2 *T) bool {
 	}
 
 	return true
-}
-
-func NetworkSecurityGroupPropagationDetailsEqual(pd1, pd2 *cdbm.NetworkSecurityGroupPropagationDetails) bool {
-	if (pd1 == nil) != (pd2 == nil) {
-		return false
-	}
-
-	// If pd1 was nil but we made it here, then
-	// both were nil, so we can return true.
-	if pd1 == nil {
-		return true
-	}
-
-	return pd1.Status.Number() == pd2.Status.Number() &&
-		PtrsEqual(pd1.Details, pd2.Details) &&
-		slices.Equal(pd1.UnpropagatedInstanceIds, pd2.UnpropagatedInstanceIds) &&
-		slices.Equal(pd1.RelatedInstanceIds, pd2.RelatedInstanceIds)
-
-}
-
-func MachineCapabilitiesEqual(cap1 *cdbm.MachineCapability, cap2 *cdbm.MachineCapability) bool {
-
-	return PtrsEqual(cap1.Cores, cap2.Cores) &&
-		PtrsEqual(cap1.Threads, cap2.Threads) &&
-		PtrsEqual(cap1.Count, cap2.Count) &&
-		PtrsEqual(cap1.DeviceType, cap2.DeviceType) &&
-		cap1.Name == cap2.Name &&
-		cap1.Type == cap2.Type &&
-		PtrsEqual(cap1.Capacity, cap2.Capacity) &&
-		PtrsEqual(cap1.Frequency, cap2.Frequency) &&
-		PtrsEqual(cap1.HardwareRevision, cap2.HardwareRevision) &&
-		PtrsEqual(cap1.Vendor, cap2.Vendor) &&
-		slices.Equal(cap1.InactiveDevices, cap2.InactiveDevices) &&
-		cap1.Index == cap2.Index
 }
 
 // IsTimeWithinStaleInventoryThreshold checks if the action time is within the threshold where we could be processing an older inventory


### PR DESCRIPTION
Small cleanup of two `XxxEqual` helpers in `workflow/pkg/util/common.go` that were really equality methods (noticed in https://github.com/NVIDIA/infra-controller/pull/2173, and I figured it might have been applicable to other places).

Changes:
- `MachineCapability.Equal(other)`
- `NetworkSecurityGroupPropagationDetails.Equal(other)`
- Prior helpers deleted, and callsites switched from `.XxxEqual(a, b)` to `a.Equal(b)`.

Tests added!

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

