### PR TITLE
chore: cargo make format-nightly to correct lint errors release/0.8.0

### DIFF
--- a/crates/agent/src/tests/common/mod.rs
+++ b/crates/agent/src/tests/common/mod.rs
@@ -15,15 +15,20 @@
  * limitations under the License.
  */
 
+use std::convert::Infallible;
 use std::net::{SocketAddr, TcpListener};
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 use std::{env, fs};
 
-use axum::http::header;
+use axum::body::Bytes;
+use axum::http::{HeaderMap, HeaderName, HeaderValue, Response, header};
 use axum::response::IntoResponse;
 use axum_server::tls_rustls::RustlsConfig;
+use http_body::{Body as HttpBody, Frame};
 use rustls::ServerConfig;
 use rustls_pemfile::Item;
 use rustls_pki_types::PrivateKeyDer;
@@ -128,6 +133,7 @@ pub async fn run_grpc_server(
     app: axum::Router<()>,
 ) -> eyre::Result<(SocketAddr, tokio::task::JoinHandle<()>)> {
     let listener = TcpListener::bind("127.0.0.1:0")?; // 0 let OS choose available port
+    listener.set_nonblocking(true)?;
     let addr = listener.local_addr()?;
     let server_config = make_rustls_server_config()?;
     let join_handle = tokio::spawn(async move {
@@ -201,6 +207,50 @@ async fn wait_for_server_to_start(addr: SocketAddr) -> eyre::Result<()> {
     Ok(())
 }
 
+struct GrpcBody {
+    data: Option<Bytes>,
+    trailers: Option<HeaderMap>,
+}
+
+impl GrpcBody {
+    fn new(data: Vec<u8>) -> Self {
+        let mut trailers = HeaderMap::new();
+        trailers.insert(
+            HeaderName::from_static("grpc-status"),
+            HeaderValue::from_static("0"),
+        );
+
+        Self {
+            data: Some(Bytes::from(data)),
+            trailers: Some(trailers),
+        }
+    }
+}
+
+impl HttpBody for GrpcBody {
+    type Data = Bytes;
+    type Error = Infallible;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+        if let Some(data) = this.data.take() {
+            return Poll::Ready(Some(Ok(Frame::data(data))));
+        }
+        if let Some(trailers) = this.trailers.take() {
+            return Poll::Ready(Some(Ok(Frame::trailers(trailers))));
+        }
+
+        Poll::Ready(None)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.data.is_none() && self.trailers.is_none()
+    }
+}
+
 /// Takes an rpc object (built from rpc/proto/forge.proto) and turns into into a gRPC axum response
 pub fn respond(out: impl prost::Message) -> impl IntoResponse {
     let msg_len = out.encoded_len() as u32;
@@ -212,6 +262,8 @@ pub fn respond(out: impl prost::Message) -> impl IntoResponse {
     // and finally the message
     out.encode(&mut body).unwrap();
 
-    let headers = [(header::CONTENT_TYPE, "application/grpc+tonic")];
-    (headers, body)
+    Response::builder()
+        .header(header::CONTENT_TYPE, "application/grpc+tonic")
+        .body(GrpcBody::new(body))
+        .unwrap()
 }

--- a/crates/dhcp/src/mock_api_server.rs
+++ b/crates/dhcp/src/mock_api_server.rs
@@ -21,13 +21,16 @@
 ///
 /// Module only included if #cfg(test)
 use std::collections::HashMap;
+use std::convert::Infallible;
 use std::net::{SocketAddr, SocketAddrV4};
+use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
 
 use ::rpc::forge as rpc;
-use http_body_util::{BodyExt, Full};
-use hyper::body::{Bytes, Incoming};
+use http_body_util::BodyExt;
+use hyper::body::{Body as HttpBody, Bytes, Frame, Incoming};
 use hyper::server::conn::http2;
 use hyper::service::service_fn;
 use hyper::{Request, Response, body, header};
@@ -147,7 +150,7 @@ impl MockAPIServer {
                                 let c3 = c3.clone();
                                 let i3 = i3.clone();
                                 async move {
-                                    Ok::<Response<Full<Bytes>>, hyper::Error>(MockAPIServer::handler(req, c3.clone(), i3.clone()).await.unwrap())
+                                    Ok::<Response<GrpcBody>, hyper::Error>(MockAPIServer::handler(req, c3.clone(), i3.clone()).await.unwrap())
                                 }
                             })).await.inspect_err(|e| eprintln!("ERROR: {e:?}")).unwrap()
                         });
