### PR TITLE
feat(api-web): add/remove SKU from a machine in admin UI

### DIFF
--- a/crates/api-web/src/action_status.rs
+++ b/crates/api-web/src/action_status.rs
@@ -31,6 +31,7 @@ pub(crate) enum Type {
     DisableSecureBoot,
     EnableLockdown,
     DisableLockdown,
+    Sku,
 }
 
 impl Type {
@@ -48,6 +49,7 @@ impl Type {
                 "disable_secure_boot" => Some(Type::DisableSecureBoot),
                 "enable_lockdown" => Some(Type::EnableLockdown),
                 "disable_lockdown" => Some(Type::DisableLockdown),
+                "sku" => Some(Type::Sku),
                 _ => None,
             })
     }
@@ -64,6 +66,7 @@ impl Type {
                 Type::DisableSecureBoot => "disable_secure_boot",
                 Type::EnableLockdown => "enable_lockdown",
                 Type::DisableLockdown => "disable_lockdown",
+                Type::Sku => "sku",
             },
         )
     }
@@ -77,6 +80,7 @@ impl Type {
             Type::DisableSecureBoot => "Disable Secure Boot",
             Type::EnableLockdown => "Enable Lockdown",
             Type::DisableLockdown => "Disable Lockdown",
+            Type::Sku => "SKU Assignment",
         }
     }
 }

--- a/crates/api-web/src/lib.rs
+++ b/crates/api-web/src/lib.rs
@@ -562,6 +562,7 @@ pub fn routes(api: Arc<Api>) -> eyre::Result<NormalizePath<Router>> {
                 "/machine/{machine_id}/quarantine",
                 post(machine::quarantine),
             )
+            .route("/machine/{machine_id}/sku", post(machine::sku))
             .route(
                 "/machine/{machine_id}/set-dpu-first-boot-order",
                 post(machine::set_dpu_first_boot_order),

--- a/crates/api-web/src/machine.rs
+++ b/crates/api-web/src/machine.rs
@@ -459,6 +459,7 @@ struct MachineDetail<'a> {
     capabilities_json: String,
     validation_runs: Vec<ValidationRun>,
     hw_sku: String,
+    available_skus: Vec<String>,
     quarantine_state: Option<ManagedHostQuarantineState>,
     quarantine_state_is_link: bool,
     instance_type_id: String,
@@ -761,6 +762,7 @@ impl From<forgerpc::Machine> for MachineDetail<'_> {
                 .unwrap_or_default(),
             validation_runs: Vec::new(),
             hw_sku: m.hw_sku.unwrap_or_default(),
+            available_skus: Vec::new(), // filled in later
             quarantine_state_is_link: quarantine_state
                 .as_ref()
                 .is_some_and(|r| r.reason_str().starts_with("http")),
@@ -831,6 +833,23 @@ pub async fn detail(
             }
             Err(e) => return e,
         };
+    }
+
+    // Populate the list of SKUs available for assignment (hosts only).
+    if display.is_host {
+        match state
+            .get_all_sku_ids(tonic::Request::new(()))
+            .await
+            .map(|response| response.into_inner())
+        {
+            Ok(mut sku_ids) => {
+                sku_ids.ids.sort_unstable();
+                display.available_skus = sku_ids.ids;
+            }
+            Err(err) => {
+                tracing::warn!(%err, %machine_id, "get_all_sku_ids failed");
+            }
+        }
     }
 
     // Get validation results
@@ -999,6 +1018,84 @@ pub async fn quarantine(
     }
 
     Redirect::to(&view_url).into_response()
