### PR TITLE
chore(rest-api): Set default phone home URL to use dedicated IP

### DIFF
--- a/rest-api/api/internal/config/config.go
+++ b/rest-api/api/internal/config/config.go
@@ -242,7 +242,7 @@ func NewConfig() *Config {
 	c.v.SetDefault(ConfigTracingEnabled, false)
 
 	// SiteConfig default phone home url
-	c.v.SetDefault(ConfigSitePhoneHomeUrl, "http://localhost")
+	c.v.SetDefault(ConfigSitePhoneHomeUrl, "http://169.254.169.254:7777/latest/meta-data/phone_home")
 
 	// Keycloak needs to be explicitly enabled via config
 	c.v.SetDefault(ConfigKeycloakEnabled, false)

--- a/rest-api/api/pkg/api/model/util/testing.go
+++ b/rest-api/api/pkg/api/model/util/testing.go
@@ -113,7 +113,7 @@ autoinstall:
 var TestCommonPhoneHomeSegment = `
 phone_home:
   empty_key_for_validation:
-  url: http://localhost
+  url: http://169.254.169.254:7777/latest/meta-data/phone_home
   post: all`
 
 var TestCommonPhoneHomeCloudInit = `#cloud-config


### PR DESCRIPTION
## Description
Sets the default URL to one which will work in a default setup.    Using localhost will always fail, so doesn't seem useful.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
https://github.com/NVIDIA/infra-controller/issues/2258

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