@@ -192,7 +195,7 @@ impl MockAPIServer {
         req: Request<Incoming>,
         calls: Arc<Mutex<HashMap<String, usize>>>,
         fail: Arc<Mutex<bool>>,
-    ) -> Result<Response<Full<Bytes>>, MockAPIServerError> {
+    ) -> Result<Response<GrpcBody>, MockAPIServerError> {
         let path = req.uri().path();
         calls
             .lock()
@@ -207,9 +210,7 @@ impl MockAPIServer {
                 if inject_failure {
                     Err(MockAPIServerError::MockAPIFetchMachineError)
                 } else {
-                    Ok(Response::new(
-                        MockAPIServer::discover_dhcp(req).await.into(),
-                    ))
+                    Ok(grpc_response(MockAPIServer::discover_dhcp(req).await))
                 }
             }
             ENDPOINT_EXPIRE_DHCP_LEASE => {
@@ -245,8 +246,60 @@ impl Drop for MockAPIServer {
     }
 }
 
-/// Takes an rpc object (built from rpc/proto/forge.proto) and turns into into a gRPC axum response
-fn respond(out: impl prost::Message) -> Result<Response<Full<Bytes>>, MockAPIServerError> {
+struct GrpcBody {
+    data: Option<Bytes>,
+    trailers: Option<hyper::HeaderMap>,
+}
+
+impl GrpcBody {
+    fn new(data: Vec<u8>) -> Self {
+        let mut trailers = hyper::HeaderMap::new();
+        trailers.insert(
+            header::HeaderName::from_static("grpc-status"),
+            header::HeaderValue::from_static("0"),
+        );
+
+        Self {
+            data: Some(Bytes::from(data)),
+            trailers: Some(trailers),
+        }
+    }
+}
+
+impl HttpBody for GrpcBody {
+    type Data = Bytes;
+    type Error = Infallible;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+        if let Some(data) = this.data.take() {
+            return Poll::Ready(Some(Ok(Frame::data(data))));
+        }
+        if let Some(trailers) = this.trailers.take() {
+            return Poll::Ready(Some(Ok(Frame::trailers(trailers))));
+        }
+
+        Poll::Ready(None)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.data.is_none() && self.trailers.is_none()
+    }
+}
+
+fn grpc_response(body: Vec<u8>) -> Response<GrpcBody> {
+    Response::builder()
+        .status(200)
+        .header(header::CONTENT_TYPE, "application/grpc+tonic")
+        .body(GrpcBody::new(body))
+        .unwrap()
+}
+
+/// Takes an rpc object (built from rpc/proto/forge.proto) and turns into into a gRPC response
+fn respond(out: impl prost::Message) -> Result<Response<GrpcBody>, MockAPIServerError> {
     let msg_len = out.encoded_len() as u32;
     let mut body = Vec::with_capacity(1 + 4 + msg_len as usize);
     // first byte is compression: 0 means none
@@ -256,9 +309,5 @@ fn respond(out: impl prost::Message) -> Result<Response<Full<Bytes>>, MockAPISer
     // and finally the message
     out.encode(&mut body).unwrap();
 
-    Ok(Response::builder()
-        .status(200)
-        .header(header::CONTENT_TYPE, "application/grpc+tonic")
-        .body(body.into())
-        .unwrap())
+    Ok(grpc_response(body))
 }

--- a/crates/utils/src/managed_host_display.rs
+++ b/crates/utils/src/managed_host_display.rs
@@ -261,7 +261,7 @@ impl From<Machine> for ManagedHostOutput {
             // dpus and exploration_report are filled in later
             health_overrides,
             dpus: Default::default(),
-            exploration_report: Default::default()
+            exploration_report: Default::default(),
         }
     }
 }


### PR DESCRIPTION
Fixes linting error on release/0.8.0 branch

      * cherry-pick GrpcBody to work with updates grpc-status which was
        introduced as part of PR #2133
      * Axum 0.7 `from_tcp_rustls` return a `Server` directory, not a Result.
        Since this PR deliberately does not pull in the Axum 0.8 (which does
        return a Result) we change it back to the 0.7 way


Fixes https://github.com/NVIDIA/infra-controller/issues/2294

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

