### PR TITLE
feat: and now enhance machine_interfaces with a full MachineBootInterface

### DIFF
--- a/crates/api-core/src/handlers/managed_host.rs
+++ b/crates/api-core/src/handlers/managed_host.rs
@@ -153,21 +153,6 @@ pub(crate) async fn set_primary_dpu(
         })?
         .mac_address;
 
-    // The operator picked this primary NIC by MAC. Resolve its Redfish interface
-    // id from the host's exploration report so we can send a complete pair (which
-    // enables the interface-id fallback); if the report has no id for it, target
-    // the MAC alone.
-    let boot_interface_id = db::explored_endpoints::find_by_ips(&mut txn, vec![bmc_addr])
-        .await?
-        .into_iter()
-        .next()
-        .and_then(|endpoint| {
-            endpoint
-                .report
-                .find_interface_id_for_mac(primary_interface_mac_address)
-                .map(str::to_string)
-        });
-
     txn.rollback().await?;
 
     let Some(current_primary_interface_id) = current_primary_interface_id else {
@@ -183,10 +168,10 @@ pub(crate) async fn set_primary_dpu(
         .into());
     };
 
-    // Set the boot device. Send the complete (MAC + interface id) pair when the
-    // report gave us an id, so the boot-order call can fall back to the interface
-    // id; otherwise target the MAC alone.
-    let boot_target = match boot_interface_id {
+    // Set the boot device. The new primary interface row already stores its
+    // Redfish interface id, so send the complete (MAC + id) pair when present,
+    // allowing for interface ID fallback (and target the MAC alone otherwise).
+    let boot_target = match new_primary_interface.boot_interface_id.clone() {
         Some(interface_id) => BootInterfaceTarget::Pair(MachineBootInterface {
             mac_address: primary_interface_mac_address,
             interface_id,

--- a/crates/api-core/src/tests/site_explorer.rs
+++ b/crates/api-core/src/tests/site_explorer.rs
@@ -3410,6 +3410,49 @@ async fn test_site_explorer_auto_corrects_nic_mode_per_expected_machine(
     Ok(())
 }
 
+/// A managed host's DPU-facing `machine_interface` is created (via DHCP) with
+/// just a MAC and no `boot_interface_id`. The exploration that ingests the host
+/// then backfills the vendor-specific Redfish interface id onto that row, matched
+/// by MAC, at which the primary interface ends up with a full `MachineBootInterface`.
+/// This is the same backfill path any DHCP-derived interface takes (the capture is
+/// keyed on MAC, not on how the row was created).
+#[sqlx_test]
+async fn test_site_explorer_backfills_boot_interface_id_onto_machine_interface(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+
+    let dpu = DpuConfig::default();
+    let host_pf_mac = dpu.host_mac_address;
+    let mh = common::api_fixtures::create_managed_host_with_config(
+        &env,
+        ManagedHostConfig::with_dpus(vec![dpu]),
+    )
+    .await;
+
+    let mut txn = env.pool.begin().await?;
+    let interfaces = db::machine_interface::find_by_machine_ids(&mut txn, &[mh.id]).await?;
+    let primary = interfaces
+        .get(&mh.id)
+        .into_iter()
+        .flatten()
+        .find(|i| i.primary_interface)
+        .expect("ingested host should have a primary machine_interface");
+
+    // The primary row is the DPU host-PF interface (same factory MAC), now
+    // holding both halves of the pair: its MAC plus the Redfish interface id the
+    // host report named for it. The `ManagedHostConfig` fixture ids its DPU
+    // interfaces "NIC.Slot.{index + 5}-1", so the first DPU is "NIC.Slot.5-1".
+    assert_eq!(primary.mac_address, host_pf_mac);
+    assert_eq!(
+        primary.boot_interface_id.as_deref(),
+        Some("NIC.Slot.5-1"),
+        "exploration should backfill the Redfish interface id onto the machine_interface row",
+    );
+
+    Ok(())
+}
+
 /// A Managed Host whose `expected_machines` row is later removed becomes an
 /// orphan: `audit_exploration_results` emits an `OrphanManagedHost` health
 /// alert on the host's Machine. Re-adding the entry clears the alert on the

--- a/crates/api-db/migrations/20260605215213_machine_interfaces_boot_interface_id.sql
+++ b/crates/api-db/migrations/20260605215213_machine_interfaces_boot_interface_id.sql
@@ -1,0 +1,4 @@
+-- Add boot_interface_id to machine_interfaces so each interface row holds a
+-- full MachineBootInterface pair with the MAC plus the vendor-named Redfish
+-- EthernetInterface.Id.
+ALTER TABLE machine_interfaces ADD COLUMN boot_interface_id text;

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -182,6 +182,25 @@ pub async fn set_primary_interface(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
+/// Records the vendor-native Redfish `EthernetInterface.Id` on the machine_interface
+/// row(s) with the given MAC. Captured by site-explorer per exploration; callers only
+/// invoke this when the id resolves from the current report, so a wiped MAC leaves the
+/// last-known-good id in place.
+pub async fn set_boot_interface_id(
+    mac_address: MacAddress,
+    boot_interface_id: &str,
+    txn: &mut PgConnection,
+) -> Result<(), DatabaseError> {
+    let query = "UPDATE machine_interfaces SET boot_interface_id=$1 WHERE mac_address=$2";
+    sqlx::query(query)
+        .bind(boot_interface_id)
+        .bind(mac_address)
+        .execute(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
 pub async fn associate_interface_with_dpu_machine(
     interface_id: &MachineInterfaceId,
     dpu_machine_id: &MachineId,

--- a/crates/api-model/src/machine/capabilities.rs
+++ b/crates/api-model/src/machine/capabilities.rs
@@ -630,6 +630,7 @@ mod tests {
                     interface_type: InterfaceType::Data,
                     primary_interface: true,
                     mac_address: MacAddress::from_str("08:c0:eb:cb:0e:96").unwrap(),
+                    boot_interface_id: None,
                     attached_dpu_machine_id: Some(
                         MachineId::from_str(
                             "fm100dsbiu5ckus880v8407u0mkcensa39cule26im5gnpvmuufckacguc0",
@@ -654,6 +655,7 @@ mod tests {
                     interface_type: InterfaceType::Data,
                     primary_interface: true,
                     mac_address: MacAddress::from_str("08:c0:eb:cb:0e:97").unwrap(),
+                    boot_interface_id: None,
                     attached_dpu_machine_id: Some(
                         MachineId::from_str(
                             "fm100dsg23d2f4tq4tt5m2hgib5pcldrm3gvefbduau7gj3itgc3iqg3lpg",
@@ -756,6 +758,7 @@ mod tests {
                 interface_type: InterfaceType::Data,
                 primary_interface: true,
                 mac_address: MacAddress::from_str("00:00:00:00:00:00").unwrap(),
+                boot_interface_id: None,
                 attached_dpu_machine_id: None,
                 domain_id: None,
                 machine_id: None,

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -131,11 +131,6 @@ pub struct ManagedHostStateSnapshot {
     pub host_snapshot: Machine,
     pub dpu_snapshots: Vec<Machine>,
     pub dpa_interface_snapshots: Vec<DpaInterface>,
-    /// The host's boot interface (MAC + Redfish interface id), captured by
-    /// site-explorer. Populated at read time by `load_object_state` (like
-    /// `dpa_interface_snapshots`); `None` until the host has been explored with
-    /// a fully-resolved boot interface.
-    pub boot_interface: Option<MachineBootInterface>,
     /// If there is an instance provisioned on top of the machine, this holds
     /// its state
     pub instance: Option<InstanceSnapshot>,
@@ -213,8 +208,6 @@ impl<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> for ManagedHostStateSnapshot {
             host_snapshot,
             dpu_snapshots,
             dpa_interface_snapshots,
-            // Filled by load_object_state later (see dpa_interface_snapshots).
-            boot_interface: None,
             managed_state,
             instance,
             rack_health_overrides,
@@ -280,19 +273,38 @@ impl From<ManagedHostStateSnapshotError> for sqlx::Error {
 ///    so it's on the caller to figure out. What this usually means is the
 ///    caller passes `boot_interface_mac: None` to machine_setup, and then
 ///    subsequent logic flows from there (e.g. ::NoDpu handling).
-fn pick_boot_interface_mac(
+fn pick_boot_interface(
     interfaces: &[MachineInterfaceSnapshot],
-) -> Option<mac_address::MacAddress> {
+) -> Option<&MachineInterfaceSnapshot> {
     // The primary wins!
     if let Some(primary) = interfaces.iter().find(|x| x.primary_interface) {
-        return Some(primary.mac_address);
+        return Some(primary);
     }
     // ..no primary, so lets try to find *some* interface.
     interfaces
         .iter()
         .filter(|x| x.network_segment_type != Some(NetworkSegmentType::Underlay))
         .min_by_key(|x| x.mac_address)
-        .map(|x| x.mac_address)
+}
+
+fn pick_boot_interface_mac(
+    interfaces: &[MachineInterfaceSnapshot],
+) -> Option<mac_address::MacAddress> {
+    pick_boot_interface(interfaces).map(|x| x.mac_address)
+}
+
+/// Resolves the boot interface to a fully-populated [`MachineBootInterface`]
+/// (MAC + Redfish interface id) from the picked interface's own row. Split out
+/// like `pick_boot_interface_mac` so it's unit-testable without a full snapshot.
+fn pick_boot_interface_pair(
+    interfaces: &[MachineInterfaceSnapshot],
+) -> Option<MachineBootInterface> {
+    pick_boot_interface(interfaces).and_then(|interface| {
+        MachineBootInterface::from_parts(
+            Some(interface.mac_address),
+            interface.boot_interface_id.clone(),
+        )
+    })
 }
 
 impl ManagedHostStateSnapshot {
@@ -363,6 +375,19 @@ impl ManagedHostStateSnapshot {
     /// into things like machine_setup, is_bios_setup, etc.
     pub fn boot_interface_mac(&self) -> Option<mac_address::MacAddress> {
         pick_boot_interface_mac(&self.host_snapshot.interfaces)
+    }
+
+    /// Returns the host's boot interface as a fully-populated
+    /// [`MachineBootInterface`] (MAC + Redfish interface id), derived from the
+    /// same primary `machine_interface` row that [`Self::boot_interface_mac`]
+    /// selects.
+    ///
+    /// Returns `None` when that row hasn't captured a Redfish interface id yet
+    /// (e.g. not yet explored, or a zero-DPU host) -- callers then target the MAC
+    /// alone. Because the MAC and id come from one row, the pair can never name a
+    /// different interface than `boot_interface_mac`.
+    pub fn boot_interface(&self) -> Option<MachineBootInterface> {
+        pick_boot_interface_pair(&self.host_snapshot.interfaces)
     }
 
     /// Returns `true` if override report is hw_health, `false` otherwise.
@@ -2321,6 +2346,11 @@ pub struct MachineInterfaceSnapshot {
     pub interface_type: InterfaceType,
     pub primary_interface: bool,
     pub mac_address: MacAddress,
+    /// Vendor-native Redfish `EthernetInterface.Id` for this interface, captured
+    /// by site-explorer alongside the MAC. Combined with `mac_address` it forms a
+    /// [`MachineBootInterface`]; for the `primary_interface` row that pair is the
+    /// host's boot device.
+    pub boot_interface_id: Option<String>,
     pub attached_dpu_machine_id: Option<MachineId>,
     pub domain_id: Option<DomainId>,
     pub machine_id: Option<MachineId>,
@@ -2345,6 +2375,7 @@ impl MachineInterfaceSnapshot {
             machine_id: None,
             segment_id: uuid::Uuid::nil().into(),
             mac_address,
+            boot_interface_id: None,
             hostname: String::new(),
             interface_type: InterfaceType::Data,
             primary_interface: true,
@@ -2643,6 +2674,7 @@ impl<'r> FromRow<'r, PgRow> for MachineInterfaceSnapshot {
             hostname: row.try_get("hostname")?,
             interface_type: row.try_get("interface_type")?,
             mac_address: row.try_get("mac_address")?,
+            boot_interface_id: row.try_get("boot_interface_id")?,
             primary_interface: row.try_get("primary_interface")?,
             created: row.try_get("created")?,
             last_dhcp: row.try_get("last_dhcp")?,
@@ -3318,6 +3350,38 @@ mod tests {
             pick_boot_interface_mac(&interfaces),
             Some(onboard_mac_lo.parse().unwrap())
         );
+    }
+
+    // boot_interface() derives the full pair from the SAME primary row that the
+    // MAC selection uses, so the MAC and id can never name different interfaces.
+    #[test]
+    fn pick_boot_interface_pair_uses_primary_rows_mac_and_id() {
+        let other = build_mock_interface(
+            "05:00:00:00:00:01",
+            false,
+            Some(NetworkSegmentType::HostInband),
+        );
+        let primary = MachineInterfaceSnapshot {
+            boot_interface_id: Some("NIC.Slot.7-1-1".to_string()),
+            ..build_mock_interface("10:00:00:00:00:01", true, Some(NetworkSegmentType::Admin))
+        };
+
+        assert_eq!(
+            pick_boot_interface_pair(&[other, primary]),
+            Some(MachineBootInterface {
+                mac_address: "10:00:00:00:00:01".parse().unwrap(),
+                interface_id: "NIC.Slot.7-1-1".to_string(),
+            })
+        );
+    }
+
+    // When the primary row hasn't captured a Redfish interface id yet, there's no
+    // complete pair -- callers fall back to the MAC alone.
+    #[test]
+    fn pick_boot_interface_pair_is_none_without_captured_id() {
+        let primary =
+            build_mock_interface("10:00:00:00:00:01", true, Some(NetworkSegmentType::Admin));
+        assert_eq!(pick_boot_interface_pair(&[primary]), None);
     }
 
     // Check the case  where only the BMC has been discovered so far (which

--- a/crates/machine-controller/src/boot_interface.rs
+++ b/crates/machine-controller/src/boot_interface.rs
@@ -21,17 +21,17 @@ use model::machine::ManagedHostStateSnapshot;
 
 /// Resolve how to target this host's boot interface for Redfish setup calls.
 ///
-/// Prefers the stored, fully-captured boot interface (MAC + Redfish interface
-/// id), which enables the MAC-first / interface-id fallback; it falls back to
-/// the machine-interfaces-derived MAC (no id fallback) when no captured boot
-/// interface is available yet.
+/// Uses the host's primary `machine_interface`: when that row has a captured
+/// Redfish interface id, the full pair is returned (enabling the MAC-first /
+/// interface-id fallback); otherwise it targets the MAC alone. Both come from the
+/// same row, so the pair can never name a different interface than the MAC.
 ///
 /// Returns `None` only when the host has no boot interface at all (e.g. only the
 /// BMC has been discovered, or the primary NIC hasn't appeared yet).
 pub fn boot_interface_target(
     mh_snapshot: &ManagedHostStateSnapshot,
 ) -> Option<BootInterfaceTarget> {
-    if let Some(boot_interface) = mh_snapshot.boot_interface.clone() {
+    if let Some(boot_interface) = mh_snapshot.boot_interface() {
         return Some(BootInterfaceTarget::Pair(boot_interface));
     }
     mh_snapshot

--- a/crates/machine-controller/src/io.rs
+++ b/crates/machine-controller/src/io.rs
@@ -103,18 +103,6 @@ impl StateControllerIO for MachineStateControllerIO {
             let dpa_snapshots =
                 db::dpa_interface::find_by_machine_id(&mut *txn, *machine_id).await?;
             retstate.dpa_interface_snapshots = dpa_snapshots;
-
-            // Populate the host's stored boot interface (MAC + Redfish interface id)
-            // from its explored endpoint, so setup flows can target the MAC first
-            // and fall back to the [stable] interface id when the MAC isn't resolvable.
-            if let Ok(bmc_ip) = retstate.host_snapshot.bmc_info.ip_addr() {
-                retstate.boot_interface =
-                    db::explored_endpoints::find_by_ips(&mut *txn, vec![bmc_ip])
-                        .await?
-                        .into_iter()
-                        .next()
-                        .and_then(|ep| ep.boot_interface());
-            }
         };
 
         return Ok(retstate);

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -1003,6 +1003,9 @@ impl SiteExplorer {
 
         let mut managed_hosts = Vec::new();
         let mut boot_interfaces: Vec<(IpAddr, MachineBootInterface)> = Vec::new();
+        // Per-DPU (host PF MAC -> Redfish interface id) pairs to stamp onto their
+        // machine_interfaces rows so the primary row holds the full boot pair.
+        let mut interface_boot_ids: Vec<(MacAddress, String)> = Vec::new();
 
         for (_, ep) in explored_hosts {
             // Resolve the operator-declared DPU mode for this host once;
@@ -1271,6 +1274,18 @@ impl SiteExplorer {
                 });
             }
 
+            // Capture each explored DPU interface's Redfish interface id onto its
+            // machine_interfaces row (matched by MAC), so the primary-flagged row
+            // holds the full boot pair (MAC + id). Last-known-good: only record
+            // when the id resolves from this report -- a wiped MAC keeps its prior id.
+            for dpu in &dpus_explored_for_host {
+                if let Some(mac) = dpu.host_pf_mac_address
+                    && let Some(interface_id) = ep.report.find_interface_id_for_mac(mac)
+                {
+                    interface_boot_ids.push((mac, interface_id.to_string()));
+                }
+            }
+
             // For NicMode hosts, don't attach DPUs even if matching
             // discovered some: the operator has declared "treat this host
             // as zero-DPU". Any DPU hardware has already had `set_nic_mode`
@@ -1315,6 +1330,12 @@ impl SiteExplorer {
         // Persist boot interface MACs for host endpoints
         for (address, boot_interface) in &boot_interfaces {
             db::explored_endpoints::set_boot_interface(*address, boot_interface, &mut txn).await?;
+        }
+
+        // Stamp each DPU interface's Redfish id onto its machine_interfaces row so the
+        // primary-flagged row is the host's complete boot interface (MAC + id).
+        for (mac, interface_id) in &interface_boot_ids {
+            db::machine_interface::set_boot_interface_id(*mac, interface_id, &mut txn).await?;
         }
 
         txn.commit().await?;


### PR DESCRIPTION
## Description

This supports https://github.com/NVIDIA/infra-controller/issues/2169.

This a follow up to #2261, where a new `MachineBootInterface` struct was introduced that pairs our already-stored interface MAC address with its paired Redfish-reported interface ID. We've always had the IDs in our exploration reports, we've just never used them. However (as described in #2261), we recently discovered some nuance to flipping DPUs to NIC mode, in that the MAC address disappears entirely from Redfish, and the path to reconcile is to [re]set based on the interface ID (which, at the end of the day, is what we look up on the Redfish side via MAC address anyway).

NOW, I would have *loved* to have had a single single source of truth, where we'd have a single `MachineBootInterface` that we manage/track throughout the lifetime of the machine. However, we can't quite do that yet, but I'm trying to work towards it, by ensuring *both* ways we manage boot device configuration are standardized as a `MachineBootInterface`. So, we now have:

- `ExploredEndpoint::boot_interface()` <-- comes from/managed in `explored_endpoints`.
- `ManagedHostStateSnapshot::boot_interface()` <-- comes from/managed in `machine_interfaces`

In the case of `ExploredEndpoint::boot_interface()`, this is the `MachineBootInterface` that we apply our "pick the correct boot device" logic to *before* the machine becomes a managed host. Think preingestion, predicted host, etc. The machine isn't a managed host yet, and as part of getting that machine ready to become a managed host, we are doing some low-level groundwork to prepare it, *including* setting the correct boot device for UEFI HTTP booting (e.g. historically the MAC address of the DPU in DPU mode), with calls like `machine_setup` being used as part of these flow(s).

...but alas, we have yet *another* way of managing the primary boot device: in `machine_interfaces`. When we start building out the scaffolding for a machine, we'll create `machine_interfaces` entrie(s) for it, and, using the same logic (via `fetch_host_primary_interface_mac`) we used to set the first boot device per `explored_endpoints`; we'll also mark that `machine_interfaces` as the `primary_interface`, which is used to drive a number of other things ONCE the machine becomes a managed host. This is ALSO where any operator overrides can move where `primary_interface` points (aka `set_primary_dpu`).

Technically, this is where the two CAN diverge. We use our own "pick the right boot interface" logic to do initial baseline setup (with `ExploredEndpoint::boot_interface()` data), with the flows using it being:
- The periodic `site-explorer` loop I mentioned (`update_explored_endpoints`), which may update the `MachineBootInterface` with each cycle.
- `machine_setup` and `set_dpu_first` (both via `resolve_admin_boot_interface_target`).
- `explore` and `refresh_endpoint_report` (which you can fire off via the `admin-cli`).

..but once the machine crosses over into being a managed host, `ManagedHostStateSnapshot::boot_interface()` is effectively the managed boot interface data used by the other flows:
- `machine_setup` again (this time via the `machine-controller`, which calls it via `configure_host_bios`, which calls `boot_interface_target`, which calls `machine_setup`).
- `set_primary_dpu` (which twiddles `machine_interfaces` directly)

And in the case, say `set_primary_dpu(...)` is called, the `ExploredEndpoint::boot_interface()` values are left untouched; this continues to remain the baseline/fallback/default, BUT, is continually managed by `site-explorer`, so if we, say, deploy some updated logic that adjusts how we compute the boot interface, the baseline `ExploredEndpoint::boot_interface()` will change. BUT, if the machine has already crossed over into being a managed host, it doesn't matter -- `ManagedHostStateSnapshot::boot_interface()` has effectively been locked in as the boot interface for the duration of this managed hosts's life, and the only way to fiddle with it is the operator endpoints that we've created to allow operators to adjust that data (i.e. fiddle with where `machine_interfaces.primary_interface` points) -- operator endpoints being really just `set_primary_dpu` (the only endpoint that moves `primary_interface`).

NOW, as I've been working on this, I've considered maybe doing a follow-up PR where we have a single source of truth, and both the `ExploredEndpoint::boot_interface()` and `ManagedHostStateSnapshot::boot_interface()` would get folded into a single location that is managed. HOWEVER, I think the handoff works: we delete a managed host, wipe its machine interfaces, and a baseline exploration is used to re-configure the machine back to a "brand new"/preingestion state (boot interface and all). And then once we start running through the state controller states (like `HostInit` and eventually get to `SetBootOrder` and `CheckBootOrder`, that's where operators can then get involved with overrides as needed); it's probably good to keep that line drawn. We could probably still centralize it into a single `boot_interfaces` table though where we have `MachineBootInterface::default()` and `MachineBootInterface::managed()` or something? I don't know. Still trying to think about it.

In the meantime, this at least gets us to the point that managed hosts now needing an interface ID can use it!

Tests added to make sure it does what we want, including the flows creating `machine_interfaces`, DHCP'ing, setting primary, setting primary DPU, etc.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->



Closes #2169
