### PR TITLE
feat(admin-cli): add usage examples to all commands; restructure browse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,6 +1065,7 @@ dependencies = [
  "libredfish",
  "librms",
  "mac_address",
+ "pandoc",
  "prettytable-rs",
  "reqwest 0.13.4",
  "serde",
@@ -6048,6 +6049,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -7813,6 +7823,15 @@ dependencies = [
  "tokio",
  "windows",
  "windows-strings",
+]
+
+[[package]]
+name = "pandoc"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "463d53d1a77a4291203dbf9d461365609e6857c95bd7d807098bffdc0a02a65c"
+dependencies = [
+ "itertools 0.12.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,7 @@ oauth2 = { default-features = false, version = "5" }
 octseq = "0.6.1"
 oid-registry = "0.8"
 once_cell = "1.19"
+pandoc = "0.8.11"
 pin-project-lite = "0.2"
 pkcs1 = "0.7.5"
 prettyplease = "0.2.30"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -99,6 +99,33 @@ script = '''
 cargo run -p carbide-admin-cli -- generate-man --out-dir target/man
 '''
 
+[tasks.gen-cli-docs]
+category = "Build"
+description = "Generate the carbide-admin-cli markdown reference into docs/cli"
+workspace = false
+# `generate-cli-docs` renders each command's man page and converts it to
+# markdown with pandoc, so the `pandoc` binary must be installed. It writes one
+# directory per top-level command under docs/cli/commands plus the four domain
+# index files (Hardware/Network/Tenant/Admin). The hand-authored pages
+# (README.md, setup.md, workflows.md, rest-cli-parity.md) are left alone.
+script = '''
+cargo run -p carbide-admin-cli -- generate-cli-docs --out-dir docs/cli
+'''
+
+[tasks.check-cli-docs]
+category = "Test"
+description = "Fail if docs/cli is stale or a command is missing a domain"
+workspace = false
+# Keeps the checked-in CLI reference honest as commands are added. First the
+# domain-mapping test fails CI if a new command is not categorized in
+# cli_domains.yaml; then we regenerate and fail if the result differs from
+# what is committed (regenerate locally with `cargo make gen-cli-docs`).
+script = '''
+cargo test -p carbide-admin-cli cfg::cli_options::tests
+cargo run -p carbide-admin-cli -- generate-cli-docs --out-dir docs/cli
+git diff --exit-code -- docs/cli
+'''
+
 [tasks.build-cli]
 category = "Build"
 description = "Build carbide-admin-cli locally using debian container. Ensures correct GCC version is used."

--- a/crates/admin-cli/AGENTS.md
+++ b/crates/admin-cli/AGENTS.md
@@ -1,0 +1,370 @@
+# AGENTS.md — admin-cli
+
+Guidance for AI coding agents (and humans) working on the admin CLI
+(`carbide-admin-cli`). This file is symlinked to `CLAUDE.md`; edit
+`AGENTS.md` and the other name follows.
+
+See the repo-root [`AGENTS.md`](../../AGENTS.md) for build/test/lint
+commands and overall conventions. This file documents admin-CLI–specific
+conventions: the per-command help **examples** under `--help` (below),
+and how we surface **errors** to the user ("Error messages" at the end).
+
+## Command help examples (`after_long_help`)
+
+Every leaf subcommand carries a worked `EXAMPLES:` section, rendered by
+clap's `after_long_help`. It appears at the bottom of `--help` (the long
+help; `-h` shows only the summary). The goal is that a reader who runs
+`carbide-admin-cli <path> --help` sees concrete, copy-pasteable
+invocations covering the realistic ways to use that command — not just a
+list of flags.
+
+### The convention
+
+Attach `#[command(after_long_help = "...")]` to the clap `Args`/`Opts`
+struct (or enum) that backs the subcommand:
+
+```rust
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all VPCs:
+    $ carbide-admin-cli vpc show
+
+Show details for one VPC:
+    $ carbide-admin-cli vpc show 12345678-1234-5678-90ab-cdef01234567
+
+")]
+pub struct Args {
+    // fields ...
+}
+```
+
+Formatting rules, all load-bearing:
+
+- Open with the literal `EXAMPLES:` header, then a blank line.
+- Each example is a **description line ending in `:`**, then the command
+  on the next line indented **four spaces** and prefixed with `$ `.
+- One blank line between examples; one trailing blank line before the
+  closing `"`.
+- The leading `\` after the opening quote swallows the first newline so
+  the block starts cleanly at `EXAMPLES:`.
+- Always use the real binary name `carbide-admin-cli` and the **kebab-case
+  command path** as clap renders it (see "Getting the command path"
+  below).
+- For commands too long for one source line, break with a trailing `\`
+  inside the string literal. clap collapses the wrapped string back to a
+  single rendered line, so the example still copy-pastes as one command.
+  **Indent each continuation line four spaces** to align it under the `$ `
+  command. Rust's `\`-newline escape strips that leading whitespace, so the
+  indent is invisible in the rendered help — it is purely for source
+  readability, but keep it consistent:
+
+  ```rust
+  #[command(after_long_help = "\
+  EXAMPLES:
+
+  Peer two VPCs:
+      $ carbide-admin-cli vpc-peering create 12345678-1234-5678-90ab-cdef01234567 \
+      abcdef01-2345-6789-abcd-ef0123456789
+
+  ")]
+  ```
+
+- Escape any literal `"` inside the string as `\"` (e.g. quoted
+  `--description \"Front-end subnet\"`).
+
+### Realistic placeholder values
+
+Use believable, consistent placeholders rather than `<ID>` angle
+brackets — they read better and copy-paste into a real shell shape:
+
+| Kind             | Placeholder                                |
+| ---------------- | ------------------------------------------ |
+| UUID / resource id | `12345678-1234-5678-90ab-cdef01234567` (use `abcdef01-2345-6789-abcd-ef0123456789` for a second) |
+| Tenant org id    | `fds34511233a`                             |
+| BMC / host IP    | `192.0.2.10` (TEST-NET-1; host BMC `192.0.2.20`), with port as `192.0.2.10:22` |
+| Username         | `admin`                                    |
+| Password         | `mypassword` (use `mynewpassword` for a password being *set*) — keep it obviously a placeholder, never something that reads like a real secret |
+| MAC address      | `00:11:22:33:44:55`                        |
+| SKU id           | `DGX-H100-640GB`                           |
+| File / dir paths | `./skus.json`, `/path/to/tpm-ca.der`       |
+
+Where a field is an enum, use a **real variant** (`internal-maintenance`,
+`nvidia`, `ready`), not a made-up token — read the `ValueEnum` /
+`possible values` to pick one.
+
+### Deciding what goes in EXAMPLES
+
+The flag list already documents *what each option is*. Examples exist to
+show *how the command is actually used*. Derive them from the struct's
+fields, not from imagination:
+
+1. **The happy path first.** One example of the simplest, most common
+   invocation (often "list all" or the single required positional).
+2. **One example per meaningful axis of variation**, where an axis is a
+   distinct way to drive the command:
+   - each **selector / filter** that changes *what* is acted on
+     (`--vpc-id`, `--contains`, `--tenant-org-id`, a positional id vs.
+     no id);
+   - each **mode** in a mutually-exclusive set — surface both sides
+     (`--pause` *and* `--resume`; "fill missing" vs `--replace-all`);
+   - **important optional flags** that change behavior
+     (`--force`, `--delete-interfaces`, `--print-only`, `--id` override).
+3. **Cover both "all" and "one"** for show/list commands (list
+   everything, then show a single entity by id).
+4. **Show destructive / forceful flags explicitly** so readers see how to
+   invoke them deliberately (`--force`, `--replace`, `--replace-all`).
+5. **Stop there.** Don't enumerate every flag combination — pick
+   representative ones. Two to six examples is the normal range; a
+   single-purpose command may have just one.
+
+Let the field declarations drive coverage: positionals (required vs
+`Option`), `ArgGroup`s, `conflicts_with`, and `ValueEnum`s each map
+naturally to an example or a chosen value.
+
+### Getting the command path right
+
+The path in the example must match what clap actually parses. Check the
+parent `enum Cmd` and any attributes before assuming the name:
+
+- Enum variants are kebab-cased by default (`ShowMachines` →
+  `show-machines`), but verify — some enums set `rename_all`.
+- `#[clap(name = "refresh")]` renames a command (`RefreshEndpoint` is
+  invoked as `refresh`, not `refresh-endpoint`).
+- `visible_alias` / `alias` add alternatives but the canonical name is
+  what you should write.
+- Nested groups (`#[clap(subcommand)]`) add a path segment
+  (`site-explorer get-report endpoint`).
+
+### Placement for tricky clap shapes
+
+A block can live on the command's argument struct/enum **or directly on
+the enum variant** that defines the subcommand. Both render on that
+subcommand's `--help`. Pick whichever gives an accurate, per-command
+example:
+
+- **Struct/enum that is the command's own argument type** — the default.
+  Put the block there (as in every `Args` example above).
+- **Variant-level `#[command(after_long_help = "...")]`** — attach the
+  attribute to the *variant* in the subcommand enum rather than to a
+  payload struct. This is the right tool for the two cases below:
+  - **Unit variants** (`ForceOff` → `force-off`): they have no payload
+    struct, so a variant-level block is the only place to put an example.
+    But don't reflexively add one — see "When a unit variant is worth an
+    example" below.
+  - **A payload struct shared by two or more variants**
+    (`ChangeUefiPassword(UefiPassword)` *and*
+    `ClearUefiPassword(UefiPassword)`; `SetBootOrderDpuFirst` *and*
+    `IsBootOrderSetup`, both `SetBootOrderDpuFirstArgs`): a block on the
+    shared struct would render the *same* text — with the wrong command
+    name — under every variant. Put a distinct block on **each variant**
+    instead, and leave the shared struct bare.
+- **Type alias** (`pub type Args = ShowSkuOptions;`): put the attribute
+  on the aliased struct itself (`ShowSkuOptions` in `common.rs`). It
+  renders for the command that uses the alias directly.
+- **Flattened newtype** (`#[clap(flatten)] pub inner: ShowSkuOptions`):
+  a flattened struct contributes *fields only* — its command-level help
+  is ignored. Put the `EXAMPLES:` block on the **outer newtype**, and do
+  not rely on a block on a struct that is only ever flattened.
+- **Nested subcommand enum**: put a block on the enum for the group's own
+  `--help` (covering its variants), and a block on each variant's struct
+  (or variant) for that variant's `--help`.
+
+A variant-level block sits between the variant's doc comment and the
+variant itself:
+
+```rust
+    /// Change UEFI password
+    #[command(after_long_help = \"\\
+EXAMPLES:
+
+Change the UEFI password:
+    $ carbide-admin-cli redfish ... change-uefi-password --current-password X --new-password Y
+
+\")]
+    ChangeUefiPassword(UefiPassword),
+```
+
+### When a unit variant is worth an example
+
+A no-argument subcommand (`get-power-state`, `boot-hdd`, `on`,
+`thermal-metrics`, …) is already documented by its doc-comment `about`
+plus the credential pattern shown in the parent command's top-level
+block. A per-variant `EXAMPLES:` block that just repeats
+`... --password mypassword <verb>` adds noise, not signal. So **do not
+add a block to a trivial unit variant.**
+
+Add one only when the example teaches something the `--help` page
+wouldn't otherwise show, e.g.:
+
+- a **hidden alias** declared with `#[clap(alias = "...")]` (as opposed
+  to `visible_alias`, which clap already prints). `force-off`,
+  `force-restart`, `graceful-restart` and `graceful-shutdown` each carry
+  a hidden alias (`off`, `reset`, `restart`, `shutdown`), so their block
+  surfaces it — that's the only place the reader learns the short form
+  exists;
+- a non-obvious value format, ordering constraint, or prerequisite that
+  the flag/about text doesn't capture.
+
+The same "does the example add information?" test from "Deciding what
+goes in EXAMPLES" governs here — it just resolves to *zero* examples for
+the common trivial case.
+
+### Verifying the rendered output
+
+Build, then render the long help and read the bottom:
+
+```bash
+cargo build -p carbide-admin-cli
+# Capture to a file — the sandbox has a pipe-drop bug, so `... | grep`
+# may silently show nothing even when the block is present.
+cargo run -q -p carbide-admin-cli -- <command path> --help > tmp/help.txt 2>&1
+sed -n '/EXAMPLES/,$p' tmp/help.txt
+```
+
+Confirm the wrapped (`\`-continued) commands collapsed to single lines
+and that the command path matches the real subcommand name.
+
+## Generated reference docs (man pages and `docs/cli`)
+
+Two hidden subcommands turn the live clap tree into documentation, so the
+reference can't drift from the code. Both are `hide = true` (they don't show
+in `--help`) and write to a directory you pass with `--out-dir`:
+
+- `generate-man` renders a roff man page per command/subcommand via
+  `clap_mangen` (one file each, named by the full path, e.g.
+  `carbide-admin-cli-vpc-show.1`). Run it with `cargo make gen-man`.
+- `generate-cli-docs` builds the `docs/cli` markdown reference. It renders the
+  same man pages, converts each to GitHub-flavored markdown with **pandoc**
+  (the `pandoc` *binary* must be on `PATH` — it's installed in the CI build
+  images), and reorganizes them into one directory per top-level command
+  (`docs/cli/commands/<command>/<command>.md`, with each descendant beside it
+  as `<command>-<sub>.md`). The man page's OPTIONS/SYNOPSIS give each page its
+  per-flag detail; the `EXAMPLES:` block you write becomes that page's
+  `## Examples`. Run it with `cargo make gen-cli-docs`.
+
+The hand-authored pages (`docs/cli/README.md`, `setup.md`, `workflows.md`,
+`rest-cli-parity.md`) are editorial and are **not** regenerated — leave them be.
+
+### Categorizing a new command
+
+Every visible top-level command must be assigned a domain (Hardware, Network,
+Tenant, or Admin) in `crates/admin-cli/cli_domains.yaml` — that file is the
+single source of truth for how the reference is grouped, parsed by
+`domain_for_command` in `cfg/cli_options.rs`. When you add a top-level command,
+add its rendered name (kebab-case, as clap prints it) under the right domain.
+Two tests keep the YAML honest:
+
+- `every_command_has_a_domain` fails if a visible command is missing from the
+  YAML;
+- `no_unknown_commands_in_domain_map` fails if the YAML names a command that no
+  longer exists.
+
+### Keeping `docs/cli` in sync
+
+`docs/cli` is committed, so regenerate and commit it whenever you change a
+command's help, examples, structure, or domain:
+
+```bash
+cargo make gen-cli-docs   # regenerate docs/cli (needs the pandoc binary)
+```
+
+CI runs `cargo make check-cli-docs`, which runs the two domain tests, then
+regenerates and fails on any `git diff` in `docs/cli` — so a forgotten
+regeneration (or an uncategorized command) is caught there.
+
+## Error messages
+
+This is a user-facing CLI, so errors should read like a tool talking to
+an operator, not a Rust program dumping its guts. Two rules:
+
+### Errors render as a message chain, not a stack trace
+
+`main` installs color-eyre with both the source-location section and the
+"run with `RUST_BACKTRACE`" footer turned off:
+
+```rust
+color_eyre::config::HookBuilder::default()
+    .display_location_section(false)
+    .display_env_section(false)
+    .install()?;
+```
+
+So a failed command prints just its error and the cause chain — nothing
+about which `.rs:line` propagated it. **Do not re-enable those sections.**
+A backtrace is still captured when the user explicitly sets
+`RUST_BACKTRACE=1`.
+
+Because the location is gone, **the `.context()` chain *is* the error
+message.** This makes the repo-wide "`.context()` before every `?`" rule
+load-bearing here: write context that completes "while attempting to …"
+so the rendered chain reads as a coherent story
+(`Network error talking to BMC at … → error sending request → tcp connect
+error → deadline has elapsed`).
+
+### A bad invocation is a clap error, not an eyre error
+
+A problem with *how the command was invoked* — a missing argument, a value
+that should have been required — should look like every other clap error
+(the red `error:` prefix, a `Usage:` line, `try '--help'`, and **exit code
+2**), never a generic `eyre!` that exits 1 with no usage.
+
+The first choice is to **let clap enforce it** by giving the arg a
+non-`Option` type. A `String` (not `Option<String>`) field with no default is
+required automatically, so clap renders it as mandatory in the `Usage:` line
+(`--address <ADDRESS>`, unbracketed) on the parent *and* every subcommand —
+that usage line is the requiredness signal, so you don't need a custom
+`help_heading = "Required"` to advertise it (a heading only re-groups the
+arg on the *parent* `--help` and shows nothing on subcommands; skip it).
+Prefer the non-`Option` type over an explicit `required = true` on an
+`Option<_>`: it removes the always-`Some` field, so the handler reads
+`action.address` directly with no dead `None` branch (a `None` branch there is
+unreachable and would have to raise a runtime `eyre!`, which is exactly the
+exit-1 error this section forbids). But a required arg and `global` are
+mutually exclusive (clap rejects a required `global` arg), and only `global`
+propagates an arg into each subcommand's *option list*, so for a flag shared
+across a family of subcommands you pick:
+
+| approach | enforced by | flag listed in subcommand `--help` | `--foo` after the subcommand |
+| --- | --- | --- | --- |
+| required parent arg (non-`Option` type) | clap (auto) | usage line only (not the option list) | ✗ (must precede the subcommand) |
+| `global` parent arg + hand-validation | **you** | yes, full option entry | ✓ |
+
+redfish uses the **first row** — prefer clap-native enforcement whenever you
+can live with its constraints:
+
+```rust
+// on RedfishAction: a non-Option String is required by clap automatically,
+// so the handler uses `action.address` directly — no None branch to handle.
+#[clap(long, help = "IP:port of machine BMC. Port is optional and defaults to 443")]
+pub address: String,
+```
+```
+Usage: carbide-admin-cli redfish [OPTIONS] --address <ADDRESS> <COMMAND>
+```
+
+With the first row clap does the work — no validation code in `main.rs`, and
+a missing flag prints clap's own "the following required arguments were not
+provided" (exit 2). Accept its two constraints: the flag must come *before*
+the subcommand, and the requirement applies to **every** subcommand of that
+parent — including ones that don't actually use it (redfish's `browse`
+proxies through the API server and ignores `--address`, but is still
+required to pass it). That uniformity was the accepted trade for clap-native
+enforcement. (redfish keeps only `--address` required this way;
+`--username`/`--password` are left optional.)
+
+Fall back to the **second row** only when an arg genuinely must stay
+`global` (positionable after the subcommand, or required for some
+subcommands but not others). Then hand-validate at the dispatch site and
+raise a clap error so it still looks native — never a runtime
+`eyre!("Missing --foo")` deep in a handler:
+
+```rust
+use clap::CommandFactory;          // already imported in main.rs
+use clap::error::ErrorKind;
+
+CliOptions::command()
+    .error(ErrorKind::MissingRequiredArgument, "…actionable message…")
+    .exit();                       // prints to stderr, exits 2, never returns
+```

--- a/crates/admin-cli/CLAUDE.md
+++ b/crates/admin-cli/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/admin-cli/Cargo.toml
+++ b/crates/admin-cli/Cargo.toml
@@ -58,6 +58,7 @@ ipnet = { workspace = true }
 libredfish = { workspace = true }
 librms = { workspace = true }
 mac_address = { workspace = true }
+pandoc = { workspace = true }
 prettytable-rs = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { features = ["derive"], workspace = true }

--- a/crates/admin-cli/cli_domains.yaml
+++ b/crates/admin-cli/cli_domains.yaml
@@ -1,0 +1,83 @@
+# Operator-facing grouping of top-level `carbide-admin-cli` commands, used to
+# organize the generated CLI reference under docs/cli (run
+# `carbide-admin-cli generate-cli-docs`).
+#
+# Keyed by domain; each value is the list of command names (as rendered in
+# --help, e.g. "managed-host", "tenant-key-set") in that domain. When you add a
+# new top-level command, add it here under the right domain — the
+# `every_command_has_a_domain` test fails CI if a visible command is missing,
+# and `no_unknown_commands_in_domain_map` fails if an entry here no longer
+# matches a real command.
+
+hardware:
+  - machine
+  - managed-host
+  - host
+  - machine-interfaces
+  - machine-validation
+  - dpu
+  - dpu-remediation
+  - dpf
+  - dpa
+  - bmc-machine
+  - boot-override
+  - credential
+  - power-shelf
+  - switch
+  - managed-switch
+  - rack
+  - firmware
+  - component-manager
+  - attestation
+  - redfish
+  - rms
+  - mlx
+  - scout-stream
+  - tpm-ca
+  - sku
+  - inventory
+  - set
+  - trim-table
+  - nvl-partition
+  - nvlink-nmxc-endpoints
+  - browse
+
+network:
+  - vpc
+  - vpc-peering
+  - vpc-prefix
+  - network-segment
+  - network-device
+  - network-security-group
+  - route-server
+  - domain
+  - ip
+  - ib-partition
+  - logical-partition
+  - resource-pool
+  - nvl-domain
+  - spx-partition
+
+tenant:
+  - tenant
+  - tenant-key-set
+  - instance
+  - instance-type
+  - compute-allocation
+  - expected-machine
+  - expected-power-shelf
+  - expected-rack
+  - expected-switch
+  - operating-system
+  - os-image
+  - ipxe-template
+  - extension-service
+  - site-explorer
+
+admin:
+  - version
+  - generate-shell-complete
+  - ping
+  - dev-env
+  - ssh
+  - jump

