### PR TITLE
feat(helm): add opt-in legacy carbide/forge name aliases for nico-api…

### DIFF
--- a/helm/charts/nico-api/templates/legacy-alias-service.yaml
+++ b/helm/charts/nico-api/templates/legacy-alias-service.yaml
@@ -1,0 +1,62 @@
+{{/*
+Legacy name aliases — opt-in ExternalName Services that make the legacy
+"carbide-api.forge-system.svc.cluster.local" hostname (and any other
+configured alias) resolve to this chart's nico-api Service.
+
+Why: pre-rename binaries (admin CLI, dpu-agent, log-parser, health, pxe,
+bmc-proxy, ssh-console, dsx-exchange-consumer, rvs, dhcp-server) hardcode
+the legacy URL as their default. Rebuilding those binaries to use the
+modern nico-api.<ns>.svc.cluster.local name is forward-only and does not
+help mixed fleets, so the chart provides the alias instead — both names
+work simultaneously, pointing at the same pods.
+
+Notes:
+- Cross-namespace lookups: the alias is an ExternalName Service in
+  `<alias.namespace>` that CNAMEs to nico-api.<this-ns>.svc.cluster.local.
+- The alias namespace is created with `helm.sh/resource-policy: keep` so
+  uninstalling nico-api does not delete the namespace if other resources
+  live there.
+- Clients running in-cluster against the legacy hostname will still hit
+  the resolver's ndots-based search expansion. To avoid an initial
+  NXDOMAIN round trip, set `dnsConfig.options: [{name: ndots, value: "2"}]`
+  on the consuming pod, or update the consuming binary to use a
+  trailing-dot FQDN.
+*/}}
+{{- if and .Values.legacyAlias .Values.legacyAlias.enabled }}
+{{- range $alias := .Values.legacyAlias.aliases }}
+{{- if $alias.createNamespace }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $alias.namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
+    nico.nvidia.com/purpose: "legacy-compat namespace for nico-api aliases"
+  labels:
+    {{- include "nico-api.labels" $ | nindent 4 }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $alias.name }}
+  namespace: {{ $alias.namespace }}
+  labels:
+    {{- include "nico-api.labels" $ | nindent 4 }}
+    nico.nvidia.com/legacy-alias-of: {{ include "nico-api.name" $ }}
+spec:
+  type: ExternalName
+  externalName: {{ include "nico-api.name" $ }}.{{ include "nico-api.namespace" $ }}.svc.cluster.local
+  ports:
+    - name: grpc
+      port: 1079
+      protocol: TCP
+    - name: metrics
+      port: 1080
+      protocol: TCP
+    - name: profiler
+      port: 1081
+      protocol: TCP
+{{- end }}
+{{- end }}

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -32,6 +32,35 @@ global:
 ## Override the release namespace (defaults to helm install -n <namespace>)
 namespaceOverride: ""
 
+## Legacy name aliases — opt-in ExternalName Services so binaries that
+## hardcode the pre-rename hostnames (e.g. `carbide-api.forge-system.svc.
+## cluster.local:1079`) continue to resolve to this chart's nico-api
+## Service. Both the modern and legacy names resolve simultaneously; they
+## share the same pods. Disable when running an all-modern fleet.
+##
+## Each entry creates:
+##   - the alias namespace (if `createNamespace: true`, with
+##     `helm.sh/resource-policy: keep` so a helm uninstall does not delete
+##     it).
+##   - an ExternalName Service `<name>.<namespace>` that CNAMEs to
+##     `nico-api.<this-namespace>.svc.cluster.local`.
+##
+## Clients running in-cluster against the legacy hostname should set
+## `dnsConfig.options: [{name: ndots, value: "2"}]` on their pod so the
+## resolver tries the literal FQDN first rather than ndots search
+## expansion (which would otherwise try `carbide-api.forge-system.svc.
+## cluster.local.<pod-search-domain>` first and get NXDOMAIN).
+legacyAlias:
+  # On by default to match the chart's cert SAN posture (the `nico-api`
+  # Certificate already includes `carbide-api.forge-system.svc.cluster.local`
+  # as a SAN). Flip to false on all-modern fleets where no client uses the
+  # legacy hostname.
+  enabled: true
+  aliases:
+    - name: carbide-api
+      namespace: forge-system
+      createNamespace: true
+
 replicas: 1
 automountServiceAccountToken: true
 annotations:

--- a/helm/charts/nico-pxe/templates/legacy-alias-service.yaml
+++ b/helm/charts/nico-pxe/templates/legacy-alias-service.yaml
@@ -1,0 +1,37 @@
+{{/*
+Legacy name alias — opt-in ExternalName Service that makes the legacy
+"carbide-pxe.<alias-namespace>.svc.cluster.local" hostname resolve to
+this chart's nico-pxe Service.
+
+Why: pre-rename binaries (DPU agents, host PXE loaders) hardcode the
+legacy URL. Rather than rebuild every consumer, the chart provides the
+alias so both the modern and legacy names resolve simultaneously,
+pointing at the same pods.
+
+Note: this template only creates the Service. The alias namespace is
+expected to exist already — when the umbrella chart's nico-api
+legacyAlias is enabled (its own template creates the namespace with
+`helm.sh/resource-policy: keep`). If you enable nico-pxe's alias
+without nico-api's, the namespace must already exist by some other
+means or this Service apply will fail.
+*/}}
+{{- if and .Values.legacyAlias .Values.legacyAlias.enabled }}
+{{- range $alias := .Values.legacyAlias.aliases }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $alias.name }}
+  namespace: {{ $alias.namespace }}
+  labels:
+    {{- include "nico-pxe.labels" $ | nindent 4 }}
+    nico.nvidia.com/legacy-alias-of: {{ include "nico-pxe.name" $ }}
+spec:
+  type: ExternalName
+  externalName: {{ include "nico-pxe.name" $ }}.{{ include "nico-pxe.namespace" $ }}.svc.cluster.local
+  ports:
+    - name: http
+      port: {{ $.Values.service.port | default 8080 }}
+      protocol: TCP
+{{- end }}
+{{- end }}

--- a/helm/charts/nico-pxe/values.yaml
+++ b/helm/charts/nico-pxe/values.yaml
@@ -25,6 +25,24 @@ global:
 ## Override the release namespace (defaults to helm install -n <namespace>)
 namespaceOverride: ""
 
+## Legacy name aliases — opt-in ExternalName Services so binaries that
+## hardcode the pre-rename hostname (e.g. `carbide-pxe.forge-system.svc.
+## cluster.local`) continue to resolve to this chart's nico-pxe Service.
+## See helm/charts/nico-api/values.yaml `legacyAlias` for the full
+## explanation; this chart's variant creates only the Service. The alias
+## namespace is owned by nico-api's legacyAlias template, so enable
+## nico-api.legacyAlias in tandem.
+legacyAlias:
+  # On by default to match the chart's cert SAN posture (the `nico-pxe`
+  # Certificate already includes `carbide-pxe.forge-system.svc.cluster.local`
+  # as a SAN). Flip to false on all-modern fleets where no client uses the
+  # legacy hostname. Requires `nico-api.legacyAlias.enabled` to be true so
+  # the `forge-system` namespace is owned by nico-api's template.
+  enabled: true
+  aliases:
+    - name: carbide-pxe
+      namespace: forge-system
+
 replicas: 1
 
 ## Optional init containers (general-purpose pass-through)


### PR DESCRIPTION
## Description
Adds ExternalName Services that make the pre-rename hostnames resolve back to the modern chart Services, so binaries that hardcode the legacy URLs continue to work without rebuild. Both names work simultaneously, pointing at the same pods.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

