### PR TITLE
feat: make any host interface the primary, not just a DPU

### DIFF
--- a/crates/admin-cli/src/managed_host/mod.rs
+++ b/crates/admin-cli/src/managed_host/mod.rs
@@ -21,6 +21,7 @@ mod power_options;
 mod quarantine;
 mod reset_host_reprovisioning;
 mod set_primary_dpu;
+mod set_primary_interface;
 mod show;
 mod start_updates;
 
@@ -57,7 +58,9 @@ pub enum Cmd {
     PowerOptions(power_options::Args),
     #[clap(about = "Start updates for machines with delayed updates, such as GB200")]
     StartUpdates(start_updates::Args),
-    #[clap(about = "Set the primary DPU for the managed host")]
+    #[clap(about = "Set the primary interface (boot device) for the managed host")]
+    SetPrimaryInterface(set_primary_interface::Args),
+    #[clap(about = "Deprecated: use set-primary-interface. Sets the primary DPU.")]
     SetPrimaryDpu(set_primary_dpu::Args),
     #[clap(about = "Download debug bundle with logs for a specific host")]
     DebugBundle(debug_bundle::Args),

--- a/crates/admin-cli/src/managed_host/set_primary_interface/args.rs
+++ b/crates/admin-cli/src/managed_host/set_primary_interface/args.rs
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+use clap::Parser;
+use rpc::forge as forgerpc;
+
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Make a host interface the primary (boot) interface:
+    $ carbide-admin-cli managed-host set-primary-interface 12345678-1234-5678-90ab-cdef01234567 \
+    abcdef01-2345-6789-abcd-ef0123456789
+
+Promote an interface and reboot the host afterward:
+    $ carbide-admin-cli managed-host set-primary-interface 12345678-1234-5678-90ab-cdef01234567 \
+    abcdef01-2345-6789-abcd-ef0123456789 --reboot
+
+Tip: list a host's interface ids with 'managed-host show <HOST_MACHINE_ID>'.
+")]
+pub struct Args {
+    #[clap(help = "ID of the host machine")]
+    pub host_machine_id: MachineId,
+    #[clap(help = "ID of the machine interface to make primary (the boot device)")]
+    pub interface_id: MachineInterfaceId,
+    #[clap(long, help = "Reboot the host after the update")]
+    pub reboot: bool,
+}
+
+impl From<Args> for forgerpc::SetPrimaryInterfaceRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            host_machine_id: Some(args.host_machine_id),
+            interface_id: Some(args.interface_id),
+            reboot: args.reboot,
+        }
+    }
+}

--- a/crates/admin-cli/src/managed_host/set_primary_interface/cmd.rs
+++ b/crates/admin-cli/src/managed_host/set_primary_interface/cmd.rs
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::args::Args;
+use crate::errors::CarbideCliResult;
+use crate::rpc::ApiClient;
+
+pub async fn set_primary_interface(api_client: &ApiClient, args: Args) -> CarbideCliResult<()> {
+    api_client.0.set_primary_interface(args).await?;
+    Ok(())
+}

--- a/crates/admin-cli/src/managed_host/set_primary_interface/mod.rs
+++ b/crates/admin-cli/src/managed_host/set_primary_interface/mod.rs
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::set_primary_interface(&ctx.api_client, self).await?;
+        Ok(())
+    }
+}

--- a/crates/admin-cli/src/managed_host/tests.rs
+++ b/crates/admin-cli/src/managed_host/tests.rs
@@ -266,6 +266,26 @@ fn parse_set_primary_dpu() {
     }
 }
 
+// parse_set_primary_interface ensures set-primary-interface parses
+// with required args (a host machine id and a machine interface id).
+#[test]
+fn parse_set_primary_interface() {
+    let cmd = Cmd::try_parse_from([
+        "managed-host",
+        "set-primary-interface",
+        TEST_MACHINE_ID,
+        "00000000-0000-0000-0000-000000000001",
+    ])
+    .expect("should parse set-primary-interface");
+
+    match cmd {
+        Cmd::SetPrimaryInterface(args) => {
+            assert!(!args.reboot);
+        }
+        _ => panic!("expected SetPrimaryInterface variant"),
+    }
+}
+
 // parse_debug_bundle ensures debug-bundle parses with
 // required args.
 #[test]

--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -2913,6 +2913,13 @@ impl Forge for Api {
         crate::handlers::managed_host::set_primary_dpu(self, request).await
     }
 
