### PR TITLE
test(nvue-client): read REPO_ROOT at runtime for config tests

### DIFF
--- a/crates/nvue-client/src/config.rs
+++ b/crates/nvue-client/src/config.rs
@@ -184,7 +184,9 @@ mod tests {
 
     // Enumerate the startup config files from the agent crate's directory.
     fn enumerate_agent_configs() -> Vec<PathBuf> {
-        let repo_root = Path::new(std::env!("REPO_ROOT"));
+        let repo_root =
+            std::env::var("REPO_ROOT").expect("REPO_ROOT must be set to the repository root");
+        let repo_root = Path::new(&repo_root);
         let agent_templates_tests_dir = {
             let mut buf = repo_root.to_path_buf();
             buf.extend(["crates", "agent", "templates", "tests"]);


### PR DESCRIPTION
## Description

Avoid enforcing REPO_ROOT at compile time so checks like clippy can run without requiring the environment variable during compilation.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

#2257 

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

