### PR TITLE
fix(build): reduce default Rust test stack size

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -30,7 +30,7 @@ FORGE_CA_PATH = { value = "${REPO_ROOT}/dev/forge_${FORGE_CA}root.pem" }
 
 # Temporary: increase Rust test thread stack to avoid stack overflows in tests.
 # TODO: remove after stack-heavy tests/code paths are refactored.
-RUST_MIN_STACK = { value = "8388608", condition = { env_not_set = ["RUST_MIN_STACK"] } }
+RUST_MIN_STACK = { value = "4194304", condition = { env_not_set = ["RUST_MIN_STACK"] } }
 
 BUILD_CONTAINER_X86_URL = { value = "urm.nvidia.com/swngc-ngcc-docker-local/forge/carbide/x86-64/build-container:latest", condition = { env_not_set = [
   "BUILD_CONTAINER_X86_URL",


### PR DESCRIPTION
## Description

I see multiple aarch64 failed builds of tests recently. This PR reduces stack size assuming that these fails.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

