### PR TITLE
docs: Machine Identity (SPIFFE)

### DIFF
--- a/book/src/configuration/configurability.md
+++ b/book/src/configuration/configurability.md
@@ -187,7 +187,7 @@ explicitly enabled in the TOML.
 | `[dsx_exchange_event_bus]` | MQTT event bus for managed-host state and BMS metadata | Requires MQTT broker. Pairs with the `nico-dsx-exchange-consumer` subchart. |
 | `[fnn]` | L3 VPC overlay networking (VXLAN) | Requires `routing_profiles` and route targets. |
 | `[spdm]` | SPDM hardware attestation (NRAS-based secure boot) | |
-| `[machine_identity]` | SPIFFE JWT-SVID issuance for tenant DPU identity | Per-org JWT signing. See [Day 0 Machine Identity](../../../docs/getting-started/installation-options/day0-machine-identity.md) and [Machine Identity (Day 1)](../../../docs/configuration/machine_identity.md). |
+| `[machine_identity]` | SPIFFE JWT-SVID issuance for machine (host) identity | Per-org JWT signing. See [Day 0 Machine Identity](../../../docs/getting-started/installation-options/day0-machine-identity.md) and [Machine Identity (Day 1)](../../../docs/configuration/machine_identity.md). |
 | `[measured_boot_collector]` | TPM-based attestation metrics | |
 | `[machine_validation_config]` | Pre-ingestion validation tests | |
 | `[component_manager]` | NvLink switch and power shelf management | |
@@ -1054,7 +1054,7 @@ on or off.
 | FNN (L3 VPC overlay) | siteConfig | `[fnn]` present | off | Tenant VPC networking via VXLAN; needs `routing_profiles` and route targets. |
 | Attestation | siteConfig | `attestation_enabled = true` | off | TPM-based machine attestation; adds a `Measuring` state before `Ready`. |
 | Measured Boot Metrics | siteConfig | `[measured_boot_collector].enabled` | off | Exporter for TPM-based attestation metrics. |
-| Machine Identity (SPIFFE JWT-SVID) | siteConfig | `[machine_identity].enabled` | off | Per-org JWT signing for tenant DPU identity tokens. See [Day 0](../../../docs/getting-started/installation-options/day0-machine-identity.md) and [Day 1](../../../docs/configuration/machine_identity.md) docs. |
+| Machine Identity (SPIFFE JWT-SVID) | siteConfig | `[machine_identity].enabled` | off | Per-org JWT signing for machine identity tokens. See [Day 0](../../../docs/getting-started/installation-options/day0-machine-identity.md) and [Day 1](../../../docs/configuration/machine_identity.md) docs. |
 | Machine Validation | siteConfig | `[machine_validation_config].enabled` | off | Pre-ingestion validation tests. |
 | SPDM | siteConfig | `[spdm].enabled` | off | Hardware attestation via NRAS. |
 | Rack Management | siteConfig | `rack_management_enabled = true` | off | Standalone infrastructure manager mode (GB200/GB300/VR144). |

--- a/book/src/configuration/configurability.md
+++ b/book/src/configuration/configurability.md
@@ -187,7 +187,7 @@ explicitly enabled in the TOML.
 | `[dsx_exchange_event_bus]` | MQTT event bus for managed-host state and BMS metadata | Requires MQTT broker. Pairs with the `nico-dsx-exchange-consumer` subchart. |
 | `[fnn]` | L3 VPC overlay networking (VXLAN) | Requires `routing_profiles` and route targets. |
 | `[spdm]` | SPDM hardware attestation (NRAS-based secure boot) | |
-| `[machine_identity]` | SPIFFE JWT-SVID issuance for tenant DPU identity | Per-org JWT signing. |
+| `[machine_identity]` | SPIFFE JWT-SVID issuance for tenant DPU identity | Per-org JWT signing. See [Day 0 Machine Identity](../../../docs/getting-started/installation-options/day0-machine-identity.md) and [Machine Identity (Day 1)](../../../docs/configuration/machine_identity.md). |
 | `[measured_boot_collector]` | TPM-based attestation metrics | |
 | `[machine_validation_config]` | Pre-ingestion validation tests | |
 | `[component_manager]` | NvLink switch and power shelf management | |
@@ -1054,7 +1054,7 @@ on or off.
 | FNN (L3 VPC overlay) | siteConfig | `[fnn]` present | off | Tenant VPC networking via VXLAN; needs `routing_profiles` and route targets. |
 | Attestation | siteConfig | `attestation_enabled = true` | off | TPM-based machine attestation; adds a `Measuring` state before `Ready`. |
 | Measured Boot Metrics | siteConfig | `[measured_boot_collector].enabled` | off | Exporter for TPM-based attestation metrics. |
-| Machine Identity (SPIFFE JWT-SVID) | siteConfig | `[machine_identity].enabled` | off | Per-org JWT signing for tenant DPU identity tokens. |
+| Machine Identity (SPIFFE JWT-SVID) | siteConfig | `[machine_identity].enabled` | off | Per-org JWT signing for tenant DPU identity tokens. See [Day 0](../../../docs/getting-started/installation-options/day0-machine-identity.md) and [Day 1](../../../docs/configuration/machine_identity.md) docs. |
 | Machine Validation | siteConfig | `[machine_validation_config].enabled` | off | Pre-ingestion validation tests. |
 | SPDM | siteConfig | `[spdm].enabled` | off | Hardware attestation via NRAS. |
 | Rack Management | siteConfig | `rack_management_enabled = true` | off | Standalone infrastructure manager mode (GB200/GB300/VR144). |

--- a/docs/configuration/machine_identity.md
+++ b/docs/configuration/machine_identity.md
@@ -4,7 +4,7 @@ Operator guide for per-organization **machine identity** configuration: JWT-SVID
 
 This is a **Day 1 (Configuration)** activity. Complete [Day 0 Machine Identity](../getting-started/installation-options/day0-machine-identity.md) first — site secrets, `[machine_identity]` in site config, and a healthy `nico-api` with `enabled = true`.
 
