### PR TITLE
fix: Remove requirement for access token for rms fw update

### DIFF
--- a/crates/admin-cli/src/component_manager/update_firmware/args.rs
+++ b/crates/admin-cli/src/component_manager/update_firmware/args.rs
@@ -153,7 +153,7 @@ pub struct FirmwareSourceArgs {
 
     #[clap(
         long = "access-token",
-        help = "Artifact access token; required with --sot-json-file"
+        help = "Artifact access token for RMS SOT JSON downloads; omit or pass empty for NOAUTH"
     )]
     pub access_token: Option<String>,
 }
@@ -187,20 +187,17 @@ fn resolve_firmware_source(
             }
         }
         (None, Some(sot_json_file), access_token) => {
-            let token = access_token.ok_or_else(|| {
-                CarbideCliError::GenericError(
-                    "--access-token is required with --sot-json-file".to_string(),
-                )
-            })?;
-            if token.trim().is_empty() {
-                return Err(CarbideCliError::GenericError(
-                    "--access-token must not be empty".to_string(),
-                ));
-            }
+            let token = access_token.and_then(|token| {
+                if token.trim().is_empty() {
+                    None
+                } else {
+                    Some(token)
+                }
+            });
 
             let config_json = std::fs::read_to_string(sot_json_file)?;
             serde_json::from_str::<serde_json::Value>(&config_json)?;
-            Ok((config_json, Some(token)))
+            Ok((config_json, token))
         }
     }
 }
