### PR TITLE
fix: correctly type BmcInfo IP addresses as IpAddr

### DIFF
--- a/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
@@ -975,7 +975,7 @@ pub(crate) async fn validate_and_complete_bmc_endpoint_request(
 
             Ok((
                 rpc::BmcEndpointRequest {
-                    ip_address: bmc_ip.to_owned(),
+                    ip_address: bmc_ip.to_string(),
                     mac_address: Some(bmc_mac_address.to_string()),
                 },
                 Some(machine_id),

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -1044,18 +1044,10 @@ async fn resolve_compute_tray_endpoints(
             continue;
         };
 
-        let Some(ip_str) = machine.bmc_info.ip.as_ref() else {
+        let Some(bmc_ip) = machine.bmc_info.ip else {
             unresolved.push(UnresolvedDevice {
                 id: machine_id,
                 reason: "BMC IP not configured".into(),
-            });
-            continue;
-        };
-
-        let Ok(bmc_ip) = ip_str.parse::<IpAddr>() else {
-            unresolved.push(UnresolvedDevice {
-                id: machine_id,
-                reason: format!("unparseable BMC IP: {ip_str}"),
             });
             continue;
         };

--- a/crates/api-core/src/handlers/instance.rs
+++ b/crates/api-core/src/handlers/instance.rs
@@ -1022,10 +1022,11 @@ pub(crate) async fn invoke_power(
     // TODO: The API call should maybe not directly trigger the reboot
     // but instead queue it for the state handler. That will avoid racing
     // with other internal reboot requests from the state handler.
+    let bmc_ip = bmc_ip.to_string();
     let client = api
         .redfish_pool
         .create_client(
-            bmc_ip,
+            &bmc_ip,
             snapshot.host_snapshot.bmc_info.port,
             RedfishAuth::Key(CredentialKey::BmcCredentials {
                 credential_type: BmcCredentialType::BmcRoot { bmc_mac_address },

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -16,8 +16,6 @@
  */
 
 use std::collections::HashMap;
-use std::net::IpAddr;
-use std::str::FromStr;
 
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge as rpc;
@@ -465,10 +463,11 @@ pub(crate) async fn admin_force_delete_machine(
     }
 
     if let Some(machine) = &host_machine {
-        if let Some(ip) = machine.bmc_info.ip.as_deref() {
+        if let Some(ip) = machine.bmc_info.ip {
             if let Some(bmc_mac_address) = machine.bmc_info.mac {
+                let ip_address = ip.to_string();
                 tracing::info!(
-                    ip,
+                    %ip,
                     machine_id = %machine.id,
                     "BMC IP and MAC address for machine was found. Trying to perform Bios unlock",
                 );
@@ -476,7 +475,7 @@ pub(crate) async fn admin_force_delete_machine(
                 match api
                     .redfish_pool
                     .create_client(
-                        ip,
+                        &ip_address,
                         machine.bmc_info.port,
                         RedfishAuth::Key(CredentialKey::BmcCredentials {
                             credential_type: BmcCredentialType::BmcRoot { bmc_mac_address },
@@ -583,13 +582,12 @@ pub(crate) async fn admin_force_delete_machine(
 
     if let Some(machine) = &host_machine {
         if request.delete_bmc_interfaces
-            && let Some(bmc_ip) = &machine.bmc_info.ip
+            && let Some(bmc_ip) = machine.bmc_info.ip
         {
             response.host_bmc_interface_associated = true;
-            if let Ok(ip_addr) = IpAddr::from_str(bmc_ip)
-                && db::machine_interface::delete_by_ip(&mut txn, ip_addr)
-                    .await?
-                    .is_some()
+            if db::machine_interface::delete_by_ip(&mut txn, bmc_ip)
+                .await?
+                .is_some()
             {
                 response.host_bmc_interface_deleted = true;
             }
@@ -603,9 +601,7 @@ pub(crate) async fn admin_force_delete_machine(
             response.host_interfaces_deleted = true;
         }
 
-        if let Some(addr) = &machine.bmc_info.ip
-            && let Ok(addr) = IpAddr::from_str(addr)
-        {
+        if let Some(addr) = machine.bmc_info.ip {
             tracing::info!("Cleaning up explored endpoint at {addr} {}", machine.id);
 
             db::explored_endpoints::delete(&mut txn, addr).await?;
@@ -667,13 +663,12 @@ pub(crate) async fn admin_force_delete_machine(
         db::network_devices::dpu_to_network_device_map::delete(&mut txn, &dpu_machine.id).await?;
 
         if request.delete_bmc_interfaces
-            && let Some(bmc_ip) = &dpu_machine.bmc_info.ip
+            && let Some(bmc_ip) = dpu_machine.bmc_info.ip
         {
             response.dpu_bmc_interface_associated = true;
-            if let Ok(ip_addr) = IpAddr::from_str(bmc_ip)
-                && db::machine_interface::delete_by_ip(&mut txn, ip_addr)
-                    .await?
-                    .is_some()
+            if db::machine_interface::delete_by_ip(&mut txn, bmc_ip)
+                .await?
+                .is_some()
             {
                 response.dpu_bmc_interface_deleted = true;
             }
@@ -691,9 +686,7 @@ pub(crate) async fn admin_force_delete_machine(
             response.dpu_interfaces_deleted = true;
         }
 
-        if let Some(addr) = &dpu_machine.bmc_info.ip
-            && let Ok(addr) = IpAddr::from_str(addr)
-        {
+        if let Some(addr) = dpu_machine.bmc_info.ip {
             tracing::info!("Cleaning up explored endpoint at {addr} {}", dpu_machine.id);
 
             db::explored_endpoints::delete(&mut txn, addr).await?;

--- a/crates/api-core/src/handlers/machine_interface.rs
+++ b/crates/api-core/src/handlers/machine_interface.rs
@@ -199,9 +199,9 @@ pub(crate) async fn find_bmc_ips(
             };
 
             // Get the BMC IP out of the machine topology
-            let bmc_ip = match machine_topology.topology.bmc_info.ip.map(|ip| ip.parse()) {
-                Some(Ok(ip)) => ip,
-                None | Some(Err(_)) => {
+            let bmc_ip = match machine_topology.topology.bmc_info.ip {
+                Some(ip) => ip,
+                None => {
                     return Ok(Response::new(rpc::BmcIpList::default()));
                 }
             };

--- a/crates/api-core/src/handlers/managed_host.rs
+++ b/crates/api-core/src/handlers/managed_host.rs
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-use std::net::{IpAddr, SocketAddr};
-use std::str::FromStr;
+use std::net::SocketAddr;
 
 use ::rpc::forge as rpc;
 use carbide_redfish::boot_interface::BootInterfaceTarget;
@@ -236,7 +235,7 @@ async fn set_primary_interface_core(
             id: host_machine_id.to_string(),
         })?;
 
-    let bmc_addr_str = machine
+    let bmc_addr = machine
         .bmc_info
         .ip
         .ok_or_else(|| CarbideError::NotFoundError {
@@ -244,7 +243,6 @@ async fn set_primary_interface_core(
             id: host_machine_id.to_string(),
         })?;
 
-    let bmc_addr = IpAddr::from_str(&bmc_addr_str).map_err(CarbideError::AddressParseError)?;
     let bmc_socket_addr = SocketAddr::new(bmc_addr, 443);
 
     let bmc_interface = db::machine_interface::find_by_ip(&mut txn, bmc_addr)

--- a/crates/api-core/src/tests/dns.rs
+++ b/crates/api-core/src/tests/dns.rs
@@ -143,7 +143,7 @@ async fn test_dns(pool: sqlx::PgPool) {
             .unwrap()
             .into_inner();
         assert_eq!(
-            topology.topology().bmc_info.ip.as_ref().unwrap().as_str(),
+            topology.topology().bmc_info.ip.unwrap().to_string(),
             &*bmc_record.records[0].content
         );
         assert_eq!(

--- a/crates/api-core/src/tests/machine_bmc_metadata.rs
+++ b/crates/api-core/src/tests/machine_bmc_metadata.rs
@@ -23,6 +23,28 @@ use sqlx::PgPool;
 
 use crate::tests::common;
 
+#[test]
+fn bmc_info_accepts_ipv6_from_proto() {
+    let bmc_info = model::bmc_info::BmcInfo::try_from(rpc::forge::BmcInfo {
+        ip: Some("2001:db8::1".into()),
+        ..Default::default()
+    })
+    .unwrap();
+
+    assert_eq!(bmc_info.ip, Some("2001:db8::1".parse().unwrap()));
+}
+
+#[test]
+fn bmc_info_rejects_invalid_proto_ip() {
+    let err = model::bmc_info::BmcInfo::try_from(rpc::forge::BmcInfo {
+        ip: Some("not-an-ip".into()),
+        ..Default::default()
+    })
+    .unwrap_err();
+
+    assert!(err.to_string().contains("Invalid BMC IP"));
+}
+
 #[crate::sqlx_test]
 async fn fetch_bmc_credentials(pool: PgPool) {
     let env = create_test_env(pool).await;

--- a/crates/api-core/src/tests/machine_creator.rs
+++ b/crates/api-core/src/tests/machine_creator.rs
@@ -209,10 +209,7 @@ async fn test_site_explorer_creates_managed_host(
         dpu_machine.hardware_info.as_ref().unwrap().machine_type,
         CpuArchitecture::Aarch64,
     );
-    assert_eq!(
-        dpu_machine.bmc_info.ip.clone().unwrap(),
-        dpu_bmc_ip.to_string()
-    );
+    assert_eq!(dpu_machine.bmc_info.ip, Some(dpu_bmc_ip));
 
     assert_eq!(
         format!(

--- a/crates/api-core/src/tests/machine_interfaces.rs
+++ b/crates/api-core/src/tests/machine_interfaces.rs
@@ -799,7 +799,7 @@ async fn machine_bmc_info_uses_bmc_interface_and_interfaces_exclude_it(
         .addresses
         .first()
         .expect("host BMC interface must have an address")
-        .to_string();
+        .to_owned();
     assert_eq!(host_bmc_interface_mac, host_bmc_mac);
 
     let dpu_bmc_interface = interfaces
@@ -815,7 +815,7 @@ async fn machine_bmc_info_uses_bmc_interface_and_interfaces_exclude_it(
         .addresses
         .first()
         .expect("DPU BMC interface must have an address")
-        .to_string();
+        .to_owned();
     assert_eq!(dpu_bmc_interface_mac, dpu_bmc_mac);
 
     assert_eq!(
@@ -823,10 +823,7 @@ async fn machine_bmc_info_uses_bmc_interface_and_interfaces_exclude_it(
         Some(host_bmc_interface_id)
     );
     assert_eq!(host_machine.bmc_info.mac, Some(host_bmc_interface_mac));
-    assert_eq!(
-        host_machine.bmc_info.ip.as_deref(),
-        Some(host_bmc_interface_ip.as_str())
-    );
+    assert_eq!(host_machine.bmc_info.ip, Some(host_bmc_interface_ip));
     assert!(
         host_machine
             .interfaces
@@ -840,10 +837,7 @@ async fn machine_bmc_info_uses_bmc_interface_and_interfaces_exclude_it(
         Some(dpu_bmc_interface_id)
     );
     assert_eq!(dpu_machine.bmc_info.mac, Some(dpu_bmc_interface_mac));
-    assert_eq!(
-        dpu_machine.bmc_info.ip.as_deref(),
-        Some(dpu_bmc_interface_ip.as_str())
-    );
+    assert_eq!(dpu_machine.bmc_info.ip, Some(dpu_bmc_interface_ip));
     assert!(
         dpu_machine
             .interfaces
@@ -859,6 +853,8 @@ async fn machine_bmc_info_uses_bmc_interface_and_interfaces_exclude_it(
     let rpc_bmc_type = rpc::forge::InterfaceType::Bmc as i32;
     let host_bmc_interface_mac = host_bmc_interface_mac.to_string();
     let dpu_bmc_interface_mac = dpu_bmc_interface_mac.to_string();
+    let host_bmc_interface_ip = host_bmc_interface_ip.to_string();
+    let dpu_bmc_interface_ip = dpu_bmc_interface_ip.to_string();
 
     let host_bmc_info = host_rpc_machine
         .bmc_info

--- a/crates/api-core/src/tests/site_explorer.rs
+++ b/crates/api-core/src/tests/site_explorer.rs
@@ -1595,7 +1595,7 @@ async fn test_fallback_dpu_serial(pool: PgPool) -> Result<(), Box<dyn std::error
         assert!(
             <Vec<Machine> as AsRef<Vec<Machine>>>::as_ref(&machines)
                 .iter()
-                .any(|x| { x.bmc_info.ip.clone().unwrap_or_default() == bmc_ip })
+                .any(|x| { x.bmc_info.ip.is_some_and(|ip| ip.to_string() == bmc_ip) })
         );
     }
     Ok(())
@@ -2317,12 +2317,10 @@ async fn test_delete_explored_endpoint(pool: PgPool) -> Result<(), Box<dyn std::
 
     // Verify both endpoints still exist
     let mut txn = env.pool.begin().await?;
-    let host_endpoints =
-        db::explored_endpoints::find_all_by_ip(IpAddr::from_str(host_ip)?, &mut txn).await?;
+    let host_endpoints = db::explored_endpoints::find_all_by_ip(*host_ip, &mut txn).await?;
     assert_eq!(host_endpoints.len(), 1);
 
-    let dpu_endpoints =
-        db::explored_endpoints::find_all_by_ip(IpAddr::from_str(dpu_ip)?, &mut txn).await?;
+    let dpu_endpoints = db::explored_endpoints::find_all_by_ip(*dpu_ip, &mut txn).await?;
     assert_eq!(dpu_endpoints.len(), 1);
     txn.commit().await?;
 

--- a/crates/api-db/src/bmc_metadata.rs
+++ b/crates/api-db/src/bmc_metadata.rs
@@ -64,8 +64,7 @@ pub async fn update_bmc_network_into_machine_interfaces(
     let interface = if let Some(interface_id) = bmc_info.machine_interface_id {
         crate::machine_interface::find_one(&mut *txn, interface_id).await?
     } else if let Some(bmc_ip) = bmc_info.ip.as_ref() {
-        let bmc_ip_address = bmc_ip.parse()?;
-        crate::machine_interface::find_by_ip(&mut *txn, bmc_ip_address)
+        crate::machine_interface::find_by_ip(&mut *txn, *bmc_ip)
             .await?
             .ok_or_else(|| DatabaseError::NotFoundError {
                 kind: "machine_interfaces.address",
@@ -112,7 +111,7 @@ pub async fn enrich_mac_address(
         )));
     }
 
-    let bmc_ip_address = bmc_info.ip.clone().unwrap().parse()?;
+    let bmc_ip_address = bmc_info.ip.unwrap();
     if bmc_info.mac.is_none() {
         if let Some(bmc_machine_interface) =
             crate::machine_interface::find_by_ip(&mut *txn, bmc_ip_address).await?

--- a/crates/api-model/src/bmc_info.rs
+++ b/crates/api-model/src/bmc_info.rs
@@ -27,14 +27,10 @@ use sqlx::{FromRow, Row};
 use version_compare::Cmp;
 
 use crate::errors::{ModelError, ModelResult};
-// TODO(chet): Once SocketAddr::parse_ascii is no longer an experimental
-// feature, it would be good to parse bmc_info.ip to verify it's a valid IP
-// address.
-
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BmcInfo {
     pub machine_interface_id: Option<MachineInterfaceId>,
-    pub ip: Option<String>,
+    pub ip: Option<IpAddr>,
     pub port: Option<u16>,
     pub mac: Option<MacAddress>,
     pub version: Option<String>,
@@ -62,13 +58,7 @@ impl<'r> FromRow<'r, PgRow> for BmcInfo {
 
 impl BmcInfo {
     pub fn ip_addr(&self) -> Result<IpAddr, Report> {
-        self.ip
-            .as_ref()
-            .ok_or(eyre! {"Missing BMC address"})?
-            .parse()
-            .map_err(|e| {
-                eyre! {"Bad address {:?} {e}", self.ip }
-            })
+        self.ip.ok_or(eyre! {"Missing BMC address"})
     }
 }
 

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1012,8 +1012,6 @@ impl Machine {
     pub fn bmc_addr(&self) -> Option<SocketAddr> {
         self.bmc_info
             .ip
-            .as_ref()
-            .and_then(|ip| ip.parse().ok())
             .map(|ip| SocketAddr::new(ip, self.bmc_info.port.unwrap_or(443)))
     }
 

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -567,7 +567,7 @@ impl ExploredDpu {
 
     pub fn bmc_info(&self) -> BmcInfo {
         BmcInfo {
-            ip: Some(self.bmc_ip.to_string()),
+            ip: Some(self.bmc_ip),
             mac: self
                 .report
                 .managers
@@ -657,7 +657,7 @@ pub struct ExploredManagedHost {
 impl ExploredManagedHost {
     pub fn bmc_info(&self) -> BmcInfo {
         BmcInfo {
-            ip: Some(self.host_bmc_ip.to_string()),
+            ip: Some(self.host_bmc_ip),
             ..Default::default()
         }
     }
@@ -677,7 +677,7 @@ pub struct ExploredManagedSwitch {
 impl ExploredManagedSwitch {
     pub fn bmc_info(&self) -> BmcInfo {
         BmcInfo {
-            ip: Some(self.bmc_ip.to_string()),
+            ip: Some(self.bmc_ip),
             ..Default::default()
         }
     }

--- a/crates/api-web/src/managed_host.rs
+++ b/crates/api-web/src/managed_host.rs
@@ -149,7 +149,11 @@ impl ManagedHostRowDisplay {
                 )
             })
             .unwrap_or_default();
-        let host_bmc_ip = host_snapshot.bmc_info.ip.unwrap_or_default();
+        let host_bmc_ip = host_snapshot
+            .bmc_info
+            .ip
+            .map(|ip| ip.to_string())
+            .unwrap_or_default();
         let host_bmc_mac = host_snapshot
             .bmc_info
             .mac
@@ -212,7 +216,11 @@ impl ManagedHostRowDisplay {
 
 impl From<model::machine::Machine> for AttachedDpuRowDisplay {
     fn from(item: Machine) -> Self {
-        let bmc_ip = item.bmc_info.ip.unwrap_or_default();
+        let bmc_ip = item
+            .bmc_info
+            .ip
+            .map(|ip| ip.to_string())
+            .unwrap_or_default();
         let bmc_mac = item.bmc_info.mac.map(|m| m.to_string()).unwrap_or_default();
         let primary_iface = item.interfaces.iter().find(|i| i.primary_interface);
         let oob_ip = primary_iface

--- a/crates/api-web/src/redfish_browser.rs
+++ b/crates/api-web/src/redfish_browser.rs
@@ -208,8 +208,11 @@ async fn find_machine_id(
             continue;
         };
 
-        // We normalize the IPs to make string comparison more likely to succeed
-        let Ok(ip) = bmc_info.ip.unwrap().parse::<std::net::IpAddr>() else {
+        let Some(ip) = bmc_info.ip else {
+            continue;
+        };
+
+        let Ok(ip) = ip.parse::<std::net::IpAddr>() else {
             continue;
         };
 

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -2911,22 +2911,12 @@ async fn handle_dpu_reprovision(
                         }
                     })?;
 
-                    let bmc_ip_address = state
-                        .host_snapshot
-                        .bmc_info
-                        .ip
-                        .clone()
-                        .ok_or_else(|| StateHandlerError::MissingData {
+                    let bmc_ip_address = state.host_snapshot.bmc_info.ip.ok_or_else(|| {
+                        StateHandlerError::MissingData {
                             object_id: state.host_snapshot.id.to_string(),
                             missing: "bmc_ip",
-                        })?
-                        .parse()
-                        .map_err(|e| {
-                            StateHandlerError::GenericError(eyre!(
-                                "parsing the host's BMC IP address failed: {}",
-                                e
-                            ))
-                        })?;
+                        }
+                    })?;
 
                     if let Err(ipmitool_error) = ctx
                         .services
@@ -9498,18 +9488,9 @@ async fn do_ipmi_restart(
     let ip: IpAddr = machine
         .bmc_info
         .ip
-        .as_ref()
         .ok_or_else(|| StateHandlerError::MissingData {
             object_id: machine.id.to_string(),
             missing: "bmc_ip",
-        })?
-        .parse()
-        .map_err(|e| {
-            StateHandlerError::GenericError(eyre!(
-                "parsing BMC IP address for {} failed: {}",
-                machine.id,
-                e
-            ))
         })?;
     let credential_key = CredentialKey::BmcCredentials {
         credential_type: BmcCredentialType::BmcRoot {

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -40,9 +40,8 @@ fn dpf_error(error: DpfError) -> StateHandlerError {
     ExternalServiceError::with_source("dpf", "", error.to_string(), "dpf_error", error).into()
 }
 
-// wrapper so we can get an error without copying it at every call site
-fn bmc_ip(machine: &Machine) -> Result<&str, StateHandlerError> {
-    machine.bmc_info.ip.as_deref().ok_or_else(|| {
+fn bmc_ip(machine: &Machine) -> Result<String, StateHandlerError> {
+    machine.bmc_info.ip.map(|ip| ip.to_string()).ok_or_else(|| {
         StateHandlerError::GenericError(eyre::eyre!("BMC IP is not set for machine {}", machine.id))
     })
 }
@@ -196,8 +195,8 @@ async fn create_and_register_dpudevices_and_dpunode(
             .unwrap_or_default();
         let device_info = carbide_dpf::DpuDeviceInfo {
             device_id: dpf_id(dpu)?,
-            dpu_bmc_ip: bmc_ip(dpu)?.to_string(),
-            host_bmc_ip: bmc_ip(&state.host_snapshot)?.to_string(),
+            dpu_bmc_ip: bmc_ip(dpu)?,
+            host_bmc_ip: bmc_ip(&state.host_snapshot)?,
             serial_number: serial_number.to_string(),
             dpu_machine_id: dpu.id.to_string(),
             is_primary: dpu.id == primary_dpu_id,
@@ -215,7 +214,7 @@ async fn create_and_register_dpudevices_and_dpunode(
         .collect::<Result<_, _>>()?;
     let node_info = carbide_dpf::DpuNodeInfo {
         node_id: dpf_id(&state.host_snapshot)?,
-        host_bmc_ip: bmc_ip(&state.host_snapshot)?.to_string(),
+        host_bmc_ip: bmc_ip(&state.host_snapshot)?,
         device_ids,
     };
     dpf_sdk

--- a/crates/rack/src/firmware_update.rs
+++ b/crates/rack/src/firmware_update.rs
@@ -86,7 +86,6 @@ pub async fn load_rack_firmware_inventory(
             .topology()
             .bmc_info
             .ip
-            .as_deref()
             .ok_or_else(|| eyre!("machine {} missing BMC IP", machine_id))?;
         let (bmc_username, bmc_password) =
             fetch_bmc_credentials(credential_manager, bmc_mac).await?;

--- a/crates/rpc/src/model/bmc_info.rs
+++ b/crates/rpc/src/model/bmc_info.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use std::net::IpAddr;
+
 use mac_address::MacAddress;
 use model::bmc_info::{BmcInfo, UserRoles};
 
@@ -36,7 +38,12 @@ impl TryFrom<rpc::BmcInfo> for BmcInfo {
 
         Ok(BmcInfo {
             machine_interface_id: value.machine_interface_id,
-            ip: value.ip,
+            ip: match value.ip.as_deref() {
+                None | Some("") => None,
+                Some(ip) => Some(ip.parse::<IpAddr>().map_err(|_| {
+                    RpcDataConversionError::InvalidArgument(format!("Invalid BMC IP: {ip}"))
+                })?),
+            },
             port: value.port.map(|p| p as u16),
             mac,
             version: value.version,
@@ -49,7 +56,7 @@ impl From<BmcInfo> for rpc::BmcInfo {
     fn from(value: BmcInfo) -> Self {
         rpc::BmcInfo {
             machine_interface_id: value.machine_interface_id,
-            ip: value.ip,
+            ip: value.ip.map(|ip| ip.to_string()),
             port: value.port.map(|p| p as u32),
             mac: value.mac.map(|mac| mac.to_string()),
             version: value.version,


### PR DESCRIPTION
## Description

This makes a tweak to parse BMC IP strings once at the RPC boundary, and then keep the model value as `IpAddr`. Callers that need protobufs, Redfish clients, or UI fields now stringify at the edge instead of reparsing stored topology data.

Even drops an old TODO I had:
```
- // TODO(chet): Once SocketAddr::parse_ascii is no longer an experimental
- // feature, it would be good to parse bmc_info.ip to verify it's a valid IP
- // address.
```

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

