### PR TITLE
fix(machine-controller): gate initial-discovery cleanup on a confirmed host identity

### DIFF
--- a/crates/api-core/src/handlers/machine_scout.rs
+++ b/crates/api-core/src/handlers/machine_scout.rs
@@ -241,7 +241,13 @@ pub(crate) async fn forge_agent_control(
             ManagedHostState::HostInit {
                 machine_state: MachineState::WaitingForDiscovery,
             } => {
-                if host_machine.last_cleanup_time.is_some() {
+                // A predicted host isn't the real machine yet, so don't make it wait on
+                // cleanup: send it to discovery, which promotes it; the promoted host then
+                // waits for its storage cleanup. Mirrors the state handler's
+                // WaitingForDiscovery guard.
+                if host_machine.last_cleanup_time.is_some()
+                    || !host_machine.id.machine_type().is_host()
+                {
                     (Action::discovery(), Some(txn))
                 } else {
                     tracing::info!("Waiting for initial storage cleanup before host discovery");

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -5047,7 +5047,13 @@ impl StateHandler for HostMachineStateHandler {
                     }
                 }
                 MachineState::WaitingForDiscovery => {
-                    if mh_snapshot.host_snapshot.last_cleanup_time.is_none() {
+                    // Storage cleanup is a destructive disk wipe (NVMe/HDD) that scout runs after a
+                    // reset, so only a real, discovered host enters it. A predicted host waits for
+                    // discovery to promote it; the promoted host then does the cleanup.
+                    // (machine_scout.rs mirrors this on the scout side.)
+                    if mh_snapshot.host_snapshot.last_cleanup_time.is_none()
+                        && host_machine_id.machine_type().is_host()
+                    {
                         return Ok(StateHandlerOutcome::transition(waiting_for_cleanup_state(
                             CleanupState::Init,
                             CleanupContext::InitialDiscovery,


### PR DESCRIPTION
## Description

This fixes one of our current flaky tests (`test_find_instances_by_ids` fails 10% of the time-ish). The test has been around forever. We just recently broke things ever so subtly.

TLDR is stop doing a `Transition` for predicted hosts, so `WaitingForDiscovery` continues to be a `Wait`.

Storage cleanup during initial discovery wipes a host's NVMe/HDD by driving it through a reset, so it should run only against a machine whose identity is confirmed. This scopes that cleanup to identified hosts: a proactively-created predicted host now [goes back to] waiting at `WaitingForDiscovery` until discovery promotes it, and the promoted host performs the cleanup.

A veerrrry subtle bug had been introduced in [#1748](https://github.com/NVIDIA/infra-controller/pull/1748) which a predicted host (aka an `fm100p*`, derived from a DPU before its own discovery) could reach `WaitingForDiscovery` first, but then be routed into a cleanup it can never complete -- nothing is bound to its ID to answer `cleanup_machine_completed` -- leaving it wedged in `WaitingForCleanup{InitialDiscovery}`. That surfaced as a test flake in `test_find_instances_by_ids`, which waits for the host to get to `HostInit` while it works through the DPU states.

This became flaky because it was a race:
- The `dpu_state_controller_iterations` step polls the [still predicted] host and expects it to settle in some `HostInit`-specific sub-state while the DPU phase wraps up.
- Before [#1748](https://github.com/NVIDIA/infra-controller/pull/1748), `HostInit{WaitingForDiscovery}` would call a `Wait` on a predicted host — the host sat there waiting for discovery via scout -- so the poll reliably caught it.
- After [#1748](https://github.com/NVIDIA/infra-controller/pull/1748), `WaitingForDiscovery` effectively became a passthrough predicted hosts: the instant the host would land there, we would see `last_cleanup_time` was unset and transition immediately into `WaitingForCleanup{InitialDiscovery}` (...which isn't `HostInit`, and as such can never finish, since nothing answers its cleanup), but since we call `Wait`, it... waits...

After narrowing it down to #1748, I was able to confirm this test passed 50/50 times (I ran it 50 times) *before* #1748, and then began to flake ~10% after. With this adjustment, its now back to passing 100% (50/50 times).

Fwiw, no blame! I purposely didn't look at who the author was of that PR, because this is just as likely to happen to me as it is to anyone else!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

