### PR TITLE
fix: Keep hostname and IP Address in sync during stale IP cleanup and reallocation

### DIFF
--- a/crates/api-core/src/dhcp/expire.rs
+++ b/crates/api-core/src/dhcp/expire.rs
@@ -39,6 +39,12 @@ pub async fn expire_dhcp_lease(
         .transpose()?;
 
     let mut txn = api.txn_begin().await?;
+
+    // Look up the interface that owns this IP before deleting so we can clear
+    // its hostname afterward. The JOIN in find_by_ip requires the address row
+    // to still exist, so we must do this before the delete.
+    let interface = db::machine_interface::find_by_ip(&mut txn, ip_address).await?;
+
     // When the caller provides the MAC, scope the delete to the (ip, mac)
     // pair. Otherwise, just call the address-only variant, which would
     // be something we would see from an admin-cli call used for deleting
@@ -62,6 +68,18 @@ pub async fn expire_dhcp_lease(
             .await?
         }
     };
+
+    // Clear the hostname so DNS stays consistent. The next DHCP discover will
+    // re-derive the hostname from the newly allocated IP.
+    if deleted && let Some(iface) = interface {
+        db::machine_interface::sync_hostname_after_address_change(
+            &mut txn,
+            iface.id,
+            &iface.mac_address,
+        )
+        .await?;
+    }
+
     txn.commit().await?;
 
     let status = if deleted {

--- a/crates/api-core/src/tests/dhcp_lease_expiration.rs
+++ b/crates/api-core/src/tests/dhcp_lease_expiration.rs
@@ -341,6 +341,83 @@ async fn test_expire_with_matching_mac_releases(
 }
 
 #[crate::sqlx_test]
+async fn test_expire_resets_hostname_and_discover_restores_it(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let mac_address = "aa:bb:cc:dd:ee:0d";
+
+    // Initial discover: interface is created and an IP-derived hostname is set.
+    let response1 = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(mac_address, FIXTURE_DHCP_RELAY_ADDRESS).tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let original_ip = response1.address.clone();
+    assert!(
+        !original_ip.is_empty(),
+        "should get an IP on first discover"
+    );
+
+    // The hostname must match the IP (dots replaced with dashes for IPv4).
+    let interface_id = response1.machine_interface_id.unwrap();
+    let mut txn = env.pool.begin().await?;
+    let iface = db::machine_interface::find_one(&mut *txn, interface_id).await?;
+    let expected_hostname = original_ip.replace('.', "-");
+    assert_eq!(
+        iface.hostname, expected_hostname,
+        "hostname should be derived from the allocated IP"
+    );
+    drop(txn);
+
+    // Expire the lease.
+    let expire_response = env
+        .api
+        .expire_dhcp_lease(Request::new(ExpireDhcpLeaseRequest {
+            ip_address: original_ip.clone(),
+            mac_address: None,
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(expire_response.status(), ExpireDhcpLeaseStatus::Released);
+
+    // After expiry the hostname must be the dormant no-IP placeholder.
+    let mut txn = env.pool.begin().await?;
+    let iface_after_expiry = db::machine_interface::find_one(&mut *txn, interface_id).await?;
+    let expected_dormant = format!("noip-{}", mac_address.replace(':', "-"));
+    assert_eq!(
+        iface_after_expiry.hostname.to_lowercase(),
+        expected_dormant.to_lowercase(),
+        "hostname should be reset to dormant placeholder after lease expiry"
+    );
+    drop(txn);
+
+    // Re-discover: a new IP is allocated and the hostname must be updated.
+    let response2 = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(mac_address, FIXTURE_DHCP_RELAY_ADDRESS).tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let new_ip = response2.address.clone();
+    assert!(!new_ip.is_empty(), "should get an IP after re-allocation");
+
+    let mut txn = env.pool.begin().await?;
+    let iface_after_rediscover = db::machine_interface::find_one(&mut *txn, interface_id).await?;
+    let expected_new_hostname = new_ip.replace('.', "-");
+    assert_eq!(
+        iface_after_rediscover.hostname.to_lowercase(),
+        expected_new_hostname.to_lowercase(),
+        "hostname should match the newly allocated IP after rediscover"
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn test_expire_with_mismatched_mac_is_no_op(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -1962,6 +1962,31 @@ fn dormant_admin_hostname(mac_address: &MacAddress) -> String {
     format!("noip-{}", mac_address.to_string().replace(':', "-"))
 }
 
+/// Syncs a machine interface's hostname to its current address state after an address deletion.
+///
+/// - If the interface still has addresses, picks IPv4 (preferred) or the first remaining address
+///   and updates the hostname while preserving the existing domain_id.
+/// - If no addresses remain, resets to the dormant `noip-{mac}` placeholder and clears domain_id.
+pub async fn sync_hostname_after_address_change(
+    txn: &mut PgConnection,
+    interface_id: MachineInterfaceId,
+    mac_address: &MacAddress,
+) -> DatabaseResult<()> {
+    let snapshot = find_one(&mut *txn, interface_id).await?;
+    let (hostname, domain_id) = if let Some(addr) = snapshot
+        .addresses
+        .iter()
+        .find(|a| a.is_ipv4())
+        .or(snapshot.addresses.first())
+    {
+        (address_to_hostname(addr)?, snapshot.domain_id)
+    } else {
+        (dormant_admin_hostname(mac_address), None)
+    };
+    update_hostname_and_domain(txn, interface_id, &hostname, domain_id).await?;
+    Ok(())
+}
+
 pub async fn find_by_machine_and_segment(
     txn: &mut PgConnection,
     machine_id: &MachineId,
@@ -2128,6 +2153,19 @@ pub async fn allocate_address_for_family(
     }
 
     fast_txn.commit().await?;
+
+    // Sync the hostname to the newly allocated address so it stays consistent
+    // with machine_interface_addresses. Prefer IPv4 (more human-readable).
+    if let Some(addr) = allocated_addresses
+        .iter()
+        .find(|a| a.is_ipv4())
+        .or(allocated_addresses.first())
+    {
+        let hostname = address_to_hostname(addr)?;
+        update_hostname_and_domain(txn, interface_id, &hostname, segment.config.subdomain_id)
+            .await?;
+    }
+
     Ok(allocated_addresses)
 }
 


### PR DESCRIPTION
## Description
Keep hostname and IP Address in sync during stale IP cleanup and reallocation.

When a DHCP lease expires, the IP address is removed from  machine_interface_addresses but the hostname column in machine_interfaces (derived from the IP, e.g. 192-168-1-5) is left stale. When a new IP is allocated on the next DHCP discover, the hostname is never updated either — leaving DNS permanently out of sync with the interface's actual IP. 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

