### PR TITLE
fix(preingestion): make BMC time-sync failures recoverable

### DIFF
--- a/crates/api-core/src/handlers/site_explorer.rs
+++ b/crates/api-core/src/handlers/site_explorer.rs
@@ -163,6 +163,14 @@ pub(crate) async fn clear_site_exploration_error(
     let mut txn = api.txn_begin().await?;
 
     db::explored_endpoints::clear_last_known_error(bmc_ip, &mut txn).await?;
+    // A terminal preingestion `Failed` state is the operator-visible error for a
+    // stuck host, but it lives in `preingestion_state`, not in the exploration
+    // report cleared above. Reset it to `Initial` here so clearing the error
+    // actually retries preingestion instead of requiring a force-delete of the
+    // endpoint. Non-failed states are left untouched.
+    if db::explored_endpoints::reset_failed_preingestion(bmc_ip, &mut txn).await? {
+        tracing::info!("Reset failed preingestion to initial for {bmc_ip} on error clear");
+    }
 
     txn.commit().await?;
 

--- a/crates/api-core/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api-core/src/tests/host_bmc_firmware_test.rs
@@ -2366,6 +2366,7 @@ async fn test_preingestion_time_sync_reset_flow(
     db::explored_endpoints::set_preingestion_time_sync_reset(
         ip_addr,
         TimeSyncResetPhase::Start,
+        0,
         &mut txn,
     )
     .await?;
@@ -2546,6 +2547,7 @@ async fn test_preingestion_time_sync_retry_logic(
     db::explored_endpoints::set_preingestion_time_sync_reset(
         ip_addr,
         TimeSyncResetPhase::WaitHostBoot,
+        0,
         &mut txn,
     )
     .await?;
@@ -2582,6 +2584,147 @@ async fn test_preingestion_time_sync_retry_logic(
         _ => {
             // Could be other states if firmware upgrade is needed
         }
+    }
+    txn.commit().await?;
+
+    Ok(())
+}
+
+/// When the BMC clock is still out of sync after a reset cycle but the retry
+/// budget is not yet exhausted, the endpoint should re-enter the reset cycle
+/// (TimeSyncReset Start) with an incremented attempt count rather than failing.
+#[crate::sqlx_test]
+async fn test_time_sync_retry_reenters_reset_before_failing(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+
+    // Simulate a BMC clock that is well past the 5 minute threshold.
+    env.redfish_sim.set_bmc_time_offset_seconds(600);
+
+    let mgr = PreingestionManager::new(
+        pool.clone(),
+        env.config.preingestion_manager(),
+        env.redfish_sim.clone(),
+        env.test_meter.meter(),
+        None,
+        None,
+        None,
+        env.api.work_lock_manager_handle.clone(),
+    );
+
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder("b8:3f:d2:90:97:a6", "192.0.2.1")
+                .vendor_string("iDRac")
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let addr = response.address.as_str();
+    let ip_addr = IpAddr::from_str(addr).unwrap();
+
+    let mut txn = pool.begin().await.unwrap();
+    insert_endpoint_version(&mut txn, addr, "6.00.30.00", "1.13.2", false).await?;
+    // First reset cycle just finished (attempt 0), awaiting the boot-wait recheck.
+    db::explored_endpoints::set_preingestion_time_sync_reset(
+        ip_addr,
+        TimeSyncResetPhase::WaitHostBoot,
+        0,
+        &mut txn,
+    )
+    .await?;
+    // Backdate last_time so the boot wait is considered elapsed.
+    db::explored_endpoints::pregestion_hostboot_time_test(ip_addr, &mut txn).await?;
+    txn.commit().await?;
+
+    mgr.run_single_iteration().await?;
+
+    let mut txn = pool.begin().await.unwrap();
+    let endpoints = db::explored_endpoints::find_all_by_ip(ip_addr, &mut txn).await?;
+    match &endpoints
+        .first()
+        .expect("endpoint should exist")
+        .preingestion_state
+    {
+        PreingestionState::TimeSyncReset { phase, attempt, .. } => {
+            assert_eq!(
+                *phase,
+                TimeSyncResetPhase::Start,
+                "should retry reset cycle"
+            );
+            assert_eq!(*attempt, 1, "attempt counter should be incremented");
+        }
+        other => panic!("expected a retried TimeSyncReset, got: {other:?}"),
+    }
+    txn.commit().await?;
+
+    Ok(())
+}
+
+/// Once the reset retry budget is exhausted and the BMC clock is still out of
+/// sync, preingestion should fail terminally.
+#[crate::sqlx_test]
+async fn test_time_sync_fails_after_max_attempts(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    env.redfish_sim.set_bmc_time_offset_seconds(600);
+
+    let mgr = PreingestionManager::new(
+        pool.clone(),
+        env.config.preingestion_manager(),
+        env.redfish_sim.clone(),
+        env.test_meter.meter(),
+        None,
+        None,
+        None,
+        env.api.work_lock_manager_handle.clone(),
+    );
+
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder("b8:3f:d2:90:97:a6", "192.0.2.1")
+                .vendor_string("iDRac")
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let addr = response.address.as_str();
+    let ip_addr = IpAddr::from_str(addr).unwrap();
+
+    let mut txn = pool.begin().await.unwrap();
+    insert_endpoint_version(&mut txn, addr, "6.00.30.00", "1.13.2", false).await?;
+    // Final allowed reset cycle (attempt 2 == MAX_TIME_SYNC_RESET_ATTEMPTS - 1)
+    // just finished, awaiting the boot-wait recheck.
+    db::explored_endpoints::set_preingestion_time_sync_reset(
+        ip_addr,
+        TimeSyncResetPhase::WaitHostBoot,
+        2,
+        &mut txn,
+    )
+    .await?;
+    db::explored_endpoints::pregestion_hostboot_time_test(ip_addr, &mut txn).await?;
+    txn.commit().await?;
+
+    mgr.run_single_iteration().await?;
+
+    let mut txn = pool.begin().await.unwrap();
+    let endpoints = db::explored_endpoints::find_all_by_ip(ip_addr, &mut txn).await?;
+    match &endpoints
+        .first()
+        .expect("endpoint should exist")
+        .preingestion_state
+    {
+        PreingestionState::Failed { reason } => {
+            assert!(
+                reason.contains("time synchronization failed"),
+                "unexpected failure reason: {reason}"
+            );
+        }
+        other => panic!("expected Failed after exhausting retries, got: {other:?}"),
     }
     txn.commit().await?;
 

--- a/crates/api-core/src/tests/site_explorer.rs
+++ b/crates/api-core/src/tests/site_explorer.rs
@@ -36,7 +36,7 @@ use model::machine::{LoadSnapshotOptions, Machine, ManagedHostStateSnapshot};
 use model::metadata::Metadata;
 use model::site_explorer::{
     Chassis, ComputerSystem, EndpointExplorationError, EndpointExplorationReport, EndpointType,
-    ExploredDpu, ExploredEndpoint, ExploredManagedHost, UefiDevicePath,
+    ExploredDpu, ExploredEndpoint, ExploredManagedHost, PreingestionState, UefiDevicePath,
 };
 use model::switch::SwitchSearchFilter;
 use rpc::forge::GetSiteExplorationRequest;
@@ -1619,6 +1619,52 @@ async fn test_site_explorer_clear_last_known_error(
     assert_eq!(nodes.len(), 1);
     let node = nodes.first();
     assert_eq!(node.unwrap().report.last_exploration_error, None);
+
+    Ok(())
+}
+
+/// Clearing the site exploration error should also lift a terminal preingestion
+/// `Failed` state back to `Initial`, so an operator can retry preingestion
+/// without force-deleting and rediscovering the endpoint.
+#[sqlx_test]
+async fn test_clear_error_resets_failed_preingestion(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool).await;
+    let mut txn = db::Transaction::begin(&env.pool).await?;
+    let ip_address = "192.168.1.2";
+    let bmc_ip: IpAddr = IpAddr::from_str(ip_address)?;
+
+    let mut report: EndpointExplorationReport = DpuConfig::default().into();
+    report.generate_machine_id(false)?;
+    db::explored_endpoints::insert(bmc_ip, &report, false, &mut txn).await?;
+
+    // Put the endpoint in the terminal Failed preingestion state, as a failed
+    // BMC time sync would.
+    db::explored_endpoints::set_preingestion_failed(
+        bmc_ip,
+        "BMC time synchronization failed after 3 reset attempts. Time difference exceeds 5 minutes threshold.".to_string(),
+        &mut txn,
+    )
+    .await?;
+    txn.commit().await?;
+
+    env.api
+        .clear_site_exploration_error(Request::new(rpc::forge::ClearSiteExplorationErrorRequest {
+            ip_address: ip_address.to_string(),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let mut txn = db::Transaction::begin(&env.pool).await?;
+    let nodes = db::explored_endpoints::find_all_by_ip(bmc_ip, &mut txn).await?;
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(
+        nodes.first().unwrap().preingestion_state,
+        PreingestionState::Initial,
+        "clearing the error should reset a Failed preingestion to Initial"
+    );
 
     Ok(())
 }

--- a/crates/api-db/src/explored_endpoints.rs
+++ b/crates/api-db/src/explored_endpoints.rs
@@ -432,11 +432,13 @@ pub async fn set_preingestion_initial_bmc_reset(
 pub async fn set_preingestion_time_sync_reset(
     address: IpAddr,
     phase: TimeSyncResetPhase,
+    attempt: u32,
     txn: &mut PgConnection,
 ) -> Result<(), DatabaseError> {
     let state = PreingestionState::TimeSyncReset {
         phase,
         last_time: Utc::now(),
+        attempt,
     };
     set_preingestion(address, state, txn).await
 }
@@ -592,6 +594,26 @@ pub async fn set_preingestion_failed(
 ) -> Result<(), DatabaseError> {
     let state = PreingestionState::Failed { reason };
     set_preingestion(address, state, txn).await
+}
+
+/// If the endpoint's preingestion is in the terminal `Failed` state, reset it
+/// back to `Initial` so preingestion runs again from the top. States other than
+/// `Failed` are left untouched, so this is safe to call unconditionally when an
+/// operator clears an error. Returns true if a `Failed` state was actually reset.
+pub async fn reset_failed_preingestion(
+    address: IpAddr,
+    txn: &mut PgConnection,
+) -> Result<bool, DatabaseError> {
+    let query = "
+UPDATE explored_endpoints
+SET preingestion_state = '{\"state\":\"initial\"}'
+WHERE address = $1 AND preingestion_state->>'state' = 'failed'";
+    let result = sqlx::query(query)
+        .bind(address)
+        .execute(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+    Ok(result.rows_affected() > 0)
 }
 
 pub async fn insert(

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -396,6 +396,12 @@ pub enum PreingestionState {
     TimeSyncReset {
         phase: TimeSyncResetPhase,
         last_time: DateTime<Utc>,
+        /// How many full reset cycles have already been attempted for this
+        /// endpoint. Used to retry a transient clock failure a bounded number
+        /// of times before giving up. Defaults to 0 so states serialized
+        /// before this field existed still deserialize.
+        #[serde(default)]
+        attempt: u32,
     },
     UpgradeFirmwareWait {
         task_id: String,

--- a/crates/preingestion-manager/src/lib.rs
+++ b/crates/preingestion-manager/src/lib.rs
@@ -370,9 +370,13 @@ async fn one_endpoint(
                 .await?;
             false
         }
-        PreingestionState::TimeSyncReset { phase, last_time } => {
+        PreingestionState::TimeSyncReset {
+            phase,
+            last_time,
+            attempt,
+        } => {
             static_info
-                .time_sync_resets(db, endpoint, phase, Some(last_time))
+                .time_sync_resets(db, endpoint, phase, Some(last_time), *attempt)
                 .await?;
             false
         }
@@ -1310,7 +1314,7 @@ impl PreingestionManagerStatic {
                     "{} BMC time is out of sync, initiating reset to fix time synchronization",
                     endpoint.address
                 );
-                self.time_sync_resets(db, endpoint, &TimeSyncResetPhase::Start, None)
+                self.time_sync_resets(db, endpoint, &TimeSyncResetPhase::Start, None, 0)
                     .await
             }
             Err(e) => {
@@ -1652,7 +1656,16 @@ impl PreingestionManagerStatic {
         endpoint: &ExploredEndpoint,
         phase: &TimeSyncResetPhase,
         last_time: Option<&DateTime<Utc>>,
+        attempt: u32,
     ) -> PreingestionManagerResult<bool> {
+        // Number of full reset cycles (power off -> BMC reset -> power on ->
+        // 20 min boot wait -> recheck) to attempt before declaring failure. A
+        // BMC clock that is out of sync just after a power event is often a
+        // transient condition that self-heals once NTP converges, which can
+        // take longer than a single boot-wait window; retrying gives it time
+        // instead of going terminal on the first miss.
+        const MAX_TIME_SYNC_RESET_ATTEMPTS: u32 = 3;
+
         let redfish_client = match self
             .redfish_client_pool
             .create_client_for_ingested_host(endpoint.address, db)
@@ -1682,6 +1695,7 @@ impl PreingestionManagerStatic {
                     db::explored_endpoints::set_preingestion_time_sync_reset(
                         endpoint.address,
                         TimeSyncResetPhase::BMCWasReset,
+                        attempt,
                         txn,
                     )
                     .boxed()
@@ -1704,6 +1718,7 @@ impl PreingestionManagerStatic {
                     db::explored_endpoints::set_preingestion_time_sync_reset(
                         endpoint.address,
                         TimeSyncResetPhase::WaitHostBoot,
+                        attempt,
                         txn,
                     )
                     .boxed()
@@ -1732,15 +1747,42 @@ impl PreingestionManagerStatic {
                         Ok(delayed_upgrade)
                     }
                     Ok(false) => {
-                        // Time is still not in sync after reset, fail now
+                        // Time is still not in sync after this reset cycle.
+                        // `attempt` counts cycles already completed, so this is
+                        // attempt number `attempt + 1`. Retry another full reset
+                        // cycle until we exhaust the budget, then fail.
+                        let attempts_done = attempt + 1;
+                        if attempts_done < MAX_TIME_SYNC_RESET_ATTEMPTS {
+                            tracing::warn!(
+                                "{} BMC time still out of sync after reset attempt {}/{}, retrying reset",
+                                endpoint.address,
+                                attempts_done,
+                                MAX_TIME_SYNC_RESET_ATTEMPTS
+                            );
+                            db.with_txn(|txn| {
+                                db::explored_endpoints::set_preingestion_time_sync_reset(
+                                    endpoint.address,
+                                    TimeSyncResetPhase::Start,
+                                    attempts_done,
+                                    txn,
+                                )
+                                .boxed()
+                            })
+                            .await??;
+                            return Ok(false);
+                        }
+
                         tracing::error!(
-                            "{} BMC time is still out of sync after reset attempt, failing preingestion",
-                            endpoint.address
+                            "{} BMC time is still out of sync after {} reset attempts, failing preingestion",
+                            endpoint.address,
+                            attempts_done
                         );
                         db.with_txn(|txn| {
                             db::explored_endpoints::set_preingestion_failed(
                                 endpoint.address,
-                                "BMC time synchronization failed after reset attempt. Time difference exceeds 5 minutes threshold.".to_string(),
+                                format!(
+                                    "BMC time synchronization failed after {attempts_done} reset attempts. Time difference exceeds 5 minutes threshold."
+                                ),
                                 txn,
                             )
                             .boxed()

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -57,6 +57,11 @@ struct RedfishSimState {
     machine_setup_bios_job_id: Option<String>,
     is_bios_setup: Option<bool>,
     job_state_sequence: VecDeque<JobState>,
+    /// Offset (in seconds) applied to the BMC `DateTime` returned by
+    /// `get_manager`, relative to the controller's `Utc::now()`. Defaults to 0
+    /// (perfectly in sync); tests set it to simulate a BMC clock that is out of
+    /// sync to exercise the time-sync reset/retry path.
+    bmc_time_offset_seconds: i64,
     /// Records every call to `RedfishClientPool::create_client` so tests can
     /// assert what vendor was passed at each call site.
     create_client_calls: Vec<CreateClientCall>,
@@ -150,6 +155,13 @@ impl RedfishSim {
 
     pub fn set_is_bios_setup(&self, ready: bool) {
         self.state.lock().unwrap().is_bios_setup = Some(ready);
+    }
+
+    /// Set the offset (in seconds) applied to the BMC `DateTime` returned by
+    /// `get_manager`, relative to the controller clock. Use a value larger than
+    /// the time-sync threshold to simulate an out-of-sync BMC clock.
+    pub fn set_bmc_time_offset_seconds(&self, offset: i64) {
+        self.state.lock().unwrap().bmc_time_offset_seconds = offset;
     }
 
     /// Returns a snapshot of every `create_client` call made through this sim,
@@ -1029,8 +1041,10 @@ impl Redfish for RedfishSimClient {
         }"##,
             )
             .unwrap();
-            // Update the date_time to current time for tests
-            manager.date_time = Some(chrono::Utc::now());
+            // Update the date_time to current time for tests, applying any
+            // configured offset so tests can simulate an out-of-sync BMC clock.
+            let offset = self.state.lock().unwrap().bmc_time_offset_seconds;
+            manager.date_time = Some(chrono::Utc::now() + chrono::Duration::seconds(offset));
             Ok(manager)
         })
     }


### PR DESCRIPTION
Two Supermicro machines got stuck in a terminal pre-ingestion Failed state with "BMC time synchronization failed after reset attempt". The BMC clocks were actually fine; the failure was a transient out-of-sync condition at probe time that became permanent, and the only recovery was force-deleting and rediscovering the endpoint.

Fix 1: retry instead of failing terminally. TimeSyncReset now carries an attempt counter; when the post-reset recheck is still out of sync it re-enters the reset cycle (each with its 20-minute boot wait) up to MAX_TIME_SYNC_RESET_ATTEMPTS before going Failed, giving a slow-to-NTP-sync BMC time to converge.

Fix 2: make "clear error" actually retry. The terminal failure lives in preingestion_state, not the exploration report that clear_last_known_error touched, so clearing the error left the host stuck. clear_site_exploration_error now also resets a Failed preingestion back to Initial (non-failed states untouched), so operators can retry without force-deleting the endpoint.

Adds a configurable BMC clock offset to the Redfish sim so the previously untested out-of-sync path can be exercised, plus tests for the retry-then-fail behavior and the clear-error reset.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [X] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

