### PR TITLE
[#2210] bug: fix metadata identity API call from host instance

### DIFF
--- a/crates/agent/src/instance_metadata_endpoint.rs
+++ b/crates/agent/src/instance_metadata_endpoint.rs
@@ -70,9 +70,9 @@ pub trait InstanceMetadataRouterState: Sync + Send {
     );
     async fn phone_home(&self) -> Result<(), eyre::Error>;
 
-    /// Calls Carbide `SignMachineIdentity` gRPC using the agent's TLS client identity. The SPIFFE ID
-    /// in the client certificate must match the managed host machine row used by Carbide for
-    /// tenant identity config.
+    /// Calls Carbide `SignMachineIdentity` gRPC using the agent's DPU TLS client identity.
+    /// Carbide maps the DPU SPIFFE ID to the owning host when resolving the active instance and
+    /// tenant identity config; the issued JWT `sub` still reflects the caller's machine ID.
     ///
     /// **Note:** `GET …/meta-data/identity` does not use this trait method directly; it goes through
     /// [`Self::serve_meta_data_identity`], which enforces the identity rate limit before Carbide or

--- a/crates/api-db/src/tenant_identity_config.rs
+++ b/crates/api-db/src/tenant_identity_config.rs
@@ -333,8 +333,7 @@ pub async fn find_by_machine_id(
     txn: &mut PgConnection,
     machine_id: &MachineId,
 ) -> DatabaseResult<TenantIdentityConfig> {
-    let instance_machine_id =
-        instance_machine_id_for_identity_lookup(txn, machine_id).await?;
+    let instance_machine_id = instance_machine_id_for_identity_lookup(txn, machine_id).await?;
     let row = sqlx::query_as::<_, TenantIdentityConfig>(
         r"
         SELECT tic.organization_id, tic.issuer, tic.default_audience, tic.allowed_audiences,

--- a/crates/api-db/src/tenant_identity_config.rs
+++ b/crates/api-db/src/tenant_identity_config.rs
@@ -348,7 +348,7 @@ pub async fn find_by_machine_id(
         INNER JOIN instances i ON tic.organization_id = i.tenant_org
         WHERE i.machine_id = $1 AND i.deleted IS NULL AND tic.enabled = true",
     )
-    .bind(&instance_machine_id)
+    .bind(instance_machine_id)
     .fetch_optional(&mut *txn)
     .await
     .map_err(|e| DatabaseError::query("SELECT tenant_identity_config BY machine_id", e))?;

--- a/crates/api-db/src/tenant_identity_config.rs
+++ b/crates/api-db/src/tenant_identity_config.rs
@@ -310,12 +310,31 @@ where
         .map_err(|e| DatabaseError::query("SELECT tenant_identity_config BY organization_id", e))
 }
 
+/// Machine ID used to locate the active instance when resolving tenant identity config.
+///
+/// Instances are host-scoped (`instances.machine_id` is the host). DPU agents call
+/// `SignMachineIdentity` with a DPU mTLS identity, so map DPU callers to their owning host first.
+async fn instance_machine_id_for_identity_lookup(
+    txn: &mut PgConnection,
+    machine_id: &MachineId,
+) -> DatabaseResult<MachineId> {
+    if !machine_id.machine_type().is_dpu() {
+        return Ok(*machine_id);
+    }
+    let Some(host) = crate::machine::find_host_by_dpu_machine_id(txn, machine_id).await? else {
+        return Ok(*machine_id);
+    };
+    Ok(host.id)
+}
+
 /// Resolve tenant identity config for machine-identity RPCs: one join query, then overlap GC, then
 /// reload by org PK so the row matches the post-GC database state (GC may clear a JWKS slot).
 pub async fn find_by_machine_id(
     txn: &mut PgConnection,
     machine_id: &MachineId,
 ) -> DatabaseResult<TenantIdentityConfig> {
+    let instance_machine_id =
+        instance_machine_id_for_identity_lookup(txn, machine_id).await?;
     let row = sqlx::query_as::<_, TenantIdentityConfig>(
         r"
         SELECT tic.organization_id, tic.issuer, tic.default_audience, tic.allowed_audiences,
@@ -329,7 +348,7 @@ pub async fn find_by_machine_id(
         INNER JOIN instances i ON tic.organization_id = i.tenant_org
         WHERE i.machine_id = $1 AND i.deleted IS NULL AND tic.enabled = true",
     )
-    .bind(machine_id)
+    .bind(&instance_machine_id)
     .fetch_optional(&mut *txn)
     .await
     .map_err(|e| DatabaseError::query("SELECT tenant_identity_config BY machine_id", e))?;


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->

## Summary
Fixes `SignMachineIdentity` / IMDS identity failures when the DPU agent calls with its machine mTLS cert (`fm100d...`) while the active instance is stored on the host (`fm100h...`).
Fixes #2210
## Problem
`SignMachineIdentity` returned:
NotFound: machine_identity not found: fm100d...

even when:
- An active instance existed on the host
- Tenant identity config existed for the tenant org (`enabled: true`, audience `api` allowed)
**Root cause:** Instances are host-scoped (`instances.machine_id` = `fm100h...`), but the DPU agent authenticates with a DPU cert (`fm100d...`). `tenant_identity_config::find_by_machine_id` joined on the cert machine ID directly, while `FindInstanceByMachineID` already resolved DPU → host.

| Component | Machine ID used |
| --- | --- |
| DPU cert / `SignMachineIdentity` caller | `fm100d...` (DPU) |
| `instances.machine_id` in DB | `fm100h...` (host) |
| `FindInstanceByMachineID` | Resolves DPU → host ✅ |
| `find_by_machine_id` (before fix) | Used DPU ID directly ❌ |

## Solution
Resolve DPU → host before joining `instances` when looking up tenant identity config. JWT `sub` still uses the **caller's** machine ID from the cert (unchanged in the handler).
## Changes
### `crates/api-db/src/tenant_identity_config.rs`
- Added `instance_machine_id_for_identity_lookup()`:
  - **Host** callers → use machine ID as-is
  - **DPU** callers → resolve to owning host via `find_host_by_dpu_machine_id()`
- Updated `find_by_machine_id()` to query using the resolved host machine ID
### `crates/agent/src/instance_metadata_endpoint.rs`
- Updated doc comment on `sign_machine_identity` to reflect DPU cert + host instance resolution (replaces incorrect “cert must match host machine row” wording)

## Test plan
- [ ] Deploy updated carbide-api to dev site
- [ ] From DPU, verify direct gRPC signing:
  ```bash
  grpcurl -insecure \
    -cacert /opt/forge/forge_root.pem \
    -cert /opt/forge/machine_cert.pem \
    -key /opt/forge/machine_cert.key \
    -d '{"audience": ["api"]}' \
    carbide-api.forge:443 forge.Forge/SignMachineIdentity
Expected: response includes accessToken, tokenType, expiresInSec


 From Host, verify IMDS identity endpoint:

curl -s http://169.254.169.254/latest/meta-data/identity
Expected: JWT token body (not 503 / NotFound)


 Confirm host-cert path still works (no regression for fm100h... callers)


 Confirm machine with no instance still returns NotFound

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
Fixes #2210

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
