### PR TITLE
fix: tracing tests from hardcoded param

### DIFF
--- a/crates/api/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api/src/tests/common/api_fixtures/mod.rs
@@ -1608,7 +1608,7 @@ pub async fn create_test_env_with_overrides(
         site_explorer_enabled: config.site_explorer.enabled.clone(),
         create_machines: config.site_explorer.create_machines.clone(),
         bmc_proxy: config.site_explorer.bmc_proxy.clone(),
-        tracing_enabled: Arc::new(false.into()),
+        tracing_enabled: Arc::new(runtime_config.tracing.enabled.into()),
     };
 
     let bmc_proxy = Arc::new(ArcSwap::new(None.into()));


### PR DESCRIPTION
## Description
Fixes tests due to hardcoded param. Failing tests on v0.10.0 for:

- test_tracing_config_enabled_can_be_disabled_when_runtime_changes_allowed
- test_tracing_dynamic_config_rejected_when_runtime_changes_disabled

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
Using CI pipeline build/test
