### PR TITLE
fix: IpAddr typing on configured network prefixes and gateways

### DIFF
--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -3731,8 +3731,8 @@ firmware_url = "https://firmware.example.com/fw-b.bin"
             networks.get("admin").unwrap(),
             &NetworkDefinition {
                 segment_type: NetworkDefinitionSegmentType::Admin,
-                prefix: "172.20.0.0/24".to_string(),
-                gateway: "172.20.0.1".to_string(),
+                prefix: "172.20.0.0/24".parse().unwrap(),
+                gateway: "172.20.0.1".parse().unwrap(),
                 mtu: 9000,
                 reserve_first: 5,
                 allocation_strategy: Default::default(),
@@ -3743,8 +3743,8 @@ firmware_url = "https://firmware.example.com/fw-b.bin"
             networks.get("DEV1-C09-IPMI-01").unwrap(),
             &NetworkDefinition {
                 segment_type: NetworkDefinitionSegmentType::Underlay,
-                prefix: "172.99.0.0/26".to_string(),
-                gateway: "172.99.0.1".to_string(),
+                prefix: "172.99.0.0/26".parse().unwrap(),
+                gateway: "172.99.0.1".parse().unwrap(),
                 mtu: 1500,
                 reserve_first: 5,
                 allocation_strategy: Default::default(),

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -1491,10 +1491,12 @@ mod tests {
         prefix: &str,
         segment_type: NetworkDefinitionSegmentType,
     ) -> NetworkDefinition {
+        let prefix = prefix.parse::<ipnetwork::IpNetwork>().unwrap();
         NetworkDefinition {
             segment_type,
-            prefix: prefix.to_string(),
-            gateway: "".to_string(),
+            prefix,
+            // Test helper placeholder; callers under test do not use this as a routable gateway.
+            gateway: prefix.network(),
             mtu: 0,
             reserve_first: 0,
             allocation_strategy: Default::default(),

--- a/crates/api-core/src/tests/network_segment.rs
+++ b/crates/api-core/src/tests/network_segment.rs
@@ -496,8 +496,8 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
             "admin".to_string(),
             NetworkDefinition {
                 segment_type: NetworkDefinitionSegmentType::Admin,
-                prefix: "172.20.0.0/24".to_string(),
-                gateway: "172.20.0.1".to_string(),
+                prefix: "172.20.0.0/24".parse().unwrap(),
+                gateway: "172.20.0.1".parse().unwrap(),
                 mtu: 9000,
                 reserve_first: 5,
                 allocation_strategy: Default::default(),
@@ -507,8 +507,8 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
             "DEV1-C09-IPMI-01".to_string(),
             NetworkDefinition {
                 segment_type: NetworkDefinitionSegmentType::Underlay,
-                prefix: "172.99.0.0/26".to_string(),
-                gateway: "172.99.0.1".to_string(),
+                prefix: "172.99.0.0/26".parse().unwrap(),
+                gateway: "172.99.0.1".parse().unwrap(),
                 mtu: 1500,
                 reserve_first: 5,
                 allocation_strategy: Default::default(),
@@ -518,8 +518,8 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
             "ZERO-DPU-HOST-01-SWP7".to_string(),
             NetworkDefinition {
                 segment_type: NetworkDefinitionSegmentType::HostInband,
-                prefix: "10.217.18.192/30".to_string(),
-                gateway: "10.217.18.193".to_string(),
+                prefix: "10.217.18.192/30".parse().unwrap(),
+                gateway: "10.217.18.193".parse().unwrap(),
                 mtu: 1500,
                 reserve_first: 1,
                 allocation_strategy: Default::default(),

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -931,8 +931,8 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let def = NetworkDefinition {
             segment_type: NetworkDefinitionSegmentType::Admin,
-            prefix: "192.168.1.0/24".to_string(),
-            gateway: "192.168.1.1".to_string(),
+            prefix: "192.168.1.0/24".parse().unwrap(),
+            gateway: "192.168.1.1".parse().unwrap(),
             mtu: 1500,
             reserve_first: 5,
             allocation_strategy: Default::default(),
@@ -967,8 +967,8 @@ mod tests {
     fn def(prefix: &str, gateway: &str) -> NetworkDefinition {
         NetworkDefinition {
             segment_type: NetworkDefinitionSegmentType::Admin,
-            prefix: prefix.to_string(),
-            gateway: gateway.to_string(),
+            prefix: prefix.parse().unwrap(),
+            gateway: gateway.parse().unwrap(),
             mtu: 1500,
             reserve_first: 3,
             allocation_strategy: Default::default(),

--- a/crates/api-model/src/network_segment/mod.rs
+++ b/crates/api-model/src/network_segment/mod.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use std::fmt;
+use std::net::IpAddr;
 use std::str::FromStr;
 
 use carbide_uuid::domain::DomainId;
@@ -22,6 +23,7 @@ use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::vpc::VpcId;
 use chrono::{DateTime, Utc};
 use config_version::{ConfigVersion, Versioned};
+use ipnetwork::IpNetwork;
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgRow;
 use sqlx::{Column, FromRow, Row};
@@ -76,9 +78,9 @@ pub struct NetworkDefinition {
     #[serde(rename = "type")]
     pub segment_type: NetworkDefinitionSegmentType,
     /// CIDR notation
-    pub prefix: String,
+    pub prefix: IpNetwork,
     /// Usually the first IP in the prefix range
-    pub gateway: String,
+    pub gateway: IpAddr,
     /// Typically 9000 for admin network, 1500 for underlay
     pub mtu: i32,
     /// How many addresses to skip before allocating
@@ -320,12 +322,8 @@ impl NewNetworkSegment {
         value: &NetworkDefinition,
     ) -> Result<Self, ModelError> {
         let prefix = NewNetworkPrefix {
-            prefix: value.prefix.parse().map_err(|_| {
-                ModelError::InvalidArgument(format!("Invalid network prefix: {}", value.prefix))
-            })?,
-            gateway: Some(value.gateway.parse().map_err(|_| {
-                ModelError::InvalidArgument(format!("Invalid gateway address: {}", value.gateway))
-            })?),
+            prefix: value.prefix,
+            gateway: Some(value.gateway),
             num_reserved: value.reserve_first,
         };
         Ok(NewNetworkSegment {


### PR DESCRIPTION
## Description

Small tweak to keep configured network prefixes and gateways as `IpAddr` typed values after deserialization. Network creation can now pass them through directly instead of reparsing the same config strings.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

