### PR TITLE
feat(api): Include additional state details in DpuInfo

### DIFF
--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -964,10 +964,12 @@ async fn handle_get_dpu_info_list(
             DpuInfo {
                 id: "fm100dsvstfujf6mis0gpsoi81tadmllicv7rqo4s7gc16gi0t2478672vg".to_string(),
                 loopback_ip: "172.20.0.119".to_string(),
+                observed_status: None,
             },
             DpuInfo {
                 id: "fm100dsjd1vuk6gklgvh0ao8t7r7tk1pt101ub5ck0g3j7lqcm8h3rf1p8g".to_string(),
                 loopback_ip: "172.20.0.200".to_string(),
+                observed_status: None,
             },
         ],
     })

--- a/crates/agent/src/tests/test_network_monitor.rs
+++ b/crates/agent/src/tests/test_network_monitor.rs
@@ -166,10 +166,12 @@ async fn handle_get_dpu_info_list(
             rpc::DpuInfo {
                 id: DPU_ID.to_string(),
                 loopback_ip: "172.20.0.119".to_string(),
+                observed_status: None,
             },
             rpc::DpuInfo {
                 id: DEST_DPU_ID.to_string(),
                 loopback_ip: "172.20.0.200".to_string(),
+                observed_status: None,
             },
         ],
     })

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -795,9 +795,6 @@ pub(crate) async fn record_dpu_network_status(
     let request = request.into_inner();
     let dpu_machine_id = convert_and_log_machine_id(request.dpu_machine_id.as_ref())?;
 
-    // TODO: persist this somewhere
-    let _fabric_interfaces_data = request.fabric_interfaces.as_slice();
-
     let mut txn = api.txn_begin().await?;
 
     // Load the DPU Object. We require it to update the health report based

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -714,7 +714,7 @@ pub(crate) async fn admin_force_delete_machine(
     Ok(Response::new(response))
 }
 
-/// Retrieves all DPU information including id and loopback IP
+/// Retrieves all DPU information including operational state.
 pub(crate) async fn get_dpu_info_list(
     api: &Api,
     request: Request<rpc::GetDpuInfoListRequest>,
@@ -723,7 +723,7 @@ pub(crate) async fn get_dpu_info_list(
 
     let mut txn = api.txn_begin().await?;
 
-    let dpu_list = db::machine::find_dpu_ids_and_loopback_ips(&mut txn).await?;
+    let dpu_list = db::machine::find_dpu_infos(&mut txn).await?;
 
     txn.commit().await?;
 

--- a/crates/api-core/src/tests/dpu_info_list.rs
+++ b/crates/api-core/src/tests/dpu_info_list.rs
@@ -14,9 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use chrono::Utc;
 use common::api_fixtures::dpu::loopback_ip;
 use common::api_fixtures::{create_managed_host, create_test_env};
+use rpc::Timestamp;
 use rpc::forge::forge_server::Forge;
+use rpc::forge::{DpuNetworkStatus, FabricInterfaceData, LinkData};
 
 use crate::tests::common;
 
@@ -25,6 +28,53 @@ async fn test_get_dpu_info_list(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;
     let dpu_machine_id_1 = create_managed_host(&env).await.dpu().id;
     let dpu_machine_id_2 = create_managed_host(&env).await.dpu().id;
+
+    let observed_at = Utc::now();
+    let heartbeat_timestamp = Timestamp::from(observed_at);
+    let fabric_interface =
+        |interface_name: &str, carrier_up: Option<bool>, state: &str| FabricInterfaceData {
+            interface_name: interface_name.to_string(),
+            link_data: Some(LinkData {
+                link_type: Some("ethernet".to_string()),
+                state: Some(state.to_string()),
+                carrier_up,
+                mtu: Some(1500),
+                carrier_up_count: None,
+                carrier_down_count: None,
+            }),
+        };
+
+    // Persist a current network status with fabric interface data for one DPU.
+    env.api
+        .record_dpu_network_status(tonic::Request::new(DpuNetworkStatus {
+            dpu_machine_id: Some(dpu_machine_id_1),
+            dpu_agent_version: Some("test".to_string()),
+            observed_at: Some(heartbeat_timestamp),
+            dpu_health: Some(rpc::health::HealthReport {
+                source: "forge-dpu-agent".to_string(),
+                triggered_by: None,
+                observed_at: None,
+                successes: vec![],
+                alerts: vec![],
+            }),
+            network_config_version: None,
+            instance_id: None,
+            instance_config_version: None,
+            instance_network_config_version: None,
+            interfaces: vec![],
+            network_config_error: None,
+            client_certificate_expiry_unix_epoch_secs: None,
+            fabric_interfaces: vec![
+                fabric_interface("pf0vf0_if_r", Some(false), "down"),
+                fabric_interface("pf0dpu0", Some(true), "up"),
+                fabric_interface("p0_if", Some(true), "up"),
+            ],
+            last_dhcp_requests: vec![],
+            dpu_extension_service_version: None,
+            dpu_extension_services: vec![],
+        }))
+        .await
+        .unwrap();
 
     // Make RPC call to get list of DPU information
     let dpu_list = env
@@ -58,4 +108,44 @@ async fn test_get_dpu_info_list(pool: sqlx::PgPool) {
     dpu_loopback_ips.sort();
     exp_loopback_ips.sort();
     assert_eq!(dpu_loopback_ips, exp_loopback_ips);
+
+    // Check that operational fields are populated from persisted DPU state.
+    let dpu_1 = dpu_list
+        .iter()
+        .find(|dpu| dpu.id == dpu_machine_id_1.to_string())
+        .unwrap();
+    let observed_status = dpu_1.observed_status.as_ref().unwrap();
+    assert_eq!(
+        observed_status
+            .os_operational_state
+            .as_ref()
+            .map(|state| state.state_detail.as_str()),
+        Some("Ready")
+    );
+    assert_eq!(
+        observed_status.firmware_version.as_deref(),
+        Some("24.42.1000")
+    );
+    assert_eq!(observed_status.last_heartbeat, Some(heartbeat_timestamp));
+    assert_eq!(observed_status.representors.len(), 2);
+    let pf0dpu0 = observed_status
+        .representors
+        .iter()
+        .find(|representor| representor.name == "pf0dpu0")
+        .unwrap();
+    assert_eq!(pf0dpu0.carrier_up, Some(true));
+    assert_eq!(pf0dpu0.state.as_deref(), Some("up"));
+    let pf0vf0_if_r = observed_status
+        .representors
+        .iter()
+        .find(|representor| representor.name == "pf0vf0_if_r")
+        .unwrap();
+    assert_eq!(pf0vf0_if_r.carrier_up, Some(false));
+    assert_eq!(pf0vf0_if_r.state.as_deref(), Some("down"));
+    assert!(
+        !observed_status
+            .representors
+            .iter()
+            .any(|representor| representor.name == "p0_if")
+    );
 }

--- a/crates/api-core/src/tests/dpu_machine_update.rs
+++ b/crates/api-core/src/tests/dpu_machine_update.rs
@@ -140,6 +140,7 @@ async fn test_find_available_outdated_dpus_with_unhealthy(
         agent_version_superseded_at: None,
         instance_network_observation: None,
         extension_service_observation: None,
+        fabric_interfaces: vec![],
     };
 
     let health_report = health_report::HealthReport {

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -38,15 +38,17 @@ use model::hardware_info::{MachineInventory, MachineNvLinkInfo};
 use model::machine::infiniband::MachineInfinibandStatusObservation;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::network::{
-    MachineNetworkStatusObservation, ManagedHostNetworkConfig, ManagedHostQuarantineState,
+    DpuFabricInterfaceStatusObservation, MachineNetworkStatusObservation, ManagedHostNetworkConfig,
+    ManagedHostQuarantineState,
 };
 use model::machine::nvlink::MachineNvLinkStatusObservation;
 use model::machine::spx::MachineSpxStatusObservation;
 use model::machine::upgrade_policy::AgentUpgradePolicy;
 use model::machine::{
-    Dpf, DpuInfo, FailureDetails, HostProfile, Machine, MachineInterfaceSnapshot,
-    MachineLastRebootRequested, MachineLastRebootRequestedMode, MachineValidationContext,
-    ManagedHostState, ReprovisionRequest, UpgradeDecision,
+    Dpf, DpuInfo, DpuInfoStatusObservation, DpuOsOperationalState, DpuRepresentorStatus,
+    FailureDetails, HostProfile, Machine, MachineInterfaceSnapshot, MachineLastRebootRequested,
+    MachineLastRebootRequestedMode, MachineValidationContext, ManagedHostState, ReprovisionRequest,
+    UpgradeDecision,
 };
 use model::machine_interface_address::MachineInterfaceAssociation;
 use model::metadata::Metadata;
@@ -1992,31 +1994,95 @@ pub async fn update_failure_details_by_machine_id(
     Ok(())
 }
 
-/// Find a list of dpu information
+/// Find a list of DPU operational information.
 ///
-/// Returns: `Vec<DpuInfo>` - A list of DPU information of DPU id and loopback Ip addresses
+/// Returns: `Vec<DpuInfo>` - A list of DPU information with loopback and operational state.
 ///
 /// Arguments
 ///
 /// * `txn` - A reference to currently open database transaction
-pub async fn find_dpu_ids_and_loopback_ips(
-    txn: &mut PgConnection,
-) -> Result<Vec<DpuInfo>, DatabaseError> {
-    // Get all DPU IP addresses except the requester DPU machine
-    let query = "
-        SELECT id, network_config->>'loopback_ip' AS loopback_ip
-        FROM machines
-        WHERE network_config->>'loopback_ip' IS NOT NULL";
+pub async fn find_dpu_infos(txn: &mut PgConnection) -> Result<Vec<DpuInfo>, DatabaseError> {
+    type DpuInfoRow = (
+        String,
+        String,
+        sqlx::types::Json<ManagedHostState>,
+        sqlx::types::Json<Option<MachineNetworkStatusObservation>>,
+        Option<String>,
+    );
 
-    let dpu_infos: Vec<DpuInfo> = sqlx::query_as(query)
+    // Pull the DPU rows with the JSON fields needed to shape the response.
+    let query = r#"
+        SELECT
+            m.id,
+            m.network_config->>'loopback_ip' AS loopback_ip,
+            m.controller_state,
+            COALESCE(m.network_status_observation, 'null'::jsonb) AS network_status_observation,
+            mt.topology->'discovery_data'->'Info'->'dpu_info'->>'firmware_version' AS firmware_version
+        FROM machines m
+        LEFT JOIN machine_topologies mt ON mt.machine_id = m.id
+        WHERE m.network_config->>'loopback_ip' IS NOT NULL
+        ORDER BY m.id"#;
+
+    let dpu_rows: Vec<DpuInfoRow> = sqlx::query_as(query)
         .fetch_all(txn)
         .await
-        .map_err(|e| DatabaseError::query(query, e))?
-        .into_iter()
-        .map(|(id, loopback_ip)| DpuInfo { id, loopback_ip })
-        .collect();
+        .map_err(|e| DatabaseError::query(query, e))?;
 
-    Ok(dpu_infos)
+    // TODO: Replace this heuristic once the agent reports interface roles explicitly.
+    let is_representor = |interface_name: &str| interface_name.starts_with("pf");
+
+    let representor_statuses = |interfaces: &[DpuFabricInterfaceStatusObservation]| {
+        let mut representors: Vec<_> = interfaces
+            .iter()
+            .filter(|interface| is_representor(&interface.interface_name))
+            .map(|interface| DpuRepresentorStatus {
+                name: interface.interface_name.clone(),
+                carrier_up: interface
+                    .link_data
+                    .as_ref()
+                    .and_then(|link| link.carrier_up),
+                state: interface
+                    .link_data
+                    .as_ref()
+                    .and_then(|link| link.state.clone()),
+            })
+            .collect();
+
+        representors.sort_by(|left, right| left.name.cmp(&right.name));
+        representors
+    };
+
+    // Shape each DB row into the public DPU info model.
+    dpu_rows
+        .into_iter()
+        .map(
+            |(id, loopback_ip, controller_state, network_status_observation, firmware_version)| {
+                let dpu_id = MachineId::from_str(&id).map_err(|e| {
+                    DatabaseError::internal(format!("Invalid DPU machine ID {id}: {e}"))
+                })?;
+                let network_status_observation = network_status_observation.0;
+                let representors = network_status_observation
+                    .as_ref()
+                    .map(|observation| representor_statuses(&observation.fabric_interfaces))
+                    .unwrap_or_default();
+
+                Ok(DpuInfo {
+                    id,
+                    loopback_ip,
+                    observed_status: Some(DpuInfoStatusObservation {
+                        os_operational_state: Some(DpuOsOperationalState {
+                            state_detail: controller_state.0.dpu_state_string(&dpu_id),
+                        }),
+                        firmware_version,
+                        representors,
+                        last_heartbeat: network_status_observation
+                            .as_ref()
+                            .map(|observation| observation.observed_at),
+                    }),
+                })
+            },
+        )
+        .collect()
 }
 
 /// Allocate a value from the loopback IP resource pool.

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -81,9 +81,30 @@ pub mod topology;
 pub mod upgrade_policy;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DpuOsOperationalState {
+    pub state_detail: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DpuRepresentorStatus {
+    pub name: String,
+    pub carrier_up: Option<bool>,
+    pub state: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DpuInfoStatusObservation {
+    pub os_operational_state: Option<DpuOsOperationalState>,
+    pub firmware_version: Option<String>,
+    pub representors: Vec<DpuRepresentorStatus>,
+    pub last_heartbeat: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DpuInfo {
     pub id: String,
     pub loopback_ip: String,
+    pub observed_status: Option<DpuInfoStatusObservation>,
 }
 
 type DpuDeviceMappings = (HashMap<MachineId, String>, HashMap<String, Vec<MachineId>>);

--- a/crates/api-model/src/machine/network.rs
+++ b/crates/api-model/src/machine/network.rs
@@ -25,6 +25,24 @@ use serde::{Deserialize, Serialize};
 use crate::instance::status::extension_service::InstanceExtensionServiceStatusObservation;
 use crate::instance::status::network::InstanceNetworkStatusObservation;
 
+/// The fabric interface status last reported by a DPU agent.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DpuFabricInterfaceStatusObservation {
+    pub interface_name: String,
+    pub link_data: Option<DpuLinkStatusObservation>,
+}
+
+/// The persisted subset of link attributes reported for a DPU fabric interface.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DpuLinkStatusObservation {
+    pub link_type: Option<String>,
+    pub state: Option<String>,
+    pub carrier_up: Option<bool>,
+    pub mtu: Option<u32>,
+    pub carrier_up_count: Option<u32>,
+    pub carrier_down_count: Option<u32>,
+}
+
 /// The network status that was last reported by the networking subsystem
 /// Stored in a Postgres JSON field so new fields have to be Option until fully deployed
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -37,6 +55,8 @@ pub struct MachineNetworkStatusObservation {
     pub agent_version_superseded_at: Option<DateTime<Utc>>,
     pub instance_network_observation: Option<InstanceNetworkStatusObservation>,
     pub extension_service_observation: Option<InstanceExtensionServiceStatusObservation>,
+    #[serde(default)]
+    pub fabric_interfaces: Vec<DpuFabricInterfaceStatusObservation>,
 }
 
 impl MachineNetworkStatusObservation {

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -5412,9 +5412,27 @@ message HostReprovisioningListResponse {
   repeated HostReprovisioningListItem hosts = 1;
 }
 
+message DpuOsOperationalState {
+  string state_detail = 1;
+}
+
+message DpuRepresentorStatus {
+  string name = 1;
+  optional bool carrier_up = 2;
+  optional string state = 3;
+}
+
+message DpuInfoStatusObservation {
+  optional DpuOsOperationalState os_operational_state = 1;
+  optional string firmware_version = 2;
+  repeated DpuRepresentorStatus representors = 3;
+  optional google.protobuf.Timestamp last_heartbeat = 4;
+}
+
 message DpuInfo {
   string id = 1;
   string loopback_ip = 2;
+  optional DpuInfoStatusObservation observed_status = 3;
 }
 
 message GetDpuInfoListRequest {

--- a/crates/rpc/src/model/machine/mod.rs
+++ b/crates/rpc/src/model/machine/mod.rs
@@ -22,9 +22,10 @@ use carbide_uuid::machine::{MachineId, MachineType};
 use health_report::HealthReport;
 use model::errors::{ModelError, ModelResult};
 use model::machine::{
-    DpfState, DpuInfo, DpuInitState, FailureCause, InstanceState, Machine,
-    MachineInterfaceSnapshot, MachineValidationFilter, ManagedHostState, ManagedHostStateSnapshot,
-    ReprovisionRequest, ReprovisionState, slas, state_sla,
+    DpfState, DpuInfo, DpuInfoStatusObservation, DpuInitState, DpuOsOperationalState,
+    DpuRepresentorStatus, FailureCause, InstanceState, Machine, MachineInterfaceSnapshot,
+    MachineValidationFilter, ManagedHostState, ManagedHostStateSnapshot, ReprovisionRequest,
+    ReprovisionState, slas, state_sla,
 };
 use model::machine_interface::InterfaceType;
 use model::network_segment::NetworkSegmentType;
@@ -44,11 +45,45 @@ pub mod nvlink;
 pub mod spx;
 pub mod upgrade_policy;
 
+impl From<DpuOsOperationalState> for rpc::forge::DpuOsOperationalState {
+    fn from(state: DpuOsOperationalState) -> Self {
+        Self {
+            state_detail: state.state_detail,
+        }
+    }
+}
+
+impl From<DpuRepresentorStatus> for rpc::forge::DpuRepresentorStatus {
+    fn from(status: DpuRepresentorStatus) -> Self {
+        Self {
+            name: status.name,
+            carrier_up: status.carrier_up,
+            state: status.state,
+        }
+    }
+}
+
+impl From<DpuInfoStatusObservation> for rpc::forge::DpuInfoStatusObservation {
+    fn from(observation: DpuInfoStatusObservation) -> Self {
+        Self {
+            os_operational_state: observation.os_operational_state.map(Into::into),
+            firmware_version: observation.firmware_version,
+            representors: observation
+                .representors
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            last_heartbeat: observation.last_heartbeat.map(rpc::Timestamp::from),
+        }
+    }
+}
+
 impl From<DpuInfo> for rpc::forge::DpuInfo {
     fn from(info: DpuInfo) -> Self {
         rpc::forge::DpuInfo {
             id: info.id,
             loopback_ip: info.loopback_ip,
+            observed_status: info.observed_status.map(Into::into),
         }
     }
 }
@@ -523,16 +558,65 @@ fn machine_instance_network_restrictions(
 #[cfg(test)]
 mod test {
     use crate as rpc;
-    use crate::model::machine::DpuInfo;
+    use crate::model::machine::{
+        DpuInfo, DpuInfoStatusObservation, DpuOsOperationalState, DpuRepresentorStatus,
+    };
 
     #[test]
     fn dpu_info_to_rpc() {
         let info = DpuInfo {
             id: "dpu-123".to_string(),
             loopback_ip: "10.0.0.1".to_string(),
+            observed_status: Some(DpuInfoStatusObservation {
+                os_operational_state: Some(DpuOsOperationalState {
+                    state_detail: "Ready".to_string(),
+                }),
+                firmware_version: Some("24.42.1000".to_string()),
+                representors: vec![
+                    DpuRepresentorStatus {
+                        name: "pf0hpf_if".to_string(),
+                        carrier_up: Some(true),
+                        state: Some("up".to_string()),
+                    },
+                    DpuRepresentorStatus {
+                        name: "pf0vf0_if_r".to_string(),
+                        carrier_up: Some(false),
+                        state: Some("down".to_string()),
+                    },
+                ],
+                last_heartbeat: Some(chrono::Utc::now()),
+            }),
         };
+        let expected_last_heartbeat = info
+            .observed_status
+            .as_ref()
+            .and_then(|observation| observation.last_heartbeat)
+            .map(rpc::Timestamp::from);
         let rpc_info: rpc::forge::DpuInfo = info.into();
         assert_eq!(rpc_info.id, "dpu-123");
         assert_eq!(rpc_info.loopback_ip, "10.0.0.1");
+        let observed_status = rpc_info.observed_status.as_ref().unwrap();
+        assert_eq!(
+            observed_status
+                .os_operational_state
+                .as_ref()
+                .map(|state| state.state_detail.as_str()),
+            Some("Ready")
+        );
+        assert_eq!(
+            observed_status.firmware_version.as_deref(),
+            Some("24.42.1000")
+        );
+        assert_eq!(observed_status.representors.len(), 2);
+        assert_eq!(observed_status.representors[0].name, "pf0hpf_if");
+        assert_eq!(observed_status.representors[0].carrier_up, Some(true));
+        assert_eq!(observed_status.representors[0].state.as_deref(), Some("up"));
+        assert_eq!(observed_status.representors[1].name, "pf0vf0_if_r");
+        assert_eq!(observed_status.representors[1].carrier_up, Some(false));
+        assert_eq!(
+            observed_status.representors[1].state.as_deref(),
+            Some("down")
+        );
+        assert_eq!(observed_status.last_heartbeat, expected_last_heartbeat);
     }
 }

--- a/crates/rpc/src/model/machine/network.rs
+++ b/crates/rpc/src/model/machine/network.rs
@@ -24,11 +24,56 @@ use model::instance::status::network::{
     InstanceInterfaceStatusObservation, InstanceNetworkStatusObservation,
 };
 use model::machine::network::{
-    MachineNetworkStatusObservation, ManagedHostQuarantineMode, ManagedHostQuarantineState,
+    DpuFabricInterfaceStatusObservation, DpuLinkStatusObservation, MachineNetworkStatusObservation,
+    ManagedHostQuarantineMode, ManagedHostQuarantineState,
 };
 
 use crate::errors::RpcDataConversionError;
 use crate::forge as rpc;
+
+impl From<rpc::FabricInterfaceData> for DpuFabricInterfaceStatusObservation {
+    fn from(interface: rpc::FabricInterfaceData) -> Self {
+        Self {
+            interface_name: interface.interface_name,
+            link_data: interface.link_data.map(Into::into),
+        }
+    }
+}
+
+impl From<rpc::LinkData> for DpuLinkStatusObservation {
+    fn from(link: rpc::LinkData) -> Self {
+        Self {
+            link_type: link.link_type,
+            state: link.state,
+            carrier_up: link.carrier_up,
+            mtu: link.mtu,
+            carrier_up_count: link.carrier_up_count,
+            carrier_down_count: link.carrier_down_count,
+        }
+    }
+}
+
+impl From<DpuFabricInterfaceStatusObservation> for rpc::FabricInterfaceData {
+    fn from(interface: DpuFabricInterfaceStatusObservation) -> Self {
+        Self {
+            interface_name: interface.interface_name,
+            link_data: interface.link_data.map(Into::into),
+        }
+    }
+}
+
+impl From<DpuLinkStatusObservation> for rpc::LinkData {
+    fn from(link: DpuLinkStatusObservation) -> Self {
+        Self {
+            link_type: link.link_type,
+            state: link.state,
+            carrier_up: link.carrier_up,
+            mtu: link.mtu,
+            carrier_up_count: link.carrier_up_count,
+            carrier_down_count: link.carrier_down_count,
+        }
+    }
+}
 
 impl TryFrom<rpc::DpuNetworkStatus> for MachineNetworkStatusObservation {
     type Error = RpcDataConversionError;
@@ -115,6 +160,7 @@ impl TryFrom<rpc::DpuNetworkStatus> for MachineNetworkStatusObservation {
             agent_version_superseded_at: None,
             instance_network_observation,
             extension_service_observation,
+            fabric_interfaces: obs.fabric_interfaces.into_iter().map(Into::into).collect(),
         })
     }
 }
@@ -138,7 +184,7 @@ impl From<MachineNetworkStatusObservation> for rpc::DpuNetworkStatus {
             network_config_error: None,
             client_certificate_expiry_unix_epoch_secs: None,
             dpu_health: None,
-            fabric_interfaces: vec![],
+            fabric_interfaces: m.fabric_interfaces.into_iter().map(Into::into).collect(),
             last_dhcp_requests: vec![],
             dpu_extension_service_version: None,
             dpu_extension_services: vec![],


### PR DESCRIPTION
## Description

This PR extends DpuInfo to include more details around firmware, OS, and representor state.  The OS and representor details have been added as structs so we can extend them later if desired.  For representors, this also lets us express "admin" down vs "carrier down" for down states.

Relates to #2081 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

Satisfies: https://github.com/NVIDIA/infra-controller/issues/2081