### PR TITLE
feat: reset BOSS config on Dell R770s before volume creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6481,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.4#dd2152ac5642c5256b893e396647e159003d0071"
+source = "git+https://github.com/kdhulipala-wq/libredfish.git?branch=kcd-r770-fix-volume#1e72ab1313149586b9d46f1ef9733e54ea9e35f0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,12 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.4" }
+# TEMPORARY: pinned to a fork branch that adds Dell reset_storage_config
+# (DellRaidService.ResetConfig) as a workaround for STOR060 on Dell R770 (iDRAC10).
+# The branch is v0.44.4 + that single additive commit. Swap back to an upstream
+# NVIDIA/libredfish tag once the change is released (and remove once Dell ships a
+# fixed iDRAC firmware). See https://github.com/kdhulipala-wq/libredfish/tree/kcd-r770-fix-volume
+libredfish = { git = "https://github.com/kdhulipala-wq/libredfish.git", branch = "kcd-r770-fix-volume" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.12-rc4" }
 ansi-to-html = "0.2.2"
 

--- a/crates/admin-cli/src/redfish/args.rs
+++ b/crates/admin-cli/src/redfish/args.rs
@@ -176,6 +176,9 @@ pub enum Cmd {
     GetBossController,
     DecomissionController(DecomissionControllerArgs),
     CreateVolume(CreateVolumeArgs),
+    // TEMPORARY WORKAROUND (Dell R770 / iDRAC10): reset a storage controller's
+    // config via DellRaidService.ResetConfig. Remove once Dell ships a fixed iDRAC firmware.
+    ResetConfig(ResetConfigArgs),
     IsBootOrderSetup(SetBootOrderDpuFirstArgs),
 }
 
@@ -319,6 +322,13 @@ pub struct CreateVolumeArgs {
     pub controller_id: String,
     #[clap(long, help = "volume_name")]
     pub volume_name: String,
+}
+
+// TEMPORARY WORKAROUND (Dell R770 / iDRAC10): see RedfishCommands::ResetConfig.
+#[derive(Parser, Debug, PartialEq, Clone)]
+pub struct ResetConfigArgs {
+    #[clap(long, help = "controller_id")]
+    pub controller_id: String,
 }
 
 #[derive(Parser, Debug, PartialEq, Clone)]

--- a/crates/admin-cli/src/redfish/cmds.rs
+++ b/crates/admin-cli/src/redfish/cmds.rs
@@ -589,6 +589,13 @@ pub async fn action(action: RedfishAction) -> color_eyre::Result<()> {
                 tracing::info!("No JID");
             }
         }
