### PR TITLE
chore: raise the metadata label cap from 10 to 16

### DIFF
--- a/crates/api-core/src/tests/common/metadata.rs
+++ b/crates/api-core/src/tests/common/metadata.rs
@@ -135,7 +135,7 @@ pub fn invalid_metadata_testcases(
             ).to_string(),
         ),
         (
-            // Maximum of 10 labels
+            // Maximum of 16 labels
             rpc::forge::Metadata {
                 name: "aa".to_string(),
                 description: "".to_string(),
@@ -182,9 +182,33 @@ pub fn invalid_metadata_testcases(
                 rpc::forge::Label {
                     key: "key11".to_string(),
                     value: None,
+                },
+                rpc::forge::Label {
+                    key: "key12".to_string(),
+                    value: None,
+                },
+                rpc::forge::Label {
+                    key: "key13".to_string(),
+                    value: None,
+                },
+                rpc::forge::Label {
+                    key: "key14".to_string(),
+                    value: None,
+                },
+                rpc::forge::Label {
+                    key: "key15".to_string(),
+                    value: None,
+                },
+                rpc::forge::Label {
+                    key: "key16".to_string(),
+                    value: None,
+                },
+                rpc::forge::Label {
+                    key: "key17".to_string(),
+                    value: None,
                 },],
             },
-            "Invalid value: Cannot have more than 10 labels".to_string()
+            "Invalid value: Cannot have more than 16 labels".to_string()
         ),
     ].to_vec();
 

--- a/crates/api-model/src/metadata.rs
+++ b/crates/api-model/src/metadata.rs
@@ -21,6 +21,9 @@ use serde::Deserialize;
 
 use crate::ConfigValidationError;
 
+/// Maximum number of labels allowed on a resource's metadata.
+const MAX_LABELS: usize = 16;
+
 /// Metadata that can get associated with Forge managed resources
 #[derive(Debug, Default, Clone, PartialEq, Eq, Deserialize)]
 pub struct Metadata {
@@ -96,9 +99,10 @@ impl Metadata {
             }
         }
 
-        if self.labels.len() > 10 {
+        if self.labels.len() > MAX_LABELS {
             return Err(ConfigValidationError::InvalidValue(format!(
-                "Cannot have more than 10 labels, got {}",
+                "Cannot have more than {} labels, got {}",
+                MAX_LABELS,
                 self.labels.len()
             )));
         }
@@ -230,11 +234,11 @@ mod tests {
             Err(ConfigValidationError::InvalidValue(_))
         ));
 
-        // Too many labels
+        // Too many labels (17 > 16)
         let metadata = Metadata {
             name: "nice name".to_string(),
             description: "anything is fine".to_string(),
-            labels: "abcdefghijk"
+            labels: "abcdefghijklmnopq"
                 .chars()
                 .map(|c| (c.to_string(), "x".to_string()))
                 .collect(),


### PR DESCRIPTION
## Description

Raising the per-resource metadata label cap from 10 to 16. Going to start storing some Launch Layer-derived metadata here, and while I don't want it to blow out, I want to go to at least 16. If it gets any larger, then yeah maybe we need structured data or shove it in some other field, which is probably why it got capped at 16 to begin with?

Tests updated.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

