### PR TITLE
fix: normalize IPv6 DNS instance hostnames

### DIFF
--- a/crates/api-db/migrations/20260607120000_ipv6_dns_hostname_normalization.sql
+++ b/crates/api-db/migrations/20260607120000_ipv6_dns_hostname_normalization.sql
@@ -1,0 +1,99 @@
+-- Normalize address-derived DNS hostnames consistently with the Rust
+-- address_to_hostname helper. IPv6 addresses must use fully expanded,
+-- zero-padded hextets joined with dashes.
+
+CREATE OR REPLACE FUNCTION nico_inet_to_dns_hostname(address inet)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+STRICT
+AS $$
+DECLARE
+    address_text text;
+    parts text[];
+    left_groups text[] := ARRAY[]::text[];
+    right_groups text[] := ARRAY[]::text[];
+    groups text[] := ARRAY[]::text[];
+    embedded_ipv4_text text;
+    embedded_ipv4_parts text[];
+    missing_groups integer;
+    hostname text;
+BEGIN
+    IF family(address) = 4 THEN
+        RETURN replace(host(address), '.', '-');
+    END IF;
+
+    address_text := host(address);
+    embedded_ipv4_text := substring(
+        address_text FROM '([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})$'
+    );
+    IF embedded_ipv4_text IS NOT NULL THEN
+        embedded_ipv4_parts := string_to_array(embedded_ipv4_text, '.');
+        address_text := regexp_replace(
+            address_text,
+            '([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})$',
+            to_hex(embedded_ipv4_parts[1]::integer * 256 + embedded_ipv4_parts[2]::integer)
+                || ':'
+                || to_hex(embedded_ipv4_parts[3]::integer * 256 + embedded_ipv4_parts[4]::integer)
+        );
+    END IF;
+
+    parts := regexp_split_to_array(address_text, '::');
+
+    IF parts[1] IS NOT NULL AND parts[1] != '' THEN
+        left_groups := string_to_array(parts[1], ':');
+    END IF;
+
+    IF cardinality(parts) > 1 AND parts[2] != '' THEN
+        right_groups := string_to_array(parts[2], ':');
+    END IF;
+
+    missing_groups := 8 - cardinality(left_groups) - cardinality(right_groups);
+    IF missing_groups < 0 THEN
+        RAISE EXCEPTION 'invalid IPv6 address expansion for %', address_text;
+    END IF;
+
+    groups := left_groups;
+    IF missing_groups > 0 THEN
+        groups := groups || array_fill('0'::text, ARRAY[missing_groups]);
+    END IF;
+    groups := groups || right_groups;
+
+    IF cardinality(groups) != 8 THEN
+        RAISE EXCEPTION 'invalid IPv6 address expansion for %', address_text;
+    END IF;
+
+    SELECT string_agg(lpad(lower(group_text), 4, '0'), '-' ORDER BY group_index)
+    INTO hostname
+    FROM unnest(groups) WITH ORDINALITY AS expanded(group_text, group_index);
+
+    RETURN hostname;
+END;
+$$;
+
+CREATE OR REPLACE VIEW dns_records_instance AS
+SELECT
+    concat(nico_inet_to_dns_hostname(ip_addrs.value::inet), '.', d.name, '.') AS q_name,
+    ip_addrs.value::inet AS resource_record,
+    COALESCE(
+        rt.type_name,
+        CASE WHEN family(ip_addrs.value::inet) = 6 THEN 'AAAA' ELSE 'A' END
+    )::varchar(10) AS q_type,
+    meta.ttl as ttl,
+    d.id as domain_id
+FROM
+    instances i
+JOIN
+    machine_interfaces mi ON i.machine_id = mi.machine_id
+JOIN
+    domains d ON mi.domain_id = d.id
+CROSS JOIN LATERAL
+    jsonb_array_elements(i.network_config::jsonb->'interfaces') AS iface
+CROSS JOIN LATERAL
+    jsonb_each_text(iface->'ip_addrs') AS ip_addrs
+LEFT JOIN
+    dns_record_metadata meta ON meta.id = mi.id
+LEFT JOIN
+    dns_record_types rt ON meta.record_type_id = rt.id
+WHERE
+    iface->'function_id'->>'type' = 'physical';

