### PR TITLE
feat(site-explorer): power cycle [not just Dell] to apply a queued NIC mode change

### DIFF
--- a/crates/api-core/src/test_support/fixture_config.rs
+++ b/crates/api-core/src/test_support/fixture_config.rs
@@ -101,6 +101,7 @@ impl FixtureDefault for ManagedHostConfig {
             auto_assign_sku_in_fixture: true,
             hardware_info_template: HardwareInfoTemplate::Default,
             expected_machine_data: None,
+            vendor: Some(bmc_vendor::BMCVendor::Dell),
         }
     }
 }

--- a/crates/api-core/src/tests/site_explorer.rs
+++ b/crates/api-core/src/tests/site_explorer.rs
@@ -2778,6 +2778,92 @@ async fn test_site_explorer_auto_corrects_nic_mode_per_expected_machine(
     Ok(())
 }
 
+/// A queued `set_nic_mode` only takes effect after a host power cycle, and
+/// site-explorer drives that power cycle itself for every vendor -- the
+/// Redfish `ComputerSystem.Reset` action is standard across BMCs. This is
+/// the non-Dell guard for that behavior: a Lenovo host whose DPU needs the
+/// mode correction gets an automatic `PowerCycle` on its host BMC in the
+/// same pass that issued `set_nic_mode`, rather than parking on a manual
+/// power cycle.
+#[sqlx_test]
+async fn test_site_explorer_power_cycles_non_dell_host_to_apply_nic_mode(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use model::expected_machine::{DpuMode, ExpectedMachine, ExpectedMachineData};
+    use model::site_explorer::NicMode;
+
+    let env = common::api_fixtures::create_test_env(pool).await;
+
+    // DPU hardware reports DPU mode; the operator-declared NicMode override
+    // is what forces the correction (and therefore the power cycle).
+    let dpu_config = DpuConfig {
+        nic_mode: Some(NicMode::Dpu),
+        ..DpuConfig::default()
+    };
+    let mock_host = ManagedHostConfig {
+        dpus: vec![dpu_config],
+        vendor: Some(bmc_vendor::BMCVendor::Lenovo),
+        ..ManagedHostConfig::default()
+    };
+    let host_bmc_mac = mock_host.bmc_mac_address;
+
+    let mut txn = env.pool.begin().await?;
+    db::expected_machine::create(
+        &mut txn,
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: host_bmc_mac,
+            data: ExpectedMachineData {
+                bmc_username: "ADMIN".to_string(),
+                bmc_password: "PASS".to_string(),
+                serial_number: "EM-866-NIC-POWERCYCLE".to_string(),
+                metadata: model::metadata::Metadata::new_with_default_name(),
+                dpu_mode: DpuMode::NicMode,
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    common::api_fixtures::site_explorer::MockExploredHost::new(&env, mock_host)
+        .discover_dhcp_host_bmc(|_, _| Ok(()))
+        .await?
+        .discover_dhcp_dpu_bmc(0, |_, _| Ok(()))
+        .await?
+        .insert_site_exploration_results()?
+        // First iteration: initial endpoint exploration.
+        .run_site_explorer_iteration()
+        .await
+        .mark_preingestion_complete()
+        .await?
+        // Second iteration: the matching loop issues `set_nic_mode` and,
+        // with the DPU now needing reconfiguration, power-cycles the host
+        // so the queued mode change applies.
+        .run_site_explorer_iteration()
+        .await;
+
+    let nic_mode_calls = env.endpoint_explorer.set_nic_mode_calls.lock().unwrap();
+    assert!(
+        nic_mode_calls.iter().any(|(_, mode)| *mode == NicMode::Nic),
+        "expected set_nic_mode(Nic) before the power cycle; calls so far: {nic_mode_calls:?}"
+    );
+
+    let power_calls = env
+        .endpoint_explorer
+        .redfish_power_control_calls
+        .lock()
+        .unwrap();
+    assert!(
+        power_calls
+            .iter()
+            .any(|(_, action)| matches!(action, libredfish::SystemPowerControl::PowerCycle)),
+        "expected an automatic host PowerCycle on the non-Dell (Lenovo) host to apply the queued NIC mode change; power calls so far: {power_calls:?}"
+    );
+
+    Ok(())
+}
+
 /// A managed host's DPU-facing `machine_interface` is created (via DHCP) with
 /// just a MAC and no `boot_interface_id`. The exploration that ingests the host
 /// then backfills the vendor-specific Redfish interface id onto that row, matched

--- a/crates/api-model/src/test_support/managed_host.rs
+++ b/crates/api-model/src/test_support/managed_host.rs
@@ -55,6 +55,10 @@ pub struct ManagedHostConfig {
     /// - bmc username/password are not required
     /// - serial number is copied from ManagedHostConfig
     pub expected_machine_data: Option<ExpectedMachineData>,
+    /// The BMC vendor the host's exploration report presents.
+    /// Default: Dell. Override to exercise vendor-dependent paths
+    /// (e.g. the post-`set_nic_mode` host power cycle).
+    pub vendor: Option<bmc_vendor::BMCVendor>,
 }
 
 impl ManagedHostConfig {
@@ -207,7 +211,7 @@ impl From<ManagedHostConfig> for EndpointExplorationReport {
             endpoint_type: EndpointType::Bmc,
             last_exploration_error: None,
             last_exploration_latency: None,
-            vendor: Some(bmc_vendor::BMCVendor::Dell),
+            vendor: value.vendor,
             managers: vec![Manager {
                 id: "iDRAC.Embedded.1".to_string(),
                 ethernet_interfaces: vec![EthernetInterface {

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -1182,28 +1182,45 @@ impl SiteExplorer {
                         );
 
                         if !all_dpus_configured_properly_in_host {
-                            if ep.report.vendor.is_some_and(|vendor| vendor.is_dell()) {
-                                let time_since_redfish_powercycle = Utc::now()
-                                    .signed_duration_since(
-                                        ep.last_redfish_powercycle.unwrap_or_default(),
-                                    );
-                                if time_since_redfish_powercycle > self.config.reset_rate_limit {
-                                    tracing::warn!(
-                                        "power cycling Dell {} to apply nic mode change for its incorrectly configured DPUs; time since last powercycle: {time_since_redfish_powercycle}",
-                                        ep.address,
-                                    );
+                            // A queued `set_nic_mode` only takes effect after a host
+                            // power cycle, so drive one for every vendor -- the
+                            // Redfish `ComputerSystem.Reset` action is standard
+                            // across BMCs -- throttled by `reset_rate_limit`. A BMC
+                            // that refuses the request surfaces the host as needing
+                            // a manual power cycle via the pairing-blocker metric.
+                            let time_since_redfish_powercycle = Utc::now().signed_duration_since(
+                                ep.last_redfish_powercycle.unwrap_or_default(),
+                            );
+                            if time_since_redfish_powercycle > self.config.reset_rate_limit {
+                                tracing::warn!(
+                                    "power cycling host {} to apply nic mode change for its incorrectly configured DPUs; time since last powercycle: {time_since_redfish_powercycle}",
+                                    ep.address,
+                                );
 
-                                    self.redfish_powercycle(ep.address)
-                                        .await
-                                        .inspect_err(|err| tracing::warn!("site explorer failed to power cycle host {} to apply DPU mode changes: {err}", ep.address))
-                                        .ok();
+                                if let Err(err) = self.redfish_powercycle(ep.address).await {
+                                    tracing::warn!(
+                                        "site explorer failed to power cycle host {} to apply DPU mode changes: {err}; a manual power cycle may be required",
+                                        ep.address
+                                    );
+                                    metrics.increment_host_dpu_pairing_blocker(
+                                        PairingBlockerReason::ManualPowerCycleRequired,
+                                    );
                                 }
                             } else {
-                                tracing::warn!(
-                                    "wait for manual power cycle of host {}; site explorer doesn't support power cycling vendor {:#?}",
-                                    ep.address,
-                                    ep.report.vendor
-                                );
+                                // We power-cycled within the rate limit and the
+                                // DPUs still aren't in the declared mode -- either
+                                // the change is mid-flight (the host is booting, a
+                                // pass or two of normal convergence) or this
+                                // vendor's `PowerCycle` is a warm reset that never
+                                // actually drops power. Keep the pairing-blocker
+                                // signal standing so a host stuck in the warm-reset
+                                // loop stays visible to operators instead of
+                                // rebooting hourly in silence.
+                                //
+                                // TODO(chet): If the power cycle doesn't appear to
+                                // be flipping the NIC to the expected mode, this is
+                                // where we'd want to introduce a cold power cycle
+                                // (`ForceOff`/`On` or similar).
                                 metrics.increment_host_dpu_pairing_blocker(
                                     PairingBlockerReason::ManualPowerCycleRequired,
                                 );


### PR DESCRIPTION
## Description

So, a `set_nic_mode` call *queues* the mode change on the DPU's BMC, but it takes effect after the next host power cycle. `site-explorer` drives that power cycle itself, but until now it was only for **Dell** hosts -- every other vendor would just wait in `ManualPowerCycleRequired` for an operator (I think this was an oversight on my part tbh). Behind the scenes all we're doing is a `ComputerSystem.Reset` call, so it's a standard action we can do for any vendor. In short, any host whose DPUs are waiting on a DPU/NIC mode change get the same treatment.

That said, a host can still get blocked on `ManualPowerCycleRequired` in two cases:
- The BMC refused/errored when trying to reset.
- We *did* power cycle recently, and the DPUs still aren't in the declared mode.

That second case covers BMCs that return a 200, but only do a warm reset under the hood (the mode change needs a real power cycle to take) -- those hosts show up as stuck (instead of silently rebooting once an hour forever).

Overall, this change:
- Drops the Dell-only gate around the post-`set_nic_mode` power cycle; it maintains `reset_rate_limit` throttling and `last_redfish_powercycle` tracking.
- Still reports `ManualPowerCycleRequired` for power-cycle failures AND cycled (but still misconfigured) passes.

Tests a new `test_site_explorer_power_cycles_non_dell_host_to_apply_nic_mode` just to make sure a Lenovo gets the automatic `PowerCycle` in the same pass that issued `set_nic_mode` (and that the the existing Dell auto-correct still passes).

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

