### PR TITLE
feat(rest-api): Support selective hot-loading for API config, enable for phone home URL

### DIFF
--- a/rest-api/api/internal/config/config.go
+++ b/rest-api/api/internal/config/config.go
@@ -30,6 +30,8 @@ var (
 	ProjectRoot = filepath.Join(filepath.Dir(cur), "../..")
 )
 
+const defaultSitePhoneHomeUrl = "http://169.254.169.254:7777/latest/meta-data/phone_home"
+
 const (
 	// ConfigFilePath specifies the path to the config file, this contains the default path
 	ConfigFilePath = "config.file"
@@ -193,12 +195,13 @@ var config *Config
 // Config represents configurations for the service
 type Config struct {
 	sync.RWMutex
-	v               *viper.Viper
-	db              *cconfig.DBConfig
-	temporal        *cconfig.TemporalConfig
-	JwtOriginConfig *cauth.JWTOriginConfig
-	SiteConfig      *SiteConfig
-	KeycloakConfig  *cauth.KeycloakConfig
+	v                *viper.Viper
+	db               *cconfig.DBConfig
+	temporal         *cconfig.TemporalConfig
+	JwtOriginConfig  *cauth.JWTOriginConfig
+	SiteConfig       *SiteConfig
+	KeycloakConfig   *cauth.KeycloakConfig
+	sitePhoneHomeUrl string
 }
 
 // NewConfig creates a new config object
@@ -242,7 +245,7 @@ func NewConfig() *Config {
 	c.v.SetDefault(ConfigTracingEnabled, false)
 
 	// SiteConfig default phone home url
-	c.v.SetDefault(ConfigSitePhoneHomeUrl, "http://169.254.169.254:7777/latest/meta-data/phone_home")
+	c.v.SetDefault(ConfigSitePhoneHomeUrl, defaultSitePhoneHomeUrl)
 
 	// Keycloak needs to be explicitly enabled via config
 	c.v.SetDefault(ConfigKeycloakEnabled, false)
@@ -266,6 +269,7 @@ func NewConfig() *Config {
 	} else if err != nil { // Handle other errors that occurred while reading the config file
 		log.Panic().Err(err).Msgf("fatal error while reading the config file: %s", err)
 	}
+	c.SetSitePhoneHomeUrl(c.v.GetString(ConfigSitePhoneHomeUrl))
 
 	// Set values
 	c.setLogLevel()
@@ -298,6 +302,7 @@ func NewConfig() *Config {
 
 	// Watch secret files
 	c.WatchSecretFilePaths()
+	c.WatchConfigFile()
 
 	config = &c
 
@@ -855,11 +860,21 @@ func (c *Config) GetSiteManagerEndpoint() string {
 
 // SetSitePhoneHomeUrl sets the url for PhoneHome
 func (c *Config) SetSitePhoneHomeUrl(value string) {
-	c.v.Set(ConfigSitePhoneHomeUrl, value)
+	c.Lock()
+	defer c.Unlock()
+	c.sitePhoneHomeUrl = value
 }
 
 // GetSitePhoneHomeUrl gets the url for PhoneHome
 func (c *Config) GetSitePhoneHomeUrl() string {
+	c.RLock()
+	defer c.RUnlock()
+	if c.sitePhoneHomeUrl != "" {
+		return c.sitePhoneHomeUrl
+	}
+	if c.v == nil {
+		return ""
+	}
 	return c.v.GetString(ConfigSitePhoneHomeUrl)
 }
 
@@ -1101,6 +1116,44 @@ func (c *Config) WatchSecretFilePaths() {
 		eventsWG.Wait() // now, wait for event loop to end in this go-routine...
 	}()
 	initWG.Wait() // make sure that the go routine above fully ended before returning
+}
+
+// WatchConfigFile starts watching the config file for reloadable setting changes.
+func (c *Config) WatchConfigFile() {
+	configPath := c.GetPathToConfig()
+	if absPath, err := filepath.Abs(configPath); err == nil {
+		configPath = absPath
+	}
+
+	watch := viper.New()
+	watch.SetConfigFile(configPath)
+	watch.OnConfigChange(func(e fsnotify.Event) {
+		if !e.Has(fsnotify.Write) {
+			return
+		}
+		log.Info().Str("config.file", configPath).Str("event.file", e.Name).Msg("config file changed")
+		if err := c.reloadSitePhoneHomeUrl(configPath); err != nil {
+			log.Warn().Err(err).Str("config.file", configPath).Str("event.file", e.Name).Msg("failed to reload site phone home URL")
+		}
+	})
+	watch.WatchConfig()
+}
+
+func (c *Config) reloadSitePhoneHomeUrl(path string) error {
+	v := viper.New()
+	v.SetDefault(ConfigSitePhoneHomeUrl, defaultSitePhoneHomeUrl)
+	v.SetConfigFile(path)
+	if err := v.ReadInConfig(); err != nil {
+		return err
+	}
+
+	phoneHomeUrl := v.GetString(ConfigSitePhoneHomeUrl)
+	if phoneHomeUrl == "" {
+		return fmt.Errorf("invalid Site PhoneHome url")
+	}
+
+	c.SetSitePhoneHomeUrl(phoneHomeUrl)
+	return nil
 }
 
 // Close stops background tasks

--- a/rest-api/api/internal/config/config.go
+++ b/rest-api/api/internal/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -195,13 +196,12 @@ var config *Config
 // Config represents configurations for the service
 type Config struct {
 	sync.RWMutex
-	v                *viper.Viper
-	db               *cconfig.DBConfig
-	temporal         *cconfig.TemporalConfig
-	JwtOriginConfig  *cauth.JWTOriginConfig
-	SiteConfig       *SiteConfig
-	KeycloakConfig   *cauth.KeycloakConfig
-	sitePhoneHomeUrl string
+	v               *viper.Viper
+	db              *cconfig.DBConfig
+	temporal        *cconfig.TemporalConfig
+	JwtOriginConfig *cauth.JWTOriginConfig
+	SiteConfig      *SiteConfig
+	KeycloakConfig  *cauth.KeycloakConfig
 }
 
 // NewConfig creates a new config object
@@ -211,7 +211,7 @@ func NewConfig() *Config {
 	}
 
 	c := Config{
-		v: viper.New(),
+		v: newViper(),
 	}
 
 	// Set defaults
@@ -860,21 +860,17 @@ func (c *Config) GetSiteManagerEndpoint() string {
 
 // SetSitePhoneHomeUrl sets the url for PhoneHome
 func (c *Config) SetSitePhoneHomeUrl(value string) {
+	// Lock the mutex to prevent race conditions
 	c.Lock()
 	defer c.Unlock()
-	c.sitePhoneHomeUrl = value
+	c.v.Set(ConfigSitePhoneHomeUrl, value)
 }
 
 // GetSitePhoneHomeUrl gets the url for PhoneHome
 func (c *Config) GetSitePhoneHomeUrl() string {
+	// Lock the mutex to prevent race conditions
 	c.RLock()
 	defer c.RUnlock()
-	if c.sitePhoneHomeUrl != "" {
-		return c.sitePhoneHomeUrl
-	}
-	if c.v == nil {
-		return ""
-	}
 	return c.v.GetString(ConfigSitePhoneHomeUrl)
 }
 
@@ -1125,35 +1121,26 @@ func (c *Config) WatchConfigFile() {
 		configPath = absPath
 	}
 
-	watch := viper.New()
-	watch.SetConfigFile(configPath)
-	watch.OnConfigChange(func(e fsnotify.Event) {
+	watchv := newViper()
+	watchv.SetConfigFile(configPath)
+	watchv.OnConfigChange(func(e fsnotify.Event) {
 		if !e.Has(fsnotify.Write) {
 			return
 		}
+
 		log.Info().Str("config.file", configPath).Str("event.file", e.Name).Msg("config file changed")
-		if err := c.reloadSitePhoneHomeUrl(configPath); err != nil {
-			log.Warn().Err(err).Str("config.file", configPath).Str("event.file", e.Name).Msg("failed to reload site phone home URL")
+
+		// Dynamically reload config changes here
+		// NOTE: Each attribute we decide to reload must support read/write locking in get/set methods
+		// 1. Site PhoneHome URL
+		newSitePhoneHomeUrl := watchv.GetString(ConfigSitePhoneHomeUrl)
+		currentSitePhoneHomeUrl := c.GetSitePhoneHomeUrl()
+		if newSitePhoneHomeUrl != "" && newSitePhoneHomeUrl != currentSitePhoneHomeUrl {
+			c.SetSitePhoneHomeUrl(newSitePhoneHomeUrl)
+			log.Info().Str("config.file", configPath).Str("event.file", e.Name).Msg("Successfully loaded new Site phone home URL")
 		}
 	})
-	watch.WatchConfig()
-}
-
-func (c *Config) reloadSitePhoneHomeUrl(path string) error {
-	v := viper.New()
-	v.SetDefault(ConfigSitePhoneHomeUrl, defaultSitePhoneHomeUrl)
-	v.SetConfigFile(path)
-	if err := v.ReadInConfig(); err != nil {
-		return err
-	}
-
-	phoneHomeUrl := v.GetString(ConfigSitePhoneHomeUrl)
-	if phoneHomeUrl == "" {
-		return fmt.Errorf("invalid Site PhoneHome url")
-	}
-
-	c.SetSitePhoneHomeUrl(phoneHomeUrl)
-	return nil
+	watchv.WatchConfig()
 }
 
 // Close stops background tasks
@@ -1203,4 +1190,10 @@ func (c *Config) GetRateLimiterExpiresIn() int {
 // SetRateLimiterExpiresIn sets the expiration time in seconds
 func (c *Config) SetRateLimiterExpiresIn(value int) {
 	c.v.Set(ConfigRateLimiterExpiresIn, value)
+}
+
+func newViper() *viper.Viper {
+	return viper.NewWithOptions(viper.WithLogger(slog.New(zerologSlogHandler{
+		logger: log.Logger.With().Str("component", "viper").Logger(),
+	})))
 }

--- a/rest-api/api/internal/config/config_test.go
+++ b/rest-api/api/internal/config/config_test.go
@@ -6,13 +6,39 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type logContainsWriter struct {
+	needle string
+	seen   chan struct{}
+}
+
+func (w logContainsWriter) Write(p []byte) (int, error) {
+	if strings.Contains(string(p), w.needle) {
+		select {
+		case w.seen <- struct{}{}:
+		default:
+		}
+	}
+	return len(p), nil
+}
+
+func writeConfigForTest(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
 
 func TestNewConfig(t *testing.T) {
 	tests := []struct {
@@ -35,62 +61,71 @@ func TestNewConfig(t *testing.T) {
 	}
 }
 
-func TestReloadSitePhoneHomeUrl(t *testing.T) {
-	configPath := writeConfigForTest(t, `
-site:
-  phoneHomeUrl: http://initial.example/phone_home
-`)
-	cfg := &Config{}
-	cfg.SetSitePhoneHomeUrl(defaultSitePhoneHomeUrl)
+func TestConfig_WatchConfigFile(t *testing.T) {
+	const initialSitePhoneHomeURL = "http://initial.example/phone_home"
 
-	require.NoError(t, cfg.reloadSitePhoneHomeUrl(configPath))
-	assert.Equal(t, "http://initial.example/phone_home", cfg.GetSitePhoneHomeUrl())
+	tests := []struct {
+		name string // description of this test case
+		run  func(t *testing.T, c *Config, configPath string)
+	}{
+		{
+			name: "keeps current site phone home URL when changed config cannot be read",
+			run: func(t *testing.T, c *Config, configPath string) {
+				seenConfigChange := make(chan struct{}, 1)
+				previousLogger := log.Logger
+				log.Logger = zerolog.New(logContainsWriter{
+					needle: "config file changed",
+					seen:   seenConfigChange,
+				})
+				t.Cleanup(func() {
+					log.Logger = previousLogger
+				})
 
-	require.NoError(t, os.WriteFile(configPath, []byte(`
+				require.NoError(t, os.WriteFile(configPath, []byte("site:\n  phoneHomeUrl: [\n"), 0o600))
+
+				require.Eventually(t, func() bool {
+					select {
+					case <-seenConfigChange:
+						return true
+					default:
+						return false
+					}
+				}, 3*time.Second, 100*time.Millisecond)
+				assert.Equal(t, initialSitePhoneHomeURL, c.GetSitePhoneHomeUrl())
+			},
+		},
+		{
+			name: "reloads site phone home URL from changed config",
+			run: func(t *testing.T, c *Config, configPath string) {
+				const updatedSitePhoneHomeURL = "http://updated.example/phone_home"
+
+				require.NoError(t, os.WriteFile(configPath, []byte(`
+log:
+  level: debug
 site:
   phoneHomeUrl: http://updated.example/phone_home
 `), 0o600))
 
-	require.NoError(t, cfg.reloadSitePhoneHomeUrl(configPath))
-	assert.Equal(t, "http://updated.example/phone_home", cfg.GetSitePhoneHomeUrl())
-}
-
-func TestWatchConfigFileReloadsSitePhoneHomeUrl(t *testing.T) {
-	configPath := writeConfigForTest(t, `
+				require.Eventually(t, func() bool {
+					return c.GetSitePhoneHomeUrl() == updatedSitePhoneHomeURL
+				}, 3*time.Second, 100*time.Millisecond)
+				assert.Equal(t, "info", c.v.GetString(ConfigLogLevel))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := writeConfigForTest(t, `
 site:
   phoneHomeUrl: http://initial.example/phone_home
 `)
-	cfg := &Config{v: viper.New()}
-	cfg.v.SetDefault(ConfigFilePath, configPath)
-	cfg.SetSitePhoneHomeUrl("http://initial.example/phone_home")
-	cfg.WatchConfigFile()
-
-	require.NoError(t, os.WriteFile(configPath, []byte(`
-site:
-  phoneHomeUrl: http://watched.example/phone_home
-`), 0o600))
-
-	require.Eventually(t, func() bool {
-		return cfg.GetSitePhoneHomeUrl() == "http://watched.example/phone_home"
-	}, 3*time.Second, 100*time.Millisecond)
-}
-
-func TestReloadSitePhoneHomeUrlKeepsPreviousValueOnInvalidReload(t *testing.T) {
-	configPath := writeConfigForTest(t, `
-site:
-  phoneHomeUrl: ""
-`)
-	cfg := &Config{}
-	cfg.SetSitePhoneHomeUrl("http://previous.example/phone_home")
-
-	require.Error(t, cfg.reloadSitePhoneHomeUrl(configPath))
-	assert.Equal(t, "http://previous.example/phone_home", cfg.GetSitePhoneHomeUrl())
-}
-
-func writeConfigForTest(t *testing.T, content string) string {
-	t.Helper()
-
-	path := filepath.Join(t.TempDir(), "config.yaml")
-	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
-	return path
+			c := &Config{v: viper.New()}
+			c.v.SetDefault(ConfigFilePath, configPath)
+			c.v.SetConfigFile(configPath)
+			c.v.SetDefault(ConfigLogLevel, "info")
+			c.SetSitePhoneHomeUrl(initialSitePhoneHomeURL)
+			c.WatchConfigFile()
+			tt.run(t, c, configPath)
+		})
+	}
 }

--- a/rest-api/api/internal/config/config_test.go
+++ b/rest-api/api/internal/config/config_test.go
@@ -4,9 +4,14 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewConfig(t *testing.T) {
@@ -28,4 +33,64 @@ func TestNewConfig(t *testing.T) {
 			assert.Equal(t, defaultPath, got.GetPathToConfig())
 		})
 	}
+}
+
+func TestReloadSitePhoneHomeUrl(t *testing.T) {
+	configPath := writeConfigForTest(t, `
+site:
+  phoneHomeUrl: http://initial.example/phone_home
+`)
+	cfg := &Config{}
+	cfg.SetSitePhoneHomeUrl(defaultSitePhoneHomeUrl)
+
+	require.NoError(t, cfg.reloadSitePhoneHomeUrl(configPath))
+	assert.Equal(t, "http://initial.example/phone_home", cfg.GetSitePhoneHomeUrl())
+
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+site:
+  phoneHomeUrl: http://updated.example/phone_home
+`), 0o600))
+
+	require.NoError(t, cfg.reloadSitePhoneHomeUrl(configPath))
+	assert.Equal(t, "http://updated.example/phone_home", cfg.GetSitePhoneHomeUrl())
+}
+
+func TestWatchConfigFileReloadsSitePhoneHomeUrl(t *testing.T) {
+	configPath := writeConfigForTest(t, `
+site:
+  phoneHomeUrl: http://initial.example/phone_home
+`)
+	cfg := &Config{v: viper.New()}
+	cfg.v.SetDefault(ConfigFilePath, configPath)
+	cfg.SetSitePhoneHomeUrl("http://initial.example/phone_home")
+	cfg.WatchConfigFile()
+
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+site:
+  phoneHomeUrl: http://watched.example/phone_home
+`), 0o600))
+
+	require.Eventually(t, func() bool {
+		return cfg.GetSitePhoneHomeUrl() == "http://watched.example/phone_home"
+	}, 3*time.Second, 100*time.Millisecond)
+}
+
+func TestReloadSitePhoneHomeUrlKeepsPreviousValueOnInvalidReload(t *testing.T) {
+	configPath := writeConfigForTest(t, `
+site:
+  phoneHomeUrl: ""
+`)
+	cfg := &Config{}
+	cfg.SetSitePhoneHomeUrl("http://previous.example/phone_home")
+
+	require.Error(t, cfg.reloadSitePhoneHomeUrl(configPath))
+	assert.Equal(t, "http://previous.example/phone_home", cfg.GetSitePhoneHomeUrl())
+}
+
+func writeConfigForTest(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
 }

--- a/rest-api/api/internal/config/logger.go
+++ b/rest-api/api/internal/config/logger.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+type zerologSlogHandler struct {
+	logger zerolog.Logger
+	attrs  []slog.Attr
+	groups []string
+}
+
+func (h zerologSlogHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h zerologSlogHandler) Handle(_ context.Context, record slog.Record) error {
+	event := h.logger.WithLevel(h.zerologLevel(record.Level))
+	if event == nil {
+		return nil
+	}
+	for _, attr := range h.attrs {
+		h.addAttr(event, attr)
+	}
+	record.Attrs(func(attr slog.Attr) bool {
+		h.addAttr(event, attr)
+		return true
+	})
+	event.Msg(record.Message)
+	return nil
+}
+
+func (h zerologSlogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	h.attrs = append(slices.Clone(h.attrs), attrs...)
+	return h
+}
+
+func (h zerologSlogHandler) WithGroup(name string) slog.Handler {
+	if name != "" {
+		h.groups = append(slices.Clone(h.groups), name)
+	}
+	return h
+}
+
+func (h zerologSlogHandler) addAttr(event *zerolog.Event, attr slog.Attr) {
+	attr.Value = attr.Value.Resolve()
+	if attr.Equal(slog.Attr{}) {
+		return
+	}
+	key := attr.Key
+	if len(h.groups) > 0 {
+		key = strings.Join(append(slices.Clone(h.groups), key), ".")
+	}
+	event.Any(key, attr.Value.Any())
+}
+
+func (h zerologSlogHandler) zerologLevel(level slog.Level) zerolog.Level {
+	switch {
+	case level < slog.LevelInfo:
+		return zerolog.DebugLevel
+	case level < slog.LevelWarn:
+		return zerolog.InfoLevel
+	case level < slog.LevelError:
+		return zerolog.WarnLevel
+	default:
+		return zerolog.ErrorLevel
+	}
+}

--- a/rest-api/api/internal/config/logger_test.go
+++ b/rest-api/api/internal/config/logger_test.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func decodeLogLine(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+
+	var line map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &line))
+	return line
+}
+
+func TestZerologSlogHandlerZerologLevel(t *testing.T) {
+	handler := zerologSlogHandler{}
+
+	tests := []struct {
+		name  string
+		level slog.Level
+		want  zerolog.Level
+	}{
+		{
+			name:  "debug",
+			level: slog.LevelDebug,
+			want:  zerolog.DebugLevel,
+		},
+		{
+			name:  "info",
+			level: slog.LevelInfo,
+			want:  zerolog.InfoLevel,
+		},
+		{
+			name:  "warn",
+			level: slog.LevelWarn,
+			want:  zerolog.WarnLevel,
+		},
+		{
+			name:  "error",
+			level: slog.LevelError,
+			want:  zerolog.ErrorLevel,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, handler.zerologLevel(tt.level))
+		})
+	}
+}
+
+func TestZerologSlogHandlerHandleWritesAttrsAndGroups(t *testing.T) {
+	var buf bytes.Buffer
+	handler := zerologSlogHandler{
+		logger: zerolog.New(&buf),
+	}
+
+	logger := slog.New(handler.WithAttrs([]slog.Attr{
+		slog.String("component", "viper"),
+	}).WithGroup("watch"))
+	logger.Warn("config file changed", slog.String("event.file", "config.yaml"))
+
+	line := decodeLogLine(t, &buf)
+	assert.Equal(t, "warn", line["level"])
+	assert.Equal(t, "config file changed", line["message"])
+	assert.Equal(t, "viper", line["watch.component"])
+	assert.Equal(t, "config.yaml", line["watch.event.file"])
+}


### PR DESCRIPTION
## Description
- Add support for selective hot-loading of API config attributes
- When config file changes, not all attributes are reloaded because hot-reloading certain config values e.g. DB and Temporal connection requires suspending all connection
- Add support for hot-reloading `site.phoneHomeUrl` from the config file when the file is updated
- Use mutex to ensure thread-safe read/write of `site.phoneHomeUrl`
- Preserve the last good runtime URL when reload reads an invalid empty value or fails to parse the config file.

This keeps the PR scoped to the selective hot-reload path discussed in #2277 and avoids adding a REST config endpoint, config-path CLI surface, deployment changes, or Site model/API configuration.

Signed-off-by: Hasan Khan <hasank@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
Refs #2277

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated

Commands run:
- `git diff --check`
- `go test ./api/internal/config`
- `go test -race ./api/internal/config`
- `go test ./api/... -run '^$'`

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
- Held off on Site model/API configuration based on the current #2277 discussion.
- The watcher uses a dedicated Viper instance so the main config snapshot is not re-read concurrently; only `site.phoneHomeUrl` is copied into the runtime field under lock
