### PR TITLE
api-core: Parse dhcp_servers and route_servers as IP addresses

### DIFF
--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -113,7 +113,7 @@ pub struct CarbideConfig {
     /// DHCP server addresses announced to DPUs during
     /// network provisioning.
     #[serde(default)]
-    pub dhcp_servers: Vec<String>,
+    pub dhcp_servers: Vec<Ipv4Addr>,
 
     /// Route server IP addresses for L2VPN (Ethernet
     /// Virtual) network support on DPUs.
@@ -2008,7 +2008,11 @@ impl From<CarbideConfig> for rpc::forge::RuntimeConfig {
             max_database_connections: value.max_database_connections,
             enable_ip_fabric: value.ib_config.unwrap_or_default().enabled,
             asn: value.asn,
-            dhcp_servers: value.dhcp_servers,
+            dhcp_servers: value
+                .dhcp_servers
+                .into_iter()
+                .map(|addr| addr.to_string())
+                .collect(),
             route_servers: value.route_servers,
             enable_route_servers: value.enable_route_servers,
             deny_prefixes: value
@@ -2622,7 +2626,7 @@ mod tests {
         assert_eq!(config.database_url, "postgres://a:b@postgresql".to_string());
         assert_eq!(config.max_database_connections, 1333);
         assert_eq!(config.asn, 777);
-        assert_eq!(config.dhcp_servers, vec!["99.101.102.103".to_string()]);
+        assert_eq!(config.dhcp_servers, vec![Ipv4Addr::new(99, 101, 102, 103)]);
         assert!(config.route_servers.is_empty());
         assert_eq!(config.bmc_session_lockout_threshold, 5);
         assert_eq!(config.vpc_peering_policy, Some(VpcPeeringPolicy::Exclusive));
@@ -2783,7 +2787,7 @@ mod tests {
         assert_eq!(config.bmc_session_lockout_threshold, 4);
         assert_eq!(
             config.dhcp_servers,
-            vec!["1.2.3.4".to_string(), "5.6.7.8".to_string()]
+            vec![Ipv4Addr::new(1, 2, 3, 4), Ipv4Addr::new(5, 6, 7, 8)]
         );
         assert_eq!(config.vpc_peering_policy, Some(VpcPeeringPolicy::Exclusive));
         assert_eq!(
@@ -3112,7 +3116,7 @@ mod tests {
         assert_eq!(config.max_database_connections, 1333);
         assert_eq!(config.asn, 777);
         assert_eq!(config.bmc_session_lockout_threshold, 5);
-        assert_eq!(config.dhcp_servers, vec!["99.101.102.103".to_string()]);
+        assert_eq!(config.dhcp_servers, vec![Ipv4Addr::new(99, 101, 102, 103)]);
         assert_eq!(config.route_servers, vec!["9.10.11.12".to_string()]);
         assert_eq!(
             config.tls.as_ref().unwrap().identity_pemfile_path,
@@ -3338,7 +3342,7 @@ mod tests {
             assert_eq!(config.asn, 777);
             assert_eq!(
                 config.dhcp_servers,
-                vec!["1.2.3.4".to_string(), "5.6.7.8".to_string()]
+                vec![Ipv4Addr::new(1, 2, 3, 4), Ipv4Addr::new(5, 6, 7, 8)]
             );
             assert_eq!(config.route_servers, vec!["9.10.11.12".to_string()]);
             assert_eq!(config.dpu_network_monitor_pinger_type, None);

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 
 use bmc_vendor::BMCVendor;
@@ -118,7 +118,7 @@ pub struct CarbideConfig {
     /// Route server IP addresses for L2VPN (Ethernet
     /// Virtual) network support on DPUs.
     #[serde(default)]
-    pub route_servers: Vec<String>,
+    pub route_servers: Vec<IpAddr>,
 
     /// Enables route server injection into DPU FRR
     /// configs for L2VPN Ethernet Virtual networks.
@@ -2013,7 +2013,11 @@ impl From<CarbideConfig> for rpc::forge::RuntimeConfig {
                 .into_iter()
                 .map(|addr| addr.to_string())
                 .collect(),
-            route_servers: value.route_servers,
+            route_servers: value
+                .route_servers
+                .into_iter()
+                .map(|addr| addr.to_string())
+                .collect(),
             enable_route_servers: value.enable_route_servers,
             deny_prefixes: value
                 .deny_prefixes
@@ -2794,7 +2798,7 @@ mod tests {
             config.vpc_peering_policy_on_existing,
             Some(VpcPeeringPolicy::Mixed)
         );
-        assert_eq!(config.route_servers, vec!["9.10.11.12".to_string()]);
+        assert_eq!(config.route_servers, vec![Ipv4Addr::new(9, 10, 11, 12)]);
         assert_eq!(
             config.tls.as_ref().unwrap().identity_pemfile_path,
             "/path/to/cert"
@@ -3117,7 +3121,7 @@ mod tests {
         assert_eq!(config.asn, 777);
         assert_eq!(config.bmc_session_lockout_threshold, 5);
         assert_eq!(config.dhcp_servers, vec![Ipv4Addr::new(99, 101, 102, 103)]);
-        assert_eq!(config.route_servers, vec!["9.10.11.12".to_string()]);
+        assert_eq!(config.route_servers, vec![Ipv4Addr::new(9, 10, 11, 12)]);
         assert_eq!(
             config.tls.as_ref().unwrap().identity_pemfile_path,
             "/patched/path/to/cert"
@@ -3344,7 +3348,7 @@ mod tests {
                 config.dhcp_servers,
                 vec![Ipv4Addr::new(1, 2, 3, 4), Ipv4Addr::new(5, 6, 7, 8)]
             );
-            assert_eq!(config.route_servers, vec!["9.10.11.12".to_string()]);
+            assert_eq!(config.route_servers, vec![Ipv4Addr::new(9, 10, 11, 12)]);
             assert_eq!(config.dpu_network_monitor_pinger_type, None);
             assert_eq!(
                 config.tls.as_ref().unwrap().identity_pemfile_path,

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -16,9 +16,7 @@
  */
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
-use std::net::IpAddr;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
@@ -97,7 +95,6 @@ use crate::api::metrics::ApiMetricsEmitter;
 use crate::cfg::file::{CarbideConfig, InitialObjectsConfig, ListenMode};
 use crate::dpa::handler::start_dpa_handler;
 use crate::dynamic_settings::DynamicSettings;
-use crate::errors::CarbideError;
 use crate::handlers::machine_validation::apply_config_on_startup;
 use crate::listener::{AdminUiRoutesBuilder, ApiListenMode};
 use crate::logging::log_limiter::LogLimiter;
@@ -559,14 +556,12 @@ pub async fn start_api(
         // buggy -- otherwise).
         //
         // These are of course set with RouteServerSourceType::ConfigFile.
-        let route_servers: Vec<IpAddr> = carbide_config
-            .route_servers
-            .iter()
-            .map(|rs| IpAddr::from_str(rs))
-            .collect::<Result<Vec<IpAddr>, _>>()
-            .map_err(CarbideError::AddressParseError)?;
-        db::route_servers::replace(&mut txn, &route_servers, RouteServerSourceType::ConfigFile)
-            .await?;
+        db::route_servers::replace(
+            &mut txn,
+            &carbide_config.route_servers,
+            RouteServerSourceType::ConfigFile,
+        )
+        .await?;
 
         txn.commit().await?;
     };

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -605,7 +605,11 @@ pub async fn start_api(
 
     let eth_data = ethernet_virtualization::EthVirtData {
         asn: carbide_config.asn,
-        dhcp_servers: carbide_config.dhcp_servers.clone(),
+        dhcp_servers: carbide_config
+            .dhcp_servers
+            .iter()
+            .map(|addr| addr.to_string())
+            .collect(),
         deny_prefixes: carbide_config.deny_prefixes.clone(),
         site_fabric_prefixes,
     };

--- a/crates/api-web/src/filters.rs
+++ b/crates/api-web/src/filters.rs
@@ -26,6 +26,7 @@ use std::str::FromStr;
 
 use askama_escape::Escaper;
 use carbide_uuid::machine::MachineId;
+use itertools::Itertools;
 
 /// Generates HTML links for Machine IDs
 #[askama::filter_fn]
@@ -273,6 +274,15 @@ pub fn option_fmt_or(
         Some(value) => value.to_string(),
         None => default.to_string(),
     })
+}
+
+#[askama::filter_fn]
+pub fn comma_separated(
+    value: impl IntoIterator<Item = impl Display>,
+    _env: &dyn askama::Values,
+) -> askama::Result<String> {
+    let result = value.into_iter().map(|item| item.to_string()).join(", ");
+    Ok(result)
 }
 
 pub(crate) fn state_and_substate_labels(state_json: impl Display) -> (String, String) {

--- a/crates/api-web/templates/index.html
+++ b/crates/api-web/templates/index.html
@@ -152,9 +152,7 @@
 	<tr><th>Route Servers</th><td>{{ carbide_config.route_servers | comma_separated }}</td></tr>
 	<tr><th>Deny Prefixes</th><td>
 			{% if carbide_config.deny_prefixes.len() != 0 %}
-			{% for prefix in carbide_config.deny_prefixes %}
-			{{ prefix }},
-			{% endfor %}
+			{{ carbide_config.deny_prefixes | comma_separated }}
 			{% else %}
 			Not Configured
 			{% endif %}
@@ -164,9 +162,7 @@
 		<th>Site Fabric Prefixes</th>
 		<td>
 			{% if carbide_config.site_fabric_prefixes.len() != 0 %}
-			{% for prefix in carbide_config.site_fabric_prefixes %}
-			{{ prefix }},
-			{% endfor %}
+			{{ carbide_config.site_fabric_prefixes | comma_separated }}
 			{% else %}
 			Not Configured
 			{% endif %}
@@ -183,9 +179,7 @@
 		<td>
 			{% match carbide_config.networks %}
 			{% when Some with (val) %}
-			{% for network in val.keys() %}
-			{{ network }},
-			{% endfor %}
+			{{ val.keys() | comma_separated }}
 			{% else %}
 			Not Configured
 			{% endmatch %}
@@ -238,9 +232,7 @@
 	<tr>
 		<th>DPU NIC Firmware Versions</th>
 		<td>
-			{% for ver in carbide_config.dpu_config.dpu_nic_firmware_update_versions %}
-			{{ ver }},
-			{% endfor %}
+		  {{ carbide_config.dpu_config.dpu_nic_firmware_update_versions | comma_separated }}
 		</td>
 
 	</tr>

--- a/crates/api-web/templates/index.html
+++ b/crates/api-web/templates/index.html
@@ -149,7 +149,7 @@
 	<tr><th>ASN</th><td>{{ carbide_config.asn }}</td></tr>
 	<tr><th>DHCP Servers</th><td>{{ carbide_config.dhcp_servers | comma_separated }}</td></tr>
 	<tr><th>Route Server State</th><td>{% if carbide_config.enable_route_servers %}Enabled{% else %}Disabled{% endif %}</td></tr>
-	<tr><th>Route Servers</th><td>{{ carbide_config.route_servers.join(", ") }}</td></tr>
+	<tr><th>Route Servers</th><td>{{ carbide_config.route_servers | comma_separated }}</td></tr>
 	<tr><th>Deny Prefixes</th><td>
 			{% if carbide_config.deny_prefixes.len() != 0 %}
 			{% for prefix in carbide_config.deny_prefixes %}

--- a/crates/api-web/templates/index.html
+++ b/crates/api-web/templates/index.html
@@ -147,7 +147,7 @@
 		</td>
 	</tr>
 	<tr><th>ASN</th><td>{{ carbide_config.asn }}</td></tr>
-	<tr><th>DHCP Servers</th><td>{{ carbide_config.dhcp_servers.join(", ") }}</td></tr>
+	<tr><th>DHCP Servers</th><td>{{ carbide_config.dhcp_servers | comma_separated }}</td></tr>
 	<tr><th>Route Server State</th><td>{% if carbide_config.enable_route_servers %}Enabled{% else %}Disabled{% endif %}</td></tr>
 	<tr><th>Route Servers</th><td>{{ carbide_config.route_servers.join(", ") }}</td></tr>
 	<tr><th>Deny Prefixes</th><td>


### PR DESCRIPTION
## Description
The config file parser currently treats these as `Vec<String>`, when really they should be parsed as IP addresses to catch configuration errors earlier.

These changes break down like so:
* Parse `dhcp_servers` as `Vec<Ipv4Addr>` (this service address is inherently IPv4 and we should probably configure DHCPv6 as its own thing).
* Parse `route_servers` as `Vec<IpAddr>` (can be either IPv4 or IPv6).
* Introduce a `comma_separated` Askama filter to make it easier to print these in the admin UI.
* Use `comma_separated` in a few more obvious places.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [X] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