+        ResetConfig(args) => {
+            if let Some(jid) = redfish.reset_storage_config(&args.controller_id).await? {
+                tracing::info!("JID: {}", jid);
+            } else {
+                tracing::info!("No JID");
+            }
+        }
         IsBootOrderSetup(args) => {
             let setup = redfish
                 .is_boot_order_setup(&args.boot_interface_mac)

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1829,6 +1829,36 @@ pub enum CreateBossVolumeState {
     LockHost,
 }
 
+// TEMPORARY WORKAROUND (Dell PowerEdge R770 / iDRAC10, FW 1.30.10.50):
+// volume creation on a BOSS controller fails with STOR060 after a
+// ControllerDrivesDecommission. Resetting the controller config via
+// DellRaidService.ResetConfig (followed by a reboot) clears the condition.
+// Remove this context/state once Dell ships a fixed iDRAC firmware.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub struct ResetBossConfigContext {
+    pub boss_controller_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reset_boss_config_jid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iteration: Option<u32>,
+    pub reset_boss_config_state: ResetBossConfigState,
+}
+
+// TEMPORARY WORKAROUND (Dell PowerEdge R770 / iDRAC10): see ResetBossConfigContext.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(tag = "state", rename_all = "lowercase")]
+pub enum ResetBossConfigState {
+    ResetConfig,
+    WaitForJobScheduled,
+    RebootHost,
+    WaitForJobCompletion,
+    HandleJobFailure {
+        failure: String,
+        power_state: PowerState,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(tag = "state", rename_all = "lowercase")]
 pub enum CleanupState {
@@ -1840,6 +1870,12 @@ pub enum CleanupState {
     HostCleanup {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         boss_controller_id: Option<String>,
+    },
+    // TEMPORARY WORKAROUND (Dell PowerEdge R770 / iDRAC10): reset the BOSS
+    // controller config via DellRaidService.ResetConfig before recreating the
+    // volume, to work around STOR060. Remove once Dell ships a fixed iDRAC firmware.
+    ResetBossConfig {
+        reset_boss_config_context: ResetBossConfigContext,
     },
     // Only for Dells with BOSS drives (currently on Dell XE9860s)
     CreateBossVolume {

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -76,7 +76,8 @@ use model::machine::{
     MachineLastRebootRequestedMode, MachineNextStateResolver, MachineState,
     MachineValidationContext, ManagedHostState, ManagedHostStateSnapshot, MeasuringState,
     NetworkConfigUpdateState, NextStateBFBSupport, PerformPowerOperation, PowerDrainState,
-    PowerState, ReprovisionState, RetryInfo, SecureEraseBossContext, SecureEraseBossState,
+    PowerState, ReprovisionState, ResetBossConfigContext, ResetBossConfigState, RetryInfo,
+    SecureEraseBossContext, SecureEraseBossState,
     SetBootOrderInfo, SetBootOrderState, SetSecureBootState, SpdmMeasuringState, StateMachineArea,
     UefiSetupInfo, UefiSetupState, UnlockHostState, ValidationState,
     dpf_based_dpu_provisioning_possible, get_display_ids,
@@ -1095,22 +1096,147 @@ impl MachineStateHandler {
                         .await?;
 
                         let next_state = match boss_controller_id {
-                            Some(boss_controller_id) => waiting_for_cleanup_state(
-                                CleanupState::CreateBossVolume {
-                                    create_boss_volume_context: CreateBossVolumeContext {
-                                        boss_controller_id: boss_controller_id.to_string(),
-                                        create_boss_volume_jid: None,
-                                        create_boss_volume_state:
-                                            CreateBossVolumeState::CreateBossVolume,
-                                        iteration: Some(0),
-                                    },
-                                },
-                                *cleanup_context,
-                            ),
+                            Some(boss_controller_id) => {
+                                // TEMPORARY WORKAROUND (Dell PowerEdge R770 / iDRAC10): reset the
+                                // BOSS controller config via DellRaidService.ResetConfig before
+                                // recreating the volume, to work around STOR060 failures during
+                                // volume creation. Other Dells keep the existing flow.
+                                // Remove once Dell ships a fixed iDRAC firmware.
+                                if is_dell_r770(&mh_snapshot.host_snapshot, ctx).await? {
+                                    waiting_for_cleanup_state(
+                                        CleanupState::ResetBossConfig {
+                                            reset_boss_config_context: ResetBossConfigContext {
+                                                boss_controller_id: boss_controller_id.to_string(),
+                                                reset_boss_config_jid: None,
+                                                reset_boss_config_state:
+                                                    ResetBossConfigState::ResetConfig,
+                                                iteration: Some(0),
+                                            },
+                                        },
+                                        *cleanup_context,
+                                    )
+                                } else {
+                                    waiting_for_cleanup_state(
+                                        CleanupState::CreateBossVolume {
+                                            create_boss_volume_context: CreateBossVolumeContext {
+                                                boss_controller_id: boss_controller_id.to_string(),
+                                                create_boss_volume_jid: None,
+                                                create_boss_volume_state:
+                                                    CreateBossVolumeState::CreateBossVolume,
+                                                iteration: Some(0),
+                                            },
+                                        },
+                                        *cleanup_context,
+                                    )
+                                }
+                            }
                             None => post_cleanup_state(*cleanup_context),
                         };
 
                         Ok(StateHandlerOutcome::transition(next_state))
+                    }
+                    CleanupState::ResetBossConfig {
+                        reset_boss_config_context,
+                    } => {
+                        let boss_controller_id =
+                            reset_boss_config_context.boss_controller_id.clone();
+                        match reset_boss_config_context.reset_boss_config_state {
+                            ResetBossConfigState::ResetConfig => {
+                                let jid = redfish_client
+                                    .reset_storage_config(
+                                        &reset_boss_config_context.boss_controller_id,
+                                    )
+                                    .await
+                                    .map_err(|e| redfish_error("reset_storage_config", e))?;
+
+                                let next_state = waiting_for_cleanup_state(
+                                    CleanupState::ResetBossConfig {
+                                        reset_boss_config_context: ResetBossConfigContext {
+                                            boss_controller_id,
+                                            reset_boss_config_jid: jid,
+                                            reset_boss_config_state:
+                                                ResetBossConfigState::WaitForJobScheduled,
+                                            iteration: reset_boss_config_context.iteration,
+                                        },
+                                    },
+                                    *cleanup_context,
+                                );
+
+                                Ok(StateHandlerOutcome::transition(next_state))
+                            }
+                            ResetBossConfigState::WaitForJobScheduled => {
+                                let job_id = reset_boss_config_context
+                                    .reset_boss_config_jid
+                                    .clone()
+                                    .ok_or_else(|| {
+                                        StateHandlerError::GenericError(eyre::eyre!(
+                                            "could not find job ID in the Reset BOSS Config Context"
+                                        ))
+                                    })?;
+
+                                wait_for_reset_boss_config_job_to_scheduled(
+                                    redfish_client.as_ref(),
+                                    mh_snapshot,
+                                    boss_controller_id,
+                                    job_id,
+                                    reset_boss_config_context.iteration,
+                                )
+                                .await
+                            }
+                            ResetBossConfigState::RebootHost => {
+                                redfish_client
+                                    .power(SystemPowerControl::ForceRestart)
+                                    .await
+                                    .map_err(|e| redfish_error("ForceRestart", e))?;
+
+                                let next_state = waiting_for_cleanup_state(
+                                    CleanupState::ResetBossConfig {
+                                        reset_boss_config_context: ResetBossConfigContext {
+                                            boss_controller_id,
+                                            reset_boss_config_jid: reset_boss_config_context
+                                                .reset_boss_config_jid
+                                                .clone(),
+                                            reset_boss_config_state:
+                                                ResetBossConfigState::WaitForJobCompletion,
+                                            iteration: reset_boss_config_context.iteration,
+                                        },
+                                    },
+                                    *cleanup_context,
+                                );
+
+                                Ok(StateHandlerOutcome::transition(next_state))
+                            }
+                            ResetBossConfigState::WaitForJobCompletion => {
+                                let job_id = reset_boss_config_context
+                                    .reset_boss_config_jid
+                                    .clone()
+                                    .ok_or_else(|| {
+                                        StateHandlerError::GenericError(eyre::eyre!(
+                                            "could not find job ID in the Reset BOSS Config Context"
+                                        ))
+                                    })?;
+
+                                wait_for_reset_boss_config_job_to_complete(
+                                    redfish_client.as_ref(),
+                                    mh_snapshot,
+                                    boss_controller_id,
+                                    job_id,
+                                    reset_boss_config_context.iteration,
+                                )
+                                .await
+                            }
+                            ResetBossConfigState::HandleJobFailure {
+                                failure: _,
+                                power_state: _,
+                            } => {
+                                handle_reset_boss_config_job_failure(
+                                    redfish_client.as_ref(),
+                                    mh_snapshot,
+                                    ctx,
+                                )
+                                .await
+                            }
+                        }
                     }
                     CleanupState::CreateBossVolume {
                         create_boss_volume_context,
@@ -8942,6 +9068,363 @@ fn get_next_state_boss_job_failure(
         }
     };
     Ok((next_state, expected_power_state))
+}
+
+// ---------------------------------------------------------------------------
+// TEMPORARY WORKAROUND (Dell PowerEdge R770 / iDRAC10, FW 1.30.10.50):
+// On these hosts, BOSS volume creation fails with STOR060 after a
+// ControllerDrivesDecommission. We issue a DellRaidService.ResetConfig (plus a
+// reboot) before recreating the volume to clear the condition. Everything in
+// this section can be removed once Dell ships a fixed iDRAC firmware (delete
+// these helpers, the ResetBossConfig cleanup state, and the is_dell_r770 gate
+// in CleanupState::HostCleanup).
+// ---------------------------------------------------------------------------
+
+/// Returns true if this host is a Dell PowerEdge R770, which needs the
+/// DellRaidService.ResetConfig workaround before BOSS volume creation.
+async fn is_dell_r770(
+    machine: &Machine,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) -> Result<bool, StateHandlerError> {
+    if !machine.bmc_vendor().is_dell() {
+        return Ok(false);
+    }
+
+    let addr = machine
+        .bmc_info
+        .ip_addr()
+        .map_err(StateHandlerError::GenericError)?;
+    let endpoints =
+        db::explored_endpoints::find_by_ips(&mut ctx.services.db_reader, vec![addr]).await?;
+    let Some(ep) = endpoints.first() else {
+        return Ok(false);
+    };
+
+    Ok(ep
+        .report
+        .model
+        .as_deref()
+        .map(|model| model.contains("R770"))
+        .unwrap_or(false))
+}
+
+/// Poll the ResetConfig job until it is scheduled, then reboot so it applies.
+async fn wait_for_reset_boss_config_job_to_scheduled(
+    redfish_client: &dyn Redfish,
+    mh_snapshot: &ManagedHostStateSnapshot,
+    boss_controller_id: String,
+    job_id: String,
+    iteration: Option<u32>,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let cleanup_context = current_cleanup_context(mh_snapshot)?;
+    let job_state = match redfish_client.get_job_state(&job_id).await {
+        Ok(state) => state,
+        Err(e) => {
+            return handle_reset_boss_config_job_error(
+                boss_controller_id,
+                iteration.unwrap_or_default(),
+                cleanup_context,
+                redfish_error("get_job_state", e),
+                mh_snapshot.host_snapshot.state.version.since_state_change(),
+            );
+        }
+    };
+
+    let next_state = match job_state {
+        libredfish::JobState::Scheduled => waiting_for_cleanup_state(
+            CleanupState::ResetBossConfig {
+                reset_boss_config_context: ResetBossConfigContext {
+                    boss_controller_id,
+                    reset_boss_config_jid: Some(job_id),
+                    reset_boss_config_state: ResetBossConfigState::RebootHost,
+                    iteration,
+                },
+            },
+            cleanup_context,
+        ),
+        libredfish::JobState::Completed => {
+            tracing::warn!(
+                "ResetBossConfig: job {} for {} completed before being scheduled, skipping reboot",
+                job_id,
+                mh_snapshot.host_snapshot.id,
+            );
+
+            waiting_for_cleanup_state(
+                CleanupState::ResetBossConfig {
+                    reset_boss_config_context: ResetBossConfigContext {
+                        boss_controller_id,
+                        reset_boss_config_jid: Some(job_id),
+                        reset_boss_config_state: ResetBossConfigState::WaitForJobCompletion,
+                        iteration,
+                    },
+                },
+                cleanup_context,
+            )
+        }
+        libredfish::JobState::ScheduledWithErrors | libredfish::JobState::CompletedWithErrors => {
+            return handle_reset_boss_config_job_error(
+                boss_controller_id,
+                iteration.unwrap_or_default(),
+                cleanup_context,
+                StateHandlerError::GenericError(eyre::eyre!(
+                    "ResetBossConfig: job {} failed for {} with state {job_state:#?}",
+                    job_id,
+                    mh_snapshot.host_snapshot.id,
+                )),
+                mh_snapshot.host_snapshot.state.version.since_state_change(),
+            );
+        }
+        _ => {
+            return Ok(StateHandlerOutcome::wait(format!(
+                "waiting for job {job_id:#?} to be scheduled; current state: {job_state:#?}"
+            )));
+        }
+    };
+
+    Ok(StateHandlerOutcome::transition(next_state))
+}
+
+/// Poll the ResetConfig job until it completes, then proceed to volume creation.
+async fn wait_for_reset_boss_config_job_to_complete(
+    redfish_client: &dyn Redfish,
+    mh_snapshot: &ManagedHostStateSnapshot,
+    boss_controller_id: String,
+    job_id: String,
+    iteration: Option<u32>,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let cleanup_context = current_cleanup_context(mh_snapshot)?;
+
+    let job_state = match redfish_client.get_job_state(&job_id).await {
+        Ok(state) => state,
+        Err(e) => {
+            return handle_reset_boss_config_job_error(
+                boss_controller_id,
+                iteration.unwrap_or_default(),
+                cleanup_context,
+                redfish_error("get_job_state", e),
+                mh_snapshot.host_snapshot.state.version.since_state_change(),
+            );
+        }
+    };
+
+    match job_state {
+        // The controller config has been reset; proceed to (re)create the BOSS volume.
+        libredfish::JobState::Completed => {
+            let next_state = waiting_for_cleanup_state(
+                CleanupState::CreateBossVolume {
+                    create_boss_volume_context: CreateBossVolumeContext {
+                        boss_controller_id,
+                        create_boss_volume_jid: None,
+                        create_boss_volume_state: CreateBossVolumeState::CreateBossVolume,
+                        iteration: Some(0),
+                    },
+                },
+                cleanup_context,
+            );
+            Ok(StateHandlerOutcome::transition(next_state))
+        }
+        libredfish::JobState::ScheduledWithErrors | libredfish::JobState::CompletedWithErrors => {
+            handle_reset_boss_config_job_error(
+                boss_controller_id,
+                iteration.unwrap_or_default(),
+                cleanup_context,
+                StateHandlerError::GenericError(eyre::eyre!(
+                    "ResetBossConfig: job {job_id} will not complete because it is in a failure state: {job_state:#?}",
+                )),
+                mh_snapshot.host_snapshot.state.version.since_state_change(),
+            )
+        }
+        _ => Ok(StateHandlerOutcome::wait(format!(
+            "waiting for job {job_id} to complete; current state: {job_state:#?}"
+        ))),
+    }
+}
+
+/// Error/retry handling for the ResetConfig job, mirroring
+/// handle_boss_controller_job_error: ride out transient errors for 5 minutes,
+/// retry up to 3 times, then hand off to the power-cycle recovery path.
+fn handle_reset_boss_config_job_error(
+    boss_controller_id: String,
+    iterations: u32,
+    cleanup_context: CleanupContext,
+    err: StateHandlerError,
+    time_since_state_change: chrono::TimeDelta,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    if time_since_state_change.num_minutes() < 5 {
+        return Err(err);
+    }
+
+    if iterations > 3 {
+        return Err(StateHandlerError::GenericError(eyre::eyre!(
+            "We have gone through {iterations} iterations of trying to reset the config of the BOSS controller; Waiting for manual intervention: {err}",
+        )));
+    }
+
+    let next_state = waiting_for_cleanup_state(
+        CleanupState::ResetBossConfig {
+            reset_boss_config_context: ResetBossConfigContext {
+                boss_controller_id,
+                reset_boss_config_jid: None,
+                reset_boss_config_state: ResetBossConfigState::HandleJobFailure {
+                    failure: err.to_string(),
+                    power_state: PowerState::Off,
+                },
+                iteration: Some(iterations),
+            },
+        },
+        cleanup_context,
+    );
+
+    Ok(StateHandlerOutcome::transition(next_state))
+}
+
+/// Power-cycle recovery for a failed ResetConfig job, mirroring
+/// handle_boss_job_failure: power off, reset the BMC, power back on, then retry.
+async fn handle_reset_boss_config_job_failure(
+    redfish_client: &dyn Redfish,
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let (next_state, expected_power_state) =
+        get_next_state_reset_boss_config_job_failure(mh_snapshot)?;
+
+    let current_power_state = redfish_client
+        .get_power_state()
+        .await
+        .map_err(|e| redfish_error("get_power_state", e))?;
+
+    match expected_power_state {
+        PowerState::Off => {
+            if current_power_state != libredfish::PowerState::Off {
+                handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::ForceOff).await?;
+
+                return Ok(StateHandlerOutcome::wait(format!(
+                    "waiting for {} to power down; current power state: {current_power_state}",
+                    mh_snapshot.host_snapshot.id
+                )));
+            }
+
+            redfish_client
+                .bmc_reset()
+                .await
+                .map_err(|e| redfish_error("bmc_reset", e))?;
+
+            Ok(StateHandlerOutcome::transition(next_state))
+        }
+        PowerState::On => {
+            let basetime = mh_snapshot
+                .host_snapshot
+                .last_reboot_requested
+                .as_ref()
+                .map(|x| x.time)
+                .unwrap_or(mh_snapshot.host_snapshot.state.version.timestamp());
+
+            if wait(
+                &basetime,
+                ctx.services
+                    .site_config
+                    .machine_state_controller
+                    .power_down_wait,
+            ) {
+                return Ok(StateHandlerOutcome::wait(format!(
+                    "waiting for {} to power down; power_down_wait: {}",
+                    mh_snapshot.host_snapshot.id,
+                    ctx.services
+                        .site_config
+                        .machine_state_controller
+                        .power_down_wait
+                )));
+            }
+
+            if current_power_state != libredfish::PowerState::On {
+                handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::On).await?;
+
+                return Ok(StateHandlerOutcome::wait(format!(
+                    "waiting for {} to power on; current power state: {current_power_state}",
+                    mh_snapshot.host_snapshot.id,
+                )));
+            }
+
+            Ok(StateHandlerOutcome::transition(next_state))
+        }
+        _ => Err(StateHandlerError::GenericError(eyre::eyre!(
+            "unexpected expected_power_state while handling a reset boss config job failure: {expected_power_state}"
+        ))),
+    }
+}
+
+/// Computes the next state for the ResetConfig power-cycle recovery, mirroring
+/// get_next_state_boss_job_failure.
+fn get_next_state_reset_boss_config_job_failure(
+    mh_snapshot: &ManagedHostStateSnapshot,
+) -> Result<(ManagedHostState, PowerState), StateHandlerError> {
+    match &mh_snapshot.host_snapshot.state.value {
+        ManagedHostState::WaitingForCleanup {
+            cleanup_state:
+                CleanupState::ResetBossConfig {
+                    reset_boss_config_context,
+                },
+            cleanup_context,
+        } => match &reset_boss_config_context.reset_boss_config_state {
+            ResetBossConfigState::HandleJobFailure {
+                failure,
+                power_state,
+            } => match power_state {
+                PowerState::Off => Ok((
+                    waiting_for_cleanup_state(
+                        CleanupState::ResetBossConfig {
+                            reset_boss_config_context: ResetBossConfigContext {
+                                boss_controller_id: reset_boss_config_context
+                                    .boss_controller_id
+                                    .clone(),
+                                reset_boss_config_jid: None,
+                                iteration: reset_boss_config_context.iteration,
+                                reset_boss_config_state: ResetBossConfigState::HandleJobFailure {
+                                    failure: failure.to_string(),
+                                    power_state: PowerState::On,
+                                },
+                            },
+                        },
+                        *cleanup_context,
+                    ),
+                    PowerState::Off,
+                )),
+                PowerState::On => Ok((
+                    waiting_for_cleanup_state(
+                        CleanupState::ResetBossConfig {
+                            reset_boss_config_context: ResetBossConfigContext {
+                                boss_controller_id: reset_boss_config_context
+                                    .boss_controller_id
+                                    .clone(),
+                                reset_boss_config_jid: None,
+                                iteration: Some(
+                                    reset_boss_config_context.iteration.unwrap_or_default() + 1,
+                                ),
+                                reset_boss_config_state: ResetBossConfigState::ResetConfig,
+                            },
+                        },
+                        *cleanup_context,
+                    ),
+                    PowerState::On,
+                )),
+                _ => Err(StateHandlerError::GenericError(eyre::eyre!(
+                    "unexpected ResetBossConfigState::HandleJobFailure power_state for {}: {:#?}",
+                    mh_snapshot.host_snapshot.id,
+                    mh_snapshot.host_snapshot.state,
+                ))),
+            },
+            _ => Err(StateHandlerError::GenericError(eyre::eyre!(
+                "unexpected ResetBossConfig state for {}: {:#?}",
+                mh_snapshot.host_snapshot.id,
+                mh_snapshot.host_snapshot.state,
+            ))),
+        },
+        _ => Err(StateHandlerError::GenericError(eyre::eyre!(
+            "unexpected host state for {}: {:#?}",
+            mh_snapshot.host_snapshot.id,
+            mh_snapshot.host_snapshot.state,
+        ))),
+    }
 }
 
 fn handle_boss_controller_job_error(

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -77,10 +77,9 @@ use model::machine::{
     MachineValidationContext, ManagedHostState, ManagedHostStateSnapshot, MeasuringState,
     NetworkConfigUpdateState, NextStateBFBSupport, PerformPowerOperation, PowerDrainState,
     PowerState, ReprovisionState, ResetBossConfigContext, ResetBossConfigState, RetryInfo,
-    SecureEraseBossContext, SecureEraseBossState,
-    SetBootOrderInfo, SetBootOrderState, SetSecureBootState, SpdmMeasuringState, StateMachineArea,
-    UefiSetupInfo, UefiSetupState, UnlockHostState, ValidationState,
-    dpf_based_dpu_provisioning_possible, get_display_ids,
+    SecureEraseBossContext, SecureEraseBossState, SetBootOrderInfo, SetBootOrderState,
+    SetSecureBootState, SpdmMeasuringState, StateMachineArea, UefiSetupInfo, UefiSetupState,
+    UnlockHostState, ValidationState, dpf_based_dpu_provisioning_possible, get_display_ids,
 };
 use model::power_manager::PowerHandlingOutcome;
 use model::resource_pool::common::CommonPools;

--- a/crates/machine-controller/src/io.rs
+++ b/crates/machine-controller/src/io.rs
@@ -246,6 +246,7 @@ impl StateControllerIO for MachineStateControllerIO {
                 CleanupState::Init => "init",
                 CleanupState::SecureEraseBoss { .. } => "secureeraseboss",
                 CleanupState::HostCleanup { .. } => "hostcleanup",
+                CleanupState::ResetBossConfig { .. } => "resetbossconfig",
                 CleanupState::CreateBossVolume { .. } => "createbossvolume",
                 CleanupState::DisableBIOSBMCLockdown => "disablebmclockdown",
             }

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -1338,6 +1338,13 @@ impl Redfish for RedfishSimClient {
         Box::pin(async move { Ok(None) })
     }
 
+    fn reset_storage_config<'a>(
+        &'a self,
+        _controller_id: &'a str,
+    ) -> libredfish::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { Ok(None) })
+    }
+
     fn is_boot_order_setup<'a>(
         &'a self,
         boot_interface_mac: &'a str,