-The primary management surface is the **NICo REST API** (`nico-rest-api`). Use `nicocli` (TUI or REST-backed commands where available), `curl`, or your automation against the endpoints below. `SignMachineIdentity` is called by DPUs over gRPC. A few admin-only RPCs (for example `GetTenantIdentityConfiguration`) are gRPC-only as well — use **`grpcurl`** with a Forge Admin CLI mTLS certificate; see [Generating client certificates](../manuals/nico-admin-cli.md#generating-client-certificates).
+The primary management surface is the **NICo REST API** (`nico-rest-api`). Use `nicocli` (TUI or REST-backed commands where available), `curl`, or your automation against the endpoints below.
 
 Design reference: [SPIFFE JWT-SVID SDD](../design/machine-identity/spiffe-svid-sdd.md).
 
@@ -94,7 +94,7 @@ nicocli tui
 
 The TUI prompts for issuer, audiences, TTL, optional `subjectPrefix`, and optional signing-key rotation.
 
-### Read and delete
+### Read and Delete
 
 ```bash
 # GET config + signing key metadata
@@ -118,7 +118,7 @@ When token delegation is configured, NICo issues a short-lived **intermediate** 
 
 **Endpoint:** `PUT /v2/org/{org}/nico/site/{siteID}/tenant-identity/token-delegation`
 
-> **Recommendation:** Token delegation causes `nico-api` to call the org-configured `tokenEndpoint` over HTTP(S). For external STS URLs, configure site-level egress controls in `[machine_identity]` during [Day 0](../getting-started/installation-options/day0-machine-identity.md):
+> **Recommendation:** Token delegation causes `nico-api` to call the org-configured `tokenEndpoint` over HTTP(S). For external token exchange URLs, configure site-level egress controls in `[machine_identity]` during [Day 0](../getting-started/installation-options/day0-machine-identity.md):
 >
 > - `token_endpoint_http_proxy` — route outbound token-exchange HTTP through a controlled egress proxy
 > - `token_endpoint_domain_allowlist` — restrict which hostnames tenants may register on `tokenEndpoint`
@@ -188,7 +188,7 @@ Requirements summary: `rotateKey: true`, `signingKeyOverlapSeconds` ≥ `tokenTt
 | `SignMachineIdentity` → invalid audience | Audience not in allowlist | Update `allowedAudiences` |
 | IMDS 403/404/503 | Agent limits, missing config, or signing failure | Check agent logs; verify Core reachable from DPU |
 | JWKS missing second key during rotation | Overlap expired or rotation not committed | Re-check GET config `signingKeys` |
-| Token delegation HTTP errors | STS unreachable, proxy misconfigured, allowlist block | Verify `token_endpoint_http_proxy` and domain allowlist; test STS from API network namespace |
+| Token delegation HTTP errors | Token exchange service unreachable, proxy misconfigured, allowlist block | Verify `token_endpoint_http_proxy` and domain allowlist; test token exchange service from API network namespace |
 
 ### Admin inspection (Core gRPC)
 

--- a/docs/configuration/machine_identity.md
+++ b/docs/configuration/machine_identity.md
@@ -1,0 +1,219 @@
+# Machine Identity (Day 1)
+
+Operator guide for per-organization **machine identity** configuration: JWT-SVID issuance for tenant workloads, optional RFC 8693 token delegation, discovery endpoints, verification, and signing-key rotation.
+
+This is a **Day 1 (Configuration)** activity. Complete [Day 0 Machine Identity](../getting-started/installation-options/day0-machine-identity.md) first — site secrets, `[machine_identity]` in site config, and a healthy `nico-api` with `enabled = true`.
+
+The primary management surface is the **NICo REST API** (`nico-rest-api`). Use `nicocli` (TUI or REST-backed commands where available), `curl`, or your automation against the endpoints below. `SignMachineIdentity` is called by DPUs over gRPC. A few admin-only RPCs (for example `GetTenantIdentityConfiguration`) are gRPC-only as well — use **`grpcurl`** with a Forge Admin CLI mTLS certificate; see [Generating client certificates](../manuals/nico-admin-cli.md#generating-client-certificates).
+
+Design reference: [SPIFFE JWT-SVID SDD](../design/machine-identity/spiffe-svid-sdd.md).
+
+---
+
+## Before You Start
+
+You should already have:
+
+- Day 0 machine identity enabled (`[machine_identity].enabled = true` and valid encryption keys).
+- A tenant org with at least one instance in `READY` (for end-to-end signing tests).
+- A user with **`TENANT_ADMIN`** in the target org (REST management APIs). KEK re-wrap is site-operator scope: **gRPC only today**, REST API planned — see [KEK rotation](../manuals/machine_identity_kek_rotation.md).
+
+Verify REST connectivity:
+
+```bash
+nicocli site list
+nicocli user get
+```
+
+Resolve your site id (UUID) — required in all tenant-identity URLs:
+
+```bash
+nicocli site list --output json
+```
+
+---
+
+## Overview
+
+| Concern | Where it lives |
+|---|---|
+| Global enable, algorithm, KEK id, TTL bounds, egress proxy | Site `[machine_identity]` — [Day 0 guide](../getting-started/installation-options/day0-machine-identity.md) |
+| Issuer, audiences, TTL, per-org enable, signing keys | Per-org `tenant-identity/config` (REST) |
+| RFC 8693 token exchange callback | Per-org `tenant-identity/token-delegation` (REST) |
+| Workload token fetch | IMDS `GET …/meta-data/identity` on the instance (DPU agent) |
+| Direct signing | Core gRPC `SignMachineIdentity` (DPU machine cert) |
+| Public keys | REST `.well-known/jwks.json`, `.well-known/spiffe/jwks.json`, `.well-known/openid-configuration` |
+
+---
+
+## 1. Create or Update Per-Org Identity Config
+
+**Endpoint:** `PUT /v2/org/{org}/nico/site/{siteID}/tenant-identity/config`
+
+**Role:** `TENANT_ADMIN` in `{org}`.
+
+On **first** PUT, Core generates a new ES256 per-org signing keypair, encrypts the private key with the site KEK, and stores it. Subsequent PUTs reuse the keypair unless you set `rotateKey: true`.
+
+### Minimal example (direct signing)
+
+Replace `{org}`, `{site-id}`, issuer host, and audience strings for your environment. The issuer is typically the NICo REST base URL for that org/site (it becomes the JWT `iss` claim):
+
+```bash
+curl -sS -X PUT \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/tenant-identity/config" \
+  -d '{
+    "enabled": true,
+    "issuer": "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}",
+    "defaultAudience": "tenant-api",
+    "allowedAudiences": ["tenant-api"],
+    "tokenTtlSeconds": 300
+  }'
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `issuer` | Yes | JWT `iss` / OIDC issuer — `https://`, `http://`, or `spiffe://` with DNS host |
+| `defaultAudience` | Yes | Used when a caller does not specify an audience |
+| `tokenTtlSeconds` | Yes | Must fall within site `token_ttl_min_sec` … `token_ttl_max_sec` |
+| `enabled` | No | Defaults to `true`; set `false` to pause issuance while keeping config |
+| `allowedAudiences` | No | Empty/omitted → stored as `[defaultAudience]` only |
+| `subjectPrefix` | No | SPIFFE prefix for JWT `sub`; if omitted, derived from issuer trust domain |
+
+Returns **`201 Created`** on first call, **`200 OK`** on update.
+
+### nicocli TUI
+
+Interactive flow:
+
+```bash
+nicocli tui
+> tenant-identity update
+```
+
+The TUI prompts for issuer, audiences, TTL, optional `subjectPrefix`, and optional signing-key rotation.
+
+### Read and delete
+
+```bash
+# GET config + signing key metadata
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/tenant-identity/config"
+
+# DELETE (removes config and keys for the org)
+curl -sS -X DELETE -H "Authorization: Bearer $TOKEN" \
+  "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/tenant-identity/config"
+```
+
+DELETE is appropriate when offboarding an org from machine identity entirely. It does not disable site-level `[machine_identity]`.
+
+---
+
+## 2. Optional — Token Delegation
+
+When token delegation is configured, NICo issues a short-lived **intermediate** JWT-SVID to your RFC 8693 token exchange server instead of signing the final workload token directly. Use this when the tenant layer must control final token shape or audience mapping.
+
+**Prerequisite:** `tenant-identity/config` must exist (`404` otherwise).
+
+**Endpoint:** `PUT /v2/org/{org}/nico/site/{siteID}/tenant-identity/token-delegation`
+
+> **Recommendation:** Token delegation causes `nico-api` to call the org-configured `tokenEndpoint` over HTTP(S). For external STS URLs, configure site-level egress controls in `[machine_identity]` during [Day 0](../getting-started/installation-options/day0-machine-identity.md):
+>
+> - `token_endpoint_http_proxy` — route outbound token-exchange HTTP through a controlled egress proxy
+> - `token_endpoint_domain_allowlist` — restrict which hostnames tenants may register on `tokenEndpoint`
+>
+> Together these mitigate SSRF-style risk if a tenant admin supplies an endpoint the API should not reach. They are optional at install time but **strongly recommended** for production sites that delegate to external hosts.
+
+Example (adjust fields to match your STS):
+
+```bash
+curl -sS -X PUT \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/tenant-identity/token-delegation" \
+  -d '{
+    "tokenEndpoint": "https://sts.example.com/oauth/token",
+    "subjectTokenType": "urn:ietf:params:oauth:token-type:jwt",
+    "subjectTokenAudience": "tenant-exchange",
+    "clientId": "nico-delegation",
+    "clientSecretBasic": "<secret>"
+  }'
+```
+
+> **PUT is full replace:** omitting `clientSecretBasic` on an update clears stored credentials. Re-supply secrets on every update that should keep basic auth.
+
+> **Note:** `tokenEndpoint` may use `http://` with an IP address (for example a node-local sidecar). NICo allows this for in-instance STS; use allowlists and network policy in production where appropriate.
+
+```bash
+# Remove delegation (return to direct signing)
+curl -sS -X DELETE -H "Authorization: Bearer $TOKEN" \
+  "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/tenant-identity/token-delegation"
+```
+
+---
+
+## 3. Discovery and Verification
+
+Full step-by-step checks (OIDC discovery, JWKS alignment, gRPC signing, IMDS, JWT claim validation): **[Machine Identity Verification](../manuals/machine_identity_verification.md)**.
+
+Quick reference:
+
+```bash
+curl -sS "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/.well-known/openid-configuration"
+curl -sS "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/.well-known/jwks.json"
+curl -sS "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/.well-known/spiffe/jwks.json"
+```
+
+nicocli TUI: `tenant-identity openid-configuration get`, `tenant-identity jwks get`, `tenant-identity spiffe-jwks get`.
+
+---
+
+## 4. Per-Org JWT Signing Key Rotation
+
+Rotates the org’s JWT signing keypair with JWKS overlap (distinct from [KEK rotation](../manuals/machine_identity_kek_rotation.md)).
+
+Full runbook: **[JWT Signing Key Rotation](../manuals/machine_identity_signing_key_rotation.md)**.
+
+Requirements summary: `rotateKey: true`, `signingKeyOverlapSeconds` ≥ `tokenTtlSeconds` and ≤ site `signing_key_overlap_max_sec`; omit overlap when not rotating.
+
+## 5. Troubleshooting
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| PUT config → `503` | Site `[machine_identity]` disabled or invalid | Fix Day 0 config; restart `nico-api` |
+| PUT config → `400` | Invalid issuer, TTL out of bounds, bad overlap | Check OpenAPI validation messages; align with site TTL/overlap max |
+| PUT delegation → `404` | No identity config for org | Create config first |
+| `SignMachineIdentity` → NotFound | No/disabled org config, instance not READY, wrong machine | GET config; check instance; confirm DPU cert matches instance |
+| `SignMachineIdentity` → invalid audience | Audience not in allowlist | Update `allowedAudiences` |
+| IMDS 403/404/503 | Agent limits, missing config, or signing failure | Check agent logs; verify Core reachable from DPU |
+| JWKS missing second key during rotation | Overlap expired or rotation not committed | Re-check GET config `signingKeys` |
+| Token delegation HTTP errors | STS unreachable, proxy misconfigured, allowlist block | Verify `token_endpoint_http_proxy` and domain allowlist; test STS from API network namespace |
+
+### Admin inspection (Core gRPC)
+
+Site operators with a **Forge Admin CLI** mTLS certificate can inspect config with **`grpcurl`** (no REST or `nico-admin-cli` subcommand for this RPC):
+
+```bash
+grpcurl -cacert … -cert … -key … \
+  carbide-api.forge:443 forge.Forge/GetTenantIdentityConfiguration \
+  -d '{"organization_id": "<org>"}'
+```
+
+Client cert setup: [Generating client certificates](../manuals/nico-admin-cli.md#generating-client-certificates).
+
+---
+
+## 6. Related Operations
+
+| Task | Document |
+|---|---|
+| Enable site-level machine identity | [Day 0 Machine Identity](../getting-started/installation-options/day0-machine-identity.md) |
+| Verify issuance end-to-end | [Machine Identity Verification](../manuals/machine_identity_verification.md) |
+| Rotate org JWT signing keys | [JWT Signing Key Rotation](../manuals/machine_identity_signing_key_rotation.md) |
+| Rotate site master encryption key (KEK) | [Master Encryption Key Rotation](../manuals/machine_identity_kek_rotation.md) |
+| Provision instances for tenants | [Tenant Management](tenant_management.md) |
+| DPU agent IMDS limits | [Day 0 — DPU agent section](../getting-started/installation-options/day0-machine-identity.md#3-configure-dpu-agent-machine-identity-optional) |
+| Full API and data model | [SPIFFE JWT-SVID SDD](../design/machine-identity/spiffe-svid-sdd.md) |
+
+REST API details: **Tenant Identity** tag in the [REST API Reference](../openapi/getting_started.md).

--- a/docs/configuration/machine_identity.md
+++ b/docs/configuration/machine_identity.md
@@ -134,10 +134,11 @@ curl -sS -X PUT \
   "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/tenant-identity/token-delegation" \
   -d '{
     "tokenEndpoint": "https://sts.example.com/oauth/token",
-    "subjectTokenType": "urn:ietf:params:oauth:token-type:jwt",
     "subjectTokenAudience": "tenant-exchange",
-    "clientId": "nico-delegation",
-    "clientSecretBasic": "<secret>"
+    "clientSecretBasic": {
+      "clientId": "nico-delegation",
+      "clientSecret": "<secret>"
+    }
   }'
 ```
 
@@ -196,8 +197,8 @@ Site operators with a **Forge Admin CLI** mTLS certificate can inspect config wi
 
 ```bash
 grpcurl -cacert … -cert … -key … \
-  carbide-api.forge:443 forge.Forge/GetTenantIdentityConfiguration \
-  -d '{"organization_id": "<org>"}'
+  -d '{"organization_id": "<org>"}' \
+  carbide-api.forge:443 forge.Forge/GetTenantIdentityConfiguration
 ```
 
 Client cert setup: [Generating client certificates](../manuals/nico-admin-cli.md#generating-client-certificates).

--- a/docs/configuration/tenant_management.md
+++ b/docs/configuration/tenant_management.md
@@ -14,7 +14,7 @@ This guide assumes you have completed the [Quick Start Guide](../getting-started
 - At least one site registered and in `Registered` status, with machines discovered and available for allocation.
 - `nicocli` installed (`make nico-cli` from the infra-controller-rest repo) and reachable on `$PATH`.
 
-If you plan to enable **machine identity** (SPIFFE JWT-SVID issuance for tenant instances), complete [Day 0 Machine Identity](../getting-started/installation-options/day0-machine-identity.md) before provisioning instances, then configure per-org identity after tenants exist — see [Machine Identity](machine_identity.md).
+If you plan to enable SPIFFE JWT-SVID **machine identity**, complete [Day 0 Machine Identity](../getting-started/installation-options/day0-machine-identity.md) before provisioning instances, then configure per-org identity after tenants exist — see [Machine Identity](machine_identity.md).
 
 > **Note on CLI naming**: Older docs reference `carbidecli` (built via `make carbide-cli`). It's the same source under a previous name. This guide uses `nicocli` (built via `make nico-cli`) consistently.
 

--- a/docs/configuration/tenant_management.md
+++ b/docs/configuration/tenant_management.md
@@ -14,6 +14,8 @@ This guide assumes you have completed the [Quick Start Guide](../getting-started
 - At least one site registered and in `Registered` status, with machines discovered and available for allocation.
 - `nicocli` installed (`make nico-cli` from the infra-controller-rest repo) and reachable on `$PATH`.
 
+If you plan to enable **machine identity** (SPIFFE JWT-SVID issuance for tenant instances), complete [Day 0 Machine Identity](../getting-started/installation-options/day0-machine-identity.md) before provisioning instances, then configure per-org identity after tenants exist — see [Machine Identity](machine_identity.md).
+
 > **Note on CLI naming**: Older docs reference `carbidecli` (built via `make carbide-cli`). It's the same source under a previous name. This guide uses `nicocli` (built via `make nico-cli`) consistently.
 
 For nicocli mechanics and conventions (flag ordering, `api.name` selection, `--data` vs flag forms, output formats, pagination, `--debug`), see the nicocli reference guide. The examples in this guide assume you've read it.

--- a/docs/getting-started/installation-options/day0-machine-identity.md
+++ b/docs/getting-started/installation-options/day0-machine-identity.md
@@ -1,0 +1,198 @@
+# Day 0 Machine Identity Configuration
+
+This guide is the Day 0 reference for enabling **machine identity** (SPIFFE JWT-SVID issuance) at the site level. It covers the secrets, site config, and DPU agent settings that must be in place before any tenant can configure per-org identity (a Day 1 activity).
+
+Machine identity lets tenant workloads on provisioned instances obtain short-lived JWT tokens that assert a SPIFFE ID. NICo signs those tokens when a DPU calls the Core gRPC API or when a workload reads the instance metadata service (IMDS). Per-org issuer, audiences, and TTL are configured later — see [Machine Identity (Day 1)](../configuration/machine_identity.md).
+
+The design and API details live in the [SPIFFE JWT-SVID SDD](../../design/machine-identity/spiffe-svid-sdd.md). This page focuses on what an operator configures once during initial site bring-up.
+
+---
+
+## Prerequisites
+
+Before starting:
+
+- A running NICo deployment with healthy `nico-api` (Core) and `nico-rest-api` (REST).
+- Site config (`siteConfig` in `helm-prereqs/values/ncx-core.yaml` or equivalent) is already wired for your site — see [Quick Start Guide, Step 3](../quick-start.md#step-3--configure-the-site).
+
+This page assumes you have completed [Day 0 IP and Network Configuration](day0-ip-network-config.md) or equivalent network bring-up.
+
+---
+
+## What Day 0 Enables
+
+Day 0 configuration turns on the **site-wide** machinery:
+
+| Layer | What you configure | Effect |
+|---|---|---|
+| Site secrets | `machine_identity.encryption_keys` | AES keys used to encrypt per-org signing private keys at rest |
+| Site config | `[machine_identity]` in `site_config.toml` | Global enable switch, algorithm, current encryption key id, optional TTL bounds and egress controls |
+| DPU agent | Optional `[machine-identity]` | Rate limits and timeouts for IMDS `GET …/meta-data/identity` (not stored in site config) |
+
+Per-org settings (`issuer`, audiences, TTL, token delegation) are **not** Day 0 — they are created with `PUT …/tenant-identity/config` after Day 0 is complete.
+
+---
+
+## 1. Generate Master Encryption Keys
+
+Per-org JWT signing private keys are encrypted at rest with a **site master encryption key** (KEK). Generate one or more 256-bit keys and store them in site credentials.
+
+```bash
+openssl rand -base64 32
+```
+
+Record each key under a stable id (for example `kv1`, `kv2`). The id must match `current_encryption_key_id` in site config.
+
+### File-backed credentials
+
+When using a local credential snapshot (development or file-based deployments), add a `machine_identity` block:
+
+```json
+{
+  "machine_identity": {
+    "encryption_keys": {
+      "kv1": "<base64-encoded-32-byte-key>"
+    }
+  }
+}
+```
+
+### Vault-backed credentials
+
+In Vault deployments, store each key at a path that resolves to `machine_identity/encryption_keys/<key-id>` in the credential loader (for example `…/machine_identity/encryption_keys/kv1`). Follow the same secret-management process you use for other NICo site credentials.
+
+> **Important:** Keep all key ids that appear in stored ciphertext until you complete a KEK re-wrap. Decrypt always uses the `key_id` embedded in each encrypted blob, not the site’s current key id alone. See [Master Encryption Key Rotation (KEK)](../manuals/machine_identity_kek_rotation.md).
+
+---
+
+## 2. Configure Site `[machine_identity]`
+
+Add or update the `[machine_identity]` section in the NICo API site config. In Helm deployments this is typically `helm/charts/nico-api/files/carbide-api-config.toml` (rendered into the `nico-api` ConfigMap) or the `siteConfig` overlay you maintain for your environment.
+
+```toml
+[machine_identity]
+enabled = true
+current_encryption_key_id = "kv1"   # must match a key in site secrets
+algorithm = "ES256"                 # only ES256 is supported today
+
+# Optional bounds enforced on per-org tokenTtlSeconds (defaults are documented in the SDD)
+# token_ttl_min_sec = 60
+# token_ttl_max_sec = 86400
+
+# Optional: max signing_key_overlap_seconds on per-org JWT signing-key rotation
+# signing_key_overlap_max_sec = 604800
+
+# Optional: egress proxy for token delegation (RFC 8693) — see Day 1 guide
+# token_endpoint_http_proxy = "https://nico-egress-proxy.example.com"
+
+# Optional hostname allowlists (empty = no extra restriction beyond API validation)
+# trust_domain_allowlist = ["*.example.com"]
+# token_endpoint_domain_allowlist = ["sts.example.com", "*.tenant.example.com"]
+```
+
+### Field reference (Day 0)
+
+| Field | Required when `enabled = true` | Notes |
+|---|---|---|
+| `enabled` | — | `false` disables the feature; per-org PUT returns `503` |
+| `algorithm` | Yes | Must be `ES256` |
+| `current_encryption_key_id` | Yes | Must exist in `machine_identity.encryption_keys` secrets |
+| `token_ttl_min_sec` / `token_ttl_max_sec` | No | Bounds for per-org `tokenTtlSeconds` |
+| `signing_key_overlap_max_sec` | No | Upper bound for per-org signing-key rotation overlap |
+| `token_endpoint_http_proxy` | No | Recommended when using token delegation to external HTTPS STS endpoints |
+| `trust_domain_allowlist` | No | Restricts per-org JWT `issuer` trust domains |
+| `token_endpoint_domain_allowlist` | No | Restricts token delegation `token_endpoint` hosts |
+
+### Startup behavior
+
+| Scenario | Behavior |
+|---|---|
+| `[machine_identity]` section missing | Feature disabled; API starts normally |
+| Section present, `enabled = false` | Feature disabled; per-org APIs return `503` |
+| Section present, `enabled = true`, invalid or incomplete | **API fails to start** — fix config before rollout |
+| Section present, valid, `enabled = true` | Feature operational |
+
+After editing site config or secrets, **restart `nico-api`** (site config for `[machine_identity]` is not hot-reloaded).
+
+---
+
+## 3. Configure DPU Agent `[machine-identity]` (Optional)
+
+IMDS identity requests are served by the DPU agent (and standalone FMDS when used). Limits and an optional HTTP sign-proxy are configured on the agent, **not** in the API site config.
+
+Defaults apply when the section is omitted:
+
+| Setting | Default | Description |
+|---|---|---|
+| `requests-per-second` | 3 | Sustained admission rate for IMDS identity GETs (GCRA refill rate). Limits how many signing requests the agent accepts per second over time. |
+| `burst` | 8 | Maximum burst above the sustained rate before new requests must wait or are rejected. Allows short spikes without immediately hitting the limit. |
+| `wait-timeout-secs` | 2 | How long a request may block waiting for a rate-limit permit. If no capacity becomes available within this window, the agent fails the request (avoids indefinite queueing). |
+| `sign-timeout-secs` | 5 | Wall-clock timeout for the signing step — either Forge gRPC `SignMachineIdentity` or the optional HTTP sign-proxy call. |
+| `sign-proxy-url` | *(unset)* | Optional base URL for HTTP pass-through signing. When set, the agent forwards `GET {url}/latest/meta-data/identity` with the same query string instead of calling Forge gRPC. Scheme must be `http` or `https`. |
+| `sign-proxy-tls-root-ca` | *(unset)* | Optional path to a PEM file of trusted CA roots for an **`https`** sign-proxy URL (for example a private CA). Ignored for `http:` URLs. Requires `sign-proxy-url`. |
+
+Example override in the agent config file (see `crates/agent/example_agent_config.toml`):
+
+```toml
+[machine-identity]
+requests-per-second = 3
+burst = 8
+wait-timeout-secs = 2
+sign-timeout-secs = 5
+# sign-proxy-url = "https://sign-proxy.example.com/prefix"
+# sign-proxy-tls-root-ca = "/etc/forge/sign_proxy_root.pem"
+```
+
+When `sign-proxy-url` is set, the agent forwards signing to an HTTP proxy instead of calling Forge gRPC directly. Use this only when your architecture requires an out-of-band signing path.
+
+Restart or redeploy DPU agents after changing this section.
+
+---
+
+## 4. Apply and Verify Site-Level Enablement
+
+### 4.1 Confirm API startup
+
+After rollout, verify `nico-api` pods are running and logs show no machine-identity config errors:
+
+```bash
+kubectl logs -n <nico-namespace> deploy/nico-api --tail=100
+```
+
+If `[machine_identity]` is enabled but secrets or required fields are wrong, the pod will crash-loop until fixed.
+
+### 4.2 Confirm global gate (expected before Day 1)
+
+Before any org has identity config, per-org REST calls correctly return **`503 Service Unavailable`** (machine identity not enabled at site level is indistinguishable from “enabled globally but not configured for org” until you complete Day 1):
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H "Authorization: Bearer $TOKEN" \
+  "https://<nico-rest>/v2/org/<org>/nico/site/<site-id>/tenant-identity/config"
+```
+
+Once Day 0 is complete and `enabled = true`, this endpoint returns **`404`** (no config yet) or **`200`** (after Day 1), not `503`.
+
+After Day 1 config and a READY instance, run the [Machine Identity Verification](../manuals/machine_identity_verification.md) runbook for gRPC and IMDS smoke tests.
+
+---
+
+## Troubleshooting
+
+Day 0 verification uses API startup checks (§4.1) and the REST global gate (§4.2). Signing-path errors (`SignMachineIdentity`, IMDS) surface only after Day 1 and are covered in [Machine Identity Verification](../manuals/machine_identity_verification.md).
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| `nico-api` crash on startup | Missing/invalid `[machine_identity]` or unknown `current_encryption_key_id` | Fix TOML; ensure secrets contain the referenced key id |
+| Per-org GET/PUT returns `503` | Global `enabled = false` or invalid global config | Set `enabled = true` with valid required fields; restart API |
+
+---
+
+## Next Steps
+
+- [Machine Identity (Day 1)](../configuration/machine_identity.md) — per-org issuer, audiences, token delegation, JWKS/OIDC verification
+- [Machine Identity Verification](../manuals/machine_identity_verification.md) — end-to-end checks after Day 1
+- [JWT Signing Key Rotation](../manuals/machine_identity_signing_key_rotation.md) — per-org signing key rotation
+- [Master Encryption Key Rotation (KEK)](../manuals/machine_identity_kek_rotation.md) — rotate site master keys safely
+- [Tenant Management](../configuration/tenant_management.md) — allocate instances before workloads need tokens
+- [SPIFFE JWT-SVID SDD](../../design/machine-identity/spiffe-svid-sdd.md) — full design reference

--- a/docs/getting-started/installation-options/day0-machine-identity.md
+++ b/docs/getting-started/installation-options/day0-machine-identity.md
@@ -2,7 +2,7 @@
 
 This guide is the Day 0 reference for enabling **machine identity** (SPIFFE JWT-SVID issuance) at the site level. It covers the secrets, site config, and DPU agent settings that must be in place before any tenant can configure per-org identity (a Day 1 activity).
 
-Machine identity lets tenant workloads on provisioned instances obtain short-lived JWT tokens that assert a SPIFFE ID. NICo signs those tokens when a DPU calls the Core gRPC API or when a workload reads the instance metadata service (IMDS). Per-org issuer, audiences, and TTL are configured later — see [Machine Identity (Day 1)](../configuration/machine_identity.md).
+Machine identity lets tenant workloads on provisioned instances obtain short-lived JWT tokens that assert a SPIFFE ID. NICo signs those tokens when a DPU calls the Core gRPC API or when a workload reads the instance metadata service (IMDS). Per-org issuer, audiences, and TTL are configured later — see [Machine Identity (Day 1)](../../configuration/machine_identity.md).
 
 The design and API details live in the [SPIFFE JWT-SVID SDD](../../design/machine-identity/spiffe-svid-sdd.md). This page focuses on what an operator configures once during initial site bring-up.
 
@@ -61,7 +61,7 @@ When using a local credential snapshot (development or file-based deployments), 
 
 In Vault deployments, store each key at a path that resolves to `machine_identity/encryption_keys/<key-id>` in the credential loader (for example `…/machine_identity/encryption_keys/kv1`). Follow the same secret-management process you use for other NICo site credentials.
 
-> **Important:** Keep all key ids that appear in stored ciphertext until you complete a KEK re-wrap. Decrypt always uses the `key_id` embedded in each encrypted blob, not the site’s current key id alone. See [Master Encryption Key Rotation (KEK)](../manuals/machine_identity_kek_rotation.md).
+> **Important:** Keep all key ids that appear in stored ciphertext until you complete a KEK re-wrap. Decrypt always uses the `key_id` embedded in each encrypted blob, not the site’s current key id alone. See [Master Encryption Key Rotation (KEK)](../../manuals/machine_identity_kek_rotation.md).
 
 ---
 
@@ -173,13 +173,13 @@ curl -s -o /dev/null -w '%{http_code}\n' \
 
 Once Day 0 is complete and `enabled = true`, this endpoint returns **`404`** (no config yet) or **`200`** (after Day 1), not `503`.
 
-After Day 1 config and a READY instance, run the [Machine Identity Verification](../manuals/machine_identity_verification.md) runbook for gRPC and IMDS smoke tests.
+After Day 1 config and a READY instance, run the [Machine Identity Verification](../../manuals/machine_identity_verification.md) runbook for gRPC and IMDS smoke tests.
 
 ---
 
 ## Troubleshooting
 
-Day 0 verification uses API startup checks (§4.1) and the REST global gate (§4.2). Signing-path errors (`SignMachineIdentity`, IMDS) surface only after Day 1 and are covered in [Machine Identity Verification](../manuals/machine_identity_verification.md).
+Day 0 verification uses API startup checks (§4.1) and the REST global gate (§4.2). Signing-path errors (`SignMachineIdentity`, IMDS) surface only after Day 1 and are covered in [Machine Identity Verification](../../manuals/machine_identity_verification.md).
 
 | Symptom | Likely cause | Action |
 |---|---|---|
@@ -190,9 +190,9 @@ Day 0 verification uses API startup checks (§4.1) and the REST global gate (§4
 
 ## Next Steps
 
-- [Machine Identity (Day 1)](../configuration/machine_identity.md) — per-org issuer, audiences, token delegation, JWKS/OIDC verification
-- [Machine Identity Verification](../manuals/machine_identity_verification.md) — end-to-end checks after Day 1
-- [JWT Signing Key Rotation](../manuals/machine_identity_signing_key_rotation.md) — per-org signing key rotation
-- [Master Encryption Key Rotation (KEK)](../manuals/machine_identity_kek_rotation.md) — rotate site master keys safely
-- [Tenant Management](../configuration/tenant_management.md) — allocate instances before workloads need tokens
+- [Machine Identity (Day 1)](../../configuration/machine_identity.md) — per-org issuer, audiences, token delegation, JWKS/OIDC verification
+- [Machine Identity Verification](../../manuals/machine_identity_verification.md) — end-to-end checks after Day 1
+- [JWT Signing Key Rotation](../../manuals/machine_identity_signing_key_rotation.md) — per-org signing key rotation
+- [Master Encryption Key Rotation (KEK)](../../manuals/machine_identity_kek_rotation.md) — rotate site master keys safely
+- [Tenant Management](../../configuration/tenant_management.md) — allocate instances before workloads need tokens
 - [SPIFFE JWT-SVID SDD](../../design/machine-identity/spiffe-svid-sdd.md) — full design reference

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -57,6 +57,8 @@ navigation:
             - page: DPF Setup for NICo Integration
               path: manuals/dpf.md
               slug: dpf-setup
+            - page: Day 0 Machine Identity
+              path: getting-started/installation-options/day0-machine-identity.md
           slug: installation-options
 
     - section: Architecture
@@ -119,6 +121,8 @@ navigation:
           path: configuration/tenant_management.md
         - page: Organization & Permissions
           path: configuration/org-permissions.md
+        - page: Machine Identity
+          path: configuration/machine_identity.md
 
     - section: Operations (Day 2)
       contents:
@@ -142,6 +146,12 @@ navigation:
           path: manuals/networking/network_security_groups.md
         - page: InfiniBand Partitioning
           path: manuals/networking/infiniband_partitioning.md
+        - page: Machine Identity KEK Rotation
+          path: manuals/machine_identity_kek_rotation.md
+        - page: Machine Identity Verification
+          path: manuals/machine_identity_verification.md
+        - page: Machine Identity Signing Key Rotation
+          path: manuals/machine_identity_signing_key_rotation.md
         - page: NVLink Partitioning
           path: manuals/nvlink_partitioning.md
         - page: Rack-Level Administration (RLA)

--- a/docs/manuals/machine_identity_kek_rotation.md
+++ b/docs/manuals/machine_identity_kek_rotation.md
@@ -86,20 +86,21 @@ Call **`ReencryptTenantIdentitySecrets`** with `dry_run: true`. Optionally scope
 
 ```bash
 grpcurl -cacert … -cert … -key … \
-  carbide-api.forge:443 forge.Forge/ReencryptTenantIdentitySecrets \
   -d '{
     "dry_run": true
-  }'
+  }' \
+  carbide-api.forge:443 forge.Forge/ReencryptTenantIdentitySecrets
 ```
 
 Single org:
 
 ```bash
-grpcurl … forge.Forge/ReencryptTenantIdentitySecrets \
+grpcurl -cacert … -cert … -key … \
   -d '{
     "organization_id": "<org>",
     "dry_run": true
-  }'
+  }' \
+  carbide-api.forge:443 forge.Forge/ReencryptTenantIdentitySecrets
 ```
 
 Inspect the response:
@@ -120,10 +121,11 @@ Inspect the response:
 Repeat with `dry_run: false`:
 
 ```bash
-grpcurl … forge.Forge/ReencryptTenantIdentitySecrets \
+grpcurl -cacert … -cert … -key … \
   -d '{
     "dry_run": false
-  }'
+  }' \
+  carbide-api.forge:443 forge.Forge/ReencryptTenantIdentitySecrets
 ```
 
 Verify:

--- a/docs/manuals/machine_identity_kek_rotation.md
+++ b/docs/manuals/machine_identity_kek_rotation.md
@@ -1,0 +1,170 @@
+# Master Encryption Key Rotation (Machine Identity KEK)
+
+Runbook for rotating the **site master encryption key** used to protect per-org JWT signing private keys and token-delegation credentials at rest.
+
+This is **not** the same as **per-org JWT signing key rotation** (see [JWT Signing Key Rotation](machine_identity_signing_key_rotation.md)).
+
+Design background: [SPIFFE JWT-SVID SDD §3.1.1](../design/machine-identity/spiffe-svid-sdd.md).
+
+> **API surface:** Re-wrap is **Core gRPC only today** (`ReencryptTenantIdentitySecrets` via `grpcurl` with a Forge Admin CLI mTLS certificate). A **NICo REST API** for the same operation is planned; this runbook will be updated when it ships. There is no `nico-admin-cli` subcommand for re-wrap.
+
+---
+
+## Concepts
+
+| Concept | Location |
+|---|---|
+| Current KEK id (used for **new** encrypts) | `[machine_identity].current_encryption_key_id` in site config |
+| Key material | Site secrets `machine_identity.encryption_keys.<key-id>` (base64-encoded 32-byte AES key) |
+| Key id for an existing blob | Embedded **`key_id`** inside each ciphertext envelope in the database |
+
+Decrypt always loads the AES key named by the envelope’s embedded `key_id`. The site `current_encryption_key_id` only selects which key is used when **writing** new ciphertext.
+
+Fields re-wrapped per org (when present):
+
+- `encrypted_signing_key_1`
+- `encrypted_signing_key_2`
+- `encrypted_auth_method_config` (token delegation credentials)
+
+---
+
+## Prerequisites
+
+- `[machine_identity].enabled = true` and a healthy `nico-api`.
+- Credentials to invoke re-wrap: today, a **Forge Admin CLI** mTLS client certificate (see [Generating client certificates](../manuals/nico-admin-cli.md#generating-client-certificates)). When the REST API is available, provider-admin access via `nicocli` / bearer token will be an alternative.
+- Maintenance window: plan for a config change + API restart + one re-encrypt pass. Issuance can continue during re-wrap if old keys remain in secrets.
+
+---
+
+## Procedure
+
+Example rotation: `kv1` → `kv2`.
+
+### Step 1 — Add the new key to secrets
+
+Generate material:
+
+```bash
+openssl rand -base64 32
+```
+
+Add `kv2` to site credentials **without removing `kv1`**:
+
+```json
+{
+  "machine_identity": {
+    "encryption_keys": {
+      "kv1": "<existing-key>",
+      "kv2": "<new-key>"
+    }
+  }
+}
+```
+
+For Vault-backed sites, add `…/machine_identity/encryption_keys/kv2` using your standard secret workflow.
+
+Deploy/refresh credentials so `nico-api` can read both keys.
+
+### Step 2 — Point site config at the new key and restart API
+
+Update site config:
+
+```toml
+[machine_identity]
+enabled = true
+current_encryption_key_id = "kv2"
+algorithm = "ES256"
+```
+
+Restart `nico-api` (this setting is **not** hot-reloaded). New encrypts (new orgs, signing-key rotation, delegation updates) use `kv2` immediately. Existing DB rows still decrypt with `kv1` via envelope metadata.
+
+### Step 3 — Dry-run re-wrap
+
+> **Today (gRPC):** use `grpcurl` as below. **Planned:** equivalent dry-run/apply via NICo REST — watch this page and the REST API reference for updates.
+
+Call **`ReencryptTenantIdentitySecrets`** with `dry_run: true`. Optionally scope to one org.
+
+```bash
+grpcurl -cacert … -cert … -key … \
+  carbide-api.forge:443 forge.Forge/ReencryptTenantIdentitySecrets \
+  -d '{
+    "dry_run": true
+  }'
+```
+
+Single org:
+
+```bash
+grpcurl … forge.Forge/ReencryptTenantIdentitySecrets \
+  -d '{
+    "organization_id": "<org>",
+    "dry_run": true
+  }'
+```
+
+Inspect the response:
+
+| Field | Meaning |
+|---|---|
+| `current_encryption_key_id` | Target KEK id from site config (`kv2`) |
+| `rows_examined` | Rows scanned |
+| `fields_reencrypted` | Fields that **would** be re-wrapped (dry run) |
+| `fields_skipped_on_target` | Already on target key — OK |
+| `rows_skipped_all_on_target` | Entire row already on target — OK |
+| `rows_failed` / `failures` | Must be zero before apply |
+
+**Success criterion for dry run:** no failures; every row either skipped as already on target or listed for re-encryption.
+
+### Step 4 — Apply re-wrap
+
+Repeat with `dry_run: false`:
+
+```bash
+grpcurl … forge.Forge/ReencryptTenantIdentitySecrets \
+  -d '{
+    "dry_run": false
+  }'
+```
+
+Verify:
+
+- `rows_failed = 0`
+- After apply, a second dry run shows only `rows_skipped_all_on_target` / `fields_skipped_on_target`
+
+### Step 5 — Retire the old key (optional)
+
+After a successful apply and verification:
+
+1. Confirm no ciphertext still references `kv1` (second dry run with `current_encryption_key_id = "kv2"` should skip all rows).
+2. Remove `kv1` from `machine_identity.encryption_keys` in secrets.
+3. Redeploy credentials. Do **not** remove `kv1` until re-wrap completes — decrypt would fail for any remaining `kv1` envelopes.
+
+---
+
+## Rollback
+
+If apply fails partway:
+
+- **Keep both keys** in secrets.
+- Leave `current_encryption_key_id` at `kv2` (or revert to `kv1` only if you have **not** written new ciphertext with `kv2` yet).
+- Fix the reported `failures` (often missing key material or corrupt envelope).
+- Re-run dry run, then apply.
+
+If you must revert `current_encryption_key_id` to `kv1` before re-wrap completes, new writes use `kv1` again; rows already re-wrapped to `kv2` still decrypt with `kv2` until you re-run re-encrypt toward `kv1`.
+
+---
+
+## Operational Notes
+
+- Run re-wrap after **every** change to `current_encryption_key_id`.
+- Re-wrap is idempotent: rows already on the target key are skipped.
+- Org-scoped runs are useful for phased rollout; site-wide run (`organization_id` omitted) is typical for small fleets.
+- Coordinate with [JWT signing key rotation](../manuals/machine_identity_signing_key_rotation.md) — they are independent, but both affect what verifiers and decrypt paths must tolerate.
+
+---
+
+## Related Documentation
+
+- [Day 0 Machine Identity](../getting-started/installation-options/day0-machine-identity.md) — initial KEK provisioning
+- [Machine Identity (Day 1)](../configuration/machine_identity.md) — per-org config and JWT signing-key rotation
+- [SPIFFE JWT-SVID SDD §3.1.1](../design/machine-identity/spiffe-svid-sdd.md) — authoritative design

--- a/docs/manuals/machine_identity_signing_key_rotation.md
+++ b/docs/manuals/machine_identity_signing_key_rotation.md
@@ -1,0 +1,157 @@
+# Per-Org JWT Signing Key Rotation
+
+Runbook for rotating an organization’s **JWT signing keypair** used to issue SPIFFE JWT-SVIDs. Verifiers consume the rotation through JWKS overlap — no change to workload IMDS URLs.
+
+This is **not** [site master encryption key (KEK) rotation](machine_identity_kek_rotation.md), which re-wraps private keys at rest and does not publish new JWKS entries by itself.
+
+---
+
+## Concepts
+
+| Concept | Detail |
+|---|---|
+| Key slots | Each org stores up to **two** encrypted signing keypairs (`slot 1` / `slot 2`) |
+| Current signer | Exactly one slot is active for new signatures |
+| Overlap window | After rotation, the **previous** public key stays in JWKS for `signingKeyOverlapSeconds` |
+| Overlap end | Stored as `expireAt` on the inactive signing key in GET config; not a separate DB column |
+
+During overlap, tokens signed with either key must verify. After overlap, JWKS drops the retired key.
+
+---
+
+## Prerequisites
+
+- Per-org identity config already exists ([Day 1](../configuration/machine_identity.md)).
+- **`TENANT_ADMIN`** in the target org (REST API).
+- Know current `tokenTtlSeconds` for the org — overlap must be **≥** this value.
+- Know site `signing_key_overlap_max_sec` (Day 0 `[machine_identity]`) — overlap must be **≤** this bound.
+- Verifiers fetch JWKS from your published URLs — confirm they poll or cache with TTL ≤ overlap if they need seamless rotation.
+
+---
+
+## Plan Overlap Duration
+
+Choose `signingKeyOverlapSeconds` before rotating:
+
+```
+signingKeyOverlapSeconds ≥ tokenTtlSeconds
+signingKeyOverlapSeconds ≤ site signing_key_overlap_max_sec
+```
+
+Practical guidance:
+
+- **Minimum:** equal to `tokenTtlSeconds` so tokens issued just before rotation remain valid until `exp`.
+- **Recommended:** `tokenTtlSeconds` plus verifier JWKS cache TTL plus a small buffer (for example 2× TTL or cache TTL + 300s, whichever is larger, capped by site max).
+- **Long-lived tokens:** if you increase `tokenTtlSeconds`, plan overlap accordingly on the next rotation.
+
+Example: `tokenTtlSeconds = 300`, verifier caches JWKS for 600s → use at least `600`, often `900` if within site max.
+
+---
+
+## Procedure
+
+### Step 1 — Record current state
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/tenant-identity/config" \
+  | jq '{enabled, tokenTtlSeconds, signingKeys}'
+```
+
+Note the current signer and whether a previous rotation overlap is already in progress (two keys with `expireAt` on the inactive entry).
+
+### Step 2 — Rotate via REST
+
+PUT the full config with `rotateKey: true` and required overlap. All other required fields must be supplied (PUT replaces config semantics for rotation path — include issuer, audiences, TTL):
+
+```bash
+curl -sS -X PUT \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/tenant-identity/config" \
+  -d '{
+    "enabled": true,
+    "issuer": "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}",
+    "defaultAudience": "tenant-api",
+    "allowedAudiences": ["tenant-api"],
+    "tokenTtlSeconds": 300,
+    "rotateKey": true,
+    "signingKeyOverlapSeconds": 600
+  }'
+```
+
+Returns **`200 OK`**. Core generates a fresh ES256 keypair in the inactive slot, switches the current signer, and sets the overlap timer for the previous key.
+
+**Do not** send `signingKeyOverlapSeconds` when `rotateKey` is false — the API rejects it.
+
+### Step 3 — Rotate via nicocli TUI (alternative)
+
+```bash
+nicocli tui
+> tenant-identity update
+```
+
+Answer **yes** to `rotateKey`, then enter `signingKeyOverlapSeconds` when prompted.
+
+### Step 4 — Verify overlap is active
+
+**Config:**
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/tenant-identity/config" \
+  | jq '.signingKeys'
+```
+
+Expect two entries: one with `"currentSigner": true`, one with `"expireAt"` (ISO timestamp).
+
+**JWKS:**
+
+```bash
+curl -sS "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/.well-known/jwks.json" | jq '.keys | length'
+```
+
+Should be **`2`** during overlap. See [Machine Identity Verification](machine_identity_verification.md) for full checks.
+
+**Issuance:** sign a token (gRPC or IMDS) and confirm the JWT header `kid` matches the new current signer.
+
+### Step 5 — Wait for overlap to complete
+
+No operator action is required to retire the old key from JWKS — Core drops it after `expireAt`.
+
+Before decommissioning verifier config that references the old `kid`:
+
+1. Wait until `expireAt` is in the past.
+2. Re-fetch JWKS — only one key should remain.
+3. Confirm no in-flight tokens need the old key (all issued before overlap end have expired).
+
+---
+
+## Rotation Without Config Changes
+
+You can rotate keys without changing issuer, audiences, or TTL — supply the same values as GET config returns, plus `rotateKey` and `signingKeyOverlapSeconds`.
+
+If you **also** need to change `tokenTtlSeconds`, you may do both in one PUT; recompute overlap against the **new** TTL.
+
+To pause issuance without deleting config, set `"enabled": false` in a normal PUT (no rotation). Re-enable with `"enabled": true` when ready.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| PUT → `400` on overlap | Overlap &lt; TTL or &gt; site max | Adjust `signingKeyOverlapSeconds` |
+| PUT → `400` overlap without rotate | `signingKeyOverlapSeconds` sent alone | Omit overlap unless `rotateKey: true` |
+| JWKS still one key after rotate | Propagation delay or rotation failed | Re-check GET `signingKeys`; retry PUT if only one slot updated |
+| Verifiers fail after rotate | Cache stale JWKS or overlap too short | Increase overlap; lower verifier cache TTL |
+| Two keys forever | Overlap timer not expiring | Inspect `expireAt`; check Core logs; confirm clock sync |
+
+---
+
+## Related Documentation
+
+- [Machine Identity Verification](machine_identity_verification.md) — JWKS, gRPC, and IMDS checks after rotation
+- [Machine Identity (Day 1)](../configuration/machine_identity.md) — initial org config and token delegation
+- [Master Encryption Key Rotation (KEK)](machine_identity_kek_rotation.md) — site master key at rest (orthogonal to JWKS)
+- [SPIFFE JWT-SVID SDD](../design/machine-identity/spiffe-svid-sdd.md) — authoritative design

--- a/docs/manuals/machine_identity_verification.md
+++ b/docs/manuals/machine_identity_verification.md
@@ -159,12 +159,30 @@ Or use [jwt.io](https://jwt.io) in non-production environments only — do not p
 |---|---|
 | Discovery/JWKS 404 | Confirm org, site id, and REST routing; config must exist |
 | JWKS empty | Org config missing or disabled; check GET config |
-| IMDS 403/404/503/timeout | Agent logs, Core reachability from DPU, agent `sign-timeout-secs`; try [DPU-side debugging](#dpu-side-debugging-optional) |
+| IMDS 403/404/503/timeout | Agent logs, `sign-timeout-secs`, Core or sign-proxy reachability; see [DPU-side debugging](#dpu-side-debugging-optional) |
 | Valid JWT, verifier rejects | Clock skew, wrong JWKS URL, overlap ended for old `kid`, wrong `iss`/`aud` check |
 
 ### DPU-side debugging (optional)
 
-Use this only when IMDS fails and you need to isolate the DPU agent from Core signing. Requires shell access on the DPU and its machine certificate (`/opt/forge/machine_cert.pem`, paths may vary):
+When IMDS fails, check the DPU agent first: logs, `[machine-identity]` rate limits, and `sign-timeout-secs` ([Day 0](../getting-started/installation-options/day0-machine-identity.md#3-configure-dpu-agent-machine-identity-optional)).
+
+If the agent has **`sign-proxy-url`** set, IMDS forwards to that HTTP service instead of calling Core directly. Test the proxy from the DPU with the same request IMDS would send:
+
+```bash
+curl -sS -H 'Metadata: true' \
+  --cacert /etc/forge/sign_proxy_root.pem \
+  'https://sign-proxy.example.com/prefix/latest/meta-data/identity?aud=<allowed-audience>'
+```
+
+Use `--cacert` when `sign-proxy-tls-root-ca` is configured; omit it for `http:` URLs or when the proxy uses a public CA.
+
+### Reference: `SignMachineIdentity` gRPC (optional)
+
+This is **not** part of routine operator verification — IMDS (§4) is sufficient for end-to-end checks on the default path.
+
+Keep it as a **reference** if you operate a custom HTTP sign proxy (`sign-proxy-url`) whose implementation calls **`forge.Forge/SignMachineIdentity`** on the backend. Use it to validate the gRPC leg independently while developing or troubleshooting proxy code.
+
+From a host that holds the DPU machine certificate (`/opt/forge/machine_cert.pem`, paths may vary):
 
 ```bash
 grpcurl -insecure \
@@ -181,9 +199,7 @@ grpcurl -insecure \
 | Invalid audience | Audience not in `allowedAudiences` |
 | `UNAVAILABLE` | Site `[machine_identity]` disabled or broken global config |
 
-If gRPC succeeds but IMDS fails, focus on the DPU agent (rate limits, `sign-timeout-secs`, connectivity). If both fail with the same error class, check Day 0/Day 1 config.
-
-> **DPU vs host SPIFFE ID:** DPU certificates use the DPU machine id (`…d…`). NICo resolves DPU callers to the host instance record before loading tenant identity config.
+If this call succeeds but IMDS via your proxy fails, the issue is in the proxy HTTP layer (URL, TLS, headers, timeouts) — not Core signing.
 
 ---
 

--- a/docs/manuals/machine_identity_verification.md
+++ b/docs/manuals/machine_identity_verification.md
@@ -1,0 +1,195 @@
+# Machine Identity Verification
+
+Runbook for verifying that machine identity (SPIFFE JWT-SVID issuance) is configured correctly: discovery documents, JWKS, and the workload IMDS path.
+
+Use this after [Day 0](../getting-started/installation-options/day0-machine-identity.md) and [Day 1](../configuration/machine_identity.md) configuration, or when troubleshooting token issuance.
+
+---
+
+## Prerequisites
+
+- Site `[machine_identity].enabled = true` and valid encryption keys ([Day 0](../getting-started/installation-options/day0-machine-identity.md)).
+- Per-org `tenant-identity/config` exists with `enabled: true` ([Day 1](../configuration/machine_identity.md)).
+- At least one instance in **`READY`** assigned to the org under test.
+- Network access from a workload on that instance to `169.254.169.254` (IMDS).
+
+Collect `{org}`, `{site-id}`, and an allowed audience (for example `tenant-api`) from your identity config:
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/tenant-identity/config"
+```
+
+---
+
+## Verification Checklist
+
+| Step | What it proves | Section |
+|---|---|---|
+| OIDC discovery | Issuer URL and JWKS URI are published | [§1](#1-oidc-discovery) |
+| JWKS / SPIFFE JWKS | Verifiers can fetch signing public keys | [§2](#2-jwks-endpoints) |
+| Config vs JWKS | Published keys match stored org config | [§3](#3-align-config-with-jwks) |
+| IMDS identity | End-to-end issuance for the instance | [§4](#4-imds-workload-path) |
+| JWT claims | Token content matches policy | [§5](#5-decode-and-validate-jwt-claims) |
+
+IMDS is the operator-facing check. The DPU agent calls Core gRPC `SignMachineIdentity` internally on that path — you do not need to invoke that RPC directly for routine verification. See [DPU-side debugging](#dpu-side-debugging-optional) when isolating agent vs Core failures.
+
+---
+
+## 1. OIDC Discovery
+
+```bash
+curl -sS "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/.well-known/openid-configuration" | jq .
+```
+
+nicocli TUI: `tenant-identity openid-configuration get`
+
+Confirm:
+
+- `issuer` matches the value in your tenant identity config.
+- `jwks_uri` points at the org/site JWKS URL under the same REST base.
+- Document is reachable from wherever your verifiers run (ingress, mTLS, or internal DNS as designed).
+
+---
+
+## 2. JWKS Endpoints
+
+**OIDC JWKS** (JWT verifiers):
+
+```bash
+curl -sS "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/.well-known/jwks.json" | jq .
+```
+
+**SPIFFE JWKS**:
+
+```bash
+curl -sS "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/.well-known/spiffe/jwks.json" | jq .
+```
+
+nicocli TUI: `tenant-identity jwks get`, `tenant-identity spiffe-jwks get`
+
+Confirm:
+
+- Response is a JWK Set with at least one key.
+- Key type/curve matches site algorithm (`ES256` → `kty: EC`, `crv: P-256`).
+- During [signing-key rotation](machine_identity_signing_key_rotation.md), **two** keys may appear until the overlap window ends.
+
+---
+
+## 3. Align Config with JWKS
+
+Compare GET config `signingKeys` with JWKS:
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/tenant-identity/config" | jq '.signingKeys'
+```
+
+| Config field | JWKS expectation |
+|---|---|
+| Entry with `currentSigner: true` | Must appear in JWKS |
+| Entry with `expireAt` set | Previous key; must still appear in JWKS until overlap expires |
+| Single entry, no `expireAt` | JWKS should contain one signing key |
+
+Mismatch between config and JWKS usually indicates a stale cache, incomplete rotation, or REST/Core sync delay — re-fetch after a short wait; if persistent, check Core logs and repeat GET/JWKS.
+
+---
+
+## 4. IMDS (Workload Path)
+
+From a workload network namespace on the instance:
+
+```bash
+# JSON (default)
+curl -sS -H 'Metadata: true' \
+  'http://169.254.169.254/latest/meta-data/identity?aud=<allowed-audience>'
+
+# Plain JWT
+curl -sS -H 'Metadata: true' -H 'Accept: text/plain' \
+  'http://169.254.169.254/latest/meta-data/identity?aud=<allowed-audience>'
+```
+
+Success (JSON): HTTP 200 with `access_token`, `token_type`, `expires_in`, and `issued_token_type`.
+
+Notes:
+
+- The `Metadata: true` header is required (AWS IMDS compatibility).
+- Multiple audiences: repeat `aud=` query parameters; URL-encode values with special characters.
+- Rate limits come from the DPU agent `[machine-identity]` section — see [Day 0](../getting-started/installation-options/day0-machine-identity.md#3-configure-dpu-agent-machine-identity-optional). HTTP 429 indicates throttling.
+
+### Token delegation path
+
+If the org uses [token delegation](../configuration/machine_identity.md#2-optional--token-delegation), IMDS still returns a workload token, but Core may exchange via the configured STS. Verification steps are the same at the IMDS layer; additionally confirm your STS receives the intermediate token and returns the final token (STS logs/metrics).
+
+---
+
+## 5. Decode and Validate JWT Claims
+
+Extract the JWT from IMDS JSON (`access_token`) or the plain IMDS body, then decode (offline):
+
+```bash
+# Header
+echo '<jwt>' | cut -d. -f1 | base64 -d 2>/dev/null | jq .
+
+# Payload
+echo '<jwt>' | cut -d. -f2 | base64 -d 2>/dev/null | jq .
+```
+
+Or use [jwt.io](https://jwt.io) in non-production environments only — do not paste production tokens into third-party sites.
+
+| Claim | Expected |
+|---|---|
+| `iss` | Matches configured `issuer` |
+| `sub` | SPIFFE ID under configured `subjectPrefix` + workload path |
+| `aud` | Contains requested audience; must be in org allowlist |
+| `exp` | Within `tokenTtlSeconds` of issuance |
+| `iat` / `nbf` | Reasonable skew relative to verifier clock |
+
+**Signature verification:** fetch JWKS (§2), locate the key by `kid` in the JWT header, verify ES256 signature with your JWT library or:
+
+```bash
+# Example with jwt-cli (if installed): jwt verify --alg ES256 --jwks <url> '<jwt>'
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Action |
+|---|---|
+| Discovery/JWKS 404 | Confirm org, site id, and REST routing; config must exist |
+| JWKS empty | Org config missing or disabled; check GET config |
+| IMDS 403/404/503/timeout | Agent logs, Core reachability from DPU, agent `sign-timeout-secs`; try [DPU-side debugging](#dpu-side-debugging-optional) |
+| Valid JWT, verifier rejects | Clock skew, wrong JWKS URL, overlap ended for old `kid`, wrong `iss`/`aud` check |
+
+### DPU-side debugging (optional)
+
+Use this only when IMDS fails and you need to isolate the DPU agent from Core signing. Requires shell access on the DPU and its machine certificate (`/opt/forge/machine_cert.pem`, paths may vary):
+
+```bash
+grpcurl -insecure \
+  -cacert /opt/forge/forge_root.pem \
+  -cert /opt/forge/machine_cert.pem \
+  -key /opt/forge/machine_cert.key \
+  -d '{"audience": ["<allowed-audience>"]}' \
+  carbide-api.forge:443 forge.Forge/SignMachineIdentity
+```
+
+| gRPC result | Likely cause |
+|---|---|
+| `NotFound` / `machine_identity not found` | No org config, org disabled, instance not READY, or DPU not linked to instance |
+| Invalid audience | Audience not in `allowedAudiences` |
+| `UNAVAILABLE` | Site `[machine_identity]` disabled or broken global config |
+
+If gRPC succeeds but IMDS fails, focus on the DPU agent (rate limits, `sign-timeout-secs`, connectivity). If both fail with the same error class, check Day 0/Day 1 config.
+
+> **DPU vs host SPIFFE ID:** DPU certificates use the DPU machine id (`…d…`). NICo resolves DPU callers to the host instance record before loading tenant identity config.
+
+---
+
+## Related Documentation
+
+- [Machine Identity (Day 1)](../configuration/machine_identity.md) — configure issuer, audiences, delegation
+- [JWT Signing Key Rotation](machine_identity_signing_key_rotation.md) — rotate org signing keys and re-verify JWKS
+- [Master Encryption Key Rotation (KEK)](machine_identity_kek_rotation.md) — site master key (does not change JWKS)
+- [Day 0 Machine Identity](../getting-started/installation-options/day0-machine-identity.md) — site enablement

--- a/docs/manuals/machine_identity_verification.md
+++ b/docs/manuals/machine_identity_verification.md
@@ -10,7 +10,7 @@ Use this after [Day 0](../getting-started/installation-options/day0-machine-iden
 
 - Site `[machine_identity].enabled = true` and valid encryption keys ([Day 0](../getting-started/installation-options/day0-machine-identity.md)).
 - Per-org `tenant-identity/config` exists with `enabled: true` ([Day 1](../configuration/machine_identity.md)).
-- At least one instance in **`READY`** assigned to the org under test.
+- At least one instance in `**READY**` assigned to the org under test.
 - Network access from a workload on that instance to `169.254.169.254` (IMDS).
 
 Collect `{org}`, `{site-id}`, and an allowed audience (for example `tenant-api`) from your identity config:
@@ -24,13 +24,15 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
 
 ## Verification Checklist
 
-| Step | What it proves | Section |
-|---|---|---|
-| OIDC discovery | Issuer URL and JWKS URI are published | [§1](#1-oidc-discovery) |
-| JWKS / SPIFFE JWKS | Verifiers can fetch signing public keys | [§2](#2-jwks-endpoints) |
-| Config vs JWKS | Published keys match stored org config | [§3](#3-align-config-with-jwks) |
-| IMDS identity | End-to-end issuance for the instance | [§4](#4-imds-workload-path) |
-| JWT claims | Token content matches policy | [§5](#5-decode-and-validate-jwt-claims) |
+
+| Step               | What it proves                          | Section                                 |
+| ------------------ | --------------------------------------- | --------------------------------------- |
+| OIDC discovery     | Issuer URL and JWKS URI are published   | [§1](#1-oidc-discovery)                 |
+| JWKS / SPIFFE JWKS | Verifiers can fetch signing public keys | [§2](#2-jwks-endpoints)                 |
+| Config vs JWKS     | Published keys match stored org config  | [§3](#3-align-config-with-jwks)         |
+| IMDS identity      | End-to-end issuance for the instance    | [§4](#4-imds-workload-path)             |
+| JWT claims         | Token content matches policy            | [§5](#5-decode-and-validate-jwt-claims) |
+
 
 IMDS is the operator-facing check. The DPU agent calls Core gRPC `SignMachineIdentity` internally on that path — you do not need to invoke that RPC directly for routine verification. See [DPU-side debugging](#dpu-side-debugging-optional) when isolating agent vs Core failures.
 
@@ -85,11 +87,13 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
   "https://<nico-rest>/v2/org/{org}/nico/site/{site-id}/tenant-identity/config" | jq '.signingKeys'
 ```
 
-| Config field | JWKS expectation |
-|---|---|
-| Entry with `currentSigner: true` | Must appear in JWKS |
-| Entry with `expireAt` set | Previous key; must still appear in JWKS until overlap expires |
-| Single entry, no `expireAt` | JWKS should contain one signing key |
+
+| Config field                     | JWKS expectation                                              |
+| -------------------------------- | ------------------------------------------------------------- |
+| Entry with `currentSigner: true` | Must appear in JWKS                                           |
+| Entry with `expireAt` set        | Previous key; must still appear in JWKS until overlap expires |
+| Single entry, no `expireAt`      | JWKS should contain one signing key                           |
+
 
 Mismatch between config and JWKS usually indicates a stale cache, incomplete rotation, or REST/Core sync delay — re-fetch after a short wait; if persistent, check Core logs and repeat GET/JWKS.
 
@@ -137,13 +141,15 @@ echo '<jwt>' | cut -d. -f2 | base64 -d 2>/dev/null | jq .
 
 Or use [jwt.io](https://jwt.io) in non-production environments only — do not paste production tokens into third-party sites.
 
-| Claim | Expected |
-|---|---|
-| `iss` | Matches configured `issuer` |
-| `sub` | SPIFFE ID under configured `subjectPrefix` + workload path |
-| `aud` | Contains requested audience; must be in org allowlist |
-| `exp` | Within `tokenTtlSeconds` of issuance |
-| `iat` / `nbf` | Reasonable skew relative to verifier clock |
+
+| Claim         | Expected                                                   |
+| ------------- | ---------------------------------------------------------- |
+| `iss`         | Matches configured `issuer`                                |
+| `sub`         | SPIFFE ID under configured `subjectPrefix` + workload path |
+| `aud`         | Contains requested audience; must be in org allowlist      |
+| `exp`         | Within `tokenTtlSeconds` of issuance                       |
+| `iat` / `nbf` | Reasonable skew relative to verifier clock                 |
+
 
 **Signature verification:** fetch JWKS (§2), locate the key by `kid` in the JWT header, verify ES256 signature with your JWT library or:
 
@@ -155,18 +161,20 @@ Or use [jwt.io](https://jwt.io) in non-production environments only — do not p
 
 ## Troubleshooting
 
-| Symptom | Action |
-|---|---|
-| Discovery/JWKS 404 | Confirm org, site id, and REST routing; config must exist |
-| JWKS empty | Org config missing or disabled; check GET config |
-| IMDS 403/404/503/timeout | Agent logs, `sign-timeout-secs`, Core or sign-proxy reachability; see [DPU-side debugging](#dpu-side-debugging-optional) |
-| Valid JWT, verifier rejects | Clock skew, wrong JWKS URL, overlap ended for old `kid`, wrong `iss`/`aud` check |
+
+| Symptom                     | Action                                                                                                                   |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Discovery/JWKS 404          | Confirm org, site id, and REST routing; config must exist                                                                |
+| JWKS empty                  | Org config missing or disabled; check GET config                                                                         |
+| IMDS 403/404/503/timeout    | Agent logs, `sign-timeout-secs`, Core or sign-proxy reachability; see [DPU-side debugging](#dpu-side-debugging-optional) |
+| Valid JWT, verifier rejects | Clock skew, wrong JWKS URL, overlap ended for old `kid`, wrong `iss`/`aud` check                                         |
+
 
 ### DPU-side debugging (optional)
 
 When IMDS fails, check the DPU agent first: logs, `[machine-identity]` rate limits, and `sign-timeout-secs` ([Day 0](../getting-started/installation-options/day0-machine-identity.md#3-configure-dpu-agent-machine-identity-optional)).
 
-If the agent has **`sign-proxy-url`** set, IMDS forwards to that HTTP service instead of calling Core directly. Test the proxy from the DPU with the same request IMDS would send:
+If the agent has `**sign-proxy-url**` set, IMDS forwards to that HTTP service instead of calling Core directly. Test the proxy from the DPU with the same request IMDS would send:
 
 ```bash
 curl -sS -H 'Metadata: true' \
@@ -180,12 +188,12 @@ Use `--cacert` when `sign-proxy-tls-root-ca` is configured; omit it for `http:` 
 
 This is **not** part of routine operator verification — IMDS (§4) is sufficient for end-to-end checks on the default path.
 
-Keep it as a **reference** if you operate a custom HTTP sign proxy (`sign-proxy-url`) whose implementation calls **`forge.Forge/SignMachineIdentity`** on the backend. Use it to validate the gRPC leg independently while developing or troubleshooting proxy code.
+Keep it as a **reference** if you operate a custom HTTP sign proxy (`sign-proxy-url`) whose implementation calls `**forge.Forge/SignMachineIdentity`** on the backend. Use it to validate the gRPC leg independently while developing or troubleshooting proxy code.
 
 From a host that holds the DPU machine certificate (`/opt/forge/machine_cert.pem`, paths may vary):
 
 ```bash
-grpcurl -insecure \
+grpcurl \
   -cacert /opt/forge/forge_root.pem \
   -cert /opt/forge/machine_cert.pem \
   -key /opt/forge/machine_cert.key \
@@ -193,11 +201,13 @@ grpcurl -insecure \
   carbide-api.forge:443 forge.Forge/SignMachineIdentity
 ```
 
-| gRPC result | Likely cause |
-|---|---|
+
+| gRPC result                               | Likely cause                                                                   |
+| ----------------------------------------- | ------------------------------------------------------------------------------ |
 | `NotFound` / `machine_identity not found` | No org config, org disabled, instance not READY, or DPU not linked to instance |
-| Invalid audience | Audience not in `allowedAudiences` |
-| `UNAVAILABLE` | Site `[machine_identity]` disabled or broken global config |
+| Invalid audience                          | Audience not in `allowedAudiences`                                             |
+| `UNAVAILABLE`                             | Site `[machine_identity]` disabled or broken global config                     |
+
 
 If this call succeeds but IMDS via your proxy fails, the issue is in the proxy HTTP layer (URL, TLS, headers, timeouts) — not Core signing.
 
@@ -209,3 +219,4 @@ If this call succeeds but IMDS via your proxy fails, the issue is in the proxy H
 - [JWT Signing Key Rotation](machine_identity_signing_key_rotation.md) — rotate org signing keys and re-verify JWKS
 - [Master Encryption Key Rotation (KEK)](machine_identity_kek_rotation.md) — site master key (does not change JWKS)
 - [Day 0 Machine Identity](../getting-started/installation-options/day0-machine-identity.md) — site enablement
+

--- a/docs/manuals/machine_identity_verification.md
+++ b/docs/manuals/machine_identity_verification.md
@@ -10,7 +10,7 @@ Use this after [Day 0](../getting-started/installation-options/day0-machine-iden
 
 - Site `[machine_identity].enabled = true` and valid encryption keys ([Day 0](../getting-started/installation-options/day0-machine-identity.md)).
 - Per-org `tenant-identity/config` exists with `enabled: true` ([Day 1](../configuration/machine_identity.md)).
-- At least one instance in `**READY**` assigned to the org under test.
+- At least one instance in **`READY`** assigned to the org under test.
 - Network access from a workload on that instance to `169.254.169.254` (IMDS).
 
 Collect `{org}`, `{site-id}`, and an allowed audience (for example `tenant-api`) from your identity config:
@@ -174,7 +174,7 @@ Or use [jwt.io](https://jwt.io) in non-production environments only — do not p
 
 When IMDS fails, check the DPU agent first: logs, `[machine-identity]` rate limits, and `sign-timeout-secs` ([Day 0](../getting-started/installation-options/day0-machine-identity.md#3-configure-dpu-agent-machine-identity-optional)).
 
-If the agent has `**sign-proxy-url**` set, IMDS forwards to that HTTP service instead of calling Core directly. Test the proxy from the DPU with the same request IMDS would send:
+If the agent has `sign-proxy-url` set, IMDS forwards to that HTTP service instead of calling Core directly. Test the proxy from the DPU with the same request IMDS would send:
 
 ```bash
 curl -sS -H 'Metadata: true' \
@@ -188,7 +188,7 @@ Use `--cacert` when `sign-proxy-tls-root-ca` is configured; omit it for `http:` 
 
 This is **not** part of routine operator verification — IMDS (§4) is sufficient for end-to-end checks on the default path.
 
-Keep it as a **reference** if you operate a custom HTTP sign proxy (`sign-proxy-url`) whose implementation calls `**forge.Forge/SignMachineIdentity`** on the backend. Use it to validate the gRPC leg independently while developing or troubleshooting proxy code.
+Keep it as a **reference** if you operate a custom HTTP sign proxy (`sign-proxy-url`) whose implementation calls `forge.Forge/SignMachineIdentity` on the backend. Use it to validate the gRPC leg independently while developing or troubleshooting proxy code.
 
 From a host that holds the DPU machine certificate (`/opt/forge/machine_cert.pem`, paths may vary):
 
@@ -204,7 +204,7 @@ grpcurl \
 
 | gRPC result                               | Likely cause                                                                   |
 | ----------------------------------------- | ------------------------------------------------------------------------------ |
-| `NotFound` / `machine_identity not found` | No org config, org disabled, instance not READY, or DPU not linked to instance |
+| `NotFound` / `machine_identity not found` | No org config, org disabled, instance not `READY`, or DPU not linked to instance |
 | Invalid audience                          | Audience not in `allowedAudiences`                                             |
 | `UNAVAILABLE`                             | Site `[machine_identity]` disabled or broken global config                     |
 


### PR DESCRIPTION
## Description
<!-- Describe what this PR does -->
# Machine Identity Operator Documentation — Branch Summary

**Issue:** [#1981](https://github.com/NVIDIA/ncx-infra-controller-core/issues/1981) SPIFFE machine identity user documentation 
Document the user settings and configurations for enabling machine identity features in Nico.


**Scope:** ~970 lines added across 8 doc files (+ minor cross-links and nav)

---

## New documentation

| Document | Purpose |
|---|---|
| [`docs/getting-started/installation-options/day0-machine-identity.md`](../../getting-started/installation-options/day0-machine-identity.md) | Day 0: KEK secrets, site `[machine_identity]`, DPU agent `[machine-identity]` (incl. sign-proxy settings), site-level verification |
| [`docs/configuration/machine_identity.md`](../../configuration/machine_identity.md) | Day 1: per-org config, token delegation, SSRF proxy/allowlist recommendation, links to runbooks |
| [`docs/manuals/machine_identity_verification.md`](../../manuals/machine_identity_verification.md) | REST + IMDS verification checklist; optional gRPC reference for custom sign-proxy backends |
| [`docs/manuals/machine_identity_signing_key_rotation.md`](../../manuals/machine_identity_signing_key_rotation.md) | Per-org JWT signing key rotation with JWKS overlap |
| [`docs/manuals/machine_identity_kek_rotation.md`](../../manuals/machine_identity_kek_rotation.md) | Site KEK re-wrap (gRPC today; REST planned) |

---

## Navigation and cross-links

- **`docs/index.yml`** — Day 0 page, Day 1 config page, three Operations runbooks
- **`book/src/configuration/configurability.md`** — links to Day 0/Day 1 docs
- **`docs/configuration/tenant_management.md`** — pointer to machine identity setup (“tenant instances”, not “tenant workloads”)

---

## Design choices reflected in docs

- Day 0 verification via REST global gate only (no DPU smoke tests)
- No Profile A/B/C taxonomy; sidecar/IP `tokenEndpoint` documented as a simple note
- Verification runbook is operator-facing (REST + IMDS); `SignMachineIdentity` / `grpcurl` kept as optional reference for custom `sign-proxy-url` implementations
- KEK rotation documented as gRPC-only for now, with REST API noted as coming

---

## Related design reference

- [SPIFFE JWT-SVID SDD](spiffe-svid-sdd.md) — authoritative design (unchanged; operator docs complement it)


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
#1981
#261