### PR TITLE
feat(rest-api): write all expected-inventory device metadata to Core

### DIFF
--- a/rest-api/db/pkg/db/model/common.go
+++ b/rest-api/db/pkg/db/model/common.go
@@ -4,6 +4,8 @@
 package model
 
 import (
+	"strconv"
+
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -62,4 +64,71 @@ func (l *Labels) FromProto(protoLabels []*cwssaws.Label) {
 		result[label.Key] = value
 	}
 	*l = result
+}
+
+// Expected-inventory metadata label keys. These mirror the flat source field
+// names from the REST API write path and are emitted as-is into Core's Metadata
+// labels, so Core persists the full inventory dataset and Flow can read it back
+// and structure it as it sees fit.
+//
+// TODO: replace this flat label passthrough with a structured InventoryData
+// type (device + rack-position fields) carried explicitly, rather than packing
+// the values into stringly-typed labels. Follow-up PR.
+const (
+	ExpectedComponentLabelManufacturer    = "manufacturer"
+	ExpectedComponentLabelModel           = "model"
+	ExpectedComponentLabelFirmwareVersion = "firmware_version"
+	ExpectedComponentLabelSlotID          = "slot_id"
+	ExpectedComponentLabelTrayIdx         = "tray_idx"
+	ExpectedComponentLabelHostID          = "host_id"
+)
+
+// expectedComponentLabelsInput carries the flat device/rack columns that its
+// ToProto method maps into an expected component's Metadata labels. Grouping
+// them into a struct keeps the call sites self-documenting and avoids a long,
+// transposition-prone arg list.
+type expectedComponentLabelsInput struct {
+	Manufacturer    *string
+	Model           *string
+	FirmwareVersion *string
+	SlotID          *int32
+	TrayIdx         *int32
+	HostID          *int32
+	Labels          Labels
+}
+
+// ToProto merges the input's labels with the flat device/rack columns, each
+// emitted as a label keyed by its source field name (see the
+// ExpectedComponentLabel* constants). A system field takes precedence over a
+// colliding user label, since the field value is the authoritative inventory
+// data. Returns nil when there are no labels at all. Name and description are
+// not labels -- callers set those on Metadata directly.
+func (in expectedComponentLabelsInput) ToProto() []*cwssaws.Label {
+	// Merge through a map so a system field overrides a colliding user label.
+	merged := make(map[string]string, len(in.Labels)+6)
+	for k, v := range in.Labels {
+		merged[k] = v
+	}
+	if in.Manufacturer != nil {
+		merged[ExpectedComponentLabelManufacturer] = *in.Manufacturer
+	}
+	if in.Model != nil {
+		merged[ExpectedComponentLabelModel] = *in.Model
+	}
+	if in.FirmwareVersion != nil {
+		merged[ExpectedComponentLabelFirmwareVersion] = *in.FirmwareVersion
+	}
+	if in.SlotID != nil {
+		merged[ExpectedComponentLabelSlotID] = strconv.FormatInt(int64(*in.SlotID), 10)
+	}
+	if in.TrayIdx != nil {
+		merged[ExpectedComponentLabelTrayIdx] = strconv.FormatInt(int64(*in.TrayIdx), 10)
+	}
+	if in.HostID != nil {
+		merged[ExpectedComponentLabelHostID] = strconv.FormatInt(int64(*in.HostID), 10)
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return Labels(merged).ToProto()
 }

--- a/rest-api/db/pkg/db/model/common_test.go
+++ b/rest-api/db/pkg/db/model/common_test.go
@@ -107,3 +107,61 @@ func TestLabels_FromProto_OverwritesExistingReceiver(t *testing.T) {
 		assert.Nil(t, l)
 	})
 }
+
+// labelsAsMap collapses a proto Label slice into a Labels map so assertions
+// don't depend on slice ordering (user labels come from a map iteration).
+func labelsAsMap(protoLabels []*cwssaws.Label) Labels {
+	var l Labels
+	l.FromProto(protoLabels)
+	return l
+}
+
+func TestExpectedComponentLabelsInput_ToProto(t *testing.T) {
+	t.Run("merges user labels with the flat device fields", func(t *testing.T) {
+		got := labelsAsMap(expectedComponentLabelsInput{
+			Manufacturer:    cutil.GetPtr("NVIDIA"),
+			Model:           cutil.GetPtr("MGX"),
+			FirmwareVersion: cutil.GetPtr("25.06-2"),
+			SlotID:          cutil.GetPtr(int32(3)),
+			TrayIdx:         cutil.GetPtr(int32(0)), // zero is a valid position
+			HostID:          cutil.GetPtr(int32(1)),
+			Labels:          Labels{"environment": "prod", "team": "infra"},
+		}.ToProto())
+		assert.Equal(t, Labels{
+			"environment":      "prod",
+			"team":             "infra",
+			"manufacturer":     "NVIDIA",
+			"model":            "MGX",
+			"firmware_version": "25.06-2",
+			"slot_id":          "3",
+			"tray_idx":         "0",
+			"host_id":          "1",
+		}, got)
+	})
+
+	t.Run("returns nil when there are no labels", func(t *testing.T) {
+		assert.Nil(t, expectedComponentLabelsInput{}.ToProto())
+	})
+
+	t.Run("device fields only, no user labels", func(t *testing.T) {
+		got := labelsAsMap(expectedComponentLabelsInput{
+			Manufacturer: cutil.GetPtr("NVIDIA"),
+			SlotID:       cutil.GetPtr(int32(0)),
+		}.ToProto())
+		assert.Equal(t, Labels{
+			"manufacturer": "NVIDIA",
+			"slot_id":      "0",
+		}, got)
+	})
+
+	t.Run("system field wins over a conflicting user label", func(t *testing.T) {
+		got := labelsAsMap(expectedComponentLabelsInput{
+			Manufacturer: cutil.GetPtr("NVIDIA"),
+			Labels:       Labels{"manufacturer": "user-supplied", "extra": "kept"},
+		}.ToProto())
+		assert.Equal(t, Labels{
+			"manufacturer": "NVIDIA", // system value wins
+			"extra":        "kept",   // non-conflicting user label preserved
+		}, got)
+	})
+}

