### PR TITLE
feat: Log every gRPC call on server and client paths in Flow

### DIFF
--- a/rest-api/flow/internal/common/grpclog/client.go
+++ b/rest-api/flow/internal/common/grpclog/client.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package grpclog
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+)
+
+// UnaryClientInterceptor returns a gRPC unary client interceptor that emits a
+// single structured log line per outgoing RPC on completion. Fields:
+//
+//   - grpc.target       caller-supplied label identifying the remote, e.g.
+//     "nico-core-api". Distinguishes logs when a binary speaks to multiple
+//     gRPC servers.
+//   - grpc.service      service name parsed from the full method
+//   - grpc.method       method name parsed from the full method
+//   - grpc.code         status code as a string
+//   - grpc.duration_ms  wall-clock latency in milliseconds
+//   - grpc.error        status message, only present on failure
+//
+// The log level is derived from the status code via LevelFromCode.
+//
+// target is a human-friendly label, not the dial address: a stable
+// non-cardinal value (e.g. "nico-core-api") is much easier to grep than a
+// service-discovered DNS name that changes per pod.
+func UnaryClientInterceptor(target string) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		fullMethod string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		start := time.Now()
+		err := invoker(ctx, fullMethod, req, reply, cc, opts...)
+		durMs := time.Since(start).Milliseconds()
+
+		st, _ := status.FromError(err)
+		service, method := splitFullMethod(fullMethod)
+
+		ev := log.WithLevel(LevelFromCode(st.Code())).
+			Str("grpc.target", target).
+			Str("grpc.service", service).
+			Str("grpc.method", method).
+			Str("grpc.code", st.Code().String()).
+			Int64("grpc.duration_ms", durMs)
+
+		if err != nil {
+			ev = ev.Str("grpc.error", st.Message())
+		}
+		ev.Msg("grpc client call")
+
+		return err
+	}
+}

