### PR TITLE
fix(sku): reject empty SKU ID on create and replace

### DIFF
--- a/crates/api-core/src/tests/sku.rs
+++ b/crates/api-core/src/tests/sku.rs
@@ -427,6 +427,24 @@ pub mod tests {
     }
 
     #[crate::sqlx_test]
+    pub async fn test_sku_create_rejects_empty_id(pool: sqlx::PgPool) -> Result<(), eyre::Error> {
+        let mut txn = pool.begin().await?;
+        let rpc_sku: rpc::forge::Sku = serde_json::de::from_str(FULL_SKU_DATA)?;
+        let mut sku: Sku = rpc_sku.into();
+        sku.id = String::new();
+
+        let error = db::sku::create(&mut txn, &sku)
+            .await
+            .expect_err("Creating a SKU with an empty ID should have failed");
+
+        assert_eq!(
+            error.to_string(),
+            "Argument is invalid: SKU ID must not be empty"
+        );
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
     pub async fn test_sku_delete(pool: sqlx::PgPool) -> Result<(), eyre::Error> {
         let mut txn = pool.begin().await?;
         let rpc_sku: rpc::forge::Sku = serde_json::de::from_str(FULL_SKU_DATA)?;

--- a/crates/api-db/src/sku.rs
+++ b/crates/api-db/src/sku.rs
@@ -88,6 +88,12 @@ pub async fn create(txn: &mut PgConnection, sku: &Sku) -> Result<(), DatabaseErr
         ));
     }
 
+    if sku.id.is_empty() {
+        return Err(DatabaseError::InvalidArgument(
+            "SKU ID must not be empty".to_string(),
+        ));
+    }
+
     let mut inner_txn = Transaction::begin_inner(txn).await?;
 
     let query = "LOCK TABLE machine_skus IN ACCESS EXCLUSIVE MODE";
@@ -209,6 +215,12 @@ pub async fn replace(txn: &mut PgConnection, sku: &Sku) -> Result<Sku, DatabaseE
     if sku.schema_version != CURRENT_SKU_VERSION {
         return Err(DatabaseError::InvalidArgument(
             "SKU version is no longer supported".to_string(),
+        ));
+    }
+
+    if sku.id.is_empty() {
+        return Err(DatabaseError::InvalidArgument(
+            "SKU ID must not be empty".to_string(),
         ));
     }
 


### PR DESCRIPTION
A SKU could be created with an empty id (the proto id field defaults to "" when omitted, and nothing validated it), which Postgres accepts as a valid primary key. Duplicate-content detection would then match that row and report "Specified SKU matches SKU with ID: " with an empty id.

Reject empty ids in db::sku::create and db::sku::replace so the empty-id row can never be inserted, and replace fails fast with a clear message instead of a cryptic RowNotFound.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [X] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

