### PR TITLE
feat(machine-a-tron): register expected switches and power shelves

### DIFF
--- a/crates/bmc-mock/src/auth_router.rs
+++ b/crates/bmc-mock/src/auth_router.rs
@@ -165,6 +165,7 @@ impl AuthMiddleware {
 pub struct Authorizer {
     account_service_state: Arc<AccountServiceState>,
     session_service_state: Arc<SessionServiceState>,
+    forbid_factory_default_password: bool,
 }
 
 impl Authorizer {
@@ -176,7 +177,13 @@ impl Authorizer {
         Self {
             account_service_state,
             session_service_state,
+            forbid_factory_default_password: true,
         }
+    }
+
+    pub fn permit_factory_default_password(mut self) -> Self {
+        self.forbid_factory_default_password = false;
+        self
     }
 
     fn authorize(
@@ -202,7 +209,8 @@ impl Authorizer {
             .account_service_state
             .is_authorized(actual.username(), actual.password())
         {
-            if !permit_factory_default
+            if self.forbid_factory_default_password
+                && !permit_factory_default
                 && self
                     .account_service_state
                     .is_factory_default_password(actual.username(), actual.password())

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -44,6 +44,10 @@ pub struct HostMachineInfo {
     pub serial: String,
     pub dpus: Vec<DpuMachineInfo>,
     pub non_dpu_mac_address: Option<MacAddress>,
+    #[serde(default)]
+    pub nvos_mac_addresses: Vec<MacAddress>,
+    #[serde(default)]
+    pub switch_serial_number: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -142,15 +146,29 @@ impl DpuMachineInfo {
 impl HostMachineInfo {
     pub fn new(hw_type: HostHardwareType, dpus: Vec<DpuMachineInfo>) -> Self {
         let bmc_mac_address = next_mac();
+        let nvos_mac_addresses = if matches!(hw_type, HostHardwareType::NvidiaSwitchNd5200Ld) {
+            vec![next_mac()]
+        } else {
+            vec![]
+        };
+        let switch_serial_number = nvos_mac_addresses
+            .first()
+            .map(|mac| format!("MT{}", mac.to_string().replace(':', "")));
         Self {
             hw_type,
             bmc_mac_address,
             serial: bmc_mac_address.to_string().replace(':', ""),
-            non_dpu_mac_address: if dpus.is_empty() {
+            non_dpu_mac_address: if dpus.is_empty()
+                && !matches!(
+                    hw_type,
+                    HostHardwareType::LiteOnPowerShelf | HostHardwareType::NvidiaSwitchNd5200Ld
+                ) {
                 Some(next_mac())
             } else {
                 None
             },
+            nvos_mac_addresses,
+            switch_serial_number,
             dpus,
         }
     }
@@ -446,11 +464,15 @@ impl HostMachineInfo {
 
     fn nvidia_switch_nd5200_ld(&self) -> hw::nvidia_switch_nd5200_ld::NvidiaSwitchNd5200Ld<'_> {
         hw::nvidia_switch_nd5200_ld::NvidiaSwitchNd5200Ld {
-            bmc_mac_address_eth0: next_mac(),
+            bmc_mac_address_eth0: self.bmc_mac_address,
             bmc_mac_address_eth1: next_mac(),
             bmc_mac_address_usb0: next_mac(),
             bmc_serial_number: Cow::Borrowed(&self.serial),
-            switch_serial_number: format!("MT{}", next_mac().to_string().replace(':', "")).into(),
+            switch_serial_number: self
+                .switch_serial_number
+                .as_deref()
+                .unwrap_or(&self.serial)
+                .into(),
         }
     }
 

--- a/crates/bmc-mock/src/mock_machine_router.rs
+++ b/crates/bmc-mock/src/mock_machine_router.rs
@@ -23,7 +23,10 @@ use crate::auth_router::Authorizer;
 use crate::bmc_state::BmcState;
 use crate::injection::InjectionStore;
 use crate::redfish::manager::ManagerState;
-use crate::{Callbacks, MachineInfo, SystemPowerControl, auth_router, middleware_router, redfish};
+use crate::{
+    Callbacks, HostHardwareType, MachineInfo, SystemPowerControl, auth_router, middleware_router,
+    redfish,
+};
 
 #[derive(Debug)]
 pub enum BmcCommand {
@@ -121,14 +124,21 @@ pub fn machine_router(
     };
     let account_service_state = state.account_service_state.clone();
     let session_service_state = state.session_service_state.clone();
+    let permit_factory_default_password = matches!(
+        &machine_info,
+        MachineInfo::Host(h) if h.hw_type == HostHardwareType::LiteOnPowerShelf
+    );
     let router = ([
         Box::new(redfish::expander_router::append),
         Box::new(move |router| {
             if redfish_auth {
-                auth_router::append(
-                    router,
-                    Authorizer::new(account_service_state, session_service_state),
-                )
+                let authorizer = Authorizer::new(account_service_state, session_service_state);
+                let authorizer = if permit_factory_default_password {
+                    authorizer.permit_factory_default_password()
+                } else {
+                    authorizer
+                };
+                auth_router::append(router, authorizer)
             } else {
                 router
             }

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -25,8 +25,9 @@ use mac_address::MacAddress;
 use rpc::forge::instance_operating_system_config::Variant;
 use rpc::forge::machine_cleanup_info::CleanupStepResult;
 use rpc::forge::{
-    ConfigSetting, ExpectedMachine, InlineIpxe, InstanceOperatingSystemConfig,
-    MachinesByIdsRequest, PxeInstructions, SetDynamicConfigRequest, VpcVirtualizationType,
+    ConfigSetting, ExpectedMachine, ExpectedPowerShelf, ExpectedSwitch, InlineIpxe,
+    InstanceOperatingSystemConfig, MachinesByIdsRequest, PxeInstructions, SetDynamicConfigRequest,
+    VpcVirtualizationType,
 };
 use rpc::protos::forge_api_client::ForgeApiClient;
 
@@ -533,6 +534,55 @@ impl ApiClient {
                 bmc_retain_credentials: None,
                 dpu_mode: dpu_mode.map(|m| m as i32),
                 host_lifecycle_profile: None,
+            })
+            .await
+            .map_err(ClientApiError::InvocationError)
+    }
+
+    /// Registers a mock expected power shelf.
+    pub async fn add_expected_power_shelf(
+        &self,
+        bmc_mac_address: String,
+        shelf_serial_number: String,
+    ) -> ClientApiResult<()> {
+        self.0
+            .add_expected_power_shelf(ExpectedPowerShelf {
+                expected_power_shelf_id: None,
+                bmc_mac_address,
+                bmc_username: DUMMY_FACTORY_USERNAME.to_string(),
+                bmc_password: DUMMY_FACTORY_PASSWORD.to_string(),
+                shelf_serial_number,
+                bmc_ip_address: String::new(),
+                metadata: None,
+                rack_id: None,
+                bmc_retain_credentials: Some(true),
+            })
+            .await
+            .map_err(ClientApiError::InvocationError)
+    }
+
+    /// Registers a mock expected switch.
+    pub async fn add_expected_switch(
+        &self,
+        bmc_mac_address: String,
+        switch_serial_number: String,
+        nvos_mac_addresses: Vec<String>,
+    ) -> ClientApiResult<()> {
+        self.0
+            .add_expected_switch(ExpectedSwitch {
+                expected_switch_id: None,
+                bmc_mac_address,
+                nvos_mac_addresses,
+                bmc_username: DUMMY_FACTORY_USERNAME.to_string(),
+                bmc_password: DUMMY_FACTORY_PASSWORD.to_string(),
+                switch_serial_number,
+                nvos_username: None,
+                nvos_password: None,
+                bmc_ip_address: String::new(),
+                nvos_ip_address: None,
+                metadata: None,
+                rack_id: None,
+                bmc_retain_credentials: None,
             })
             .await
             .map_err(ClientApiError::InvocationError)

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -329,6 +329,10 @@ pub struct PersistedHostMachine {
     pub serial: String,
     pub dpus: Vec<PersistedDpuMachine>,
     pub non_dpu_mac_address: Option<MacAddress>,
+    #[serde(default)]
+    pub nvos_mac_addresses: Vec<MacAddress>,
+    #[serde(default)]
+    pub switch_serial_number: Option<String>,
     pub observed_machine_id: Option<MachineId>,
     pub installed_os: OsImage,
     pub tpm_ek_certificate: Option<Vec<u8>>,
@@ -344,6 +348,8 @@ impl From<PersistedHostMachine> for HostMachineInfo {
             serial: value.serial,
             dpus: value.dpus.into_iter().map(Into::into).collect(),
             non_dpu_mac_address: value.non_dpu_mac_address,
+            nvos_mac_addresses: value.nvos_mac_addresses,
+            switch_serial_number: value.switch_serial_number,
         }
     }
 }

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -101,6 +101,8 @@ impl HostMachine {
                 .map(Into::into)
                 .collect(),
             non_dpu_mac_address: persisted_host_machine.non_dpu_mac_address,
+            nvos_mac_addresses: persisted_host_machine.nvos_mac_addresses.clone(),
+            switch_serial_number: persisted_host_machine.switch_serial_number.clone(),
         };
         let dpus = dpu_machines
             .into_iter()
@@ -587,6 +589,8 @@ impl HostMachineHandle {
             serial: self.0.host_info.serial.clone(),
             dpus: self.0.dpus.iter().map(|d| d.persisted()).collect(),
             non_dpu_mac_address: self.0.host_info.non_dpu_mac_address,
+            nvos_mac_addresses: self.0.host_info.nvos_mac_addresses.clone(),
+            switch_serial_number: self.0.host_info.switch_serial_number.clone(),
             observed_machine_id: live_state.observed_machine_id,
             installed_os: live_state.installed_os,
             tpm_ek_certificate: live_state.tpm_ek_certificate.clone(),

--- a/crates/machine-a-tron/src/machine_a_tron.rs
+++ b/crates/machine-a-tron/src/machine_a_tron.rs
@@ -17,8 +17,9 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use bmc_mock::HostHardwareType;
 use futures::future::try_join_all;
-use rpc::forge::VpcVirtualizationType;
+use rpc::forge::{DpuMode, VpcVirtualizationType};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -99,37 +100,73 @@ impl MachineATron {
 
         if self.app_context.app_config.register_expected_machines {
             for machine in &machines {
-                // Derive the expected `dpu_mode` from the machine's
-                // MachineConfig: zero-DPU hosts declare `NoDpu`, hosts
-                // running their DPUs as NICs declare `NicMode`, everything
-                // else defers to the absolute default (DpuMode).
-                // Site-explorer's ingestion gate requires this explicit
-                // declaration for any host without DPU PCIe devices.
-                let dpu_mode = self
-                    .app_context
-                    .app_config
-                    .machines
-                    .get(machine.machine_config_section())
-                    .and_then(|config| {
-                        if config.dpu_per_host_count == 0 {
-                            Some(rpc::forge::DpuMode::NoDpu)
-                        } else if config.dpus_in_nic_mode {
-                            Some(rpc::forge::DpuMode::NicMode)
-                        } else {
-                            None
-                        }
-                    });
-                // Inform the API that we have finished our reboot (ie. scout is now running)
-                self.app_context
-                    .api_client()
-                    .add_expected_machine(
-                        machine.host_info().bmc_mac_address.to_string(),
-                        machine.host_info().serial.clone(),
-                        dpu_mode,
-                    )
-                    .await
+                let host_info = machine.host_info();
+                let result = match host_info.hw_type {
+                    HostHardwareType::LiteOnPowerShelf => {
+                        self.app_context
+                            .api_client()
+                            .add_expected_power_shelf(
+                                host_info.bmc_mac_address.to_string(),
+                                host_info.serial.clone(),
+                            )
+                            .await
+                    }
+                    HostHardwareType::NvidiaSwitchNd5200Ld => {
+                        self.app_context
+                            .api_client()
+                            .add_expected_switch(
+                                host_info.bmc_mac_address.to_string(),
+                                host_info
+                                    .switch_serial_number
+                                    .clone()
+                                    .unwrap_or_else(|| host_info.serial.clone()),
+                                host_info
+                                    .nvos_mac_addresses
+                                    .iter()
+                                    .map(|mac| mac.to_string())
+                                    .collect(),
+                            )
+                            .await
+                    }
+                    _ => {
+                        // Derive the expected `dpu_mode` from the machine's
+                        // MachineConfig: zero-DPU hosts declare `NoDpu`, hosts
+                        // running their DPUs as NICs declare `NicMode`, everything
+                        // else defers to the absolute default (DpuMode).
+                        // Site-explorer's ingestion gate requires this explicit
+                        // declaration for any host without DPU PCIe devices.
+                        let dpu_mode = self
+                            .app_context
+                            .app_config
+                            .machines
+                            .get(machine.machine_config_section())
+                            .and_then(|config| {
+                                if config.dpu_per_host_count == 0 {
+                                    Some(DpuMode::NoDpu)
+                                } else if config.dpus_in_nic_mode {
+                                    Some(DpuMode::NicMode)
+                                } else {
+                                    None
+                                }
+                            });
+                        self.app_context
+                            .api_client()
+                            .add_expected_machine(
+                                host_info.bmc_mac_address.to_string(),
+                                host_info.serial.clone(),
+                                dpu_mode,
+                            )
+                            .await
+                    }
+                };
+
+                result
                     .inspect_err(|e| {
-                        tracing::warn!(error=?e, "error adding expected machine, likely already ingested");
+                        tracing::warn!(
+                            error=?e,
+                            hw_type=%host_info.hw_type,
+                            "error adding expected inventory record, likely already ingested"
+                        );
                     })
                     .ok();
             }

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -23,9 +23,9 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use bmc_mock::{
-    BmcCommand, BmcState, BootOptionKind, Callbacks, HostMachineInfo, HostnameQuerying,
-    MachineInfo, MockPowerState, POWER_CYCLE_DELAY, SetSystemPowerError, SetSystemPowerResult,
-    SystemPowerControl,
+    BmcCommand, BmcState, BootOptionKind, Callbacks, HostHardwareType, HostMachineInfo,
+    HostnameQuerying, MachineInfo, MockPowerState, POWER_CYCLE_DELAY, SetSystemPowerError,
+    SetSystemPowerResult, SystemPowerControl,
 };
 use carbide_network::virtualization::build_dual_stack_list;
 use carbide_uuid::machine::MachineId;
@@ -230,6 +230,8 @@ impl MachineStateMachine {
                         serial: h.serial,
                         dpus: h.dpus.into_iter().map(Into::into).collect(),
                         non_dpu_mac_address: h.non_dpu_mac_address,
+                        nvos_mac_addresses: h.nvos_mac_addresses,
+                        switch_serial_number: h.switch_serial_number,
                     }),
                 ),
                 PersistedMachine::Dpu(d) => (
@@ -942,6 +944,7 @@ impl MachineStateMachine {
         );
 
         let pw_override = match &self.machine_info {
+            MachineInfo::Host(host) if host.hw_type == HostHardwareType::LiteOnPowerShelf => None,
             MachineInfo::Host(_) => self.app_context.app_config.host_bmc_password.as_deref(),
             MachineInfo::Dpu(_) => self.app_context.app_config.dpu_bmc_password.as_deref(),
         };
@@ -986,7 +989,14 @@ impl MachineStateMachine {
     }
 
     fn is_bmc_only(info: &MachineInfo, config: &MachineConfig) -> bool {
-        matches!(info, MachineInfo::Dpu(_)) && config.dpus_in_nic_mode
+        match info {
+            MachineInfo::Dpu(_) => config.dpus_in_nic_mode,
+            MachineInfo::Host(host) => matches!(
+                host.hw_type,
+                bmc_mock::HostHardwareType::LiteOnPowerShelf
+                    | bmc_mock::HostHardwareType::NvidiaSwitchNd5200Ld
+            ),
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Register LiteOn power shelves and NVIDIA switches as their expected inventory types instead of expected machines. Preserve switch NVOS MAC/serial data across persistence and adjust mock BMC handling for BMC-only hardware.

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

#1864 

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
