### PR TITLE
Add `--zero-dpu` flag to admin-cli

### DIFF
--- a/crates/admin-cli/src/instance/allocate/args.rs
+++ b/crates/admin-cli/src/instance/allocate/args.rs
@@ -71,6 +71,9 @@ pub struct Args {
     #[clap(short, long, help = "The VPC prefix to assign to a PF")]
     pub vpc_prefix_id: Vec<VpcPrefixId>,
 
+    #[clap(long, help = "Allocate a zero-dpu host")]
+    pub zero_dpu: bool,
+
     #[clap(long, help = "The VPC prefix to assign to a VF")]
     pub vf_vpc_prefix_id: Vec<VpcPrefixId>,
 

--- a/crates/admin-cli/src/instance/allocate/cmd.rs
+++ b/crates/admin-cli/src/instance/allocate/cmd.rs
@@ -68,9 +68,13 @@ pub async fn allocate(
         // Batch mode: all-or-nothing
         let mut requests = Vec::new();
         for i in 0..number {
-            let Some(machine) =
-                machine::get_next_free_machine(api_client, &mut machine_ids, min_interface_count)
-                    .await
+            let Some(machine) = machine::get_next_free_machine(
+                api_client,
+                &mut machine_ids,
+                min_interface_count,
+                allocate_request.zero_dpu,
+            )
+            .await
             else {
                 return Err(CarbideCliError::GenericError(format!(
                     "Need {} machines but only {} available.",
@@ -106,9 +110,13 @@ pub async fn allocate(
     } else {
         // Sequential mode: partial success allowed
         for i in 0..number {
-            let Some(machine) =
-                machine::get_next_free_machine(api_client, &mut machine_ids, min_interface_count)
-                    .await
+            let Some(machine) = machine::get_next_free_machine(
+                api_client,
+                &mut machine_ids,
+                min_interface_count,
+                allocate_request.zero_dpu,
+            )
+            .await
             else {
                 tracing::error!("No available machines.");
                 break;

--- a/crates/admin-cli/src/machine/show/cmd.rs
+++ b/crates/admin-cli/src/machine/show/cmd.rs
@@ -428,6 +428,7 @@ pub async fn get_next_free_machine(
     api_client: &ApiClient,
     machine_ids: &mut VecDeque<MachineId>,
     min_interface_count: usize,
+    zero_dpu: bool,
 ) -> Option<Machine> {
     while let Some(id) = machine_ids.pop_front() {
         tracing::debug!("Checking {}", id);
@@ -435,6 +436,9 @@ pub async fn get_next_free_machine(
             if machine.state != "Ready" {
                 tracing::debug!("Machine is not ready");
                 continue;
+            }
+            if zero_dpu {
+                return Some(machine);
             }
             if let Some(discovery_info) = &machine.discovery_info {
                 let dpu_interfaces = discovery_info

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -1261,7 +1261,9 @@ impl ApiClient {
                     .pci_properties
                     .as_ref()
                     .map(|pci| &pci.vendor)
-                    .is_some_and(|v| v.to_ascii_lowercase().contains("mellanox"))
+                    .is_some_and(|v| {
+                        v.to_ascii_lowercase().contains("mellanox") || allocate_instance.zero_dpu
+                    })
             });
             let mut interface_config = Vec::default();
             let mut vf_chunk_iter = vf_network_segment_ids.chunks(vfs_per_pf);
@@ -1463,8 +1465,12 @@ impl ApiClient {
             tenant: Some(tenant_config),
             os: allocate_instance.os.clone(),
             network: Some(rpc::InstanceNetworkConfig {
-                interfaces: interface_configs,
-                auto: false,
+                interfaces: if allocate_instance.zero_dpu {
+                    vec![]
+                } else {
+                    interface_configs
+                },
+                auto: allocate_instance.zero_dpu,
             }),
             network_security_group_id: allocate_instance.network_security_group_id.clone(),
             infiniband: None,


### PR DESCRIPTION
## Description
Currently there are a few issues if we try to allocate instances onto hosts with no DPU's. Adding a `--zero-dpu` flag overrides some behavior to make it work:

- When looking at machines on which to allocate, we would explicitly reject any if there were no DPUs on them... stop doing that if the `--zero-dpu` flag is passed.

- When finding machine interfaces in the destination subnet, we would exclude interfaces that don't have "mellanox" in the PCI properties. Don't do this if `--zero-dpu` is passed.

- If `--zero-dpu` is passed, don't pass any interfaces in the InstanceAllocationRequest, and set `auto: true`.

## Type of Change
- [X] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
#2205 

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


Closes #2205
