### PR TITLE
fix: drop NICO_REST_REPO / NICO_REPO env vars

### DIFF
--- a/book/src/configuration/configurability.md
+++ b/book/src/configuration/configurability.md
@@ -423,7 +423,6 @@ values files.
 | `NICO_IMAGE_REGISTRY` | Image registry hosting NICo Core images | `host[/path]`, e.g. `my-registry.example.com/infra-controller` |
 | `NICO_CORE_IMAGE_TAG` | NICo Core image tag | `vX.Y.Z` or git-derived tag |
 | `NICO_REST_IMAGE_TAG` | NICo REST image tag | `vX.Y.Z` |
-| `NICO_REST_REPO` | Path to a local clone of `infra-controller-rest` | Filesystem path; auto-detected from siblings |
 | `REGISTRY_PULL_SECRET` | Raw registry API key | **Raw key string** (e.g. `nvapi-...`). Not a file path. Not a JSON dockerconfig. |
 | `REGISTRY_PULL_USERNAME` | Registry username | Defaults to `$oauthtoken` (correct for `nvcr.io`) |
 | `KUBECONFIG` | Cluster kubeconfig | Filesystem path |

--- a/helm-prereqs/README.md
+++ b/helm-prereqs/README.md
@@ -101,7 +101,6 @@ The tables below summarize the keys that must be set per site.
 | `NICO_IMAGE_REGISTRY` | Yes, unless `--skip-core --skip-rest` | Base image registry for all NICo images (e.g. `my-registry.example.com/nico`) |
 | `NICO_CORE_IMAGE_TAG` | Yes, unless `--skip-core` | NICo Core image tag (e.g. `v2025.12.30-rc1`) |
 | `NICO_REST_IMAGE_TAG` | Yes, unless `--skip-rest` | NICo REST image tag (e.g. `v1.0.4`) |
-| `NICO_REST_REPO` | Required unless `--skip-rest` | Path to local clone of `infra-controller-rest`. Auto-detected from sibling directories. `NICO_REPO` is accepted as a deprecated alias. |
 | `NICO_SITE_UUID` | No | Stable UUID for this site. Defaults to `a1b2c3d4-e5f6-4000-8000-000000000001`. |
 | `NICO_MANAGE_DEFAULT_STORAGE_CLASS` | No | Whether `setup.sh` marks `local-path` as the default StorageClass. Defaults to `true`. Set to `false` when the cluster already has an operator-managed default StorageClass. |
 | `NICO_STORAGE_CLASS` | No | StorageClass used by Vault data/audit PVCs. Defaults to `local-path-persistent`. |

--- a/helm-prereqs/preflight.sh
+++ b/helm-prereqs/preflight.sh
@@ -496,41 +496,24 @@ if [[ -n "${NICO_IMAGE_REGISTRY:-}" ]] && command -v curl &>/dev/null; then
 fi
 
 # ---------------------------------------------------------------------------
-# 9. NICo REST repo
+# 9. NICo REST source tree (in-tree at ../rest-api)
+#
+# The REST stack lives in this repo under rest-api/. No separate clone is
+# supported any more; the legacy NICO_REST_REPO / NICO_REPO env vars and the
+# sibling-directory fallbacks were removed once rest-api/ became part of
+# core. If rest-api/ is missing the checkout is broken — error out so the
+# user fixes it rather than installing a half-stack.
 # ---------------------------------------------------------------------------
-NICO_REST_REPO_RESOLVED=""
+NICO_REST_DIR=""
 _NICO_REST_ENABLED=true
 [[ "${SKIP_REST:-false}" == "true" ]] && _NICO_REST_ENABLED=false
 
-NICO_CLONE_URL="https://github.com/NVIDIA/infra-controller-rest.git"
-NICO_CLONE_PARENT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-
 if ${_NICO_REST_ENABLED}; then
