### PR TITLE
fix: DPU Extension Service status only include used DPUs

### DIFF
--- a/crates/api-core/src/tests/dpu_reprovisioning.rs
+++ b/crates/api-core/src/tests/dpu_reprovisioning.rs
@@ -615,6 +615,7 @@ async fn assert_reprov_tenant_state(
         instance_snapshot_derive_status(
             &db_instance,
             device_id_maps.1,
+            host.primary_attached_dpu_machine_id(),
             host.state.clone().value,
             None,
             None,

--- a/crates/api-core/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api-core/src/tests/host_bmc_firmware_test.rs
@@ -1263,6 +1263,7 @@ async fn test_instance_upgrading_actual_part_2(
         instance_snapshot_derive_status(
             &instance,
             device_id_maps.1,
+            host.primary_attached_dpu_machine_id(),
             host.state.clone().value,
             None,
             None,
@@ -1304,6 +1305,7 @@ async fn test_instance_upgrading_actual_part_2(
         instance_snapshot_derive_status(
             &instance,
             device_id_maps.1,
+            host.primary_attached_dpu_machine_id(),
             host.state.clone().value,
             None,
             None,
@@ -1355,6 +1357,7 @@ async fn test_instance_upgrading_actual_part_2(
         instance_snapshot_derive_status(
             &instance,
             device_id_maps.1,
+            host.primary_attached_dpu_machine_id(),
             host.state.clone().value,
             None,
             None,
@@ -1403,6 +1406,7 @@ async fn test_instance_upgrading_actual_part_2(
         instance_snapshot_derive_status(
             &instance,
             device_id_maps.1,
+            host.primary_attached_dpu_machine_id(),
             host.state.clone().value,
             None,
             None,
@@ -1441,6 +1445,7 @@ async fn test_instance_upgrading_actual_part_2(
         instance_snapshot_derive_status(
             &instance,
             device_id_maps.1,
+            host.primary_attached_dpu_machine_id(),
             host.state.clone().value,
             None,
             None,
@@ -1501,6 +1506,7 @@ async fn test_instance_upgrading_actual_part_2(
         instance_snapshot_derive_status(
             &instance,
             device_id_maps.1,
+            host.primary_attached_dpu_machine_id(),
             host.state.clone().value,
             None,
             None,
@@ -1539,6 +1545,7 @@ async fn test_instance_upgrading_actual_part_2(
         instance_snapshot_derive_status(
             &instance,
             device_id_maps.1,
+            host.primary_attached_dpu_machine_id(),
             host.state.clone().value,
             None,
             None,
@@ -1589,6 +1596,7 @@ async fn test_instance_upgrading_actual_part_2(
         instance_snapshot_derive_status(
             &instance,
             device_id_maps.1,
+            host.primary_attached_dpu_machine_id(),
             host.state.clone().value,
             None,
             None,
@@ -1659,6 +1667,7 @@ async fn test_instance_upgrading_actual_part_2(
         instance_snapshot_derive_status(
             &instance,
             device_id_maps.1,
+            host.primary_attached_dpu_machine_id(),
             host.state.clone().value,
             None,
             None,
@@ -1725,6 +1734,7 @@ async fn test_instance_upgrading_actual_part_2(
         instance_snapshot_derive_status(
             &instance,
             device_id_maps.1,
+            host.primary_attached_dpu_machine_id(),
             host.state.clone().value,
             None,
             None,
@@ -1763,6 +1773,7 @@ async fn test_instance_upgrading_actual_part_2(
         instance_snapshot_derive_status(
             &instance,
             device_id_maps.1,
+            host.primary_attached_dpu_machine_id(),
             host.state.clone().value,
             None,
             None,
@@ -1799,6 +1810,7 @@ async fn test_instance_upgrading_actual_part_2(
         instance_snapshot_derive_status(
             &instance,
             device_id_maps.1,
+            host.primary_attached_dpu_machine_id(),
             host.state.clone().value,
             None,
             None,
@@ -1830,6 +1842,7 @@ async fn test_instance_upgrading_actual_part_2(
         instance_snapshot_derive_status(
             &instance,
             device_id_maps.1,
+            host.primary_attached_dpu_machine_id(),
             host.state.clone().value,
             None,
             None,

--- a/crates/api-model/src/instance/config/network.rs
+++ b/crates/api-model/src/instance/config/network.rs
@@ -240,6 +240,60 @@ impl InstanceNetworkConfig {
         }
     }
 
+    /// Returns the DPU machine IDs used by the instance network configuration.
+    pub fn get_used_dpus(
+        &self,
+        device_to_id_map: &HashMap<String, Vec<MachineId>>,
+        primary_dpu_machine_id: Option<MachineId>,
+    ) -> Vec<MachineId> {
+        let device_locators: Vec<&DeviceLocator> = self
+            .interfaces
+            .iter()
+            .filter_map(|i| i.device_locator.as_ref())
+            .collect();
+
+        let legacy_physical_interface_count = self
+            .interfaces
+            .iter()
+            .filter(|iface| {
+                iface.function_id == InterfaceFunctionId::Physical {}
+                    && iface.device_locator.is_none()
+            })
+            .count();
+
+        let use_primary_dpu_only = legacy_physical_interface_count > 0
+            || device_locators.is_empty()
+            || device_to_id_map.is_empty();
+
+        if use_primary_dpu_only {
+            return primary_dpu_machine_id.into_iter().collect();
+        }
+
+        let used_dpus: Vec<MachineId> = device_locators
+            .iter()
+            .filter_map(|device_locator| {
+                device_to_id_map
+                    .get(&device_locator.device)
+                    .and_then(|dpu_ids| dpu_ids.get(device_locator.device_instance))
+                    .copied()
+            })
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+
+        if used_dpus.is_empty() {
+            return device_to_id_map
+                .values()
+                .flatten()
+                .copied()
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect();
+        }
+
+        used_dpus
+    }
+
     /// Validates the network configuration.
     ///
     /// Note: this is also called on POST-resolution configs (i.e. after

--- a/crates/api-model/src/instance/status/extension_service.rs
+++ b/crates/api-model/src/instance/status/extension_service.rs
@@ -44,7 +44,7 @@ impl InstanceExtensionServicesStatus {
     /// For each extension service, we aggregate the statuses from all DPUs.
     /// The config passed must be from database (not rpc InstanceConfig), and must contain any terminating services.
     pub fn from_config_and_observations(
-        dpu_id_to_device_map: &HashMap<String, Vec<MachineId>>,
+        dpu_ids: &[MachineId],
         config: Versioned<&InstanceExtensionServicesConfig>,
         observations: &HashMap<MachineId, InstanceExtensionServiceStatusObservation>,
     ) -> Self {
@@ -57,15 +57,11 @@ impl InstanceExtensionServicesStatus {
             };
         }
 
-        // Extract all unique DPU machine IDs from the dpu_id_to_device_map
-        let all_dpu_ids: Vec<MachineId> =
-            dpu_id_to_device_map.values().flatten().copied().collect();
-
         // Instance allocation rejects non-empty service_configs on zero-DPU
         // hosts, so, in practice, we *shouldn't* reach here. BUT, if we do,
         // assume it's from something like a stale pre-validation instance,
         // and just report unsynced.
-        if all_dpu_ids.is_empty() {
+        if dpu_ids.is_empty() {
             return Self::unsynced_for_config(&config);
         }
 
@@ -76,7 +72,7 @@ impl InstanceExtensionServicesStatus {
         for service in config.service_configs.iter() {
             let mut dpu_statuses = vec![];
 
-            for dpu_id in &all_dpu_ids {
+            for dpu_id in dpu_ids {
                 match observations.get(dpu_id) {
                     // DPU has observation with matching config version
                     Some(obs) if obs.config_version == config.version => {
@@ -439,18 +435,17 @@ mod tests {
         InstanceExtensionServiceConfig, InstanceExtensionServicesConfig,
     };
 
-    fn get_test_machine_id() -> MachineId {
-        MachineId::from_str("fm100dskla0ihp0pn4tv7v1js2k2mo37sl0jjr8141okqg8pjpdpfihaa80").unwrap()
+    fn get_dpu_ids() -> Vec<MachineId> {
+        vec![
+            MachineId::from_str("fm100dskla0ihp0pn4tv7v1js2k2mo37sl0jjr8141okqg8pjpdpfihaa80")
+                .unwrap(),
+            MachineId::from_str("fm100ds27v4uuq7sgs4gsjummskt0b3tedugtpevjrbfh6su081n9jufcq0")
+                .unwrap(),
+        ]
     }
 
     fn get_test_service_id() -> ExtensionServiceId {
         ExtensionServiceId::from_str("00000000-0000-0000-0000-000000000000").unwrap()
-    }
-
-    fn create_dpu_map_with_one_dpu() -> HashMap<String, Vec<MachineId>> {
-        let mut map = HashMap::new();
-        map.insert("device0".to_string(), vec![get_test_machine_id()]);
-        map
     }
 
     fn create_service_config(version: ConfigVersion) -> InstanceExtensionServicesConfig {
@@ -464,14 +459,14 @@ mod tests {
     }
 
     fn create_observation(
+        dpu_id: MachineId,
         config_version: ConfigVersion,
         service_version: ConfigVersion,
         status: ExtensionServiceDeploymentStatus,
     ) -> HashMap<MachineId, InstanceExtensionServiceStatusObservation> {
         let mut observations = HashMap::new();
         observations.insert(
-            MachineId::from_str("fm100dskla0ihp0pn4tv7v1js2k2mo37sl0jjr8141okqg8pjpdpfihaa80")
-                .unwrap(),
+            dpu_id,
             InstanceExtensionServiceStatusObservation {
                 config_version,
                 instance_config_version: None,
@@ -497,10 +492,9 @@ mod tests {
         let config = create_service_config(service_version);
 
         let config_version = ConfigVersion::initial();
-        let dpu_map = create_dpu_map_with_one_dpu();
 
         let status = InstanceExtensionServicesStatus::from_config_and_observations(
-            &dpu_map,
+            &[get_dpu_ids()[0]],
             Versioned::new(&config, config_version),
             &HashMap::new(),
         );
@@ -530,15 +524,17 @@ mod tests {
         let config = create_service_config(service_version);
         let config_version = ConfigVersion::initial();
 
-        let dpu_map = create_dpu_map_with_one_dpu();
+        let dpu_id = get_dpu_ids()[0];
+
         let observations = create_observation(
+            dpu_id,
             config_version,
             service_version,
             ExtensionServiceDeploymentStatus::Running,
         );
 
         let status = InstanceExtensionServicesStatus::from_config_and_observations(
-            &dpu_map,
+            &[dpu_id],
             Versioned::new(&config, config_version),
             &observations,
         );
@@ -552,7 +548,7 @@ mod tests {
         assert_eq!(status.extension_services[0].dpu_statuses.len(), 1);
         assert_eq!(
             status.extension_services[0].dpu_statuses[0].machine_id,
-            get_test_machine_id(),
+            dpu_id,
         );
         assert_eq!(
             status.extension_services[0].dpu_statuses[0].status,
@@ -568,15 +564,16 @@ mod tests {
     fn extension_service_status_with_outdated_observation() {
         let config = create_service_config(ConfigVersion::initial());
         let version = ConfigVersion::initial();
-        let dpu_map = create_dpu_map_with_one_dpu();
+        let dpu_id = get_dpu_ids()[0];
         let observations = create_observation(
+            dpu_id,
             ConfigVersion::initial(),
             ConfigVersion::initial(),
             ExtensionServiceDeploymentStatus::Running,
         );
 
         let status = InstanceExtensionServicesStatus::from_config_and_observations(
-            &dpu_map,
+            &[dpu_id],
             Versioned::new(&config, version.increment()), // Increment config version for extension service config
             &observations,                                // Observation has initial config version
         );
@@ -616,22 +613,19 @@ mod tests {
         let config_version = ConfigVersion::initial();
 
         // Create a map with two DPUs
-        let dpu1_id = get_test_machine_id();
-        let dpu2_id =
-            MachineId::from_str("fm100ds27v4uuq7sgs4gsjummskt0b3tedugtpevjrbfh6su081n9jufcq0")
-                .unwrap();
-        let mut dpu_map = HashMap::new();
-        dpu_map.insert("device0".to_string(), vec![dpu1_id, dpu2_id]);
+        let dpu1_id = get_dpu_ids()[0];
+        let dpu2_id = get_dpu_ids()[1];
 
         // Create observation for only one DPU
         let observations = create_observation(
+            dpu1_id,
             config_version,
             service_version,
             ExtensionServiceDeploymentStatus::Running,
         );
 
         let status = InstanceExtensionServicesStatus::from_config_and_observations(
-            &dpu_map,
+            &[dpu1_id, dpu2_id],
             Versioned::new(&config, config_version),
             &observations,
         );
@@ -671,12 +665,8 @@ mod tests {
         let config_version = ConfigVersion::initial();
 
         // Create a map with two DPUs
-        let dpu1_id = get_test_machine_id();
-        let dpu2_id =
-            MachineId::from_str("fm100ds27v4uuq7sgs4gsjummskt0b3tedugtpevjrbfh6su081n9jufcq0")
-                .unwrap();
-        let mut dpu_map = HashMap::new();
-        dpu_map.insert("device0".to_string(), vec![dpu1_id, dpu2_id]);
+        let dpu1_id = get_dpu_ids()[0];
+        let dpu2_id = get_dpu_ids()[1];
 
         // Create observations for both DPUs
         let mut observations = HashMap::new();
@@ -718,7 +708,7 @@ mod tests {
         );
 
         let status = InstanceExtensionServicesStatus::from_config_and_observations(
-            &dpu_map,
+            &[dpu1_id, dpu2_id],
             Versioned::new(&config, config_version),
             &observations,
         );
@@ -743,6 +733,76 @@ mod tests {
         // Readiness check: configs synced and all services running, should be Ready
         let readiness = compute_extension_services_readiness(&status);
         assert_eq!(readiness, ExtensionServicesReadiness::Ready);
+    }
+
+    #[test]
+    fn extension_service_status_scopes_to_target_dpus() {
+        let service_version = ConfigVersion::initial();
+        let config = create_service_config(service_version);
+        let config_version = ConfigVersion::initial();
+
+        let dpu1_id = get_dpu_ids()[0];
+        let dpu2_id = get_dpu_ids()[1];
+
+        let mut observations = HashMap::new();
+        observations.insert(
+            dpu1_id,
+            InstanceExtensionServiceStatusObservation {
+                config_version,
+                instance_config_version: None,
+                extension_service_statuses: vec![ExtensionServiceStatusObservation {
+                    service_id: get_test_service_id(),
+                    service_type: ExtensionServiceType::KubernetesPod,
+                    service_name: "test-service".to_string(),
+                    version: service_version,
+                    removed: None,
+                    overall_state: ExtensionServiceDeploymentStatus::Running,
+                    components: vec![],
+                    message: String::new(),
+                }],
+                observed_at: chrono::Utc::now(),
+            },
+        );
+        observations.insert(
+            dpu2_id,
+            InstanceExtensionServiceStatusObservation {
+                config_version,
+                instance_config_version: None,
+                extension_service_statuses: vec![ExtensionServiceStatusObservation {
+                    service_id: get_test_service_id(),
+                    service_type: ExtensionServiceType::KubernetesPod,
+                    service_name: "test-service".to_string(),
+                    version: service_version,
+                    removed: None,
+                    overall_state: ExtensionServiceDeploymentStatus::Pending,
+                    components: vec![],
+                    message: "No pod sandbox found".to_string(),
+                }],
+                observed_at: chrono::Utc::now(),
+            },
+        );
+
+        let status = InstanceExtensionServicesStatus::from_config_and_observations(
+            &[dpu1_id],
+            Versioned::new(&config, config_version),
+            &observations,
+        );
+
+        assert_eq!(status.configs_synced, SyncState::Synced);
+        assert_eq!(status.extension_services.len(), 1);
+        assert_eq!(
+            status.extension_services[0].overall_status,
+            ExtensionServiceDeploymentStatus::Running
+        );
+        assert_eq!(status.extension_services[0].dpu_statuses.len(), 1);
+        assert_eq!(
+            status.extension_services[0].dpu_statuses[0].machine_id,
+            dpu1_id
+        );
+        assert_eq!(
+            compute_extension_services_readiness(&status),
+            ExtensionServicesReadiness::Ready
+        );
     }
 
     #[test]
@@ -811,6 +871,7 @@ mod tests {
     }
 
     fn create_observation_two_versions(
+        dpu_id: MachineId,
         cfg_version: ConfigVersion,
         v_new: ConfigVersion,
         new_state: ExtensionServiceDeploymentStatus,
@@ -819,7 +880,7 @@ mod tests {
     ) -> HashMap<MachineId, InstanceExtensionServiceStatusObservation> {
         let mut observations = HashMap::new();
         observations.insert(
-            get_test_machine_id(),
+            dpu_id,
             InstanceExtensionServiceStatusObservation {
                 config_version: cfg_version,
                 instance_config_version: None,
@@ -853,6 +914,8 @@ mod tests {
 
     #[test]
     fn extension_service_get_terminated_service_keys() {
+        let dpu_id = get_dpu_ids()[0];
+
         let init_version = ConfigVersion::initial();
         let second_version = init_version.increment();
         let config = InstanceExtensionServicesConfig {
@@ -870,8 +933,8 @@ mod tests {
             ],
         };
         let config_version = ConfigVersion::initial();
-        let dpu_map = create_dpu_map_with_one_dpu();
         let observations = create_observation_two_versions(
+            dpu_id,
             config_version,
             second_version,
             ExtensionServiceDeploymentStatus::Running,
@@ -880,7 +943,7 @@ mod tests {
         );
 
         let status = InstanceExtensionServicesStatus::from_config_and_observations(
-            &dpu_map,
+            &[dpu_id],
             Versioned::new(&config, config_version),
             &observations,
         );

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1071,6 +1071,13 @@ impl Machine {
         )))
     }
 
+    pub fn primary_attached_dpu_machine_id(&self) -> Option<MachineId> {
+        self.interfaces
+            .iter()
+            .find(|iface| iface.primary_interface)
+            .and_then(|iface| iface.attached_dpu_machine_id)
+    }
+
     pub fn get_dpu_device_and_id_mappings(&self) -> ModelResult<DpuDeviceMappings> {
         if self.is_dpu() {
             return Err(ModelError::DpuMappingError(

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -6387,9 +6387,7 @@ fn get_extension_services_status(
         .get_dpu_device_and_id_mappings()
         .unwrap_or_else(|_| (HashMap::default(), HashMap::default()));
 
-    let primary_dpu_machine_id = mh_snapshot
-        .host_snapshot
-        .primary_attached_dpu_machine_id();
+    let primary_dpu_machine_id = mh_snapshot.host_snapshot.primary_attached_dpu_machine_id();
     let used_dpus = instance
         .config
         .network

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -6377,19 +6377,27 @@ impl StateHandler for InstanceStateHandler {
 }
 
 // Gets extension services status from DB, checks if any removed services are fully terminated
-// across all DPUs, if so, remove them from the instance config in the DB(without updating the version).
+// across targeted DPUs, if so, remove them from the instance config in the DB(without updating the version).
 fn get_extension_services_status(
     mh_snapshot: &ManagedHostStateSnapshot,
     instance: &InstanceSnapshot,
 ) -> InstanceExtensionServicesStatus {
-    let (_, dpu_id_to_device_map) = mh_snapshot
+    let (_, device_to_id_map) = mh_snapshot
         .host_snapshot
         .get_dpu_device_and_id_mappings()
         .unwrap_or_else(|_| (HashMap::default(), HashMap::default()));
 
-    // Gather instance extension services status from all DPU observations
+    let primary_dpu_machine_id = mh_snapshot
+        .host_snapshot
+        .primary_attached_dpu_machine_id();
+    let used_dpus = instance
+        .config
+        .network
+        .get_used_dpus(&device_to_id_map, primary_dpu_machine_id);
+
+    // Gather instance extension services status from targeted DPUs.
     InstanceExtensionServicesStatus::from_config_and_observations(
-        &dpu_id_to_device_map,
+        &used_dpus,
         Versioned::new(
             &instance.config.extension_services,
             instance.extension_services_config_version,

--- a/crates/rpc/src/model/instance/snapshot.rs
+++ b/crates/rpc/src/model/instance/snapshot.rs
@@ -36,6 +36,7 @@ use crate::model::instance::status::instance_status_from_config_and_observation;
 pub fn instance_snapshot_derive_status(
     snapshot: &InstanceSnapshot,
     dpu_id_to_device_map: HashMap<String, Vec<MachineId>>,
+    primary_dpu_machine_id: Option<MachineId>,
     managed_host_state: ManagedHostState,
     reprovision_request: Option<ReprovisionRequest>,
     ib_status: Option<&MachineInfinibandStatusObservation>,
@@ -45,6 +46,7 @@ pub fn instance_snapshot_derive_status(
 ) -> Result<InstanceStatus, RpcDataConversionError> {
     instance_status_from_config_and_observation(
         dpu_id_to_device_map,
+        primary_dpu_machine_id,
         Versioned::new(&snapshot.config, snapshot.config_version),
         Versioned::new(&snapshot.config.network, snapshot.network_config_version),
         Versioned::new(&snapshot.config.infiniband, snapshot.ib_config_version),

--- a/crates/rpc/src/model/instance/status.rs
+++ b/crates/rpc/src/model/instance/status.rs
@@ -103,10 +103,9 @@ pub fn instance_status_from_config_and_observation(
         // If observations.network.instance_config_version was None, then "ignore"
     }
 
-    let used_dpu_ids =
-        network_config
-            .value
-            .get_used_dpus(&dpu_id_to_device_map, primary_dpu_machine_id);
+    let used_dpu_ids = network_config
+        .value
+        .get_used_dpus(&dpu_id_to_device_map, primary_dpu_machine_id);
 
     let network =
         model::instance::status::network::InstanceNetworkStatus::from_config_and_observations(

--- a/crates/rpc/src/model/instance/status.rs
+++ b/crates/rpc/src/model/instance/status.rs
@@ -71,6 +71,7 @@ impl TryFrom<InstanceStatus> for rpc::InstanceStatus {
 #[allow(clippy::too_many_arguments)]
 pub fn instance_status_from_config_and_observation(
     dpu_id_to_device_map: HashMap<String, Vec<MachineId>>,
+    primary_dpu_machine_id: Option<MachineId>,
     instance_config: Versioned<&InstanceConfig>,
     network_config: Versioned<&InstanceNetworkConfig>,
     ib_config: Versioned<&InstanceInfinibandConfig>,
@@ -102,9 +103,14 @@ pub fn instance_status_from_config_and_observation(
         // If observations.network.instance_config_version was None, then "ignore"
     }
 
+    let used_dpu_ids =
+        network_config
+            .value
+            .get_used_dpus(&dpu_id_to_device_map, primary_dpu_machine_id);
+
     let network =
         model::instance::status::network::InstanceNetworkStatus::from_config_and_observations(
-            dpu_id_to_device_map.clone(),
+            dpu_id_to_device_map,
             network_config,
             &observations.network,
             is_network_config_request_pending,
@@ -117,7 +123,7 @@ pub fn instance_status_from_config_and_observation(
 
     let extension_services =
         model::instance::status::extension_service::InstanceExtensionServicesStatus::from_config_and_observations(
-            &dpu_id_to_device_map,
+            &used_dpu_ids,
             extension_services_config,
             &observations.extension_services,
         );
@@ -260,6 +266,7 @@ mod tests {
 
         let status = instance_status_from_config_and_observation(
             HashMap::new(),
+            None,
             Versioned::new(&config, version),
             Versioned::new(&config.network, version),
             Versioned::new(&config.infiniband, version),

--- a/crates/rpc/src/model/machine/mod.rs
+++ b/crates/rpc/src/model/machine/mod.rs
@@ -116,6 +116,7 @@ impl RpcTryFrom<ManagedHostStateSnapshot> for Option<rpc::Instance> {
         let status = instance_snapshot_derive_status(
             &instance,
             dpu_id_to_device_map,
+            snapshot.host_snapshot.primary_attached_dpu_machine_id(),
             snapshot.managed_state.clone(),
             reprovision_request,
             snapshot


### PR DESCRIPTION
## Description
This PR fixes a DPU Extension Service status aggregation [nvbug](https://nvbugspro.nvidia.com/bug/6014658/4) on multi-DPU hosts. Previously, the extension service status aggregation considered every DPU associated with the instance, even when an DPU(secondary DPU) is not being used. As a result, since any unused DPU will never report extension services as `Running`, the overall DPU Extension Service status for the instance will not reach `Running` either, preventing instance status from reaching `Ready`.

This PR adds filtering to only the DPUs actually used by the instance, which is derived from instance network config using `get_used_dpus` helper. Note this filtering is added before:
- Instance deployment when the state machine evaluates extension service readiness in `WaitingForExtensionServicesConfig` state
- Instance status queries when tenants read instance status through RPC call
But not before
- instance termination check, when the state machine waits for extension services to be `Terminated` in `WaitingForNetworkReconfig`, it still checks all DPUs so no change happens there. 

Also, the DPU agent side has no change. When DPU is not being used, the DPU agent does not deploy any extension services configured for the instance. in which case the agent reports the extension services' status to be "terminated". This is because from the agent's perspective, it cannot tell whether it is not being used and on admin network because 1) has an associated instance but not being configured by tenant, or 2) associated instance is being terminated. 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

