### PR TITLE
fix: correctly type the ExpectedHostNic.fixed_ip as IpAddr

### DIFF
--- a/crates/api-core/src/dhcp/discover.rs
+++ b/crates/api-core/src/dhcp/discover.rs
@@ -262,13 +262,8 @@ pub async fn discover_dhcp(
                             is_primary_nic = Some(pmac == parsed_mac);
                         }
                         if let Some(ref nic) = host_nic
-                            && let Some(fixed_ip_str) = &nic.fixed_ip
+                            && let Some(fixed_ip) = nic.fixed_ip
                         {
-                            let fixed_ip: IpAddr = fixed_ip_str.parse().map_err(|_| {
-                            CarbideError::InvalidArgument(format!(
-                                "invalid fixed_ip on ExpectedHostNic {parsed_mac}: {fixed_ip_str}"
-                            ))
-                        })?;
                             // It looks like there's a DHCP reservation for this address,
                             // so make an idempotent call to ensure we have a preallocated
                             // machine interface (and machine interface address) for it,

--- a/crates/api-core/src/handlers/expected_machine.rs
+++ b/crates/api-core/src/handlers/expected_machine.rs
@@ -124,14 +124,6 @@ pub(crate) fn validate_expected_machine_for_insert(
 ) -> Result<(), CarbideError> {
     validate_at_most_one_primary_host_nic(&machine.data.host_nics)?;
 
-    for nic in &machine.data.host_nics {
-        if let Some(ref ip_str) = nic.fixed_ip {
-            let _: std::net::IpAddr = ip_str.parse().map_err(|_| {
-                CarbideError::InvalidArgument(format!("invalid fixed_ip: {ip_str}"))
-            })?;
-        }
-    }
-
     Ok(())
 }
 
@@ -237,10 +229,7 @@ pub(crate) async fn update(
 
     // Update/create machine interfaces for host NICs with fixed IPs.
     for nic in &machine.data.host_nics {
-        if let Some(ref ip_str) = nic.fixed_ip {
-            let ip: std::net::IpAddr = ip_str.parse().map_err(|_| {
-                CarbideError::InvalidArgument(format!("invalid fixed_ip: {ip_str}"))
-            })?;
+        if let Some(ip) = nic.fixed_ip {
             update_preallocated_machine_interface(&mut txn, nic.mac_address, ip).await?;
         }
     }

--- a/crates/api-core/src/tests/expected_machine.rs
+++ b/crates/api-core/src/tests/expected_machine.rs
@@ -2125,6 +2125,94 @@ async fn test_add_expected_machine_with_invalid_static_ip(pool: sqlx::PgPool) {
     );
 }
 
+#[test]
+fn test_expected_machine_data_accepts_ipv6_host_nic_fixed_ip() {
+    let expected_machine = rpc::forge::ExpectedMachine {
+        bmc_mac_address: "5A:5B:5C:5D:5E:65".to_string(),
+        bmc_username: "root".into(),
+        bmc_password: "testpass".into(),
+        chassis_serial_number: "IPV6-HOST-NIC-FIXED-IP".into(),
+        host_nics: vec![rpc::forge::ExpectedHostNic {
+            mac_address: "5A:5B:5C:5D:5E:66".to_string(),
+            fixed_ip: Some("2001:db8::66".to_string()),
+            ..Default::default()
+        }],
+        metadata: Some(rpc::forge::Metadata::default()),
+        id: Some(::rpc::common::Uuid {
+            value: uuid::Uuid::new_v4().to_string(),
+        }),
+        ..Default::default()
+    };
+
+    let data = ExpectedMachineData::try_from(expected_machine).unwrap();
+
+    assert_eq!(
+        data.host_nics[0].fixed_ip,
+        Some("2001:db8::66".parse().unwrap())
+    );
+}
+
+#[test]
+fn test_expected_machine_data_rejects_invalid_host_nic_fixed_ip() {
+    let expected_machine = rpc::forge::ExpectedMachine {
+        bmc_mac_address: "5A:5B:5C:5D:5E:65".to_string(),
+        bmc_username: "root".into(),
+        bmc_password: "testpass".into(),
+        chassis_serial_number: "INVALID-HOST-NIC-FIXED-IP".into(),
+        host_nics: vec![rpc::forge::ExpectedHostNic {
+            mac_address: "5A:5B:5C:5D:5E:66".to_string(),
+            fixed_ip: Some("not-a-valid-ip".to_string()),
+            ..Default::default()
+        }],
+        metadata: Some(rpc::forge::Metadata::default()),
+        id: Some(::rpc::common::Uuid {
+            value: uuid::Uuid::new_v4().to_string(),
+        }),
+        ..Default::default()
+    };
+
+    let err = match ExpectedMachineData::try_from(expected_machine) {
+        Ok(_) => panic!("invalid host NIC fixed IP should fail conversion"),
+        Err(err) => err,
+    };
+
+    assert!(err.to_string().contains("Invalid fixed IP"));
+}
+
+#[test]
+fn test_expected_machine_data_rejects_invalid_host_nic_mac_address() {
+    let expected_machine = rpc::forge::ExpectedMachine {
+        bmc_mac_address: "5A:5B:5C:5D:5E:65".to_string(),
+        bmc_username: "root".into(),
+        bmc_password: "testpass".into(),
+        chassis_serial_number: "INVALID-HOST-NIC-MAC".into(),
+        host_nics: vec![rpc::forge::ExpectedHostNic {
+            mac_address: "not-a-mac".to_string(),
+            fixed_ip: Some("192.0.2.66".to_string()),
+            ..Default::default()
+        }],
+        metadata: Some(rpc::forge::Metadata::default()),
+        id: Some(::rpc::common::Uuid {
+            value: uuid::Uuid::new_v4().to_string(),
+        }),
+        ..Default::default()
+    };
+
+    let err = match ExpectedMachineData::try_from(expected_machine) {
+        Ok(_) => panic!("invalid host NIC MAC should fail conversion"),
+        Err(err) => err,
+    };
+
+    assert!(
+        matches!(
+            &err,
+            ::rpc::errors::RpcDataConversionError::InvalidMacAddress(mac)
+                if mac == "not-a-mac"
+        ),
+        "got: {err}"
+    );
+}
+
 /// Adding an expected machine with `host_nics[].fixed_ip` should result in a static
 /// `machine_interface` for that NIC. The materialization is deferred: site-explorer's
 /// reconciliation pass (or the DHCP discover hook) is what creates the row. The test
@@ -3004,7 +3092,7 @@ async fn test_create_missing_from_preallocates_interfaces(
             host_nics: vec![model::expected_machine::ExpectedHostNic {
                 mac_address: nic_mac,
                 nic_type: Some("onboard".into()),
-                fixed_ip: Some(host_ip.to_string()),
+                fixed_ip: Some(host_ip),
                 fixed_mask: None,
                 fixed_gateway: None,
                 primary: Some(true),

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -94,7 +94,7 @@ pub struct ExpectedHostNic {
     pub mac_address: MacAddress,
     // something to help the dhcp code select the right ip subnet, eg: bf3, onboard, cx8, oob, etc.
     pub nic_type: Option<String>,
-    pub fixed_ip: Option<String>,
+    pub fixed_ip: Option<IpAddr>,
     pub fixed_mask: Option<String>,
     pub fixed_gateway: Option<String>,
     /// When true, `primary` flags this NIC as the host's boot (primary)

--- a/crates/rpc/src/model/expected_machine.rs
+++ b/crates/rpc/src/model/expected_machine.rs
@@ -83,7 +83,7 @@ impl From<ExpectedHostNic> for rpc::forge::ExpectedHostNic {
         rpc::forge::ExpectedHostNic {
             mac_address: expected_host_nic.mac_address.to_string(),
             nic_type: expected_host_nic.nic_type,
-            fixed_ip: expected_host_nic.fixed_ip,
+            fixed_ip: expected_host_nic.fixed_ip.map(|ip| ip.to_string()),
             fixed_mask: expected_host_nic.fixed_mask,
             fixed_gateway: expected_host_nic.fixed_gateway,
             primary: expected_host_nic.primary,
@@ -91,16 +91,27 @@ impl From<ExpectedHostNic> for rpc::forge::ExpectedHostNic {
     }
 }
 
-impl From<rpc::forge::ExpectedHostNic> for ExpectedHostNic {
-    fn from(expected_host_nic: rpc::forge::ExpectedHostNic) -> Self {
-        ExpectedHostNic {
-            mac_address: expected_host_nic.mac_address.parse().unwrap_or_default(),
+impl TryFrom<rpc::forge::ExpectedHostNic> for ExpectedHostNic {
+    type Error = RpcDataConversionError;
+
+    fn try_from(expected_host_nic: rpc::forge::ExpectedHostNic) -> Result<Self, Self::Error> {
+        let mac_address = expected_host_nic.mac_address.parse().map_err(|_| {
+            RpcDataConversionError::InvalidMacAddress(expected_host_nic.mac_address.clone())
+        })?;
+
+        Ok(ExpectedHostNic {
+            mac_address,
             nic_type: expected_host_nic.nic_type,
-            fixed_ip: expected_host_nic.fixed_ip,
+            fixed_ip: match expected_host_nic.fixed_ip.as_deref() {
+                None | Some("") => None,
+                Some(ip) => Some(ip.parse::<IpAddr>().map_err(|_| {
+                    RpcDataConversionError::InvalidArgument(format!("Invalid fixed IP: {ip}"))
+                })?),
+            },
             fixed_mask: expected_host_nic.fixed_mask,
             fixed_gateway: expected_host_nic.fixed_gateway,
             primary: expected_host_nic.primary,
-        }
+        })
     }
 }
 
@@ -193,7 +204,11 @@ impl TryFrom<rpc::forge::ExpectedMachine> for ExpectedMachineData {
             fallback_dpu_serial_numbers: em.fallback_dpu_serial_numbers,
             sku_id: em.sku_id,
             metadata: metadata_from_request(em.metadata)?,
-            host_nics: em.host_nics.into_iter().map(|nic| nic.into()).collect(),
+            host_nics: em
+                .host_nics
+                .into_iter()
+                .map(ExpectedHostNic::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
             rack_id: em.rack_id,
             default_pause_ingestion_and_poweron: em.default_pause_ingestion_and_poweron,
             dpf_enabled: em.is_dpf_enabled,

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -1565,20 +1565,8 @@ impl SiteExplorer {
                 .await;
             }
             for nic in &expected_machine.data.host_nics {
-                let Some(ip_str) = nic.fixed_ip.as_deref() else {
+                let Some(ip) = nic.fixed_ip else {
                     continue;
-                };
-                let ip: IpAddr = match ip_str.parse() {
-                    Ok(ip) => ip,
-                    Err(error) => {
-                        tracing::warn!(
-                            %error,
-                            nic_mac = %nic.mac_address,
-                            fixed_ip = %ip_str,
-                            "Site-explorer preallocation: invalid fixed_ip on expected_machine host NIC"
-                        );
-                        continue;
-                    }
                 };
                 try_preallocate_one(
                     &self.database_connection,

--- a/crates/site-explorer/tests/reconcile.rs
+++ b/crates/site-explorer/tests/reconcile.rs
@@ -219,6 +219,7 @@ async fn test_site_explorer_reconcile_preallocates_host_nic_fixed_ip(
     let bmc_mac: MacAddress = "AA:BB:CC:DD:E1:01".parse().unwrap();
     let nic_mac: MacAddress = "AA:BB:CC:DD:E1:02".parse().unwrap();
     let fixed_ip = "10.99.0.20";
+    let parsed_fixed_ip: IpAddr = fixed_ip.parse().unwrap();
 
     let mut txn = pool.begin().await?;
     db::expected_machine::create(
@@ -231,7 +232,7 @@ async fn test_site_explorer_reconcile_preallocates_host_nic_fixed_ip(
                 host_nics: vec![model::expected_machine::ExpectedHostNic {
                     mac_address: nic_mac,
                     nic_type: Some("onboard".into()),
-                    fixed_ip: Some(fixed_ip.into()),
+                    fixed_ip: Some(parsed_fixed_ip),
                     fixed_mask: None,
                     fixed_gateway: None,
                     primary: None,
@@ -243,7 +244,6 @@ async fn test_site_explorer_reconcile_preallocates_host_nic_fixed_ip(
     .await?;
     txn.commit().await?;
 
-    let parsed_fixed_ip: IpAddr = fixed_ip.parse().unwrap();
     carbide_site_explorer::try_preallocate_one(
         &pool,
         nic_mac,


### PR DESCRIPTION
## Description

This change stores `ExpectedHostNic.fixed_ip` as `IpAddr` once it crosses the RPC boundary, letting `carbide-dhcp` and `site-explorer` use the parsed address directly, while keeping the protobuf surface as a string for clients.

Tests included!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