-    _NICO_REST_REPO_INPUT="${NICO_REST_REPO:-${NICO_REPO:-}}"
-    _NICO_REST_REPO_VAR="NICO_REST_REPO"
-    [[ -z "${NICO_REST_REPO:-}" && -n "${NICO_REPO:-}" ]] && _NICO_REST_REPO_VAR="NICO_REPO"
-
-    if [[ -n "${_NICO_REST_REPO_INPUT:-}" ]]; then
-        if [[ -d "${_NICO_REST_REPO_INPUT}/helm/charts/nico-rest" ]]; then
-            NICO_REST_REPO_RESOLVED="$(cd "${_NICO_REST_REPO_INPUT}" && pwd)"
-        else
-            ERRORS+=("${_NICO_REST_REPO_VAR}='${_NICO_REST_REPO_INPUT}' but helm/charts/nico-rest was not found there")
-        fi
+    _NICO_REST_CANDIDATE="${SCRIPT_DIR}/../rest-api"
+    if [[ -d "${_NICO_REST_CANDIDATE}/helm/charts/nico-rest" ]]; then
+        NICO_REST_DIR="$(cd "${_NICO_REST_CANDIDATE}" && pwd)"
     else
-        for _candidate in \
-            "${SCRIPT_DIR}/../../infra-controller-rest" \
-            "${SCRIPT_DIR}/../../nico-rest" \
-            "${SCRIPT_DIR}/../../ncx-infra-controller-rest" \
-            "${SCRIPT_DIR}/../../ncx"; do
-            if [[ -d "${_candidate}/helm/charts/nico-rest" ]]; then
-                NICO_REST_REPO_RESOLVED="$(cd "${_candidate}" && pwd)"
-                break
-            fi
-        done
-    fi
-
-    if [[ -z "${NICO_REST_REPO_RESOLVED}" ]]; then
-        WARNINGS+=("NICo REST repo not found — expected a sibling directory with helm/charts/nico-rest")
+        ERRORS+=("rest-api/ not found at ${_NICO_REST_CANDIDATE} (or missing helm/charts/nico-rest under it) — check out the full core repo, or pass --skip-rest if you only need the infra prereqs.")
     fi
 fi
 