+}
+
+#[derive(Deserialize, Debug)]
+pub struct SkuAction {
+    action: String,
+    sku_id: Option<String>,
+    force: Option<String>,
+}
+
+/// Assign / Remove a SKU on a machine
+pub async fn sku(
+    AxumState(state): AxumState<Arc<Api>>,
+    AxumPath(machine_id): AxumPath<String>,
+    Form(form): Form<SkuAction>,
+) -> Response {
+    let view_url = format!("/admin/machine/{machine_id}#sku_view");
+
+    let machine_id = match machine_id.parse::<MachineId>() {
+        Ok(machine_id) => machine_id,
+        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+    };
+
+    // Checkboxes submit "on" when checked and are omitted otherwise.
+    let force = form.force.as_deref() == Some("on");
+
+    let result = match form.action.as_str() {
+        "assign" => {
+            let sku_id = form.sku_id.unwrap_or_default();
+            if sku_id.is_empty() {
+                let redirect_url = ActionStatus {
+                    action: action_status::Type::Sku,
+                    class: action_status::Class::Error,
+                    message: "No SKU selected".into(),
+                }
+                .update_redirect_url(&view_url);
+                return Redirect::to(&redirect_url).into_response();
+            }
+            state
+                .assign_sku_to_machine(tonic::Request::new(forgerpc::SkuMachinePair {
+                    sku_id: sku_id.clone(),
+                    machine_id: Some(machine_id),
+                    force,
+                }))
+                .await
+                .map(|_| format!("SKU {sku_id} assigned successfully"))
+        }
+        "remove" => state
+            .remove_sku_association(tonic::Request::new(forgerpc::RemoveSkuRequest {
+                machine_id: Some(machine_id),
+                force,
+            }))
+            .await
+            .map(|_| "SKU association removed successfully".to_string()),
+        unknown => {
+            tracing::error!("Expected SKU action to be 'assign' or 'remove' but got {unknown}");
+            return Redirect::to(&view_url).into_response();
+        }
+    };
+
+    let redirect_url = match result {
+        Ok(message) => ActionStatus {
+            action: action_status::Type::Sku,
+            class: action_status::Class::Success,
+            message: message.into(),
+        }
+        .update_redirect_url(&view_url),
+        Err(err) => {
+            tracing::error!(%err, %machine_id, "sku action failed");
+            ActionStatus {
+                action: action_status::Type::Sku,
+                class: action_status::Class::Error,
+                message: err.message().to_string().into(),
+            }
+            .update_redirect_url(&view_url)
+        }
+    };
+
+    Redirect::to(&redirect_url).into_response()
 }
 
 #[derive(Deserialize, Debug)]

--- a/crates/api-web/templates/machine_detail.html
+++ b/crates/api-web/templates/machine_detail.html
@@ -36,6 +36,7 @@
 			{% if !hw_sku.is_empty() %}
 			<a href="/admin/sku/{{ hw_sku }}">{{ hw_sku }}</a>
 			{% endif %}
+			<a href="#sku_view">(edit)</a>
 		</td>
 	</tr>
 		{% if has_instance_type %}
@@ -142,6 +143,64 @@
 			</form>
 		</td>
 	</tr>
+</table>
+
+<h3 id="sku_view">SKU</h3>
+<table class="detailsview">
+	<tr>
+		<th>Current SKU</th>
+		<td>
+			{% if !hw_sku.is_empty() %}
+			<a href="/admin/sku/{{ hw_sku }}">{{ hw_sku }}</a>
+			{% else %}
+			<i>None assigned</i>
+			{% endif %}
+		</td>
+	</tr>
+	<tr>
+		<th>Assign SKU</th>
+		<td>
+			<form id="assign_sku_action" method="POST" action="/admin/machine/{{ id }}/sku">
+				<input type="hidden" name="action" value="assign"/>
+				<div>
+					<label for="sku_id">SKU:</label>
+					<select id="sku_id" name="sku_id">
+						<option value="">-- select a SKU --</option>
+						{% for sku in available_skus %}
+						<option value="{{ sku }}"{% if hw_sku == *sku %} selected{% endif %}>{{ sku }}</option>
+						{% endfor %}
+					</select>
+				</div>
+				<div>
+					<label for="assign_force">Force:</label>
+					<input type="checkbox" id="assign_force" name="force"/>
+					<i>Override state checks and replace any existing SKU</i>
+				</div>
+				<button type="submit">Assign SKU</button>
+			</form>
+		</td>
+	</tr>
+	{% if !hw_sku.is_empty() %}
+	<tr>
+		<th>Remove SKU</th>
+		<td>
+			<form id="remove_sku_action" method="POST" action="/admin/machine/{{ id }}/sku">
+				<input type="hidden" name="action" value="remove"/>
+				<div>
+					<label for="remove_force">Force:</label>
+					<input type="checkbox" id="remove_force" name="force"/>
+					<i>Override state checks</i>
+				</div>
+				<button type="submit">Remove SKU</button>
+			</form>
+		</td>
+	</tr>
+	{% endif %}
+	{% if let Some(status) = action_status %}
+	{% if status.action == action_status::Type::Sku %}
+	<tr><td colspan="2">{{ status.action_result_script()|safe }}</td></tr>
+	{% endif %}
+	{% endif %}
 </table>
 {% endif %}
 
@@ -462,7 +521,7 @@ Missing BMC Data
 		maintenance_form.addEventListener("submit", are_you_sure_maintenance);
 		let quarantine_form = document.getElementById("quarantine_action");
 		quarantine_form.addEventListener("submit", are_you_sure_quarantine);
-		
+
 		// Set up Logs link
 		const machineId = "{{ id }}";
 		document.getElementById('logs-link').href = buildGrafanaLogsUrl(machineId);


### PR DESCRIPTION
Wire the existing AssignSkuToMachine / RemoveSkuAssociation RPCs into the core admin web UI. The machine detail page now has a SKU section (hosts only) with an assign form (dropdown of available SKUs + force checkbox) and a remove form, mirroring the maintenance/quarantine action pattern.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [X] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

