### PR TITLE
fix: Fixes for OTLP tracing

### DIFF
--- a/crates/api-core/src/logging/api_logs.rs
+++ b/crates/api-core/src/logging/api_logs.rs
@@ -138,6 +138,7 @@ where
                 tracing::Level::INFO,
                 "request",
                 span_id,
+                carbide.trace_root = true,
                 http.url = %request.uri(),
                 http.response.status_code = tracing::field::Empty,
                 request = tracing::field::Empty,

--- a/crates/api-core/src/logging/setup.rs
+++ b/crates/api-core/src/logging/setup.rs
@@ -134,7 +134,7 @@ pub fn setup_logging(
                         .build()?;
 
                     let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
-                        // CarbideSpanSampler selects spans that begin from our crate
+                        // CarbideSpanSampler selects explicitly marked application trace roots.
                         .with_sampler(trace_sampler.into_sampler())
                         .with_batch_exporter(otlp_exporter)
                         .with_resource(
@@ -238,12 +238,14 @@ fn create_metric_view_for_retry_histograms(
 #[derive(Debug, Clone)]
 struct CarbideSpanSampler(Arc<AtomicBool>);
 
+const CARBIDE_TRACE_ROOT_ATTRIBUTE: &str = "carbide.trace_root";
+
 impl CarbideSpanSampler {
     fn new(enabled: Arc<AtomicBool>) -> Self {
         Self(enabled)
     }
 
-    /// Construct a new Sampler that samples spans originating from the carbide crate
+    /// Construct a new Sampler that samples spans originating from carbide-api.
     fn into_sampler(self) -> Sampler {
         Sampler::ParentBased(Box::new(self))
     }
@@ -281,14 +283,7 @@ impl ShouldSample for CarbideSpanSampler {
         let should_sample = if !enabled {
             false
         } else {
-            attributes
-                .iter()
-                .find(|kv| kv.key.as_str() == "code.namespace")
-                .and_then(|v| match &v.value {
-                    Value::String(str) => Some(str.as_str()),
-                    _ => None,
-                })
-                .is_some_and(|s| s.starts_with("carbide::"))
+            is_carbide_root_span(attributes)
         };
 
         SamplingResult {
@@ -301,6 +296,12 @@ impl ShouldSample for CarbideSpanSampler {
             trace_state: Default::default(),
         }
     }
+}
+
+fn is_carbide_root_span(attributes: &[KeyValue]) -> bool {
+    attributes.iter().any(|kv| {
+        kv.key.as_str() == CARBIDE_TRACE_ROOT_ATTRIBUTE && matches!(&kv.value, Value::Bool(true))
+    })
 }
 
 pub fn create_metric_for_spancount_reader(
@@ -330,6 +331,66 @@ mod tests {
     use prometheus::{Encoder, TextEncoder};
 
     use super::*;
+
+    fn sample_decision(enabled: bool, attributes: Vec<KeyValue>) -> SamplingDecision {
+        CarbideSpanSampler::new(Arc::new(AtomicBool::new(enabled)))
+            .should_sample(
+                None,
+                TraceId::from(1),
+                "test-span",
+                &SpanKind::Internal,
+                &attributes,
+                &[],
+            )
+            .decision
+    }
+
+    #[test]
+    fn sampler_accepts_marked_root_spans_when_enabled() {
+        let decision = sample_decision(
+            true,
+            vec![KeyValue::new(CARBIDE_TRACE_ROOT_ATTRIBUTE, true)],
+        );
+
+        assert!(matches!(decision, SamplingDecision::RecordAndSample));
+    }
+
+    #[test]
+    fn sampler_drops_marked_root_spans_when_disabled() {
+        let decision = sample_decision(
+            false,
+            vec![KeyValue::new(CARBIDE_TRACE_ROOT_ATTRIBUTE, true)],
+        );
+
+        assert!(matches!(decision, SamplingDecision::Drop));
+    }
+
+    #[test]
+    fn sampler_drops_unmarked_root_spans() {
+        let decision = sample_decision(true, vec![KeyValue::new("span_id", "0xabc")]);
+
+        assert!(matches!(decision, SamplingDecision::Drop));
+    }
+
+    #[test]
+    fn sampler_drops_false_trace_root_markers() {
+        let decision = sample_decision(
+            true,
+            vec![KeyValue::new(CARBIDE_TRACE_ROOT_ATTRIBUTE, false)],
+        );
+
+        assert!(matches!(decision, SamplingDecision::Drop));
+    }
+
+    #[test]
+    fn sampler_drops_string_trace_root_markers() {
+        let decision = sample_decision(
+            true,
+            vec![KeyValue::new(CARBIDE_TRACE_ROOT_ATTRIBUTE, "true")],
+        );
+
+        assert!(matches!(decision, SamplingDecision::Drop));
+    }
 
     /// This test mostly mimics the test setup above and checks whether
     /// the prometheus opentelemetry stack will only report the most recent

--- a/crates/api-core/src/tests/preingestion_dpu_nic_mode.rs
+++ b/crates/api-core/src/tests/preingestion_dpu_nic_mode.rs
@@ -105,6 +105,7 @@ fn host_bmc_report() -> EndpointExplorationReport {
         physical_slot_number: None,
         revision_id: None,
         topology_id: None,
+        remediation_error: None,
     }
 }
 

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -402,6 +402,7 @@ impl SiteExplorer {
             tracing::Level::INFO,
             "explore_site",
             span_id,
+            carbide.trace_root = true,
             otel.status_code = tracing::field::Empty,
             otel.status_message = tracing::field::Empty,
             created_machines = tracing::field::Empty,

--- a/crates/state-controller/src/controller/builder.rs
+++ b/crates/state-controller/src/controller/builder.rs
@@ -190,14 +190,6 @@ impl<IO: StateControllerIO> Builder<IO> {
 
         let (task_sender, task_receiver) = tokio::sync::mpsc::unbounded_channel();
 
-        let span_id: String = format!("{:#x}", u64::from_le_bytes(rand::random::<[u8; 8]>()));
-        let processor_span = tracing::span!(
-            parent: None,
-            tracing::Level::INFO,
-            "state_processor",
-            span_id,
-            controller = IO::LOG_SPAN_CONTROLLER_NAME,
-        );
         let processor_metric_emitter =
             meter.map(|meter| ProcessorMetricsEmitter::new(&controller_name, &meter));
 
@@ -220,7 +212,6 @@ impl<IO: StateControllerIO> Builder<IO> {
             last_log_time: std::time::Instant::now(),
             stats_since_last_log: Default::default(),
             last_metric_emission_time: std::time::Instant::now(),
-            processor_span,
             processor_id,
         };
 

--- a/crates/state-controller/src/controller/periodic_enqueuer.rs
+++ b/crates/state-controller/src/controller/periodic_enqueuer.rs
@@ -116,6 +116,7 @@ impl<IO: StateControllerIO> PeriodicEnqueuer<IO> {
             tracing::Level::INFO,
             "periodic_enqueuer_iteration",
             span_id,
+            carbide.trace_root = true,
             controller = IO::LOG_SPAN_CONTROLLER_NAME,
             iteration_id = tracing::field::Empty,
             otel.status_code = tracing::field::Empty,

--- a/crates/state-controller/src/controller/processor.rs
+++ b/crates/state-controller/src/controller/processor.rs
@@ -76,7 +76,6 @@ pub(super) struct StateProcessor<IO: StateControllerIO> {
     /// The last time aggregate metrics had been emitted
     pub(super) last_metric_emission_time: std::time::Instant,
     pub(super) stats_since_last_log: StatsSinceLastLog,
-    pub(super) processor_span: tracing::Span,
     /// Globally unique ID that identifies the state controller (and processor) working on objects
     pub(super) processor_id: String,
     /// Emitter for broadcasting state change events to registered hooks.
@@ -143,7 +142,6 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
         let max_jitter = (dispatch_interval.as_millis() / 3) as u64;
 
         loop {
-            let span = self.processor_span.clone();
             let start = Instant::now();
             let jitter = if max_jitter > 0 {
                 rand::rng().random::<u64>() % max_jitter
@@ -153,11 +151,7 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
             let iteration_time = dispatch_interval.saturating_add(Duration::from_millis(jitter));
             let mut next_dispatch_at = start.checked_add(iteration_time).unwrap_or(start);
 
-            match self
-                .run_single_iteration(iteration_time, true)
-                .instrument(span)
-                .await
-            {
+            match self.run_single_iteration(iteration_time, true).await {
                 Ok(result) => {
                     // If any task completed, then there's a chance we can dispatch more tasks
                     // Therefore run another iteration without backoff
@@ -211,39 +205,53 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
         max_completion_wait_time: std::time::Duration,
         allow_requeue: bool,
     ) -> Result<SingleIterationResult, IterationError> {
-        let run_metrics = ProcessorIterationMetrics::default();
+        let span_id = format!("{:#x}", u64::from_le_bytes(rand::random::<[u8; 8]>()));
+        let iteration_span = tracing::span!(
+            parent: None,
+            tracing::Level::INFO,
+            "state_processor_iteration",
+            span_id,
+            carbide.trace_root = true,
+            controller = IO::LOG_SPAN_CONTROLLER_NAME,
+        );
 
-        let num_dispatched_tasks = self.dequeue_and_dispatch_object_handling_tasks().await?;
-        // We are assuming that we dispatch as many tasks that are available and fit into
-        // the queue. Therefore its ok to wait until at least one task has been dequeued
-        // before evaluating any next steps.
-        let num_completed_tasks = self
-            .wait_and_process_object_handling_task_completions(
-                max_completion_wait_time,
-                allow_requeue,
-            )
-            .await;
+        async {
+            let run_metrics = ProcessorIterationMetrics::default();
 
-        // Delete the DB entries for tasks which finished in `wait_and_process_object_handling_task_completions`.
-        self.cleanup_completed_objects().await?;
+            let num_dispatched_tasks = self.dequeue_and_dispatch_object_handling_tasks().await?;
+            // We are assuming that we dispatch as many tasks that are available and fit into
+            // the queue. Therefore its ok to wait until at least one task has been dequeued
+            // before evaluating any next steps.
+            let num_completed_tasks = self
+                .wait_and_process_object_handling_task_completions(
+                    max_completion_wait_time,
+                    allow_requeue,
+                )
+                .await;
 
-        // Schedule handler again for objects which transitioned.
-        // We queue them using the latest iteration_id.
-        // This needs to happen after `cleanup_completed_objects` to remove
-        // the old entries from the DB first.
-        self.requeue_transitioned_objects().await?;
+            // Delete the DB entries for tasks which finished in `wait_and_process_object_handling_task_completions`.
+            self.cleanup_completed_objects().await?;
 
-        self.emit_metrics_if_necessary();
-        self.emit_periodic_log_if_necessary();
+            // Schedule handler again for objects which transitioned.
+            // We queue them using the latest iteration_id.
+            // This needs to happen after `cleanup_completed_objects` to remove
+            // the old entries from the DB first.
+            self.requeue_transitioned_objects().await?;
 
-        if let Some(emitter) = self.metric_emitter.as_ref() {
-            emitter.emit_run_counters_and_histograms(&run_metrics);
+            self.emit_metrics_if_necessary();
+            self.emit_periodic_log_if_necessary();
+
+            if let Some(emitter) = self.metric_emitter.as_ref() {
+                emitter.emit_run_counters_and_histograms(&run_metrics);
+            }
+
+            Ok(SingleIterationResult {
+                num_dispatched_tasks,
+                num_completed_tasks,
+            })
         }
-
-        Ok(SingleIterationResult {
-            num_dispatched_tasks,
-            num_completed_tasks,
-        })
+        .instrument(iteration_span.clone())
+        .await
     }
 
     /// Periodically calculates aggregate metrics for all objects that have been processed
@@ -304,10 +312,7 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
         }
 
         self.last_log_time = now;
-        let db_query_metrics = {
-            let _e: tracing::span::Entered<'_> = self.processor_span.enter();
-            sqlx_query_tracing::fetch_and_update_current_span_attributes()
-        };
+        let db_query_metrics = sqlx_query_tracing::fetch_and_update_current_span_attributes();
 
         let stats = std::mem::take(&mut self.stats_since_last_log);
         let db_metrics_since_last_query = db_query_metrics.diff(&stats.db_query_metrics);


### PR DESCRIPTION
## Description
Recent updates to the opentelemetry crates have broken OTLP tracing, such that all spans are being filtered out. This is because opentelemetry no longer emits `code.namespace` metadata for spans, meaning CarbideSpanSampler would reject all traces.

Fix this by explicitly setting an attribute `carbide.trace_root = true` for toplevel spans we want to emit, and have CarbideSpanSampler check for that attribute instead of the code module, which is error-prone, especially when we do any refactoring. Then we rely on ParentBased sampling to include all child spans of that root.

Also, fix an issue where we'd begin a span from within StateController::Builder once at startup and never close it, leading to memory leaks as spans never got closed. Move the span setup to StateProcessor::run_single_iteration instead, so that the span closes at a natural time. Spans all seem to be properly closing themselves now.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
#2267

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