--- a/rest-api/flow/internal/common/grpclog/grpclog_test.go
+++ b/rest-api/flow/internal/common/grpclog/grpclog_test.go
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package grpclog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+func TestLevelFromCode(t *testing.T) {
+	cases := []struct {
+		code codes.Code
+		want zerolog.Level
+	}{
+		{codes.OK, zerolog.InfoLevel},
+		{codes.Canceled, zerolog.InfoLevel},
+		{codes.InvalidArgument, zerolog.InfoLevel},
+		{codes.NotFound, zerolog.InfoLevel},
+		{codes.AlreadyExists, zerolog.InfoLevel},
+		{codes.PermissionDenied, zerolog.InfoLevel},
+		{codes.Unauthenticated, zerolog.InfoLevel},
+		{codes.FailedPrecondition, zerolog.InfoLevel},
+		{codes.OutOfRange, zerolog.InfoLevel},
+		{codes.Unimplemented, zerolog.InfoLevel},
+
+		{codes.DeadlineExceeded, zerolog.WarnLevel},
+		{codes.ResourceExhausted, zerolog.WarnLevel},
+		{codes.Aborted, zerolog.WarnLevel},
+
+		{codes.Unknown, zerolog.ErrorLevel},
+		{codes.Internal, zerolog.ErrorLevel},
+		{codes.Unavailable, zerolog.ErrorLevel},
+		{codes.DataLoss, zerolog.ErrorLevel},
+	}
+	for _, tc := range cases {
+		t.Run(tc.code.String(), func(t *testing.T) {
+			assert.Equal(t, tc.want, LevelFromCode(tc.code))
+		})
+	}
+}
+
+func TestSplitFullMethod(t *testing.T) {
+	cases := []struct {
+		in          string
+		wantService string
+		wantMethod  string
+	}{
+		{"/forge.Forge/GetMachines", "forge.Forge", "GetMachines"},
+		{"/flow.v1.Flow/GetRackInfoByID", "flow.v1.Flow", "GetRackInfoByID"},
+		{"", "", ""},
+		{"NoSlash", "", "NoSlash"},
+		{"/JustOneSegment", "", "JustOneSegment"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			gotSvc, gotMethod := splitFullMethod(tc.in)
+			assert.Equal(t, tc.wantService, gotSvc)
+			assert.Equal(t, tc.wantMethod, gotMethod)
+		})
+	}
+}
+
+// captureLogs swaps the global zerolog logger to write JSON into a buffer for
+// the duration of the test, then restores the previous logger. It returns the
+// buffer; callers parse the line(s) themselves so each test can assert on the
+// fields it cares about without a shared schema getting in the way.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	prev := log.Logger
+	buf := &bytes.Buffer{}
+	log.Logger = zerolog.New(buf)
+	t.Cleanup(func() { log.Logger = prev })
+	return buf
+}
+
+func decodeOneLogLine(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	require.NotZero(t, buf.Len(), "expected at least one log line")
+	var line map[string]any
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &line))
+	return line
+}
+
+func TestUnaryServerInterceptor_Success(t *testing.T) {
+	buf := captureLogs(t)
+
+	ctx := peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.TCPAddr{IP: net.ParseIP("10.0.0.7"), Port: 4242},
+	})
+
+	interceptor := UnaryServerInterceptor()
+	resp, err := interceptor(
+		ctx,
+		"req-payload",
+		&grpc.UnaryServerInfo{FullMethod: "/flow.v1.Flow/GetRackInfoByID"},
+		func(ctx context.Context, req any) (any, error) { return "ok-resp", nil },
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "ok-resp", resp)
+
+	line := decodeOneLogLine(t, buf)
+	assert.Equal(t, "info", line["level"])
+	assert.Equal(t, "flow rpc handled", line["message"])
+	assert.Equal(t, "flow.v1.Flow", line["grpc.service"])
+	assert.Equal(t, "GetRackInfoByID", line["grpc.method"])
+	assert.Equal(t, "OK", line["grpc.code"])
+	assert.Equal(t, "10.0.0.7:4242", line["grpc.peer"])
+	assert.NotContains(t, line, "grpc.error", "no error field on success")
+	_, hasDur := line["grpc.duration_ms"]
+	assert.True(t, hasDur, "duration_ms field present")
+}
+
+func TestUnaryServerInterceptor_Failure(t *testing.T) {
+	buf := captureLogs(t)
+
+	interceptor := UnaryServerInterceptor()
+	failure := status.Error(codes.Unavailable, "core unreachable")
+
+	_, err := interceptor(
+		context.Background(),
+		nil,
+		&grpc.UnaryServerInfo{FullMethod: "/flow.v1.Flow/UpgradeFirmware"},
+		func(ctx context.Context, req any) (any, error) { return nil, failure },
+	)
+	require.ErrorIs(t, err, failure)
+
+	line := decodeOneLogLine(t, buf)
+	assert.Equal(t, "error", line["level"])
+	assert.Equal(t, "Unavailable", line["grpc.code"])
+	assert.Equal(t, "core unreachable", line["grpc.error"])
+	assert.NotContains(t, line, "grpc.peer", "peer field omitted when not present")
+}
+
+func TestUnaryServerInterceptor_NonStatusError(t *testing.T) {
+	// A handler that returns a plain error (not a status.Status) should still
+	// log a single line at Unknown / Error level.
+	buf := captureLogs(t)
+
+	interceptor := UnaryServerInterceptor()
+	_, err := interceptor(
+		context.Background(),
+		nil,
+		&grpc.UnaryServerInfo{FullMethod: "/flow.v1.Flow/Version"},
+		func(ctx context.Context, req any) (any, error) { return nil, errors.New("boom") },
+	)
+	require.Error(t, err)
+
+	line := decodeOneLogLine(t, buf)
+	assert.Equal(t, "error", line["level"])
+	assert.Equal(t, "Unknown", line["grpc.code"])
+	assert.Equal(t, "boom", line["grpc.error"])
+}
+
+func TestUnaryClientInterceptor_Success(t *testing.T) {
+	buf := captureLogs(t)
+
+	interceptor := UnaryClientInterceptor("nico-core-api")
+	err := interceptor(
+		context.Background(),
+		"/forge.Forge/FindMachineIds",
+		"req", "reply",
+		nil,
+		func(_ context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	line := decodeOneLogLine(t, buf)
+	assert.Equal(t, "info", line["level"])
+	assert.Equal(t, "grpc client call", line["message"])
+	assert.Equal(t, "nico-core-api", line["grpc.target"])
+	assert.Equal(t, "forge.Forge", line["grpc.service"])
+	assert.Equal(t, "FindMachineIds", line["grpc.method"])
+	assert.Equal(t, "OK", line["grpc.code"])
+	assert.NotContains(t, line, "grpc.error")
+}
+
+func TestUnaryClientInterceptor_Failure(t *testing.T) {
+	buf := captureLogs(t)
+
+	interceptor := UnaryClientInterceptor("nico-core-api")
+	failure := status.Error(codes.DeadlineExceeded, "ctx deadline exceeded")
+
+	err := interceptor(
+		context.Background(),
+		"/forge.Forge/GetPowerOptions",
+		nil, nil,
+		nil,
+		func(_ context.Context, _ string, _, _ any, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+			return failure
+		},
+	)
+	require.ErrorIs(t, err, failure)
+
+	line := decodeOneLogLine(t, buf)
+	assert.Equal(t, "warn", line["level"])
+	assert.Equal(t, "DeadlineExceeded", line["grpc.code"])
+	assert.Equal(t, "ctx deadline exceeded", line["grpc.error"])
+}

--- a/rest-api/flow/internal/common/grpclog/level.go
+++ b/rest-api/flow/internal/common/grpclog/level.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package grpclog provides zerolog-based unary interceptors for the Flow gRPC
+// server and clients. Each interceptor emits exactly one log line per RPC on
+// completion with the method, duration, and status code. Request and response
+// payloads are intentionally not logged: several NICo / Flow RPCs carry BMC
+// credentials, and full protobuf dumps make the log unreadable.
+package grpclog
+
+import (
+	"strings"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+)
+
+// LevelFromCode maps a gRPC status code to the zerolog level used when
+// reporting an RPC's outcome. The mapping is intentionally shared between the
+// server and client interceptors so a given code logs at the same level no
+// matter which side observes it.
+//
+// The classification is:
+//
+//   - Info  for OK and expected business-level outcomes that callers routinely
+//     branch on (NotFound, AlreadyExists, InvalidArgument, …). These show up
+//     during normal sync flows and should not raise alarm.
+//   - Warn  for outcomes that are usually transient but worth surfacing
+//     (DeadlineExceeded, ResourceExhausted, Aborted).
+//   - Error for outcomes that indicate the remote is broken
+//     (Unavailable, Internal, DataLoss, Unknown).
+//
+// Canceled is logged at Info because it is overwhelmingly produced by graceful
+// shutdown or a caller giving up, not by a real failure.
+func LevelFromCode(code codes.Code) zerolog.Level {
+	switch code {
+	case codes.OK,
+		codes.Canceled,
+		codes.InvalidArgument,
+		codes.NotFound,
+		codes.AlreadyExists,
+		codes.PermissionDenied,
+		codes.Unauthenticated,
+		codes.FailedPrecondition,
+		codes.OutOfRange,
+		codes.Unimplemented:
+		return zerolog.InfoLevel
+	case codes.DeadlineExceeded,
+		codes.ResourceExhausted,
+		codes.Aborted:
+		return zerolog.WarnLevel
+	default:
+		// Unknown, Internal, Unavailable, DataLoss, and any future codes
+		// default to Error: better to over-alert on a new code than to hide
+		// a real outage behind Info.
+		return zerolog.ErrorLevel
+	}
+}
+
+// splitFullMethod splits "/forge.Forge/GetMachines" into ("forge.Forge",
+// "GetMachines"). Inputs that do not contain a service / method separator are
+// returned as ("", trimmed) so the method field is still populated.
+func splitFullMethod(full string) (service, method string) {
+	trimmed := strings.TrimPrefix(full, "/")
+	if i := strings.LastIndexByte(trimmed, '/'); i >= 0 {
+		return trimmed[:i], trimmed[i+1:]
+	}
+	return "", trimmed
+}

--- a/rest-api/flow/internal/common/grpclog/server.go
+++ b/rest-api/flow/internal/common/grpclog/server.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package grpclog
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+// UnaryServerInterceptor returns a gRPC unary server interceptor that emits a
+// single structured log line per RPC on completion. Fields:
+//
+//   - grpc.service     service name parsed from the full method
+//   - grpc.method      method name parsed from the full method
+//   - grpc.code        status code as a string ("OK", "Unavailable", ...)
+//   - grpc.duration_ms wall-clock latency in milliseconds
+//   - grpc.peer        client address from the peer context, when available
+//   - grpc.error       status message, only present on failure
+//
+// The log level is derived from the status code via LevelFromCode.
+func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (any, error) {
+		start := time.Now()
+		resp, err := handler(ctx, req)
+		durMs := time.Since(start).Milliseconds()
+
+		st, _ := status.FromError(err)
+		service, method := splitFullMethod(info.FullMethod)
+
+		ev := log.WithLevel(LevelFromCode(st.Code())).
+			Str("grpc.service", service).
+			Str("grpc.method", method).
+			Str("grpc.code", st.Code().String()).
+			Int64("grpc.duration_ms", durMs)
+
+		if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {
+			ev = ev.Str("grpc.peer", p.Addr.String())
+		}
+		if err != nil {
+			ev = ev.Str("grpc.error", st.Message())
+		}
+		ev.Msg("flow rpc handled")
+
+		return resp, err
+	}
+}

--- a/rest-api/flow/internal/nicoapi/grpc.go
+++ b/rest-api/flow/internal/nicoapi/grpc.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/certs"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/common/grpclog"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/common/utils"
 	pb "github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi/gen"
 	"github.com/rs/zerolog/log"
@@ -57,7 +58,11 @@ func NewClient(grpcTimeout time.Duration) (Client, error) {
 		return nil, err
 	}
 
-	conn, err := grpc.NewClient(nicoURL, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	conn, err := grpc.NewClient(
+		nicoURL,
+		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
+		grpc.WithChainUnaryInterceptor(grpclog.UnaryClientInterceptor("nico-core-api")),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to connect to nico-core-api: %w", err)
 	}

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory.go
@@ -32,14 +32,21 @@ func runInventoryOne(
 ) {
 	var allDrifts []model.ComponentDrift
 
-	machineDrifts := syncMachines(ctx, pool, nicoClient)
+	computeReceived, machineDrifts := syncMachines(ctx, pool, nicoClient)
 	allDrifts = append(allDrifts, machineDrifts...)
 
-	nvSwitchDrifts := syncNVSwitchesNICo(ctx, pool, nicoClient)
+	switchesReceived, nvSwitchDrifts := syncNVSwitchesNICo(ctx, pool, nicoClient)
 	allDrifts = append(allDrifts, nvSwitchDrifts...)
 
-	powershelfDrifts := syncPowershelvesNICo(ctx, pool, nicoClient)
+	powershelvesReceived, powershelfDrifts := syncPowershelvesNICo(ctx, pool, nicoClient)
 	allDrifts = append(allDrifts, powershelfDrifts...)
+
+	log.Info().
+		Int("compute", computeReceived).
+		Int("nvswitches", switchesReceived).
+		Int("powershelves", powershelvesReceived).
+		Msgf("Inventory received from Core: compute=%d nvswitches=%d powershelves=%d",
+			computeReceived, switchesReceived, powershelvesReceived)
 
 	// Persist all drifts atomically (replace entire table)
 	if err := pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
@@ -79,14 +86,14 @@ func syncMachines(
 	ctx context.Context,
 	pool *cdb.Session,
 	nicoClient nicoapi.Client,
-) []model.ComponentDrift {
+) (received int, drifts []model.ComponentDrift) {
 	log.Debug().Msg("Syncing machines...")
 
 	// Step 1: Get all machine components from DB
 	allComponents, err := model.GetAllComponents(ctx, pool.DB)
 	if err != nil {
 		log.Error().Msgf("Unable to retrieve components from db: %v", err)
-		return nil
+		return 0, nil
 	}
 
 	var components []model.Component
@@ -97,15 +104,16 @@ func syncMachines(
 	}
 
 	if len(components) == 0 {
-		return nil
+		return 0, nil
 	}
 
 	// Step 2: Fetch all machine details from NICo
 	allMachineDetails, err := nicoClient.GetMachines(ctx)
 	if err != nil {
 		log.Error().Msgf("Unable to retrieve machine details from NICo: %v", err)
-		return nil
+		return 0, nil
 	}
+	received = len(allMachineDetails)
 
 	detailByID := make(map[string]nicoapi.MachineDetail)
 	for _, d := range allMachineDetails {
@@ -119,7 +127,7 @@ func syncMachines(
 	allComponents, err = model.GetAllComponents(ctx, pool.DB)
 	if err != nil {
 		log.Error().Msgf("Unable to re-read components from db after machine ID update: %v", err)
-		return nil
+		return received, nil
 	}
 	components = components[:0]
 	for _, c := range allComponents {
@@ -140,7 +148,7 @@ func syncMachines(
 	}
 
 	if len(machineIDs) == 0 {
-		return buildDriftsForUnmatchedComponents(components, allMachineDetails)
+		return received, buildDriftsForUnmatchedComponents(components, allMachineDetails)
 	}
 
 	// Step 4: Direct-write power_state (requires separate NICo API)
@@ -153,7 +161,7 @@ func syncMachines(
 	machinePositions, err := nicoClient.GetMachinePositionInfo(ctx, machineIDs)
 	if err != nil {
 		log.Error().Msgf("Unable to retrieve machine positions from NICo: %v", err)
-		return nil
+		return received, nil
 	}
 
 	positionByID := make(map[string]nicoapi.MachinePosition)
@@ -162,7 +170,6 @@ func syncMachines(
 	}
 
 	now := time.Now()
-	var drifts []model.ComponentDrift
 
 	for i := range components {
 		comp := &components[i]
@@ -227,7 +234,7 @@ func syncMachines(
 	}
 
 	log.Info().Msgf("Machine sync: %d drift(s) out of %d component(s)", len(drifts), len(components))
-	return drifts
+	return received, drifts
 }
 
 // buildDriftsForUnmatchedComponents returns missing_in_actual drifts for all
@@ -467,17 +474,17 @@ func syncNVSwitchesNICo(
 	ctx context.Context,
 	pool *cdb.Session,
 	nicoClient nicoapi.Client,
-) []model.ComponentDrift {
+) (received int, drifts []model.ComponentDrift) {
 	log.Debug().Msg("Syncing NV switches via NICo...")
 
 	expectedSwitches, err := model.GetComponentsByType(ctx, pool.DB, devicetypes.ComponentTypeNVSwitch)
 	if err != nil {
 		log.Error().Msgf("Unable to retrieve NVSwitch components from db: %v", err)
-		return nil
+		return 0, nil
 	}
 
 	if len(expectedSwitches) == 0 {
-		return nil
+		return 0, nil
 	}
 
 	expectedByBmcMac := make(map[string]*model.Component)
@@ -499,8 +506,9 @@ func syncNVSwitchesNICo(
 	linked, err := nicoClient.GetAllExpectedSwitchesLinked(ctx)
 	if err != nil {
 		log.Error().Msgf("Unable to retrieve linked expected switches from NICo: %v", err)
-		return nil
+		return 0, nil
 	}
+	received = len(linked)
 
 	linkedByMac := make(map[string]nicoapi.LinkedExpectedSwitch)
 	for _, les := range linked {
@@ -535,7 +543,6 @@ func syncNVSwitchesNICo(
 
 	// Fetch inventory from Core for all matched switches
 	now := time.Now()
-	var drifts []model.ComponentDrift
 	if len(switchIDs) > 0 {
 		invResp, err := nicoClient.GetComponentInventory(ctx, &pb.GetComponentInventoryRequest{
 			Target: &pb.GetComponentInventoryRequest_SwitchIds{
@@ -564,7 +571,7 @@ func syncNVSwitchesNICo(
 	}
 
 	log.Info().Msgf("NVSwitch NICo sync: %d drift(s) out of %d expected", len(drifts), len(expectedSwitches))
-	return drifts
+	return received, drifts
 }
 
 // ---------------------------------------------------------------------------
@@ -589,17 +596,17 @@ func syncPowershelvesNICo(
 	ctx context.Context,
 	pool *cdb.Session,
 	nicoClient nicoapi.Client,
-) []model.ComponentDrift {
+) (received int, drifts []model.ComponentDrift) {
 	log.Debug().Msg("Syncing powershelves via NICo...")
 
 	expectedPowershelves, err := model.GetComponentsByType(ctx, pool.DB, devicetypes.ComponentTypePowerShelf)
 	if err != nil {
 		log.Error().Msgf("Unable to retrieve powershelf components from db: %v", err)
-		return nil
+		return 0, nil
 	}
 
 	if len(expectedPowershelves) == 0 {
-		return nil
+		return 0, nil
 	}
 
 	expectedByPmcMac := make(map[string]*model.Component)
@@ -621,8 +628,9 @@ func syncPowershelvesNICo(
 	linked, err := nicoClient.GetAllExpectedPowerShelvesLinked(ctx)
 	if err != nil {
 		log.Error().Msgf("Unable to retrieve linked expected power shelves from NICo: %v", err)
-		return nil
+		return 0, nil
 	}
+	received = len(linked)
 
 	linkedByMac := make(map[string]nicoapi.LinkedExpectedPowerShelf)
 	for _, leps := range linked {
@@ -657,7 +665,6 @@ func syncPowershelvesNICo(
 
 	// Fetch inventory from Core for all matched power shelves
 	now := time.Now()
-	var drifts []model.ComponentDrift
 	if len(shelfIDs) > 0 {
 		invResp, err := nicoClient.GetComponentInventory(ctx, &pb.GetComponentInventoryRequest{
 			Target: &pb.GetComponentInventoryRequest_PowerShelfIds{
@@ -686,7 +693,7 @@ func syncPowershelvesNICo(
 	}
 
 	log.Info().Msgf("Powershelf NICo sync: %d drift(s) out of %d expected", len(drifts), len(expectedPowershelves))
-	return drifts
+	return received, drifts
 }
 
 // applyInventoryToComponents extracts firmware_version and power_state from

--- a/rest-api/flow/internal/service/service.go
+++ b/rest-api/flow/internal/service/service.go
@@ -17,6 +17,7 @@ import (
 
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/certs"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/common/grpclog"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/migrations"
 	inventorymanager "github.com/NVIDIA/infra-controller/rest-api/flow/internal/inventory/manager"
 	inventorystore "github.com/NVIDIA/infra-controller/rest-api/flow/internal/inventory/store"
@@ -196,7 +197,10 @@ func (s *Service) Start(ctx context.Context) (retErr error) {
 	s.taskScheduleDispatcher = dispatcher
 	log.Info().Msg("Task schedule dispatcher started")
 
-	s.grpcServer = grpc.NewServer(certOpt)
+	s.grpcServer = grpc.NewServer(
+		certOpt,
+		grpc.ChainUnaryInterceptor(grpclog.UnaryServerInterceptor()),
+	)
 
 	log.Info().Msg("gRPC server is running")
 

--- a/rest-api/flow/internal/task/operationrules/resolver_defaults.go
+++ b/rest-api/flow/internal/task/operationrules/resolver_defaults.go
@@ -535,7 +535,7 @@ func buildForcePowerOnRule() *OperationRule {
 					ComponentType: devicetypes.ComponentTypePowerShelf,
 					Stage:         4,
 					MaxParallel:   0,
-					Timeout:       4 * time.Minute,
+					Timeout:       20 * time.Minute,
 					RetryPolicy: &RetryPolicy{
 						MaxAttempts:        2,
 						InitialInterval:    5 * time.Second,
@@ -543,7 +543,7 @@ func buildForcePowerOnRule() *OperationRule {
 					},
 					MainOperation: ActionConfig{
 						Name:         ActionVerifyPowerStatus,
-						Timeout:      3 * time.Minute,
+						Timeout:      5 * time.Minute,
 						PollInterval: 5 * time.Second,
 						Parameters: map[string]any{
 							ParamExpectedStatus: "on",
@@ -554,7 +554,7 @@ func buildForcePowerOnRule() *OperationRule {
 					ComponentType: devicetypes.ComponentTypeNVSwitch,
 					Stage:         4, // Parallel with PowerShelf
 					MaxParallel:   0,
-					Timeout:       4 * time.Minute,
+					Timeout:       20 * time.Minute,
 					RetryPolicy: &RetryPolicy{
 						MaxAttempts:        2,
 						InitialInterval:    5 * time.Second,
@@ -562,7 +562,7 @@ func buildForcePowerOnRule() *OperationRule {
 					},
 					MainOperation: ActionConfig{
 						Name:         ActionVerifyPowerStatus,
-						Timeout:      3 * time.Minute,
+						Timeout:      5 * time.Minute,
 						PollInterval: 5 * time.Second,
 						Parameters: map[string]any{
 							ParamExpectedStatus: "on",
@@ -573,7 +573,7 @@ func buildForcePowerOnRule() *OperationRule {
 					ComponentType: devicetypes.ComponentTypeCompute,
 					Stage:         4, // Parallel with PowerShelf and NVSwitch
 					MaxParallel:   0,
-					Timeout:       4 * time.Minute,
+					Timeout:       20 * time.Minute,
 					RetryPolicy: &RetryPolicy{
 						MaxAttempts:        2,
 						InitialInterval:    5 * time.Second,
@@ -581,7 +581,7 @@ func buildForcePowerOnRule() *OperationRule {
 					},
 					MainOperation: ActionConfig{
 						Name:         ActionVerifyPowerStatus,
-						Timeout:      3 * time.Minute,
+						Timeout:      5 * time.Minute,
 						PollInterval: 5 * time.Second,
 						Parameters: map[string]any{
 							ParamExpectedStatus: "on",
@@ -676,7 +676,7 @@ func buildForcePowerOffRule() *OperationRule {
 					ComponentType: devicetypes.ComponentTypePowerShelf,
 					Stage:         4,
 					MaxParallel:   0,
-					Timeout:       4 * time.Minute,
+					Timeout:       20 * time.Minute,
 					RetryPolicy: &RetryPolicy{
 						MaxAttempts:        2,
 						InitialInterval:    5 * time.Second,
@@ -684,7 +684,7 @@ func buildForcePowerOffRule() *OperationRule {
 					},
 					MainOperation: ActionConfig{
 						Name:         ActionVerifyPowerStatus,
-						Timeout:      3 * time.Minute,
+						Timeout:      5 * time.Minute,
 						PollInterval: 5 * time.Second,
 						Parameters: map[string]any{
 							ParamExpectedStatus: "off",
@@ -695,7 +695,7 @@ func buildForcePowerOffRule() *OperationRule {
 					ComponentType: devicetypes.ComponentTypeNVSwitch,
 					Stage:         4, // Parallel with PowerShelf
 					MaxParallel:   0,
-					Timeout:       4 * time.Minute,
+					Timeout:       20 * time.Minute,
 					RetryPolicy: &RetryPolicy{
 						MaxAttempts:        2,
 						InitialInterval:    5 * time.Second,
@@ -703,7 +703,7 @@ func buildForcePowerOffRule() *OperationRule {
 					},
 					MainOperation: ActionConfig{
 						Name:         ActionVerifyPowerStatus,
-						Timeout:      3 * time.Minute,
+						Timeout:      5 * time.Minute,
 						PollInterval: 5 * time.Second,
 						Parameters: map[string]any{
 							ParamExpectedStatus: "off",
@@ -714,7 +714,7 @@ func buildForcePowerOffRule() *OperationRule {
 					ComponentType: devicetypes.ComponentTypeCompute,
 					Stage:         4, // Parallel with PowerShelf and NVSwitch
 					MaxParallel:   0,
-					Timeout:       4 * time.Minute,
+					Timeout:       20 * time.Minute,
 					RetryPolicy: &RetryPolicy{
 						MaxAttempts:        2,
 						InitialInterval:    5 * time.Second,
@@ -722,7 +722,7 @@ func buildForcePowerOffRule() *OperationRule {
 					},
 					MainOperation: ActionConfig{
 						Name:         ActionVerifyPowerStatus,
-						Timeout:      3 * time.Minute,
+						Timeout:      5 * time.Minute,
 						PollInterval: 5 * time.Second,
 						Parameters: map[string]any{
 							ParamExpectedStatus: "off",
@@ -1061,7 +1061,7 @@ func buildForceRestartRule() *OperationRule {
 					ComponentType: devicetypes.ComponentTypePowerShelf,
 					Stage:         4,
 					MaxParallel:   0,
-					Timeout:       4 * time.Minute,
+					Timeout:       20 * time.Minute,
 					RetryPolicy: &RetryPolicy{
 						MaxAttempts:        2,
 						InitialInterval:    5 * time.Second,
@@ -1069,7 +1069,7 @@ func buildForceRestartRule() *OperationRule {
 					},
 					MainOperation: ActionConfig{
 						Name:         ActionVerifyPowerStatus,
-						Timeout:      3 * time.Minute,
+						Timeout:      5 * time.Minute,
 						PollInterval: 15 * time.Second,
 						Parameters: map[string]any{
 							ParamExpectedStatus: "off",
@@ -1080,7 +1080,7 @@ func buildForceRestartRule() *OperationRule {
 					ComponentType: devicetypes.ComponentTypeNVSwitch,
 					Stage:         4, // Parallel with PowerShelf
 					MaxParallel:   0,
-					Timeout:       4 * time.Minute,
+					Timeout:       20 * time.Minute,
 					RetryPolicy: &RetryPolicy{
 						MaxAttempts:        2,
 						InitialInterval:    5 * time.Second,
@@ -1088,7 +1088,7 @@ func buildForceRestartRule() *OperationRule {
 					},
 					MainOperation: ActionConfig{
 						Name:         ActionVerifyPowerStatus,
-						Timeout:      3 * time.Minute,
+						Timeout:      5 * time.Minute,
 						PollInterval: 15 * time.Second,
 						Parameters: map[string]any{
 							ParamExpectedStatus: "off",
@@ -1099,7 +1099,7 @@ func buildForceRestartRule() *OperationRule {
 					ComponentType: devicetypes.ComponentTypeCompute,
 					Stage:         4, // Parallel with PowerShelf and NVSwitch
 					MaxParallel:   0,
-					Timeout:       4 * time.Minute,
+					Timeout:       20 * time.Minute,
 					RetryPolicy: &RetryPolicy{
 						MaxAttempts:        2,
 						InitialInterval:    5 * time.Second,
@@ -1107,7 +1107,7 @@ func buildForceRestartRule() *OperationRule {
 					},
 					MainOperation: ActionConfig{
 						Name:         ActionVerifyPowerStatus,
-						Timeout:      3 * time.Minute,
+						Timeout:      5 * time.Minute,
 						PollInterval: 15 * time.Second,
 						Parameters: map[string]any{
 							ParamExpectedStatus: "off",
@@ -1196,7 +1196,7 @@ func buildForceRestartRule() *OperationRule {
 					ComponentType: devicetypes.ComponentTypePowerShelf,
 					Stage:         8,
 					MaxParallel:   0,
-					Timeout:       4 * time.Minute,
+					Timeout:       20 * time.Minute,
 					RetryPolicy: &RetryPolicy{
 						MaxAttempts:        2,
 						InitialInterval:    5 * time.Second,
@@ -1204,7 +1204,7 @@ func buildForceRestartRule() *OperationRule {
 					},
 					MainOperation: ActionConfig{
 						Name:         ActionVerifyPowerStatus,
-						Timeout:      3 * time.Minute,
+						Timeout:      5 * time.Minute,
 						PollInterval: 5 * time.Second,
 						Parameters: map[string]any{
 							ParamExpectedStatus: "on",
@@ -1215,7 +1215,7 @@ func buildForceRestartRule() *OperationRule {
 					ComponentType: devicetypes.ComponentTypeNVSwitch,
 					Stage:         8, // Parallel with PowerShelf
 					MaxParallel:   0,
-					Timeout:       4 * time.Minute,
+					Timeout:       20 * time.Minute,
 					RetryPolicy: &RetryPolicy{
 						MaxAttempts:        2,
 						InitialInterval:    5 * time.Second,
@@ -1223,7 +1223,7 @@ func buildForceRestartRule() *OperationRule {
 					},
 					MainOperation: ActionConfig{
 						Name:         ActionVerifyPowerStatus,
-						Timeout:      3 * time.Minute,
+						Timeout:      5 * time.Minute,
 						PollInterval: 5 * time.Second,
 						Parameters: map[string]any{
 							ParamExpectedStatus: "on",
@@ -1234,7 +1234,7 @@ func buildForceRestartRule() *OperationRule {
 					ComponentType: devicetypes.ComponentTypeCompute,
 					Stage:         8, // Parallel with PowerShelf and NVSwitch
 					MaxParallel:   0,
-					Timeout:       4 * time.Minute,
+					Timeout:       20 * time.Minute,
 					RetryPolicy: &RetryPolicy{
 						MaxAttempts:        2,
 						InitialInterval:    5 * time.Second,
@@ -1242,7 +1242,7 @@ func buildForceRestartRule() *OperationRule {
 					},
 					MainOperation: ActionConfig{
 						Name:         ActionVerifyPowerStatus,
-						Timeout:      3 * time.Minute,
+						Timeout:      5 * time.Minute,
 						PollInterval: 5 * time.Second,
 						Parameters: map[string]any{
 							ParamExpectedStatus: "on",


### PR DESCRIPTION

## Description
- Add `flow/internal/common/grpclog/` with unary interceptors and wire them into the Flow gRPC server and the NICo (Core) gRPC client. One structured log line per RPC: `grpc.service` / `grpc.method` / `grpc.code` / `grpc.duration_ms` / `grpc.peer` or `grpc.target`. Level by status code. No payloads (BMC creds).
- Raise force-power-on Stage 4 timeouts to 20m stage / 5m action across all 12 entries (was 4m / 3m, too tight for PowerShelf and NVSwitch).


## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