--- a/rest-api/db/pkg/db/model/expectedmachine.go
+++ b/rest-api/db/pkg/db/model/expectedmachine.go
@@ -131,11 +131,24 @@ func (em *ExpectedMachine) ToProto(creds ExpectedMachineCredentials) *cwssaws.Ex
 		proto.BmcPassword = *creds.Password
 	}
 
-	if em.Labels != nil {
-		proto.Metadata = &cwssaws.Metadata{
-			Labels: em.Labels.ToProto(),
-		}
+	metadata := &cwssaws.Metadata{
+		Labels: expectedComponentLabelsInput{
+			Manufacturer:    em.Manufacturer,
+			Model:           em.Model,
+			FirmwareVersion: em.FirmwareVersion,
+			SlotID:          em.SlotID,
+			TrayIdx:         em.TrayIdx,
+			HostID:          em.HostID,
+			Labels:          em.Labels,
+		}.ToProto(),
 	}
+	if em.Name != nil {
+		metadata.Name = *em.Name
+	}
+	if em.Description != nil {
+		metadata.Description = *em.Description
+	}
+	proto.Metadata = metadata
 
 	return proto
 }

--- a/rest-api/db/pkg/db/model/expectedpowershelf.go
+++ b/rest-api/db/pkg/db/model/expectedpowershelf.go
@@ -122,11 +122,24 @@ func (eps *ExpectedPowerShelf) ToProto(creds ExpectedPowerShelfCredentials) *cws
 		proto.BmcPassword = *creds.Password
 	}
 
-	if eps.Labels != nil {
-		proto.Metadata = &cwssaws.Metadata{
-			Labels: eps.Labels.ToProto(),
-		}
+	metadata := &cwssaws.Metadata{
+		Labels: expectedComponentLabelsInput{
+			Manufacturer:    eps.Manufacturer,
+			Model:           eps.Model,
+			FirmwareVersion: eps.FirmwareVersion,
+			SlotID:          eps.SlotID,
+			TrayIdx:         eps.TrayIdx,
+			HostID:          eps.HostID,
+			Labels:          eps.Labels,
+		}.ToProto(),
 	}
+	if eps.Name != nil {
+		metadata.Name = *eps.Name
+	}
+	if eps.Description != nil {
+		metadata.Description = *eps.Description
+	}
+	proto.Metadata = metadata
 
 	return proto
 }

--- a/rest-api/db/pkg/db/model/expectedswitch.go
+++ b/rest-api/db/pkg/db/model/expectedswitch.go
@@ -129,11 +129,24 @@ func (es *ExpectedSwitch) ToProto(creds ExpectedSwitchCredentials) *cwssaws.Expe
 		proto.NvosPassword = creds.NvosPassword
 	}
 
-	if es.Labels != nil {
-		proto.Metadata = &cwssaws.Metadata{
-			Labels: es.Labels.ToProto(),
-		}
+	metadata := &cwssaws.Metadata{
+		Labels: expectedComponentLabelsInput{
+			Manufacturer:    es.Manufacturer,
+			Model:           es.Model,
+			FirmwareVersion: es.FirmwareVersion,
+			SlotID:          es.SlotID,
+			TrayIdx:         es.TrayIdx,
+			HostID:          es.HostID,
+			Labels:          es.Labels,
+		}.ToProto(),
 	}
+	if es.Name != nil {
+		metadata.Name = *es.Name
+	}
+	if es.Description != nil {
+		metadata.Description = *es.Description
+	}
+	proto.Metadata = metadata
 
 	return proto
 }


### PR DESCRIPTION
## Description

This supports https://github.com/NVIDIA/infra-controller/issues/2124.

`ExpectedMachine`, `ExpectedSwitch`, and `ExpectedPowerShelf` all have additional metadata labels (e.g. `manufacturer`, `model`, `firmware_version`, and rack-related slot/tray/host) that today reach `Flow` through flat proto fields (that come in via `rest-api`), and are only written to `Flow` as as part of how we dual-write/tee things off between `Core` and `Flow` (once it comes in via `rest-api`).

However, all of this should be going into `Core` (e.g. anything we get from the DCIM); the dual-write approach was temporary, with `Core` being the inventory source of truth (and `Flow` reading from `Core`). Generally speaking, most of the data was already there, and the rest needs to simply be plumbed through as `Metadata` labels for any consumers who want it (e.g. `Flow` is one of them)!

So, this does that, taking those existing "flat" fields that were being sent to `Flow`, and now plumbing them through to `Core` as `Metadata` labels.

The idea is `Core` tries to keep it as basic/decoupled from the `Flow` modeling as possible, which in turn lets `Flow` flexibly model its own data around the metadata as it sees fit. I had actually considered trying to model the `Core` data 1:1 around the `Flow` data, but Kun and I decided we probably don't want to do that, because we don't want that interdependency (and it could make things more difficult for both sides to adjust later on).

I *think* this is probably going to evolve somewhat over time. I could see `Core` wanting a ~firehose of metadata from Launch Layer/DCIM, but I think keeping it flat key/val is probably the right way to go about it and being flexible.

One idea would be to introduce a new `InventoryData` structure right alongside `Metadata`, so we can start populating structured data that we know is coming. TBD.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

