### PR TITLE
ci: Add CI jobs to detect proto/OpenAPI breaking changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -833,18 +833,17 @@ jobs:
         with:
           fetch-depth: 0 # Required: Buf needs the history to compare against main
 
-      - name: Setup Buf CLI
-        uses: bufbuild/buf-setup-action@v1
+      - name: Install Buf CLI
+        run: |
+          sudo curl -sSL https://github.com/bufbuild/buf/releases/download/v1.70.0/buf-Linux-x86_64 -o /usr/local/bin/buf
+          sudo chmod +x /usr/local/bin/buf
+          buf --version
 
       - name: Check for Breaking Changes
-        # If this action is not approved, the following command can be used instead:
-        # buf breaking crates/rpc/proto --against 'https://github.com/NVIDIA/infra-controller.git#branch=main,subdir=crates/rpc/proto'
-        uses: bufbuild/buf-breaking-action@v1
-        with:
-          # Points Buf to the protobuf module in this branch
-          input: 'crates/rpc/proto'
-          # Compare against the same module path on main
-          against: 'https://github.com/${{ github.repository }}.git#branch=main,subdir=crates/rpc/proto'
+        run: |
+          buf breaking crates/rpc/proto \
+            --against 'https://github.com/${{ github.repository }}.git#branch=main,subdir=crates/rpc/proto' \
+            --error-format=github-actions
 
   lint-police:
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -824,6 +824,28 @@ jobs:
       - name: Run Protolint
         run: protolint lint -config_path=.protolint.yaml crates/rpc/proto/
 
+  proto-breaking-changes:
+    name: Proto Breaking Changes Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required: Buf needs the history to compare against main
+
+      - name: Setup Buf CLI
+        uses: bufbuild/buf-setup-action@v1
+
+      - name: Check for Breaking Changes
+        # If this action is not approved, the following command can be used instead:
+        # buf breaking crates/rpc/proto --against 'https://github.com/NVIDIA/infra-controller.git#branch=main,subdir=crates/rpc/proto'
+        uses: bufbuild/buf-breaking-action@v1
+        with:
+          # Points Buf to the protobuf module in this branch
+          input: 'crates/rpc/proto'
+          # Compare against the same module path on main
+          against: 'https://github.com/${{ github.repository }}.git#branch=main,subdir=crates/rpc/proto'
+
   lint-police:
     needs:
       - prepare

--- a/.github/workflows/rest-lint-and-test.yml
+++ b/.github/workflows/rest-lint-and-test.yml
@@ -108,9 +108,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check OpenAPI breaking changes
-        # If this action is not approved, the following command can be used instead:
-        # oasdiff breaking <(git show origin/main:rest-api/openapi/spec.yaml) rest-api/openapi/spec.yaml --fail-on ERR
-        uses: oasdiff/oasdiff-action/breaking@v0.0.51
+        uses: oasdiff/oasdiff-action/breaking@a8c7f0e5649d20d623edb5b38446d3ab3d82d43c
         with:
           # Compare the exact base and head commits from this PR.
           base: '${{ github.event.pull_request.base.sha }}:rest-api/openapi/spec.yaml'

--- a/.github/workflows/rest-lint-and-test.yml
+++ b/.github/workflows/rest-lint-and-test.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           # Compare the exact base and head commits from this PR.
           base: '${{ github.event.pull_request.base.sha }}:rest-api/openapi/spec.yaml'
-          revision: '${{ github.sha }}:rest-api/openapi/spec.yaml'
+          revision: 'origin/main:rest-api/openapi/spec.yaml'
           fail-on: ERR
 
   check-generated-files:

--- a/.github/workflows/rest-lint-and-test.yml
+++ b/.github/workflows/rest-lint-and-test.yml
@@ -98,6 +98,25 @@ jobs:
       - name: Run OpenAPI lint
         run: redocly lint ./openapi/spec.yaml --format=github-actions
 
+  openapi-breaking-changes:
+    name: OpenAPI Breaking Changes Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check OpenAPI breaking changes
+        # If this action is not approved, the following command can be used instead:
+        # oasdiff breaking <(git show origin/main:rest-api/openapi/spec.yaml) rest-api/openapi/spec.yaml --fail-on ERR
+        uses: oasdiff/oasdiff-action/breaking@v0.0.51
+        with:
+          # Compare the exact base and head commits from this PR.
+          base: '${{ github.event.pull_request.base.sha }}:rest-api/openapi/spec.yaml'
+          revision: '${{ github.sha }}:rest-api/openapi/spec.yaml'
+          fail-on: ERR
+
   check-generated-files:
     name: Check Generated Files
     runs-on: linux-amd64-cpu4

--- a/Makefile
+++ b/Makefile
@@ -80,3 +80,19 @@ rest-kind-reset: ## Spin up the local kind dev cluster: cluster + cert-manager +
 #   make rest-api/generate-sdk
 rest-api/%:
 	$(MAKE) -C rest-api $*
+
+proto-breaking:
+	@echo "Checking for proto breaking changes..."
+	@if ! command -v buf >/dev/null 2>&1; then \
+		echo "buf is not installed. Please install buf: https://buf.build/docs/installation"; \
+		exit 1; \
+	fi
+	buf breaking crates/rpc/proto --against 'https://github.com/NVIDIA/infra-controller.git#branch=main,subdir=crates/rpc/proto'
+
+openapi-breaking:
+	@echo "Checking for openapi breaking changes..."
+	@if ! command -v oasdiff >/dev/null 2>&1; then \
+		echo "oasdiff is not installed. Please install oasdiff: https://github.com/oasdiff/oasdiff"; \
+		exit 1; \
+	fi
+	oasdiff breaking <(git show origin/main:rest-api/openapi/spec.yaml) rest-api/openapi/spec.yaml --fail-on ERR

--- a/crates/rpc/proto/buf.yaml
+++ b/crates/rpc/proto/buf.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: v2
+modules:
+  - path: .
+breaking:
+  use:
+    - WIRE_JSON


### PR DESCRIPTION
## Description
- Currently there are no CI process that raises awareness for proto or OpenAPI breaking changes 
- We want to automate the checks so the burden on the submitter and reviewer is lessened
- This PR adds two CI jobs, one to check for breaking changes in proto files and one to check for breaking changes in OpenAPI schema that the REST API follows

We want to initially run these jobs for informational purposes, and later decide which of them should block PR merging.

> [!NOTE]  
> The actions being used may not be NVIDIA approved. If we can't get them approved, I've added alternative commands

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
None

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
<!-- How was this tested? Check all that apply -->
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
None