@@ -541,13 +524,9 @@ _print_separator() { echo "-----------------------------------------------------
 
 if [[ ${#ERRORS[@]} -eq 0 && ${#WARNINGS[@]} -eq 0 ]]; then
     if ${_NICO_REST_ENABLED}; then
-        echo "Pre-flight OK  (NICo REST repo: ${NICO_REST_REPO_RESOLVED:-not resolved})"
+        echo "Pre-flight OK  (NICo REST source: ${NICO_REST_DIR})"
     else
         echo "Pre-flight OK  (NICo REST skipped)"
-    fi
-    if [[ -n "${NICO_REST_REPO_RESOLVED}" ]]; then
-        export NICO_REST_REPO="${NICO_REST_REPO_RESOLVED}"
-        export NICO_REPO="${NICO_REST_REPO_RESOLVED}"
     fi
     if ${_SOURCED}; then return 0; else exit 0; fi
 fi
@@ -573,49 +552,6 @@ if [[ ${#WARNINGS[@]} -gt 0 ]]; then
     done
 fi
 
-# Offer to clone NICo REST repo if missing
-if ${_NICO_REST_ENABLED} && [[ -z "${NICO_REST_REPO_RESOLVED}" ]]; then
-    echo ""
-    echo "  NICo REST repo not found."
-    echo ""
-    echo "  setup.sh Phase 7 deploys the NICo REST stack (API, workflow engine, site-agent)"
-    echo "  using Helm charts and kustomize bases from a separate repository:"
-    echo "    ${NICO_CLONE_URL}"
-    echo ""
-    echo "  Options:"
-    echo "    c) Clone it now into ${NICO_CLONE_PARENT}/infra-controller-rest"
-    echo "    s) Skip — Phase 7 will be skipped or will fail"
-    echo "    q) Quit setup entirely"
-    echo ""
-    echo "  (You can also clone it manually and re-run with:"
-    echo "   export NICO_REST_REPO=/path/to/infra-controller-rest)"
-    if [[ "${AUTO_YES:-false}" == "true" ]]; then
-        _clone_reply="s"
-    else
-        echo ""
-        read -r -p "  ➤  Clone NICo REST repo now? [c=clone / s=skip / q=quit]: " _clone_reply
-        echo ""
-    fi
-    case "${_clone_reply:-s}" in
-        c|C)
-            echo "  Cloning ${NICO_CLONE_URL} ..."
-            git clone "${NICO_CLONE_URL}" "${NICO_CLONE_PARENT}/infra-controller-rest"
-            NICO_REST_REPO_RESOLVED="${NICO_CLONE_PARENT}/infra-controller-rest"
-            export NICO_REST_REPO="${NICO_REST_REPO_RESOLVED}"
-            export NICO_REPO="${NICO_REST_REPO_RESOLVED}"
-            echo "  Cloned OK — NICO_REST_REPO=${NICO_REST_REPO}"
-            WARNINGS=("${WARNINGS[@]/NICo REST repo not found*/}")
-            ;;
-        q|Q)
-            echo "  Aborted."
-            if ${_SOURCED}; then return 1; else exit 1; fi
-            ;;
-        *)
-            echo "  Skipping NICo REST repo — step [7/7] will fail."
-            ;;
-    esac
-fi
-
 echo ""
 _print_separator
 
@@ -632,20 +568,12 @@ if [[ ${#ERRORS[@]} -eq 0 ]]; then
             if ${_SOURCED}; then return 1; else exit 1; fi
         fi
     fi
-    if [[ -n "${NICO_REST_REPO_RESOLVED}" ]]; then
-        export NICO_REST_REPO="${NICO_REST_REPO_RESOLVED}"
-        export NICO_REPO="${NICO_REST_REPO_RESOLVED}"
-    fi
     if ${_SOURCED}; then return 0; else exit 0; fi
 fi
 
 # Hard errors — default abort
 if [[ "${AUTO_YES:-false}" == "true" ]]; then
     echo "  Errors above noted — continuing (-y flag set). Things may fail."
-    if [[ -n "${NICO_REST_REPO_RESOLVED}" ]]; then
-        export NICO_REST_REPO="${NICO_REST_REPO_RESOLVED}"
-        export NICO_REPO="${NICO_REST_REPO_RESOLVED}"
-    fi
     if ${_SOURCED}; then return 0; else exit 0; fi
 fi
 
@@ -656,10 +584,6 @@ read -r -p "  ➤  Continue anyway at your own risk? [y/N]: " _reply
 echo ""
 if [[ "${_reply:-N}" =~ ^[Yy]$ ]]; then
     echo "  Continuing — good luck."
-    if [[ -n "${NICO_REST_REPO_RESOLVED}" ]]; then
-        export NICO_REST_REPO="${NICO_REST_REPO_RESOLVED}"
-        export NICO_REPO="${NICO_REST_REPO_RESOLVED}"
-    fi
     if ${_SOURCED}; then return 0; else exit 0; fi
 fi
 

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -37,10 +37,6 @@
 #                          preloaded, or use existing imagePullSecrets.
 #   REGISTRY_PULL_USERNAME Username for generated pull secrets.
 #                          Default: $oauthtoken
-#   NICO_REST_REPO          Path to infra-controller-rest. Required only when
-#                          REST is not skipped; preflight can auto-discover or
-#                          clone it if missing. NICO_REPO is accepted as a
-#                          deprecated alias.
 #   NICO_SITE_UUID          Stable REST site UUID. Used only when REST is
 #                          deployed. Default is a dev placeholder.
 #   NICO_MANAGE_DEFAULT_STORAGE_CLASS
@@ -118,8 +114,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 # ---------------------------------------------------------------------------
-# Pre-flight checks — env vars, tools, config files, NICo REST repo
-# Exports NICO_REST_REPO if resolved. Exits 1 if user declines to continue.
+# Pre-flight checks — env vars, tools, config files. Resolves NICO_REST_DIR
+# (in-tree rest-api/). Exits 1 if user declines to continue.
 # ---------------------------------------------------------------------------
 export AUTO_YES SKIP_CORE SKIP_REST SKIP_FLOW
 # shellcheck source=preflight.sh
@@ -538,13 +534,15 @@ if "${SKIP_REST}"; then
     exit 0
 fi
 
-# --- 7a. NICo REST repo (resolved and exported by preflight.sh) -------------------
-if [[ -z "${NICO_REST_REPO:-}" ]]; then
-    echo "ERROR: NICo REST repo is not set. Re-run setup.sh and choose to clone, or:"
-    echo "  export NICO_REST_REPO=/path/to/infra-controller-rest"
+# --- 7a. NICo REST source tree (in-tree at ../rest-api) --------------------------
+# preflight.sh resolves and validates rest-api/ in this repo into NICO_REST_DIR.
+# If it didn't, preflight already errored out — guard the consumer side too in
+# case someone sources setup.sh without going through preflight.
+if [[ -z "${NICO_REST_DIR:-}" ]]; then
+    echo "ERROR: NICO_REST_DIR is unset — preflight didn't resolve rest-api/. Make sure your checkout contains rest-api/helm/charts/nico-rest."
     exit 1
 fi
-echo "NICo REST repo: ${NICO_REST_REPO}"
+echo "NICo REST source: ${NICO_REST_DIR}"
 
 # Create NICo REST namespace
 kubectl create namespace nico-rest 2>/dev/null || true
@@ -556,13 +554,13 @@ if kubectl get secret ca-signing-secret -n nico-rest &>/dev/null; then
     echo "ca-signing-secret already present — skipping CA generation"
 else
     echo "Generating NICo REST CA signing secret..."
-    (cd "${NICO_REST_REPO}" && ./scripts/gen-site-ca.sh)
+    (cd "${NICO_REST_DIR}" && ./scripts/gen-site-ca.sh)
 fi
 
 # --- 7b. ClusterIssuer -------------------------------------------------------
 _SETUP_PHASE="[7b/7] NICo REST CA issuer ClusterIssuer"
 echo "=== [7b/7] NICo REST CA issuer ClusterIssuer ==="
-(cd "${NICO_REST_REPO}" && kubectl apply -k deploy/kustomize/base/cert-manager-io)
+(cd "${NICO_REST_DIR}" && kubectl apply -k deploy/kustomize/base/cert-manager-io)
 
 # --- 7c. NICo REST postgres --------------------------------------------------------
 # Simple postgres StatefulSet with all NICo databases pre-initialised:
@@ -571,7 +569,7 @@ echo "=== [7b/7] NICo REST CA issuer ClusterIssuer ==="
 # service name ("postgres") so Temporal and NICo values work without changes.
 _SETUP_PHASE="[7c/7] NICo REST postgres"
 echo "=== [7c/7] NICo REST postgres ==="
-(cd "${NICO_REST_REPO}" && kubectl apply -k deploy/kustomize/base/postgres)
+(cd "${NICO_REST_DIR}" && kubectl apply -k deploy/kustomize/base/postgres)
 kubectl rollout status statefulset/postgres -n postgres --timeout=180s
 echo "NICo REST postgres ready"
 
@@ -595,9 +593,9 @@ fi
 # --- 7e. Temporal namespace + TLS certs + db-creds --------------------------
 _SETUP_PHASE="[7e/7] Temporal TLS bootstrap"
 echo "=== [7e/7] Temporal TLS bootstrap ==="
-(cd "${NICO_REST_REPO}" && kubectl apply -f deploy/kustomize/base/temporal-helm/namespace.yaml)
-(cd "${NICO_REST_REPO}" && kubectl apply -f deploy/kustomize/base/temporal-helm/db-creds.yaml)
-(cd "${NICO_REST_REPO}" && kubectl apply -f deploy/kustomize/base/temporal-helm/certificates.yaml)
+(cd "${NICO_REST_DIR}" && kubectl apply -f deploy/kustomize/base/temporal-helm/namespace.yaml)
+(cd "${NICO_REST_DIR}" && kubectl apply -f deploy/kustomize/base/temporal-helm/db-creds.yaml)
+(cd "${NICO_REST_DIR}" && kubectl apply -f deploy/kustomize/base/temporal-helm/certificates.yaml)
 
 echo "Waiting for temporal TLS certificates to be issued..."
 kubectl wait --for=condition=Ready certificate/server-interservice-cert \
@@ -611,9 +609,9 @@ echo "Temporal TLS certs ready"
 # --- 7f. Temporal ------------------------------------------------------------
 _SETUP_PHASE="[7f/7] Temporal"
 echo "=== [7f/7] Temporal ==="
-helm upgrade --install temporal "${NICO_REST_REPO}/temporal-helm/temporal" \
+helm upgrade --install temporal "${NICO_REST_DIR}/temporal-helm/temporal" \
     --namespace temporal \
-    -f "${NICO_REST_REPO}/temporal-helm/temporal/values-kind.yaml" \
+    -f "${NICO_REST_DIR}/temporal-helm/temporal/values-kind.yaml" \
     --timeout 300s --wait
 echo "Temporal ready"
 
@@ -635,7 +633,7 @@ echo "Temporal namespaces ready"
 
 _SETUP_PHASE="[7g/7] NICo REST helm chart"
 # --- 7g. NICo REST helm chart -------------------------------------------------
-NICO_HELM_CHART="${NICO_REST_REPO}/helm/charts/nico-rest"
+NICO_HELM_CHART="${NICO_REST_DIR}/helm/charts/nico-rest"
 NICO_REST_CMD=(
     helm upgrade --install nico-rest "${NICO_HELM_CHART}"
     --namespace nico-rest
@@ -703,7 +701,7 @@ fi
 #
 # The site-agent binary also needs DB credentials for its local elektratest DB.
 # All of this is wired via --set flags so nico-rest.yaml stays registry-agnostic.
-NICO_SITE_AGENT_CHART="${NICO_REST_REPO}/helm/charts/nico-rest-site-agent"
+NICO_SITE_AGENT_CHART="${NICO_REST_DIR}/helm/charts/nico-rest-site-agent"
 
 # Stable placeholder UUID for this site (must be a valid UUID).
 NICO_SITE_UUID="${NICO_SITE_UUID:-a1b2c3d4-e5f6-4000-8000-000000000001}"

--- a/rest-api/helm/charts/nico-rest/charts/nico-rest-common/templates/secrets.yaml
+++ b/rest-api/helm/charts/nico-rest/charts/nico-rest-common/templates/secrets.yaml
@@ -2,6 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.secrets.create }}
+# db-creds and image-pull-secret are annotated as pre-install / pre-upgrade
+# hooks (weight -10) because the nico-rest-db migration Job runs as its own
+# pre-install hook at weight -5 and needs both to exist before it starts.
+# Without the hook annotations these were regular resources applied during
+# main install, AFTER the migration Job pod had already tried to start —
+# leading to "imagePullSecrets references image-pull-secret which does not
+# exist" → kubelet anonymous pull → 403 on private registries.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,6 +16,10 @@ metadata:
   namespace: {{ include "nico-rest-common.namespace" . }}
   labels:
     {{- include "nico-rest-common.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
 type: Opaque
 stringData:
   username: {{ .Values.secrets.dbCreds.username | quote }}
@@ -43,6 +54,10 @@ metadata:
   namespace: {{ include "nico-rest-common.namespace" . }}
   labels:
     {{- include "nico-rest-common.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ .Values.secrets.imagePullSecret.dockerconfigjson | quote }}


### PR DESCRIPTION
## Description
rest-api/ lives in this repo now (since the PR that merged the standalone infra-controller-rest into core), so the env-var path and the sibling-directory auto-discovery preflight.sh used to do are dead code. Pulling them out:

- preflight.sh: drop the NICO_REST_REPO / NICO_REPO lookup, the four-candidate sibling-dir fallback, the "would you like to clone NICo REST?" prompt, the NICO_CLONE_URL banner, and every export-the-env-var-back-out branch. Resolve to ${SCRIPT_DIR}/../rest-api and error out if it's missing.

- setup.sh: rename ${NICO_REST_REPO} -> ${NICO_REST_DIR} so it's obvious from a grep that this is a local shell variable set by preflight.sh, not an env var the user is supposed to point somewhere. Drop the "set the env var" hint from the help text and the missing-var error.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [X] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

