### PR TITLE
fix: correct several incorrect error messages (DPU reprovision, DPA)

### DIFF
--- a/crates/admin-cli/src/dpu/reprovision/cmd.rs
+++ b/crates/admin-cli/src/dpu/reprovision/cmd.rs
@@ -74,7 +74,7 @@ async fn apply_health_report(
         }
         _ => {
             return Err(CarbideCliError::GenericError(format!(
-                "Invalid machine ID for reprevisioning, only Hosts and DPUs are supported: {update_message}"
+                "Invalid machine ID for reprovisioning, only Hosts and DPUs are supported: {id}"
             )));
         }
     };

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -1192,7 +1192,7 @@ pub(crate) async fn trigger_dpu_reprovisioning(
 
             if ids.is_empty() {
                 return Err(CarbideError::InvalidArgument(
-                    "No DPUs are currently reprovisioning on {machine_id}, cannot restart reprovisioning. Use `set` to begin reprovisioning DPUs.".to_string(),
+                    format!("No DPUs are currently reprovisioning on {machine_id}, cannot restart reprovisioning. Use `set` to begin reprovisioning DPUs."),
                 )
                     .into());
             }

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -1110,9 +1110,9 @@ pub(crate) async fn trigger_dpu_reprovisioning(
             .classifications
             .contains(&health_report::HealthAlertClassification::prevent_allocations())
     }) {
-        return Err(CarbideError::InvalidArgument(
-            "Machine must have a 'HostUpdateInProgress' Health Alert with 'PreventAllocations' classification.".into(),
-        ).into());
+        return Err(CarbideError::InvalidArgument(format!(
+            "Machine {machine_id} must have a 'HostUpdateInProgress' health alert with the 'PreventAllocations' classification before reprovisioning. Set this precondition with: `machine health-override add --template host-update <id>`.",
+        )).into());
     }
 
     if snapshot.dpu_snapshots.iter().any(|ms| {

--- a/crates/api-db/src/dpa_interface.rs
+++ b/crates/api-db/src/dpa_interface.rs
@@ -444,7 +444,7 @@ where
 
     let snapshot = match maybe_snapshot {
         Some(sn) => sn,
-        None => return Err(eyre!("machine {machine_id} snapshot found".to_string())),
+        None => return Err(eyre!("machine {machine_id} snapshot not found")),
     };
 
     let instance = match snapshot.instance {


### PR DESCRIPTION
## Description
Cleans up four error messages in the DPU reprovision and DPA paths that were showing the wrong value, a literal {placeholder}, or slightly misleading text, so they now display the correct machine id and clearer wording.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