@@ -342,6 +339,37 @@ mod tests {
 
         assert_eq!(target_version, r#"{"Id":"fw-object"}"#);
         assert_eq!(access_token.as_deref(), Some("token"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sot_json_source_allows_missing_access_token() {
+        let path = temp_sot_file(r#"{"Id":"fw-object"}"#);
+
+        let (target_version, access_token) = resolve_firmware_source(FirmwareSourceArgs {
+            target_version: None,
+            sot_json_file: Some(path.clone()),
+            access_token: None,
+        })
+        .expect("SOT source should resolve without an access token");
+
+        assert_eq!(target_version, r#"{"Id":"fw-object"}"#);
+        assert_eq!(access_token, None);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn sot_json_source_treats_empty_access_token_as_missing() {
+        let path = temp_sot_file(r#"{"Id":"fw-object"}"#);
+
+        let (_, access_token) = resolve_firmware_source(FirmwareSourceArgs {
+            target_version: None,
+            sot_json_file: Some(path.clone()),
+            access_token: Some(String::new()),
+        })
+        .expect("SOT source should resolve with an empty access token");
+
+        assert_eq!(access_token, None);
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/admin-cli/src/rack/maintenance/args.rs
+++ b/crates/admin-cli/src/rack/maintenance/args.rs
@@ -78,7 +78,7 @@ pub struct MaintenanceOptions {
 
     #[clap(
         long = "access-token",
-        help = "Artifact access token; required with --sot-json-file"
+        help = "Artifact access token for RMS SOT JSON downloads; omit or pass empty for NOAUTH"
     )]
     pub access_token: Option<String>,
 

--- a/crates/admin-cli/src/rack/maintenance/cmd.rs
+++ b/crates/admin-cli/src/rack/maintenance/cmd.rs
@@ -58,20 +58,10 @@ fn resolve_firmware_upgrade_source(
         }
     });
 
-    if args.sot_json_file.is_some() && access_token.is_none() {
-        return Err(CarbideCliError::GenericError(
-            "--access-token is required with --sot-json-file".to_string(),
-        ));
-    }
     if requires_firmware_object_json && firmware_version.trim().is_empty() {
         return Err(CarbideCliError::GenericError(
             "--activities firmware-upgrade/nvos-update requires SOT JSON from --sot-json-file or --firmware-version"
                 .to_string(),
-        ));
-    }
-    if requires_firmware_object_json && access_token.is_none() {
-        return Err(CarbideCliError::GenericError(
-            "--activities firmware-upgrade/nvos-update requires --access-token".to_string(),
         ));
     }
     if !requires_firmware_object_json && args.sot_json_file.is_some() {
@@ -89,7 +79,7 @@ fn resolve_firmware_upgrade_source(
             "--access-token requires --activities firmware-upgrade or nvos-update".to_string(),
         ));
     }
-    if access_token.is_some() && args.firmware_version.is_some() {
+    if requires_firmware_object_json && args.firmware_version.is_some() {
         serde_json::from_str::<serde_json::Value>(&firmware_version)?;
     }
 
@@ -189,16 +179,31 @@ mod tests {
     }
 
     #[test]
-    fn firmware_upgrade_requires_access_token() {
+    fn firmware_upgrade_allows_missing_access_token() {
         let args = MaintenanceOptions {
             activities: Some(vec!["firmware-upgrade".to_string()]),
             firmware_version: Some(r#"{"Id":"fw"}"#.to_string()),
             ..options()
         };
 
-        let err = resolve_firmware_upgrade_source(&args).unwrap_err();
+        let (firmware_version, access_token) = resolve_firmware_upgrade_source(&args).unwrap();
 
-        assert!(err.to_string().contains("requires --access-token"));
+        assert_eq!(firmware_version, r#"{"Id":"fw"}"#);
+        assert_eq!(access_token, None);
+    }
+
+    #[test]
+    fn firmware_upgrade_treats_empty_access_token_as_missing() {
+        let args = MaintenanceOptions {
+            activities: Some(vec!["firmware-upgrade".to_string()]),
+            firmware_version: Some(r#"{"Id":"fw"}"#.to_string()),
+            access_token: Some(String::new()),
+            ..options()
+        };
+
+        let (_, access_token) = resolve_firmware_upgrade_source(&args).unwrap();
+
+        assert_eq!(access_token, None);
     }
 
     #[test]

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -20,6 +20,7 @@ use std::net::IpAddr;
 
 use ::rpc::common::SystemPowerControl;
 use ::rpc::forge::{self as rpc};
+use carbide_rack::firmware_object::rms_access_token_or_noauth;
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::power_shelf::PowerShelfId;
 use carbide_uuid::rack::RackId;
@@ -416,40 +417,24 @@ fn reject_power_shelf_firmware_object_json(access_token: &Option<String>) -> Res
     }
 }
 
-fn missing_firmware_object_json_status(target: &str) -> Status {
-    Status::invalid_argument(format!(
-        "access_token is required for {target} firmware updates routed through rack maintenance"
-    ))
-}
-
 fn require_firmware_object_json_for_rack_maintenance(
-    target: &str,
+    _target: &str,
     access_token: &Option<String>,
     target_version: &str,
 ) -> Result<String, Status> {
-    let Some(token) = access_token.clone() else {
-        return Err(missing_firmware_object_json_status(target));
-    };
-
     validate_firmware_object_json_request(target_version)?;
-    Ok(token)
+    Ok(rms_access_token_or_noauth(access_token.as_deref()))
 }
 
 fn require_firmware_object_json_for_direct_rms(
-    target: &str,
+    _target: &str,
     access_token: &Option<String>,
     target_version: &str,
     force_update: bool,
 ) -> Result<FirmwareUpdateOptions, Status> {
-    let Some(token) = access_token.clone() else {
-        return Err(Status::invalid_argument(format!(
-            "access_token is required for {target} firmware updates routed directly to RMS"
-        )));
-    };
-
     validate_firmware_object_json_request(target_version)?;
     Ok(FirmwareUpdateOptions {
-        access_token: Some(token),
+        access_token: Some(rms_access_token_or_noauth(access_token.as_deref())),
         force_update,
     })
 }
@@ -2242,11 +2227,13 @@ mod tests {
     }
 
     #[test]
-    fn rack_maintenance_firmware_update_requires_firmware_object_json() {
-        let err = missing_firmware_object_json_status("rack");
+    fn rack_maintenance_firmware_update_defaults_missing_access_token_to_noauth() {
+        let token = require_firmware_object_json_for_rack_maintenance("rack", &None, "{}").unwrap();
 
-        assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("access_token"));
+        assert_eq!(
+            token,
+            carbide_rack::firmware_object::RMS_NOAUTH_ACCESS_TOKEN
+        );
     }
 
     #[test]
@@ -2262,13 +2249,26 @@ mod tests {
     }
 
     #[test]
-    fn direct_rms_firmware_update_requires_access_token() {
-        let err =
-            require_firmware_object_json_for_direct_rms("switch", &None, "{}", false).unwrap_err();
+    fn rack_maintenance_firmware_update_defaults_empty_access_token_to_noauth() {
+        let token =
+            require_firmware_object_json_for_rack_maintenance("rack", &Some(String::new()), "{}")
+                .unwrap();
 
-        assert_eq!(err.code(), Code::InvalidArgument);
-        assert!(err.message().contains("access_token"));
-        assert!(err.message().contains("directly to RMS"));
+        assert_eq!(
+            token,
+            carbide_rack::firmware_object::RMS_NOAUTH_ACCESS_TOKEN
+        );
+    }
+
+    #[test]
+    fn direct_rms_firmware_update_defaults_missing_access_token_to_noauth() {
+        let options =
+            require_firmware_object_json_for_direct_rms("switch", &None, "{}", false).unwrap();
+
+        assert_eq!(
+            options.access_token.as_deref(),
+            Some(carbide_rack::firmware_object::RMS_NOAUTH_ACCESS_TOKEN)
+        );
     }
 
     #[test]

--- a/crates/api-core/src/handlers/rack.rs
+++ b/crates/api-core/src/handlers/rack.rs
@@ -19,7 +19,9 @@ use std::str::FromStr;
 
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge::{self as rpc, HealthReportEntry};
-use carbide_rack::firmware_object::rack_maintenance_access_token_key;
+use carbide_rack::firmware_object::{
+    rack_maintenance_access_token_key, rms_access_token_or_noauth,
+};
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::power_shelf::PowerShelfId;
 use carbide_uuid::rack::RackId;
@@ -523,10 +525,6 @@ fn non_empty_string(value: &str) -> Option<String> {
     (!value.is_empty()).then(|| value.to_string())
 }
 
-fn non_empty_optional_string(value: &Option<String>) -> Option<String> {
-    value.as_deref().and_then(non_empty_string)
-}
-
 fn set_maintenance_access_token(
     maintenance_access_token: &mut Option<String>,
     access_token: Option<String>,
@@ -601,18 +599,12 @@ pub(crate) async fn on_demand_rack_maintenance(
         let activity = match &entry.activity {
             Some(ProtoActivity::FirmwareUpgrade(fw)) => {
                 let firmware_version = non_empty_string(&fw.firmware_version);
-                let access_token = non_empty_optional_string(&fw.access_token);
+                let access_token = rms_access_token_or_noauth(fw.access_token.as_deref());
 
                 if firmware_version.is_none() {
                     return Err(CarbideError::InvalidArgument(
                         "firmware-upgrade rack maintenance requires SOT JSON in firmware_version"
                             .into(),
-                    )
-                    .into());
-                }
-                if access_token.is_none() {
-                    return Err(CarbideError::InvalidArgument(
-                        "firmware-upgrade rack maintenance requires access_token".into(),
                     )
                     .into());
                 }
@@ -623,7 +615,7 @@ pub(crate) async fn on_demand_rack_maintenance(
                         ))
                     })?;
                 }
-                set_maintenance_access_token(&mut maintenance_access_token, access_token)?;
+                set_maintenance_access_token(&mut maintenance_access_token, Some(access_token))?;
 
                 MaintenanceActivity::FirmwareUpgrade {
                     firmware_version,
@@ -633,17 +625,11 @@ pub(crate) async fn on_demand_rack_maintenance(
             }
             Some(ProtoActivity::NvosUpdate(nvos)) => {
                 let config_json = non_empty_string(&nvos.config_json);
-                let access_token = non_empty_optional_string(&nvos.access_token);
+                let access_token = rms_access_token_or_noauth(nvos.access_token.as_deref());
 
                 if config_json.is_none() {
                     return Err(CarbideError::InvalidArgument(
                         "nvos-update rack maintenance requires SOT JSON in config_json".into(),
-                    )
-                    .into());
-                }
-                if access_token.is_none() {
-                    return Err(CarbideError::InvalidArgument(
-                        "nvos-update rack maintenance requires access_token".into(),
                     )
                     .into());
                 }
@@ -653,7 +639,7 @@ pub(crate) async fn on_demand_rack_maintenance(
                         "nvos-update config_json must contain valid SOT JSON: {error}"
                     ))
                 })?;
-                set_maintenance_access_token(&mut maintenance_access_token, access_token)?;
+                set_maintenance_access_token(&mut maintenance_access_token, Some(access_token))?;
 
                 MaintenanceActivity::NvosUpdate { config_json }
             }

--- a/crates/api-core/src/tests/rack_state_controller/handler.rs
+++ b/crates/api-core/src/tests/rack_state_controller/handler.rs
@@ -558,13 +558,13 @@ async fn test_on_demand_rack_maintenance_schedules_firmware_and_nvos_scope(
 }
 
 #[crate::sqlx_test]
-async fn test_on_demand_rack_maintenance_rejects_firmware_without_access_token(
+async fn test_on_demand_rack_maintenance_defaults_missing_access_token_to_noauth(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env_with_overrides(pool.clone(), TestEnvOverrides::default()).await;
     let (rack_id, switch_id) = create_ready_rack_with_switch(&env, &pool).await?;
 
-    let err = crate::handlers::rack::on_demand_rack_maintenance(
+    crate::handlers::rack::on_demand_rack_maintenance(
         env.api.as_ref(),
         Request::new(rpc::forge::RackMaintenanceOnDemandRequest {
             rack_id: Some(rack_id.clone()),
@@ -587,11 +587,23 @@ async fn test_on_demand_rack_maintenance_rejects_firmware_without_access_token(
             }),
         }),
     )
-    .await
-    .expect_err("firmware-upgrade should require access_token");
+    .await?;
 
-    assert_eq!(err.code(), tonic::Code::InvalidArgument);
-    assert!(err.message().contains("access_token"));
+    let token_credentials = env
+        .test_credential_manager
+        .get_credentials(&CredentialKey::RackMaintenanceAccessToken {
+            rack_id: rack_id.clone(),
+        })
+        .await
+        .expect("credential lookup should succeed")
+        .expect("access token should be stored as a credential");
+    assert_eq!(
+        token_credentials,
+        Credentials::UsernamePassword {
+            username: "access_token".to_string(),
+            password: "NOAUTH".to_string(),
+        }
+    );
 
     Ok(())
 }

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -62,6 +62,7 @@ enum RmsTrackedFirmwareJob {
 const RMS_FIRMWARE_OBJECT_FIRMWARE_TYPE: &str = "prod";
 const RMS_SWITCH_SYSTEM_IMAGE_SOFTWARE_TYPE: &str = "prod";
 const RMS_FIRMWARE_OBJECT_HARDWARE_TYPE: &str = "any";
+const RMS_NOAUTH_ACCESS_TOKEN: &str = "NOAUTH";
 
 pub struct RmsBackend {
     client: Arc<dyn RmsApi>,
@@ -742,6 +743,13 @@ fn summarize_power_batch(batch: rms::NodeBatchResponse) -> (bool, Option<String>
     (false, Some(error))
 }
 
+fn rms_access_token_or_noauth(access_token: Option<&str>) -> String {
+    access_token
+        .filter(|token| !token.trim().is_empty())
+        .unwrap_or(RMS_NOAUTH_ACCESS_TOKEN)
+        .to_string()
+}
+
 fn apply_firmware_object_from_json_request(
     device: rms::NewNodeInfo,
     identity: &RmsIdentity,
@@ -750,15 +758,7 @@ fn apply_firmware_object_from_json_request(
     node_type: rms::NodeType,
     components: Vec<String>,
 ) -> Result<rms::ApplyFirmwareObjectFromJsonRequest, ComponentManagerError> {
-    let access_token = options
-        .access_token
-        .as_deref()
-        .filter(|token| !token.trim().is_empty())
-        .ok_or_else(|| {
-            ComponentManagerError::InvalidArgument(
-                "access_token is required for direct RMS firmware-object JSON updates".into(),
-            )
-        })?;
+    let access_token = rms_access_token_or_noauth(options.access_token.as_deref());
 
     if config_json.trim().is_empty() {
         return Err(ComponentManagerError::InvalidArgument(
@@ -776,7 +776,7 @@ fn apply_firmware_object_from_json_request(
         metadata: None,
         rack_id: identity.rack_id.clone(),
         config_json: config_json.to_owned(),
-        access_token: access_token.to_owned(),
+        access_token,
         firmware_type: RMS_FIRMWARE_OBJECT_FIRMWARE_TYPE.to_owned(),
         hardware_type: RMS_FIRMWARE_OBJECT_HARDWARE_TYPE.to_owned(),
         nodes: Some(rms::NodeSet {
@@ -793,15 +793,7 @@ fn apply_switch_system_image_from_json_request(
     config_json: &str,
     options: &FirmwareUpdateOptions,
 ) -> Result<rms::ApplySwitchSystemImageFromJsonRequest, ComponentManagerError> {
-    let access_token = options
-        .access_token
-        .as_deref()
-        .filter(|token| !token.trim().is_empty())
-        .ok_or_else(|| {
-            ComponentManagerError::InvalidArgument(
-                "access_token is required for direct RMS switch system-image JSON updates".into(),
-            )
-        })?;
+    let access_token = rms_access_token_or_noauth(options.access_token.as_deref());
 
     if config_json.trim().is_empty() {
         return Err(ComponentManagerError::InvalidArgument(
@@ -813,7 +805,7 @@ fn apply_switch_system_image_from_json_request(
         metadata: None,
         rack_id: identity.rack_id.clone(),
         config_json: config_json.to_owned(),
-        access_token: access_token.to_owned(),
+        access_token,
         software_type: RMS_SWITCH_SYSTEM_IMAGE_SOFTWARE_TYPE.to_owned(),
         hardware_type: RMS_FIRMWARE_OBJECT_HARDWARE_TYPE.to_owned(),
         nodes: Some(rms::NodeSet {
@@ -1684,6 +1676,46 @@ mod tests {
             .get(&(node_type as i32))
             .expect("component filters for node type")
             .components
+    }
+
+    #[test]
+    fn direct_rms_firmware_object_json_request_defaults_missing_access_token_to_noauth() {
+        let request = apply_firmware_object_from_json_request(
+            rms::NewNodeInfo::default(),
+            &RmsIdentity {
+                node_id: "node-1".to_string(),
+                rack_id: "rack-1".to_string(),
+            },
+            r#"{"Id":"fw-json"}"#,
+            &FirmwareUpdateOptions {
+                access_token: None,
+                force_update: false,
+            },
+            rms::NodeType::Switch,
+            Vec::new(),
+        )
+        .unwrap();
+
+        assert_eq!(request.access_token, RMS_NOAUTH_ACCESS_TOKEN);
+    }
+
+    #[test]
+    fn direct_rms_switch_system_image_request_defaults_empty_access_token_to_noauth() {
+        let request = apply_switch_system_image_from_json_request(
+            rms::NewNodeInfo::default(),
+            &RmsIdentity {
+                node_id: "node-1".to_string(),
+                rack_id: "rack-1".to_string(),
+            },
+            r#"{"Id":"fw-json"}"#,
+            &FirmwareUpdateOptions {
+                access_token: Some(String::new()),
+                force_update: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(request.access_token, RMS_NOAUTH_ACCESS_TOKEN);
     }
 
     // ---- PowerShelfManager tests ----

--- a/crates/rack/src/firmware_object.rs
+++ b/crates/rack/src/firmware_object.rs
@@ -20,6 +20,7 @@ use forge_secrets::credentials::CredentialKey;
 use model::rack_type::{RackHardwareType, RackProfile};
 
 pub const ANY_RACK_HARDWARE_TYPE: &str = "any";
+pub const RMS_NOAUTH_ACCESS_TOKEN: &str = "NOAUTH";
 
 pub fn hardware_type_wire_value(value: Option<&RackHardwareType>) -> String {
     value.map(|value| value.0.clone()).unwrap_or_default()
@@ -27,6 +28,13 @@ pub fn hardware_type_wire_value(value: Option<&RackHardwareType>) -> String {
 
 pub fn profile_hardware_type_wire_value(profile: &RackProfile) -> String {
     hardware_type_wire_value(profile.rack_hardware_type.as_ref())
+}
+
+pub fn rms_access_token_or_noauth(access_token: Option<&str>) -> String {
+    access_token
+        .filter(|token| !token.trim().is_empty())
+        .unwrap_or(RMS_NOAUTH_ACCESS_TOKEN)
+        .to_string()
 }
 
 pub fn rack_maintenance_access_token_key(rack_id: &RackId) -> CredentialKey {
@@ -42,5 +50,19 @@ mod tests {
     #[test]
     fn missing_rack_hardware_type_serializes_empty() {
         assert_eq!(hardware_type_wire_value(None), "");
+    }
+
+    #[test]
+    fn rms_access_token_defaults_to_noauth() {
+        assert_eq!(rms_access_token_or_noauth(None), RMS_NOAUTH_ACCESS_TOKEN);
+        assert_eq!(
+            rms_access_token_or_noauth(Some("")),
+            RMS_NOAUTH_ACCESS_TOKEN
+        );
+        assert_eq!(
+            rms_access_token_or_noauth(Some("   ")),
+            RMS_NOAUTH_ACCESS_TOKEN
+        );
+        assert_eq!(rms_access_token_or_noauth(Some("token")), "token");
     }
 }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -5964,13 +5964,14 @@ message MachineValidationOnDemandResponse {
 
 message FirmwareUpgradeActivity {
   // SOT JSON string passed to the backend.
-  // Explicit firmware-upgrade maintenance requests must set this and access_token.
+  // Explicit firmware-upgrade maintenance requests must set this.
   // Implicit all-activity maintenance skips firmware update when no JSON is configured.
   string firmware_version = 1;
   // Firmware components to update (e.g. "BMC", "CPLD", "BIOS").
   // When empty, all components are updated.
   repeated string components = 2;
   // Used only by the backend for artifact download when firmware_version contains SOT JSON.
+  // Optional. Omitted or empty values are passed to RMS as "NOAUTH".
   // NICo stores it as a maintenance credential, not in rack maintenance state.
   optional string access_token = 3;
   bool force_update = 4;
@@ -5983,6 +5984,7 @@ message NvosUpdateActivity {
   // Required for nvos-update activity.
   string config_json = 2;
   // Used only by the backend for artifact download when config_json is set.
+  // Optional. Omitted or empty values are passed to RMS as "NOAUTH".
   // NICo stores it as a maintenance credential, not in rack maintenance state.
   optional string access_token = 3;
 }
@@ -8207,8 +8209,8 @@ message UpdateComponentFirmwareRequest {
   // For targets routed through rack maintenance, this carries SOT JSON for
   // the backend firmware apply path.
   string target_version = 4;
-  // Required for firmware targets routed through rack maintenance.
-  // Rejected for direct dispatch paths and currently unsupported for power shelves.
+  // Optional for firmware targets routed to RMS.
+  // Omitted or empty values are passed to RMS as "NOAUTH".
   optional string access_token = 6;
   bool force_update = 7;
   // When true, bypass the state controller and dispatch directly to the


### PR DESCRIPTION
## Description

1. Make RMS SOT JSON artifact access tokens optional on Forge API paths.
2. Default missing or blank tokens to "NOAUTH" before forwarding to RMS.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
[<!-- If applicable, provide GitHub Issue. -->](https://github.com/NVIDIA/infra-controller/issues/2254)

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