--- a/crates/admin-cli/src/attestation/measured_boot/bundle/args.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/bundle/args.rs
@@ -92,6 +92,18 @@ pub enum CmdBundle {
 /// or profile name, with provided PCR values and an optional
 /// MeasurementBundleState (the default is 'active').
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create an active bundle for a profile with two PCR values:
+    $ carbide-admin-cli attestation measured-boot bundle create my-bundle \
+    12345678-1234-5678-90ab-cdef01234567 0:abc123,7:def456
+
+Create a bundle in the pending state (awaiting approval):
+    $ carbide-admin-cli attestation measured-boot bundle create my-bundle \
+    12345678-1234-5678-90ab-cdef01234567 0:abc123 --state pending
+
+")]
 pub struct Create {
     #[clap(help = "A human-readable name to give this bundle.")]
     pub name: String,
@@ -120,6 +132,18 @@ pub struct Create {
 
 /// Delete will delete a bundle for the given ID.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a bundle by ID:
+    $ carbide-admin-cli attestation measured-boot bundle delete \
+    12345678-1234-5678-90ab-cdef01234567
+
+Delete a bundle and purge its journal records:
+    $ carbide-admin-cli attestation measured-boot bundle delete \
+    12345678-1234-5678-90ab-cdef01234567 --purge-journals
+
+")]
 pub struct Delete {
     #[clap(help = "The bundle ID.")]
     pub bundle_id: MeasurementBundleId,
@@ -132,6 +156,17 @@ pub struct Delete {
 /// A parser will parse the `identifier` to determine if
 /// the API should be called w/ an ID or name selector.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Rename a bundle, letting the CLI detect whether the identifier is an ID or name:
+    $ carbide-admin-cli attestation measured-boot bundle rename old-name new-name
+
+Rename a bundle selected explicitly by ID:
+    $ carbide-admin-cli attestation measured-boot bundle rename \
+    12345678-1234-5678-90ab-cdef01234567 new-name --is-id
+
+")]
 pub struct Rename {
     #[clap(help = "The existing bundle ID or name.")]
     pub identifier: String,
@@ -159,6 +194,20 @@ impl IdNameIdentifier for Rename {
 /// Show will get + display a bundle for the given ID, or, if not ID is set,
 /// it will display all bundles and their information.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show all bundles:
+    $ carbide-admin-cli attestation measured-boot bundle show
+
+Show one bundle by ID:
+    $ carbide-admin-cli attestation measured-boot bundle show \
+    12345678-1234-5678-90ab-cdef01234567 --is-id
+
+Show one bundle by name:
+    $ carbide-admin-cli attestation measured-boot bundle show my-bundle --is-name
+
+")]
 pub struct Show {
     #[clap(help = "The optional bundle ID or name.")]
     pub identifier: Option<String>,
@@ -183,6 +232,17 @@ impl IdNameIdentifier for Show {
 /// SetState is used to set the state of the bundle (e.g. active, obsolete,
 /// retired, revoked).
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Mark a bundle obsolete (selected by name):
+    $ carbide-admin-cli attestation measured-boot bundle set-state my-bundle obsolete
+
+Revoke a known-bad bundle by ID:
+    $ carbide-admin-cli attestation measured-boot bundle set-state \
+    12345678-1234-5678-90ab-cdef01234567 revoked --is-id
+
+")]
 pub struct SetState {
     #[clap(help = "The bundle ID or name to update.")]
     pub identifier: String,
@@ -213,6 +273,16 @@ impl IdNameIdentifier for SetState {
 
 /// List provides a few ways to list things.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List metadata for all bundles:
+    $ carbide-admin-cli attestation measured-boot bundle list all
+
+List all machines matching a bundle:
+    $ carbide-admin-cli attestation measured-boot bundle list machines my-bundle
+
+")]
 pub enum List {
     #[clap(about = "List all bundles", visible_alias = "a")]
     All(ListAll),
@@ -226,10 +296,28 @@ pub enum List {
 
 /// ListAll will list all bundles.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List metadata for all bundles:
+    $ carbide-admin-cli attestation measured-boot bundle list all
+
+")]
 pub struct ListAll {}
 
 /// ListMachines lists all machines for a given bundle (by bundle name or ID).
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all machines matching a bundle by name:
+    $ carbide-admin-cli attestation measured-boot bundle list machines my-bundle
+
+List all machines matching a bundle selected explicitly by ID:
+    $ carbide-admin-cli attestation measured-boot bundle list machines \
+    12345678-1234-5678-90ab-cdef01234567 --is-id
+
+")]
 pub struct ListMachines {
     #[clap(help = "The existing bundle ID or name.")]
     pub identifier: String,
@@ -252,12 +340,28 @@ impl IdNameIdentifier for ListMachines {
 }
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Find the closest matching bundle for a report:
+    $ carbide-admin-cli attestation measured-boot bundle find-closest-match report \
+    12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub enum FindClosestMatch {
     #[clap(about = "The existing report ID.")]
     Report(ReportId),
 }
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Find the closest matching bundle for a report:
+    $ carbide-admin-cli attestation measured-boot bundle find-closest-match report \
+    12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct ReportId {
     #[clap(help = "Report ID.")]
     pub id: MeasurementReportId,

--- a/crates/admin-cli/src/attestation/measured_boot/journal/args.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/journal/args.rs
@@ -58,6 +58,14 @@ pub enum CmdJournal {
 
 /// Delete is used to delete an existing journal entry.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a journal entry by ID:
+    $ carbide-admin-cli attestation measured-boot journal delete \
+    12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Delete {
     #[clap(help = "The journal ID to delete.")]
     pub journal_id: MeasurementJournalId,
@@ -65,6 +73,17 @@ pub struct Delete {
 
 /// List is used to list all journal entry IDs.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all journal entries:
+    $ carbide-admin-cli attestation measured-boot journal list
+
+List journal entries for a single machine:
+    $ carbide-admin-cli attestation measured-boot journal list \
+    12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct List {
     #[clap(help = "List journal entries for a machine ID.")]
     pub machine_id: Option<MachineId>,
@@ -73,6 +92,17 @@ pub struct List {
 /// Show is used to show a journal entry based on ID, or all entries
 /// if no ID is provided.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show all journal entries:
+    $ carbide-admin-cli attestation measured-boot journal show
+
+Show one journal entry by ID:
+    $ carbide-admin-cli attestation measured-boot journal show \
+    12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Show {
     #[clap(help = "The optional journal entry ID.")]
     pub journal_id: Option<MeasurementJournalId>,
@@ -81,6 +111,18 @@ pub struct Show {
 /// Promote is used to promote a journal entry's report
 /// into a measurement bundle.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Promote a journal entry's report into a bundle:
+    $ carbide-admin-cli attestation measured-boot journal promote \
+    12345678-1234-5678-90ab-cdef01234567
+
+Promote only specific PCR registers (indices and ranges):
+    $ carbide-admin-cli attestation measured-boot journal promote \
+    12345678-1234-5678-90ab-cdef01234567 --pcr-registers 0,7,11-14
+
+")]
 pub struct Promote {
     #[clap(help = "The journal entry ID to promote a report from.")]
     pub journal_id: MeasurementJournalId,

--- a/crates/admin-cli/src/attestation/measured_boot/machine/args.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/machine/args.rs
@@ -55,6 +55,14 @@ pub enum CmdMachine {
 /// where the measurement report then goes through attestation in an
 /// attempt to match a bundle.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Send a measurement report (two PCR values) for a mock machine:
+    $ carbide-admin-cli attestation measured-boot machine attest \
+    12345678-1234-5678-90ab-cdef01234567 0:abc123,7:def456
+
+")]
 pub struct Attest {
     #[clap(help = "The machine ID of the machine to associate this report with.")]
     pub machine_id: MachineId,
@@ -71,11 +79,29 @@ pub struct Attest {
 
 /// List lists all candidate machines.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all mock machines:
+    $ carbide-admin-cli attestation measured-boot machine list
+
+")]
 pub struct List {}
 
 /// Show will get a candidate machine for the given ID, or all machines
 /// if no machine ID is provided.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show all mock machines:
+    $ carbide-admin-cli attestation measured-boot machine show
+
+Show one mock machine by ID:
+    $ carbide-admin-cli attestation measured-boot machine show \
+    12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Show {
     #[clap(help = "The machine ID to show.")]
     pub machine_id: Option<MachineId>,

--- a/crates/admin-cli/src/attestation/measured_boot/profile/args.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/profile/args.rs
@@ -77,6 +77,18 @@ pub enum CmdProfile {
 
 /// Create is used for creating profiles.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create a profile for a vendor/product pair:
+    $ carbide-admin-cli attestation measured-boot profile create my-profile dell \
+    poweredge_r750
+
+Create a profile with extra attributes:
+    $ carbide-admin-cli attestation measured-boot profile create my-profile dell \
+    poweredge_r750 --extra-attrs region:us-west,rack:r1
+
+")]
 pub struct Create {
     #[clap(required = true, help = "Every profile gets a name.")]
     pub name: String,
@@ -103,6 +115,17 @@ pub struct Create {
 
 /// Delete a profile by ID or name.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a profile by name:
+    $ carbide-admin-cli attestation measured-boot profile delete my-profile
+
+Delete a profile selected explicitly by ID:
+    $ carbide-admin-cli attestation measured-boot profile delete \
+    12345678-1234-5678-90ab-cdef01234567 --is-id
+
+")]
 pub struct Delete {
     #[clap(help = "The profile ID or name.")]
     pub identifier: String,
@@ -128,6 +151,17 @@ impl IdNameIdentifier for Delete {
 /// A parser will parse the `identifier` to determine if
 /// the API should be called w/ an ID or name selector.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Rename a profile, letting the CLI detect ID vs name:
+    $ carbide-admin-cli attestation measured-boot profile rename old-name new-name
+
+Rename a profile selected explicitly by ID:
+    $ carbide-admin-cli attestation measured-boot profile rename \
+    12345678-1234-5678-90ab-cdef01234567 new-name --is-id
+
+")]
 pub struct Rename {
     #[clap(help = "The existing profile ID or name.")]
     pub identifier: String,
@@ -155,6 +189,20 @@ impl IdNameIdentifier for Rename {
 /// Show will get + display a profile for the given ID or name, or, if not set,
 /// it will display all profiles and their information.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show all profiles:
+    $ carbide-admin-cli attestation measured-boot profile show
+
+Show one profile by ID:
+    $ carbide-admin-cli attestation measured-boot profile show \
+    12345678-1234-5678-90ab-cdef01234567 --is-id
+
+Show one profile by name:
+    $ carbide-admin-cli attestation measured-boot profile show my-profile --is-name
+
+")]
 pub struct Show {
     #[clap(help = "The optional profile ID or name.")]
     pub identifier: Option<String>,
@@ -178,6 +226,19 @@ impl IdNameIdentifier for Show {
 
 /// List provides a few ways to list things.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all profiles:
+    $ carbide-admin-cli attestation measured-boot profile list all
+
+List all bundles for a profile:
+    $ carbide-admin-cli attestation measured-boot profile list bundles my-profile
+
+List all machines for a profile:
+    $ carbide-admin-cli attestation measured-boot profile list machines my-profile
+
+")]
 pub enum List {
     #[clap(about = "List all profiles", visible_alias = "a")]
     All(ListAll),
@@ -197,10 +258,28 @@ pub enum List {
 
 /// ListAll will list all profiles.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all profiles:
+    $ carbide-admin-cli attestation measured-boot profile list all
+
+")]
 pub struct ListAll {}
 
 /// List all bundles for a given profile (by profile name or ID).
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all bundles for a profile by name:
+    $ carbide-admin-cli attestation measured-boot profile list bundles my-profile
+
+List all bundles for a profile selected explicitly by ID:
+    $ carbide-admin-cli attestation measured-boot profile list bundles \
+    12345678-1234-5678-90ab-cdef01234567 --is-id
+
+")]
 pub struct ListBundles {
     #[clap(help = "The profile ID or name.")]
     pub identifier: String,
@@ -224,6 +303,17 @@ impl IdNameIdentifier for ListBundles {
 
 /// List all machines for a given profile (by profile name or ID).
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all machines for a profile by name:
+    $ carbide-admin-cli attestation measured-boot profile list machines my-profile
+
+List all machines for a profile selected explicitly by ID:
+    $ carbide-admin-cli attestation measured-boot profile list machines \
+    12345678-1234-5678-90ab-cdef01234567 --is-id
+
+")]
 pub struct ListMachines {
     #[clap(help = "The profile ID or name.")]
     pub identifier: String,

--- a/crates/admin-cli/src/attestation/measured_boot/report/args.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/report/args.rs
@@ -94,6 +94,14 @@ pub enum CmdReport {
 /// Create is used for creating reports, which really
 /// should be happening during machine attestation.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create a measurement report for a machine with two PCR values:
+    $ carbide-admin-cli attestation measured-boot report create \
+    12345678-1234-5678-90ab-cdef01234567 0:abc123,7:def456
+
+")]
 pub struct Create {
     #[clap(help = "The machine ID of the machine to associate this report with.")]
     pub machine_id: MachineId,
@@ -110,6 +118,14 @@ pub struct Create {
 
 /// Delete a profile by ID.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a report by ID:
+    $ carbide-admin-cli attestation measured-boot report delete \
+    12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Delete {
     #[clap(help = "The report ID.")]
     pub report_id: MeasurementReportId,
@@ -119,6 +135,18 @@ pub struct Delete {
 /// with the ability to select which PCR registers to select from the
 /// report to use for creating the new bundle.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Promote a report into an active bundle:
+    $ carbide-admin-cli attestation measured-boot report promote \
+    12345678-1234-5678-90ab-cdef01234567
+
+Promote a report using only specific PCR registers:
+    $ carbide-admin-cli attestation measured-boot report promote \
+    12345678-1234-5678-90ab-cdef01234567 --pcr-registers 0,7,11-14
+
+")]
 pub struct Promote {
     #[clap(help = "The report ID to promote.")]
     pub report_id: MeasurementReportId,
@@ -135,6 +163,18 @@ pub struct Promote {
 /// with the ability to select which PCR registers to select from the
 /// report to use for creating the new (and revoked) bundle.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create a revoked bundle from a report:
+    $ carbide-admin-cli attestation measured-boot report revoke \
+    12345678-1234-5678-90ab-cdef01234567
+
+Revoke using only specific PCR registers:
+    $ carbide-admin-cli attestation measured-boot report revoke \
+    12345678-1234-5678-90ab-cdef01234567 --pcr-registers 0,7,11-14
+
+")]
 pub struct Revoke {
     #[clap(help = "The report ID to revoke.")]
     pub report_id: MeasurementReportId,
@@ -149,6 +189,21 @@ pub struct Revoke {
 
 /// Show a report for an ID, reports for a machine, or all reports.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show all reports:
+    $ carbide-admin-cli attestation measured-boot report show all
+
+Show one report by ID:
+    $ carbide-admin-cli attestation measured-boot report show id \
+    12345678-1234-5678-90ab-cdef01234567
+
+Show all reports for a machine:
+    $ carbide-admin-cli attestation measured-boot report show machine \
+    12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub enum ShowFor {
     #[clap(about = "Show a report ID.")]
     Id(ShowForId),
@@ -162,6 +217,14 @@ pub enum ShowFor {
 
 /// Show a report for the given ID.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show one report by ID:
+    $ carbide-admin-cli attestation measured-boot report show id \
+    12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct ShowForId {
     #[clap(help = "The report ID.")]
     pub report_id: MeasurementReportId,
@@ -169,6 +232,14 @@ pub struct ShowForId {
 
 /// Show all reports for a machine.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show all reports for a machine:
+    $ carbide-admin-cli attestation measured-boot report show machine \
+    12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct ShowForMachine {
     #[clap(help = "The profile name.")]
     pub machine_id: String,
@@ -176,6 +247,17 @@ pub struct ShowForMachine {
 
 /// List provides a few ways to list things.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all reports:
+    $ carbide-admin-cli attestation measured-boot report list all
+
+List all reports for a machine:
+    $ carbide-admin-cli attestation measured-boot report list machines \
+    12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub enum List {
     #[clap(about = "List all reports", visible_alias = "a")]
     All(ListAll),
@@ -189,10 +271,25 @@ pub enum List {
 
 /// ListAll will list all profiles.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all reports:
+    $ carbide-admin-cli attestation measured-boot report list all
+
+")]
 pub struct ListAll {}
 
 /// ListMachines will list all machines matching this report.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all reports for a machine:
+    $ carbide-admin-cli attestation measured-boot report list machines \
+    12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct ListMachines {
     #[clap(help = "The machine ID.")]
     pub machine_id: MachineId,
@@ -200,6 +297,13 @@ pub struct ListMachines {
 
 /// Match is used for finding reports matching the provided PCR pairs.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Find reports matching a set of PCR register values:
+    $ carbide-admin-cli attestation measured-boot report match 0:abc123,7:def456
+
+")]
 pub struct Match {
     #[clap(
         required = true,

--- a/crates/admin-cli/src/attestation/measured_boot/site/args.rs
+++ b/crates/admin-cli/src/attestation/measured_boot/site/args.rs
@@ -62,6 +62,13 @@ pub enum CmdSite {
 
 /// Import imports a site from a file.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Import a site model (profiles + bundles) from a JSON file:
+    $ carbide-admin-cli attestation measured-boot site import ./site.json
+
+")]
 pub struct Import {
     #[clap(help = "The path of the input JSON file.")]
     pub path: String,
@@ -69,6 +76,16 @@ pub struct Import {
 
 /// Export exports a site to stdout, a file, etc.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Export the site model to stdout:
+    $ carbide-admin-cli attestation measured-boot site export
+
+Export the site model to a file:
+    $ carbide-admin-cli attestation measured-boot site export --path ./site.json
+
+")]
 pub struct Export {
     #[clap(long, help = "An optional path to write the file to.")]
     pub path: Option<String>,
@@ -76,6 +93,21 @@ pub struct Export {
 
 /// TrustedMachine configures trusted machine settings.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Approve a machine for one-shot auto-promotion of its measurements:
+    $ carbide-admin-cli attestation measured-boot site trusted-machine approve \
+    12345678-1234-5678-90ab-cdef01234567 oneshot
+
+List all active machine approvals:
+    $ carbide-admin-cli attestation measured-boot site trusted-machine list
+
+Remove an approval by machine ID:
+    $ carbide-admin-cli attestation measured-boot site trusted-machine remove \
+    by-machine-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub enum TrustedMachine {
     #[clap(
         about = "Approve a trusted machine for auto-promoting its measurements.",
@@ -96,6 +128,21 @@ pub enum TrustedMachine {
 
 /// TrustedProfile configures trusted profile settings.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Approve a profile for persistent auto-promotion of matching machines' measurements:
+    $ carbide-admin-cli attestation measured-boot site trusted-profile approve \
+    12345678-1234-5678-90ab-cdef01234567 persist
+
+List all active profile approvals:
+    $ carbide-admin-cli attestation measured-boot site trusted-profile list
+
+Remove an approval by profile ID:
+    $ carbide-admin-cli attestation measured-boot site trusted-profile remove \
+    by-profile-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub enum TrustedProfile {
     #[clap(
         about = "Allow auto-promoting of measurements from machines matching a profile.",
@@ -117,6 +164,18 @@ pub enum TrustedProfile {
 /// ApproveMachine approves a machine for auto-promoting its measurement
 /// journal entries into a golden measurement bundle.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Approve a single machine for one-shot auto-promotion:
+    $ carbide-admin-cli attestation measured-boot site trusted-machine approve \
+    12345678-1234-5678-90ab-cdef01234567 oneshot
+
+Approve all machines persistently, restricted to specific PCR registers, with a comment:
+    $ carbide-admin-cli attestation measured-boot site trusted-machine approve '*' \
+    persist --pcr-registers 0,7 --comments \"trusted fleet\"
+
+")]
 pub struct ApproveMachine {
     #[clap(help = "The machine-id to approve (or '*' for all).")]
     pub machine_id: TrustedMachineId,
@@ -138,6 +197,18 @@ pub struct ApproveMachine {
 // understanding that its a part of the CLI UX.
 #[allow(clippy::enum_variant_names)]
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove a machine approval by approval ID:
+    $ carbide-admin-cli attestation measured-boot site trusted-machine remove \
+    by-approval-id 12345678-1234-5678-90ab-cdef01234567
+
+Remove a machine approval by machine ID:
+    $ carbide-admin-cli attestation measured-boot site trusted-machine remove \
+    by-machine-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub enum RemoveMachine {
     #[clap(about = "Remove by approval ID.")]
     ByApprovalId(RemoveMachineByApprovalId),
@@ -149,6 +220,14 @@ pub enum RemoveMachine {
 /// RemoveMachineByApprovalId removes a trusted machine approval
 /// for the given approval ID.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove a machine approval by approval ID:
+    $ carbide-admin-cli attestation measured-boot site trusted-machine remove \
+    by-approval-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct RemoveMachineByApprovalId {
     #[clap(help = "The approval-id to remove.")]
     pub approval_id: MeasurementApprovedMachineId,
@@ -157,6 +236,14 @@ pub struct RemoveMachineByApprovalId {
 /// RemoveMachineByMachineId removes a trusted machine approval
 /// for the given machine ID.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove a machine approval by machine ID:
+    $ carbide-admin-cli attestation measured-boot site trusted-machine remove \
+    by-machine-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct RemoveMachineByMachineId {
     #[clap(help = "The machine-id to remove.")]
     pub machine_id: TrustedMachineId,
@@ -164,11 +251,30 @@ pub struct RemoveMachineByMachineId {
 
 /// ListMachines is used to list all active machine approvals.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all active machine approvals:
+    $ carbide-admin-cli attestation measured-boot site trusted-machine list
+
+")]
 pub struct ListMachines {}
 
 /// ApproveProfile approves a profile for auto-promoting its
 /// measurement journal entries into a golden measurement bundle.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Approve a profile for one-shot auto-promotion:
+    $ carbide-admin-cli attestation measured-boot site trusted-profile approve \
+    12345678-1234-5678-90ab-cdef01234567 oneshot
+
+Approve a profile persistently, restricted to specific PCR registers, with a comment:
+    $ carbide-admin-cli attestation measured-boot site trusted-profile approve \
+    12345678-1234-5678-90ab-cdef01234567 persist --pcr-registers 0,7 --comments \"trusted SKU\"
+
+")]
 pub struct ApproveProfile {
     #[clap(help = "The profile-id to approve.")]
     pub profile_id: MeasurementSystemProfileId,
@@ -190,6 +296,18 @@ pub struct ApproveProfile {
 // understanding that its a part of the CLI UX.
 #[allow(clippy::enum_variant_names)]
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove a profile approval by approval ID:
+    $ carbide-admin-cli attestation measured-boot site trusted-profile remove \
+    by-approval-id 12345678-1234-5678-90ab-cdef01234567
+
+Remove a profile approval by profile ID:
+    $ carbide-admin-cli attestation measured-boot site trusted-profile remove \
+    by-profile-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub enum RemoveProfile {
     #[clap(about = "Remove by approval ID.")]
     ByApprovalId(RemoveProfileByApprovalId),
@@ -201,6 +319,14 @@ pub enum RemoveProfile {
 /// RemoveProfileByApprovalId removes a trusted profile approval
 /// for the given approval ID.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove a profile approval by approval ID:
+    $ carbide-admin-cli attestation measured-boot site trusted-profile remove \
+    by-approval-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct RemoveProfileByApprovalId {
     #[clap(help = "The approval-id to remove.")]
     pub approval_id: MeasurementApprovedProfileId,
@@ -209,6 +335,14 @@ pub struct RemoveProfileByApprovalId {
 /// RemoveProfileByProfileId removes a trusted profile approval
 /// for the given profile ID.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove a profile approval by profile ID:
+    $ carbide-admin-cli attestation measured-boot site trusted-profile remove \
+    by-profile-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct RemoveProfileByProfileId {
     #[clap(help = "The profile-id to remove.")]
     pub profile_id: MeasurementSystemProfileId,
@@ -216,6 +350,13 @@ pub struct RemoveProfileByProfileId {
 
 /// ListProfiles is used to list all active profile approvals.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all active profile approvals:
+    $ carbide-admin-cli attestation measured-boot site trusted-profile list
+
+")]
 pub struct ListProfiles {}
 
 impl From<ApproveMachine> for AddMeasurementTrustedMachineRequest {

--- a/crates/admin-cli/src/attestation/spdm/cancel/args.rs
+++ b/crates/admin-cli/src/attestation/spdm/cancel/args.rs
@@ -19,6 +19,13 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Cancel in-progress SPDM attestation for a machine:
+    $ carbide-admin-cli attestation spdm cancel 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "Machine ID")]
     pub machine_id: MachineId,

--- a/crates/admin-cli/src/attestation/spdm/get/args.rs
+++ b/crates/admin-cli/src/attestation/spdm/get/args.rs
@@ -19,6 +19,13 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Get the SPDM attestation status for a machine:
+    $ carbide-admin-cli attestation spdm get 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "Machine ID")]
     pub machine_id: MachineId,

--- a/crates/admin-cli/src/attestation/spdm/list/args.rs
+++ b/crates/admin-cli/src/attestation/spdm/list/args.rs
@@ -19,6 +19,13 @@ use carbide_uuid::machine::MachineId;
 use clap::{Parser, ValueEnum};
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all SPDM attestations recorded for a machine:
+    $ carbide-admin-cli attestation spdm list 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(long, help = "Machine ID", conflicts_with = "selector")]
     pub machine_id: Option<MachineId>,

--- a/crates/admin-cli/src/attestation/spdm/trigger/args.rs
+++ b/crates/admin-cli/src/attestation/spdm/trigger/args.rs
@@ -19,6 +19,14 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Trigger SPDM attestation for a machine with a 60-second Redfish timeout:
+    $ carbide-admin-cli attestation spdm trigger 12345678-1234-5678-90ab-cdef01234567 \
+    --redfish-timeout-secs 60
+
+")]
 pub struct Args {
     #[clap(help = "Machine ID")]
     pub machine_id: MachineId,

--- a/crates/admin-cli/src/bmc_machine/admin_power_control/args.rs
+++ b/crates/admin-cli/src/bmc_machine/admin_power_control/args.rs
@@ -21,6 +21,26 @@ use rpc::forge as forgerpc;
 use crate::bmc_machine::common::AdminPowerControlAction;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Power a machine on:
+    $ carbide-admin-cli bmc-machine admin-power-control \
+    --machine 12345678-1234-5678-90ab-cdef01234567 --action on
+
+Gracefully shut a machine down:
+    $ carbide-admin-cli bmc-machine admin-power-control \
+    --machine 12345678-1234-5678-90ab-cdef01234567 --action graceful-shutdown
+
+Force a machine off (immediate, no OS shutdown):
+    $ carbide-admin-cli bmc-machine admin-power-control \
+    --machine 12345678-1234-5678-90ab-cdef01234567 --action force-off
+
+Gracefully restart a machine:
+    $ carbide-admin-cli bmc-machine admin-power-control \
+    --machine 12345678-1234-5678-90ab-cdef01234567 --action graceful-restart
+
+")]
 pub struct Args {
     #[clap(long, help = "ID of the machine to reboot")]
     pub machine: String,

--- a/crates/admin-cli/src/bmc_machine/bmc_reset/args.rs
+++ b/crates/admin-cli/src/bmc_machine/bmc_reset/args.rs
@@ -19,6 +19,17 @@ use clap::Parser;
 use rpc::forge as forgerpc;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Reset the BMC of a machine via Redfish:
+    $ carbide-admin-cli bmc-machine bmc-reset --machine 12345678-1234-5678-90ab-cdef01234567
+
+Reset the BMC using ipmitool instead of Redfish:
+    $ carbide-admin-cli bmc-machine bmc-reset --machine 12345678-1234-5678-90ab-cdef01234567 \
+    --use-ipmitool
+
+")]
 pub struct Args {
     #[clap(long, help = "ID of the machine to reboot")]
     pub machine: String,

--- a/crates/admin-cli/src/bmc_machine/create_bmc_user/args.rs
+++ b/crates/admin-cli/src/bmc_machine/create_bmc_user/args.rs
@@ -20,6 +20,27 @@ use mac_address::MacAddress;
 use rpc::forge as forgerpc;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create a BMC user, targeting the BMC by machine id:
+    $ carbide-admin-cli bmc-machine create-bmc-user \
+    --machine 12345678-1234-5678-90ab-cdef01234567 --username admin --password mynewpassword
+
+Target the BMC by IP address:
+    $ carbide-admin-cli bmc-machine create-bmc-user \
+    --ip-address 192.0.2.20 --username admin --password mynewpassword
+
+Target the BMC by MAC address:
+    $ carbide-admin-cli bmc-machine create-bmc-user \
+    --mac-address 00:11:22:33:44:55 --username admin --password mynewpassword
+
+Create a read-only user by setting an explicit role:
+    $ carbide-admin-cli bmc-machine create-bmc-user \
+    --machine 12345678-1234-5678-90ab-cdef01234567 --username admin --password mynewpassword \
+    --role-id readonly
+
+")]
 pub struct Args {
     #[clap(long, short, help = "IP of the BMC where we want to create a new user")]
     pub ip_address: Option<String>,
@@ -39,9 +60,10 @@ pub struct Args {
     #[clap(
         long,
         short,
-        help = "Role of new BMC account ('administrator', 'operator', 'readonly', 'noaccess')"
+        value_enum,
+        help = "Role of new BMC account (default: administrator)"
     )]
-    pub role_id: Option<String>,
+    pub role_id: Option<crate::bmc_role::BmcRole>,
 }
 
 impl From<Args> for forgerpc::CreateBmcUserRequest {
@@ -60,7 +82,7 @@ impl From<Args> for forgerpc::CreateBmcUserRequest {
             machine_id: args.machine,
             create_username: args.username,
             create_password: args.password,
-            create_role_id: args.role_id,
+            create_role_id: args.role_id.map(|role| role.as_api_str().to_string()),
         }
     }
 }

--- a/crates/admin-cli/src/bmc_machine/delete_bmc_user/args.rs
+++ b/crates/admin-cli/src/bmc_machine/delete_bmc_user/args.rs
@@ -20,6 +20,20 @@ use mac_address::MacAddress;
 use rpc::forge as forgerpc;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a BMC user, targeting the BMC by machine id:
+    $ carbide-admin-cli bmc-machine delete-bmc-user \
+    --machine 12345678-1234-5678-90ab-cdef01234567 --username admin
+
+Target the BMC by IP address:
+    $ carbide-admin-cli bmc-machine delete-bmc-user --ip-address 192.0.2.20 --username admin
+
+Target the BMC by MAC address:
+    $ carbide-admin-cli bmc-machine delete-bmc-user --mac-address 00:11:22:33:44:55 --username admin
+
+")]
 pub struct Args {
     #[clap(long, short, help = "IP of the BMC where we want to delete a user")]
     pub ip_address: Option<String>,

--- a/crates/admin-cli/src/bmc_machine/enable_infinite_boot/args.rs
+++ b/crates/admin-cli/src/bmc_machine/enable_infinite_boot/args.rs
@@ -23,6 +23,18 @@ use crate::bmc_machine::common::InfiniteBootArgs;
 // specific newtype to allow sharing of InfiniteBootArgs, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Enable infinite boot on a machine:
+    $ carbide-admin-cli bmc-machine enable-infinite-boot \
+    --machine 12345678-1234-5678-90ab-cdef01234567
+
+Enable infinite boot and reboot to apply the BIOS change:
+    $ carbide-admin-cli bmc-machine enable-infinite-boot \
+    --machine 12345678-1234-5678-90ab-cdef01234567 --reboot
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: InfiniteBootArgs,

--- a/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/args.rs
+++ b/crates/admin-cli/src/bmc_machine/is_infinite_boot_enabled/args.rs
@@ -24,6 +24,14 @@ use crate::bmc_machine::common::InfiniteBootArgs;
 // specific newtype to allow sharing of InfiniteBootArgs, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Check whether infinite boot is enabled on a machine:
+    $ carbide-admin-cli bmc-machine is-infinite-boot-enabled \
+    --machine 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: InfiniteBootArgs,

--- a/crates/admin-cli/src/bmc_machine/lockdown/args.rs
+++ b/crates/admin-cli/src/bmc_machine/lockdown/args.rs
@@ -19,6 +19,22 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Enable lockdown on a machine:
+    $ carbide-admin-cli bmc-machine lockdown \
+    --machine 12345678-1234-5678-90ab-cdef01234567 --enable
+
+Disable lockdown on a machine:
+    $ carbide-admin-cli bmc-machine lockdown \
+    --machine 12345678-1234-5678-90ab-cdef01234567 --disable
+
+Enable lockdown and reboot to apply the change:
+    $ carbide-admin-cli bmc-machine lockdown \
+    --machine 12345678-1234-5678-90ab-cdef01234567 --enable --reboot
+
+")]
 pub struct Args {
     #[clap(long, help = "ID of the machine to enable/disable lockdown")]
     pub machine: MachineId,

--- a/crates/admin-cli/src/bmc_machine/lockdown_status/args.rs
+++ b/crates/admin-cli/src/bmc_machine/lockdown_status/args.rs
@@ -20,6 +20,14 @@ use clap::Parser;
 use rpc::forge as forgerpc;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Check the lockdown status of a machine:
+    $ carbide-admin-cli bmc-machine lockdown-status \
+    --machine 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(long, help = "ID of the machine to check lockdown status")]
     pub machine: MachineId,

--- a/crates/admin-cli/src/bmc_role.rs
+++ b/crates/admin-cli/src/bmc_role.rs
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! The BMC account role, shared by the `create-bmc-user` commands.
+//!
+//! Both `redfish create-bmc-user` and `bmc-machine create-bmc-user` take a
+//! role from a fixed set. Modeling it as a clap `ValueEnum` (rather than a
+//! free `String`) makes clap validate it at parse time and list the choices in
+//! `--help`, instead of each command hand-matching the string. The variants
+//! map to `libredfish::RoleId` for the direct-Redfish path and to the
+//! canonical lowercase role string for the API-request path.
+
+use clap::ValueEnum;
+use libredfish::RoleId;
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+#[clap(rename_all = "lower")]
+pub enum BmcRole {
+    Administrator,
+    Operator,
+    ReadOnly,
+    NoAccess,
+}
+
+impl BmcRole {
+    /// The canonical role string accepted by the API `CreateBmcUser` request
+    /// (matches clap's `rename_all = "lower"` rendering).
+    pub fn as_api_str(self) -> &'static str {
+        match self {
+            BmcRole::Administrator => "administrator",
+            BmcRole::Operator => "operator",
+            BmcRole::ReadOnly => "readonly",
+            BmcRole::NoAccess => "noaccess",
+        }
+    }
+}
+
+impl From<BmcRole> for RoleId {
+    fn from(role: BmcRole) -> Self {
+        match role {
+            BmcRole::Administrator => RoleId::Administrator,
+            BmcRole::Operator => RoleId::Operator,
+            BmcRole::ReadOnly => RoleId::ReadOnly,
+            BmcRole::NoAccess => RoleId::NoAccess,
+        }
+    }
+}

--- a/crates/admin-cli/src/boot_override/clear/args.rs
+++ b/crates/admin-cli/src/boot_override/clear/args.rs
@@ -24,6 +24,13 @@ use crate::boot_override::common::BootOverride;
 // specific newtype to allow sharing of BootOverride, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Clear the boot override on a machine interface:
+    $ carbide-admin-cli boot-override clear 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: BootOverride,

--- a/crates/admin-cli/src/boot_override/get/args.rs
+++ b/crates/admin-cli/src/boot_override/get/args.rs
@@ -24,6 +24,13 @@ use crate::boot_override::common::BootOverride;
 // specific newtype to allow sharing of BootOverride, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show the boot override for a machine interface:
+    $ carbide-admin-cli boot-override get 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: BootOverride,

--- a/crates/admin-cli/src/boot_override/set/args.rs
+++ b/crates/admin-cli/src/boot_override/set/args.rs
@@ -22,6 +22,22 @@ use clap::Parser;
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Set a custom iPXE script for a machine interface:
+    $ carbide-admin-cli boot-override set 12345678-1234-5678-90ab-cdef01234567 \
+    --custom-pxe ./boot.ipxe
+
+Set custom user-data for a machine interface:
+    $ carbide-admin-cli boot-override set 12345678-1234-5678-90ab-cdef01234567 \
+    --custom-user-data ./user-data.yaml
+
+Set both a custom iPXE script and custom user-data:
+    $ carbide-admin-cli boot-override set 12345678-1234-5678-90ab-cdef01234567 \
+    --custom-pxe ./boot.ipxe --custom-user-data ./user-data.yaml
+
+")]
 pub struct Args {
     pub interface_id: MachineInterfaceId,
     #[clap(short = 'p', long)]

--- a/crates/admin-cli/src/browse/mod.rs
+++ b/crates/admin-cli/src/browse/mod.rs
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! `browse` groups the API-server-proxied "walk a subsystem's resource tree"
+//! operations. Unlike `redfish` (which connects directly to a BMC and so
+//! requires `--address`), every `browse` subcommand goes through the API
+//! client and needs no BMC connection details: `redfish` (by URI), `ufm` (by
+//! fabric + path), and `nmxc` (by chassis + operation).
+
+mod nmxc;
+mod redfish;
+mod ufm;
+
+use std::collections::HashMap;
+
+use clap::Parser;
+use serde::Serialize;
+
+use crate::cfg::dispatch::Dispatch;
+use crate::errors::CarbideCliResult;
+
+#[derive(Parser, Debug, Dispatch)]
+pub enum Cmd {
+    #[clap(about = "Browse a Redfish resource tree via the API server")]
+    Redfish(redfish::Args),
+    #[clap(about = "Browse a UFM fabric via the API server")]
+    Ufm(ufm::Args),
+    #[clap(about = "Run an NMX-C browse operation via the API server")]
+    Nmxc(nmxc::Args),
+}
+
+// Pretty-prints an HTTP-style browse response. The ufm/nmxm/nmxc browse RPCs
+// all return the same shape — a raw body string, an HTTP status code, and the
+// response headers — so they share this printer. (redfish_browse predates
+// these and returns a slightly different shape, so it has its own printer.)
+//
+// The body is rendered as pretty JSON when it parses; otherwise the status,
+// headers, and raw body are printed verbatim so a non-JSON body is shown
+// rather than swallowed.
+pub(crate) fn print_http_response(
+    body: String,
+    code: i32,
+    headers: HashMap<String, String>,
+) -> CarbideCliResult<()> {
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&body) else {
+        println!("HTTP {code}");
+        for (name, value) in &headers {
+            println!("{name}: {value}");
+        }
+        println!("{body}");
+        return Ok(());
+    };
+
+    #[derive(Serialize)]
+    struct Output {
+        code: i32,
+        body: serde_json::Value,
+        headers: HashMap<String, String>,
+    }
+
+    let output = Output {
+        code,
+        body: parsed,
+        headers,
+    };
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&output).expect("Output is always serializable")
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::Cmd;
+
+    // `browse redfish` parses with a --uri and, unlike the `redfish`
+    // subcommands, requires no BMC --address.
+    #[test]
+    fn parse_browse_redfish() {
+        let cmd = Cmd::try_parse_from(["browse", "redfish", "--uri", "/redfish/v1"])
+            .expect("should parse browse redfish");
+        let Cmd::Redfish(args) = cmd else {
+            panic!("expected Redfish variant");
+        };
+        assert_eq!(args.uri, "/redfish/v1");
+    }
+}

--- a/crates/admin-cli/src/browse/nmxc/args.rs
+++ b/crates/admin-cli/src/browse/nmxc/args.rs
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::{Parser, ValueEnum};
+use rpc::forge as forgerpc;
+
+// NMX-C browse is operation-based rather than path-based: you pick one of a
+// fixed set of operations against a chassis. This CLI-side enum mirrors the
+// RPC's `NmxcBrowseOperation` (minus the `Unspecified` sentinel) so clap can
+// render and validate the choices.
+#[derive(ValueEnum, Debug, Clone)]
+#[clap(rename_all = "kebab-case")]
+pub enum NmxcOperationArg {
+    ComputeNodeInfoList,
+    GpuInfo,
+    GpuInfoList,
+}
+
+impl From<NmxcOperationArg> for forgerpc::NmxcBrowseOperation {
+    fn from(op: NmxcOperationArg) -> Self {
+        match op {
+            NmxcOperationArg::ComputeNodeInfoList => {
+                forgerpc::NmxcBrowseOperation::ComputeNodeInfoList
+            }
+            NmxcOperationArg::GpuInfo => forgerpc::NmxcBrowseOperation::GpuInfo,
+            NmxcOperationArg::GpuInfoList => forgerpc::NmxcBrowseOperation::GpuInfoList,
+        }
+    }
+}
+
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List the GPUs on a chassis via NMX-C:
+    $ carbide-admin-cli browse nmxc --chassis-serial 1234567890 --operation gpu-info-list
+
+List the compute nodes on a chassis:
+    $ carbide-admin-cli browse nmxc --chassis-serial 1234567890 --operation compute-node-info-list
+
+Get info for a specific GPU UID:
+    $ carbide-admin-cli browse nmxc --chassis-serial 1234567890 --operation gpu-info --gpu-uid 42
+
+")]
+pub struct Args {
+    #[clap(long, help = "Chassis serial number")]
+    pub chassis_serial: String,
+
+    #[clap(long, value_enum, help = "NMX-C browse operation to run")]
+    pub operation: NmxcOperationArg,
+
+    #[clap(
+        long,
+        default_value = "0",
+        help = "GPU UID (used by the gpu-info operation)"
+    )]
+    pub gpu_uid: u64,
+}

--- a/crates/admin-cli/src/browse/nmxc/cmd.rs
+++ b/crates/admin-cli/src/browse/nmxc/cmd.rs
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use rpc::forge as forgerpc;
+
+use super::args::Args;
+use crate::errors::CarbideCliResult;
+use crate::rpc::ApiClient;
+
+pub async fn browse(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let resp = api_client
+        .0
+        .nmxc_browse(forgerpc::NmxcBrowseRequest {
+            chassis_serial: args.chassis_serial,
+            operation: forgerpc::NmxcBrowseOperation::from(args.operation) as i32,
+            gpu_uid: args.gpu_uid,
+        })
+        .await?;
+    crate::browse::print_http_response(resp.body, resp.code, resp.headers)
+}

--- a/crates/admin-cli/src/browse/nmxc/mod.rs
+++ b/crates/admin-cli/src/browse/nmxc/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::browse(self, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/browse/redfish/args.rs
+++ b/crates/admin-cli/src/browse/redfish/args.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Browse a Redfish resource tree via the API server (no BMC --address needed):
+    $ carbide-admin-cli browse redfish --uri /redfish/v1/Systems
+
+")]
+pub struct Args {
+    #[clap(long, help = "Redfish URI")]
+    pub uri: String,
+}

--- a/crates/admin-cli/src/browse/redfish/cmd.rs
+++ b/crates/admin-cli/src/browse/redfish/cmd.rs
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashMap;
+
+use serde::Serialize;
+
+use super::args::Args;
+use crate::errors::CarbideCliResult;
+use crate::rpc::ApiClient;
+
+pub async fn browse(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let data = api_client.0.redfish_browse(args.uri).await?;
+
+    #[derive(Serialize, Debug)]
+    struct Output {
+        text: serde_json::Value,
+        headers: HashMap<String, String>,
+    }
+
+    // The API returns the raw response body as a string. Pretty-print it as
+    // JSON when it parses; otherwise print the raw body verbatim so a non-JSON
+    // response is still shown in full (this is a browse/debug tool — surfacing
+    // the actual body matters more than enforcing a JSON contract).
+    let text = match serde_json::from_str(&data.text) {
+        Ok(text) => text,
+        Err(_) => {
+            println!("{}", data.text);
+            return Ok(());
+        }
+    };
+
+    let output = Output {
+        text,
+        headers: data.headers,
+    };
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&output).expect("Output is always serializable")
+    );
+
+    Ok(())
+}

--- a/crates/admin-cli/src/browse/redfish/mod.rs
+++ b/crates/admin-cli/src/browse/redfish/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::browse(self, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/browse/ufm/args.rs
+++ b/crates/admin-cli/src/browse/ufm/args.rs
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Browse a UFM fabric path via the API server (no BMC --address needed):
+    $ carbide-admin-cli browse ufm --fabric-id default --path /ufmRest/resources/systems
+
+")]
+pub struct Args {
+    #[clap(long, help = "UFM fabric ID")]
+    pub fabric_id: String,
+
+    #[clap(long, help = "Path to browse within the fabric")]
+    pub path: String,
+}

--- a/crates/admin-cli/src/browse/ufm/cmd.rs
+++ b/crates/admin-cli/src/browse/ufm/cmd.rs
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use rpc::forge as forgerpc;
+
+use super::args::Args;
+use crate::errors::CarbideCliResult;
+use crate::rpc::ApiClient;
+
+pub async fn browse(args: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let resp = api_client
+        .0
+        .ufm_browse(forgerpc::UfmBrowseRequest {
+            fabric_id: args.fabric_id,
+            path: args.path,
+        })
+        .await?;
+    crate::browse::print_http_response(resp.body, resp.code, resp.headers)
+}

--- a/crates/admin-cli/src/browse/ufm/mod.rs
+++ b/crates/admin-cli/src/browse/ufm/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::browse(self, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/cfg/cli_options.rs
+++ b/crates/admin-cli/src/cfg/cli_options.rs
@@ -18,9 +18,9 @@ use clap::{Parser, ValueEnum, ValueHint};
 use rpc::admin_cli::OutputFormat;
 
 use crate::{
-    attestation, bmc_machine, boot_override, component_manager, compute_allocation, credential,
-    devenv, domain, dpa, dpu, dpu_remediation, expected_machines, expected_power_shelf,
-    expected_rack, expected_switch, extension_service, firmware, generate_man,
+    attestation, bmc_machine, boot_override, browse, component_manager, compute_allocation,
+    credential, devenv, domain, dpa, dpu, dpu_remediation, expected_machines, expected_power_shelf,
+    expected_rack, expected_switch, extension_service, firmware, generate_docs, generate_man,
     generate_shell_complete, host, ib_partition, instance, instance_type, inventory, ip,
     ipxe_template, jump, machine, machine_interfaces, machine_validation, managed_host,
     managed_switch, mlx, network_devices, network_security_group, network_segment, nvl_domain,
@@ -136,84 +136,52 @@ pub enum SortField {
 
 #[derive(Parser, Debug)]
 pub enum CliCommand {
-    #[clap(about = "Print API server version", visible_alias = "v")]
-    Version(version::Opts),
-    #[clap(about = "Machine related handling", subcommand, visible_alias = "m")]
-    Machine(machine::Cmd),
-    #[clap(about = "Instance related handling", subcommand, visible_alias = "i")]
-    Instance(instance::Cmd),
     #[clap(
-        about = "Network Segment related handling",
+        about = "MeasuredBoot or SPDM attestations",
         subcommand,
-        visible_alias = "ns"
+        visible_alias = "att"
     )]
-    NetworkSegment(network_segment::Cmd),
-    #[clap(
-        name = "nvlink-nmxc-endpoints",
-        about = "Rack chassis serial → NMX-C endpoint mappings",
-        subcommand
-    )]
-    NvlinkNmxcEndpoints(nvlink_nmxc_endpoints::Cmd),
-    #[clap(about = "Domain related handling", subcommand, visible_alias = "d")]
-    Domain(domain::Cmd),
-    #[clap(
-        about = "Managed host related handling",
-        subcommand,
-        visible_alias = "mh"
-    )]
-    ManagedHost(managed_host::Cmd),
-    #[clap(
-        about = "Managed switch related handling",
-        subcommand,
-        visible_alias = "ms"
-    )]
-    ManagedSwitch(managed_switch::Cmd),
-    #[clap(about = "Resource pool handling", subcommand, visible_alias = "rp")]
-    ResourcePool(resource_pool::Cmd),
-    #[clap(about = "Redfish BMC actions", visible_alias = "rf")]
-    Redfish(redfish::RedfishAction),
-    #[clap(about = "Network Devices handling", subcommand)]
-    NetworkDevice(network_devices::Cmd),
-    #[clap(about = "IP address handling", subcommand)]
-    Ip(ip::Cmd),
-    #[clap(about = "DPU specific handling", subcommand)]
-    Dpu(dpu::Cmd),
-    #[clap(about = "Host specific handling", subcommand)]
-    Host(host::Cmd),
-    #[clap(about = "Generate Ansible Inventory")]
-    Inventory(inventory::Cmd),
-    #[clap(about = "Machine boot override", subcommand)]
-    BootOverride(boot_override::Cmd),
+    Attestation(attestation::Cmd),
     #[clap(
         about = "BMC Machine related handling",
         subcommand,
         visible_alias = "bmc"
     )]
     BmcMachine(bmc_machine::Cmd),
+    #[clap(about = "Machine boot override", subcommand)]
+    BootOverride(boot_override::Cmd),
+    #[clap(
+        about = "Browse subsystem resource trees via the API server",
+        subcommand
+    )]
+    Browse(browse::Cmd),
+    #[clap(about = "Component manager actions", visible_alias = "cm", subcommand)]
+    ComponentManager(component_manager::Cmd),
+    #[clap(
+        about = "Compute allocation management",
+        visible_alias = "ca",
+        subcommand
+    )]
+    ComputeAllocation(compute_allocation::Cmd),
     #[clap(about = "Credential related handling", subcommand, visible_alias = "c")]
     Credential(credential::Cmd),
-    #[clap(about = "Route server handling", subcommand)]
-    RouteServer(route_server::Cmd),
-    #[clap(about = "Site explorer functions", subcommand)]
-    SiteExplorer(site_explorer::Cmd),
-    #[clap(
-        about = "Machine interfaces and address management",
-        subcommand,
-        visible_alias = "mi"
-    )]
-    MachineInterfaces(machine_interfaces::Cmd),
-    #[clap(
-        about = "Generate shell autocomplete. Source the output of this command: `source <(carbide-admin-cli generate-shell-complete bash)`"
-    )]
-    GenerateShellComplete(generate_shell_complete::Cmd),
-    #[clap(about = "Generate man pages for the CLI", hide = true)]
-    GenerateMan(generate_man::Cmd),
-    #[clap(
-        about = "Query the Version gRPC endpoint repeatedly printing how long it took and any failures."
-    )]
-    Ping(ping::Opts),
-    #[clap(about = "Set carbide-api dynamic features", subcommand)]
-    Set(set::Cmd),
+    #[clap(about = "Dev Env related handling", subcommand)]
+    DevEnv(devenv::Cmd),
+    #[clap(about = "Domain related handling", subcommand, visible_alias = "d")]
+    Domain(domain::Cmd),
+    #[clap(about = "DPA related handling", subcommand)]
+    Dpa(dpa::Cmd),
+    #[clap(subcommand)]
+    #[clap(verbatim_doc_comment)]
+    /// DPF-related commands.
+    /// Note: These commands update the DPF state of the machine, which determines DPF-based DPU re-provisioning.
+    /// The state is saved in the machine's metadata and will be deleted if the machine is force-deleted.
+    /// To make the state persistent, add the DPF state for a machine (host) to the expected machines table.
+    Dpf(crate::dpf::Cmd),
+    #[clap(about = "DPU specific handling", subcommand)]
+    Dpu(dpu::Cmd),
+    #[clap(about = "Dpu Remediation handling", subcommand)]
+    DpuRemediation(dpu_remediation::Cmd),
     #[clap(about = "Expected machine handling", subcommand, visible_alias = "em")]
     ExpectedMachine(expected_machines::Cmd),
     #[clap(
@@ -226,164 +194,301 @@ pub enum CliCommand {
     ExpectedRack(expected_rack::Cmd),
     #[clap(about = "Expected switch handling", subcommand, visible_alias = "ew")]
     ExpectedSwitch(expected_switch::Cmd),
-    #[clap(about = "VPC related handling", subcommand)]
-    Vpc(vpc::Cmd),
-    #[clap(about = "VPC peering handling", subcommand)]
-    VpcPeering(vpc_peering::Cmd),
-    #[clap(about = "VPC prefix handling", subcommand)]
-    VpcPrefix(vpc_prefix::Cmd),
-    #[clap(
-        about = "InfiniBand Partition related handling",
-        subcommand,
-        visible_alias = "ibp"
-    )]
-    IbPartition(ib_partition::Cmd),
-    #[clap(
-        about = "Tenant KeySet related handling",
-        subcommand,
-        visible_alias = "tks"
-    )]
-    TenantKeySet(tenant_keyset::Cmd),
-
-    #[clap(
-        about = "Broad search across multiple object types",
-        visible_alias = "j"
-    )]
-    Jump(jump::Cmd),
-
-    #[clap(about = "Machine Validation", subcommand, visible_alias = "mv")]
-    MachineValidation(machine_validation::Cmd),
-
-    #[clap(
-        about = "iPXE template management",
-        visible_alias = "ipxe-tmpl",
-        subcommand
-    )]
-    IpxeTemplate(ipxe_template::Cmd),
-
-    #[clap(about = "OS catalog management", visible_alias = "os", subcommand)]
-    OsImage(os_image::Cmd),
-
-    #[clap(
-        about = "Operating system definition management",
-        visible_alias = "osd",
-        subcommand
-    )]
-    OperatingSystem(operating_system::Cmd),
-
-    #[clap(about = "Manage TPM CA certificates", subcommand)]
-    TpmCa(tpm_ca::Cmd),
-
-    #[clap(
-        about = "Network security group management",
-        visible_alias = "nsg",
-        subcommand
-    )]
-    NetworkSecurityGroup(network_security_group::Cmd),
-
-    #[clap(about = "Manage machine SKUs", subcommand)]
-    Sku(sku::Cmd),
-
-    #[clap(about = "Dev Env related handling", subcommand)]
-    DevEnv(devenv::Cmd),
-
-    #[clap(about = "Instance type management", visible_alias = "it", subcommand)]
-    InstanceType(instance_type::Cmd),
-
-    #[clap(
-        about = "Compute allocation management",
-        visible_alias = "ca",
-        subcommand
-    )]
-    ComputeAllocation(compute_allocation::Cmd),
-
-    #[clap(about = "Component manager actions", visible_alias = "cm", subcommand)]
-    ComponentManager(component_manager::Cmd),
-
-    #[clap(about = "SSH Util functions", subcommand)]
-    Ssh(ssh::Cmd),
-
-    #[clap(about = "Power Shelf management", subcommand, visible_alias = "ps")]
-    PowerShelf(power_shelf::Cmd),
-
-    #[clap(about = "Switch management", subcommand, visible_alias = "sw")]
-    Switch(switch::Cmd),
-
-    #[clap(about = "Rack Management", subcommand)]
-    Rack(rack::Cmd),
-
-    #[clap(about = "RMS Actions")]
-    Rms(rms::args::RmsAction),
-
-    #[clap(about = "Firmware related actions", subcommand)]
-    Firmware(firmware::Cmd),
-
-    #[clap(about = "DPA related handling", subcommand)]
-    Dpa(dpa::Cmd),
-    #[clap(about = "Trim DB tables", subcommand)]
-    TrimTable(trim_table::Cmd),
-    #[clap(about = "Dpu Remediation handling", subcommand)]
-    DpuRemediation(dpu_remediation::Cmd),
     #[clap(
         about = "Extension service management",
         visible_alias = "es",
         subcommand
     )]
     ExtensionService(extension_service::Cmd),
-    #[clap(about = "Mellanox Device Handling", subcommand)]
-    Mlx(mlx::MlxAction),
-    #[clap(about = "Scout Stream Connection Handling", subcommand)]
-    ScoutStream(scout_stream::ScoutStreamAction),
+    #[clap(about = "Firmware related actions", subcommand)]
+    Firmware(firmware::Cmd),
+    #[clap(about = "Regenerate the docs/cli markdown reference", hide = true)]
+    GenerateCliDocs(generate_docs::Cmd),
+    #[clap(about = "Generate man pages for the CLI", hide = true)]
+    GenerateMan(generate_man::Cmd),
     #[clap(
-        about = "NvLink Partition related handling",
-        subcommand,
-        visible_alias = "nvp"
+        about = "Generate shell autocomplete. Source the output of this command: `source <(carbide-admin-cli generate-shell-complete bash)`"
     )]
-    NvlPartition(nvl_partition::Cmd),
-
+    GenerateShellComplete(generate_shell_complete::Cmd),
+    #[clap(about = "Host specific handling", subcommand)]
+    Host(host::Cmd),
     #[clap(
-        about = "SPX Partition related handling",
+        about = "InfiniBand Partition related handling",
         subcommand,
-        visible_alias = "spx"
+        visible_alias = "ibp"
     )]
-    SpxPartition(spx_partition::Cmd),
-
+    IbPartition(ib_partition::Cmd),
+    #[clap(about = "Instance related handling", subcommand, visible_alias = "i")]
+    Instance(instance::Cmd),
+    #[clap(about = "Instance type management", visible_alias = "it", subcommand)]
+    InstanceType(instance_type::Cmd),
+    #[clap(about = "Generate Ansible Inventory")]
+    Inventory(inventory::Cmd),
+    #[clap(about = "IP address handling", subcommand)]
+    Ip(ip::Cmd),
     #[clap(
-        about = "NVLink domain related handling",
-        subcommand,
-        visible_alias = "nvd"
+        about = "iPXE template management",
+        visible_alias = "ipxe-tmpl",
+        subcommand
     )]
-    NvlDomain(nvl_domain::Cmd),
-
+    IpxeTemplate(ipxe_template::Cmd),
+    #[clap(
+        about = "Broad search across multiple object types",
+        visible_alias = "j"
+    )]
+    Jump(jump::Cmd),
     #[clap(
         about = "Logical partition related handling",
         subcommand,
         visible_alias = "lp"
     )]
     LogicalPartition(nvl_logical_partition::Cmd),
-
-    #[clap(subcommand)]
-    #[clap(verbatim_doc_comment)]
-    /// DPF-related commands.
-    /// Note: These commands update the DPF state of the machine, which determines DPF-based DPU
-    /// re-provisioning. The state is saved in the machine's metadata and will be deleted if the
-    /// machine is force-deleted. To make the state persistent, add the DPF state for a machine
-    /// (host) to the expected machines table.
-    Dpf(crate::dpf::Cmd),
-
+    #[clap(about = "Machine related handling", subcommand, visible_alias = "m")]
+    Machine(machine::Cmd),
+    #[clap(
+        about = "Machine interfaces and address management",
+        subcommand,
+        visible_alias = "mi"
+    )]
+    MachineInterfaces(machine_interfaces::Cmd),
+    #[clap(about = "Machine Validation", subcommand, visible_alias = "mv")]
+    MachineValidation(machine_validation::Cmd),
+    #[clap(
+        about = "Managed host related handling",
+        subcommand,
+        visible_alias = "mh"
+    )]
+    ManagedHost(managed_host::Cmd),
+    #[clap(
+        about = "Managed switch related handling",
+        subcommand,
+        visible_alias = "ms"
+    )]
+    ManagedSwitch(managed_switch::Cmd),
+    #[clap(about = "Mellanox Device Handling", subcommand)]
+    Mlx(mlx::MlxAction),
+    #[clap(about = "Network Devices handling", subcommand)]
+    NetworkDevice(network_devices::Cmd),
+    #[clap(
+        about = "Network security group management",
+        visible_alias = "nsg",
+        subcommand
+    )]
+    NetworkSecurityGroup(network_security_group::Cmd),
+    #[clap(
+        about = "Network Segment related handling",
+        subcommand,
+        visible_alias = "ns"
+    )]
+    NetworkSegment(network_segment::Cmd),
+    #[clap(
+        about = "NVLink domain related handling",
+        subcommand,
+        visible_alias = "nvd"
+    )]
+    NvlDomain(nvl_domain::Cmd),
+    #[clap(
+        about = "NvLink Partition related handling",
+        subcommand,
+        visible_alias = "nvp"
+    )]
+    NvlPartition(nvl_partition::Cmd),
+    #[clap(
+        name = "nvlink-nmxc-endpoints",
+        about = "Rack chassis serial → NMX-C endpoint mappings",
+        subcommand
+    )]
+    NvlinkNmxcEndpoints(nvlink_nmxc_endpoints::Cmd),
+    #[clap(
+        about = "Operating system definition management",
+        visible_alias = "osd",
+        subcommand
+    )]
+    OperatingSystem(operating_system::Cmd),
+    #[clap(about = "OS catalog management", visible_alias = "os", subcommand)]
+    OsImage(os_image::Cmd),
+    #[clap(
+        about = "Query the Version gRPC endpoint repeatedly printing how long it took and any failures."
+    )]
+    Ping(ping::Opts),
+    #[clap(about = "Power Shelf management", subcommand, visible_alias = "ps")]
+    PowerShelf(power_shelf::Cmd),
+    #[clap(about = "Rack Management", subcommand)]
+    Rack(rack::Cmd),
+    #[clap(about = "Redfish BMC actions", visible_alias = "rf")]
+    Redfish(redfish::RedfishAction),
+    #[clap(about = "Resource pool handling", subcommand, visible_alias = "rp")]
+    ResourcePool(resource_pool::Cmd),
+    #[clap(about = "RMS Actions")]
+    Rms(rms::args::RmsAction),
+    #[clap(about = "Route server handling", subcommand)]
+    RouteServer(route_server::Cmd),
+    #[clap(about = "Scout Stream Connection Handling", subcommand)]
+    ScoutStream(scout_stream::ScoutStreamAction),
+    #[clap(about = "Set carbide-api dynamic features", subcommand)]
+    Set(set::Cmd),
+    #[clap(about = "Site explorer functions", subcommand)]
+    SiteExplorer(site_explorer::Cmd),
+    #[clap(about = "Manage machine SKUs", subcommand)]
+    Sku(sku::Cmd),
+    #[clap(
+        about = "SPX Partition related handling",
+        subcommand,
+        visible_alias = "spx"
+    )]
+    SpxPartition(spx_partition::Cmd),
+    #[clap(about = "SSH Util functions", subcommand)]
+    Ssh(ssh::Cmd),
+    #[clap(about = "Switch management", subcommand, visible_alias = "sw")]
+    Switch(switch::Cmd),
     #[clap(about = "Tenant management", subcommand, visible_alias = "tm")]
     Tenant(tenant::Cmd),
-
     #[clap(
-        about = "MeasuredBoot or SPDM attestations",
+        about = "Tenant KeySet related handling",
         subcommand,
-        visible_alias = "att"
+        visible_alias = "tks"
     )]
-    Attestation(attestation::Cmd),
+    TenantKeySet(tenant_keyset::Cmd),
+    #[clap(about = "Manage TPM CA certificates", subcommand)]
+    TpmCa(tpm_ca::Cmd),
+    #[clap(about = "Trim DB tables", subcommand)]
+    TrimTable(trim_table::Cmd),
+    #[clap(about = "Print API server version", visible_alias = "v")]
+    Version(version::Opts),
+    #[clap(about = "VPC related handling", subcommand)]
+    Vpc(vpc::Cmd),
+    #[clap(about = "VPC peering handling", subcommand)]
+    VpcPeering(vpc_peering::Cmd),
+    #[clap(about = "VPC prefix handling", subcommand)]
+    VpcPrefix(vpc_prefix::Cmd),
 }
 
 impl CliOptions {
     pub fn load() -> Self {
         Self::parse()
+    }
+}
+
+// =============================================================================
+// CLI documentation domains
+// =============================================================================
+//
+// The generated CLI reference (docs/cli) groups top-level commands into four
+// operator-facing domains. clap has no native way to categorize subcommands in
+// `--help`, so the grouping lives in `cli_domains.yaml` (at the crate root) as
+// the single source of truth and is consumed by the `generate-cli-docs`
+// generator.
+//
+// The YAML maps each domain to its list of command names as clap renders them
+// (e.g. "managed-host", "tenant-key-set"). We embed it with `include_str!` so
+// the binary carries the mapping with no runtime file dependency; the cost is
+// that editing the YAML requires a rebuild. The `every_command_has_a_domain`
+// test fails CI if a newly added top-level command is not assigned a domain, so
+// the docs stay categorized as the CLI grows.
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CliDomain {
+    Hardware,
+    Network,
+    Tenant,
+    Admin,
+}
+
+impl CliDomain {
+    pub fn title(self) -> &'static str {
+        match self {
+            CliDomain::Hardware => "Hardware",
+            CliDomain::Network => "Network",
+            CliDomain::Tenant => "Tenant",
+            CliDomain::Admin => "Admin",
+        }
+    }
+}
+
+/// Command-name → domain, inverted once from the `domain -> [command names]`
+/// shape of the embedded `cli_domains.yaml`.
+static COMMAND_DOMAINS: LazyLock<HashMap<String, CliDomain>> = LazyLock::new(|| {
+    let by_domain: HashMap<CliDomain, Vec<String>> = serde_yaml::from_str(include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/cli_domains.yaml"
+    )))
+    .expect("cli_domains.yaml parses as a mapping of domain -> [command names]");
+
+    let mut by_command = HashMap::new();
+    for (domain, commands) in by_domain {
+        for command in commands {
+            if let Some(previous) = by_command.insert(command.clone(), domain) {
+                panic!(
+                    "command `{command}` is listed under two domains \
+                     ({previous:?} and {domain:?}) in cli_domains.yaml"
+                );
+            }
+        }
+    }
+    by_command
+});
+
+/// The domain a top-level command belongs to, keyed by its rendered name.
+/// Returns `None` for a command absent from `cli_domains.yaml` — every visible
+/// command must be listed there or `every_command_has_a_domain` fails.
+pub fn domain_for_command(name: &str) -> Option<CliDomain> {
+    COMMAND_DOMAINS.get(name).copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use clap::CommandFactory;
+
+    use super::{COMMAND_DOMAINS, CliOptions, domain_for_command};
+
+    // Visible top-level command names as clap renders them, excluding hidden
+    // commands (e.g. generate-man) and the synthetic `help` command.
+    fn visible_command_names() -> Vec<String> {
+        CliOptions::command()
+            .get_subcommands()
+            .filter(|sub| !sub.is_hide_set())
+            .map(|sub| sub.get_name().to_string())
+            .filter(|name| name != "help")
+            .collect()
+    }
+
+    // Fails if a visible top-level command is missing from cli_domains.yaml.
+    // When someone adds a new command, this points them at the YAML so the
+    // generated docs (docs/cli) stay grouped by domain.
+    #[test]
+    fn every_command_has_a_domain() {
+        let missing: Vec<String> = visible_command_names()
+            .into_iter()
+            .filter(|name| domain_for_command(name).is_none())
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "these top-level commands have no CLI-docs domain; add them to \
+             crates/admin-cli/cli_domains.yaml: {missing:?}"
+        );
+    }
+
+    // Fails if cli_domains.yaml lists a command that no longer exists, so a
+    // rename or removal can't leave a stale entry behind.
+    #[test]
+    fn no_unknown_commands_in_domain_map() {
+        let real: HashSet<String> = visible_command_names().into_iter().collect();
+        let stale: Vec<&String> = COMMAND_DOMAINS
+            .keys()
+            .filter(|name| !real.contains(*name))
+            .collect();
+        assert!(
+            stale.is_empty(),
+            "cli_domains.yaml lists commands that are not real top-level \
+             commands; rename or remove them: {stale:?}"
+        );
     }
 }

--- a/crates/admin-cli/src/component_manager/power_control/args.rs
+++ b/crates/admin-cli/src/component_manager/power_control/args.rs
@@ -20,6 +20,22 @@ use clap::Parser;
 use crate::component_manager::common::{PowerActionArg, PowerControlTargetArgs};
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Power on a switch:
+    $ carbide-admin-cli component-manager component-power-control switch \
+    --switch-id 12345678-1234-5678-90ab-cdef01234567 --action on
+
+Force off a compute tray:
+    $ carbide-admin-cli component-manager component-power-control compute-tray \
+    --machine-id 12345678-1234-5678-90ab-cdef01234567 --action force-off
+
+AC power-cycle a power shelf:
+    $ carbide-admin-cli component-manager component-power-control power-shelf \
+    --power-shelf-id 12345678-1234-5678-90ab-cdef01234567 --action ac-powercycle
+
+")]
 pub struct Args {
     #[clap(subcommand)]
     pub target: PowerControlTargetArgs,

--- a/crates/admin-cli/src/component_manager/status/args.rs
+++ b/crates/admin-cli/src/component_manager/status/args.rs
@@ -20,6 +20,22 @@ use clap::Parser;
 use crate::component_manager::common::DeviceTargetArgs;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Get firmware update status for switches:
+    $ carbide-admin-cli component-manager get-firmware-update-status switch \
+    --switch-id 12345678-1234-5678-90ab-cdef01234567
+
+Get status for several compute trays at once:
+    $ carbide-admin-cli component-manager get-firmware-update-status compute-tray \
+    --machine-id 12345678-1234-5678-90ab-cdef01234567,abcdef01-2345-6789-abcd-ef0123456789
+
+Get status for an entire rack:
+    $ carbide-admin-cli component-manager get-firmware-update-status rack \
+    --rack-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(subcommand)]
     pub target: DeviceTargetArgs,

--- a/crates/admin-cli/src/component_manager/update_firmware/args.rs
+++ b/crates/admin-cli/src/component_manager/update_firmware/args.rs
@@ -26,6 +26,32 @@ use crate::component_manager::common::{
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Queue firmware on NVLink switches from a target version:
+    $ carbide-admin-cli component-manager update-firmware switch \
+    --switch-id 12345678-1234-5678-90ab-cdef01234567 --target-version fw-1.2.3
+
+Update only specific switch components, forcing the update:
+    $ carbide-admin-cli component-manager update-firmware switch \
+    --switch-id 12345678-1234-5678-90ab-cdef01234567 --component bmc,bios --force-update \
+    --target-version fw-1.2.3
+
+Queue firmware on compute trays from an RMS SOT JSON file:
+    $ carbide-admin-cli component-manager update-firmware compute-tray \
+    --machine-id 12345678-1234-5678-90ab-cdef01234567 --sot-json-file ./sot.json \
+    --access-token mytoken
+
+Queue firmware on power shelves:
+    $ carbide-admin-cli component-manager update-firmware power-shelf \
+    --power-shelf-id 12345678-1234-5678-90ab-cdef01234567 --target-version fw-1.2.3
+
+Queue firmware on all eligible devices in a rack:
+    $ carbide-admin-cli component-manager update-firmware rack \
+    --rack-id 12345678-1234-5678-90ab-cdef01234567 --target-version fw-1.2.3
+
+")]
 pub struct Args {
     #[clap(subcommand)]
     pub target: Target,

--- a/crates/admin-cli/src/component_manager/versions/args.rs
+++ b/crates/admin-cli/src/component_manager/versions/args.rs
@@ -20,6 +20,22 @@ use clap::Parser;
 use crate::component_manager::common::DeviceTargetArgs;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List available firmware versions for switches:
+    $ carbide-admin-cli component-manager get-firmware-versions switch \
+    --switch-id 12345678-1234-5678-90ab-cdef01234567
+
+List versions for power shelves:
+    $ carbide-admin-cli component-manager get-firmware-versions power-shelf \
+    --power-shelf-id 12345678-1234-5678-90ab-cdef01234567
+
+List versions for an entire rack:
+    $ carbide-admin-cli component-manager get-firmware-versions rack \
+    --rack-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(subcommand)]
     pub target: DeviceTargetArgs,

--- a/crates/admin-cli/src/compute_allocation/create/args.rs
+++ b/crates/admin-cli/src/compute_allocation/create/args.rs
@@ -22,6 +22,19 @@ use clap::Parser;
 use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create a compute allocation:
+    $ carbide-admin-cli compute-allocation create --tenant-organization-id fds34511233a \
+    --instance-type-id DGX-H100-640GB --count 8
+
+Create a named, labelled allocation with an explicit ID:
+    $ carbide-admin-cli compute-allocation create --id 12345678-1234-5678-90ab-cdef01234567 \
+    --tenant-organization-id fds34511233a --instance-type-id DGX-H100-640GB --count 8 \
+    --name \"training-pool\" --labels '{\"team\":\"research\"}'
+
+")]
 pub struct Args {
     #[clap(
         short = 'i',

--- a/crates/admin-cli/src/compute_allocation/delete/args.rs
+++ b/crates/admin-cli/src/compute_allocation/delete/args.rs
@@ -20,6 +20,14 @@ use carbide_uuid::compute_allocation::ComputeAllocationId;
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a compute allocation:
+    $ carbide-admin-cli compute-allocation delete --id 12345678-1234-5678-90ab-cdef01234567 \
+    --tenant-organization-id fds34511233a
+
+")]
 pub struct Args {
     #[clap(short = 'i', long, help = "Compute allocation ID to delete")]
     pub id: ComputeAllocationId,

--- a/crates/admin-cli/src/compute_allocation/show/args.rs
+++ b/crates/admin-cli/src/compute_allocation/show/args.rs
@@ -20,6 +20,22 @@ use carbide_uuid::compute_allocation::ComputeAllocationId;
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show all compute allocations:
+    $ carbide-admin-cli compute-allocation show
+
+Show one compute allocation by ID:
+    $ carbide-admin-cli compute-allocation show --id 12345678-1234-5678-90ab-cdef01234567
+
+Show allocations for one tenant:
+    $ carbide-admin-cli compute-allocation show --tenant-organization-id fds34511233a
+
+Filter by instance type:
+    $ carbide-admin-cli compute-allocation show --instance-type-id DGX-H100-640GB
+
+")]
 pub struct Args {
     #[clap(
         short = 'i',

--- a/crates/admin-cli/src/compute_allocation/update/args.rs
+++ b/crates/admin-cli/src/compute_allocation/update/args.rs
@@ -19,6 +19,22 @@ use carbide_uuid::compute_allocation::ComputeAllocationId;
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Change the allocated count:
+    $ carbide-admin-cli compute-allocation update --id 12345678-1234-5678-90ab-cdef01234567 \
+    --tenant-organization-id fds34511233a --count 16
+
+Rename and re-describe an allocation:
+    $ carbide-admin-cli compute-allocation update --id 12345678-1234-5678-90ab-cdef01234567 \
+    --tenant-organization-id fds34511233a --name \"prod-pool\" --description \"Production capacity\"
+
+Replace labels with optimistic-concurrency check on version:
+    $ carbide-admin-cli compute-allocation update --id 12345678-1234-5678-90ab-cdef01234567 \
+    --tenant-organization-id fds34511233a --labels '{\"team\":\"research\"}' --version 3
+
+")]
 pub struct Args {
     #[clap(short = 'i', long, help = "Compute allocation ID to update")]
     pub id: ComputeAllocationId,

--- a/crates/admin-cli/src/credential/add_bmc/args.rs
+++ b/crates/admin-cli/src/credential/add_bmc/args.rs
@@ -23,6 +23,17 @@ use crate::credential::common::{BmcCredentialType, password_validator};
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add the site-wide BMC root credential:
+    $ carbide-admin-cli credential add-bmc --kind=site-wide-root --username admin --password mypassword
+
+Add a per-BMC root credential for a specific MAC address:
+    $ carbide-admin-cli credential add-bmc --kind=bmc-root --username admin --password mypassword \
+    --mac-address 00:11:22:33:44:55
+
+")]
 pub struct Args {
     #[clap(
         long,

--- a/crates/admin-cli/src/credential/add_dpu_factory_default/args.rs
+++ b/crates/admin-cli/src/credential/add_dpu_factory_default/args.rs
@@ -19,6 +19,13 @@ use clap::Parser;
 use rpc::{CredentialType, forge as forgerpc};
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add the factory-default DPU BMC credential:
+    $ carbide-admin-cli credential add-dpu-factory-default --username admin --password mypassword
+
+")]
 pub struct Args {
     #[clap(long, required(true), help = "Default username: root, ADMIN, etc")]
     pub username: String,

--- a/crates/admin-cli/src/credential/add_host_factory_default/args.rs
+++ b/crates/admin-cli/src/credential/add_host_factory_default/args.rs
@@ -19,6 +19,14 @@ use clap::Parser;
 use rpc::{CredentialType, forge as forgerpc};
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add the factory-default host BMC credential for a vendor:
+    $ carbide-admin-cli credential add-host-factory-default --vendor nvidia \
+    --username admin --password mypassword
+
+")]
 pub struct Args {
     #[clap(long, required(true), help = "Default username: root, ADMIN, etc")]
     pub username: String,

--- a/crates/admin-cli/src/credential/add_nmxm/args.rs
+++ b/crates/admin-cli/src/credential/add_nmxm/args.rs
@@ -19,6 +19,13 @@ use clap::Parser;
 use rpc::{CredentialType, forge as forgerpc};
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add an NMX-M credential:
+    $ carbide-admin-cli credential add-nmx-m --username admin --password mypassword
+
+")]
 pub struct Args {
     #[clap(long, required(true), help = "Username")]
     pub username: String,

--- a/crates/admin-cli/src/credential/add_uefi/args.rs
+++ b/crates/admin-cli/src/credential/add_uefi/args.rs
@@ -22,6 +22,16 @@ use crate::credential::common::{UefiCredentialType, password_validator};
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Set the site-wide DPU UEFI default password:
+    $ carbide-admin-cli credential add-uefi --kind=dpu --password=mynewpassword
+
+Set the site-wide host UEFI default password:
+    $ carbide-admin-cli credential add-uefi --kind=host --password=mynewpassword
+
+")]
 pub struct Args {
     #[clap(long, require_equals(true), required(true), help = "The UEFI kind")]
     pub kind: UefiCredentialType,

--- a/crates/admin-cli/src/credential/add_ufm/args.rs
+++ b/crates/admin-cli/src/credential/add_ufm/args.rs
@@ -22,6 +22,13 @@ use crate::credential::common::url_validator;
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add a UFM credential with a token:
+    $ carbide-admin-cli credential add-ufm --url https://192.0.2.10 --token mypassword
+
+")]
 pub struct Args {
     #[clap(long, required(true), help = "The UFM url")]
     pub url: String,

--- a/crates/admin-cli/src/credential/bgp/set_sitewide/args.rs
+++ b/crates/admin-cli/src/credential/bgp/set_sitewide/args.rs
@@ -22,6 +22,13 @@ use crate::credential::common::password_validator;
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Set the site-wide leaf BGP session password:
+    $ carbide-admin-cli credential bgp set-sitewide --password mynewpassword
+
+")]
 pub struct Args {
     #[clap(long, required(true), help = "Leaf BGP session password")]
     pub password: String,

--- a/crates/admin-cli/src/credential/delete_bmc/args.rs
+++ b/crates/admin-cli/src/credential/delete_bmc/args.rs
@@ -22,6 +22,16 @@ use rpc::{CredentialType, forge as forgerpc};
 use crate::credential::common::BmcCredentialType;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete the site-wide BMC root credential:
+    $ carbide-admin-cli credential delete-bmc --kind=site-wide-root
+
+Delete a per-BMC root credential for a specific MAC address:
+    $ carbide-admin-cli credential delete-bmc --kind=bmc-root --mac-address 00:11:22:33:44:55
+
+")]
 pub struct Args {
     #[clap(
         long,

--- a/crates/admin-cli/src/credential/delete_nmxm/args.rs
+++ b/crates/admin-cli/src/credential/delete_nmxm/args.rs
@@ -19,6 +19,13 @@ use clap::Parser;
 use rpc::{CredentialType, forge as forgerpc};
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete an NMX-M credential by username:
+    $ carbide-admin-cli credential delete-nmx-m --username admin
+
+")]
 pub struct Args {
     #[clap(long, required(true), help = "NmxM url")]
     pub username: String,

--- a/crates/admin-cli/src/credential/delete_ufm/args.rs
+++ b/crates/admin-cli/src/credential/delete_ufm/args.rs
@@ -22,6 +22,13 @@ use crate::credential::common::url_validator;
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a UFM credential by its URL:
+    $ carbide-admin-cli credential delete-ufm --url https://192.0.2.10
+
+")]
 pub struct Args {
     #[clap(long, required(true), help = "The UFM url")]
     pub url: String,

--- a/crates/admin-cli/src/credential/generate_ufm_cert/args.rs
+++ b/crates/admin-cli/src/credential/generate_ufm_cert/args.rs
@@ -21,6 +21,16 @@ use rpc::{CredentialType, forge as forgerpc};
 use crate::credential::common::DEFAULT_IB_FABRIC_NAME;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Generate a UFM cert for the default fabric:
+    $ carbide-admin-cli credential generate-ufm-cert
+
+Generate a UFM cert for a named fabric:
+    $ carbide-admin-cli credential generate-ufm-cert --fabric default
+
+")]
 pub struct Args {
     #[clap(long, default_value_t = DEFAULT_IB_FABRIC_NAME.to_string(), help = "Infiniband fabric.")]
     pub fabric: String,

--- a/crates/admin-cli/src/devenv/config/apply/args.rs
+++ b/crates/admin-cli/src/devenv/config/apply/args.rs
@@ -18,6 +18,16 @@
 use clap::{Parser, ValueEnum};
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Apply a devenv config using network segments:
+    $ carbide-admin-cli dev-env config apply ./devenv_config.toml --mode network-segment
+
+Apply a devenv config using VPC prefixes:
+    $ carbide-admin-cli dev-env config apply ./devenv_config.toml --mode vpc-prefix
+
+")]
 pub struct Args {
     #[clap(
         help = "Path to devenv config file. Usually this is in forged repo at envs/local-dev/site/site-controller/files/generated/devenv_config.toml"

--- a/crates/admin-cli/src/domain/show/args.rs
+++ b/crates/admin-cli/src/domain/show/args.rs
@@ -19,6 +19,16 @@ use carbide_uuid::domain::DomainId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all domains:
+    $ carbide-admin-cli domain show
+
+Show one domain by ID:
+    $ carbide-admin-cli domain show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(
         short,

--- a/crates/admin-cli/src/dpa/ensure/args.rs
+++ b/crates/admin-cli/src/dpa/ensure/args.rs
@@ -19,6 +19,18 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create/ensure a DPA interface for a machine:
+    $ carbide-admin-cli dpa ensure 12345678-1234-5678-90ab-cdef01234567 \
+    00:11:22:33:44:55 BlueField3 5e:00.0
+
+Create/ensure a DPA interface with a device description:
+    $ carbide-admin-cli dpa ensure 12345678-1234-5678-90ab-cdef01234567 \
+    00:11:22:33:44:55 BlueField3 5e:00.0 \"NVIDIA BlueField-3 B3140L E-Series FHHL SuperNIC\"
+
+")]
 pub struct Args {
     #[clap(help = "Machine ID")]
     pub machine_id: MachineId,

--- a/crates/admin-cli/src/dpa/show/args.rs
+++ b/crates/admin-cli/src/dpa/show/args.rs
@@ -19,6 +19,16 @@ use carbide_uuid::dpa_interface::DpaInterfaceId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all DPA interfaces:
+    $ carbide-admin-cli dpa show
+
+Show details for one DPA interface:
+    $ carbide-admin-cli dpa show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "The DPA Interface ID to query, leave empty for all (default)")]
     pub id: Option<DpaInterfaceId>,

--- a/crates/admin-cli/src/dpf/disable/args.rs
+++ b/crates/admin-cli/src/dpf/disable/args.rs
@@ -23,6 +23,13 @@ use crate::dpf::common::DpfQuery;
 // specific newtype to allow sharing of DpfQuery, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Disable DPF for a host machine:
+    $ carbide-admin-cli dpf disable 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: DpfQuery,

--- a/crates/admin-cli/src/dpf/enable/args.rs
+++ b/crates/admin-cli/src/dpf/enable/args.rs
@@ -23,6 +23,13 @@ use crate::dpf::common::DpfQuery;
 // specific newtype to allow sharing of DpfQuery, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Enable DPF for a host machine:
+    $ carbide-admin-cli dpf enable 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: DpfQuery,

--- a/crates/admin-cli/src/dpf/service_version/args.rs
+++ b/crates/admin-cli/src/dpf/service_version/args.rs
@@ -18,4 +18,14 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Compare configured vs deployed DPF service versions:
+    $ carbide-admin-cli dpf service-version
+
+Same, using the short alias:
+    $ carbide-admin-cli dpf sv
+
+")]
 pub struct Args {}

--- a/crates/admin-cli/src/dpf/show/args.rs
+++ b/crates/admin-cli/src/dpf/show/args.rs
@@ -23,6 +23,16 @@ use crate::dpf::common::DpfQuery;
 // specific newtype to allow sharing of DpfQuery, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show DPF status for all hosts:
+    $ carbide-admin-cli dpf show
+
+Show DPF status for one host machine:
+    $ carbide-admin-cli dpf show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: DpfQuery,

--- a/crates/admin-cli/src/dpf/snapshot/args.rs
+++ b/crates/admin-cli/src/dpf/snapshot/args.rs
@@ -19,6 +19,13 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Snapshot the DPF CRs for a host machine:
+    $ carbide-admin-cli dpf snapshot 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: SnapshotQuery,

--- a/crates/admin-cli/src/dpu/agent_upgrade_policy/args.rs
+++ b/crates/admin-cli/src/dpu/agent_upgrade_policy/args.rs
@@ -19,6 +19,22 @@ use clap::{Parser, ValueEnum};
 use rpc::forge::DpuAgentUpgradePolicyRequest;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show the current forge-dpu-agent upgrade policy:
+    $ carbide-admin-cli dpu agent-upgrade-policy
+
+Allow the agent to upgrade only (never downgrade):
+    $ carbide-admin-cli dpu agent-upgrade-policy --set up-only
+
+Allow the agent to both upgrade and downgrade:
+    $ carbide-admin-cli dpu agent-upgrade-policy --set up-down
+
+Disable automatic agent version changes:
+    $ carbide-admin-cli dpu agent-upgrade-policy --set off
+
+")]
 pub struct Args {
     #[clap(long)]
     pub set: Option<AgentUpgradePolicyChoice>,

--- a/crates/admin-cli/src/dpu/health_report/args.rs
+++ b/crates/admin-cli/src/dpu/health_report/args.rs
@@ -21,14 +21,44 @@ use clap::{ArgGroup, Parser};
 use crate::machine::HealthReportTemplates;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List the health report sources for a DPU:
+    $ carbide-admin-cli dpu health-report show 12345678-1234-5678-90ab-cdef01234567
+
+Add a health report source from a predefined template:
+    $ carbide-admin-cli dpu health-report add 12345678-1234-5678-90ab-cdef01234567 \
+    --template internal-maintenance
+
+Remove a health report source from a DPU:
+    $ carbide-admin-cli dpu health-report remove 12345678-1234-5678-90ab-cdef01234567 \
+    internal-maintenance
+
+")]
 pub enum Args {
     #[clap(about = "List health report sources for a DPU")]
+    #[command(after_long_help = "\
+EXAMPLES:
+
+List the health report sources for a DPU:
+    $ carbide-admin-cli dpu health-report show 12345678-1234-5678-90ab-cdef01234567
+
+")]
     Show { dpu_id: MachineId },
     #[clap(about = "Insert a health report source for a DPU")]
     Add(HealthAddOptions),
     #[clap(about = "Print an empty health report template")]
     PrintEmptyTemplate,
     #[clap(about = "Remove a health report source from a DPU")]
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Remove a health report source from a DPU:
+    $ carbide-admin-cli dpu health-report remove 12345678-1234-5678-90ab-cdef01234567 \
+    internal-maintenance
+
+")]
     Remove {
         dpu_id: MachineId,
         report_source: String,
@@ -37,6 +67,30 @@ pub enum Args {
 
 #[derive(Parser, Debug)]
 #[clap(group(ArgGroup::new("health_report_source").required(true).args(&["health_report", "template"])))]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add a health report source from a predefined template:
+    $ carbide-admin-cli dpu health-report add 12345678-1234-5678-90ab-cdef01234567 \
+    --template internal-maintenance
+
+Add a template-based source with a custom message:
+    $ carbide-admin-cli dpu health-report add 12345678-1234-5678-90ab-cdef01234567 \
+    --template out-for-repair --message \"awaiting replacement part\"
+
+Add a raw JSON health report source:
+    $ carbide-admin-cli dpu health-report add 12345678-1234-5678-90ab-cdef01234567 \
+    --health-report '{\"status\":\"Degraded\"}'
+
+Replace the DPU's health contribution with this source:
+    $ carbide-admin-cli dpu health-report add 12345678-1234-5678-90ab-cdef01234567 \
+    --template internal-maintenance --replace
+
+Preview the report without sending it to carbide:
+    $ carbide-admin-cli dpu health-report add 12345678-1234-5678-90ab-cdef01234567 \
+    --template internal-maintenance --print-only
+
+")]
 pub struct HealthAddOptions {
     pub dpu_id: MachineId,
     #[clap(long, help = "New health report as json")]

--- a/crates/admin-cli/src/dpu/network/args.rs
+++ b/crates/admin-cli/src/dpu/network/args.rs
@@ -17,9 +17,26 @@
 
 #[derive(clap::Subcommand, Debug)]
 #[clap(rename_all = "kebab-case")]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Print network status of all DPUs:
+    $ carbide-admin-cli dpu network status
+
+Show the VPC network configuration for one DPU:
+    $ carbide-admin-cli dpu network config --machine-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub enum Args {
     #[clap(about = "Print network status of all machines")]
     Status,
     #[clap(about = "Machine network configuration, used by VPC.")]
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Show the VPC network configuration for one DPU:
+    $ carbide-admin-cli dpu network config --machine-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
     Config(crate::machine::NetworkConfigQuery),
 }

--- a/crates/admin-cli/src/dpu/reprovision/args.rs
+++ b/crates/admin-cli/src/dpu/reprovision/args.rs
@@ -21,6 +21,22 @@ use rpc::forge::dpu_reprovisioning_request::Mode;
 use rpc::forge::{DpuReprovisioningRequest, UpdateInitiator};
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all DPUs pending reprovisioning:
+    $ carbide-admin-cli dpu reprovision list
+
+Set a DPU into reprovisioning mode:
+    $ carbide-admin-cli dpu reprovision set --id 12345678-1234-5678-90ab-cdef01234567
+
+Clear reprovisioning mode for a DPU:
+    $ carbide-admin-cli dpu reprovision clear --id 12345678-1234-5678-90ab-cdef01234567
+
+Restart reprovisioning for a host:
+    $ carbide-admin-cli dpu reprovision restart --id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub enum Args {
     #[clap(about = "Set the DPU in reprovisioning mode.")]
     Set(DpuReprovisionSet),
@@ -33,6 +49,20 @@ pub enum Args {
 }
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Set a single DPU into reprovisioning mode:
+    $ carbide-admin-cli dpu reprovision set --id 12345678-1234-5678-90ab-cdef01234567
+
+Reprovision all DPUs on a host by passing the host machine id:
+    $ carbide-admin-cli dpu reprovision set --id abcdef01-2345-6789-abcd-ef0123456789
+
+Reprovision and update DPU firmware, recording a maintenance message:
+    $ carbide-admin-cli dpu reprovision set --id 12345678-1234-5678-90ab-cdef01234567 \
+    --update-firmware --update-message \"scheduled firmware refresh\"
+
+")]
 pub struct DpuReprovisionSet {
     #[clap(
         short,
@@ -65,6 +95,16 @@ impl From<&DpuReprovisionSet> for DpuReprovisioningRequest {
 }
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Clear reprovisioning mode for a single DPU:
+    $ carbide-admin-cli dpu reprovision clear --id 12345678-1234-5678-90ab-cdef01234567
+
+Clear reprovisioning for all DPUs on a host by passing the host machine id:
+    $ carbide-admin-cli dpu reprovision clear --id abcdef01-2345-6789-abcd-ef0123456789
+
+")]
 pub struct DpuReprovisionClear {
     #[clap(
         short,
@@ -90,6 +130,17 @@ impl From<&DpuReprovisionClear> for DpuReprovisioningRequest {
 }
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Restart reprovisioning for a host:
+    $ carbide-admin-cli dpu reprovision restart --id 12345678-1234-5678-90ab-cdef01234567
+
+Restart reprovisioning and update DPU firmware:
+    $ carbide-admin-cli dpu reprovision restart --id 12345678-1234-5678-90ab-cdef01234567 \
+    --update-firmware
+
+")]
 pub struct DpuReprovisionRestart {
     #[clap(
         short,

--- a/crates/admin-cli/src/dpu/versions/args.rs
+++ b/crates/admin-cli/src/dpu/versions/args.rs
@@ -18,6 +18,16 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show firmware versions for all DPUs:
+    $ carbide-admin-cli dpu versions
+
+Show only DPUs that need a firmware upgrade:
+    $ carbide-admin-cli dpu versions --updates-only
+
+")]
 pub struct Args {
     #[clap(short, long, help = "Only show DPUs that need upgrades")]
     pub updates_only: bool,

--- a/crates/admin-cli/src/dpu_remediation/approve/args.rs
+++ b/crates/admin-cli/src/dpu_remediation/approve/args.rs
@@ -20,6 +20,13 @@ use clap::Parser;
 use rpc::forge::ApproveRemediationRequest;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Approve a remediation:
+    $ carbide-admin-cli dpu-remediation approve --id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "The id of the remediation to approve", long)]
     pub id: RemediationId,

--- a/crates/admin-cli/src/dpu_remediation/create/args.rs
+++ b/crates/admin-cli/src/dpu_remediation/create/args.rs
@@ -18,6 +18,20 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create a remediation from a script:
+    $ carbide-admin-cli dpu-remediation create --script-filename ./remediate.sh
+
+Create a remediation that retries up to three times:
+    $ carbide-admin-cli dpu-remediation create --script-filename ./remediate.sh --retries 3
+
+Create a remediation with descriptive metadata and a label:
+    $ carbide-admin-cli dpu-remediation create --script-filename ./remediate.sh \
+    --meta-name \"clear-eeprom\" --meta-description \"Clears stale EEPROM state\" --label DATACENTER:XYZ
+
+")]
 pub struct Args {
     #[clap(help = "The filename of the script to run", long)]
     pub script_filename: String,

--- a/crates/admin-cli/src/dpu_remediation/disable/args.rs
+++ b/crates/admin-cli/src/dpu_remediation/disable/args.rs
@@ -20,6 +20,13 @@ use clap::Parser;
 use rpc::forge::DisableRemediationRequest;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Disable a remediation:
+    $ carbide-admin-cli dpu-remediation disable --id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "The id of the remediation to disable", long)]
     pub id: RemediationId,

--- a/crates/admin-cli/src/dpu_remediation/enable/args.rs
+++ b/crates/admin-cli/src/dpu_remediation/enable/args.rs
@@ -20,6 +20,13 @@ use clap::Parser;
 use rpc::forge::EnableRemediationRequest;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Enable a remediation:
+    $ carbide-admin-cli dpu-remediation enable --id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "The id of the remediation to enable", long)]
     pub id: RemediationId,

--- a/crates/admin-cli/src/dpu_remediation/list_applied/args.rs
+++ b/crates/admin-cli/src/dpu_remediation/list_applied/args.rs
@@ -20,6 +20,26 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all applied remediations:
+    $ carbide-admin-cli dpu-remediation list-applied
+
+List the machines a specific remediation has been applied to:
+    $ carbide-admin-cli dpu-remediation list-applied \
+    --remediation-id 12345678-1234-5678-90ab-cdef01234567
+
+List the remediations applied to a specific machine:
+    $ carbide-admin-cli dpu-remediation list-applied \
+    --machine-id abcdef01-2345-6789-abcd-ef0123456789
+
+Show full details for one remediation on one machine:
+    $ carbide-admin-cli dpu-remediation list-applied \
+    --remediation-id 12345678-1234-5678-90ab-cdef01234567 \
+    --machine-id abcdef01-2345-6789-abcd-ef0123456789
+
+")]
 pub struct Args {
     #[clap(
         help = "The remediation id to query, in case the user wants to see which machines have a specific remediation applied.  Provide both arguments to see all the details for a specific remediation and machine.",

--- a/crates/admin-cli/src/dpu_remediation/revoke/args.rs
+++ b/crates/admin-cli/src/dpu_remediation/revoke/args.rs
@@ -20,6 +20,13 @@ use clap::Parser;
 use rpc::forge::RevokeRemediationRequest;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Revoke a remediation:
+    $ carbide-admin-cli dpu-remediation revoke --id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "The id of the remediation to revoke", long)]
     pub id: RemediationId,

--- a/crates/admin-cli/src/dpu_remediation/show/args.rs
+++ b/crates/admin-cli/src/dpu_remediation/show/args.rs
@@ -19,6 +19,19 @@ use carbide_uuid::dpu_remediations::RemediationId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all remediations:
+    $ carbide-admin-cli dpu-remediation show
+
+Show details for one remediation:
+    $ carbide-admin-cli dpu-remediation show 12345678-1234-5678-90ab-cdef01234567
+
+Show a remediation including its script body:
+    $ carbide-admin-cli dpu-remediation show 12345678-1234-5678-90ab-cdef01234567 --display-script
+
+")]
 pub struct Args {
     #[clap(help = "The remediation id to query, if not provided defaults to all")]
     pub id: Option<RemediationId>,

--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -26,9 +26,32 @@ use serde::{Deserialize, Serialize};
 
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
-/// `forge-admin-cli expected-machine add` — mirrors expected switch flags; optional
+/// `carbide-admin-cli expected-machine add` — mirrors expected switch flags; optional
 /// `--bmc-ip-address` forwards to the API static-BMC pre-allocation path.
 #[derive(Parser, Debug, Serialize, Deserialize)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add an expected machine with the required identifiers:
+    $ carbide-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1
+
+Add a machine with metadata and a SKU:
+    $ carbide-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 \
+    --meta-name MyMachine --label DATACENTER:XYZ --sku-id DGX-H100-640GB
+
+Pre-allocate a static BMC IP (site-explorer path, like expected switches):
+    $ carbide-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 \
+    --bmc-ip-address 192.0.2.20
+
+Add a host whose DPU should be treated as a plain NIC:
+    $ carbide-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 \
+    --dpu-mode nic-mode
+
+")]
 pub struct Args {
     #[clap(short = 'a', long, help = "BMC MAC Address of the expected machine")]
     pub bmc_mac_address: MacAddress,

--- a/crates/admin-cli/src/expected_machines/delete/args.rs
+++ b/crates/admin-cli/src/expected_machines/delete/args.rs
@@ -22,6 +22,16 @@ use uuid::Uuid;
 use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete an expected machine by BMC MAC address:
+    $ carbide-admin-cli expected-machine delete 00:11:22:33:44:55
+
+Delete an expected machine by id:
+    $ carbide-admin-cli expected-machine delete --id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "BMC MAC address of the expected machine to delete.")]
     pub bmc_mac_address: Option<MacAddress>,
@@ -34,11 +44,8 @@ impl TryFrom<Args> for ::rpc::forge::ExpectedMachineRequest {
     type Error = CarbideCliError;
     fn try_from(args: Args) -> Result<Self, Self::Error> {
         match (args.bmc_mac_address, args.id) {
-            (Some(_), Some(_)) => Err(CarbideCliError::ChooseOneError("--bmc-mac-address", "--id")),
-            (None, None) => Err(CarbideCliError::RequireOneError(
-                "--bmc-mac-address",
-                "--id",
-            )),
+            (Some(_), Some(_)) => Err(CarbideCliError::ChooseOneError("bmc-mac-address", "--id")),
+            (None, None) => Err(CarbideCliError::RequireOneError("bmc-mac-address", "--id")),
             (None, Some(id)) => Ok(Self {
                 bmc_mac_address: String::new(),
                 id: Some(::rpc::common::Uuid {

--- a/crates/admin-cli/src/expected_machines/erase/args.rs
+++ b/crates/admin-cli/src/expected_machines/erase/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Erase every expected machine (requires explicit confirmation):
+    $ carbide-admin-cli expected-machine erase --confirm
+
+")]
 pub struct Args {
     #[clap(long, help = "Confirm that you want to erase all records.")]
     pub confirm: bool,

--- a/crates/admin-cli/src/expected_machines/mod.rs
+++ b/crates/admin-cli/src/expected_machines/mod.rs
@@ -45,10 +45,10 @@ pub enum Cmd {
     ///
     /// Examples:
     ///   # Update only SKU, preserve all other fields including metadata
-    ///   forge-admin-cli expected-machine patch --bmc-mac-address 1a:1b:1c:1d:1e:1f --sku-id new_sku
+    ///   carbide-admin-cli expected-machine patch --bmc-mac-address 1a:1b:1c:1d:1e:1f --sku-id new_sku
     ///
     ///   # Update only labels, preserve name and description
-    ///   forge-admin-cli expected-machine patch --bmc-mac-address 1a:1b:1c:1d:1e:1f \
+    ///   carbide-admin-cli expected-machine patch --bmc-mac-address 1a:1b:1c:1d:1e:1f \
     ///     --sku-id sku123 --label env:prod --label team:platform
     #[clap(verbatim_doc_comment)]
     Patch(patch::Args),
@@ -73,7 +73,7 @@ pub enum Cmd {
     ///    }
     ///
     /// Usage:
-    ///   forge-admin-cli expected-machine update --filename machine.json
+    ///   carbide-admin-cli expected-machine update --filename machine.json
     #[clap(verbatim_doc_comment)]
     Update(update::Args),
     /// Replace all entries in the expected machines table with the entries from an inputted json file.

--- a/crates/admin-cli/src/expected_machines/patch/args.rs
+++ b/crates/admin-cli/src/expected_machines/patch/args.rs
@@ -33,10 +33,10 @@ use crate::errors::CarbideCliError;
 ///
 /// Examples:
 ///   # Update only SKU, preserve all other fields including metadata
-///   forge-admin-cli expected-machine patch --bmc-mac-address 1a:1b:1c:1d:1e:1f --sku-id new_sku
+///   carbide-admin-cli expected-machine patch --bmc-mac-address 1a:1b:1c:1d:1e:1f --sku-id new_sku
 ///
 ///   # Update only labels, preserve name and description
-///   forge-admin-cli expected-machine patch --bmc-mac-address 1a:1b:1c:1d:1e:1f \
+///   carbide-admin-cli expected-machine patch --bmc-mac-address 1a:1b:1c:1d:1e:1f \
 ///     --sku-id sku123 --label env:prod --label team:platform
 #[derive(Parser, Debug, Serialize, Deserialize)]
 #[clap(verbatim_doc_comment)]
@@ -50,6 +50,26 @@ use crate::errors::CarbideCliError;
 "dpu_mode",
 "dpf_enabled",
 ])))]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Patch only the SKU of a machine, selected by BMC MAC address:
+    $ carbide-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 \
+    --sku-id DGX-H100-640GB
+
+Patch a machine selected by id:
+    $ carbide-admin-cli expected-machine patch --id 12345678-1234-5678-90ab-cdef01234567 \
+    --sku-id DGX-H100-640GB
+
+Rotate the BMC credentials (username and password must be set together):
+    $ carbide-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-username admin --bmc-password mynewpassword
+
+Change the per-host DPU mode:
+    $ carbide-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 \
+    --dpu-mode no-dpu
+
+")]
 pub struct Args {
     #[clap(short = 'a', long, help = "BMC MAC Address of the expected machine")]
     pub bmc_mac_address: Option<MacAddress>,

--- a/crates/admin-cli/src/expected_machines/replace_all/args.rs
+++ b/crates/admin-cli/src/expected_machines/replace_all/args.rs
@@ -45,6 +45,13 @@ use clap::Parser;
 ///    }
 #[derive(Parser, Debug)]
 #[clap(verbatim_doc_comment)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Replace the entire expected machines table from a JSON file:
+    $ carbide-admin-cli expected-machine replace-all --filename ./expected-machines.json
+
+")]
 pub struct Args {
     #[clap(short, long)]
     pub filename: String,

--- a/crates/admin-cli/src/expected_machines/show/args.rs
+++ b/crates/admin-cli/src/expected_machines/show/args.rs
@@ -22,6 +22,19 @@ use uuid::Uuid;
 use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all expected machines:
+    $ carbide-admin-cli expected-machine show
+
+Show one expected machine by BMC MAC address:
+    $ carbide-admin-cli expected-machine show 00:11:22:33:44:55
+
+Show one expected machine by id:
+    $ carbide-admin-cli expected-machine show --id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(
         default_value(None),

--- a/crates/admin-cli/src/expected_machines/update/args.rs
+++ b/crates/admin-cli/src/expected_machines/update/args.rs
@@ -38,9 +38,16 @@ use clap::Parser;
 ///    }
 ///
 /// Usage:
-///   forge-admin-cli expected-machine update --filename machine.json
+///   carbide-admin-cli expected-machine update --filename machine.json
 #[derive(Parser, Debug)]
 #[clap(verbatim_doc_comment)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Replace an expected machine record from a JSON file:
+    $ carbide-admin-cli expected-machine update --filename ./machine.json
+
+")]
 pub struct Args {
     #[clap(
         short,

--- a/crates/admin-cli/src/expected_power_shelf/add/args.rs
+++ b/crates/admin-cli/src/expected_power_shelf/add/args.rs
@@ -25,6 +25,24 @@ use serde::{Deserialize, Serialize};
 use crate::metadata::parse_rpc_labels;
 
 #[derive(Parser, Debug, Serialize, Deserialize)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add an expected power shelf with its BMC credentials and serial number:
+    $ carbide-admin-cli expected-power-shelf add --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-username admin --bmc-password mypassword --shelf-serial-number DGX-H100-640GB
+
+Add an expected power shelf and associate it with a rack:
+    $ carbide-admin-cli expected-power-shelf add --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-username admin --bmc-password mypassword --shelf-serial-number DGX-H100-640GB \
+    --rack_id 12345678-1234-5678-90ab-cdef01234567
+
+Add an expected power shelf with a BMC IP address and metadata name:
+    $ carbide-admin-cli expected-power-shelf add --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-username admin --bmc-password mypassword --shelf-serial-number DGX-H100-640GB \
+    --bmc-ip-address 192.0.2.20 --meta-name shelf-01
+
+")]
 pub struct Args {
     #[clap(
         short = 'a',

--- a/crates/admin-cli/src/expected_power_shelf/delete/args.rs
+++ b/crates/admin-cli/src/expected_power_shelf/delete/args.rs
@@ -22,6 +22,16 @@ use uuid::Uuid;
 use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete an expected power shelf by BMC MAC address:
+    $ carbide-admin-cli expected-power-shelf delete 00:11:22:33:44:55
+
+Delete an expected power shelf by ID:
+    $ carbide-admin-cli expected-power-shelf delete --id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "BMC MAC address of expected power shelf to delete.")]
     pub bmc_mac_address: Option<MacAddress>,

--- a/crates/admin-cli/src/expected_power_shelf/erase/args.rs
+++ b/crates/admin-cli/src/expected_power_shelf/erase/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Erase all expected power shelf records (requires explicit confirmation):
+    $ carbide-admin-cli expected-power-shelf erase --confirm
+
+")]
 pub struct Args {
     #[clap(long, help = "Confirm that you want to erase all records.")]
     pub confirm: bool,

--- a/crates/admin-cli/src/expected_power_shelf/replace_all/args.rs
+++ b/crates/admin-cli/src/expected_power_shelf/replace_all/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Replace all expected power shelves with the contents of a JSON file:
+    $ carbide-admin-cli expected-power-shelf replace-all --filename ./power-shelves.json
+
+")]
 pub struct Args {
     #[clap(short, long)]
     pub filename: String,

--- a/crates/admin-cli/src/expected_power_shelf/show/args.rs
+++ b/crates/admin-cli/src/expected_power_shelf/show/args.rs
@@ -22,6 +22,19 @@ use uuid::Uuid;
 use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all expected power shelves:
+    $ carbide-admin-cli expected-power-shelf show
+
+Show one expected power shelf by BMC MAC address:
+    $ carbide-admin-cli expected-power-shelf show 00:11:22:33:44:55
+
+Show one expected power shelf by ID:
+    $ carbide-admin-cli expected-power-shelf show --id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(
         default_value(None),

--- a/crates/admin-cli/src/expected_power_shelf/update/args.rs
+++ b/crates/admin-cli/src/expected_power_shelf/update/args.rs
@@ -26,6 +26,18 @@ use uuid::Uuid;
 use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug, Serialize, Deserialize)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Update an expected power shelf's BMC credentials, selecting it by MAC address:
+    $ carbide-admin-cli expected-power-shelf update --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-username admin --bmc-password mynewpassword
+
+Update an expected power shelf's serial number, selecting it by ID:
+    $ carbide-admin-cli expected-power-shelf update --id 12345678-1234-5678-90ab-cdef01234567 \
+    --shelf-serial-number DGX-H100-640GB
+
+")]
 #[clap(group(ArgGroup::new("group").required(true).multiple(true).args(&[
 "bmc_username",
 "bmc_password",

--- a/crates/admin-cli/src/expected_rack/add/args.rs
+++ b/crates/admin-cli/src/expected_rack/add/args.rs
@@ -22,6 +22,18 @@ use serde::{Deserialize, Serialize};
 use crate::metadata::parse_rpc_labels;
 
 #[derive(Parser, Debug, Serialize, Deserialize)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add an expected rack with its rack profile:
+    $ carbide-admin-cli expected-rack add 12345678-1234-5678-90ab-cdef01234567 \
+    abcdef01-2345-6789-abcd-ef0123456789
+
+Add an expected rack with a metadata name and a label:
+    $ carbide-admin-cli expected-rack add 12345678-1234-5678-90ab-cdef01234567 \
+    abcdef01-2345-6789-abcd-ef0123456789 --meta-name rack-01 --label DATACENTER:XYZ
+
+")]
 pub struct Args {
     #[clap(help = "Rack ID of the expected rack")]
     pub rack_id: RackId,

--- a/crates/admin-cli/src/expected_rack/delete/args.rs
+++ b/crates/admin-cli/src/expected_rack/delete/args.rs
@@ -19,6 +19,13 @@ use carbide_uuid::rack::RackId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete an expected rack by rack ID:
+    $ carbide-admin-cli expected-rack delete 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "Rack ID of expected rack to delete.")]
     pub rack_id: RackId,

--- a/crates/admin-cli/src/expected_rack/erase/args.rs
+++ b/crates/admin-cli/src/expected_rack/erase/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Erase all expected rack records (requires explicit confirmation):
+    $ carbide-admin-cli expected-rack erase --confirm
+
+")]
 pub struct Args {
     #[clap(long, help = "Confirm that you want to erase all records.")]
     pub confirm: bool,

--- a/crates/admin-cli/src/expected_rack/replace_all/args.rs
+++ b/crates/admin-cli/src/expected_rack/replace_all/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Replace all expected racks with the contents of a JSON file:
+    $ carbide-admin-cli expected-rack replace-all --filename ./racks.json
+
+")]
 pub struct Args {
     #[clap(short, long)]
     pub filename: String,

--- a/crates/admin-cli/src/expected_rack/show/args.rs
+++ b/crates/admin-cli/src/expected_rack/show/args.rs
@@ -19,6 +19,16 @@ use carbide_uuid::rack::RackId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all expected racks:
+    $ carbide-admin-cli expected-rack show
+
+Show one expected rack by rack ID:
+    $ carbide-admin-cli expected-rack show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(
         default_value(None),

--- a/crates/admin-cli/src/expected_rack/update/args.rs
+++ b/crates/admin-cli/src/expected_rack/update/args.rs
@@ -22,6 +22,18 @@ use serde::{Deserialize, Serialize};
 use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug, Serialize, Deserialize)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Update an expected rack's rack profile:
+    $ carbide-admin-cli expected-rack update 12345678-1234-5678-90ab-cdef01234567 \
+    --rack-profile-id abcdef01-2345-6789-abcd-ef0123456789
+
+Update an expected rack's metadata name:
+    $ carbide-admin-cli expected-rack update 12345678-1234-5678-90ab-cdef01234567 \
+    --rack-profile-id abcdef01-2345-6789-abcd-ef0123456789 --meta-name rack-01
+
+")]
 pub struct Args {
     #[clap(help = "Rack ID of the expected rack")]
     pub rack_id: RackId,

--- a/crates/admin-cli/src/expected_switch/add/args.rs
+++ b/crates/admin-cli/src/expected_switch/add/args.rs
@@ -25,6 +25,30 @@ use serde::{Deserialize, Serialize};
 use crate::metadata::parse_rpc_labels;
 
 #[derive(Parser, Debug, Serialize, Deserialize)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add an expected switch with its BMC credentials and serial number:
+    $ carbide-admin-cli expected-switch add --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-username admin --bmc-password mypassword --switch-serial-number DGX-H100-640GB
+
+Add an expected switch and associate it with a rack:
+    $ carbide-admin-cli expected-switch add --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-username admin --bmc-password mypassword --switch-serial-number DGX-H100-640GB \
+    --rack_id 12345678-1234-5678-90ab-cdef01234567
+
+Add an expected switch with NVOS credentials and a static NVOS IP:
+    $ carbide-admin-cli expected-switch add --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-username admin --bmc-password mypassword --switch-serial-number DGX-H100-640GB \
+    --nvos-mac-address aa:bb:cc:dd:ee:ff --nvos-username admin --nvos-password mypassword \
+    --nvos-ip-address 192.0.2.10
+
+Add an expected switch with metadata name and a label:
+    $ carbide-admin-cli expected-switch add --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-username admin --bmc-password mypassword --switch-serial-number DGX-H100-640GB \
+    --meta-name spine-01 --label DATACENTER:XYZ
+
+")]
 pub struct Args {
     #[clap(short = 'a', long, help = "BMC MAC Address of the expected switch")]
     pub bmc_mac_address: MacAddress,

--- a/crates/admin-cli/src/expected_switch/delete/args.rs
+++ b/crates/admin-cli/src/expected_switch/delete/args.rs
@@ -22,6 +22,16 @@ use uuid::Uuid;
 use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete an expected switch by BMC MAC address:
+    $ carbide-admin-cli expected-switch delete 00:11:22:33:44:55
+
+Delete an expected switch by ID:
+    $ carbide-admin-cli expected-switch delete --id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "BMC MAC address of expected switch to delete.")]
     pub bmc_mac_address: Option<MacAddress>,

--- a/crates/admin-cli/src/expected_switch/erase/args.rs
+++ b/crates/admin-cli/src/expected_switch/erase/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Erase all expected switch records (requires explicit confirmation):
+    $ carbide-admin-cli expected-switch erase --confirm
+
+")]
 pub struct Args {
     #[clap(long, help = "Confirm that you want to erase all records.")]
     pub confirm: bool,

--- a/crates/admin-cli/src/expected_switch/replace_all/args.rs
+++ b/crates/admin-cli/src/expected_switch/replace_all/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Replace all expected switches with the contents of a JSON file:
+    $ carbide-admin-cli expected-switch replace-all --filename ./switches.json
+
+")]
 pub struct Args {
     #[clap(short, long)]
     pub filename: String,

--- a/crates/admin-cli/src/expected_switch/show/args.rs
+++ b/crates/admin-cli/src/expected_switch/show/args.rs
@@ -22,6 +22,19 @@ use uuid::Uuid;
 use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all expected switches:
+    $ carbide-admin-cli expected-switch show
+
+Show one expected switch by BMC MAC address:
+    $ carbide-admin-cli expected-switch show 00:11:22:33:44:55
+
+Show one expected switch by ID:
+    $ carbide-admin-cli expected-switch show --id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(
         default_value(None),

--- a/crates/admin-cli/src/expected_switch/update/args.rs
+++ b/crates/admin-cli/src/expected_switch/update/args.rs
@@ -26,6 +26,22 @@ use uuid::Uuid;
 use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug, Serialize, Deserialize)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Update an expected switch's BMC credentials, selecting it by MAC address:
+    $ carbide-admin-cli expected-switch update --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-username admin --bmc-password mynewpassword
+
+Update an expected switch's serial number, selecting it by ID:
+    $ carbide-admin-cli expected-switch update --id 12345678-1234-5678-90ab-cdef01234567 \
+    --switch-serial-number DGX-H100-640GB
+
+Update an expected switch's NVOS credentials:
+    $ carbide-admin-cli expected-switch update --bmc-mac-address 00:11:22:33:44:55 \
+    --nvos-username admin --nvos-password mynewpassword
+
+")]
 #[clap(group(ArgGroup::new("group").required(true).multiple(true).args(&[
 "bmc_username",
 "bmc_password",

--- a/crates/admin-cli/src/extension_service/create/args.rs
+++ b/crates/admin-cli/src/extension_service/create/args.rs
@@ -22,6 +22,28 @@ use super::super::common::ExtensionServiceType;
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create a Kubernetes-pod extension service:
+    $ carbide-admin-cli extension-service create --name my-service --type kubernetes-pod \
+    --data '{\"image\":\"my-registry/my-service:1.0\"}'
+
+Create with an explicit service ID and a description:
+    $ carbide-admin-cli extension-service create --id 12345678-1234-5678-90ab-cdef01234567 \
+    --name my-service --type kubernetes-pod --data '{\"image\":\"my-registry/my-service:1.0\"}' \
+    --description \"Front-end telemetry agent\"
+
+Create scoped to a tenant organization:
+    $ carbide-admin-cli extension-service create --name my-service --type kubernetes-pod \
+    --data '{\"image\":\"my-registry/my-service:1.0\"}' --tenant-organization-id fds34511233a
+
+Create with private-registry pull credentials:
+    $ carbide-admin-cli extension-service create --name my-service --type kubernetes-pod \
+    --data '{\"image\":\"my-registry/my-service:1.0\"}' --registry-url my-registry.example.com \
+    --username admin --password mypassword
+
+")]
 pub struct Args {
     #[clap(
         short = 'i',

--- a/crates/admin-cli/src/extension_service/delete/args.rs
+++ b/crates/admin-cli/src/extension_service/delete/args.rs
@@ -18,6 +18,17 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete an entire extension service (all versions):
+    $ carbide-admin-cli extension-service delete --id 12345678-1234-5678-90ab-cdef01234567
+
+Delete only specific versions, keeping the rest:
+    $ carbide-admin-cli extension-service delete --id 12345678-1234-5678-90ab-cdef01234567 \
+    --versions 1.0,1.1
+
+")]
 pub struct Args {
     #[clap(short = 'i', long = "id", help = "The extension service ID to delete")]
     pub service_id: String,

--- a/crates/admin-cli/src/extension_service/get_version/args.rs
+++ b/crates/admin-cli/src/extension_service/get_version/args.rs
@@ -18,6 +18,17 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Get version info for all versions of a service:
+    $ carbide-admin-cli extension-service get-version --service-id 12345678-1234-5678-90ab-cdef01234567
+
+Get version info for specific versions:
+    $ carbide-admin-cli extension-service get-version --service-id 12345678-1234-5678-90ab-cdef01234567 \
+    --versions 1.0,1.1
+
+")]
 pub struct Args {
     #[clap(short = 'i', long, help = "The extension service ID")]
     pub service_id: String,

--- a/crates/admin-cli/src/extension_service/show/args.rs
+++ b/crates/admin-cli/src/extension_service/show/args.rs
@@ -20,6 +20,25 @@ use clap::Parser;
 use super::super::common::ExtensionServiceType;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show all extension services:
+    $ carbide-admin-cli extension-service show
+
+Show one extension service by ID:
+    $ carbide-admin-cli extension-service show --id 12345678-1234-5678-90ab-cdef01234567
+
+Filter by service type:
+    $ carbide-admin-cli extension-service show --type kubernetes-pod
+
+Filter by service name:
+    $ carbide-admin-cli extension-service show --name my-service
+
+Filter by tenant organization ID:
+    $ carbide-admin-cli extension-service show --tenant-organization-id fds34511233a
+
+")]
 pub struct Args {
     #[clap(
         short = 'i',

--- a/crates/admin-cli/src/extension_service/show_instances/args.rs
+++ b/crates/admin-cli/src/extension_service/show_instances/args.rs
@@ -18,6 +18,17 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show all instances using an extension service:
+    $ carbide-admin-cli extension-service show-instances --service-id 12345678-1234-5678-90ab-cdef01234567
+
+Show instances using a specific version of the service:
+    $ carbide-admin-cli extension-service show-instances --service-id 12345678-1234-5678-90ab-cdef01234567 \
+    --version 1.0
+
+")]
 pub struct Args {
     #[clap(short = 'i', long, help = "The extension service ID")]
     pub service_id: String,

--- a/crates/admin-cli/src/extension_service/update/args.rs
+++ b/crates/admin-cli/src/extension_service/update/args.rs
@@ -21,6 +21,28 @@ use clap::Parser;
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Update the data of an existing service:
+    $ carbide-admin-cli extension-service update --id 12345678-1234-5678-90ab-cdef01234567 \
+    --data '{\"image\":\"my-registry/my-service:2.0\"}'
+
+Rename a service and update its description:
+    $ carbide-admin-cli extension-service update --id 12345678-1234-5678-90ab-cdef01234567 \
+    --name my-renamed-service --description \"Updated telemetry agent\" \
+    --data '{\"image\":\"my-registry/my-service:2.0\"}'
+
+Rotate the registry pull credentials:
+    $ carbide-admin-cli extension-service update --id 12345678-1234-5678-90ab-cdef01234567 \
+    --data '{\"image\":\"my-registry/my-service:2.0\"}' --registry-url my-registry.example.com \
+    --username admin --password mynewpassword
+
+Update only if the version counter matches (optimistic concurrency):
+    $ carbide-admin-cli extension-service update --id 12345678-1234-5678-90ab-cdef01234567 \
+    --data '{\"image\":\"my-registry/my-service:2.0\"}' --if-version-ctr-match 3
+
+")]
 pub struct Args {
     #[clap(short = 'i', long = "id", help = "The extension service ID to update")]
     pub service_id: String,

--- a/crates/admin-cli/src/firmware/show/args.rs
+++ b/crates/admin-cli/src/firmware/show/args.rs
@@ -18,4 +18,11 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show all available firmware:
+    $ carbide-admin-cli firmware show
+
+")]
 pub struct Args {}

--- a/crates/admin-cli/src/generate_docs/args.rs
+++ b/crates/admin-cli/src/generate_docs/args.rs
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Regenerate the CLI reference in place (the default docs/cli):
+    $ carbide-admin-cli generate-cli-docs
+
+Write the generated pages to a different directory:
+    $ carbide-admin-cli generate-cli-docs --out-dir /tmp/cli-docs
+
+")]
+pub struct Cmd {
+    /// Directory to write the generated markdown into. Created if it does not
+    /// exist. One `commands/<command>.md` page is written per top-level
+    /// command, plus the four domain index pages
+    /// (`hardware.md`/`network.md`/`tenant.md`/`admin.md`). Hand-authored
+    /// pages (`README.md`, `workflows.md`, `setup.md`, …) are left untouched.
+    #[clap(long, default_value = "docs/cli")]
+    pub out_dir: PathBuf,
+}

--- a/crates/admin-cli/src/generate_docs/cmds.rs
+++ b/crates/admin-cli/src/generate_docs/cmds.rs
@@ -1,0 +1,348 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Generates the `docs/cli` markdown reference from the live clap command tree.
+//!
+//! The per-command pages are derived from the same man pages the
+//! `generate-man` subcommand produces: we render every command's roff man page
+//! with `clap_mangen`, convert each to GitHub-flavored markdown with `pandoc`,
+//! and reorganize them into one directory per top-level command. Using the man
+//! pages (rather than hand-walking clap's `about`/`after_long_help`) is what
+//! gives each page its full SYNOPSIS and per-flag OPTIONS detail.
+//!
+//! Layout: `commands/<command>/<command>.md` is the base page for a top-level
+//! command, and each (flattened) descendant gets `commands/<command>/<command>-<sub>.md`
+//! beside it, cross-linked via a breadcrumb and a Subcommands table. The four
+//! domain index pages (Hardware/Network/Tenant/Admin) are written from
+//! [`crate::cfg::cli_options::domain_for_command`]. Hand-authored pages
+//! (`README.md`, `workflows.md`, `setup.md`, `rest-cli-parity.md`) are not
+//! touched — operator workflows are editorial and cannot be machine-generated.
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+use clap::{Command, CommandFactory};
+
+use crate::cfg::cli_options::{CliDomain, CliOptions, domain_for_command};
+use crate::errors::{CarbideCliError, CarbideCliResult};
+
+const BIN: &str = "carbide-admin-cli";
+const DOMAINS: [CliDomain; 4] = [
+    CliDomain::Hardware,
+    CliDomain::Network,
+    CliDomain::Tenant,
+    CliDomain::Admin,
+];
+
+pub fn generate(out_dir: &Path) -> CarbideCliResult<()> {
+    let root = CliOptions::command().name(BIN);
+
+    // Render every command's roff man page into a scratch directory. clap_mangen
+    // names each file by the full command path joined with '-' (e.g.
+    // `carbide-admin-cli-vpc-show.1`), which we reconstruct per node below.
+    let man_dir = std::env::temp_dir().join("carbide-admin-cli-cli-docs-man");
+    let _ = std::fs::remove_dir_all(&man_dir);
+    std::fs::create_dir_all(&man_dir)?;
+    clap_mangen::generate_to(root.clone(), &man_dir)?;
+
+    // One directory per top-level command, holding that command's page plus a
+    // page for each (flattened) descendant. Rebuilt from scratch so a renamed or
+    // removed command can't leave a stale page behind.
+    let commands_dir = out_dir.join("commands");
+    let _ = std::fs::remove_dir_all(&commands_dir);
+    std::fs::create_dir_all(&commands_dir)?;
+
+    // (name, one-line description, domain) for every visible top-level command,
+    // used to build the domain index pages.
+    let mut top_level: Vec<(String, String, CliDomain)> = Vec::new();
+
+    for sub in root.get_subcommands() {
+        if sub.is_hide_set() || sub.get_name() == "help" {
+            continue;
+        }
+        let name = sub.get_name().to_string();
+        let about = first_line(&styled(sub.get_about()));
+        let domain = domain_for_command(&name).ok_or_else(|| {
+            CarbideCliError::GenericError(format!(
+                "command `{name}` has no CLI-docs domain; add it to \
+                 crates/admin-cli/cli_domains.yaml"
+            ))
+        })?;
+
+        let dir = commands_dir.join(&name);
+        std::fs::create_dir_all(&dir)?;
+        render_node(
+            sub,
+            vec![BIN.to_string(), name.clone()],
+            domain,
+            &man_dir,
+            &dir,
+        )?;
+
+        top_level.push((name, about, domain));
+    }
+
+    top_level.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for domain in DOMAINS {
+        let rows: Vec<&(String, String, CliDomain)> =
+            top_level.iter().filter(|c| c.2 == domain).collect();
+        std::fs::write(
+            out_dir.join(format!("{}.md", slug(domain))),
+            render_domain_index(domain, &rows),
+        )?;
+    }
+
+    let _ = std::fs::remove_dir_all(&man_dir);
+    Ok(())
+}
+
+/// Writes the markdown page for `cmd` (whose full path from the binary is
+/// `path`, e.g. `["carbide-admin-cli", "vpc", "show"]`) and recurses into its
+/// visible subcommands. Every page for one top-level command lives flat in
+/// `dir`, named by the path below the binary joined with '-' (so `vpc show`
+/// becomes `vpc-show.md`).
+fn render_node(
+    cmd: &Command,
+    path: Vec<String>,
+    domain: CliDomain,
+    man_dir: &Path,
+    dir: &Path,
+) -> CarbideCliResult<()> {
+    // The man page body, minus the sections we re-render ourselves: SUBCOMMANDS
+    // (we emit a linked table) and EXTRA (the after_long_help examples, which
+    // roff mangles — we re-render them from the clap command instead).
+    let man_file = man_dir.join(format!("{}.1", path.join("-")));
+    let body = strip_sections(&man_to_markdown(&man_file)?, &["SUBCOMMANDS", "EXTRA"]);
+
+    let children: Vec<&Command> = cmd
+        .get_subcommands()
+        .filter(|c| !c.is_hide_set() && c.get_name() != "help")
+        .collect();
+
+    std::fs::write(
+        dir.join(format!("{}.md", stem(&path))),
+        render_command_page(cmd, &path, domain, &body, &children),
+    )?;
+
+    for child in &children {
+        let mut child_path = path.clone();
+        child_path.push(child.get_name().to_string());
+        render_node(child, child_path, domain, man_dir, dir)?;
+    }
+    Ok(())
+}
+
+fn render_command_page(
+    cmd: &Command,
+    path: &[String],
+    domain: CliDomain,
+    body: &str,
+    children: &[&Command],
+) -> String {
+    let mut s = String::new();
+    let _ = writeln!(s, "# `{}`\n", path.join(" "));
+    let _ = writeln!(s, "{}\n", breadcrumb(path, domain));
+
+    // SYNOPSIS / DESCRIPTION / OPTIONS lifted from the man page.
+    let _ = writeln!(s, "{}\n", body.trim_end());
+
+    if let Some(examples) = example_commands(cmd) {
+        let _ = writeln!(s, "## Examples\n");
+        let _ = writeln!(s, "```sh\n{examples}\n```\n");
+    }
+
+    if !children.is_empty() {
+        let _ = writeln!(s, "## Subcommands\n");
+        let _ = writeln!(s, "| Subcommand | Description |");
+        let _ = writeln!(s, "|---|---|");
+        // Children live beside this page; their stem extends this command's.
+        let prefix = stem(path);
+        for child in children {
+            let child_name = child.get_name();
+            let _ = writeln!(
+                s,
+                "| [`{child_name}`](./{prefix}-{child_name}.md) | {} |",
+                first_line(&styled(child.get_about()))
+            );
+        }
+        let _ = writeln!(s);
+    }
+
+    let _ = writeln!(s, "---\n");
+    let _ = writeln!(
+        s,
+        "**See also:** [{} commands](../../{}.md) · [CLI reference index](../../README.md)",
+        domain.title(),
+        slug(domain),
+    );
+    s
+}
+
+fn render_domain_index(domain: CliDomain, rows: &[&(String, String, CliDomain)]) -> String {
+    let mut s = String::new();
+    let _ = writeln!(s, "# CLI reference — {}\n", domain.title());
+    let _ = writeln!(s, "{}\n", intro(domain));
+    let _ = writeln!(
+        s,
+        "For global flags and setup, see [the overview](./README.md) and \
+         [`setup.md`](./setup.md). For task-oriented sequences see \
+         [`workflows.md`](./workflows.md).\n"
+    );
+    let _ = writeln!(s, "| Command | Description |");
+    let _ = writeln!(s, "|---|---|");
+    for (name, about, _) in rows {
+        let about = if about.is_empty() {
+            String::new()
+        } else if about.ends_with('.') {
+            about.clone()
+        } else {
+            format!("{about}.")
+        };
+        let _ = writeln!(s, "| [`{name}`](./commands/{name}/{name}.md) | {about} |");
+    }
+    s
+}
+
+// ---- helpers ----
+
+/// The page stem for a command path: the path below the binary joined with '-'
+/// (`["carbide-admin-cli", "vpc", "show"]` -> `"vpc-show"`). Both the file name
+/// and the in-directory links use this.
+fn stem(path: &[String]) -> String {
+    path[1..].join("-")
+}
+
+/// A one-line navigation trail: the domain index, then each ancestor command as
+/// a link, then the current command in bold.
+fn breadcrumb(path: &[String], domain: CliDomain) -> String {
+    let mut parts = vec![format!(
+        "[{} commands](../../{}.md)",
+        domain.title(),
+        slug(domain)
+    )];
+    // Ancestors are everything between the binary and this command; each links
+    // to its own page (which shares this directory).
+    for depth in 2..path.len() {
+        let ancestor = &path[depth - 1];
+        let ancestor_stem = path[1..depth].join("-");
+        parts.push(format!("[{ancestor}](./{ancestor_stem}.md)"));
+    }
+    parts.push(format!(
+        "**{}**",
+        path.last()
+            .expect("a command path always has at least the binary")
+    ));
+    format!("_{}_", parts.join(" › "))
+}
+
+/// Removes the named top-level (`## `) sections from pandoc's markdown, heading
+/// included, up to the next `## ` heading or end of document. Matching is
+/// case-insensitive on the section title (man sections are single words like
+/// `SUBCOMMANDS`).
+fn strip_sections(md: &str, names: &[&str]) -> String {
+    let mut out = String::new();
+    let mut skipping = false;
+    for line in md.lines() {
+        if let Some(heading) = line.strip_prefix("## ") {
+            skipping = names.iter().any(|n| heading.trim().eq_ignore_ascii_case(n));
+            if skipping {
+                continue;
+            }
+        }
+        if !skipping {
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// Converts a roff man page to GitHub-flavored markdown via pandoc, demoting the
+/// man page's `# NAME`/`# OPTIONS`/… sections to `## ` so each generated page
+/// can own the `# ` title (the full command invocation).
+fn man_to_markdown(man_file: &Path) -> CarbideCliResult<String> {
+    let mut pandoc = pandoc::new();
+    pandoc.add_input(man_file);
+    pandoc.set_input_format(pandoc::InputFormat::Other("man".to_string()), Vec::new());
+    pandoc.set_output_format(pandoc::OutputFormat::Other("gfm".to_string()), Vec::new());
+    pandoc.add_option(pandoc::PandocOption::ShiftHeadingLevelBy(1));
+    pandoc.set_output(pandoc::OutputKind::Pipe);
+
+    match pandoc.execute() {
+        Ok(pandoc::PandocOutput::ToBuffer(markdown)) => Ok(markdown),
+        Ok(_) => Err(CarbideCliError::GenericError(format!(
+            "pandoc returned non-text output converting man page {}",
+            man_file.display()
+        ))),
+        Err(err) => Err(CarbideCliError::GenericError(format!(
+            "while converting man page {} to markdown with pandoc: {err}",
+            man_file.display()
+        ))),
+    }
+}
+
+// A clap `StyledStr` rendered to plain text.
+fn styled(s: Option<&clap::builder::StyledStr>) -> String {
+    s.map(|s| s.to_string()).unwrap_or_default()
+}
+
+fn first_line(s: &str) -> String {
+    s.lines().next().unwrap_or("").trim().to_string()
+}
+
+// The example command lines from a command's `after_long_help` EXAMPLES block:
+// the lines beginning with the `$ ` shell prompt, with the prompt stripped.
+fn example_commands(cmd: &Command) -> Option<String> {
+    let help = cmd.get_after_long_help()?.to_string();
+    let cmds: Vec<String> = help
+        .lines()
+        .map(str::trim)
+        .filter_map(|l| l.strip_prefix("$ "))
+        .map(str::to_string)
+        .collect();
+    (!cmds.is_empty()).then(|| cmds.join("\n"))
+}
+
+fn slug(d: CliDomain) -> &'static str {
+    match d {
+        CliDomain::Hardware => "hardware",
+        CliDomain::Network => "network",
+        CliDomain::Tenant => "tenant",
+        CliDomain::Admin => "admin",
+    }
+}
+
+fn intro(d: CliDomain) -> &'static str {
+    match d {
+        CliDomain::Hardware => {
+            "Live hardware and lifecycle operations: machines, BMC, DPUs, firmware \
+             and component lifecycle, attestation, low-level passthrough (Redfish, \
+             RMS, MLX), and operator utilities."
+        }
+        CliDomain::Network => {
+            "VPCs, peerings, prefixes, network segments and devices, security groups, \
+             IB/NVLink fabric partitions, IP/domain lookups, and resource pools."
+        }
+        CliDomain::Tenant => {
+            "Tenants and tenant keysets, instances and instance types, compute \
+             allocations, the declarative `expected-*` inventory, operating systems \
+             and OS images, iPXE templates, extension services, and the site explorer."
+        }
+        CliDomain::Admin => "CLI and system utilities.",
+    }
+}

--- a/crates/admin-cli/src/generate_docs/mod.rs
+++ b/crates/admin-cli/src/generate_docs/mod.rs
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmds;
+
+pub use args::Cmd;
+
+use crate::cfg::dispatch::Dispatch;
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+
+impl Run for Cmd {
+    async fn run(self, _ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmds::generate(&self.out_dir)
+    }
+}
+
+impl Dispatch for Cmd {
+    async fn dispatch(self, mut ctx: RuntimeContext) -> CarbideCliResult<()> {
+        self.run(&mut ctx).await
+    }
+}

--- a/crates/admin-cli/src/generate_man/args.rs
+++ b/crates/admin-cli/src/generate_man/args.rs
@@ -20,6 +20,16 @@ use std::path::PathBuf;
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Generate man pages into the default ./man directory:
+    $ carbide-admin-cli generate-man
+
+Generate man pages into a specific directory:
+    $ carbide-admin-cli generate-man --out-dir /usr/local/share/man/man1
+
+")]
 pub struct Cmd {
     /// Directory to write the generated man pages into. Created if it does
     /// not exist. `clap_mangen` writes one `<command>.1` file per command

--- a/crates/admin-cli/src/generate_shell_complete/args.rs
+++ b/crates/admin-cli/src/generate_shell_complete/args.rs
@@ -18,6 +18,19 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Load bash completions into the current shell:
+    $ source <(carbide-admin-cli generate-shell-complete bash)
+
+Write zsh completions to a file on the fpath:
+    $ carbide-admin-cli generate-shell-complete zsh > ~/.zfunc/_carbide-admin-cli
+
+Generate fish completions:
+    $ carbide-admin-cli generate-shell-complete fish
+
+")]
 pub struct Cmd {
     #[clap(subcommand)]
     pub shell: Shell,

--- a/crates/admin-cli/src/generate_shell_complete/cmds.rs
+++ b/crates/admin-cli/src/generate_shell_complete/cmds.rs
@@ -31,19 +31,19 @@ pub fn generate(shell: Shell) -> CarbideCliResult<()> {
             clap_complete::generate(
                 clap_complete::shells::Bash,
                 &mut cmd,
-                "forge-admin-cli",
+                "carbide-admin-cli",
                 &mut io::stdout(),
             );
             // Make completion work for alias `fa`
             io::stdout().write_all(
-                b"complete -F _forge-admin-cli -o nosort -o bashdefault -o default fa\n",
+                b"complete -F _carbide-admin-cli -o nosort -o bashdefault -o default fa\n",
             )?;
         }
         Shell::Fish => {
             clap_complete::generate(
                 clap_complete::shells::Fish,
                 &mut cmd,
-                "forge-admin-cli",
+                "carbide-admin-cli",
                 &mut io::stdout(),
             );
         }
@@ -51,7 +51,7 @@ pub fn generate(shell: Shell) -> CarbideCliResult<()> {
             clap_complete::generate(
                 clap_complete::shells::Zsh,
                 &mut cmd,
-                "forge-admin-cli",
+                "carbide-admin-cli",
                 &mut io::stdout(),
             );
         }

--- a/crates/admin-cli/src/host/clear_uefi_password/args.rs
+++ b/crates/admin-cli/src/host/clear_uefi_password/args.rs
@@ -24,6 +24,16 @@ use crate::machine::MachineQuery;
 // specific newtype to allow sharing of MachineQuery, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Clear the UEFI password for a host by machine ID:
+    $ carbide-admin-cli host clear-uefi-password --query 12345678-1234-5678-90ab-cdef01234567
+
+Clear the UEFI password for a host selected by MAC address:
+    $ carbide-admin-cli host clear-uefi-password --query 00:11:22:33:44:55
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: MachineQuery,

--- a/crates/admin-cli/src/host/generate_host_uefi_password/args.rs
+++ b/crates/admin-cli/src/host/generate_host_uefi_password/args.rs
@@ -18,4 +18,11 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Generate a site-default host UEFI password to store in Vault:
+    $ carbide-admin-cli host generate-host-uefi-password
+
+")]
 pub struct Args {}

--- a/crates/admin-cli/src/host/reprovision/args.rs
+++ b/crates/admin-cli/src/host/reprovision/args.rs
@@ -21,6 +21,19 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Set a host into reprovisioning mode:
+    $ carbide-admin-cli host reprovision set --id 12345678-1234-5678-90ab-cdef01234567
+
+Clear reprovisioning mode for a host:
+    $ carbide-admin-cli host reprovision clear --id 12345678-1234-5678-90ab-cdef01234567
+
+List all hosts pending reprovisioning:
+    $ carbide-admin-cli host reprovision list
+
+")]
 pub enum Args {
     #[clap(about = "Set the host in reprovisioning mode.")]
     Set(ReprovisionSet),
@@ -34,6 +47,21 @@ pub enum Args {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Set a host into reprovisioning mode:
+    $ carbide-admin-cli host reprovision set --id 12345678-1234-5678-90ab-cdef01234567
+
+Set into reprovisioning mode and update firmware:
+    $ carbide-admin-cli host reprovision set --id 12345678-1234-5678-90ab-cdef01234567 \
+    --update-firmware
+
+Set into reprovisioning mode and raise a health alert with a message:
+    $ carbide-admin-cli host reprovision set --id 12345678-1234-5678-90ab-cdef01234567 \
+    --update-message \"Quarterly firmware refresh\"
+
+")]
 pub struct ReprovisionSet {
     #[clap(short, long, help = "Machine ID for which reprovisioning is needed.")]
     pub id: MachineId,
@@ -60,6 +88,17 @@ impl From<&ReprovisionSet> for HostReprovisioningRequest {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Clear reprovisioning mode for a host:
+    $ carbide-admin-cli host reprovision clear --id 12345678-1234-5678-90ab-cdef01234567
+
+Clear reprovisioning mode and update firmware:
+    $ carbide-admin-cli host reprovision clear --id 12345678-1234-5678-90ab-cdef01234567 \
+    --update-firmware
+
+")]
 pub struct ReprovisionClear {
     #[clap(
         short,
@@ -83,6 +122,14 @@ impl From<ReprovisionClear> for HostReprovisioningRequest {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Mark manual firmware upgrade complete for a host:
+    $ carbide-admin-cli host reprovision mark-manual-upgrade-complete \
+    --id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct ManualFirmwareUpgradeComplete {
     #[clap(
         short,

--- a/crates/admin-cli/src/host/set_uefi_password/args.rs
+++ b/crates/admin-cli/src/host/set_uefi_password/args.rs
@@ -24,6 +24,16 @@ use crate::machine::MachineQuery;
 // specific newtype to allow sharing of MachineQuery, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Set the UEFI password for a host by machine ID:
+    $ carbide-admin-cli host set-uefi-password --query 12345678-1234-5678-90ab-cdef01234567
+
+Set the UEFI password for a host selected by MAC address:
+    $ carbide-admin-cli host set-uefi-password --query 00:11:22:33:44:55
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: MachineQuery,

--- a/crates/admin-cli/src/ib_partition/show/args.rs
+++ b/crates/admin-cli/src/ib_partition/show/args.rs
@@ -19,6 +19,22 @@ use carbide_uuid::infiniband::IBPartitionId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all InfiniBand partitions:
+    $ carbide-admin-cli ib-partition show
+
+Show one InfiniBand partition by ID:
+    $ carbide-admin-cli ib-partition show 12345678-1234-5678-90ab-cdef01234567
+
+List partitions for one tenant:
+    $ carbide-admin-cli ib-partition show --tenant-org-id fds34511233a
+
+Find a partition by name:
+    $ carbide-admin-cli ib-partition show --name my-partition
+
+")]
 pub struct Args {
     #[clap(
         default_value(None),

--- a/crates/admin-cli/src/instance/allocate/args.rs
+++ b/crates/admin-cli/src/instance/allocate/args.rs
@@ -22,6 +22,36 @@ use rpc::forge::{InstanceOperatingSystemConfig, InstanceSpxConfig};
 
 #[derive(Parser, Debug)]
 #[clap(group(ArgGroup::new("selector").required(true).args(&["subnet", "vpc_prefix_id"])))]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Allocate one instance onto a VPC prefix:
+    $ carbide-admin-cli instance allocate --prefix-name eth0 \
+    --vpc-prefix-id 12345678-1234-5678-90ab-cdef01234567
+
+Allocate one instance onto a subnet:
+    $ carbide-admin-cli instance allocate --prefix-name eth0 --subnet 192.0.2.0/24
+
+Allocate several instances at once:
+    $ carbide-admin-cli instance allocate --number 4 --prefix-name eth0 \
+    --vpc-prefix-id 12345678-1234-5678-90ab-cdef01234567
+
+Allocate transactionally (all-or-nothing for --number > 1):
+    $ carbide-admin-cli instance allocate --number 4 --prefix-name eth0 \
+    --vpc-prefix-id 12345678-1234-5678-90ab-cdef01234567 --transactional
+
+Allocate onto specific machines:
+    $ carbide-admin-cli instance allocate --prefix-name eth0 \
+    --vpc-prefix-id 12345678-1234-5678-90ab-cdef01234567 \
+    --machine-id 12345678-1234-5678-90ab-cdef01234567
+
+Allocate with an expected instance type and a network security group:
+    $ carbide-admin-cli instance allocate --prefix-name eth0 \
+    --vpc-prefix-id 12345678-1234-5678-90ab-cdef01234567 \
+    --instance-type-id abcdef01-2345-6789-abcd-ef0123456789 \
+    --network-security-group-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(short, long)]
     pub number: Option<u16>,

--- a/crates/admin-cli/src/instance/reboot/args.rs
+++ b/crates/admin-cli/src/instance/reboot/args.rs
@@ -19,6 +19,21 @@ use carbide_uuid::instance::InstanceId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Reboot an instance:
+    $ carbide-admin-cli instance reboot --instance 12345678-1234-5678-90ab-cdef01234567
+
+Reboot and apply any pending firmware updates:
+    $ carbide-admin-cli instance reboot --instance 12345678-1234-5678-90ab-cdef01234567 \
+    --apply-updates-on-reboot
+
+Reboot into the custom PXE flow:
+    $ carbide-admin-cli instance reboot --instance 12345678-1234-5678-90ab-cdef01234567 \
+    --custom-pxe
+
+")]
 pub struct Args {
     #[clap(short, long)]
     pub instance: InstanceId,

--- a/crates/admin-cli/src/instance/release/args.rs
+++ b/crates/admin-cli/src/instance/release/args.rs
@@ -23,6 +23,19 @@ use clap::{ArgGroup, Parser};
         ArgGroup::new("release_instance")
         .required(true)
         .args(&["instance", "machine", "label_key"])))]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Release an instance by id:
+    $ carbide-admin-cli instance release --instance 12345678-1234-5678-90ab-cdef01234567
+
+Release the instance on a machine:
+    $ carbide-admin-cli instance release --machine 12345678-1234-5678-90ab-cdef01234567
+
+Release every instance matching a label:
+    $ carbide-admin-cli instance release --label-key role --label-value training
+
+")]
 pub struct Args {
     #[clap(short, long)]
     pub instance: Option<String>,

--- a/crates/admin-cli/src/instance/show/args.rs
+++ b/crates/admin-cli/src/instance/show/args.rs
@@ -24,6 +24,28 @@ use clap::Parser;
 // TODO: Possibly add the ability to filter by a list of tenant
 // org IDs and/or VPC IDs.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all instances:
+    $ carbide-admin-cli instance show
+
+Show a single instance by id:
+    $ carbide-admin-cli instance show 12345678-1234-5678-90ab-cdef01234567
+
+List instances for one tenant org:
+    $ carbide-admin-cli instance show --tenant-org-id fds34511233a
+
+List instances in a VPC:
+    $ carbide-admin-cli instance show --vpc-id abcdef01-2345-6789-abcd-ef0123456789
+
+List instances matching a label:
+    $ carbide-admin-cli instance show --label-key role --label-value training
+
+List instances of an instance type:
+    $ carbide-admin-cli instance show --instance-type-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(
         default_value(""),

--- a/crates/admin-cli/src/instance/update_ib_config/args.rs
+++ b/crates/admin-cli/src/instance/update_ib_config/args.rs
@@ -20,6 +20,14 @@ use clap::Parser;
 use rpc::InstanceInfinibandConfig;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Update an instance's InfiniBand configuration:
+    $ carbide-admin-cli instance update-ib-config --instance 12345678-1234-5678-90ab-cdef01234567 \
+    --config '{\"partitions\":[]}'
+
+")]
 pub struct Args {
     #[clap(short, long, required(true))]
     pub instance: InstanceId,

--- a/crates/admin-cli/src/instance/update_nvlink_config/args.rs
+++ b/crates/admin-cli/src/instance/update_nvlink_config/args.rs
@@ -20,6 +20,15 @@ use clap::Parser;
 use rpc::forge::InstanceNvLinkConfig;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Update an instance's NVLink configuration:
+    $ carbide-admin-cli instance update-nv-link-config \
+    --instance 12345678-1234-5678-90ab-cdef01234567 \
+    --config '{\"partition_id\":\"abcdef01-2345-6789-abcd-ef0123456789\"}'
+
+")]
 pub struct Args {
     #[clap(short, long, required(true))]
     pub instance: InstanceId,

--- a/crates/admin-cli/src/instance/update_os/args.rs
+++ b/crates/admin-cli/src/instance/update_os/args.rs
@@ -20,6 +20,14 @@ use clap::Parser;
 use rpc::forge::InstanceOperatingSystemConfig;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Update an instance's OS configuration:
+    $ carbide-admin-cli instance update-os --instance 12345678-1234-5678-90ab-cdef01234567 \
+    --os '{\"os_image_id\":\"abcdef01-2345-6789-abcd-ef0123456789\"}'
+
+")]
 pub struct Args {
     #[clap(short, long, required(true))]
     pub instance: InstanceId,

--- a/crates/admin-cli/src/instance/update_spx_config/args.rs
+++ b/crates/admin-cli/src/instance/update_spx_config/args.rs
@@ -20,6 +20,15 @@ use clap::Parser;
 use rpc::forge::InstanceSpxConfig;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Update an instance's SPX configuration:
+    $ carbide-admin-cli instance update-spx-config \
+    --instance 12345678-1234-5678-90ab-cdef01234567 \
+    --config '{\"partition_id\":\"abcdef01-2345-6789-abcd-ef0123456789\"}'
+
+")]
 pub struct Args {
     #[clap(short, long, required(true))]
     pub instance: InstanceId,

--- a/crates/admin-cli/src/instance_type/associate/args.rs
+++ b/crates/admin-cli/src/instance_type/associate/args.rs
@@ -21,6 +21,18 @@ use rpc::forge::AssociateMachinesWithInstanceTypeRequest;
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Associate one machine with an instance type:
+    $ carbide-admin-cli instance-type associate 12345678-1234-5678-90ab-cdef01234567 \
+    abcdef01-2345-6789-abcd-ef0123456789
+
+Associate several machines (comma-separated, no spaces):
+    $ carbide-admin-cli instance-type associate 12345678-1234-5678-90ab-cdef01234567 \
+    abcdef01-2345-6789-abcd-ef0123456789,11111111-2222-3333-4444-555555555555
+
+")]
 pub struct Args {
     #[clap(help = "InstanceTypeId")]
     pub instance_type_id: String,

--- a/crates/admin-cli/src/instance_type/create/args.rs
+++ b/crates/admin-cli/src/instance_type/create/args.rs
@@ -21,6 +21,23 @@ use rpc::forge::{self as forgerpc, CreateInstanceTypeRequest, InstanceTypeAttrib
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create an instance type with a name and description:
+    $ carbide-admin-cli instance-type create --name dgx-h100 \
+    --description \"DGX H100 640GB\"
+
+Create with labels and desired-capability filters:
+    $ carbide-admin-cli instance-type create --name dgx-h100 \
+    --labels '{\"tier\":\"premium\"}' \
+    --desired-capabilities '[{\"key\":\"gpu_count\",\"value\":\"8\"}]'
+
+Create with an explicit id:
+    $ carbide-admin-cli instance-type create --id 12345678-1234-5678-90ab-cdef01234567 \
+    --name dgx-h100
+
+")]
 pub struct Args {
     #[clap(
         short = 'i',

--- a/crates/admin-cli/src/instance_type/delete/args.rs
+++ b/crates/admin-cli/src/instance_type/delete/args.rs
@@ -19,6 +19,13 @@ use clap::Parser;
 use rpc::forge::DeleteInstanceTypeRequest;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete an instance type by id:
+    $ carbide-admin-cli instance-type delete --id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(short = 'i', long, help = "Instance type ID to delete")]
     pub id: String,

--- a/crates/admin-cli/src/instance_type/disassociate/args.rs
+++ b/crates/admin-cli/src/instance_type/disassociate/args.rs
@@ -20,6 +20,13 @@ use clap::Parser;
 use rpc::forge::RemoveMachineInstanceTypeAssociationRequest;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove a machine's instance-type association:
+    $ carbide-admin-cli instance-type disassociate 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "Machine Id")]
     pub machine_id: MachineId,

--- a/crates/admin-cli/src/instance_type/show/args.rs
+++ b/crates/admin-cli/src/instance_type/show/args.rs
@@ -18,6 +18,19 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all instance types:
+    $ carbide-admin-cli instance-type show
+
+Show a single instance type by id:
+    $ carbide-admin-cli instance-type show --id 12345678-1234-5678-90ab-cdef01234567
+
+List instance types with allocation counts:
+    $ carbide-admin-cli instance-type show --show-stats true
+
+")]
 pub struct Args {
     #[clap(
         short = 'i',

--- a/crates/admin-cli/src/instance_type/update/args.rs
+++ b/crates/admin-cli/src/instance_type/update/args.rs
@@ -18,6 +18,23 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Rename an instance type:
+    $ carbide-admin-cli instance-type update --id 12345678-1234-5678-90ab-cdef01234567 \
+    --name dgx-h100-640gb
+
+Replace labels and capability filters (both overwrite completely):
+    $ carbide-admin-cli instance-type update --id 12345678-1234-5678-90ab-cdef01234567 \
+    --labels '{\"tier\":\"premium\"}' \
+    --desired-capabilities '[{\"key\":\"gpu_count\",\"value\":\"8\"}]'
+
+Update with optimistic concurrency on the record version:
+    $ carbide-admin-cli instance-type update --id 12345678-1234-5678-90ab-cdef01234567 \
+    --description \"DGX H100 640GB\" --version 3
+
+")]
 pub struct Args {
     #[clap(short = 'i', long, help = "Instance type ID to update")]
     pub id: String,

--- a/crates/admin-cli/src/inventory/args.rs
+++ b/crates/admin-cli/src/inventory/args.rs
@@ -18,6 +18,16 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Print the Ansible inventory to stdout:
+    $ carbide-admin-cli inventory
+
+Write the Ansible inventory to a file:
+    $ carbide-admin-cli inventory --filename ./inventory.ini
+
+")]
 pub struct Cmd {
     #[clap(short, long, help = "Write to file")]
     pub filename: Option<String>,

--- a/crates/admin-cli/src/ip/find/args.rs
+++ b/crates/admin-cli/src/ip/find/args.rs
@@ -18,6 +18,16 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Identify what owns an IPv4 address:
+    $ carbide-admin-cli ip find 192.0.2.10
+
+Identify what owns an IPv6 address:
+    $ carbide-admin-cli ip find 2001:db8::1
+
+")]
 pub struct Args {
     /// The IP address we are looking to identify
     pub ip: std::net::IpAddr,

--- a/crates/admin-cli/src/ipxe_template/show/args.rs
+++ b/crates/admin-cli/src/ipxe_template/show/args.rs
@@ -18,6 +18,16 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all iPXE templates:
+    $ carbide-admin-cli ipxe-template show
+
+Show one iPXE template by ID:
+    $ carbide-admin-cli ipxe-template show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "Template ID (UUID); omit to list all.")]
     pub id: Option<String>,

--- a/crates/admin-cli/src/jump/args.rs
+++ b/crates/admin-cli/src/jump/args.rs
@@ -18,6 +18,19 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Find an object by its UUID (machine, instance, VPC, etc.):
+    $ carbide-admin-cli jump 12345678-1234-5678-90ab-cdef01234567
+
+Find whatever owns an IP address:
+    $ carbide-admin-cli jump 192.0.2.10
+
+Find a machine interface by its MAC address:
+    $ carbide-admin-cli jump 00:11:22:33:44:55
+
+")]
 pub struct Cmd {
     #[clap(required(true), help = "The machine ID, IP, UUID, etc, to find")]
     pub id: String,

--- a/crates/admin-cli/src/machine/auto_update/args.rs
+++ b/crates/admin-cli/src/machine/auto_update/args.rs
@@ -20,6 +20,19 @@ use clap::{ArgGroup, Parser};
 
 #[derive(Parser, Debug, Clone)]
 #[clap(group(ArgGroup::new("autoupdate_action").required(true).args(&["enable", "disable", "clear"])))]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Force-enable firmware auto-update for a host:
+    $ carbide-admin-cli machine auto-update --machine 12345678-1234-5678-90ab-cdef01234567 --enable
+
+Force-disable it:
+    $ carbide-admin-cli machine auto-update --machine 12345678-1234-5678-90ab-cdef01234567 --disable
+
+Clear the per-machine override (fall back to global/config):
+    $ carbide-admin-cli machine auto-update --machine 12345678-1234-5678-90ab-cdef01234567 --clear
+
+")]
 pub struct Args {
     #[clap(long, help = "Machine ID of the host to change")]
     pub machine: MachineId,

--- a/crates/admin-cli/src/machine/force_delete/args.rs
+++ b/crates/admin-cli/src/machine/force_delete/args.rs
@@ -19,6 +19,17 @@ use clap::Parser;
 use rpc::forge::AdminForceDeleteMachineRequest;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Force delete a machine (by UUID, IPv4, MAC, or hostname):
+    $ carbide-admin-cli machine force-delete --machine 12345678-1234-5678-90ab-cdef01234567
+
+Force delete a machine and its interfaces (redeploy kea afterward):
+    $ carbide-admin-cli machine force-delete --machine 12345678-1234-5678-90ab-cdef01234567 \
+    --delete-interfaces
+
+")]
 pub struct Args {
     #[clap(
         long,

--- a/crates/admin-cli/src/machine/hardware_info/args.rs
+++ b/crates/admin-cli/src/machine/hardware_info/args.rs
@@ -19,6 +19,17 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show a machine's hardware info:
+    $ carbide-admin-cli machine hardware-info show --machine 12345678-1234-5678-90ab-cdef01234567
+
+Update a machine's GPUs from a JSON file:
+    $ carbide-admin-cli machine hardware-info update gpus --machine 12345678-1234-5678-90ab-cdef01234567 \
+    --gpu-json-file ./gpus.json
+
+")]
 pub enum Args {
     #[clap(about = "Show the hardware info of the machine")]
     Show(ShowMachineHardwareInfo),

--- a/crates/admin-cli/src/machine/health_report/args.rs
+++ b/crates/admin-cli/src/machine/health_report/args.rs
@@ -19,6 +19,24 @@ use carbide_uuid::machine::MachineId;
 use clap::{ArgGroup, Parser, ValueEnum};
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List a machine's health report entries:
+    $ carbide-admin-cli machine health-report show 12345678-1234-5678-90ab-cdef01234567
+
+Add a health report entry from a template:
+    $ carbide-admin-cli machine health-report add 12345678-1234-5678-90ab-cdef01234567 \
+    --template internal-maintenance --message \"Firmware upgrade in progress\"
+
+Remove a health report entry by its source:
+    $ carbide-admin-cli machine health-report remove 12345678-1234-5678-90ab-cdef01234567 \
+    internal-maintenance
+
+Print an empty health report template:
+    $ carbide-admin-cli machine health-report print-empty-template
+
+")]
 pub enum Args {
     #[clap(about = "List the health report entries")]
     Show { machine_id: MachineId },

--- a/crates/admin-cli/src/machine/metadata/args.rs
+++ b/crates/admin-cli/src/machine/metadata/args.rs
@@ -33,12 +33,27 @@ pub enum Args {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show a machine's metadata:
+    $ carbide-admin-cli machine metadata show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct MachineMetadataCommandShow {
     #[clap(help = "The machine which should get updated metadata")]
     pub machine: MachineId,
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Set a machine's name and description:
+    $ carbide-admin-cli machine metadata set 12345678-1234-5678-90ab-cdef01234567 \
+    --name gpu-node-01 --description \"Rack 4, tray 2\"
+
+")]
 pub struct MachineMetadataCommandSet {
     #[clap(help = "The machine which should get updated metadata")]
     pub machine: MachineId,
@@ -49,6 +64,17 @@ pub struct MachineMetadataCommandSet {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add a key-only label:
+    $ carbide-admin-cli machine metadata add-label 12345678-1234-5678-90ab-cdef01234567 --key edge
+
+Add a key/value label:
+    $ carbide-admin-cli machine metadata add-label 12345678-1234-5678-90ab-cdef01234567 \
+    --key rack --value 4
+
+")]
 pub struct MachineMetadataCommandAddLabel {
     #[clap(help = "The machine which should get updated metadata")]
     pub machine: MachineId,
@@ -59,6 +85,14 @@ pub struct MachineMetadataCommandAddLabel {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove one or more labels by key:
+    $ carbide-admin-cli machine metadata remove-labels 12345678-1234-5678-90ab-cdef01234567 \
+    --keys rack --keys edge
+
+")]
 pub struct MachineMetadataCommandRemoveLabels {
     #[clap(help = "The machine which should get updated metadata")]
     pub machine: MachineId,
@@ -67,6 +101,17 @@ pub struct MachineMetadataCommandRemoveLabels {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Fill in missing metadata from the expected-machine (leaving existing values intact):
+    $ carbide-admin-cli machine metadata from-expected-machine 12345678-1234-5678-90ab-cdef01234567
+
+Overwrite the machine's metadata with the expected-machine's values:
+    $ carbide-admin-cli machine metadata from-expected-machine 12345678-1234-5678-90ab-cdef01234567 \
+    --replace-all
+
+")]
 pub struct MachineMetadataCommandFromExpectedMachine {
     #[clap(help = "The machine which should get updated metadata")]
     pub machine: MachineId,

--- a/crates/admin-cli/src/machine/network/args.rs
+++ b/crates/admin-cli/src/machine/network/args.rs
@@ -20,6 +20,16 @@ use clap::Parser;
 use super::super::common::NetworkConfigQuery;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Print the network status of all machines:
+    $ carbide-admin-cli machine network status
+
+Show the VPC network configuration for a DPU:
+    $ carbide-admin-cli machine network config --machine-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub enum Args {
     #[clap(about = "Print network status of all machines")]
     Status,

--- a/crates/admin-cli/src/machine/nvlink_info/args.rs
+++ b/crates/admin-cli/src/machine/nvlink_info/args.rs
@@ -19,6 +19,16 @@ use carbide_uuid::machine::MachineId;
 use clap::{Parser, Subcommand};
 
 #[derive(Subcommand, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show existing NVLink info for a machine:
+    $ carbide-admin-cli machine nvlink-info show 12345678-1234-5678-90ab-cdef01234567
+
+Build NVLink info from Redfish + NMX-C and persist it:
+    $ carbide-admin-cli machine nvlink-info populate 12345678-1234-5678-90ab-cdef01234567 --update-db
+
+")]
 pub enum Args {
     #[clap(about = "Show existing NVLink info")]
     Show(NvlinkInfoArgs),

--- a/crates/admin-cli/src/machine/positions/args.rs
+++ b/crates/admin-cli/src/machine/positions/args.rs
@@ -19,6 +19,16 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show rack positions for all machines:
+    $ carbide-admin-cli machine positions
+
+Show positions for specific machines:
+    $ carbide-admin-cli machine positions --machine 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(
         short = 'm',

--- a/crates/admin-cli/src/machine/reboot/args.rs
+++ b/crates/admin-cli/src/machine/reboot/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Reboot a machine:
+    $ carbide-admin-cli machine reboot --machine 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(long, help = "ID of the machine to reboot")]
     pub machine: String,

--- a/crates/admin-cli/src/machine/show/args.rs
+++ b/crates/admin-cli/src/machine/show/args.rs
@@ -20,6 +20,20 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 #[clap(disable_help_flag = true)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all machines:
+    $ carbide-admin-cli machine show
+
+Show one machine by ID:
+    $ carbide-admin-cli machine show 12345678-1234-5678-90ab-cdef01234567
+
+Show only DPUs (or only hosts):
+    $ carbide-admin-cli machine show --dpus
+    $ carbide-admin-cli machine show --hosts
+
+")]
 pub struct Args {
     #[clap(long, action = clap::ArgAction::HelpLong)]
     pub help: Option<bool>,

--- a/crates/admin-cli/src/machine_interfaces/assign_address/args.rs
+++ b/crates/admin-cli/src/machine_interfaces/assign_address/args.rs
@@ -21,6 +21,13 @@ use carbide_uuid::machine::MachineInterfaceId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Assign a static address to a machine interface:
+    $ carbide-admin-cli machine-interfaces assign-address 12345678-1234-5678-90ab-cdef01234567 192.0.2.20
+
+")]
 pub struct Args {
     #[clap(help = "The machine interface ID to assign the address to")]
     pub interface_id: MachineInterfaceId,

--- a/crates/admin-cli/src/machine_interfaces/delete/args.rs
+++ b/crates/admin-cli/src/machine_interfaces/delete/args.rs
@@ -19,6 +19,13 @@ use carbide_uuid::machine::MachineInterfaceId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a machine interface by ID (redeploy kea afterward):
+    $ carbide-admin-cli machine-interfaces delete 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "The interface ID to delete. Redeploy kea after deleting machine interfaces.")]
     pub interface_id: MachineInterfaceId,

--- a/crates/admin-cli/src/machine_interfaces/remove_address/args.rs
+++ b/crates/admin-cli/src/machine_interfaces/remove_address/args.rs
@@ -21,6 +21,13 @@ use carbide_uuid::machine::MachineInterfaceId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove a static address from a machine interface:
+    $ carbide-admin-cli machine-interfaces remove-address 12345678-1234-5678-90ab-cdef01234567 10.0.0.5
+
+")]
 pub struct Args {
     #[clap(help = "The machine interface ID to remove the address from")]
     pub interface_id: MachineInterfaceId,

--- a/crates/admin-cli/src/machine_interfaces/show/args.rs
+++ b/crates/admin-cli/src/machine_interfaces/show/args.rs
@@ -19,6 +19,16 @@ use carbide_uuid::machine::MachineInterfaceId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all machine interfaces:
+    $ carbide-admin-cli machine-interfaces show
+
+Show one machine interface by ID:
+    $ carbide-admin-cli machine-interfaces show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(
         short,

--- a/crates/admin-cli/src/machine_interfaces/show_addresses/args.rs
+++ b/crates/admin-cli/src/machine_interfaces/show_addresses/args.rs
@@ -19,6 +19,13 @@ use carbide_uuid::machine::MachineInterfaceId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show the addresses on a machine interface:
+    $ carbide-admin-cli machine-interfaces show-addresses 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "The machine interface ID to show addresses for")]
     pub interface_id: MachineInterfaceId,

--- a/crates/admin-cli/src/machine_validation/external_config/args.rs
+++ b/crates/admin-cli/src/machine_validation/external_config/args.rs
@@ -18,6 +18,20 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show external config entries by name:
+    $ carbide-admin-cli machine-validation external-config show --name my-config
+
+Add or update an external config from a file:
+    $ carbide-admin-cli machine-validation external-config add-update --name my-config \
+    --file-name ./config.toml --description \"validation overrides\"
+
+Remove an external config:
+    $ carbide-admin-cli machine-validation external-config remove --name my-config
+
+")]
 pub enum Args {
     #[clap(about = "Show External config")]
     Show(ExternalConfigShowOptions),

--- a/crates/admin-cli/src/machine_validation/on_demand/args.rs
+++ b/crates/admin-cli/src/machine_validation/on_demand/args.rs
@@ -19,6 +19,17 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Start on-demand validation for a machine:
+    $ carbide-admin-cli machine-validation on-demand start --machine 12345678-1234-5678-90ab-cdef01234567
+
+Start with a restricted set of allowed tests, including unverified:
+    $ carbide-admin-cli machine-validation on-demand start --machine 12345678-1234-5678-90ab-cdef01234567 \
+    --allowed-tests gpu_bandwidth --run-unverfied-tests
+
+")]
 pub enum Args {
     #[clap(about = "Start on demand machine validation")]
     Start(OnDemandOptions),

--- a/crates/admin-cli/src/machine_validation/results/args.rs
+++ b/crates/admin-cli/src/machine_validation/results/args.rs
@@ -20,6 +20,20 @@ use carbide_uuid::machine_validation::MachineValidationId;
 use clap::{ArgGroup, Parser};
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show validation results for a machine:
+    $ carbide-admin-cli machine-validation results show --machine 12345678-1234-5678-90ab-cdef01234567
+
+Show results for a specific validation run:
+    $ carbide-admin-cli machine-validation results show --validation-id 12345678-1234-5678-90ab-cdef01234567
+
+Show one test's result within a run (with history):
+    $ carbide-admin-cli machine-validation results show --validation-id 12345678-1234-5678-90ab-cdef01234567 \
+    --test-name gpu_bandwidth --history
+
+")]
 pub enum Args {
     #[clap(about = "Show results")]
     Show(ShowResultsOptions),

--- a/crates/admin-cli/src/machine_validation/runs/args.rs
+++ b/crates/admin-cli/src/machine_validation/runs/args.rs
@@ -19,6 +19,17 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show all validation runs:
+    $ carbide-admin-cli machine-validation runs show
+
+Show runs for one machine, including history:
+    $ carbide-admin-cli machine-validation runs show --machine 12345678-1234-5678-90ab-cdef01234567 \
+    --history
+
+")]
 pub enum Args {
     #[clap(about = "Show Runs")]
     Show(ShowRunsOptions),

--- a/crates/admin-cli/src/machine_validation/tests_cmd/args.rs
+++ b/crates/admin-cli/src/machine_validation/tests_cmd/args.rs
@@ -18,6 +18,20 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List supported tests (optionally including unverified):
+    $ carbide-admin-cli machine-validation tests show
+
+Verify a test version:
+    $ carbide-admin-cli machine-validation tests verify --test-id gpu_bandwidth --version 1.2.0
+
+Enable / disable a test version:
+    $ carbide-admin-cli machine-validation tests enable --test-id gpu_bandwidth --version 1.2.0
+    $ carbide-admin-cli machine-validation tests disable --test-id gpu_bandwidth --version 1.2.0
+
+")]
 pub enum Args {
     #[clap(about = "Show tests")]
     Show(ShowTestOptions),

--- a/crates/admin-cli/src/main.rs
+++ b/crates/admin-cli/src/main.rs
@@ -45,7 +45,9 @@ use crate::rpc::ApiClient;
 mod async_write;
 mod attestation;
 mod bmc_machine;
+mod bmc_role;
 mod boot_override;
+mod browse;
 mod cfg;
 mod component_manager;
 mod compute_allocation;
@@ -64,6 +66,7 @@ mod expected_rack;
 mod expected_switch;
 mod extension_service;
 mod firmware;
+mod generate_docs;
 mod generate_man;
 mod generate_shell_complete;
 mod health_utils;
@@ -127,7 +130,14 @@ pub fn invalid_machine_id() -> String {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> color_eyre::Result<()> {
-    color_eyre::install()?;
+    // This is a user-facing CLI, so keep error output to the message chain.
+    // The source-code `Location:` block and the "run with RUST_BACKTRACE"
+    // footer are developer noise on an expected failure (a missing flag, an
+    // unreachable BMC); a backtrace is still captured when RUST_BACKTRACE is set.
+    color_eyre::config::HookBuilder::default()
+        .display_location_section(false)
+        .display_env_section(false)
+        .install()?;
 
     let config = CliOptions::load();
     if config.version {
@@ -162,12 +172,13 @@ async fn main() -> color_eyre::Result<()> {
         .try_init()?;
 
     if let Some(CliCommand::Redfish(ref ra)) = config.commands {
-        match ra.command {
-            redfish::Cmd::Browse(_) => {}
-            _ => {
-                return redfish::action(ra.clone()).await;
-            }
-        }
+        // Redfish talks straight to a BMC, so it's handled here — before the
+        // API client is built — rather than via the ctx-based dispatch below.
+        // (Browsing a Redfish tree through the API server is a separate
+        // top-level command, `browse redfish`, which does not need a BMC.)
+        // --address is clap-`required` on RedfishAction; --username/--password
+        // are optional.
+        return redfish::action(ra.clone()).await;
     }
     if let Some(CliCommand::Rms(ref rms)) = config.commands {
         // do rms same as redfish above
@@ -230,6 +241,7 @@ async fn main() -> color_eyre::Result<()> {
         CliCommand::ExpectedSwitch(cmd) => cmd.dispatch(ctx).await?,
         CliCommand::ExtensionService(cmd) => cmd.dispatch(ctx).await?,
         CliCommand::Firmware(cmd) => cmd.dispatch(ctx).await?,
+        CliCommand::GenerateCliDocs(cmd) => cmd.dispatch(ctx).await?,
         CliCommand::GenerateMan(cmd) => cmd.dispatch(ctx).await?,
         CliCommand::GenerateShellComplete(cmd) => cmd.dispatch(ctx).await?,
         CliCommand::Host(cmd) => cmd.dispatch(ctx).await?,
@@ -276,14 +288,9 @@ async fn main() -> color_eyre::Result<()> {
         CliCommand::VpcPeering(cmd) => cmd.dispatch(ctx).await?,
         CliCommand::VpcPrefix(cmd) => cmd.dispatch(ctx).await?,
         CliCommand::Dpf(cmd) => cmd.dispatch(ctx).await?,
-        CliCommand::Redfish(action) => {
-            if let redfish::Cmd::Browse(redfish::UriInfo { uri }) = &action.command {
-                return redfish::handle_browse_command(&ctx.api_client, uri).await;
-            }
-
-            // Handled earlier
-            unreachable!();
-        }
+        CliCommand::Browse(cmd) => cmd.dispatch(ctx).await?,
+        // Redfish is handled before the API client is built (see above).
+        CliCommand::Redfish(_) => unreachable!("redfish is dispatched before client init"),
         _ => return Err(eyre!("Unsupported command")),
     }
 

--- a/crates/admin-cli/src/managed_host/debug_bundle/args.rs
+++ b/crates/admin-cli/src/managed_host/debug_bundle/args.rs
@@ -18,6 +18,18 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Download a debug bundle for a host over a time range:
+    $ carbide-admin-cli managed-host debug-bundle 12345678-1234-5678-90ab-cdef01234567 \
+    --start-time \"2026-01-02 03:04:05\" --end-time \"2026-01-02 04:00:00\"
+
+Collect from a start time to now, interpreting times as UTC:
+    $ carbide-admin-cli managed-host debug-bundle 12345678-1234-5678-90ab-cdef01234567 \
+    --start-time 03:04:05 --utc
+
+")]
 pub struct Args {
     #[clap(help = "The host machine ID to collect logs for")]
     pub host_id: String,

--- a/crates/admin-cli/src/managed_host/maintenance/args.rs
+++ b/crates/admin-cli/src/managed_host/maintenance/args.rs
@@ -20,7 +20,7 @@ use clap::Parser;
 use rpc::forge as forgerpc;
 
 /// Enable or disable maintenance mode on a managed host.
-/// To list machines in maintenance mode use `forge-admin-cli mh show --all --fix`
+/// To list machines in maintenance mode use `carbide-admin-cli mh show --all --fix`
 #[derive(Parser, Debug)]
 pub enum Args {
     /// Put this machine into maintenance mode. Prevents an instance being assigned to it.
@@ -30,6 +30,14 @@ pub enum Args {
 }
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Put a host into maintenance mode (prevents instance assignment):
+    $ carbide-admin-cli managed-host maintenance on --host 12345678-1234-5678-90ab-cdef01234567 \
+    --reference https://tickets.example.com/MH-42
+
+")]
 pub struct MaintenanceOn {
     #[clap(long, required(true), help = "Managed Host ID")]
     pub host: MachineId,
@@ -54,6 +62,13 @@ impl From<MaintenanceOn> for forgerpc::MaintenanceRequest {
 }
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Return a host to normal operation:
+    $ carbide-admin-cli managed-host maintenance off --host 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct MaintenanceOff {
     #[clap(long, required(true), help = "Managed Host ID")]
     pub host: MachineId,

--- a/crates/admin-cli/src/managed_host/power_options/args.rs
+++ b/crates/admin-cli/src/managed_host/power_options/args.rs
@@ -21,11 +21,45 @@ use rpc::forge::{self as forgerpc, PowerOptionUpdateRequest};
 
 #[derive(Parser, Debug)]
 pub enum Args {
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Show power options for all hosts:
+    $ carbide-admin-cli managed-host power-options show
+
+Show power options for one host:
+    $ carbide-admin-cli managed-host power-options show 12345678-1234-5678-90ab-cdef01234567
+
+")]
     Show(ShowPowerOptions),
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Set a host's desired power state (on / off / power-manager-disabled):
+    $ carbide-admin-cli managed-host power-options update 12345678-1234-5678-90ab-cdef01234567 \
+    --desired-power-state off
+
+")]
     Update(UpdatePowerOptions),
     #[clap(about = "Get machine ingestion state")]
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Get the ingestion state for a machine by its BMC MAC:
+    $ carbide-admin-cli managed-host power-options get-machine-ingestion-state \
+    --mac-address 00:11:22:33:44:55
+
+")]
     GetMachineIngestionState(BmcMacAddress),
     #[clap(about = "Allow a machine to power on")]
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Allow a machine to be ingested and powered on:
+    $ carbide-admin-cli managed-host power-options allow-ingestion-and-power-on \
+    --mac-address 00:11:22:33:44:55
+
+")]
     AllowIngestionAndPowerOn(BmcMacAddress),
 }
 

--- a/crates/admin-cli/src/managed_host/quarantine/args.rs
+++ b/crates/admin-cli/src/managed_host/quarantine/args.rs
@@ -29,6 +29,14 @@ pub enum Args {
 }
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Quarantine a host (blocks all host network traffic):
+    $ carbide-admin-cli managed-host quarantine on --host 12345678-1234-5678-90ab-cdef01234567 \
+    --reason \"suspected compromise\"
+
+")]
 pub struct QuarantineOn {
     #[clap(long, required(true), help = "Managed Host ID")]
     pub host: MachineId,
@@ -55,6 +63,13 @@ impl From<QuarantineOn> for forgerpc::SetManagedHostQuarantineStateRequest {
 }
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Take a host out of quarantine:
+    $ carbide-admin-cli managed-host quarantine off --host 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct QuarantineOff {
     #[clap(long, required(true), help = "Managed Host ID")]
     pub host: MachineId,

--- a/crates/admin-cli/src/managed_host/reset_host_reprovisioning/args.rs
+++ b/crates/admin-cli/src/managed_host/reset_host_reprovisioning/args.rs
@@ -20,6 +20,13 @@ use clap::Parser;
 
 /// Reset host reprovisioning state
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Reset a host's reprovisioning back to CheckingFirmware:
+    $ carbide-admin-cli managed-host reset-host-reprovisioning --machine 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(long, required(true), help = "Machine ID to reset host reprovision on")]
     pub machine: MachineId,

--- a/crates/admin-cli/src/managed_host/set_primary_dpu/args.rs
+++ b/crates/admin-cli/src/managed_host/set_primary_dpu/args.rs
@@ -20,6 +20,18 @@ use clap::Parser;
 use rpc::forge as forgerpc;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Set the primary DPU for a host:
+    $ carbide-admin-cli managed-host set-primary-dpu 12345678-1234-5678-90ab-cdef01234567 \
+    abcdef01-2345-6789-abcd-ef0123456789
+
+Set the primary DPU and reboot the host afterward:
+    $ carbide-admin-cli managed-host set-primary-dpu 12345678-1234-5678-90ab-cdef01234567 \
+    abcdef01-2345-6789-abcd-ef0123456789 --reboot
+
+")]
 pub struct Args {
     #[clap(help = "ID of the host machine")]
     pub host_machine_id: MachineId,

--- a/crates/admin-cli/src/managed_host/show/args.rs
+++ b/crates/admin-cli/src/managed_host/show/args.rs
@@ -20,6 +20,19 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 #[clap(disable_help_flag = true)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all managed hosts:
+    $ carbide-admin-cli managed-host show
+
+Show details for one host (by host or DPU machine ID):
+    $ carbide-admin-cli managed-host show 12345678-1234-5678-90ab-cdef01234567
+
+Show the summary with IP details:
+    $ carbide-admin-cli managed-host show --ips
+
+")]
 pub struct Args {
     #[clap(long, action = clap::ArgAction::HelpLong)]
     help: Option<bool>,

--- a/crates/admin-cli/src/managed_host/start_updates/args.rs
+++ b/crates/admin-cli/src/managed_host/start_updates/args.rs
@@ -19,6 +19,17 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Start delayed updates for one or more machines now:
+    $ carbide-admin-cli managed-host start-updates --machines 12345678-1234-5678-90ab-cdef01234567
+
+Schedule the update window for a specific start time:
+    $ carbide-admin-cli managed-host start-updates --machines 12345678-1234-5678-90ab-cdef01234567 \
+    --start 2026-01-02T03:04:05
+
+")]
 pub struct Args {
     #[clap(long, required(true), help = "Machine IDs to update, space separated", num_args = 1.., value_delimiter = ' ')]
     pub machines: Vec<MachineId>,

--- a/crates/admin-cli/src/managed_switch/delete/args.rs
+++ b/crates/admin-cli/src/managed_switch/delete/args.rs
@@ -21,6 +21,13 @@ use carbide_uuid::switch::SwitchId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a managed switch by ID:
+    $ carbide-admin-cli managed-switch delete 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "Switch ID to delete.")]
     pub switch_id: String,

--- a/crates/admin-cli/src/managed_switch/list/args.rs
+++ b/crates/admin-cli/src/managed_switch/list/args.rs
@@ -18,4 +18,11 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all managed switches:
+    $ carbide-admin-cli managed-switch list
+
+")]
 pub struct Args;

--- a/crates/admin-cli/src/managed_switch/show/args.rs
+++ b/crates/admin-cli/src/managed_switch/show/args.rs
@@ -21,6 +21,16 @@ use carbide_uuid::switch::SwitchId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all managed switches:
+    $ carbide-admin-cli managed-switch show
+
+Show one managed switch by ID or name:
+    $ carbide-admin-cli managed-switch show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "Switch ID or name to show details for (leave empty for all)")]
     pub identifier: Option<String>,

--- a/crates/admin-cli/src/mlx/config/args.rs
+++ b/crates/admin-cli/src/mlx/config/args.rs
@@ -26,6 +26,21 @@ use crate::errors::{CarbideCliError, CarbideCliResult};
 
 // ConfigCommand are the config subcommands.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Query device configuration values (all, or specific comma-separated variables):
+    $ carbide-admin-cli mlx config query 12345678-1234-5678-90ab-cdef01234567 0000:01:00.0 my-registry
+
+Set configuration values (variable=value, comma-separated):
+    $ carbide-admin-cli mlx config set 12345678-1234-5678-90ab-cdef01234567 0000:01:00.0 my-registry \
+    LINK_TYPE=eth,SRIOV_EN=true
+
+Compare a device against expected values:
+    $ carbide-admin-cli mlx config compare 12345678-1234-5678-90ab-cdef01234567 0000:01:00.0 my-registry \
+    LINK_TYPE=eth
+
+")]
 pub enum ConfigCommand {
     #[clap(about = "Query device configuration values")]
     Query(ConfigQueryCommand),

--- a/crates/admin-cli/src/mlx/connections/args.rs
+++ b/crates/admin-cli/src/mlx/connections/args.rs
@@ -24,6 +24,16 @@ use rpc::protos::forge as forge_pb;
 
 // ConnectionsCommand are the connections subcommands.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show all active scout stream connections:
+    $ carbide-admin-cli mlx connections show
+
+Disconnect a machine's scout stream connection:
+    $ carbide-admin-cli mlx connections disconnect 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub enum ConnectionsCommand {
     #[clap(about = "Show all active scout stream connections")]
     Show(ConnectionsShowCommand),

--- a/crates/admin-cli/src/mlx/info/args.rs
+++ b/crates/admin-cli/src/mlx/info/args.rs
@@ -24,6 +24,16 @@ use rpc::protos::mlx_device as mlx_device_pb;
 
 // InfoCommand are the info subcommands.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Get device info for one device on a machine:
+    $ carbide-admin-cli mlx info device 12345678-1234-5678-90ab-cdef01234567 0000:01:00.0
+
+Get the full device report for a machine:
+    $ carbide-admin-cli mlx info machine 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub enum InfoCommand {
     #[clap(about = "Get MlxDeviceInfo for a device on a machine")]
     Device(InfoDeviceCommand),

--- a/crates/admin-cli/src/mlx/lockdown/args.rs
+++ b/crates/admin-cli/src/mlx/lockdown/args.rs
@@ -24,6 +24,19 @@ use rpc::protos::mlx_device as mlx_device_pb;
 
 // LockdownCommand are the lockdown subcommands.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Lock hardware access on a device:
+    $ carbide-admin-cli mlx lockdown lock 12345678-1234-5678-90ab-cdef01234567 0000:01:00.0
+
+Unlock hardware access on a device:
+    $ carbide-admin-cli mlx lockdown unlock 12345678-1234-5678-90ab-cdef01234567 0000:01:00.0
+
+Check a device's lockdown status:
+    $ carbide-admin-cli mlx lockdown status 12345678-1234-5678-90ab-cdef01234567 0000:01:00.0
+
+")]
 pub enum LockdownCommand {
     #[clap(about = "Lock hardware access on a device")]
     Lock(LockdownLockCommand),

--- a/crates/admin-cli/src/mlx/profile/args.rs
+++ b/crates/admin-cli/src/mlx/profile/args.rs
@@ -24,6 +24,24 @@ use rpc::protos::mlx_device as mlx_device_pb;
 
 // ProfileCommand are the profile subcommands.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all available profiles:
+    $ carbide-admin-cli mlx profile list
+
+Show a profile's details:
+    $ carbide-admin-cli mlx profile show my-profile
+
+Sync a profile to a device on a machine:
+    $ carbide-admin-cli mlx profile sync 12345678-1234-5678-90ab-cdef01234567 0000:01:00.0 \
+    --profile-name my-profile
+
+Compare a device against a profile:
+    $ carbide-admin-cli mlx profile compare 12345678-1234-5678-90ab-cdef01234567 0000:01:00.0 \
+    --profile-name my-profile
+
+")]
 pub enum ProfileCommand {
     #[clap(about = "Synchronize a profile to a device on a given machine")]
     Sync(ProfileSyncCommand),

--- a/crates/admin-cli/src/mlx/registry/args.rs
+++ b/crates/admin-cli/src/mlx/registry/args.rs
@@ -24,6 +24,16 @@ use rpc::protos::mlx_device as mlx_device_pb;
 
 // RegistryCommand are the registry subcommands.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List the variable registries available on a machine:
+    $ carbide-admin-cli mlx registry list 12345678-1234-5678-90ab-cdef01234567
+
+Show one registry's details:
+    $ carbide-admin-cli mlx registry show 12345678-1234-5678-90ab-cdef01234567 my-registry
+
+")]
 pub enum RegistryCommand {
     #[clap(about = "List all available registries")]
     List(RegistryListCommand),

--- a/crates/admin-cli/src/network_devices/show/args.rs
+++ b/crates/admin-cli/src/network_devices/show/args.rs
@@ -18,6 +18,16 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show the full network topology (all devices):
+    $ carbide-admin-cli network-device show
+
+Show one network device by MAC:
+    $ carbide-admin-cli network-device show mac=00:11:22:33:44:55
+
+")]
 pub struct Args {
     #[clap(
         short,

--- a/crates/admin-cli/src/network_security_group/attach/args.rs
+++ b/crates/admin-cli/src/network_security_group/attach/args.rs
@@ -20,6 +20,18 @@ use carbide_uuid::vpc::VpcId;
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Attach a network security group to a VPC:
+    $ carbide-admin-cli network-security-group attach --id 12345678-1234-5678-90ab-cdef01234567 \
+    --vpc-id abcdef01-2345-6789-abcd-ef0123456789
+
+Attach it to a single instance:
+    $ carbide-admin-cli network-security-group attach --id 12345678-1234-5678-90ab-cdef01234567 \
+    --instance-id abcdef01-2345-6789-abcd-ef0123456789
+
+")]
 pub struct Args {
     #[clap(short = 'n', long, help = "Network security group ID to attach")]
     pub id: String,

--- a/crates/admin-cli/src/network_security_group/create/args.rs
+++ b/crates/admin-cli/src/network_security_group/create/args.rs
@@ -23,6 +23,18 @@ use rpc::forge::{
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create a network security group for a tenant:
+    $ carbide-admin-cli network-security-group create --tenant-organization-id fds34511233a \
+    --name web-tier
+
+Create one with stateful egress and labels:
+    $ carbide-admin-cli network-security-group create --tenant-organization-id fds34511233a \
+    --name web-tier --stateful-egress --labels '{\"env\":\"prod\"}'
+
+")]
 pub struct Args {
     #[clap(
         short = 'i',

--- a/crates/admin-cli/src/network_security_group/delete/args.rs
+++ b/crates/admin-cli/src/network_security_group/delete/args.rs
@@ -19,6 +19,14 @@ use clap::Parser;
 use rpc::forge::DeleteNetworkSecurityGroupRequest;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a network security group:
+    $ carbide-admin-cli network-security-group delete --id 12345678-1234-5678-90ab-cdef01234567 \
+    --tenant-organization-id fds34511233a
+
+")]
 pub struct Args {
     #[clap(short = 'i', long, help = "Network security group ID to delete")]
     pub id: String,

--- a/crates/admin-cli/src/network_security_group/detach/args.rs
+++ b/crates/admin-cli/src/network_security_group/detach/args.rs
@@ -20,6 +20,16 @@ use carbide_uuid::vpc::VpcId;
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove the network security group from a VPC:
+    $ carbide-admin-cli network-security-group detach --vpc-id 12345678-1234-5678-90ab-cdef01234567
+
+Remove it from a single instance:
+    $ carbide-admin-cli network-security-group detach --instance-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(
         short = 'v',

--- a/crates/admin-cli/src/network_security_group/show/args.rs
+++ b/crates/admin-cli/src/network_security_group/show/args.rs
@@ -18,6 +18,16 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all network security groups:
+    $ carbide-admin-cli network-security-group show
+
+Show one network security group by ID:
+    $ carbide-admin-cli network-security-group show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "Optional, network security group ID to restrict the search")]
     pub id: Option<String>,

--- a/crates/admin-cli/src/network_security_group/show_attachments/args.rs
+++ b/crates/admin-cli/src/network_security_group/show_attachments/args.rs
@@ -18,6 +18,17 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show what is attached to a network security group:
+    $ carbide-admin-cli network-security-group show-attachments --id 12345678-1234-5678-90ab-cdef01234567
+
+Include objects inheriting the group from a parent:
+    $ carbide-admin-cli network-security-group show-attachments --id 12345678-1234-5678-90ab-cdef01234567 \
+    --include-indirect
+
+")]
 pub struct Args {
     #[clap(short = 'i', long, help = "network security group ID to query")]
     pub id: String,

--- a/crates/admin-cli/src/network_security_group/update/args.rs
+++ b/crates/admin-cli/src/network_security_group/update/args.rs
@@ -18,6 +18,18 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Rename a network security group:
+    $ carbide-admin-cli network-security-group update --id 12345678-1234-5678-90ab-cdef01234567 \
+    --tenant-organization-id fds34511233a --name web-tier
+
+Replace its rule set from JSON (overwrites all existing rules):
+    $ carbide-admin-cli network-security-group update --id 12345678-1234-5678-90ab-cdef01234567 \
+    --tenant-organization-id fds34511233a --rules '[...]'
+
+")]
 pub struct Args {
     #[clap(short = 'i', long, help = "Network security group ID to update")]
     pub id: String,

--- a/crates/admin-cli/src/network_segment/delete/args.rs
+++ b/crates/admin-cli/src/network_segment/delete/args.rs
@@ -19,6 +19,13 @@ use carbide_uuid::network::NetworkSegmentId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a network segment by ID:
+    $ carbide-admin-cli network-segment delete --id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(long, help = "Id of the network segment")]
     pub id: NetworkSegmentId,

--- a/crates/admin-cli/src/network_segment/show/args.rs
+++ b/crates/admin-cli/src/network_segment/show/args.rs
@@ -19,6 +19,19 @@ use carbide_uuid::network::NetworkSegmentId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all network segments:
+    $ carbide-admin-cli network-segment show
+
+Show one network segment by ID:
+    $ carbide-admin-cli network-segment show 12345678-1234-5678-90ab-cdef01234567
+
+Filter by tenant org:
+    $ carbide-admin-cli network-segment show --tenant-org-id fds34511233a
+
+")]
 pub struct Args {
     #[clap(
         default_value(None),

--- a/crates/admin-cli/src/nvl_domain/health_report/args.rs
+++ b/crates/admin-cli/src/nvl_domain/health_report/args.rs
@@ -19,6 +19,20 @@ use carbide_uuid::nvlink::NvLinkDomainId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List the health report sources for an NVLink domain:
+    $ carbide-admin-cli nvl-domain health-report show 12345678-1234-5678-90ab-cdef01234567
+
+Remove a health report source (source name from `health-report show`):
+    $ carbide-admin-cli nvl-domain health-report remove 12345678-1234-5678-90ab-cdef01234567 \
+    internal-maintenance
+
+Print an empty health report template:
+    $ carbide-admin-cli nvl-domain health-report print-empty-template
+
+")]
 pub enum Args {
     #[clap(about = "List health report sources for an NVLink domain")]
     Show { domain_id: NvLinkDomainId },

--- a/crates/admin-cli/src/nvl_logical_partition/create/args.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/create/args.rs
@@ -19,6 +19,14 @@ use ::rpc::forge as forgerpc;
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create a logical partition for a tenant:
+    $ carbide-admin-cli logical-partition create --name my-partition \
+    --tenant-organization-id fds34511233a
+
+")]
 pub struct Args {
     #[clap(short = 'n', long, help = "name of the partition")]
     pub name: String,

--- a/crates/admin-cli/src/nvl_logical_partition/delete/args.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/delete/args.rs
@@ -22,6 +22,13 @@ use clap::Parser;
 use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a logical partition by name:
+    $ carbide-admin-cli logical-partition delete --name my-partition
+
+")]
 pub struct Args {
     #[clap(short = 'n', long, help = "name of the partition")]
     pub name: String,

--- a/crates/admin-cli/src/nvl_logical_partition/show/args.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/show/args.rs
@@ -18,6 +18,19 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all logical partitions:
+    $ carbide-admin-cli logical-partition show
+
+Show one logical partition by ID:
+    $ carbide-admin-cli logical-partition show 12345678-1234-5678-90ab-cdef01234567
+
+Filter by name:
+    $ carbide-admin-cli logical-partition show --name my-partition
+
+")]
 pub struct Args {
     #[clap(
         default_value(""),

--- a/crates/admin-cli/src/nvl_partition/show/args.rs
+++ b/crates/admin-cli/src/nvl_partition/show/args.rs
@@ -18,6 +18,22 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all NvLink partitions:
+    $ carbide-admin-cli nvl-partition show
+
+Show one NvLink partition by ID:
+    $ carbide-admin-cli nvl-partition show 12345678-1234-5678-90ab-cdef01234567
+
+Filter by tenant org:
+    $ carbide-admin-cli nvl-partition show --tenant-org-id fds34511233a
+
+Filter by name:
+    $ carbide-admin-cli nvl-partition show --name my-partition
+
+")]
 pub struct Args {
     #[clap(
         default_value(""),

--- a/crates/admin-cli/src/nvlink_nmxc_endpoints/create.rs
+++ b/crates/admin-cli/src/nvlink_nmxc_endpoints/create.rs
@@ -11,6 +11,14 @@ use crate::cfg::runtime::RuntimeContext;
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Insert a chassis serial to NMX-C endpoint mapping:
+    $ carbide-admin-cli nvlink-nmxc-endpoints create --chassis-serial 1234567890123 \
+    --endpoint https://192.0.2.10:50051
+
+")]
 pub struct Args {
     #[clap(long, value_name = "SERIAL")]
     pub chassis_serial: String,

--- a/crates/admin-cli/src/nvlink_nmxc_endpoints/delete.rs
+++ b/crates/admin-cli/src/nvlink_nmxc_endpoints/delete.rs
@@ -11,6 +11,13 @@ use crate::cfg::runtime::RuntimeContext;
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove the mapping for a chassis serial:
+    $ carbide-admin-cli nvlink-nmxc-endpoints delete --chassis-serial 1234567890123
+
+")]
 pub struct Args {
     #[clap(long, value_name = "SERIAL")]
     pub chassis_serial: String,

--- a/crates/admin-cli/src/nvlink_nmxc_endpoints/show.rs
+++ b/crates/admin-cli/src/nvlink_nmxc_endpoints/show.rs
@@ -13,6 +13,16 @@ use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all chassis serial to NMX-C endpoint mappings:
+    $ carbide-admin-cli nvlink-nmxc-endpoints show
+
+Show the mapping for one chassis serial:
+    $ carbide-admin-cli nvlink-nmxc-endpoints show --chassis-serial 1234567890123
+
+")]
 pub struct Args {
     /// If set, show only this chassis serial
     #[clap(long, value_name = "SERIAL")]

--- a/crates/admin-cli/src/nvlink_nmxc_endpoints/update.rs
+++ b/crates/admin-cli/src/nvlink_nmxc_endpoints/update.rs
@@ -11,6 +11,14 @@ use crate::cfg::runtime::RuntimeContext;
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Change the NMX-C endpoint URL for a chassis serial:
+    $ carbide-admin-cli nvlink-nmxc-endpoints update --chassis-serial 1234567890123 \
+    --endpoint https://192.0.2.20:50051
+
+")]
 pub struct Args {
     #[clap(long, value_name = "SERIAL")]
     pub chassis_serial: String,

--- a/crates/admin-cli/src/operating_system/create/args.rs
+++ b/crates/admin-cli/src/operating_system/create/args.rs
@@ -21,6 +21,17 @@ use clap::Parser;
 use crate::operating_system::common::parse_param;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create an OS definition:
+    $ carbide-admin-cli operating-system create --name ubuntu-22.04 --org fds34511233a
+
+Create one with a description, inactive, allowing parameter overrides:
+    $ carbide-admin-cli operating-system create --name ubuntu-22.04 --org fds34511233a \
+    --description \"Ubuntu 22.04 base\" --is-active false --allow-override
+
+")]
 pub struct Args {
     #[clap(short, long, help = "Name of the operating system definition.")]
     pub name: String,

--- a/crates/admin-cli/src/operating_system/delete/args.rs
+++ b/crates/admin-cli/src/operating_system/delete/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete an operating system definition by ID:
+    $ carbide-admin-cli operating-system delete 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "UUID of the operating system definition to delete.")]
     pub id: String,

--- a/crates/admin-cli/src/operating_system/get_artifacts/args.rs
+++ b/crates/admin-cli/src/operating_system/get_artifacts/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Get the artifact list for an OS definition:
+    $ carbide-admin-cli operating-system get-artifacts 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "UUID of the operating system definition.")]
     pub id: String,

--- a/crates/admin-cli/src/operating_system/set_cached_url/args.rs
+++ b/crates/admin-cli/src/operating_system/set_cached_url/args.rs
@@ -34,6 +34,18 @@ fn parse_cached_url_update(s: &str) -> Result<IpxeTemplateArtifactUpdateRequest,
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Set the cached_url for an artifact:
+    $ carbide-admin-cli operating-system set-cached-url 12345678-1234-5678-90ab-cdef01234567 \
+    --set kernel=https://cache.example.com/vmlinuz
+
+Clear the cached_url for an artifact (NAME= with empty URL):
+    $ carbide-admin-cli operating-system set-cached-url 12345678-1234-5678-90ab-cdef01234567 \
+    --set kernel=
+
+")]
 pub struct Args {
     #[clap(help = "UUID of the operating system definition.")]
     pub id: String,

--- a/crates/admin-cli/src/operating_system/show/args.rs
+++ b/crates/admin-cli/src/operating_system/show/args.rs
@@ -18,6 +18,19 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all operating system definitions:
+    $ carbide-admin-cli operating-system show
+
+Show one OS definition by ID:
+    $ carbide-admin-cli operating-system show 12345678-1234-5678-90ab-cdef01234567
+
+List the OS definitions for an organization:
+    $ carbide-admin-cli operating-system show --org fds34511233a
+
+")]
 pub struct Args {
     #[clap(help = "Operating system definition ID; omit to list all.")]
     pub id: Option<String>,

--- a/crates/admin-cli/src/operating_system/update/args.rs
+++ b/crates/admin-cli/src/operating_system/update/args.rs
@@ -21,6 +21,21 @@ use clap::Parser;
 use crate::operating_system::common::parse_param;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Rename an OS definition and update its description:
+    $ carbide-admin-cli operating-system update 12345678-1234-5678-90ab-cdef01234567 \
+    --name ubuntu-22.04 --description \"Ubuntu 22.04 base\"
+
+Deactivate an OS definition:
+    $ carbide-admin-cli operating-system update 12345678-1234-5678-90ab-cdef01234567 --is-active false
+
+Replace the iPXE boot script:
+    $ carbide-admin-cli operating-system update 12345678-1234-5678-90ab-cdef01234567 \
+    --ipxe-script \"#!ipxe …\"
+
+")]
 pub struct Args {
     #[clap(help = "UUID of the operating system definition to update.")]
     pub id: String,

--- a/crates/admin-cli/src/os_image/create/args.rs
+++ b/crates/admin-cli/src/os_image/create/args.rs
@@ -22,6 +22,19 @@ use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::os_image::common::str_to_rpc_uuid;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create an OS image entry in a tenant's catalog:
+    $ carbide-admin-cli os-image create --id 12345678-1234-5678-90ab-cdef01234567 \
+    --url https://images.example.com/ubuntu.qcow2 --digest sha256:abcd… --tenant-org-id fds34511233a
+
+Create one with a name/description and a Bearer auth token for the image URL:
+    $ carbide-admin-cli os-image create --id 12345678-1234-5678-90ab-cdef01234567 \
+    --url https://images.example.com/ubuntu.qcow2 --digest sha256:abcd… --tenant-org-id fds34511233a \
+    --name ubuntu-22.04 --description \"Ubuntu 22.04 base\" --auth-type Bearer --auth-token <token>
+
+")]
 pub struct Args {
     #[clap(short = 'i', long, help = "uuid of the OS image to create.")]
     pub id: String,

--- a/crates/admin-cli/src/os_image/delete/args.rs
+++ b/crates/admin-cli/src/os_image/delete/args.rs
@@ -22,6 +22,14 @@ use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::os_image::common::str_to_rpc_uuid;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete an OS image (must be unused by any instance):
+    $ carbide-admin-cli os-image delete --id 12345678-1234-5678-90ab-cdef01234567 \
+    --tenant-org-id fds34511233a
+
+")]
 pub struct Args {
     #[clap(short = 'i', long, help = "uuid of the OS image to delete.")]
     pub id: String,

--- a/crates/admin-cli/src/os_image/show/args.rs
+++ b/crates/admin-cli/src/os_image/show/args.rs
@@ -21,6 +21,19 @@ use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::os_image::common::str_to_rpc_uuid;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show a single OS image by UUID:
+    $ carbide-admin-cli os-image show --id 12345678-1234-5678-90ab-cdef01234567
+
+List all OS images for a tenant:
+    $ carbide-admin-cli os-image show --tenant-org-id fds34511233a
+
+List every OS image:
+    $ carbide-admin-cli os-image show
+
+")]
 pub struct Args {
     #[clap(short = 'i', long, help = "uuid of the OS image to show.")]
     pub id: Option<String>,

--- a/crates/admin-cli/src/os_image/update/args.rs
+++ b/crates/admin-cli/src/os_image/update/args.rs
@@ -21,6 +21,18 @@ use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::os_image::common::str_to_rpc_uuid;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Rename an OS image and update its description:
+    $ carbide-admin-cli os-image update --id 12345678-1234-5678-90ab-cdef01234567 \
+    --name ubuntu-22.04 --description \"Ubuntu 22.04 base\"
+
+Rotate the image URL's auth token:
+    $ carbide-admin-cli os-image update --id 12345678-1234-5678-90ab-cdef01234567 \
+    --auth-type Bearer --auth-token <token>
+
+")]
 pub struct Args {
     #[clap(short = 'i', long, help = "uuid of the OS image to update.")]
     pub id: String,

--- a/crates/admin-cli/src/ping/args.rs
+++ b/crates/admin-cli/src/ping/args.rs
@@ -18,6 +18,16 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Ping the API server (default 1s interval):
+    $ carbide-admin-cli ping
+
+Ping twice a second:
+    $ carbide-admin-cli ping --interval 0.5
+
+")]
 pub struct Opts {
     #[clap(
         short,

--- a/crates/admin-cli/src/power_shelf/delete/args.rs
+++ b/crates/admin-cli/src/power_shelf/delete/args.rs
@@ -21,6 +21,13 @@ use carbide_uuid::power_shelf::PowerShelfId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a power shelf by ID:
+    $ carbide-admin-cli power-shelf delete 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "Power Shelf ID to delete.")]
     pub power_shelf_id: String,

--- a/crates/admin-cli/src/power_shelf/force_delete/args.rs
+++ b/crates/admin-cli/src/power_shelf/force_delete/args.rs
@@ -19,6 +19,16 @@ use carbide_uuid::power_shelf::PowerShelfId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Force delete a power shelf:
+    $ carbide-admin-cli power-shelf force-delete 12345678-1234-5678-90ab-cdef01234567
+
+Force delete a power shelf and its machine interfaces:
+    $ carbide-admin-cli power-shelf force-delete 12345678-1234-5678-90ab-cdef01234567 --delete-interfaces
+
+")]
 pub struct Args {
     #[clap(help = "Power Shelf ID to force delete.")]
     pub power_shelf_id: PowerShelfId,

--- a/crates/admin-cli/src/power_shelf/health_report/add/args.rs
+++ b/crates/admin-cli/src/power_shelf/health_report/add/args.rs
@@ -22,6 +22,22 @@ use crate::machine::HealthReportTemplates;
 
 #[derive(Parser, Debug)]
 #[clap(group(ArgGroup::new("health_report_source").required(true).args(&["health_report", "template"])))]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add a health report source from a predefined template:
+    $ carbide-admin-cli power-shelf health-report add 12345678-1234-5678-90ab-cdef01234567 \
+    --template internal-maintenance --message \"Firmware upgrade in progress\"
+
+Add a health report source from raw JSON:
+    $ carbide-admin-cli power-shelf health-report add 12345678-1234-5678-90ab-cdef01234567 \
+    --health-report '{...}'
+
+Preview the report without sending it:
+    $ carbide-admin-cli power-shelf health-report add 12345678-1234-5678-90ab-cdef01234567 \
+    --template degraded --print-only
+
+")]
 pub struct Args {
     pub power_shelf_id: PowerShelfId,
     #[clap(long, help = "New health report as json")]

--- a/crates/admin-cli/src/power_shelf/health_report/remove/args.rs
+++ b/crates/admin-cli/src/power_shelf/health_report/remove/args.rs
@@ -19,6 +19,14 @@ use carbide_uuid::power_shelf::PowerShelfId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove a health report source from a power shelf (source name from `health-report show`):
+    $ carbide-admin-cli power-shelf health-report remove 12345678-1234-5678-90ab-cdef01234567 \
+    internal-maintenance
+
+")]
 pub struct Args {
     pub power_shelf_id: PowerShelfId,
     pub report_source: String,

--- a/crates/admin-cli/src/power_shelf/health_report/show/args.rs
+++ b/crates/admin-cli/src/power_shelf/health_report/show/args.rs
@@ -19,6 +19,13 @@ use carbide_uuid::power_shelf::PowerShelfId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List the health report sources for a power shelf:
+    $ carbide-admin-cli power-shelf health-report show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "Power Shelf ID to show health reports for")]
     pub power_shelf_id: PowerShelfId,

--- a/crates/admin-cli/src/power_shelf/list/args.rs
+++ b/crates/admin-cli/src/power_shelf/list/args.rs
@@ -20,6 +20,22 @@ use mac_address::MacAddress;
 use rpc::forge::DeletedFilter;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all live power shelves:
+    $ carbide-admin-cli power-shelf list
+
+Include deleted power shelves:
+    $ carbide-admin-cli power-shelf list --deleted include
+
+Filter by controller state:
+    $ carbide-admin-cli power-shelf list --controller-state ready
+
+Find a power shelf by its BMC MAC address:
+    $ carbide-admin-cli power-shelf list --bmc-mac 00:11:22:33:44:55
+
+")]
 pub struct Args {
     /// Include deleted power shelves
     #[clap(long, value_enum, default_value = "exclude")]

--- a/crates/admin-cli/src/power_shelf/maintenance/args.rs
+++ b/crates/admin-cli/src/power_shelf/maintenance/args.rs
@@ -26,8 +26,32 @@ use rpc::forge as forgerpc;
 #[allow(clippy::enum_variant_names)]
 pub enum Args {
     /// Request the listed power shelves to power on.
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Power on a power shelf:
+    $ carbide-admin-cli power-shelf maintenance power-on --power-shelf-id 12345678-1234-5678-90ab-cdef01234567
+
+Power on several at once, citing a reference ticket:
+    $ carbide-admin-cli power-shelf maintenance power-on \
+    --power-shelf-id 12345678-1234-5678-90ab-cdef01234567 abcdef01-2345-6789-abcd-ef0123456789 \
+    --reference https://tickets.example.com/PS-42
+
+")]
     PowerOn(MaintenancePowerArgs),
     /// Request the listed power shelves to power off.
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Power off a power shelf:
+    $ carbide-admin-cli power-shelf maintenance power-off --power-shelf-id 12345678-1234-5678-90ab-cdef01234567
+
+Power off several at once, citing a reference ticket:
+    $ carbide-admin-cli power-shelf maintenance power-off \
+    --power-shelf-id 12345678-1234-5678-90ab-cdef01234567 abcdef01-2345-6789-abcd-ef0123456789 \
+    --reference https://tickets.example.com/PS-42
+
+")]
     PowerOff(MaintenancePowerArgs),
 }
 

--- a/crates/admin-cli/src/power_shelf/metadata/args.rs
+++ b/crates/admin-cli/src/power_shelf/metadata/args.rs
@@ -33,12 +33,27 @@ pub enum Args {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show a power shelf's metadata:
+    $ carbide-admin-cli power-shelf metadata show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct PowerShelfMetadataCommandShow {
     #[clap(help = "The power shelf which should get its metadata displayed")]
     pub power_shelf: PowerShelfId,
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Set a power shelf's name and description:
+    $ carbide-admin-cli power-shelf metadata set 12345678-1234-5678-90ab-cdef01234567 \
+    --name ps-01 --description \"Rack 4 power shelf\"
+
+")]
 pub struct PowerShelfMetadataCommandSet {
     #[clap(help = "The power shelf which should get updated metadata")]
     pub power_shelf: PowerShelfId,
@@ -49,6 +64,17 @@ pub struct PowerShelfMetadataCommandSet {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add a key-only label:
+    $ carbide-admin-cli power-shelf metadata add-label 12345678-1234-5678-90ab-cdef01234567 --key edge
+
+Add a key/value label:
+    $ carbide-admin-cli power-shelf metadata add-label 12345678-1234-5678-90ab-cdef01234567 \
+    --key row --value C
+
+")]
 pub struct PowerShelfMetadataCommandAddLabel {
     #[clap(help = "The power shelf which should get updated metadata")]
     pub power_shelf: PowerShelfId,
@@ -59,6 +85,14 @@ pub struct PowerShelfMetadataCommandAddLabel {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove one or more labels by key:
+    $ carbide-admin-cli power-shelf metadata remove-labels 12345678-1234-5678-90ab-cdef01234567 \
+    --keys row --keys edge
+
+")]
 pub struct PowerShelfMetadataCommandRemoveLabels {
     #[clap(help = "The power shelf which should get updated metadata")]
     pub power_shelf: PowerShelfId,
@@ -67,6 +101,17 @@ pub struct PowerShelfMetadataCommandRemoveLabels {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Fill in missing metadata from the expected-power-shelf (leaving existing values intact):
+    $ carbide-admin-cli power-shelf metadata from-expected-power-shelf 12345678-1234-5678-90ab-cdef01234567
+
+Overwrite the power shelf's metadata with the expected-power-shelf's values:
+    $ carbide-admin-cli power-shelf metadata from-expected-power-shelf 12345678-1234-5678-90ab-cdef01234567 \
+    --replace-all
+
+")]
 pub struct PowerShelfMetadataCommandFromExpectedPowerShelf {
     #[clap(help = "The power shelf which should get updated metadata")]
     pub power_shelf: PowerShelfId,

--- a/crates/admin-cli/src/power_shelf/show/args.rs
+++ b/crates/admin-cli/src/power_shelf/show/args.rs
@@ -18,6 +18,16 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all power shelves:
+    $ carbide-admin-cli power-shelf show
+
+Show one power shelf by ID or name:
+    $ carbide-admin-cli power-shelf show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "Power shelf ID or name to show (leave empty for all)")]
     pub identifier: Option<String>,

--- a/crates/admin-cli/src/rack/delete/args.rs
+++ b/crates/admin-cli/src/rack/delete/args.rs
@@ -18,6 +18,16 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a rack by ID:
+    $ carbide-admin-cli rack delete 12345678-1234-5678-90ab-cdef01234567
+
+Delete a rack by name:
+    $ carbide-admin-cli rack delete rack-01
+
+")]
 pub struct Args {
     #[clap(
         help = "Rack ID or name to delete (should not have any associated compute trays, nvlink switches or power shelves)"

--- a/crates/admin-cli/src/rack/list/args.rs
+++ b/crates/admin-cli/src/rack/list/args.rs
@@ -18,4 +18,11 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all racks:
+    $ carbide-admin-cli rack list
+
+")]
 pub struct Args;

--- a/crates/admin-cli/src/rack/maintenance/args.rs
+++ b/crates/admin-cli/src/rack/maintenance/args.rs
@@ -27,6 +27,21 @@ pub enum Args {
 }
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Start maintenance on a full rack (all activities, all components):
+    $ carbide-admin-cli rack maintenance start --rack 12345678-1234-5678-90ab-cdef01234567
+
+Run only a firmware upgrade on specific machines:
+    $ carbide-admin-cli rack maintenance start --rack 12345678-1234-5678-90ab-cdef01234567 \
+    --machine-ids m1,m2 --activities firmware-upgrade
+
+Firmware upgrade from a SOT JSON file, forcing the update:
+    $ carbide-admin-cli rack maintenance start --rack 12345678-1234-5678-90ab-cdef01234567 \
+    --activities firmware-upgrade --sot-json-file ./sot.json --access-token \"$TOKEN\" --force-update
+
+")]
 pub struct MaintenanceOptions {
     #[clap(short, long, help = "Rack ID to start maintenance on")]
     pub rack: RackId,

--- a/crates/admin-cli/src/rack/metadata/args.rs
+++ b/crates/admin-cli/src/rack/metadata/args.rs
@@ -33,12 +33,27 @@ pub enum Args {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show a rack's metadata:
+    $ carbide-admin-cli rack metadata show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct RackMetadataCommandShow {
     #[clap(help = "The rack which should get its metadata displayed")]
     pub rack: RackId,
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Set a rack's name and description:
+    $ carbide-admin-cli rack metadata set 12345678-1234-5678-90ab-cdef01234567 \
+    --name rack-01 --description \"Row C, position 1\"
+
+")]
 pub struct RackMetadataCommandSet {
     #[clap(help = "The rack which should get updated metadata")]
     pub rack: RackId,
@@ -49,6 +64,17 @@ pub struct RackMetadataCommandSet {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add a key-only label:
+    $ carbide-admin-cli rack metadata add-label 12345678-1234-5678-90ab-cdef01234567 --key edge
+
+Add a key/value label:
+    $ carbide-admin-cli rack metadata add-label 12345678-1234-5678-90ab-cdef01234567 \
+    --key row --value C
+
+")]
 pub struct RackMetadataCommandAddLabel {
     #[clap(help = "The rack which should get updated metadata")]
     pub rack: RackId,
@@ -59,6 +85,14 @@ pub struct RackMetadataCommandAddLabel {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove one or more labels by key:
+    $ carbide-admin-cli rack metadata remove-labels 12345678-1234-5678-90ab-cdef01234567 \
+    --keys row --keys edge
+
+")]
 pub struct RackMetadataCommandRemoveLabels {
     #[clap(help = "The rack which should get updated metadata")]
     pub rack: RackId,
@@ -67,6 +101,17 @@ pub struct RackMetadataCommandRemoveLabels {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Fill in missing metadata from the expected-rack (leaving existing values intact):
+    $ carbide-admin-cli rack metadata from-expected-rack 12345678-1234-5678-90ab-cdef01234567
+
+Overwrite the rack's metadata with the expected-rack's values:
+    $ carbide-admin-cli rack metadata from-expected-rack 12345678-1234-5678-90ab-cdef01234567 \
+    --replace-all
+
+")]
 pub struct RackMetadataCommandFromExpectedRack {
     #[clap(help = "The rack which should get updated metadata")]
     pub rack: RackId,

--- a/crates/admin-cli/src/rack/profile/show/args.rs
+++ b/crates/admin-cli/src/rack/profile/show/args.rs
@@ -19,6 +19,13 @@ use carbide_uuid::rack::RackId;
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show the profile for a rack:
+    $ carbide-admin-cli rack profile show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "Rack ID to get profile for")]
     pub rack_id: RackId,

--- a/crates/admin-cli/src/rack/show/args.rs
+++ b/crates/admin-cli/src/rack/show/args.rs
@@ -19,6 +19,16 @@ use carbide_uuid::rack::RackId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all racks:
+    $ carbide-admin-cli rack show
+
+Show details for one rack:
+    $ carbide-admin-cli rack show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "Rack ID to show (leave empty for all)")]
     pub rack: Option<RackId>,

--- a/crates/admin-cli/src/redfish/args.rs
+++ b/crates/admin-cli/src/redfish/args.rs
@@ -21,21 +21,50 @@ use clap::{ArgGroup, Parser};
 use libredfish::model::update_service::ComponentType;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Every redfish command targets a BMC: --address is required, --username
+and --password are optional, and all are given before the subcommand:
+
+Read the current power state:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword get-power-state
+
+Power a machine on:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword on
+
+Force a machine off (alias: off):
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword force-off
+
+Set PXE first in the boot order:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword boot-pxe
+
+Update host firmware from a local package:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    update-firmware-multipart --filename ./host-fw.bin
+
+Browse an arbitrary Redfish URI:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    browse --uri /redfish/v1/Systems
+
+")]
 pub struct RedfishAction {
     #[clap(subcommand)]
     pub command: Cmd,
 
+    // A non-`Option` field is required by clap automatically, which renders
+    // `--address <ADDRESS>` (unbracketed) in the usage line and rejects a
+    // missing value as a clap error (exit 2) — no runtime validation needed.
     #[clap(
         long,
-        global = true,
         help = "IP:port of machine BMC. Port is optional and defaults to 443"
     )]
-    pub address: Option<String>,
+    pub address: String,
 
-    #[clap(long, global = true, help = "Username for machine BMC")]
+    #[clap(long, help = "Username for machine BMC")]
     pub username: Option<String>,
 
-    #[clap(long, global = true, help = "Password for machine BMC")]
+    #[clap(long, help = "Password for machine BMC")]
     pub password: Option<String>,
 }
 
@@ -80,19 +109,47 @@ pub enum Cmd {
     LockdownStatus,
     /// Force turn machine off
     #[clap(alias = "off", verbatim_doc_comment)]
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Force a machine off (also accepted as the alias `off`):
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword force-off
+
+")]
     ForceOff,
     /// Force restart. This is equivalent to pressing the reset button on the front panel.
     /// - Will not restart DPUs
     /// - Will apply pending BIOS/UEFI setting changes
     #[clap(alias = "reset", verbatim_doc_comment)]
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Force-restart a machine (also accepted as the alias `reset`):
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword force-restart
+
+")]
     ForceRestart,
     /// Graceful restart. Asks the OS to restart via ACPI
     /// - Might restart DPUs if no OS is running
     /// - Will not apply pending BIOS/UEFI setting changes
     #[clap(alias = "restart", verbatim_doc_comment)]
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Gracefully restart a machine (also accepted as the alias `restart`):
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword graceful-restart
+
+")]
     GracefulRestart,
     /// Graceful host shutdown
     #[clap(alias = "shutdown", verbatim_doc_comment)]
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Gracefully shut a machine down (also accepted as the alias `shutdown`):
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword graceful-shutdown
+
+")]
     GracefulShutdown,
     /// AC power cycle
     ACPowerCycle,
@@ -124,7 +181,7 @@ pub enum Cmd {
     DisableSecureBoot,
     /// List Chassis
     GetChassisAll,
-    // List Chassis Subsystem
+    /// List Chassis Subsystem
     GetChassis(Chassis),
     /// Show BMC's Ethernet interface information
     GetBmcEthernetInterfaces,
@@ -137,56 +194,108 @@ pub enum Cmd {
     /// Change password for a BMC user
     ChangeBmcPassword(BmcPassword),
     /// Change UEFI password
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Change the UEFI password (supply the current and new values):
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    change-uefi-password --current-password mycurrentpassword --new-password mynewpassword
+
+")]
     ChangeUefiPassword(UefiPassword),
     #[clap(about = "DPU specific operations", subcommand)]
     Dpu(DpuOperations),
+    /// Get information about the managers
     GetManager,
     /// Update host firmware
     UpdateFirmwareMultipart(Multipart),
-    // Get detailed info on a Redfish task
+    /// Get detailed info on a Redfish task
     GetTask(Task),
-    // Get a list of Redfish tasks
+    /// Get a list of Redfish tasks
     GetTasks,
     /// Clear UEFI password
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Clear the UEFI password (supply the current one):
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    clear-uefi-password --current-password mycurrentpassword --new-password ''
+
+")]
     ClearUefiPassword(UefiPassword),
-    // Is IPMI enabled over LAN
+    /// Is IPMI enabled over LAN
     IsIpmiOverLanEnabled,
-    // Enable IPMI over LAN
+    /// Enable IPMI over LAN
     EnableIpmiOverLan,
-    // Disable IPMI over LAN
+    /// Disable IPMI over LAN
     DisableIpmiOverLan,
-    // Get Base Mac Address (DPU only)
+    /// Get Base Mac Address (DPU only)
     GetBaseMacAddress,
-    // Clear Nvram (Viking only)
+    /// Clear Nvram (Viking only)
     ClearNvram,
-    // Redfish browser
-    Browse(UriInfo),
-    // Set BIOS options
+    /// Set BIOS options
     SetBios(SetBios),
+    /// Get DPU mode
     GetNicMode,
+    /// Is infinite boot enable
     IsInfiniteBootEnabled,
+    /// Enable infinite boot
     EnableInfiniteBoot,
-    SetNicMode,
+    /// Set DPU NIC mode
+    #[clap(visible_alias = "set-nic-mode")]
     SetDpuMode,
+    /// Power cycle a machine
     ChassisResetCard1Powercycle,
+    /// Set the DPU as the first boot target
+    /// Set the boot order so the DPU boots first
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Set the boot order so the DPU boots first:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    set-boot-order-dpu-first --boot-interface-mac 00:11:22:33:44:55
+
+")]
     SetBootOrderDpuFirst(SetBootOrderDpuFirstArgs),
+    /// Get status of the rshim process on DPU
     GetHostRshim,
+    /// Enable rshim on DPU
     EnableHostRshim,
+    /// Disable rshim on dpu
     DisableHostRshim,
+    /// Get the Boss Controller
     GetBossController,
-    DecomissionController(DecomissionControllerArgs),
+    /// Decommission a storage controller
+    DecommissionController(DecomissionControllerArgs),
+    /// Create a storage volume
     CreateVolume(CreateVolumeArgs),
+    /// Check if boot order is set correctly
+    /// Check whether the DPU-first boot order is already configured
+    #[command(after_long_help = "\
+EXAMPLES:
+
+Check whether the DPU-first boot order is already configured:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    is-boot-order-setup --boot-interface-mac 00:11:22:33:44:55
+
+")]
     IsBootOrderSetup(SetBootOrderDpuFirstArgs),
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
-pub struct UriInfo {
-    #[clap(long, help = "Redfish URI")]
-    pub uri: String,
-}
-
-#[derive(Parser, Debug, PartialEq, Clone)]
 #[clap(group(ArgGroup::new("selector").required(true).args(&["all", "id"])))]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all BIOS boot options:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    get-boot-option --all
+
+Show one boot option by ID:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    get-boot-option --id Boot0001
+
+")]
 pub struct BootOptionSelector {
     #[clap(long)]
     pub all: bool,
@@ -195,6 +304,18 @@ pub struct BootOptionSelector {
 }
 
 #[derive(clap::Parser, Debug, PartialEq, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show DPU firmware versions:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    dpu firmware show --all
+
+Show DPU port information:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    dpu ports
+
+")]
 pub enum DpuOperations {
     /// BMC's FW Commands
     #[clap(visible_alias = "fw", about = "BMC's FW Commands", subcommand)]
@@ -204,6 +325,22 @@ pub enum DpuOperations {
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Print the DPU firmware update status:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    dpu firmware status
+
+Update the DPU BMC firmware from a package:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    dpu firmware update --package ./bmc-fw.fwpkg
+
+Show all discovered firmware versions:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    dpu firmware show --all
+
+")]
 pub enum FwCommand {
     /// Print FW update status
     Status,
@@ -214,6 +351,14 @@ pub enum FwCommand {
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Install a DPU BMC firmware package:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    dpu firmware update --package ./bmc-fw.fwpkg
+
+")]
 pub struct FwPackage {
     #[clap(short, long, help = "FW package to install")]
     pub package: PathBuf,
@@ -228,6 +373,14 @@ pub struct UefiPassword {
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Rename a BMC account:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    change-bmc-username --old-user svc-ops --new-user svc-platform
+
+")]
 pub struct BmcUsername {
     #[clap(long, help = "Old username")]
     pub old_user: String,
@@ -236,6 +389,14 @@ pub struct BmcUsername {
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Change a BMC user's password:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    change-bmc-password --user svc-ops --new-password 'mynewpassword'
+
+")]
 pub struct BmcPassword {
     #[clap(long, help = "New BMC password")]
     pub new_password: String,
@@ -244,6 +405,18 @@ pub struct BmcPassword {
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Update host firmware from a local file:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    update-firmware-multipart --filename ./host-fw.bin
+
+Update firmware and specify the component type:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    update-firmware-multipart --filename ./uefi.bin --component-type uefi
+
+")]
 pub struct Multipart {
     #[clap(long, help = "Local filename for the firmware to be installed")]
     pub filename: String,
@@ -255,18 +428,46 @@ pub struct Multipart {
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Get details for a Redfish task:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    get-task --taskid JID_123456789012
+
+")]
 pub struct Task {
     #[clap(long, help = "Task ID")]
     pub taskid: String,
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show one chassis subsystem by ID:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    get-chassis --chassis-id Chassis-1
+
+")]
 pub struct Chassis {
     #[clap(long, help = "Chassis ID")]
     pub chassis_id: String,
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create a BMC user (defaults to the administrator role):
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    create-bmc-user --user svc-ops --new-password 'mynewpassword'
+
+Create a read-only BMC user:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    create-bmc-user --user auditor --new-password 'mynewpassword' --role-id readonly
+
+")]
 pub struct BmcUser {
     #[clap(long, help = "BMC password")]
     pub new_password: String,
@@ -274,18 +475,35 @@ pub struct BmcUser {
     pub user: String,
     #[clap(
         long,
-        help = "BMC role (administrator, operator, readonly, noaccess). Default to administrator"
+        value_enum,
+        help = "BMC role for the new account (default: administrator)"
     )]
-    pub role_id: Option<String>,
+    pub role_id: Option<crate::bmc_role::BmcRole>,
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a BMC user by name:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    delete-bmc-user --user svc-ops
+
+")]
 pub struct DeleteBmcUser {
     #[clap(long, help = "BMC user")]
     pub user: String,
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Run the standard machine setup:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    machine-setup --boot-interface-mac 00:11:22:33:44:55
+
+")]
 pub struct MachineSetupArgs {
     #[clap(long, help = "boot_interface_mac")]
     pub boot_interface_mac: Option<String>,
@@ -296,6 +514,14 @@ pub struct MachineSetupArgs {
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Check what machine-setup steps remain:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    machine-setup-status --boot-interface-mac 00:11:22:33:44:55
+
+")]
 pub struct MachineSetupStatusArgs {
     #[clap(long, help = "boot_interface_mac")]
     pub boot_interface_mac: Option<String>,
@@ -308,12 +534,28 @@ pub struct SetBootOrderDpuFirstArgs {
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Decommission a storage controller:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    decomission-controller --controller-id RAID.Slot.1-1
+
+")]
 pub struct DecomissionControllerArgs {
     #[clap(long, help = "controller_id")]
     pub controller_id: String,
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create a volume on a storage controller:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    create-volume --controller-id RAID.Slot.1-1 --volume-name data0
+
+")]
 pub struct CreateVolumeArgs {
     #[clap(long, help = "controller_id")]
     pub controller_id: String,
@@ -326,6 +568,22 @@ pub struct CreateVolumeArgs {
         ArgGroup::new("show_fw")
         .required(true)
         .args(&["all", "bmc", "dpu_os", "uefi", "fw"])))]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show all discovered firmware key/values:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    dpu firmware show --all
+
+Show just the DPU OS version:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    dpu firmware show --dpu-os
+
+Show a specific firmware type by name:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    dpu firmware show DPU_NIC
+
+")]
 pub struct ShowFw {
     #[clap(
         short,
@@ -363,6 +621,18 @@ pub struct ShowFw {
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show all DPU ports:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    dpu ports
+
+Show a single port by name:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    dpu ports eth0
+
+")]
 pub struct ShowPort {
     #[clap(
         short,
@@ -381,6 +651,14 @@ pub struct ShowPort {
 }
 
 #[derive(Parser, Debug, Clone, PartialEq)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Set one or more BIOS attributes from JSON:
+    $ carbide-admin-cli redfish --address 192.0.2.10 --username admin --password mypassword \
+    set-bios --attributes '{\"OperatingModes_ChooseOperatingMode\": \"MaximumPerformance\"}'
+
+")]
 pub struct SetBios {
     #[clap(
         long,

--- a/crates/admin-cli/src/redfish/cmds.rs
+++ b/crates/admin-cli/src/redfish/cmds.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::time::Duration;
 
-use color_eyre::eyre::eyre;
+use eyre::eyre;
 use libredfish::model::oem::nvidia_dpu::NicMode;
 use libredfish::model::software_inventory::SoftwareInventory;
 use libredfish::model::task::{Task, TaskState};
@@ -32,45 +32,13 @@ use libredfish::{
 };
 use mac_address::MacAddress;
 use prettytable::{Table, row};
-use serde::Serialize;
 use tracing::warn;
 
 use super::args::{Cmd, DpuOperations, FwCommand, RedfishAction, ShowFw, ShowPort};
-use crate::rpc::ApiClient;
-
-pub async fn handle_browse_command(api_client: &ApiClient, uri: &str) -> color_eyre::Result<()> {
-    let data = api_client.0.redfish_browse(uri.to_string()).await?;
-    #[derive(Serialize, Debug)]
-    struct Output {
-        text: serde_json::Value,
-        headers: HashMap<String, String>,
-    }
-
-    let text = match serde_json::from_str(&data.text) {
-        Ok(text) => text,
-        Err(_) => {
-            println!("{data:?}");
-            return Ok(());
-        }
-    };
-
-    let output = Output {
-        text,
-        headers: data.headers,
-    };
-    println!("{}", serde_json::to_string_pretty(&output).unwrap());
-
-    Ok(())
-}
 
 pub async fn action(action: RedfishAction) -> color_eyre::Result<()> {
     let endpoint = libredfish::Endpoint {
-        host: match action.address {
-            Some(a) => a,
-            None => {
-                return Err(eyre!("Missing --address"));
-            }
-        },
+        host: action.address,
         user: action.username,
         password: action.password,
         ..Default::default()
@@ -328,18 +296,12 @@ pub async fn action(action: RedfishAction) -> color_eyre::Result<()> {
             }
         }
         CreateBmcUser(bmc_user) => {
-            let role: RoleId = match bmc_user
+            // clap has already validated --role-id against the allowed set;
+            // default to Administrator when it is omitted.
+            let role: RoleId = bmc_user
                 .role_id
-                .unwrap_or("Administrator".to_string())
-                .to_lowercase()
-                .as_str()
-            {
-                "administrator" => RoleId::Administrator,
-                "operator" => RoleId::Operator,
-                "readonly" => RoleId::ReadOnly,
-                "noaccess" => RoleId::NoAccess,
-                _ => RoleId::Administrator,
-            };
+                .map(RoleId::from)
+                .unwrap_or(RoleId::Administrator);
             redfish
                 .create_user(&bmc_user.user, &bmc_user.new_password, role)
                 .await?;
@@ -506,9 +468,6 @@ pub async fn action(action: RedfishAction) -> color_eyre::Result<()> {
         ClearNvram => {
             redfish.clear_nvram().await?;
         }
-        Browse(_) => {
-            unreachable!();
-        }
         SetBios(set_bios) => {
             let attrmap: HashMap<String, serde_json::Value> =
                 serde_json::from_str(set_bios.attributes.as_str()).unwrap();
@@ -530,9 +489,6 @@ pub async fn action(action: RedfishAction) -> color_eyre::Result<()> {
         EnableInfiniteBoot => {
             redfish.enable_infinite_boot().await?;
             println!("BIOS changes require a system restart to take effect.");
-        }
-        SetNicMode => {
-            redfish.set_nic_mode(NicMode::Nic).await?;
         }
         SetDpuMode => {
             redfish.set_nic_mode(NicMode::Dpu).await?;
@@ -580,7 +536,7 @@ pub async fn action(action: RedfishAction) -> color_eyre::Result<()> {
                 tracing::info!("Did not find BOSS Controller");
             }
         }
-        DecomissionController(args) => {
+        DecommissionController(args) => {
             if let Some(jid) = redfish
                 .decommission_storage_controller(&args.controller_id)
                 .await?

--- a/crates/admin-cli/src/redfish/mod.rs
+++ b/crates/admin-cli/src/redfish/mod.rs
@@ -21,5 +21,5 @@ pub mod cmds;
 #[cfg(test)]
 mod tests;
 
-pub use args::{Cmd, RedfishAction, UriInfo};
-pub use cmds::{action, handle_browse_command};
+pub use args::RedfishAction;
+pub use cmds::action;

--- a/crates/admin-cli/src/redfish/tests.rs
+++ b/crates/admin-cli/src/redfish/tests.rs
@@ -48,7 +48,8 @@ fn verify_cmd_structure() {
 #[test]
 fn parse_bios_attrs() {
     let action =
-        RedfishAction::try_parse_from(["redfish", "bios-attrs"]).expect("should parse bios-attrs");
+        RedfishAction::try_parse_from(["redfish", "--address", "192.0.2.10", "bios-attrs"])
+            .expect("should parse bios-attrs");
 
     assert!(matches!(action.command, Cmd::BiosAttrs));
 }
@@ -56,8 +57,8 @@ fn parse_bios_attrs() {
 // parse_boot_hdd ensures boot-hdd parses.
 #[test]
 fn parse_boot_hdd() {
-    let action =
-        RedfishAction::try_parse_from(["redfish", "boot-hdd"]).expect("should parse boot-hdd");
+    let action = RedfishAction::try_parse_from(["redfish", "--address", "192.0.2.10", "boot-hdd"])
+        .expect("should parse boot-hdd");
 
     assert!(matches!(action.command, Cmd::BootHdd));
 }
@@ -65,8 +66,8 @@ fn parse_boot_hdd() {
 // parse_boot_pxe ensures boot-pxe parses.
 #[test]
 fn parse_boot_pxe() {
-    let action =
-        RedfishAction::try_parse_from(["redfish", "boot-pxe"]).expect("should parse boot-pxe");
+    let action = RedfishAction::try_parse_from(["redfish", "--address", "192.0.2.10", "boot-pxe"])
+        .expect("should parse boot-pxe");
 
     assert!(matches!(action.command, Cmd::BootPxe));
 }
@@ -74,8 +75,9 @@ fn parse_boot_pxe() {
 // parse_get_power_state ensures get-power-state parses.
 #[test]
 fn parse_get_power_state() {
-    let action = RedfishAction::try_parse_from(["redfish", "get-power-state"])
-        .expect("should parse get-power-state");
+    let action =
+        RedfishAction::try_parse_from(["redfish", "--address", "192.0.2.10", "get-power-state"])
+            .expect("should parse get-power-state");
 
     assert!(matches!(action.command, Cmd::GetPowerState));
 }
@@ -83,8 +85,8 @@ fn parse_get_power_state() {
 // parse_force_off ensures force-off parses.
 #[test]
 fn parse_force_off() {
-    let action =
-        RedfishAction::try_parse_from(["redfish", "force-off"]).expect("should parse force-off");
+    let action = RedfishAction::try_parse_from(["redfish", "--address", "192.0.2.10", "force-off"])
+        .expect("should parse force-off");
 
     assert!(matches!(action.command, Cmd::ForceOff));
 }
@@ -92,8 +94,9 @@ fn parse_force_off() {
 // parse_force_restart ensures force-restart parses.
 #[test]
 fn parse_force_restart() {
-    let action = RedfishAction::try_parse_from(["redfish", "force-restart"])
-        .expect("should parse force-restart");
+    let action =
+        RedfishAction::try_parse_from(["redfish", "--address", "192.0.2.10", "force-restart"])
+            .expect("should parse force-restart");
 
     assert!(matches!(action.command, Cmd::ForceRestart));
 }
@@ -101,7 +104,8 @@ fn parse_force_restart() {
 // parse_on ensures on parses.
 #[test]
 fn parse_on() {
-    let action = RedfishAction::try_parse_from(["redfish", "on"]).expect("should parse on");
+    let action = RedfishAction::try_parse_from(["redfish", "--address", "192.0.2.10", "on"])
+        .expect("should parse on");
 
     assert!(matches!(action.command, Cmd::On));
 }
@@ -114,7 +118,20 @@ fn parse_with_address() {
         RedfishAction::try_parse_from(["redfish", "--address", "192.168.1.100", "get-power-state"])
             .expect("should parse with address");
 
-    assert_eq!(action.address, Some("192.168.1.100".to_string()));
+    assert_eq!(action.address, "192.168.1.100");
+}
+
+// parse_missing_address_is_error ensures a missing --address is rejected by
+// clap itself (a usage error with exit code 2), enforcing the requirement at
+// parse time rather than via a runtime check in the handler. The requirement
+// lives on the parent, so one representative subcommand covers every variant.
+#[test]
+fn parse_missing_address_is_error() {
+    let err = RedfishAction::try_parse_from(["redfish", "get-power-state"])
+        .expect_err("missing --address should be a parse error");
+
+    assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    assert_eq!(err.exit_code(), 2);
 }
 
 // parse_with_credentials ensures command parses with
@@ -143,6 +160,8 @@ fn parse_with_credentials() {
 fn parse_create_bmc_user() {
     let action = RedfishAction::try_parse_from([
         "redfish",
+        "--address",
+        "192.0.2.10",
         "create-bmc-user",
         "--new-password",
         "secret",
@@ -163,25 +182,18 @@ fn parse_create_bmc_user() {
 // parse_dpu_firmware_status ensures dpu firmware status parses.
 #[test]
 fn parse_dpu_firmware_status() {
-    let action = RedfishAction::try_parse_from(["redfish", "dpu", "firmware", "status"])
-        .expect("should parse dpu firmware status");
+    let action = RedfishAction::try_parse_from([
+        "redfish",
+        "--address",
+        "192.0.2.10",
+        "dpu",
+        "firmware",
+        "status",
+    ])
+    .expect("should parse dpu firmware status");
 
     match action.command {
         Cmd::Dpu(DpuOperations::Firmware(FwCommand::Status)) => {}
         _ => panic!("expected Dpu Firmware Status variant"),
-    }
-}
-
-// parse_browse ensures browse parses with uri.
-#[test]
-fn parse_browse() {
-    let action = RedfishAction::try_parse_from(["redfish", "browse", "--uri", "/redfish/v1"])
-        .expect("should parse browse");
-
-    match action.command {
-        Cmd::Browse(args) => {
-            assert_eq!(args.uri, "/redfish/v1");
-        }
-        _ => panic!("expected Browse variant"),
     }
 }

--- a/crates/admin-cli/src/resource_pool/grow/args.rs
+++ b/crates/admin-cli/src/resource_pool/grow/args.rs
@@ -22,6 +22,13 @@ use clap::{ArgGroup, Parser};
         ArgGroup::new("grow")
         .required(true)
         .args(&["filename"])))]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add capacity to resource pools from a TOML file:
+    $ carbide-admin-cli resource-pool grow --filename ./grow-pools.toml
+
+")]
 pub struct Args {
     #[clap(short, long)]
     pub filename: String,

--- a/crates/admin-cli/src/resource_pool/list/args.rs
+++ b/crates/admin-cli/src/resource_pool/list/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Default)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all resource pools with their stats:
+    $ carbide-admin-cli resource-pool list
+
+")]
 pub struct Args;
 
 impl From<Args> for ::rpc::forge::ListResourcePoolsRequest {

--- a/crates/admin-cli/src/rms/args.rs
+++ b/crates/admin-cli/src/rms/args.rs
@@ -18,6 +18,24 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Get the full RMS inventory (RMS URL taken from --url or config):
+    $ carbide-admin-cli rms --url https://rms.example.com:8443 inventory
+
+Get a rack's power-on sequence (URL from config):
+    $ carbide-admin-cli rms power-on-sequence rack-1
+
+Talk to RMS over mTLS with explicit certs:
+    $ carbide-admin-cli rms --url https://rms.example.com:8443 \
+    --root-ca /etc/rms/ca.crt --client-cert /etc/rms/client.crt \
+    --client-key /etc/rms/client.key inventory
+
+The --url, --root-ca, --client-cert and --client-key flags are global and
+may be given before or after the subcommand.
+
+")]
 pub struct RmsAction {
     #[clap(subcommand)]
     pub command: Cmd,
@@ -49,6 +67,13 @@ pub enum Cmd {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Get the power-on sequence for a rack:
+    $ carbide-admin-cli rms power-on-sequence rack-1
+
+")]
 pub struct PowerOnSequence {
     #[clap(help = "Rack ID to get power sequence for")]
     pub rack_id: String,
@@ -64,6 +89,13 @@ impl From<PowerOnSequence> for librms::protos::rack_manager::GetRackPowerOnSeque
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Get the power state of a node in a rack:
+    $ carbide-admin-cli rms power-state rack-1 node-1
+
+")]
 pub struct PowerState {
     #[clap(help = "Rack ID to get power sequence for")]
     pub rack_id: String,
@@ -82,6 +114,13 @@ impl From<PowerState> for librms::protos::rack_manager::GetPowerStateRequest {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Get the firmware inventory for a node in a rack:
+    $ carbide-admin-cli rms firmware-inventory rack-1 node-1
+
+")]
 pub struct FirmwareInventory {
     #[clap(help = "Rack ID to get power sequence for")]
     pub rack_id: String,

--- a/crates/admin-cli/src/route_server/add/args.rs
+++ b/crates/admin-cli/src/route_server/add/args.rs
@@ -23,6 +23,16 @@ use crate::route_server::common::AddressArgs;
 // specific newtype to allow sharing of AddressArgs, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add one or more route server addresses:
+    $ carbide-admin-cli route-server add 10.0.0.1,10.0.0.2
+
+Add ephemerally against config-file entries (break-glass):
+    $ carbide-admin-cli route-server add 10.0.0.1 --source-type config_file
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: AddressArgs,

--- a/crates/admin-cli/src/route_server/get/args.rs
+++ b/crates/admin-cli/src/route_server/get/args.rs
@@ -18,4 +18,11 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all configured route servers:
+    $ carbide-admin-cli route-server get
+
+")]
 pub struct Args {}

--- a/crates/admin-cli/src/route_server/remove/args.rs
+++ b/crates/admin-cli/src/route_server/remove/args.rs
@@ -23,6 +23,16 @@ use crate::route_server::common::AddressArgs;
 // specific newtype to allow sharing of AddressArgs, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove one or more route server addresses:
+    $ carbide-admin-cli route-server remove 10.0.0.1,10.0.0.2
+
+Remove ephemerally against config-file entries (break-glass):
+    $ carbide-admin-cli route-server remove 10.0.0.1 --source-type config_file
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: AddressArgs,

--- a/crates/admin-cli/src/route_server/replace/args.rs
+++ b/crates/admin-cli/src/route_server/replace/args.rs
@@ -23,6 +23,13 @@ use crate::route_server::common::AddressArgs;
 // specific newtype to allow sharing of AddressArgs, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Replace the entire route server list with a new set:
+    $ carbide-admin-cli route-server replace 10.0.0.1,10.0.0.2,10.0.0.3
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: AddressArgs,

--- a/crates/admin-cli/src/scout_stream/mod.rs
+++ b/crates/admin-cli/src/scout_stream/mod.rs
@@ -43,16 +43,37 @@ pub enum ScoutStreamAction {
 
 // ConnectionsShowCommand shows all active scout stream connections.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show all active scout stream connections:
+    $ carbide-admin-cli scout-stream show
+
+")]
 pub struct ConnectionsShowCommand {}
 
 // ConnectionsDisconnectCommand disconnects a machine based on machine ID.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Disconnect a machine's scout stream connection:
+    $ carbide-admin-cli scout-stream disconnect 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct ConnectionsDisconnectCommand {
     pub machine_id: MachineId,
 }
 
 // ConnectionsPingCommand pings a machine based on machine ID.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Ping-test a machine's scout stream connection:
+    $ carbide-admin-cli scout-stream ping 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct ConnectionsPingCommand {
     pub machine_id: MachineId,
 }

--- a/crates/admin-cli/src/set/bmc_proxy/args.rs
+++ b/crates/admin-cli/src/set/bmc_proxy/args.rs
@@ -18,6 +18,16 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Enable the BMC proxy and point it at a host:port:
+    $ carbide-admin-cli set bmc-proxy --enabled true --proxy 192.0.2.10:8080
+
+Disable the BMC proxy:
+    $ carbide-admin-cli set bmc-proxy --enabled false
+
+")]
 pub struct Args {
     #[clap(long, action = clap::ArgAction::Set, help = "Enable site-explorer bmc_proxy")]
     pub enabled: bool,

--- a/crates/admin-cli/src/set/create_machines/args.rs
+++ b/crates/admin-cli/src/set/create_machines/args.rs
@@ -19,6 +19,16 @@ use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
 #[clap(group = clap::ArgGroup::new("toggle").required(true))]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Enable automatic machine creation:
+    $ carbide-admin-cli set create-machines --enable
+
+Disable automatic machine creation:
+    $ carbide-admin-cli set create-machines --disable
+
+")]
 pub struct Args {
     #[clap(long, group = "toggle", help = "Enable machine creation")]
     pub enable: bool,

--- a/crates/admin-cli/src/set/log_filter/args.rs
+++ b/crates/admin-cli/src/set/log_filter/args.rs
@@ -18,6 +18,16 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Raise the server's log level, reverting after the default 1h:
+    $ carbide-admin-cli set log-filter --filter debug
+
+Set a targeted filter that reverts after 30 minutes:
+    $ carbide-admin-cli set log-filter --filter carbide_api=trace,info --expiry 30min
+
+")]
 pub struct Args {
     #[clap(short, long, help = "Set server's RUST_LOG.")]
     pub filter: String,

--- a/crates/admin-cli/src/set/site_explorer_enabled/args.rs
+++ b/crates/admin-cli/src/set/site_explorer_enabled/args.rs
@@ -19,6 +19,16 @@ use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
 #[clap(group = clap::ArgGroup::new("toggle").required(true))]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Enable site-explorer:
+    $ carbide-admin-cli set site-explorer --enable
+
+Disable site-explorer:
+    $ carbide-admin-cli set site-explorer --disable
+
+")]
 pub struct Args {
     #[clap(long, group = "toggle", help = "Enable site-explorer")]
     pub enable: bool,

--- a/crates/admin-cli/src/set/tracing_enabled/args.rs
+++ b/crates/admin-cli/src/set/tracing_enabled/args.rs
@@ -19,6 +19,16 @@ use clap::Parser;
 use clap::builder::BoolishValueParser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Enable OTLP trace/span export:
+    $ carbide-admin-cli set tracing-enabled true
+
+Disable OTLP trace/span export:
+    $ carbide-admin-cli set tracing-enabled false
+
+")]
 pub struct Args {
     #[arg(num_args = 1, value_parser = BoolishValueParser::new(), action = clap::ArgAction::Set, value_name = "true|false")]
     pub value: bool,

--- a/crates/admin-cli/src/site_explorer/clear_error/args.rs
+++ b/crates/admin-cli/src/site_explorer/clear_error/args.rs
@@ -23,6 +23,13 @@ use super::super::common::ExploreOptions;
 // specific newtype to allow sharing of ExploreOptions, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Clear the last known error for a BMC in the latest report:
+    $ carbide-admin-cli site-explorer clear-error 192.0.2.10
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: ExploreOptions,

--- a/crates/admin-cli/src/site_explorer/copy_bfb_to_dpu_rshim/args.rs
+++ b/crates/admin-cli/src/site_explorer/copy_bfb_to_dpu_rshim/args.rs
@@ -19,6 +19,18 @@ use clap::Parser;
 use mac_address::MacAddress;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Copy a BFB to a DPU's rshim via its BMC, power-cycling the host afterward:
+    $ carbide-admin-cli site-explorer copy-bfb-to-dpu-rshim 192.0.2.10 \
+    --host-bmc-ip 192.0.2.20
+
+Power-cycle the host first to release rshim control to the DPU BMC:
+    $ carbide-admin-cli site-explorer copy-bfb-to-dpu-rshim 192.0.2.10 \
+    --host-bmc-ip 192.0.2.20 --pre-copy-powercycle
+
+")]
 pub struct Args {
     #[clap(help = "BMC IP address or hostname with optional port")]
     pub address: String,

--- a/crates/admin-cli/src/site_explorer/delete/args.rs
+++ b/crates/admin-cli/src/site_explorer/delete/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete an explored endpoint from the database:
+    $ carbide-admin-cli site-explorer delete --address 192.0.2.10
+
+")]
 pub struct Args {
     #[clap(long, help = "BMC IP address of the endpoint to delete")]
     pub address: String,

--- a/crates/admin-cli/src/site_explorer/explore/args.rs
+++ b/crates/admin-cli/src/site_explorer/explore/args.rs
@@ -23,6 +23,16 @@ use super::super::common::ExploreOptions;
 // specific newtype to allow sharing of ExploreOptions, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Explore a single host now and print the report (not stored):
+    $ carbide-admin-cli site-explorer explore 192.0.2.10
+
+Explore a host, supplying the MAC it sent DHCP from:
+    $ carbide-admin-cli site-explorer explore 192.0.2.10 --mac 00:11:22:33:44:55
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: ExploreOptions,

--- a/crates/admin-cli/src/site_explorer/get_report/args.rs
+++ b/crates/admin-cli/src/site_explorer/get_report/args.rs
@@ -18,6 +18,19 @@
 use clap::{ArgGroup, Parser};
 
 #[derive(Parser, Debug, PartialEq)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Dump the entire latest report as JSON:
+    $ carbide-admin-cli site-explorer get-report all
+
+Show discovered managed-host details:
+    $ carbide-admin-cli site-explorer get-report managed-host
+
+Show explored endpoint details:
+    $ carbide-admin-cli site-explorer get-report endpoint
+
+")]
 pub enum Args {
     #[clap(about = "Get everything in Json")]
     All,
@@ -29,6 +42,22 @@ pub enum Args {
 
 #[derive(Parser, Debug, PartialEq)]
 #[clap(group(ArgGroup::new("selector").required(false).args(&["erroronly", "successonly"])))]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all explored endpoints:
+    $ carbide-admin-cli site-explorer get-report endpoint
+
+Show one endpoint by BMC IP:
+    $ carbide-admin-cli site-explorer get-report endpoint 192.0.2.10
+
+Show only endpoints that errored, filtered by vendor:
+    $ carbide-admin-cli site-explorer get-report endpoint --erroronly --vendor nvidia
+
+Show only endpoints not yet paired to a managed host:
+    $ carbide-admin-cli site-explorer get-report endpoint --unpairedonly
+
+")]
 pub struct EndpointInfo {
     #[clap(help = "BMC IP address of Endpoint.")]
     pub address: Option<String>,
@@ -55,6 +84,19 @@ pub struct EndpointInfo {
 }
 
 #[derive(Parser, Debug, PartialEq)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all discovered managed hosts:
+    $ carbide-admin-cli site-explorer get-report managed-host
+
+Show one managed host by its host/DPU BMC IP:
+    $ carbide-admin-cli site-explorer get-report managed-host 192.0.2.10
+
+Filter managed hosts by vendor:
+    $ carbide-admin-cli site-explorer get-report managed-host --vendor nvidia
+
+")]
 pub struct ManagedHostInfo {
     #[clap(help = "BMC IP address of host or DPU")]
     pub address: Option<String>,

--- a/crates/admin-cli/src/site_explorer/have_credentials/args.rs
+++ b/crates/admin-cli/src/site_explorer/have_credentials/args.rs
@@ -23,6 +23,13 @@ use super::super::common::ExploreOptions;
 // specific newtype to allow sharing of ExploreOptions, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Check whether carbide has working credentials for a BMC:
+    $ carbide-admin-cli site-explorer have-credentials 192.0.2.10
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: ExploreOptions,

--- a/crates/admin-cli/src/site_explorer/is_bmc_in_managed_host/args.rs
+++ b/crates/admin-cli/src/site_explorer/is_bmc_in_managed_host/args.rs
@@ -23,6 +23,13 @@ use super::super::common::ExploreOptions;
 // specific newtype to allow sharing of ExploreOptions, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Check whether a BMC belongs to a discovered managed host:
+    $ carbide-admin-cli site-explorer is-bmc-in-managed-host 192.0.2.10
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: ExploreOptions,

--- a/crates/admin-cli/src/site_explorer/re_explore/args.rs
+++ b/crates/admin-cli/src/site_explorer/re_explore/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Queue a host for re-exploration in the next cycle (result is stored):
+    $ carbide-admin-cli site-explorer re-explore 192.0.2.10
+
+")]
 pub struct Args {
     #[clap(help = "BMC IP address")]
     pub address: String,

--- a/crates/admin-cli/src/site_explorer/refresh_endpoint/args.rs
+++ b/crates/admin-cli/src/site_explorer/refresh_endpoint/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Immediately probe a BMC endpoint and persist the report:
+    $ carbide-admin-cli site-explorer refresh 192.0.2.10
+
+")]
 pub struct Args {
     #[clap(help = "BMC IP address")]
     pub address: String,

--- a/crates/admin-cli/src/site_explorer/remediation/args.rs
+++ b/crates/admin-cli/src/site_explorer/remediation/args.rs
@@ -18,6 +18,16 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Pause remediation actions for an endpoint:
+    $ carbide-admin-cli site-explorer remediation 192.0.2.10 --pause
+
+Resume remediation actions for an endpoint:
+    $ carbide-admin-cli site-explorer remediation 192.0.2.10 --resume
+
+")]
 pub struct Args {
     #[clap(help = "BMC IP address of the endpoint")]
     pub address: String,

--- a/crates/admin-cli/src/sku/assign/args.rs
+++ b/crates/admin-cli/src/sku/assign/args.rs
@@ -19,6 +19,16 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Assign a SKU to a machine:
+    $ carbide-admin-cli sku assign DGX-H100-640GB 12345678-1234-5678-90ab-cdef01234567
+
+Force the assignment even if the machine does not verify against the SKU:
+    $ carbide-admin-cli sku assign DGX-H100-640GB 12345678-1234-5678-90ab-cdef01234567 --force
+
+")]
 pub struct Args {
     pub sku_id: String,
     pub machine_id: MachineId,

--- a/crates/admin-cli/src/sku/bulk_update_metadata/args.rs
+++ b/crates/admin-cli/src/sku/bulk_update_metadata/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Update metadata for many SKUs from a CSV file:
+    $ carbide-admin-cli sku bulk-update-metadata ./sku-metadata.csv
+
+")]
 pub struct Args {
     #[clap(help = "The CSV file to use to update metadata for multiple skus")]
     pub filename: String,

--- a/crates/admin-cli/src/sku/common.rs
+++ b/crates/admin-cli/src/sku/common.rs
@@ -18,12 +18,32 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all SKUs:
+    $ carbide-admin-cli sku show
+
+Show details for one SKU:
+    $ carbide-admin-cli sku show DGX-H100-640GB
+
+")]
 pub struct ShowSkuOptions {
     #[clap(help = "Show SKU details")]
     pub sku_id: Option<String>,
 }
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create SKUs from a file:
+    $ carbide-admin-cli sku create ./skus.json
+
+Create from a file but override the SKU ID:
+    $ carbide-admin-cli sku create ./skus.json --id DGX-H100-640GB
+
+")]
 pub struct CreateSkuOptions {
     #[clap(help = "The filename of the SKU data")]
     pub filename: String,

--- a/crates/admin-cli/src/sku/delete/args.rs
+++ b/crates/admin-cli/src/sku/delete/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a SKU by ID:
+    $ carbide-admin-cli sku delete DGX-H100-640GB
+
+")]
 pub struct Args {
     pub sku_id: String,
 }

--- a/crates/admin-cli/src/sku/generate/args.rs
+++ b/crates/admin-cli/src/sku/generate/args.rs
@@ -19,6 +19,16 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Generate SKU data from an existing machine:
+    $ carbide-admin-cli sku generate 12345678-1234-5678-90ab-cdef01234567
+
+Generate and override the resulting SKU ID:
+    $ carbide-admin-cli sku generate 12345678-1234-5678-90ab-cdef01234567 --id DGX-H100-640GB
+
+")]
 pub struct Args {
     #[clap(help = "The machine id of the machine to use to generate a SKU")]
     pub machine_id: MachineId,

--- a/crates/admin-cli/src/sku/replace/args.rs
+++ b/crates/admin-cli/src/sku/replace/args.rs
@@ -23,6 +23,13 @@ use super::super::common::CreateSkuOptions;
 // specific newtype to allow sharing of CreateSkuOptions, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Replace a SKU's component list from a file:
+    $ carbide-admin-cli sku replace ./skus.json --id DGX-H100-640GB
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: CreateSkuOptions,

--- a/crates/admin-cli/src/sku/show_machines/args.rs
+++ b/crates/admin-cli/src/sku/show_machines/args.rs
@@ -23,6 +23,13 @@ use super::super::common::ShowSkuOptions;
 // specific newtype to allow sharing of ShowSkuOptions, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show the machines assigned to a SKU:
+    $ carbide-admin-cli sku show-machines DGX-H100-640GB
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: ShowSkuOptions,

--- a/crates/admin-cli/src/sku/unassign/args.rs
+++ b/crates/admin-cli/src/sku/unassign/args.rs
@@ -19,6 +19,16 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Unassign whatever SKU is assigned to a machine:
+    $ carbide-admin-cli sku unassign 12345678-1234-5678-90ab-cdef01234567
+
+Force the unassignment:
+    $ carbide-admin-cli sku unassign 12345678-1234-5678-90ab-cdef01234567 --force
+
+")]
 pub struct Args {
     #[clap(help = "The machine id of the machine to unassign")]
     pub machine_id: MachineId,

--- a/crates/admin-cli/src/sku/update_metadata/args.rs
+++ b/crates/admin-cli/src/sku/update_metadata/args.rs
@@ -19,6 +19,20 @@ use clap::{ArgGroup, Parser};
 
 #[derive(Parser, Debug)]
 #[clap(group(ArgGroup::new("group").required(true).multiple(true).args(&["description", "device_type"])))]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Update a SKU's description:
+    $ carbide-admin-cli sku update-metadata DGX-H100-640GB --description \"DGX H100 640GB\"
+
+Update a SKU's device type:
+    $ carbide-admin-cli sku update-metadata DGX-H100-640GB --device-type gpu-server
+
+Update both at once:
+    $ carbide-admin-cli sku update-metadata DGX-H100-640GB \
+    --description \"DGX H100 640GB\" --device-type gpu-server
+
+")]
 pub struct Args {
     #[clap(help = "SKU ID of the SKU to update")]
     pub sku_id: String,

--- a/crates/admin-cli/src/sku/verify/args.rs
+++ b/crates/admin-cli/src/sku/verify/args.rs
@@ -19,6 +19,13 @@ use carbide_uuid::machine::MachineId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Verify a machine against its assigned SKU:
+    $ carbide-admin-cli sku verify 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     pub machine_id: MachineId,
 }

--- a/crates/admin-cli/src/spx_partition/show/args.rs
+++ b/crates/admin-cli/src/spx_partition/show/args.rs
@@ -19,6 +19,22 @@ use carbide_uuid::spx::SpxPartitionId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all SPX partitions:
+    $ carbide-admin-cli spx-partition show
+
+Show one partition by ID:
+    $ carbide-admin-cli spx-partition show 12345678-1234-5678-90ab-cdef01234567
+
+Filter by tenant org:
+    $ carbide-admin-cli spx-partition show --tenant-org-id fds34511233a
+
+Filter by name:
+    $ carbide-admin-cli spx-partition show --name my-partition
+
+")]
 pub struct Args {
     #[clap(
         default_value(None),

--- a/crates/admin-cli/src/ssh/copy_bfb/args.rs
+++ b/crates/admin-cli/src/ssh/copy_bfb/args.rs
@@ -20,6 +20,13 @@ use clap::Parser;
 use super::super::common::SshArgs;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Copy a BFB image to a DPU BMC's RSHIM:
+    $ carbide-admin-cli ssh copy-bfb 192.0.2.10:22 admin mypassword /path/to/image.bfb
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub ssh_args: SshArgs,

--- a/crates/admin-cli/src/ssh/disable_rshim/args.rs
+++ b/crates/admin-cli/src/ssh/disable_rshim/args.rs
@@ -23,6 +23,13 @@ use super::super::common::SshArgs;
 // specific newtype to allow sharing of SshArgs, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Disable the RSHIM interface on a DPU BMC:
+    $ carbide-admin-cli ssh disable-rshim 192.0.2.10:22 admin mypassword
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: SshArgs,

--- a/crates/admin-cli/src/ssh/enable_rshim/args.rs
+++ b/crates/admin-cli/src/ssh/enable_rshim/args.rs
@@ -23,6 +23,13 @@ use super::super::common::SshArgs;
 // specific newtype to allow sharing of SshArgs, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Enable the RSHIM interface on a DPU BMC:
+    $ carbide-admin-cli ssh enable-rshim 192.0.2.10:22 admin mypassword
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: SshArgs,

--- a/crates/admin-cli/src/ssh/get_rshim_status/args.rs
+++ b/crates/admin-cli/src/ssh/get_rshim_status/args.rs
@@ -23,6 +23,13 @@ use super::super::common::SshArgs;
 // specific newtype to allow sharing of SshArgs, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Query the RSHIM status on a DPU BMC:
+    $ carbide-admin-cli ssh get-rshim-status 192.0.2.10:22 admin mypassword
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: SshArgs,

--- a/crates/admin-cli/src/ssh/show_obmc_log/args.rs
+++ b/crates/admin-cli/src/ssh/show_obmc_log/args.rs
@@ -23,6 +23,13 @@ use super::super::common::SshArgs;
 // specific newtype to allow sharing of SshArgs, and still
 // providing a subcommand-specific Run trait implementation.
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Dump the OpenBMC log from a DPU BMC:
+    $ carbide-admin-cli ssh show-obmc-log 192.0.2.10:22 admin mypassword
+
+")]
 pub struct Args {
     #[clap(flatten)]
     pub inner: SshArgs,

--- a/crates/admin-cli/src/switch/force_delete/args.rs
+++ b/crates/admin-cli/src/switch/force_delete/args.rs
@@ -19,6 +19,16 @@ use carbide_uuid::switch::SwitchId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Force delete a switch:
+    $ carbide-admin-cli switch force-delete 12345678-1234-5678-90ab-cdef01234567
+
+Force delete a switch and its machine interfaces:
+    $ carbide-admin-cli switch force-delete 12345678-1234-5678-90ab-cdef01234567 --delete-interfaces
+
+")]
 pub struct Args {
     #[clap(help = "Switch ID to force delete.")]
     pub switch_id: SwitchId,

--- a/crates/admin-cli/src/switch/health_report/add/args.rs
+++ b/crates/admin-cli/src/switch/health_report/add/args.rs
@@ -22,6 +22,22 @@ use crate::machine::HealthReportTemplates;
 
 #[derive(Parser, Debug)]
 #[clap(group(ArgGroup::new("health_report_source").required(true).args(&["health_report", "template"])))]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add a health report source from a predefined template:
+    $ carbide-admin-cli switch health-report add 12345678-1234-5678-90ab-cdef01234567 \
+    --template internal-maintenance --message \"Firmware upgrade in progress\"
+
+Add a health report source from raw JSON:
+    $ carbide-admin-cli switch health-report add 12345678-1234-5678-90ab-cdef01234567 \
+    --health-report '{...}'
+
+Preview the report without sending it:
+    $ carbide-admin-cli switch health-report add 12345678-1234-5678-90ab-cdef01234567 \
+    --template degraded --print-only
+
+")]
 pub struct Args {
     pub switch_id: SwitchId,
     #[clap(long, help = "New health report as json")]

--- a/crates/admin-cli/src/switch/health_report/remove/args.rs
+++ b/crates/admin-cli/src/switch/health_report/remove/args.rs
@@ -19,6 +19,14 @@ use carbide_uuid::switch::SwitchId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove a health report source from a switch (source name from `health-report show`):
+    $ carbide-admin-cli switch health-report remove 12345678-1234-5678-90ab-cdef01234567 \
+    internal-maintenance
+
+")]
 pub struct Args {
     pub switch_id: SwitchId,
     pub report_source: String,

--- a/crates/admin-cli/src/switch/health_report/show/args.rs
+++ b/crates/admin-cli/src/switch/health_report/show/args.rs
@@ -19,6 +19,13 @@ use carbide_uuid::switch::SwitchId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List the health report sources for a switch:
+    $ carbide-admin-cli switch health-report show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(help = "Switch ID to show health reports for")]
     pub switch_id: SwitchId,

--- a/crates/admin-cli/src/switch/list/args.rs
+++ b/crates/admin-cli/src/switch/list/args.rs
@@ -20,6 +20,22 @@ use mac_address::MacAddress;
 use rpc::forge::DeletedFilter;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all live switches:
+    $ carbide-admin-cli switch list
+
+Include deleted switches:
+    $ carbide-admin-cli switch list --deleted include
+
+Filter by controller state:
+    $ carbide-admin-cli switch list --controller-state ready
+
+Find a switch by its BMC MAC address:
+    $ carbide-admin-cli switch list --bmc-mac 00:11:22:33:44:55
+
+")]
 pub struct Args {
     /// Include deleted switches
     #[clap(long, value_enum, default_value = "exclude")]

--- a/crates/admin-cli/src/switch/metadata/args.rs
+++ b/crates/admin-cli/src/switch/metadata/args.rs
@@ -33,12 +33,27 @@ pub enum Args {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show a switch's metadata:
+    $ carbide-admin-cli switch metadata show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct SwitchMetadataCommandShow {
     #[clap(help = "The switch which should get its metadata displayed")]
     pub switch: SwitchId,
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Set a switch's name and description:
+    $ carbide-admin-cli switch metadata set 12345678-1234-5678-90ab-cdef01234567 \
+    --name spine-01 --description \"Rack 4 spine\"
+
+")]
 pub struct SwitchMetadataCommandSet {
     #[clap(help = "The switch which should get updated metadata")]
     pub switch: SwitchId,
@@ -49,6 +64,17 @@ pub struct SwitchMetadataCommandSet {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add a key-only label:
+    $ carbide-admin-cli switch metadata add-label 12345678-1234-5678-90ab-cdef01234567 --key edge
+
+Add a key/value label:
+    $ carbide-admin-cli switch metadata add-label 12345678-1234-5678-90ab-cdef01234567 \
+    --key env --value prod
+
+")]
 pub struct SwitchMetadataCommandAddLabel {
     #[clap(help = "The switch which should get updated metadata")]
     pub switch: SwitchId,
@@ -59,6 +85,14 @@ pub struct SwitchMetadataCommandAddLabel {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Remove one or more labels by key:
+    $ carbide-admin-cli switch metadata remove-labels 12345678-1234-5678-90ab-cdef01234567 \
+    --keys env --keys edge
+
+")]
 pub struct SwitchMetadataCommandRemoveLabels {
     #[clap(help = "The switch which should get updated metadata")]
     pub switch: SwitchId,
@@ -67,6 +101,17 @@ pub struct SwitchMetadataCommandRemoveLabels {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Fill in missing metadata from the expected-switch (leaving existing values intact):
+    $ carbide-admin-cli switch metadata from-expected-switch 12345678-1234-5678-90ab-cdef01234567
+
+Overwrite the switch's metadata with the expected-switch's values:
+    $ carbide-admin-cli switch metadata from-expected-switch 12345678-1234-5678-90ab-cdef01234567 \
+    --replace-all
+
+")]
 pub struct SwitchMetadataCommandFromExpectedSwitch {
     #[clap(help = "The switch which should get updated metadata")]
     pub switch: SwitchId,

--- a/crates/admin-cli/src/switch/show/args.rs
+++ b/crates/admin-cli/src/switch/show/args.rs
@@ -19,6 +19,16 @@ use carbide_uuid::switch::SwitchId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all switches:
+    $ carbide-admin-cli switch show
+
+Show details for one switch:
+    $ carbide-admin-cli switch show 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(
         default_value(None),

--- a/crates/admin-cli/src/tenant/show/args.rs
+++ b/crates/admin-cli/src/tenant/show/args.rs
@@ -19,6 +19,16 @@ use clap::Parser;
 use rpc::forge::FindTenantRequest;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all tenants:
+    $ carbide-admin-cli tenant show
+
+Show details for one tenant org:
+    $ carbide-admin-cli tenant show fds34511233a
+
+")]
 pub struct Args {
     #[clap(help = "Optional, tenant org ID to restrict the search")]
     pub tenant_org: Option<String>,

--- a/crates/admin-cli/src/tenant/update/args.rs
+++ b/crates/admin-cli/src/tenant/update/args.rs
@@ -18,6 +18,19 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Rename a tenant org:
+    $ carbide-admin-cli tenant update fds34511233a --name \"Acme Corp\"
+
+Apply a routing profile to a tenant:
+    $ carbide-admin-cli tenant update fds34511233a --routing-profile-type default
+
+Update only if the record is still at a known version (optimistic concurrency):
+    $ carbide-admin-cli tenant update fds34511233a --name \"Acme Corp\" --version 7
+
+")]
 pub struct Args {
     #[clap(help = "Tenant org ID to update", default_value(None))]
     pub tenant_org: String,

--- a/crates/admin-cli/src/tenant_keyset/show/args.rs
+++ b/crates/admin-cli/src/tenant_keyset/show/args.rs
@@ -21,6 +21,19 @@ use clap::Parser;
 use crate::errors::CarbideCliError;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all tenant keysets:
+    $ carbide-admin-cli tenant-key-set show
+
+Show one keyset by its <tenant_org_id>/<keyset_id>:
+    $ carbide-admin-cli tenant-key-set show fds34511233a/87654321-4321-8765-cdef-0123456789ab
+
+Filter by tenant org:
+    $ carbide-admin-cli tenant-key-set show --tenant-org-id fds34511233a
+
+")]
 pub struct Args {
     #[clap(
         default_value(""),

--- a/crates/admin-cli/src/tpm_ca/add/args.rs
+++ b/crates/admin-cli/src/tpm_ca/add/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add a CA certificate from a DER/CER/PEM file:
+    $ carbide-admin-cli tpm-ca add --filename /path/to/tpm-ca.der
+
+")]
 pub struct Args {
     #[clap(short, long, help = "File name containing certificate in DER format")]
     pub filename: String,

--- a/crates/admin-cli/src/tpm_ca/add_bulk/args.rs
+++ b/crates/admin-cli/src/tpm_ca/add_bulk/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Add every certificate in a directory as a CA certificate:
+    $ carbide-admin-cli tpm-ca add-bulk --dirname /path/to/tpm-ca-certs/
+
+")]
 pub struct Args {
     #[clap(short, long, help = "Directory path containing all CA certs")]
     pub dirname: String,

--- a/crates/admin-cli/src/tpm_ca/delete/args.rs
+++ b/crates/admin-cli/src/tpm_ca/delete/args.rs
@@ -18,6 +18,13 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a TPM CA certificate by its id (from `tpm-ca show`):
+    $ carbide-admin-cli tpm-ca delete --ca-id 42
+
+")]
 pub struct Args {
     #[clap(short, long, help = "TPM CA id obtained from the show command")]
     pub ca_id: i32,

--- a/crates/admin-cli/src/tpm_ca/show_unmatched_ek/args.rs
+++ b/crates/admin-cli/src/tpm_ca/show_unmatched_ek/args.rs
@@ -18,4 +18,11 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show TPM EK certificates that have no matching CA:
+    $ carbide-admin-cli tpm-ca show-unmatched-ek
+
+")]
 pub struct Args;

--- a/crates/admin-cli/src/trim_table/measured_boot/args.rs
+++ b/crates/admin-cli/src/trim_table/measured_boot/args.rs
@@ -18,6 +18,16 @@
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Keep the 1000 most recent measured-boot reports, deleting the rest:
+    $ carbide-admin-cli trim-table measured-boot --keep-entries 1000
+
+Trim down to the latest report only:
+    $ carbide-admin-cli trim-table measured-boot --keep-entries 1
+
+")]
 pub struct Args {
     #[clap(help = "Number of entries to keep")]
     #[arg(long)]

--- a/crates/admin-cli/src/version/args.rs
+++ b/crates/admin-cli/src/version/args.rs
@@ -18,6 +18,16 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show client and server versions:
+    $ carbide-admin-cli version
+
+Also display the runtime config:
+    $ carbide-admin-cli version --show-runtime-config
+
+")]
 pub struct Opts {
     #[clap(short, long, action, help = "Display Runtime Config also.")]
     pub show_runtime_config: bool,

--- a/crates/admin-cli/src/version/cmds.rs
+++ b/crates/admin-cli/src/version/cmds.rs
@@ -63,9 +63,9 @@ pub async fn handle_show_version(
         "carbide-api:\n\tbuild_version={}, build_date={}, git_sha={}, rust_version={}, build_user={}, build_hostname={}",
         v.build_version, v.build_date, v.git_sha, v.rust_version, v.build_user, v.build_hostname,
     );
-    // Same as running `forge-admin-cli --version`
+    // Same as running `carbide-admin-cli --version`
     println!();
-    println!("forge-admin-cli:\n\t{}", carbide_version::version!());
+    println!("carbide-admin-cli:\n\t{}", carbide_version::version!());
 
     if opts.show_runtime_config {
         let config = v

--- a/crates/admin-cli/src/vpc/set_virtualizer/args.rs
+++ b/crates/admin-cli/src/vpc/set_virtualizer/args.rs
@@ -50,6 +50,7 @@ impl From<VpcVirtualizationTypeArg> for ::rpc::forge::VpcVirtualizationType {
 }
 #[derive(Parser, Debug)]
 #[command(after_long_help = "\
+EXAMPLES:
 Set virtualizer to FNN on VPC:
     $ carbide-admin-cli vpc set-virtualizer 12345678-1234-5678-90ab-cdef01234567 fnn
 

--- a/crates/admin-cli/src/vpc/show/args.rs
+++ b/crates/admin-cli/src/vpc/show/args.rs
@@ -20,13 +20,15 @@ use clap::Parser;
 
 #[derive(Parser, Debug)]
 #[command(after_long_help = "\
+EXAMPLES:
+
 List all VPCs:
     $ carbide-admin-cli vpc show
 
-Show details for one VPC
+Show details for one VPC:
     $ carbide-admin-cli vpc show 12345678-1234-5678-90ab-cdef01234567
 
-Filter by tenant org
+Filter by tenant org:
     $ carbide-admin-cli vpc show --tenant-org-id fds34511233a
 
 Filter by label:

--- a/crates/admin-cli/src/vpc_peering/create/args.rs
+++ b/crates/admin-cli/src/vpc_peering/create/args.rs
@@ -21,6 +21,18 @@ use clap::Parser;
 use rpc::forge::VpcPeeringCreationRequest;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Peer two VPCs:
+    $ carbide-admin-cli vpc-peering create 12345678-1234-5678-90ab-cdef01234567 \
+    abcdef01-2345-6789-abcd-ef0123456789
+
+Peer two VPCs with a chosen peering ID:
+    $ carbide-admin-cli vpc-peering create 12345678-1234-5678-90ab-cdef01234567 \
+    abcdef01-2345-6789-abcd-ef0123456789 --id 0fedcba9-8765-4321-0fed-cba987654321
+
+")]
 pub struct Args {
     #[clap(help = "The ID of one VPC ID to peer")]
     pub vpc1_id: VpcId,

--- a/crates/admin-cli/src/vpc_peering/delete/args.rs
+++ b/crates/admin-cli/src/vpc_peering/delete/args.rs
@@ -19,6 +19,13 @@ use carbide_uuid::vpc_peering::VpcPeeringId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a VPC peering:
+    $ carbide-admin-cli vpc-peering delete --id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(long, required(true), help = "The ID of the VPC peering to delete")]
     pub id: VpcPeeringId,

--- a/crates/admin-cli/src/vpc_peering/show/args.rs
+++ b/crates/admin-cli/src/vpc_peering/show/args.rs
@@ -20,6 +20,19 @@ use carbide_uuid::vpc_peering::VpcPeeringId;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all VPC peerings:
+    $ carbide-admin-cli vpc-peering show
+
+Show details for one VPC peering:
+    $ carbide-admin-cli vpc-peering show --id 12345678-1234-5678-90ab-cdef01234567
+
+List the peerings for one VPC:
+    $ carbide-admin-cli vpc-peering show --vpc-id 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(
         long,

--- a/crates/admin-cli/src/vpc_prefix/create/args.rs
+++ b/crates/admin-cli/src/vpc_prefix/create/args.rs
@@ -21,6 +21,19 @@ use ipnet::IpNet;
 use rpc::forge::VpcPrefixCreationRequest;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create a prefix in a VPC:
+    $ carbide-admin-cli vpc-prefix create --vpc-id 12345678-1234-5678-90ab-cdef01234567 \
+    --prefix 10.0.0.0/24 --name web-tier
+
+Create a prefix with a description and labels:
+    $ carbide-admin-cli vpc-prefix create --vpc-id 12345678-1234-5678-90ab-cdef01234567 \
+    --prefix 10.0.0.0/24 --name web-tier --description \"Front-end subnet\" \
+    --label environment:production --label team:platform
+
+")]
 pub struct Args {
     #[clap(
         long,

--- a/crates/admin-cli/src/vpc_prefix/delete/args.rs
+++ b/crates/admin-cli/src/vpc_prefix/delete/args.rs
@@ -20,6 +20,13 @@ use clap::Parser;
 use rpc::forge::VpcPrefixDeletionRequest;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a VPC prefix by ID:
+    $ carbide-admin-cli vpc-prefix delete 12345678-1234-5678-90ab-cdef01234567
+
+")]
 pub struct Args {
     #[clap(value_name = "VpcPrefixId")]
     pub vpc_prefix_id: VpcPrefixId,

--- a/crates/admin-cli/src/vpc_prefix/show/args.rs
+++ b/crates/admin-cli/src/vpc_prefix/show/args.rs
@@ -23,6 +23,28 @@ use rpc::forge::DeletedFilter;
 use crate::vpc_prefix::common::VpcPrefixSelector;
 
 #[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all VPC prefixes:
+    $ carbide-admin-cli vpc-prefix show
+
+Show one prefix by ID:
+    $ carbide-admin-cli vpc-prefix show 12345678-1234-5678-90ab-cdef01234567
+
+Show one prefix by its exact CIDR:
+    $ carbide-admin-cli vpc-prefix show 10.0.0.0/24
+
+List the prefixes belonging to one VPC:
+    $ carbide-admin-cli vpc-prefix show --vpc-id 12345678-1234-5678-90ab-cdef01234567
+
+Find the prefix that contains an address:
+    $ carbide-admin-cli vpc-prefix show --contains 10.0.0.5
+
+Find the prefixes contained by a larger prefix:
+    $ carbide-admin-cli vpc-prefix show --contained-by 10.0.0.0/16
+
+")]
 pub struct Args {
     #[clap(
         name = "VpcPrefixSelector",

--- a/dev/docker/Dockerfile.build-container-aarch64
+++ b/dev/docker/Dockerfile.build-container-aarch64
@@ -53,6 +53,7 @@ RUN CACHEKEY=${CI_COMMIT_SHORT_SHA} apt update &&  \
 		libssl-dev \
 		libtss2-dev \
 		libudev-dev \
+		pandoc \
 		pkg-config \
 		tpm2-tools \
 		postgresql-15 \

--- a/dev/docker/Dockerfile.build-container-x86_64
+++ b/dev/docker/Dockerfile.build-container-x86_64
@@ -57,6 +57,7 @@ RUN CACHEKEY=${CI_COMMIT_SHORT_SHA} apt update && \
 	libtss2-dev \
 	lld \
 	openipmi \
+	pandoc \
 	pkg-config \
 	protobuf-compiler-grpc \
 	postgresql-15 \


### PR DESCRIPTION
## Description

Add an EXAMPLES section to the long help (--help) of essentially every admin-cli subcommand, rendered via clap's `after_long_help`. Each block shows the realistic ways to invoke the command -- the happy path.

The conventions for writing live in `crates/admin-cli/AGENTS.md` (symlinked to `CLAUDE.md`) so the same style can be applied to new commands: the format, placeholder values, how to derive the kebab-case command path, and where to place the attribute for tricky clap shapes (type aliases, flattened newtypes, nested subcommand enums, payload structs shared by several variants, and unit variants).

Alongside the docs, three behavior changes:

* `redfish --address` is now a real clap `required` argument rather than an optional `global` validated by hand. clap forbids `required` on a `global` arg, so the connection flags must now precede the subcommand; `--username`/`--password` remain optional.

* `redfish browse` moved to a new top-level `browse` command group. Browsing a resource tree goes through the API server, not a BMC, so it needs no `--address` -- but keeping it under `redfish` forced the required `--address`. `browse` now hosts the API-proxied browsers that share that property: `browse redfish` (by URI), `browse ufm` (fabric + path), and `browse nmxc` (chassis + operation). `redfish` is now purely BMC operations.

* CLI errors render as just their message chain. color-eyre is configured to drop the source-location block and the "run with RUST_BACKTRACE" footer (developer noise on an expected failure; a backtrace is still captured when RUST_BACKTRACE is set). With the location gone the `.context()` chain is the user-facing error, and a bad invocation is surfaced as a clap usage error (exit code 2) instead of a generic report.

* Order the CliCommand variants alphabetically so `carbide-admin-cli --help` lists commands in a predictable order.

* Make `--role-id` on both `create-bmc-user` commands a clap ValueEnum (administrator/operator/readonly/noaccess) instead of a free String. This validates the value at parse time, and lists the choices in --help.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://github.com/NVIDIA/infra-controller/issues/2011

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [X] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