--- a/crates/api-db/src/dns/mod.rs
+++ b/crates/api-db/src/dns/mod.rs
@@ -27,6 +27,7 @@ pub fn normalize_domain(name: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use sqlx::Row;
 
     #[test]
     fn test_normalize_domain_name() {
@@ -34,5 +35,140 @@ mod tests {
         let expected = "example.com";
         let normalized = super::normalize_domain(domain_name);
         assert_eq!(normalized, expected);
+    }
+
+    #[crate::sqlx_test]
+    async fn test_dns_hostname_from_ipv6_expands_to_rust_format(pool: sqlx::PgPool) {
+        let cases = [
+            ("192.168.1.2", "192-168-1-2"),
+            ("::", "0000-0000-0000-0000-0000-0000-0000-0000"),
+            ("::1", "0000-0000-0000-0000-0000-0000-0000-0001"),
+            ("2001:db8::2", "2001-0db8-0000-0000-0000-0000-0000-0002"),
+            (
+                "::ffff:192.0.2.128",
+                "0000-0000-0000-0000-0000-ffff-c000-0280",
+            ),
+        ];
+
+        for (address, expected_hostname) in cases {
+            let hostname: String = sqlx::query_scalar("SELECT nico_inet_to_dns_hostname($1::inet)")
+                .bind(address)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+            assert_eq!(hostname, expected_hostname);
+        }
+    }
+
+    #[crate::sqlx_test]
+    async fn test_dns_records_instance_ipv6_qname_expands_hostname(pool: sqlx::PgPool) {
+        sqlx::query(
+            "INSERT INTO domains (id, name)
+             VALUES ('10000000-0000-0000-0000-000000000001', 'dwrt1.com')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO network_segments (id, name, version)
+             VALUES ('20000000-0000-0000-0000-000000000001', 'tenant-segment', 'test')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO machines (id, dpf)
+             VALUES ('host-1', '{\"enabled\": true, \"used_for_ingestion\": false}'::jsonb)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO machine_interfaces (
+                id,
+                machine_id,
+                segment_id,
+                mac_address,
+                domain_id,
+                primary_interface,
+                hostname,
+                association_type
+             )
+             VALUES (
+                '30000000-0000-0000-0000-000000000001',
+                'host-1',
+                '20000000-0000-0000-0000-000000000001',
+                '02:00:00:00:00:01',
+                '10000000-0000-0000-0000-000000000001',
+                true,
+                'host-1',
+                'Machine'
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let network_config = serde_json::json!({
+            "interfaces": [
+                {
+                    "function_id": { "type": "physical" },
+                    "ip_addrs": {
+                        "unspecified": "::",
+                        "loopback": "::1",
+                        "tenant": "2001:db8::2"
+                    }
+                }
+            ]
+        });
+
+        sqlx::query("INSERT INTO instances (machine_id, network_config) VALUES ($1, $2::jsonb)")
+            .bind("host-1")
+            .bind(network_config)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let rows = sqlx::query(
+            "SELECT DISTINCT q_name, host(resource_record) AS resource_record
+             FROM dns_records_instance",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+        let records = rows
+            .iter()
+            .map(|row| {
+                (
+                    row.try_get::<String, _>("resource_record").unwrap(),
+                    row.try_get::<String, _>("q_name").unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let expected_records = vec![
+            (
+                "::".to_string(),
+                "0000-0000-0000-0000-0000-0000-0000-0000.dwrt1.com.".to_string(),
+            ),
+            (
+                "::1".to_string(),
+                "0000-0000-0000-0000-0000-0000-0000-0001.dwrt1.com.".to_string(),
+            ),
+            (
+                "2001:db8::2".to_string(),
+                "2001-0db8-0000-0000-0000-0000-0000-0002.dwrt1.com.".to_string(),
+            ),
+        ];
+
+        assert_eq!(records.len(), expected_records.len());
+        for expected_record in expected_records {
+            assert!(records.contains(&expected_record));
+        }
     }
 }


### PR DESCRIPTION
## Description
- Add a database helper that normalizes `inet` values to the same hostname format as the Rust `address_to_hostname` helper.
- Redefine `dns_records_instance` to use fully expanded, zero-padded IPv6 hextets joined by dashes.
- Add DB tests for the helper and the real `dns_records_instance` view so compressed IPv6 addresses like `2001:db8::2` produce the expected FQDN.

Signed-off-by: Hasan Khan [hasank@nvidia.com](mailto:hasank@nvidia.com)

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
Fixes #2244

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Ran locally in a Rust 1.95.0 container with PostgreSQL 15:
- `cargo test -p carbide-api-db test_dns_hostname_from_ipv6_expands_to_rust_format -- --nocapture`
- `cargo test -p carbide-api-db test_dns_records_instance_ipv6_qname_expands_hostname -- --nocapture`
- `cargo fmt --check --package carbide-api-db --package carbide-api-core`
- `git diff --check`

Also smoke-tested the migration SQL directly against PostgreSQL for IPv4, compressed IPv6, zero/loopback IPv6, and IPv4-mapped IPv6 forms.

## Additional Notes
A broader local `carbide-api-core` targeted test was attempted, but the local Docker/Colima environment killed `rustc` with `SIGKILL` while compiling `libredfish`. The DB-scoped tests pass and cover the production migration/view path changed by this PR.