--- a/docs/architecture/state_machines/managedhost.md
+++ b/docs/architecture/state_machines/managedhost.md
@@ -689,6 +689,13 @@ stateDiagram-v2
         state "HandleJobFailure" as C_SEB_HandleJobFailure
     }
     state C_HostCleanup
+    state "ResetBossConfig (Dell R770 workaround)" as C_ResetBossConfig {
+        state "ResetConfig" as C_RBC_ResetConfig
+        state "WaitForJobScheduled" as C_RBC_WaitForJobScheduled
+        state "RebootHost" as C_RBC_RebootHost
+        state "WaitForJobCompletion" as C_RBC_WaitForJobCompletion
+        state "HandleJobFailure" as C_RBC_HandleJobFailure
+    }
     state C_CreateBossVolume {
         state "CreateBossVolume" as C_SBV_CreateBossVolume
         state "WaitForJobScheduled" as C_SBV_WaitForJobScheduled
@@ -715,8 +722,18 @@ stateDiagram-v2
     C_SEB_HandleJobFailure --> C_SEB_SecureEraseBoss : Retry
     C_SEB_HandleJobFailure --> C_SEB_HandleJobFailure : Power cycle (Off / On)
     C_HostCleanup --> C_HostCleanup : Wait for cleanup
-    C_HostCleanup --> C_SBV_CreateBossVolume : if Boss controller present
+    C_HostCleanup --> C_RBC_ResetConfig : if Boss controller present AND Dell R770 (workaround)
+    C_HostCleanup --> C_SBV_CreateBossVolume : if Boss controller present AND not R770
     C_HostCleanup --> BomValidating_BV_UpdatingInventory : if Boss controller not present
+
+    C_RBC_ResetConfig --> C_RBC_WaitForJobScheduled
+    C_RBC_WaitForJobScheduled --> C_RBC_RebootHost
+    C_RBC_RebootHost --> C_RBC_WaitForJobCompletion
+    C_RBC_WaitForJobCompletion --> C_RBC_HandleJobFailure : Job fail
+    C_RBC_WaitForJobCompletion --> C_SBV_CreateBossVolume : Job success
+    C_RBC_WaitForJobCompletion --> C_RBC_WaitForJobCompletion : Wait job to complete
+    C_RBC_HandleJobFailure --> C_RBC_ResetConfig : Retry
+    C_RBC_HandleJobFailure --> C_RBC_HandleJobFailure : Power cycle (Off / On)
 
     C_SBV_CreateBossVolume --> C_SBV_WaitForJobScheduled
     C_SBV_WaitForJobScheduled --> C_SBV_RebootHost


### PR DESCRIPTION
## Description
Works around STOR060 on Dell R770 (iDRAC10), where BOSS volume creation fails after a `ControllerDrivesDecommission` during instance termination. Also adds a new R770-gated `ResetBossConfig` cleanup state that runs `DellRaidService.ResetConfig` + reboot before recreating the volume. Other Dells are unchanged. Also adds an `admin-cli redfish reset-config` command.

## Type of Change
- [x] **Fix** - Bug fixes

## Related Issues (Optional)
- [#2008](https://github.com/NVIDIA/infra-controller/issues/2008)

## Breaking Changes
- [ ] This PR contains breaking changes

## Additional Notes
This PR temporarily pins `libredfish` to a fork branch adding `reset_storage_config`; we will swap this back to an upstream tag before we merge it.