### PR TITLE
ci(rest): remove concurrency block to match core CI

### DIFF
--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -15,10 +15,6 @@ on:
       - "v[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]*"
       - "v[0-9].[0-9].[0-9]-rc[0-9]*"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   changes:
     name: Detect REST CI Gate


### PR DESCRIPTION
Closes #2231

## Problem
On `main`, REST CI runs were cancelled by `cancel-in-progress: true` whenever a newer commit landed. `rest-ci-pass` counts `cancelled` as failure → spurious red on main, and the cancelled commit never pushed its REST artifacts, so REST and Core could land on **different version tags** for the same monorepo commit.

Observed: commit `11144ffb` → Core CI completed (~72m) but REST CI cancelled after ~3.5m by the next push. Asymmetry: core's `ci.yaml` has **no `concurrency` block at all** (never cancels); `rest-ci.yml` had `cancel-in-progress: true`.

## Fix
Remove the `concurrency` block from `rest-ci.yml` entirely, matching core `ci.yaml`. REST CI now never cancels in-progress runs — every commit (PR or main) runs to completion and main/release/tag commits always push their artifacts, keeping REST + Core on the same tag.

## Not included
Separate Core CI flake on main (`carbide-api-integration-tests` "deadline has elapsed" timeout) — flaky test, will try a retry separately.