### PR TITLE
nvue-client: Use slightly stronger types for NvueConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7457,6 +7457,7 @@ dependencies = [
 name = "nvue-client"
 version = "0.0.0"
 dependencies = [
+ "glob",
  "reqwest 0.13.4",
  "serde",
  "serde_json",

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -34,8 +34,8 @@ use carbide_network::ip::prefix::Ipv4Net;
 use carbide_network::virtualization::{VpcVirtualizationType, build_dual_stack_list};
 use eyre::WrapErr;
 use mac_address::MacAddress;
-use nvue_client::client::NvueClientError;
-use nvue_client::{NvueClient, NvueConfig};
+use nvue_client::client::{NvueClient, NvueClientError};
+use nvue_client::config::{NvueConfig, NvueConfigWithHeader};
 use serde::Deserialize;
 use tokio::process::Command as TokioCommand;
 use tokio::time::timeout;
@@ -656,7 +656,8 @@ pub async fn update_nvue(
             Ok(true)
         }
         NvueUpdateFlavor::RestApi { nvue_context } => {
-            let config = NvueConfig::from_yaml(&next_contents)
+            let config = NvueConfigWithHeader::from_yaml(&next_contents)
+                .map(|config_with_header| config_with_header.into_nvue_config())
                 .map_err(|e| eyre::eyre!("Couldn't parse NVUE config as YAML: {e}"))?;
             let revision_id = nvue_context
                 .update_config(&config)

--- a/crates/nvue-client/Cargo.toml
+++ b/crates/nvue-client/Cargo.toml
@@ -34,5 +34,8 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 
+[dev-dependencies]
+glob = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/nvue-client/src/client.rs
+++ b/crates/nvue-client/src/client.rs
@@ -22,8 +22,7 @@ use reqwest::header::{ACCEPT, HeaderMap, HeaderValue};
 use reqwest::{Client, ClientBuilder, Method, Response, Url};
 pub use serde_json::Value as JsonValue;
 
-use crate::NvueConfig;
-use crate::config::NvueRevision;
+use crate::config::{NvueConfig, NvueConfigWithHeader, NvueRevision};
 
 #[derive(Debug)]
 pub struct NvueClient {
@@ -105,7 +104,7 @@ impl NvueClient {
 
     /// Return the config that is tagged as "applied" (in other words, the one
     /// that is currently running on the system).
-    pub async fn get_applied_config(&self) -> Result<NvueConfig, NvueClientError> {
+    pub async fn get_applied_config(&self) -> Result<NvueConfigWithHeader, NvueClientError> {
         const PATH: &str = "/nvue_v1/?rev=applied&filled=false";
         let request = self.request(Method::GET, PATH)?.build()?;
         let response = self.execute(request).await?;

--- a/crates/nvue-client/src/client.rs
+++ b/crates/nvue-client/src/client.rs
@@ -142,19 +142,6 @@ impl NvueClient {
         let _response = self.execute(request).await?;
 
         let builder = self.request(Method::PATCH, &revision_path)?;
-        let mut config = config.clone();
-        // Just in case the config we got was derived from an older one,
-        // let's clear the rev-id from the header.
-        config.remove_rev_id();
-        // The startup templates wrap the payload in a [{header:...},{set:...}] list.
-        // The REST API expects only the inner config object, so strip the wrapper.
-        // If the config is a top-level array but has no "set" entry that is a
-        // schema error — surface it now rather than letting the API reject it
-        // with a cryptic response.
-        let config = match config.extract_set_payload()? {
-            Some(inner) => inner,
-            None => config,
-        };
         let builder = builder.json(&config);
         let request = builder.build()?;
         let _response = self.execute(request).await?;

--- a/crates/nvue-client/src/config.rs
+++ b/crates/nvue-client/src/config.rs
@@ -17,57 +17,45 @@
 
 use std::hash::{DefaultHasher, Hash, Hasher};
 
-use crate::client::NvueClientError;
-
 #[derive(Clone, Debug, Hash, serde::Deserialize, serde::Serialize)]
-#[serde(transparent)]
-pub struct NvueConfig {
-    // FIXME: Replace this with a more strongly typed inner representation
-    config_json: serde_json::Value,
+pub struct NvueConfigWithHeader {
+    pub header: serde_json::Value,
+    #[serde(rename = "set")]
+    pub config: NvueConfig,
 }
 
-impl NvueConfig {
+impl NvueConfigWithHeader {
+    /// Consume `self` and return just the `NvueConfig` inside it.
+    pub fn into_nvue_config(self) -> NvueConfig {
+        self.config
+    }
+
     pub fn from_yaml(yaml: &str) -> Result<Self, serde_yaml::Error> {
         serde_yaml::from_str(yaml)
     }
 
     pub fn remove_rev_id(&mut self) {
-        if let serde_json::Value::Object(config_root) = &mut self.config_json
-            && let Some(header_value) = config_root.get_mut("header")
-            && let serde_json::Value::Object(header_object) = header_value
-        {
+        if let serde_json::Value::Object(header_object) = &mut self.header {
             let _ = header_object.remove("rev-id");
         }
     }
+}
 
-    /// Extract the value under the `set` key from the top-level list structure
-    /// produced by the NVUE startup templates (i.e. `[{header: ...}, {set: ...}]`).
-    ///
-    /// Returns:
-    /// - `Ok(Some(_))` if the config was a template-wrapped array and a `set`
-    ///   entry was found.
-    /// - `Ok(None)` if the config is not an array, i.e. it is already a plain
-    ///   object and can be used as-is.
-    /// - `Err(SchemaMismatch)` if the config *is* a top-level array but
-    ///   contains no `set` entry — this is an unexpected shape that would
-    ///   produce a hard-to-debug REST API rejection if sent as-is.
-    pub fn extract_set_payload(&self) -> Result<Option<Self>, NvueClientError> {
-        if let serde_json::Value::Array(arr) = &self.config_json {
-            for item in arr {
-                if let serde_json::Value::Object(map) = item
-                    && let Some(set_value) = map.get("set")
-                {
-                    return Ok(Some(Self {
-                        config_json: set_value.clone(),
-                    }));
-                }
-            }
-            Err(NvueClientError::SchemaMismatch(
-                "config is a top-level array but contains no \"set\" entry",
-            ))
-        } else {
-            Ok(None)
-        }
+#[derive(Clone, Debug, Hash, serde::Deserialize, serde::Serialize)]
+pub struct NvueConfig {
+    pub bridge: serde_json::Value,
+    pub evpn: serde_json::Value,
+    pub interface: serde_json::Value,
+    pub nve: serde_json::Value,
+    pub router: serde_json::Value,
+    pub system: serde_json::Value,
+    pub vrf: serde_json::Value,
+    pub acl: serde_json::Value,
+}
+
+impl NvueConfig {
+    pub fn from_yaml(yaml: &str) -> Result<Self, serde_yaml::Error> {
+        serde_yaml::from_str(yaml)
     }
 
     pub fn u64_hash(&self) -> u64 {

--- a/crates/nvue-client/src/config.rs
+++ b/crates/nvue-client/src/config.rs
@@ -154,3 +154,60 @@ impl NvueRevision {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::*;
+
+    #[test]
+    fn test_header_parse() {
+        let header_yaml =
+            "model: VX\nnvue-api-version: nvue_v1\nrev-id: 1.0\nversion: Cumulus Linux 5.6.0\n";
+        let _parsed: NvueConfigHeader =
+            serde_yaml::from_str(header_yaml).expect("Failed to parse header YAML");
+    }
+
+    // At some point this should probably be moved to the agent's tests once
+    // we're reasonably sure the types in here are correct.
+    #[test]
+    fn test_parse_agent_nvue_configs() {
+        let paths = enumerate_agent_configs();
+        paths.into_iter().for_each(|path| {
+            eprintln!("Attempting to parse {path}", path = path.display());
+            let contents = std::fs::read_to_string(&path).expect("Couldn't read NVUE file");
+            let _parsed: NvueConfigWithHeader =
+                serde_yaml::from_str(&contents).expect("Couldn't parse NVUE file");
+        });
+    }
+
+    // Enumerate the startup config files from the agent crate's directory.
+    fn enumerate_agent_configs() -> Vec<PathBuf> {
+        let repo_root = Path::new(std::env!("REPO_ROOT"));
+        let agent_templates_tests_dir = {
+            let mut buf = repo_root.to_path_buf();
+            buf.extend(["crates", "agent", "templates", "tests"]);
+            buf
+        };
+        if !agent_templates_tests_dir.is_dir() {
+            panic!(
+                "Couldn't find the agent's template tests directory at {location}",
+                location = agent_templates_tests_dir.display()
+            );
+        }
+
+        let pattern = {
+            let mut buf = agent_templates_tests_dir;
+            buf.push("nvue_*.yaml.expected");
+            buf
+        };
+
+        let pattern = pattern.to_string_lossy();
+        let paths = glob::glob(pattern.as_ref()).expect("Failed to glob agent NVUE files");
+        paths
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .expect("Failed to iterate agent NVUE paths")
+    }
+}

--- a/crates/nvue-client/src/config.rs
+++ b/crates/nvue-client/src/config.rs
@@ -17,9 +17,37 @@
 
 use std::hash::{DefaultHasher, Hash, Hasher};
 
+use crate::client::NvueClientError;
+
 #[derive(Clone, Debug, Hash, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct NvueConfig {
+    pub bridge: Option<serde_json::Value>,
+    pub evpn: Option<serde_json::Value>,
+    pub interface: Option<serde_json::Value>,
+    pub nve: Option<serde_json::Value>,
+    pub router: Option<serde_json::Value>,
+    pub system: Option<serde_json::Value>,
+    pub vrf: Option<serde_json::Value>,
+    pub acl: Option<serde_json::Value>,
+}
+
+impl NvueConfig {
+    pub fn from_yaml(yaml: &str) -> Result<Self, serde_yaml::Error> {
+        serde_yaml::from_str(yaml)
+    }
+
+    pub fn u64_hash(&self) -> u64 {
+        let mut h = DefaultHasher::new();
+        self.hash(&mut h);
+        h.finish()
+    }
+}
+
+#[derive(Clone, Debug, Hash, serde::Deserialize, serde::Serialize)]
+#[serde(try_from = "NvueConfigKeyValueSequence")]
 pub struct NvueConfigWithHeader {
-    pub header: serde_json::Value,
+    pub header: NvueConfigHeader,
     #[serde(rename = "set")]
     pub config: NvueConfig,
 }
@@ -33,35 +61,77 @@ impl NvueConfigWithHeader {
     pub fn from_yaml(yaml: &str) -> Result<Self, serde_yaml::Error> {
         serde_yaml::from_str(yaml)
     }
-
-    pub fn remove_rev_id(&mut self) {
-        if let serde_json::Value::Object(header_object) = &mut self.header {
-            let _ = header_object.remove("rev-id");
-        }
-    }
 }
 
 #[derive(Clone, Debug, Hash, serde::Deserialize, serde::Serialize)]
-pub struct NvueConfig {
-    pub bridge: serde_json::Value,
-    pub evpn: serde_json::Value,
-    pub interface: serde_json::Value,
-    pub nve: serde_json::Value,
-    pub router: serde_json::Value,
-    pub system: serde_json::Value,
-    pub vrf: serde_json::Value,
-    pub acl: serde_json::Value,
+#[serde(rename_all = "kebab-case")]
+pub struct NvueConfigHeader {
+    pub model: Option<String>,
+    pub nvue_api_version: Option<String>,
+    // Ideally rev_id would also be Option<String>, but there's a serde_yaml
+    // bug that prevents the value from being coereced to String when
+    // this NvueConfigHeader is inside a container (I think because of the
+    // `transparent` attribute on `NvueConfigKeyValueSequence`?)
+    pub rev_id: Option<serde_json::Value>,
+    pub version: Option<String>,
 }
 
-impl NvueConfig {
-    pub fn from_yaml(yaml: &str) -> Result<Self, serde_yaml::Error> {
-        serde_yaml::from_str(yaml)
-    }
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(untagged)]
+enum NvueConfigKeyValueEntry {
+    Header { header: NvueConfigHeader },
+    SetConfig { set: NvueConfig },
+}
 
-    pub fn u64_hash(&self) -> u64 {
-        let mut h = DefaultHasher::new();
-        self.hash(&mut h);
-        h.finish()
+/// This models the structure of the startup config file, which uses
+/// the sequence-of-single-key-maps pattern at its top level. This is
+/// used as an intermediate deserialization step before converting to
+/// `NvueConfigWithHeader`.
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(transparent)]
+struct NvueConfigKeyValueSequence {
+    entries: Vec<NvueConfigKeyValueEntry>,
+}
+
+impl TryFrom<NvueConfigKeyValueSequence> for NvueConfigWithHeader {
+    type Error = NvueClientError;
+
+    fn try_from(value: NvueConfigKeyValueSequence) -> Result<Self, Self::Error> {
+        use NvueConfigKeyValueEntry::*;
+
+        let mut header_entry = None;
+        let mut config_entry = None;
+
+        for entry in value.entries.into_iter() {
+            match entry {
+                Header { header } => {
+                    let previous = header_entry.replace(header);
+                    if previous.is_some() {
+                        return Err(NvueClientError::SchemaMismatch(
+                            "Found more than one 'header' object in sequence",
+                        ));
+                    }
+                }
+                SetConfig { set } => {
+                    let previous = config_entry.replace(set);
+                    if previous.is_some() {
+                        return Err(NvueClientError::SchemaMismatch(
+                            "Found more than one 'set' object in sequence",
+                        ));
+                    }
+                }
+            }
+        }
+
+        match (header_entry, config_entry) {
+            (Some(header), Some(config)) => Ok(NvueConfigWithHeader { header, config }),
+            (None, _) => Err(NvueClientError::SchemaMismatch(
+                "No 'header' object found in sequence",
+            )),
+            (_, None) => Err(NvueClientError::SchemaMismatch(
+                "No 'set' object found in sequence",
+            )),
+        }
     }
 }
 


### PR DESCRIPTION
## Description
Before this, we treated everything inside an `NvueConfig` as `serde_json::Value` without caring about its structure. This branch changes a few things about this:
- Add the root-level keys (`vrf`, `router`, `bridge`, etc.) to `NvueConfig`. Below this the types are still `Value`s but it should reject a lot more obviously-invalid configurations.
- Use different types for `NvueConfig` and `NvueConfigWithHeader`. `NvueConfig` is what the API wants us to send it when applying a new configuration, but it generally responds with `NvueConfigWithHeader` from its config-related endpoints. The startup YAML file is also a `NvueConfigWithHeader`.
- Add tests to parse the current agent configs (to be moved to the agent crate later).

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

