### PR TITLE
Validate that the ARM64 binaries are 64KB page size compatible

### DIFF
--- a/Makefile-package.toml
+++ b/Makefile-package.toml
@@ -40,6 +40,8 @@ category = "Build"
 description = "Build the .deb package"
 workspace = false
 script = '''
+    set -e
+
     if [ "${CARBIDE_ARCH}" = "x86_64" ]
     then
         DEB_ARCH="amd64"
@@ -66,6 +68,10 @@ script = '''
     WORKING_DIR="${REPO_ROOT}/target/${CARBIDE_ARCH}-unknown-linux-gnu/${PACKAGE_BIN}_${PKG_VERSION}_${DEB_ARCH}"
     mkdir -p "${WORKING_DIR}/lib/systemd/system"
     mkdir -p "${WORKING_DIR}${INSTALL_DIR}"
+    if [ "${CARBIDE_ARCH}" = "aarch64" ]
+    then
+        bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/${CARBIDE_ARCH}-unknown-linux-gnu/${CARBIDE_PROFILE}/${PACKAGE_BIN}"
+    fi
     cp "${REPO_ROOT}/target/${CARBIDE_ARCH}-unknown-linux-gnu/${CARBIDE_PROFILE}/${PACKAGE_BIN}" "${WORKING_DIR}${INSTALL_DIR}"
     cp ${MISC_DIR}/*.service "${WORKING_DIR}/lib/systemd/system/"
     cp -r ${DEB_CONFIG_DIR} "${WORKING_DIR}/"

--- a/Makefile-package.toml
+++ b/Makefile-package.toml
@@ -70,7 +70,11 @@ script = '''
     mkdir -p "${WORKING_DIR}${INSTALL_DIR}"
     if [ "${CARBIDE_ARCH}" = "aarch64" ]
     then
-        bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/${CARBIDE_ARCH}-unknown-linux-gnu/${CARBIDE_PROFILE}/${PACKAGE_BIN}"
+        for path in \
+            "${REPO_ROOT}/target/${CARBIDE_ARCH}-unknown-linux-gnu/${CARBIDE_PROFILE}/${PACKAGE_BIN}" \
+            "${REPO_ROOT}/target/${CARBIDE_PROFILE}/${PACKAGE_BIN}"; do
+            bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" --allow-empty "${path}"
+        done
     fi
     cp "${REPO_ROOT}/target/${CARBIDE_ARCH}-unknown-linux-gnu/${CARBIDE_PROFILE}/${PACKAGE_BIN}" "${WORKING_DIR}${INSTALL_DIR}"
     cp ${MISC_DIR}/*.service "${WORKING_DIR}/lib/systemd/system/"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -612,6 +612,41 @@ args = [
   "@@split(CARGO_MAKE_CARGO_BUILD_TEST_FLAGS, )",
 ]
 
+[tasks.check-aarch64-release-container-services-page-size]
+workspace = false
+script = '''
+set -e
+
+target_triple="${CARGO_BUILD_TARGET:-}"
+machine="$(uname -m)"
+
+if [ "${target_triple}" = "aarch64-unknown-linux-gnu" ]; then
+  target_dir="${REPO_ROOT}/target/${target_triple}/release"
+elif [ "${machine}" = "aarch64" ] || [ "${machine}" = "arm64" ]; then
+  target_dir="${REPO_ROOT}/target/release"
+else
+  echo "Skipping aarch64 ELF page size checks on ${machine}"
+  exit 0
+fi
+
+for artifact in \
+  carbide-api \
+  carbide \
+  carbide-dns \
+  carbide-admin-cli \
+  carbide-dsx-exchange-consumer \
+  forge-dpu-agent \
+  forge-dhcp-server \
+  forge-hw-health \
+  forge-log-parser \
+  ssh-console \
+  carbide-bmc-proxy \
+  libdhcp.so; do
+  test -f "${target_dir}/${artifact}" || { echo "missing aarch64 artifact: ${target_dir}/${artifact}"; exit 1; }
+  bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${target_dir}/${artifact}"
+done
+'''
+
 [tasks.build-and-test-release-container-services]
 workspace = false
 # Important: We only build perform a single build task here since every additional
@@ -623,6 +658,7 @@ workspace = false
 dependencies = [
   "build-release", # Start with release builds, since some artifacts are used in integration tests
   "test-flow",     # Then run all tests
+  "check-aarch64-release-container-services-page-size",
 ]
 
 [tasks.clippy-ci-flow]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -617,18 +617,6 @@ workspace = false
 script = '''
 set -e
 
-target_triple="${CARGO_BUILD_TARGET:-}"
-machine="$(uname -m)"
-
-if [ "${target_triple}" = "aarch64-unknown-linux-gnu" ]; then
-  target_dir="${REPO_ROOT}/target/${target_triple}/release"
-elif [ "${machine}" = "aarch64" ] || [ "${machine}" = "arm64" ]; then
-  target_dir="${REPO_ROOT}/target/release"
-else
-  echo "Skipping aarch64 ELF page size checks on ${machine}"
-  exit 0
-fi
-
 for artifact in \
   carbide-api \
   carbide \
@@ -642,8 +630,11 @@ for artifact in \
   ssh-console \
   carbide-bmc-proxy \
   libdhcp.so; do
-  test -f "${target_dir}/${artifact}" || { echo "missing aarch64 artifact: ${target_dir}/${artifact}"; exit 1; }
-  bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${target_dir}/${artifact}"
+  for path in \
+    "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/${artifact}" \
+    "${REPO_ROOT}/target/release/${artifact}"; do
+    bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" --allow-empty "${path}"
+  done
 done
 '''
 

--- a/bluefield/Makefile.toml
+++ b/bluefield/Makefile.toml
@@ -16,6 +16,9 @@
 #
 
 [env]
+REPO_ROOT = { script = [
+  "dirname $(cargo locate-project --message-format plain --workspace)",
+] }
 # e.g. 2024.05.24-rc1-0-0-g786e94757
 DPU_AGENT_PKG_VERSION = { script = [
   "echo $(git describe --tags --first-parent --always --long | cut -c 2-)",
@@ -78,6 +81,8 @@ category = "Build"
 description = "cross compile forge-dpu-agent and dhcp server locally"
 workspace = false
 script = '''
+set -e
+
 docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) \
     --env CARGO_HOME=/cargo \
     -v $CARGO_HOME:/cargo \
@@ -94,6 +99,8 @@ docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) \
     "/carbide/target/aarch64-unknown-linux-gnu/release/forge-dpu-agent"
     docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) build-artifacts-container-cross-aarch64:latest "aarch64-linux-gnu-strip" \
     "/carbide/target/aarch64-unknown-linux-gnu/release/forge-dhcp-server"
+bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dpu-agent"
+bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dhcp-server"
 '''
 dependencies = [
   { name = "build-cross-docker-image", path = "${REPO_ROOT}" },
@@ -104,21 +111,21 @@ dependencies = [
 category = "Build"
 workspace = false
 description = "Referring to the prebuilt 'build' task doesn't work here, since it always tries to build the full workspace - including targets that are not aarch64 compatible"
-command = "cargo"
-args = [
-  "build",
-  "--release",
-  "--bin",
-  "forge-dpu-agent",
-  "--bin",
-  "forge-dhcp-server",
-]
+script = '''
+set -e
+
+cargo build --release --target=aarch64-unknown-linux-gnu --bin forge-dpu-agent --bin forge-dhcp-server
+bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dpu-agent"
+bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dhcp-server"
+'''
 
 [tasks.build-fmds]
 category = "Build"
 description = "cross compile carbide-fmds locally"
 workspace = false
 script = '''
+set -e
+
 docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) \
     --env CARGO_HOME=/cargo \
     -v $CARGO_HOME:/cargo \
@@ -131,6 +138,7 @@ docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) \
     "carbide-fmds"
     docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) build-artifacts-container-cross-aarch64:latest "aarch64-linux-gnu-strip" \
     "/carbide/target/aarch64-unknown-linux-gnu/release/carbide-fmds"
+bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/carbide-fmds"
 '''
 dependencies = [
   { name = "build-cross-docker-image", path = "${REPO_ROOT}" },
@@ -141,14 +149,20 @@ dependencies = [
 category = "Build"
 workspace = false
 description = "Build carbide-fmds for CI"
-command = "cargo"
-args = ["build", "--release", "--bin", "carbide-fmds"]
+script = '''
+set -e
+
+cargo build --release --target=aarch64-unknown-linux-gnu --bin carbide-fmds
+bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/carbide-fmds"
+'''
 
 [tasks.build-dpu-otel-agent]
 category = "Build"
 description = "cross compile forge-dpu-otel-agent locally"
 workspace = false
 script = '''
+set -e
+
 docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) \
     --env CARGO_HOME=/cargo \
     -v $CARGO_HOME:/cargo \
@@ -161,6 +175,7 @@ docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) \
     "forge-dpu-otel-agent"
     docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) build-artifacts-container-cross-aarch64:latest "aarch64-linux-gnu-strip" \
     "/carbide/target/aarch64-unknown-linux-gnu/release/forge-dpu-otel-agent"
+bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dpu-otel-agent"
 '''
 dependencies = [
   { name = "build-cross-docker-image", path = "${REPO_ROOT}" },
@@ -171,8 +186,12 @@ dependencies = [
 category = "Build"
 workspace = false
 description = "Referring to the prebuilt 'build' task doesn't work here, since it always tries to build the full workspace - including targets that are not aarch64 compatible"
-command = "cargo"
-args = ["build", "--release", "--bin", "forge-dpu-otel-agent"]
+script = '''
+set -e
+
+cargo build --release --target=aarch64-unknown-linux-gnu --bin forge-dpu-otel-agent
+bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dpu-otel-agent"
+'''
 
 [tasks.download-otelcol-builder]
 category = "Build"

--- a/bluefield/Makefile.toml
+++ b/bluefield/Makefile.toml
@@ -99,8 +99,13 @@ docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) \
     "/carbide/target/aarch64-unknown-linux-gnu/release/forge-dpu-agent"
     docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) build-artifacts-container-cross-aarch64:latest "aarch64-linux-gnu-strip" \
     "/carbide/target/aarch64-unknown-linux-gnu/release/forge-dhcp-server"
-bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dpu-agent"
-bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dhcp-server"
+for path in \
+    "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dpu-agent" \
+    "${REPO_ROOT}/target/release/forge-dpu-agent" \
+    "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dhcp-server" \
+    "${REPO_ROOT}/target/release/forge-dhcp-server"; do
+    bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" --allow-empty "${path}"
+done
 '''
 dependencies = [
   { name = "build-cross-docker-image", path = "${REPO_ROOT}" },
@@ -114,9 +119,14 @@ description = "Referring to the prebuilt 'build' task doesn't work here, since i
 script = '''
 set -e
 
-cargo build --release --target=aarch64-unknown-linux-gnu --bin forge-dpu-agent --bin forge-dhcp-server
-bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dpu-agent"
-bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dhcp-server"
+cargo build --release --bin forge-dpu-agent --bin forge-dhcp-server
+for path in \
+    "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dpu-agent" \
+    "${REPO_ROOT}/target/release/forge-dpu-agent" \
+    "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dhcp-server" \
+    "${REPO_ROOT}/target/release/forge-dhcp-server"; do
+    bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" --allow-empty "${path}"
+done
 '''
 
 [tasks.build-fmds]
@@ -138,7 +148,11 @@ docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) \
     "carbide-fmds"
     docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) build-artifacts-container-cross-aarch64:latest "aarch64-linux-gnu-strip" \
     "/carbide/target/aarch64-unknown-linux-gnu/release/carbide-fmds"
-bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/carbide-fmds"
+for path in \
+    "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/carbide-fmds" \
+    "${REPO_ROOT}/target/release/carbide-fmds"; do
+    bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" --allow-empty "${path}"
+done
 '''
 dependencies = [
   { name = "build-cross-docker-image", path = "${REPO_ROOT}" },
@@ -152,8 +166,12 @@ description = "Build carbide-fmds for CI"
 script = '''
 set -e
 
-cargo build --release --target=aarch64-unknown-linux-gnu --bin carbide-fmds
-bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/carbide-fmds"
+cargo build --release --bin carbide-fmds
+for path in \
+    "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/carbide-fmds" \
+    "${REPO_ROOT}/target/release/carbide-fmds"; do
+    bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" --allow-empty "${path}"
+done
 '''
 
 [tasks.build-dpu-otel-agent]
@@ -175,7 +193,11 @@ docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) \
     "forge-dpu-otel-agent"
     docker run --rm -v $REPO_ROOT:/carbide --user $(id -u):$(id -g) build-artifacts-container-cross-aarch64:latest "aarch64-linux-gnu-strip" \
     "/carbide/target/aarch64-unknown-linux-gnu/release/forge-dpu-otel-agent"
-bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dpu-otel-agent"
+for path in \
+    "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dpu-otel-agent" \
+    "${REPO_ROOT}/target/release/forge-dpu-otel-agent"; do
+    bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" --allow-empty "${path}"
+done
 '''
 dependencies = [
   { name = "build-cross-docker-image", path = "${REPO_ROOT}" },
@@ -189,8 +211,12 @@ description = "Referring to the prebuilt 'build' task doesn't work here, since i
 script = '''
 set -e
 
-cargo build --release --target=aarch64-unknown-linux-gnu --bin forge-dpu-otel-agent
-bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dpu-otel-agent"
+cargo build --release --bin forge-dpu-otel-agent
+for path in \
+    "${REPO_ROOT}/target/aarch64-unknown-linux-gnu/release/forge-dpu-otel-agent" \
+    "${REPO_ROOT}/target/release/forge-dpu-otel-agent"; do
+    bash "${REPO_ROOT}/scripts/check-aarch64-pagesize.sh" --allow-empty "${path}"
+done
 '''
 
 [tasks.download-otelcol-builder]

--- a/scripts/check-aarch64-pagesize.sh
+++ b/scripts/check-aarch64-pagesize.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: check-aarch64-pagesize.sh [--allow-empty] [--min-page-size BYTES] [ROOT]
+
+Scans ROOT for aarch64 ELF executables/shared objects and verifies every
+PT_LOAD segment can be mapped on a kernel with the requested page size.
+
+Options:
+  --allow-empty           Succeed when no aarch64 ELF files are found.
+  --min-page-size BYTES   Minimum supported kernel page size. Default: 65536.
+  -h, --help              Show this help.
+EOF
+}
+
+root="."
+min_page_size=$((64 * 1024))
+allow_empty=false
+
+while (($#)); do
+    case "$1" in
+        --allow-empty)
+            allow_empty=true
+            shift
+            ;;
+        --min-page-size)
+            if (($# < 2)); then
+                echo "error: --min-page-size requires a value" >&2
+                exit 2
+            fi
+            min_page_size="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "error: unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            root="$1"
+            shift
+            if (($#)); then
+                echo "error: only one ROOT argument is supported" >&2
+                usage >&2
+                exit 2
+            fi
+            ;;
+    esac
+done
+
+if (($#)); then
+    root="$1"
+    shift
+fi
+
+if (($#)); then
+    echo "error: only one ROOT argument is supported" >&2
+    usage >&2
+    exit 2
+fi
+
+if ! [[ "$min_page_size" =~ ^[0-9]+$ ]] || (( min_page_size <= 0 )); then
+    echo "error: --min-page-size must be a positive integer byte count" >&2
+    exit 2
+fi
+
+checked=0
+failed=0
+
+if ! command -v readelf >/dev/null 2>&1; then
+    echo "error: required command not found: readelf" >&2
+    exit 2
+fi
+
+while IFS= read -r -d '' candidate; do
+    elf_header="$(readelf -h "$candidate" 2>/dev/null || true)"
+
+    # Keep only aarch64 ELF files.
+    machine="$(awk -F: '/Machine:/ { gsub(/^[[:space:]]+/, "", $2); print $2; exit }' <<<"$elf_header")"
+    if [[ "$machine" != "AArch64" ]]; then
+        continue
+    fi
+
+    # Ignore relocatable object files; they do not have meaningful LOAD alignment.
+    elf_type="$(awk '/Type:/ { print $2; exit }' <<<"$elf_header")"
+    if [[ "$elf_type" != "EXEC" && "$elf_type" != "DYN" ]]; then
+        continue
+    fi
+
+    segment_count=0
+    file_failed=0
+    while read -r offset vaddr align; do
+        if [[ -z "$offset" || -z "$vaddr" || -z "$align" ]]; then
+            continue
+        fi
+
+        segment_count=$((segment_count + 1))
+        align_value=$((align))
+        offset_value=$((offset))
+        vaddr_value=$((vaddr))
+
+        if (( align_value < min_page_size )); then
+            printf 'FAIL p_align=0x%x below required 0x%x %s\n' \
+                "$align_value" "$min_page_size" "$candidate"
+            file_failed=1
+        fi
+
+        if (( (offset_value % min_page_size) != (vaddr_value % min_page_size) )); then
+            printf 'FAIL p_offset=0x%x p_vaddr=0x%x not congruent modulo 0x%x %s\n' \
+                "$offset_value" "$vaddr_value" "$min_page_size" "$candidate"
+            file_failed=1
+        fi
+    done < <(readelf -lW "$candidate" 2>/dev/null | awk '$1 == "LOAD" { print $2, $3, $NF }')
+
+    checked=$((checked + 1))
+
+    if (( segment_count == 0 )); then
+        printf 'FAIL no PT_LOAD segments found %s\n' "$candidate"
+        failed=1
+    elif (( file_failed )); then
+        failed=1
+    else
+        printf 'OK   page_size=0x%x load_segments=%d %s\n' \
+            "$min_page_size" "$segment_count" "$candidate"
+    fi
+done < <(find "$root" -type f -print0)
+
+printf 'Checked %d aarch64 ELF executable/shared object(s)\n' "$checked"
+if (( checked == 0 )) && [[ "$allow_empty" != true ]]; then
+    echo "FAIL no aarch64 ELF executable/shared object(s) found" >&2
+    failed=1
+fi
+
+exit "$failed"

--- a/scripts/check-aarch64-pagesize.sh
+++ b/scripts/check-aarch64-pagesize.sh
@@ -74,6 +74,17 @@ if ! [[ "$min_page_size" =~ ^[0-9]+$ ]] || (( min_page_size <= 0 )); then
     exit 2
 fi
 
+if [[ ! -e "$root" ]]; then
+    if [[ "$allow_empty" == true ]]; then
+        printf 'SKIP missing %s\n' "$root"
+        printf 'Checked 0 aarch64 ELF executable/shared object(s)\n'
+        exit 0
+    fi
+
+    echo "error: path does not exist: $root" >&2
+    exit 2
+fi
+
 checked=0
 failed=0
 


### PR DESCRIPTION
## Description
Issue 334 requests that all ARM64 binaries support kernels with 64KB page sizes.
That appears to be the default in the linker that rust is using, and the built in linker that go uses.   We also don't appear to be directly calling any system calls that would require page size or page aligned buffers.

This PR adds some validation to the build process, to check the compatibility after compile.

## Type of Change
<!-- Check one that best describes this PR -->
- [X] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://github.com/NVIDIA/infra-controller/issues/334

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

