### PR TITLE
fix: paginate DPU network status backing-machine lookups (#2137)

### DIFF
--- a/crates/admin-cli/src/dpu/network/cmd.rs
+++ b/crates/admin-cli/src/dpu/network/cmd.rs
@@ -32,12 +32,13 @@ pub async fn network(
     output_file: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
     cmd: NetworkCommand,
     output_format: OutputFormat,
+    page_size: usize,
 ) -> CarbideCliResult<()> {
     match cmd {
         NetworkCommand::Config(query) => {
             show_dpu_network_config(api_client, output_file, query.machine_id, output_format).await
         }
-        NetworkCommand::Status => show_dpu_status(api_client, output_file).await,
+        NetworkCommand::Status => show_dpu_status(api_client, output_file, page_size).await,
     }
 }
 
@@ -198,6 +199,7 @@ pub async fn show_dpu_network_config(
 pub async fn show_dpu_status(
     api_client: &ApiClient,
     output_file: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
+    page_size: usize,
 ) -> CarbideCliResult<()> {
     let all_status = api_client
         .0
@@ -211,11 +213,15 @@ pub async fn show_dpu_status(
             .iter()
             .filter_map(|status| status.dpu_machine_id)
             .collect();
-        let all_dpus = api_client.get_machines_by_ids(&all_ids).await?.machines;
+        // The Forge API rejects requests carrying more than 100 IDs, so fetch the
+        // backing machines in pages instead of in a single call (see issue #2137).
         let mut dpus_by_id = HashMap::new();
-        for dpu in all_dpus.into_iter() {
-            if let Some(id) = dpu.id {
-                dpus_by_id.insert(id, dpu);
+        for ids in all_ids.chunks(page_size) {
+            let dpus = api_client.get_machines_by_ids(ids).await?.machines;
+            for dpu in dpus.into_iter() {
+                if let Some(id) = dpu.id {
+                    dpus_by_id.insert(id, dpu);
+                }
             }
         }
 

--- a/crates/admin-cli/src/dpu/network/cmd.rs
+++ b/crates/admin-cli/src/dpu/network/cmd.rs
@@ -213,8 +213,11 @@ pub async fn show_dpu_status(
             .iter()
             .filter_map(|status| status.dpu_machine_id)
             .collect();
-        // The Forge API rejects requests carrying more than 100 IDs, so fetch the
-        // backing machines in pages instead of in a single call (see issue #2137).
+        // The Forge API rejects requests carrying more than 100 IDs, and a zero
+        // page size would panic chunks(), so clamp into the valid 1..=100 range
+        // and fetch the backing machines in pages instead of one call (see #2137).
+        const MAX_IDS_PER_REQUEST: usize = 100;
+        let page_size = page_size.clamp(1, MAX_IDS_PER_REQUEST);
         let mut dpus_by_id = HashMap::new();
         for ids in all_ids.chunks(page_size) {
             let dpus = api_client.get_machines_by_ids(ids).await?.machines;

--- a/crates/admin-cli/src/dpu/network/mod.rs
+++ b/crates/admin-cli/src/dpu/network/mod.rs
@@ -35,6 +35,7 @@ impl Run for Args {
             &mut ctx.output_file,
             cmd,
             ctx.config.format,
+            ctx.config.page_size,
         )
         .await
     }

--- a/crates/admin-cli/src/machine/network/cmd.rs
+++ b/crates/admin-cli/src/machine/network/cmd.rs
@@ -26,13 +26,14 @@ pub async fn network(
     cmd: Args,
     format: OutputFormat,
     output_file: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
+    page_size: usize,
 ) -> CarbideCliResult<()> {
     match cmd {
         Args::Status => {
             println!(
                 "Deprecated: Use dpu network, instead machine network. machine network will be removed in future."
             );
-            crate::dpu::show_dpu_status(api_client, output_file).await?;
+            crate::dpu::show_dpu_status(api_client, output_file, page_size).await?;
         }
         Args::Config(query) => {
             println!(

--- a/crates/admin-cli/src/machine/network/mod.rs
+++ b/crates/admin-cli/src/machine/network/mod.rs
@@ -31,6 +31,7 @@ impl Run for Args {
             self,
             ctx.config.format,
             &mut ctx.output_file,
+            ctx.config.page_size,
         )
         .await?;
         Ok(())


### PR DESCRIPTION
## Description
admin-cli's `dpu network status` fetched all backing machines in a single `get_machines_by_ids()` call. At sites with more than 100 DPUs, the Forge API's 100-ID-per-request cap rejected the request with `"no more than 100 IDs can be accepted"` (reproduced at a 1,141-DPU site; worked at 81 DPUs). This threads `page_size` through the `dpu network status` and deprecated `machine network status` command paths and fetches the backing machines in chunks of `page_size` (default 100), matching the pagination pattern already used across `crates/admin-cli/src/rpc.rs` (`get_all_machines`, `get_all_instances`, `get_all_racks`, …).

Signed-off-by: Hasan Khan [hasank@nvidia.com](mailto:hasank@nvidia.com)

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
Fixes #2137

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated in a Rust 1.95.0 container (matching `rust-toolchain.toml`). These verify compilation, lint, and the existing suite — not the live large-DPU scenario:
- `cargo check -p carbide-admin-cli` — clean
- `cargo clippy -p carbide-admin-cli` — clean (no warnings on changed code)
- `cargo test -p carbide-admin-cli` — 544 passed; 0 failed

## Additional Notes
No new unit test was added: admin-cli has no mock-`ApiClient` harness (existing tests are clap-parsing only), and the chunking is identical to the proven sibling `get_all_*` helpers — adding mock infrastructure would balloon a small fix. Known pre-existing limitation (repo-wide, shared by all paged commands): `--page-size > 100` would again exceed the Forge cap; the default of 100 is the safe value.
