### PR TITLE
fix: reject malformed expected host NIC MACs

### DIFF
--- a/crates/rpc/src/model/expected_machine.rs
+++ b/crates/rpc/src/model/expected_machine.rs
@@ -91,16 +91,22 @@ impl From<ExpectedHostNic> for rpc::forge::ExpectedHostNic {
     }
 }
 
-impl From<rpc::forge::ExpectedHostNic> for ExpectedHostNic {
-    fn from(expected_host_nic: rpc::forge::ExpectedHostNic) -> Self {
-        ExpectedHostNic {
-            mac_address: expected_host_nic.mac_address.parse().unwrap_or_default(),
+impl TryFrom<rpc::forge::ExpectedHostNic> for ExpectedHostNic {
+    type Error = RpcDataConversionError;
+
+    fn try_from(expected_host_nic: rpc::forge::ExpectedHostNic) -> Result<Self, Self::Error> {
+        let mac_address = expected_host_nic.mac_address.parse().map_err(|_| {
+            RpcDataConversionError::InvalidMacAddress(expected_host_nic.mac_address.clone())
+        })?;
+
+        Ok(ExpectedHostNic {
+            mac_address,
             nic_type: expected_host_nic.nic_type,
             fixed_ip: expected_host_nic.fixed_ip,
             fixed_mask: expected_host_nic.fixed_mask,
             fixed_gateway: expected_host_nic.fixed_gateway,
             primary: expected_host_nic.primary,
-        }
+        })
     }
 }
 
@@ -193,7 +199,11 @@ impl TryFrom<rpc::forge::ExpectedMachine> for ExpectedMachineData {
             fallback_dpu_serial_numbers: em.fallback_dpu_serial_numbers,
             sku_id: em.sku_id,
             metadata: metadata_from_request(em.metadata)?,
-            host_nics: em.host_nics.into_iter().map(|nic| nic.into()).collect(),
+            host_nics: em
+                .host_nics
+                .into_iter()
+                .map(ExpectedHostNic::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
             rack_id: em.rack_id,
             default_pause_ingestion_and_poweron: em.default_pause_ingestion_and_poweron,
             dpf_enabled: em.is_dpf_enabled,
@@ -267,6 +277,36 @@ mod tests {
         for mode in [DpuMode::DpuMode, DpuMode::NicMode, DpuMode::NoDpu] {
             assert_eq!(DpuMode::from(rpc::forge::DpuMode::from(mode)), mode);
         }
+    }
+
+    #[test]
+    fn expected_host_nic_rejects_invalid_mac_address() {
+        let err = ExpectedHostNic::try_from(rpc::forge::ExpectedHostNic {
+            mac_address: "not-a-mac".into(),
+            ..Default::default()
+        })
+        .unwrap_err();
+
+        assert!(
+            matches!(err, RpcDataConversionError::InvalidMacAddress(mac) if mac == "not-a-mac")
+        );
+    }
+
+    #[test]
+    fn expected_machine_data_rejects_invalid_host_nic_mac_address() {
+        let mut rpc_machine = make_rpc_expected_machine(None);
+        rpc_machine.host_nics.push(rpc::forge::ExpectedHostNic {
+            mac_address: "not-a-mac".into(),
+            ..Default::default()
+        });
+
+        let Err(err) = ExpectedMachineData::try_from(rpc_machine) else {
+            panic!("expected invalid host NIC MAC address");
+        };
+
+        assert!(
+            matches!(err, RpcDataConversionError::InvalidMacAddress(mac) if mac == "not-a-mac")
+        );
     }
 
     fn make_rpc_expected_machine(disable_lockdown: Option<bool>) -> rpc::forge::ExpectedMachine {


### PR DESCRIPTION
## Description

Stop defaulting bad expected host NIC MAC addresses to the zero MAC. This keeps the RPC conversion boundary honest when callers send malformed NIC data.

Primary callouts are:
- `ExpectedHostNic` now uses TryFrom for the RPC model conversion.
- `ExpectedMachineData::try_from` propagates host NIC conversion errors.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