+    async fn set_primary_interface(
+        &self,
+        request: Request<rpc::SetPrimaryInterfaceRequest>,
+    ) -> Result<Response<()>, Status> {
+        crate::handlers::managed_host::set_primary_interface(self, request).await
+    }
+
     async fn create_dpu_extension_service(
         &self,
         request: Request<rpc::CreateDpuExtensionServiceRequest>,

--- a/crates/api-core/src/auth/internal_rbac_rules.rs
+++ b/crates/api-core/src/auth/internal_rbac_rules.rs
@@ -645,6 +645,7 @@ impl InternalRBACRules {
         x.perm("DetermineMachineIngestionState", vec![ForgeAdminCLI, Flow]);
         x.perm("AllowIngestionAndPowerOn", vec![ForgeAdminCLI, Flow]);
         x.perm("SetPrimaryDpu", vec![ForgeAdminCLI]);
+        x.perm("SetPrimaryInterface", vec![ForgeAdminCLI]);
         x.perm("CreateDpuExtensionService", vec![ForgeAdminCLI, SiteAgent]);
         x.perm("UpdateDpuExtensionService", vec![ForgeAdminCLI, SiteAgent]);
         x.perm("DeleteDpuExtensionService", vec![ForgeAdminCLI, SiteAgent]);

--- a/crates/api-core/src/handlers/managed_host.rs
+++ b/crates/api-core/src/handlers/managed_host.rs
@@ -20,9 +20,11 @@ use std::str::FromStr;
 
 use ::rpc::forge as rpc;
 use carbide_redfish::boot_interface::BootInterfaceTarget;
+use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use model::machine::LoadSnapshotOptions;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine_boot_interface::MachineBootInterface;
+use model::network_segment::NetworkSegmentType;
 use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
@@ -30,19 +32,6 @@ use crate::api::{Api, log_machine_id, log_request_data};
 use crate::auth::AuthContext;
 use crate::handlers::utils::convert_and_log_machine_id;
 
-// This is a work-around for FORGE-7085.  Due to an issue with interface reporting in the host BMC
-// its possible that the primary DPU is not the lowest slot DPU.  Functionally this is not a problem
-// but the host names interfaces by pci address so the behavior between machines of the same type
-// is different.
-//
-// this function is broken into the following parts
-// 1. collect interface and bmc information
-// 2. set the boot device
-// 3. update the primary interface and network config versions.
-// 4. reboot the host if requested.
-//
-// No transaction should be held during 2 or 4 since they are requests to the host bmc.
-//
 pub(crate) async fn set_primary_dpu(
     api: &Api,
     request: Request<rpc::SetPrimaryDpuRequest>,
@@ -59,12 +48,13 @@ pub(crate) async fn set_primary_dpu(
 
     log_machine_id(&host_machine_id);
 
+    // `set-primary-dpu` is the DPU-only alias for `set-primary-interface`: it
+    // keeps the zero-DPU guard and resolves the DPU to its host interface, then
+    // defers to the generic core that does the actual work.
     let mut txn = api.txn_begin().await?;
 
-    // Reject early on a zero-DPU host to provide a better error,
-    // otherwise we'd end up just looping over snapshots below,
-    // and eventually error that it couldn't deetermine the primary
-    // interface ID, which is kind of confusing.
+    // Reject early on a zero-DPU host to provide a better error, otherwise we'd
+    // fail later looking for the DPU's interface, which is more confusing.
     let snapshot =
         db::managed_host::load_snapshot(&mut txn, &host_machine_id, LoadSnapshotOptions::default())
             .await?
@@ -81,7 +71,91 @@ pub(crate) async fn set_primary_dpu(
 
     let interface_map =
         db::machine_interface::find_by_machine_ids(&mut txn, &[host_machine_id]).await?;
+    let new_primary_interface_id = interface_map
+        .get(&host_machine_id)
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "Machine",
+            id: host_machine_id.to_string(),
+        })?
+        .iter()
+        .find(|interface| interface.attached_dpu_machine_id == Some(dpu_machine_id))
+        .map(|interface| interface.id)
+        .ok_or_else(|| {
+            CarbideError::InvalidArgument(format!(
+                "DPU {dpu_machine_id} has no interface on host {host_machine_id}"
+            ))
+        })?;
+    txn.rollback().await?;
 
+    set_primary_interface_core(
+        api,
+        host_machine_id,
+        new_primary_interface_id,
+        request.reboot,
+    )
+    .await
+}
+
+/// Make any host interface -- DPU or not -- the primary (boot) interface,
+/// identified directly by its machine-interface id. This is the generic form of
+/// [`set_primary_dpu`]; unlike that alias it also works on zero-DPU hosts.
+pub(crate) async fn set_primary_interface(
+    api: &Api,
+    request: Request<rpc::SetPrimaryInterfaceRequest>,
+) -> Result<Response<()>, Status> {
+    log_request_data(&request);
+
+    let request = request.into_inner();
+    let host_machine_id = request
+        .host_machine_id
+        .ok_or_else(|| CarbideError::InvalidArgument("Host Machine ID is required".to_string()))?;
+    let interface_id = request
+        .interface_id
+        .ok_or_else(|| CarbideError::InvalidArgument("Interface ID is required".to_string()))?;
+
+    log_machine_id(&host_machine_id);
+
+    set_primary_interface_core(api, host_machine_id, interface_id, request.reboot).await
+}
+
+// Move the primary (boot) interface flag to `new_primary_interface_id` and point
+// the host's boot device at it. Shared by `set_primary_dpu` and
+// `set_primary_interface`.
+//
+// Originally a work-around for FORGE-7085: a host BMC can report the primary DPU
+// as something other than the lowest-slot DPU, and because the host names
+// interfaces by PCI address the behavior differs between identical machines.
+//
+// Broken into the following parts:
+// 1. collect interface and bmc information
+// 2. set the boot device
+// 3. update the primary interface and network config versions.
+// 4. reboot the host if requested.
+//
+// No transaction should be held during 2 or 4 since they are requests to the host bmc.
+async fn set_primary_interface_core(
+    api: &Api,
+    host_machine_id: MachineId,
+    new_primary_interface_id: MachineInterfaceId,
+    reboot: bool,
+) -> Result<Response<()>, Status> {
+    // `host_machine_id` must be a host machine. Reject DPU (or other non-host) ids
+    // up front -- before any DB load or BMC side effect -- so callers get a clear
+    // InvalidArgument instead of a confusing failure deeper in interface/BMC lookup.
+    // `set_primary_dpu` resolves its DPU to the host's interface and also passes a
+    // host id here, so this guards both entry points.
+    if !host_machine_id.machine_type().is_host() {
+        return Err(CarbideError::InvalidArgument(format!(
+            "Machine {host_machine_id} is not a host machine; set-primary-interface can \
+             only promote an interface on a host"
+        ))
+        .into());
+    }
+
+    let mut txn = api.txn_begin().await?;
+
+    let interface_map =
+        db::machine_interface::find_by_machine_ids(&mut txn, &[host_machine_id]).await?;
     let interface_snapshots =
         interface_map
             .get(&host_machine_id)
@@ -90,35 +164,68 @@ pub(crate) async fn set_primary_dpu(
                 id: host_machine_id.to_string(),
             })?;
 
-    // Find the interface id for the old primary dpu and the interface for the new primary dpu.  they have to be found
-    // before the db update since the "only one primary" constraint will cause a failure
-    // if the new interface is found first.
-    let mut current_primary_interface_id = None;
+    // Find the current primary and the requested new primary before the db
+    // update, since the "only one primary" constraint will fail if the new
+    // interface is set before the old one is cleared.
+    let mut current_primary_interface = None;
     let mut new_primary_interface = None;
-
     for interface_snapshot in interface_snapshots {
-        if interface_snapshot.primary_interface {
-            let Some(attached_dpu_machine_id) = interface_snapshot.attached_dpu_machine_id else {
-                return Err(CarbideError::InvalidArgument(
-                    "Primary interface is not associated with a DPU.  Operation not supported"
-                        .to_string(),
-                )
-                .into());
-            };
-
-            if attached_dpu_machine_id == dpu_machine_id {
-                return Err(CarbideError::InvalidArgument(
-                    "Requested DPU is already primary".to_string(),
-                )
-                .into());
-            }
-            current_primary_interface_id = Some(interface_snapshot.id);
-            tracing::info!("Removing primary from {}", attached_dpu_machine_id);
-        } else if interface_snapshot.attached_dpu_machine_id == Some(dpu_machine_id) {
+        if interface_snapshot.id == new_primary_interface_id {
             new_primary_interface = Some(interface_snapshot);
-            tracing::info!("Setting primary on {}", dpu_machine_id);
+        } else if interface_snapshot.primary_interface {
+            current_primary_interface = Some(interface_snapshot);
         }
     }
+    let current_primary_interface_id = current_primary_interface.map(|interface| interface.id);
+    // Whether the host currently has an Admin-segment primary. Drives whether the
+    // pre-move admin reconciliation below is needed (see its comment).
+    let current_primary_is_admin = current_primary_interface
+        .is_some_and(|interface| interface.network_segment_type == Some(NetworkSegmentType::Admin));
+
+    let new_primary_interface = new_primary_interface.ok_or_else(|| {
+        CarbideError::InvalidArgument(format!(
+            "Interface {new_primary_interface_id} not found on host {host_machine_id}"
+        ))
+    })?;
+    if new_primary_interface.primary_interface {
+        return Err(CarbideError::InvalidArgument(
+            "Requested interface is already primary".to_string(),
+        )
+        .into());
+    }
+
+    // On a DPU-managed host the primary interface must stay on the Admin segment:
+    // the host's admin DHCP address and DNS identity follow the primary, and
+    // `reconcile_admin_addresses_for_host` (below) errors if a host with
+    // DPU-backed admin interfaces is left with no primary admin interface.
+    // Promoting a non-admin interface would trip that *after* the BMC boot order
+    // was already changed, leaving the BMC and the database disagreeing. Zero-DPU
+    // hosts have no DPU-backed admin interface, so this never constrains them.
+    let host_has_dpu_backed_admin_interface = interface_snapshots.iter().any(|interface| {
+        interface
+            .attached_dpu_machine_id
+            .is_some_and(|dpu| dpu != host_machine_id)
+            && interface.network_segment_type == Some(NetworkSegmentType::Admin)
+    });
+    if host_has_dpu_backed_admin_interface
+        && new_primary_interface.network_segment_type != Some(NetworkSegmentType::Admin)
+    {
+        return Err(CarbideError::InvalidArgument(format!(
+            "Interface {new_primary_interface_id} is not on the Admin segment; a \
+             DPU-managed host's primary interface must be an Admin interface"
+        ))
+        .into());
+    }
+
+    let primary_interface_mac_address = new_primary_interface.mac_address;
+    let boot_interface_id = new_primary_interface.boot_interface_id.clone();
+
+    tracing::info!(
+        host = %host_machine_id,
+        new_primary = %new_primary_interface_id,
+        previous_primary = ?current_primary_interface_id,
+        "moving the host's primary (boot) interface",
+    );
 
     // we need to set the boot device or the host will no longer be able to boot.  we need BMC info.
     // the same BMC info is used if a reboot was requested.
@@ -147,31 +254,12 @@ pub(crate) async fn set_primary_dpu(
             id: bmc_addr.to_string(),
         })?;
 
-    let primary_interface_mac_address = new_primary_interface
-        .ok_or_else(|| {
-            CarbideError::internal("Primary interface disappeared during update".to_string())
-        })?
-        .mac_address;
-
     txn.rollback().await?;
-
-    let Some(current_primary_interface_id) = current_primary_interface_id else {
-        return Err(CarbideError::internal(
-            "Could not determing old primary interface id".to_string(),
-        )
-        .into());
-    };
-    let Some(new_primary_interface) = new_primary_interface else {
-        return Err(CarbideError::internal(
-            "Could not determing new primary interface id".to_string(),
-        )
-        .into());
-    };
 
     // Set the boot device. The new primary interface row already stores its
     // Redfish interface id, so send the complete (MAC + id) pair when present,
     // allowing for interface ID fallback (and target the MAC alone otherwise).
-    let boot_target = match new_primary_interface.boot_interface_id.clone() {
+    let boot_target = match boot_interface_id {
         Some(interface_id) => BootInterfaceTarget::Pair(MachineBootInterface {
             mac_address: primary_interface_mac_address,
             interface_id,
@@ -185,14 +273,30 @@ pub(crate) async fn set_primary_dpu(
 
     let mut txn = api.txn_begin().await?;
 
-    // Normalize any legacy over-allocation before changing the primary flag so
-    // the current active DHCP address is the address reconciliation can move.
-    db::machine_interface::reconcile_admin_addresses_for_host(&mut txn, &host_machine_id).await?;
+    // Normalize the current admin primary's address before moving the flag, so the
+    // active DHCP address is one reconciliation can move onto the new primary --
+    // but only when there IS a current admin primary to preserve. If the host has
+    // no admin primary (e.g. a DPU-backed host whose primary was cleared or sits
+    // off the Admin segment -- an off-happy-path state), this pre-move pass would
+    // error on that broken state *after* the BMC boot order was already changed,
+    // leaving the BMC and database disagreeing. Skipping it lets set_primary_interface
+    // repair such a host; the post-move pass below sets the new primary's admin
+    // ownership from scratch.
+    if current_primary_is_admin {
+        db::machine_interface::reconcile_admin_addresses_for_host(&mut txn, &host_machine_id)
+            .await?;
+    }
 
-    // update the primary interface
-    db::machine_interface::set_primary_interface(&current_primary_interface_id, false, &mut txn)
+    // update the primary interface: clear the old primary (if any), then set the new.
+    if let Some(current_primary_interface_id) = current_primary_interface_id {
+        db::machine_interface::set_primary_interface(
+            &current_primary_interface_id,
+            false,
+            &mut txn,
+        )
         .await?;
-    db::machine_interface::set_primary_interface(&new_primary_interface.id, true, &mut txn).await?;
+    }
+    db::machine_interface::set_primary_interface(&new_primary_interface_id, true, &mut txn).await?;
 
     // Reconcile admin address ownership after the primary flag moves.
     db::machine_interface::reconcile_admin_addresses_for_host(&mut txn, &host_machine_id).await?;
@@ -226,7 +330,7 @@ pub(crate) async fn set_primary_dpu(
     // optionally reboot the host.  if there is an instance, this is probably a required step,
     // but an operator will need to make that call.  The scout image handles this pretty well,
     // albeit with a leftover IP on the unused interface
-    if request.reboot {
+    if reboot {
         api.endpoint_explorer
             .redfish_power_control(
                 bmc_socket_addr,

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -202,6 +202,8 @@ mod service_health_metrics;
 #[cfg(test)]
 mod set_primary_dpu;
 #[cfg(test)]
+mod set_primary_interface;
+#[cfg(test)]
 mod site_explorer;
 #[cfg(test)]
 mod sku;

--- a/crates/api-core/src/tests/set_primary_dpu.rs
+++ b/crates/api-core/src/tests/set_primary_dpu.rs
@@ -28,11 +28,10 @@ use crate::tests::common::api_fixtures::network_segment::{
     create_host_inband_network_segment, create_underlay_network_segment,
 };
 
-// On a zero-DPU host the handler's interface scan never finds a row with a
-// matching `attached_dpu_machine_id`, which previously bubbled up as a
-// generic "Could not determine old primary interface id..." internal
-// error. Reject up-front with `FailedPrecondition` and a message that
-// names the underlying reason.
+// On a zero-DPU host, set-primary-dpu has no DPU to resolve to an interface, so
+// the alias rejects up-front with `FailedPrecondition` and a message that names
+// the underlying reason -- rather than failing later, more confusingly, when the
+// DPU-to-interface lookup comes up empty.
 #[crate::sqlx_test]
 async fn test_set_primary_dpu_rejects_zero_dpu_host(
     pool: sqlx::PgPool,

--- a/crates/api-core/src/tests/set_primary_interface.rs
+++ b/crates/api-core/src/tests/set_primary_interface.rs
@@ -1,0 +1,439 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::str::FromStr;
+
+use carbide_uuid::machine::MachineInterfaceId;
+use ipnetwork::IpNetwork;
+use model::network_segment::NetworkSegmentType;
+use rpc::forge;
+use rpc::forge::forge_server::Forge;
+
+use crate::tests::common::api_fixtures;
+use crate::tests::common::api_fixtures::dpu::DpuConfig;
+use crate::tests::common::api_fixtures::managed_host::ManagedHostConfig;
+use crate::tests::common::api_fixtures::network_segment::{
+    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY,
+    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY, create_admin_network_segment,
+    create_host_inband_network_segment, create_underlay_network_segment,
+};
+
+// Unlike `set_primary_dpu`, `set_primary_interface` has no zero-DPU guard -- a
+// zero-DPU host is a first-class target. So on a zero-DPU host the call must get
+// PAST the would-be guard: it can still fail (here, because the interface id
+// doesn't exist), but never with the `FailedPrecondition` "zero-DPU" rejection
+// that `set_primary_dpu` returns for the same host.
+#[crate::sqlx_test]
+async fn test_set_primary_interface_does_not_apply_the_zero_dpu_guard(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Zero-DPU host ingestion needs a HostInband network segment whose CIDR
+    // covers the relay address; the default test env doesn't define one.
+    let env = api_fixtures::create_test_env_with_overrides(
+        pool,
+        api_fixtures::TestEnvOverrides {
+            site_prefixes: Some(vec![
+                IpNetwork::new(
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+                IpNetwork::new(
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+                IpNetwork::new(
+                    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+            ]),
+            create_network_segments: Some(false),
+            ..Default::default()
+        },
+    )
+    .await;
+    // HostInband segments must live in a Flat VPC. The test doesn't otherwise
+    // need a non-Flat VPC, so create only a Flat one for the segment.
+    let flat_vpc_id = api_fixtures::network_segment::create_default_flat_vpc(
+        &env.api,
+        "set-primary-interface flat vpc",
+    )
+    .await;
+    create_underlay_network_segment(&env.api).await;
+    create_admin_network_segment(&env.api).await;
+    create_host_inband_network_segment(&env.api, Some(flat_vpc_id)).await;
+    env.run_network_segment_controller_iteration().await;
+    env.run_network_segment_controller_iteration().await;
+
+    let zero_dpu_host =
+        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::with_dpus(vec![])).await?;
+
+    // A well-formed but non-existent interface id: the handler must try to look
+    // it up -- which is only reachable once it's past the would-be zero-DPU
+    // guard -- and then fail because the interface isn't there.
+    let missing_interface_id =
+        MachineInterfaceId::from_str("11111111-1111-1111-1111-111111111111").unwrap();
+
+    let result = env
+        .api
+        .set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
+            host_machine_id: Some(zero_dpu_host.host_snapshot.id),
+            interface_id: Some(missing_interface_id),
+            reboot: false,
+        }))
+        .await;
+
+    let err = result.expect_err("a non-existent interface id should still fail the request");
+    // Getting PAST the (would-be) zero-DPU guard means we reach the interface
+    // lookup and fail THERE -- an InvalidArgument about the missing interface,
+    // never the FailedPrecondition "zero-DPU" rejection set_primary_dpu returns.
+    assert_eq!(
+        err.code(),
+        tonic::Code::InvalidArgument,
+        "a zero-DPU host should reach the interface lookup, not be rejected by a zero-DPU guard; got {}: {}",
+        err.code(),
+        err.message(),
+    );
+    assert!(
+        err.message().contains("not found"),
+        "expected the missing-interface error, got: {}",
+        err.message(),
+    );
+
+    Ok(())
+}
+
+// Success path: `set_primary_interface` promotes any interface (by id) to be the
+// host's primary boot interface. A two-DPU host starts with one primary host
+// interface and one non-primary one; promoting the non-primary by id must move
+// the primary flag onto it. The handler sets the host's boot order on the BMC
+// *before* moving the flag, so a successful promotion already implies the
+// boot-order call ran (it would have errored out before the flag move otherwise).
+#[crate::sqlx_test]
+async fn test_set_primary_interface_promotes_a_non_primary_interface(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = api_fixtures::create_test_env(pool).await;
+
+    let host = api_fixtures::site_explorer::new_host(
+        &env,
+        ManagedHostConfig::with_dpus(vec![DpuConfig::default(), DpuConfig::default()]),
+    )
+    .await?;
+    let host_id = host.host_snapshot.id;
+
+    // One host interface is primary; pick a different (non-primary) host NIC to promote.
+    let (original_primary_id, promote_id) = {
+        let mut txn = env.pool.begin().await?;
+        let interfaces = db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
+            .await?
+            .remove(&host_id)
+            .expect("host should have interface rows");
+        let original_primary_id = interfaces
+            .iter()
+            .find(|i| i.primary_interface)
+            .expect("host should start with a primary interface")
+            .id;
+        let promote_id = interfaces
+            .iter()
+            .find(|i| !i.primary_interface && i.attached_dpu_machine_id.is_some())
+            .expect("host should have a non-primary host interface to promote")
+            .id;
+        (original_primary_id, promote_id)
+    };
+
+    env.api
+        .set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
+            host_machine_id: Some(host_id),
+            interface_id: Some(promote_id),
+            reboot: false,
+        }))
+        .await?;
+
+    // The primary flag moved onto the promoted interface, and off the old one.
+    let after = {
+        let mut txn = env.pool.begin().await?;
+        db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
+            .await?
+            .remove(&host_id)
+            .expect("host should still have interface rows")
+    };
+    let primaries_now: Vec<_> = after
+        .iter()
+        .filter(|i| i.primary_interface)
+        .map(|i| i.id)
+        .collect();
+    assert_eq!(
+        primaries_now,
+        vec![promote_id],
+        "exactly the promoted interface should be primary",
+    );
+    assert!(
+        !after
+            .iter()
+            .find(|i| i.id == original_primary_id)
+            .unwrap()
+            .primary_interface,
+        "the previously-primary interface should no longer be primary",
+    );
+
+    Ok(())
+}
+
+// A DPU-managed host's primary must stay on the Admin segment (the admin DHCP
+// address + DNS identity follow it, and admin-address reconciliation requires a
+// primary among the host's DPU-backed admin interfaces). set_primary_interface
+// rejects a non-admin target up-front -- BEFORE touching the BMC -- rather than
+// failing deeper in reconciliation with the boot order already changed.
+#[crate::sqlx_test]
+async fn test_set_primary_interface_rejects_non_admin_interface_on_dpu_host(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = api_fixtures::create_test_env(pool).await;
+
+    let host = api_fixtures::site_explorer::new_host(
+        &env,
+        ManagedHostConfig::with_dpus(vec![DpuConfig::default(), DpuConfig::default()]),
+    )
+    .await?;
+    let host_id = host.host_snapshot.id;
+
+    // A non-primary host interface to target. The host's other DPU interface
+    // stays the Admin primary, so the host still has a DPU-backed admin link.
+    let promote_id = {
+        let mut txn = env.pool.begin().await?;
+        db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
+            .await?
+            .remove(&host_id)
+            .expect("host should have interface rows")
+            .into_iter()
+            .find(|i| !i.primary_interface && i.attached_dpu_machine_id.is_some())
+            .expect("host should have a non-primary host interface")
+            .id
+    };
+
+    // Craft the (off-happy-path) mixed shape: move that interface onto a
+    // non-admin segment so it is no longer Admin-segment.
+    sqlx::query(
+        "UPDATE machine_interfaces SET segment_id = \
+         (SELECT id FROM network_segments WHERE network_segment_type <> 'admin' LIMIT 1) \
+         WHERE id = $1",
+    )
+    .bind(promote_id)
+    .execute(&env.pool)
+    .await?;
+
+    let err = env
+        .api
+        .set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
+            host_machine_id: Some(host_id),
+            interface_id: Some(promote_id),
+            reboot: false,
+        }))
+        .await
+        .expect_err("promoting a non-admin interface on a DPU host should be rejected");
+
+    assert_eq!(
+        err.code(),
+        tonic::Code::InvalidArgument,
+        "expected an up-front InvalidArgument, got {}: {}",
+        err.code(),
+        err.message(),
+    );
+    assert!(
+        err.message().contains("Admin segment"),
+        "expected the Admin-segment guard message, got: {}",
+        err.message(),
+    );
+
+    Ok(())
+}
+
+// Success path on a ZERO-DPU host -- the case this feature exists to enable. A
+// zero-DPU host has no DPU-backed admin interface, so neither the zero-DPU guard
+// nor the Admin-segment constraint applies, and set_primary_interface can promote
+// its plain HostInband NIC. (A zero-DPU host has no primary flag set at ingestion,
+// so this records the first primary.)
+#[crate::sqlx_test]
+async fn test_set_primary_interface_promotes_a_zero_dpu_host_interface(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Zero-DPU host ingestion needs a HostInband segment whose CIDR covers the
+    // relay address; the default test env doesn't define one.
+    let env = api_fixtures::create_test_env_with_overrides(
+        pool,
+        api_fixtures::TestEnvOverrides {
+            site_prefixes: Some(vec![
+                IpNetwork::new(
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+                IpNetwork::new(
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+                IpNetwork::new(
+                    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+            ]),
+            create_network_segments: Some(false),
+            ..Default::default()
+        },
+    )
+    .await;
+    // HostInband segments must live in a Flat VPC.
+    let flat_vpc_id = api_fixtures::network_segment::create_default_flat_vpc(
+        &env.api,
+        "set-primary-interface zero-dpu flat vpc",
+    )
+    .await;
+    create_underlay_network_segment(&env.api).await;
+    create_admin_network_segment(&env.api).await;
+    create_host_inband_network_segment(&env.api, Some(flat_vpc_id)).await;
+    env.run_network_segment_controller_iteration().await;
+    env.run_network_segment_controller_iteration().await;
+
+    let zero_dpu_host =
+        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::with_dpus(vec![])).await?;
+    let host_id = zero_dpu_host.host_snapshot.id;
+
+    // A zero-DPU host's plain NIC lands on the HostInband segment and is not flagged
+    // primary at ingestion -- promote it by id.
+    let promote_id = {
+        let mut txn = env.pool.begin().await?;
+        db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
+            .await?
+            .remove(&host_id)
+            .expect("zero-DPU host should have interface rows")
+            .into_iter()
+            .find(|i| {
+                i.network_segment_type == Some(NetworkSegmentType::HostInband)
+                    && !i.primary_interface
+            })
+            .expect("zero-DPU host should have a non-primary HostInband interface")
+            .id
+    };
+
+    env.api
+        .set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
+            host_machine_id: Some(host_id),
+            interface_id: Some(promote_id),
+            reboot: false,
+        }))
+        .await?;
+
+    // Exactly the promoted interface is now primary.
+    let primaries_now: Vec<_> = {
+        let mut txn = env.pool.begin().await?;
+        db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
+            .await?
+            .remove(&host_id)
+            .expect("zero-DPU host should still have interface rows")
+            .into_iter()
+            .filter(|i| i.primary_interface)
+            .map(|i| i.id)
+            .collect()
+    };
+    assert_eq!(
+        primaries_now,
+        vec![promote_id],
+        "exactly the promoted zero-DPU interface should be primary",
+    );
+
+    Ok(())
+}
+
+// Regression for the pre-move reconcile ordering: on a DPU-backed host left with NO
+// admin primary (an off-happy-path state), promoting a valid Admin interface must
+// SUCCEED -- repairing the host -- rather than erroring in admin reconciliation
+// after the BMC boot order was already changed. set_primary_interface skips the
+// pre-move reconcile when there is no admin primary to preserve.
+#[crate::sqlx_test]
+async fn test_set_primary_interface_repairs_dpu_host_with_no_admin_primary(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = api_fixtures::create_test_env(pool).await;
+
+    let host = api_fixtures::site_explorer::new_host(
+        &env,
+        ManagedHostConfig::with_dpus(vec![DpuConfig::default(), DpuConfig::default()]),
+    )
+    .await?;
+    let host_id = host.host_snapshot.id;
+
+    // The current Admin primary, plus a non-primary Admin interface to promote.
+    let (current_primary_id, promote_id) = {
+        let mut txn = env.pool.begin().await?;
+        let interfaces = db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
+            .await?
+            .remove(&host_id)
+            .expect("host should have interface rows");
+        let current_primary_id = interfaces
+            .iter()
+            .find(|i| i.primary_interface)
+            .expect("host should start with a primary interface")
+            .id;
+        let promote_id = interfaces
+            .iter()
+            .find(|i| !i.primary_interface && i.attached_dpu_machine_id.is_some())
+            .expect("host should have a non-primary DPU-backed interface")
+            .id;
+        (current_primary_id, promote_id)
+    };
+
+    // Break the happy path: clear the host's primary flag, leaving its DPU-backed
+    // admin interfaces with no primary -- the state the pre-move reconcile chokes on.
+    sqlx::query("UPDATE machine_interfaces SET primary_interface = false WHERE id = $1")
+        .bind(current_primary_id)
+        .execute(&env.pool)
+        .await?;
+
+    // Promoting the Admin interface must succeed (repair), not error after the BMC call.
+    env.api
+        .set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
+            host_machine_id: Some(host_id),
+            interface_id: Some(promote_id),
+            reboot: false,
+        }))
+        .await?;
+
+    // The promoted interface is now the only primary.
+    let primaries_now: Vec<_> = {
+        let mut txn = env.pool.begin().await?;
+        db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
+            .await?
+            .remove(&host_id)
+            .expect("host should still have interface rows")
+            .into_iter()
+            .filter(|i| i.primary_interface)
+            .map(|i| i.id)
+            .collect()
+    };
+    assert_eq!(
+        primaries_now,
+        vec![promote_id],
+        "exactly the promoted interface should be primary after the repair",
+    );
+
+    Ok(())
+}

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -766,6 +766,9 @@ service Forge {
   // end DPU Remediation APIs
 
   rpc SetPrimaryDpu(SetPrimaryDpuRequest) returns (google.protobuf.Empty);
+  // Make any host interface (DPU or not) the primary / boot interface. This is
+  // the generic form of SetPrimaryDpu, which it deprecates.
+  rpc SetPrimaryInterface(SetPrimaryInterfaceRequest) returns (google.protobuf.Empty);
 
   // Extension service version management
   rpc CreateDpuExtensionService(CreateDpuExtensionServiceRequest) returns (DpuExtensionService);
@@ -7611,6 +7614,12 @@ message SetPrimaryDpuRequest {
   common.MachineId host_machine_id = 1;
   common.MachineId dpu_machine_id = 2;
   bool reboot=3;
+}
+
+message SetPrimaryInterfaceRequest {
+  common.MachineId host_machine_id = 1;
+  common.MachineInterfaceId interface_id = 2;
+  bool reboot = 3;
 }
 
 // DPU Extension Service Types and Messages


### PR DESCRIPTION
## Description

This supports https://github.com/NVIDIA/infra-controller/issues/2169.

This adds a `SetPrimaryInterface` RPC -- the generic form of `SetPrimaryDpu` -- so an operator can make any host interface the primary [boot] interface, identified directly by its `MachineInterfaceId`, rather than only a DPU. It pairs with storing every NICs Redfish `interface_id`; now that each host NIC records its boot interface, any of them can be promoted to the boot device, including on a "zero-DPU" host that has no DPU to promote in the first place.

`SetPrimaryDpu` stays as a deprecated, DPU-only alias. It keeps its "DPU only" check and resolves the requested DPU to its host interface, then defers to the same underlying logic -- moving the `primary_interface` flag and pointing the boot device at the chosen interface. We can remove it in a follow-up, but it's not that big of a deal to keep it.

All said, highlights:
- New `SetPrimaryInterface` RPC and a `managed-host set-primary-interface <host> <interface-id>` CLI command.
- `SetPrimaryDpu` (and `set-primary-dpu`) remain as an alias.
- Both handlers share one implementation.
- No schema or query changes.

Tests added, including a CLI parse test for the new command, plus an `api-core` test to make sure `set_primary_interface` gets past the zero-DPU guard that `set_primary_dpu` still cares about.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

