### PR TITLE
chore(rest-api): Inline basic deletion-request protos in handlers

### DIFF
--- a/rest-api/api/pkg/api/handler/instancetype.go
+++ b/rest-api/api/pkg/api/handler/instancetype.go
@@ -26,6 +26,7 @@ import (
 	cdbm "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/model"
 	cdbp "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/paginator"
 	swe "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/error"
+	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 
 	cwma "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/activity/machine"
 	cwu "github.com/NVIDIA/infra-controller/rest-api/workflow/pkg/util"
@@ -1461,7 +1462,9 @@ func (dith DeleteInstanceTypeHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		deleteInstanceTypeRequest := it.ToDeletionRequestProto()
+		deleteInstanceTypeRequest := &cwssaws.DeleteInstanceTypeRequest{
+			Id: it.ID.String(),
+		}
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:                       "instance-type-delete-" + it.ID.String(),

--- a/rest-api/api/pkg/api/handler/vpc.go
+++ b/rest-api/api/pkg/api/handler/vpc.go
@@ -1744,7 +1744,9 @@ func (dvh DeleteVPCHandler) Handle(c echo.Context) error {
 			return cutil.NewAPIError(http.StatusInternalServerError, "Failed to retrieve client for Site", nil)
 		}
 
-		deleteVpcRequest := vpc.ToDeletionRequestProto()
+		deleteVpcRequest := &cwssaws.VpcDeletionRequest{
+			Id: &cwssaws.VpcId{Value: vpc.GetSiteID().String()},
+		}
 
 		workflowOptions := temporalClient.StartWorkflowOptions{
 			ID:                       "vpc-delete-" + vpc.ID.String(),

--- a/rest-api/db/pkg/db/model/instancetype.go
+++ b/rest-api/db/pkg/db/model/instancetype.go
@@ -187,15 +187,6 @@ func (it *InstanceType) FromProto(proto *cwssaws.InstanceType) {
 	}
 }
 
-// ToDeletionRequestProto builds the workflow request that asks a Site
-// to delete this InstanceType. Lives on the entity because the delete
-// handler has no API request body — the entity's ID is the only input.
-func (it *InstanceType) ToDeletionRequestProto() *cwssaws.DeleteInstanceTypeRequest {
-	return &cwssaws.DeleteInstanceTypeRequest{
-		Id: it.ID.String(),
-	}
-}
-
 var _ bun.BeforeAppendModelHook = (*InstanceType)(nil)
 
 // BeforeAppendModel is a hook that is called before the model is appended to the query

--- a/rest-api/db/pkg/db/model/instancetype_test.go
+++ b/rest-api/db/pkg/db/model/instancetype_test.go
@@ -158,14 +158,6 @@ func TestInstanceType_FromProto(t *testing.T) {
 	})
 }
 
-func TestInstanceType_ToDeletionRequestProto(t *testing.T) {
-	id := uuid.New()
-	it := &InstanceType{ID: id}
-	req := it.ToDeletionRequestProto()
-	require.NotNil(t, req)
-	assert.Equal(t, id.String(), req.Id)
-}
-
 func TestLabels_ToProto(t *testing.T) {
 	t.Run("nil map yields nil slice", func(t *testing.T) {
 		var l Labels

--- a/rest-api/db/pkg/db/model/vpc.go
+++ b/rest-api/db/pkg/db/model/vpc.go
@@ -270,14 +270,6 @@ func (vpc *Vpc) FromProto(proto *cwssaws.Vpc) {
 	}
 }
 
-// ToDeletionRequestProto builds the workflow request that asks a Site to
-// delete this VPC.
-func (vpc *Vpc) ToDeletionRequestProto() *cwssaws.VpcDeletionRequest {
-	return &cwssaws.VpcDeletionRequest{
-		Id: &cwssaws.VpcId{Value: vpc.GetSiteID().String()},
-	}
-}
-
 // VpcCreateInput input parameters for Create method
 type VpcCreateInput struct {
 	Name                                   string

--- a/rest-api/db/pkg/db/model/vpc_test.go
+++ b/rest-api/db/pkg/db/model/vpc_test.go
@@ -1495,15 +1495,6 @@ func TestVpc_GetSiteID(t *testing.T) {
 	})
 }
 
-func TestVpc_ToDeletionRequestProto(t *testing.T) {
-	id := uuid.New()
-	v := &Vpc{ID: id}
-	req := v.ToDeletionRequestProto()
-	require.NotNil(t, req)
-	require.NotNil(t, req.Id)
-	assert.Equal(t, id.String(), req.Id.Value)
-}
-
 func TestVpc_ToProto(t *testing.T) {
 	id := uuid.New()
 	desc := "primary"


### PR DESCRIPTION
## Summary

Following review feedback on #2180, apply the same DB-agnostic principle to the two previously-merged entities that follow a similar pattern.

- Inlined `ToDeletionRequestProto` at the delete-handler callsite for **InstanceType** and **Vpc**; both were just ID wrapping, and the DB model doesn't need to know about workflow request types for that.
- Dropped the now-unused entity methods and their tests.

Pairs with #2180 (Subnet) which removes the same method there.

Another option could have been to further nest `.ToProto()`, but given what it was it seemed like it might have been overkill.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
