### PR TITLE
feat: store every NIC interface ID, not just DPU interface IDs

### DIFF
--- a/crates/api-core/src/tests/site_explorer.rs
+++ b/crates/api-core/src/tests/site_explorer.rs
@@ -3453,6 +3453,64 @@ async fn test_site_explorer_backfills_boot_interface_id_onto_machine_interface(
     Ok(())
 }
 
+/// A zero-DPU host whose only NIC is a plain (non-DPU) host NIC.
+/// We expect to walk over the report ethernet interfaces and record
+/// the NIC's Redfish-reported interface id onto its machine_interface
+/// row, matched/paired with its MAC address.
+#[sqlx_test]
+async fn test_site_explorer_records_boot_interface_id_onto_non_dpu_nic(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides {
+            site_prefixes: Some(vec![
+                IpNetwork::new(
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+                IpNetwork::new(
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+            ]),
+            ..Default::default()
+        },
+    )
+    .await;
+    create_host_inband_network_segment(&env.api, None).await;
+
+    let non_dpu_mac = MacAddress::from_str("d4:04:e6:84:13:98").unwrap();
+    let mh = common::api_fixtures::create_managed_host_with_config(
+        &env,
+        ManagedHostConfig {
+            dpus: vec![],
+            non_dpu_macs: vec![non_dpu_mac],
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let mut txn = env.pool.begin().await?;
+    let interfaces = db::machine_interface::find_by_machine_ids(&mut txn, &[mh.id]).await?;
+    let nic = interfaces
+        .get(&mh.id)
+        .into_iter()
+        .flatten()
+        .find(|i| i.mac_address == non_dpu_mac)
+        .expect("the non-DPU host NIC should have a machine_interface row");
+
+    assert_eq!(
+        nic.boot_interface_id.as_deref(),
+        Some("NIC.Embedded.1-1-1"),
+        "exploration should record a non-DPU NIC's Redfish interface id on its row",
+    );
+
+    Ok(())
+}
+
 /// A Managed Host whose `expected_machines` row is later removed becomes an
 /// orphan: `audit_exploration_results` emits an `OrphanManagedHost` health
 /// alert on the host's Machine. Re-adding the entry clears the alert on the

--- a/crates/api-model/src/machine_boot_interface.rs
+++ b/crates/api-model/src/machine_boot_interface.rs
@@ -41,19 +41,20 @@ pub struct MachineBootInterface {
 
 impl MachineBootInterface {
     /// Builds a `MachineBootInterface` from the optional `(mac, interface_id)`
-    /// parts of a record, returning `Some` only when *both* are present.
+    /// parts of a record, returning `Some` only when *both* are present and the
+    /// interface id is non-empty.
     ///
     /// This is the single place the "only retain a fully-populated boot
-    /// interface" rule is enforced: a partial pair (only one of the two
-    /// resolved) yields `None`, so callers keep the last-known-good record
-    /// rather than persisting a half-empty one.
+    /// interface" rule is enforced: a partial pair (a missing MAC, or a missing
+    /// or empty interface id) yields `None`, so callers keep the last-known-good
+    /// record rather than persisting a half-empty one.
     pub fn from_parts(
         mac_address: Option<MacAddress>,
         interface_id: Option<String>,
     ) -> Option<Self> {
         Some(Self {
             mac_address: mac_address?,
-            interface_id: interface_id?,
+            interface_id: interface_id.filter(|s| !s.is_empty())?,
         })
     }
 }
@@ -77,6 +78,11 @@ mod tests {
             MachineBootInterface::from_parts(Some(mac), None),
             None,
             "a present MAC with no interface id is not fully populated"
+        );
+        assert_eq!(
+            MachineBootInterface::from_parts(Some(mac), Some(String::new())),
+            None,
+            "a present MAC with an empty interface id is not fully populated"
         );
         assert_eq!(
             MachineBootInterface::from_parts(None, Some("NIC.Slot.7-1-1".to_string())),

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -159,7 +159,9 @@ impl EndpointExplorationReport {
     }
 
     /// Finds the Redfish interface id of the host ethernet interface whose MAC
-    /// matches `mac`, if any.
+    /// matches `mac`, if any. An interface that reports an empty id is treated
+    /// as having none, so callers never capture an empty string as the id (which
+    /// would otherwise clobber a previously stored, valid one).
     ///
     /// Used to capture the boot interface's [stable] Redfish interface id
     /// alongside its MAC, giving setup calls a second, [stable] handle to target
@@ -169,7 +171,19 @@ impl EndpointExplorationReport {
             .iter()
             .flat_map(|s| s.ethernet_interfaces.iter())
             .find(|e| e.mac_address == Some(mac))
-            .and_then(|e| e.id.as_deref())
+            .and_then(|e| e.id.as_deref().filter(|id| !id.is_empty()))
+    }
+
+    /// Yields a [`MachineBootInterface`] for every host ethernet interface that
+    /// reports both a MAC and a non-empty Redfish interface id -- for any NIC
+    /// type (integrated NICs, SuperNICs, DPUs in NIC mode, DPU host-PFs).
+    /// Interfaces missing either half are skipped (via
+    /// [`MachineBootInterface::from_parts`]).
+    pub fn complete_boot_interfaces(&self) -> impl Iterator<Item = MachineBootInterface> + '_ {
+        self.systems
+            .iter()
+            .flat_map(|s| s.ethernet_interfaces.iter())
+            .filter_map(|e| MachineBootInterface::from_parts(e.mac_address, e.id.clone()))
     }
 }
 
@@ -2107,6 +2121,89 @@ mod tests {
         };
         // MAC present but no interface id -> can't form a fully-populated pair.
         assert_eq!(report.find_interface_id_for_mac(mac), None);
+    }
+
+    #[test]
+    fn find_interface_id_for_mac_none_when_id_empty() {
+        let mac = MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01]);
+        let report = EndpointExplorationReport {
+            systems: vec![ComputerSystem {
+                ethernet_interfaces: vec![EthernetInterface {
+                    id: Some(String::new()),
+                    mac_address: Some(mac),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        // An empty id is not a usable interface id, so it's treated as absent --
+        // the capture then keeps the last-known-good stored boot interface
+        // rather than clobbering it with an empty string.
+        assert_eq!(report.find_interface_id_for_mac(mac), None);
+    }
+
+    #[test]
+    fn complete_boot_interfaces_yields_every_nic_regardless_of_type() {
+        let dpu_mac = MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01]);
+        let integrated_mac = MacAddress::new([0xD4, 0x04, 0xE6, 0x84, 0x13, 0x98]);
+        let id_less_mac = MacAddress::new([0x11, 0x22, 0x33, 0x44, 0x55, 0x66]);
+        let empty_id_mac = MacAddress::new([0x22, 0x33, 0x44, 0x55, 0x66, 0x77]);
+        let report = EndpointExplorationReport {
+            systems: vec![ComputerSystem {
+                ethernet_interfaces: vec![
+                    // A DPU host-PF -- the only kind the DPU-only capture reached...
+                    EthernetInterface {
+                        id: Some("NIC.Slot.7-1-1".to_string()),
+                        mac_address: Some(dpu_mac),
+                        ..Default::default()
+                    },
+                    // ...and a non-DPU integrated NIC, which is now yielded too.
+                    EthernetInterface {
+                        id: Some("NIC.Embedded.1-1-1".to_string()),
+                        mac_address: Some(integrated_mac),
+                        ..Default::default()
+                    },
+                    // No id -> can't form a pair, skipped.
+                    EthernetInterface {
+                        id: None,
+                        mac_address: Some(id_less_mac),
+                        ..Default::default()
+                    },
+                    // No MAC -> nothing to key on, skipped.
+                    EthernetInterface {
+                        id: Some("NIC.Embedded.2-1-1".to_string()),
+                        mac_address: None,
+                        ..Default::default()
+                    },
+                    // Empty id -> not a usable id, skipped (don't clobber last-known-good).
+                    EthernetInterface {
+                        id: Some(String::new()),
+                        mac_address: Some(empty_id_mac),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let boot_interfaces: Vec<MachineBootInterface> =
+            report.complete_boot_interfaces().collect();
+        assert_eq!(
+            boot_interfaces,
+            vec![
+                MachineBootInterface {
+                    mac_address: dpu_mac,
+                    interface_id: "NIC.Slot.7-1-1".to_string(),
+                },
+                MachineBootInterface {
+                    mac_address: integrated_mac,
+                    interface_id: "NIC.Embedded.1-1-1".to_string(),
+                },
+            ],
+            "complete_boot_interfaces should yield a MachineBootInterface for every NIC with both a MAC and a non-empty id -- DPU or not -- and skip the rest",
+        );
     }
 
     #[test]

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -1003,11 +1003,44 @@ impl SiteExplorer {
 
         let mut managed_hosts = Vec::new();
         let mut boot_interfaces: Vec<(IpAddr, MachineBootInterface)> = Vec::new();
-        // Per-DPU (host PF MAC -> Redfish interface id) pairs to stamp onto their
-        // machine_interfaces rows so the primary row holds the full boot pair.
-        let mut interface_boot_ids: Vec<(MacAddress, String)> = Vec::new();
+        // Each host NIC's full boot interface (MAC + Redfish id), to record on
+        // its machine_interfaces row so the primary row holds the complete pair.
+        let mut nic_boot_interfaces: Vec<MachineBootInterface> = Vec::new();
 
         for (_, ep) in explored_hosts {
+            // Record every host NIC's boot interface (MAC + Redfish id) on its
+            // machine_interfaces row (matched by MAC), so the primary-flagged
+            // row holds the full pair -- whatever the NIC type (integrated NICs,
+            // SuperNICs, DPU host-PFs, DPUs in NIC mode). This sits before the
+            // zero-DPU/NoDpu and unmatched-host `continue`s below, so every
+            // explored host is covered -- including a zero-DPU host whose primary
+            // boots from a plain NIC. The UPDATE no-ops for MACs with no row
+            // (e.g. a never-cabled NIC). Last-known-good: only NICs that resolve
+            // a full pair in this report are recorded, so a wiped MAC keeps its
+            // prior id.
+            nic_boot_interfaces.extend(ep.report.complete_boot_interfaces());
+
+            // Surface partial records -- a host NIC reporting only one of (MAC,
+            // interface id). `complete_boot_interfaces` skips these, so log here
+            // to make it visible that we saw, and ignored, an incomplete NIC.
+            for iface in ep
+                .report
+                .systems
+                .iter()
+                .flat_map(|s| s.ethernet_interfaces.iter())
+            {
+                let has_mac = iface.mac_address.is_some();
+                let has_id = iface.id.as_deref().is_some_and(|s| !s.is_empty());
+                if has_mac != has_id {
+                    tracing::info!(
+                        address = %ep.address,
+                        mac = ?iface.mac_address,
+                        interface_id = ?iface.id,
+                        "site-explorer: host NIC reported with only one of (MAC, interface id) -- not recording its boot interface",
+                    );
+                }
+            }
+
             // Resolve the operator-declared DPU mode for this host once;
             // it drives both auto-correction (`check_and_configure_dpu_mode`
             // below -- operator override wins over BF3 model heuristics)
@@ -1274,18 +1307,6 @@ impl SiteExplorer {
                 });
             }
 
-            // Capture each explored DPU interface's Redfish interface id onto its
-            // machine_interfaces row (matched by MAC), so the primary-flagged row
-            // holds the full boot pair (MAC + id). Last-known-good: only record
-            // when the id resolves from this report -- a wiped MAC keeps its prior id.
-            for dpu in &dpus_explored_for_host {
-                if let Some(mac) = dpu.host_pf_mac_address
-                    && let Some(interface_id) = ep.report.find_interface_id_for_mac(mac)
-                {
-                    interface_boot_ids.push((mac, interface_id.to_string()));
-                }
-            }
-
             // For NicMode hosts, don't attach DPUs even if matching
             // discovered some: the operator has declared "treat this host
             // as zero-DPU". Any DPU hardware has already had `set_nic_mode`
@@ -1332,10 +1353,15 @@ impl SiteExplorer {
             db::explored_endpoints::set_boot_interface(*address, boot_interface, &mut txn).await?;
         }
 
-        // Stamp each DPU interface's Redfish id onto its machine_interfaces row so the
+        // Record each host NIC's Redfish id on its machine_interfaces row so the
         // primary-flagged row is the host's complete boot interface (MAC + id).
-        for (mac, interface_id) in &interface_boot_ids {
-            db::machine_interface::set_boot_interface_id(*mac, interface_id, &mut txn).await?;
+        for boot_interface in &nic_boot_interfaces {
+            db::machine_interface::set_boot_interface_id(
+                boot_interface.mac_address,
+                &boot_interface.interface_id,
+                &mut txn,
+            )
+            .await?;
         }
 
         txn.commit().await?;


### PR DESCRIPTION
## Description

This supports https://github.com/NVIDIA/infra-controller/issues/2169.

This follows on #2285, which gave each managed host interface its own `MachineBootInterface` -- the MAC address plus the Redfish-reported `EthernetInterface.Id` -- but site-explorer only ever filled the id in for DPU PFs. This updates it to record the interface ID on *every* host NIC in the exploration report, alongside its MAC, regardless of the type, e.g.

- DPUs (DPU mode or NIC mode).
- SuperNICs (Connect-X).
- Integrated "dumb" NICs.

They now all get their interface ID recorded alongside their MAC address. That's the groundwork for any of them to be a first-class boot interface. There will be a separate PR where I'll be switching `set_primary_dpu` to be more generically named `set_primary_interface` as a result of this as well.

Tests added to make sure the behavior works as expected.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

