### PR TITLE
ci: split release-container tests into separate job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -506,6 +506,55 @@ jobs:
       tag_latest: false
     secrets: inherit
 
+  test-release-container-services:
+    if: ${{ always() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
+    needs:
+      - prepare
+      - build-container-x86_64
+      - build-runtime-container-x86_64
+    runs-on: linux-amd64-cpu16
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login to NVCR
+        uses: ./.github/actions/docker-auth
+        with:
+          username: ${{ secrets.NVCR_USERNAME }}
+          token: ${{ secrets.NVCR_TOKEN }}
+
+      - name: Run release-container service tests
+        env:
+          BUILD_CONTAINER: nvcr.io/0837451325059433/carbide-dev/build-container-x86_64:${{ needs.prepare.outputs.build_container_x86_64_version }}
+          CI_COMMIT_SHORT_SHA: ${{ needs.prepare.outputs.short_sha }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${{ github.workspace }}/.sccache"
+          docker pull "${BUILD_CONTAINER}"
+          docker run --rm \
+            -v "${{ github.workspace }}:/carbide" \
+            -v "${{ github.workspace }}/.sccache:/sccache" \
+            -w /carbide \
+            -e CARGO_HOME=/carbide/cargo \
+            -e CARGO_INCREMENTAL=0 \
+            -e CARGO_MAKE_SKIP_CODECOV=true \
+            -e DATABASE_URL='postgresql://root@%2Fvar%2Frun%2Fpostgresql/root' \
+            -e SCCACHE_DIR=/sccache \
+            -e RUSTC_WRAPPER=sccache \
+            -e CARGO_PROFILE_RELEASE_DEBUG=true \
+            -e CI_COMMIT_SHORT_SHA="${CI_COMMIT_SHORT_SHA}" \
+            -e VERSION="${VERSION}" \
+            -e CONTAINER_REPO_ROOT=/carbide \
+            "${BUILD_CONTAINER}" \
+            bash -c '
+              set -euo pipefail
+              git config --global --add safe.directory /carbide
+              /etc/init.d/postgresql start
+              sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;"
+              createdb root
+              cargo make test-release-container-services
+            '
 
   # ============================================================================
   # BUILD STAGE - Forge CLI (Multi-arch)
@@ -1230,6 +1279,7 @@ jobs:
       - build-artifacts-container-aarch64
       - build-release-container-x86_64
       - build-release-container-aarch64
+      - test-release-container-services
       - build-boot-artifacts-x86
       - build-boot-artifacts-bfb
       - build-boot-artifacts-ephemeral-image-x86-host
@@ -1264,7 +1314,7 @@ jobs:
           echo "|-----|--------|" >> "$GITHUB_STEP_SUMMARY"
           echo "$NEEDS" | jq -r '
             to_entries[]
-            | select(.key | startswith("build-"))
+            | select((.key | startswith("build-")) or (.key | startswith("test-")))
             | "| \(.key) | \(if .value.result == "failure" then "**\(.value.result)**" else .value.result end) |"
           ' >> "$GITHUB_STEP_SUMMARY"
 
@@ -1332,6 +1382,7 @@ jobs:
       - build-artifacts-container-aarch64
       - build-release-container-x86_64
       - build-release-container-aarch64
+      - test-release-container-services
       - build-boot-artifacts-x86
       - build-boot-artifacts-bfb
       - build-boot-artifacts-ephemeral-image-x86-host
@@ -1388,6 +1439,7 @@ jobs:
       - prepare
       - build-release-container-x86_64
       - build-release-container-aarch64
+      - test-release-container-services
       - security-secret-scan
       - lint-police
     steps:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -668,6 +668,19 @@ for artifact in \
 done
 '''
 
+[tasks.build-release-container-services]
+workspace = false
+dependencies = [
+  "build-release",
+  "check-aarch64-release-container-services-page-size",
+]
+
+[tasks.test-release-container-services]
+workspace = false
+dependencies = [
+  "test-flow",
+]
+
 [tasks.build-and-test-release-container-services]
 workspace = false
 # Important: We only build perform a single build task here since every additional

--- a/dev/docker/Dockerfile.release-container-aarch64
+++ b/dev/docker/Dockerfile.release-container-aarch64
@@ -43,8 +43,8 @@ RUN --mount=type=cache,id=sccache-aarch64,target=/sccache \
   /etc/init.d/postgresql start && \
   sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;" && \
   createdb root && \
-  cargo make build-and-test-release-container-services && \
-  echo "$(date): Finished cargo make build-and-test-release-container-services\n" && \
+  cargo make build-release-container-services && \
+  echo "$(date): Finished cargo make build-release-container-services\n" && \
   mkdir -p /carbide/target/bin && \
   find /carbide/target/release -maxdepth 1 -type f -exec cp -t /carbide/target/bin {} + && \
   rm -rf /carbide/target/debug && \

--- a/dev/docker/Dockerfile.release-container-x86_64
+++ b/dev/docker/Dockerfile.release-container-x86_64
@@ -43,8 +43,8 @@ RUN --mount=type=cache,id=sccache-x86_64,target=/sccache \
   /etc/init.d/postgresql start && \
   sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;" && \
   createdb root && \
-  cargo make build-and-test-release-container-services && \
-  echo "$(date): Finished cargo make build-and-test-release-container-services\n" && \
+  cargo make build-release-container-services && \
+  echo "$(date): Finished cargo make build-release-container-services\n" && \
   mkdir -p /carbide/target/bin && \
   find /carbide/target/release -maxdepth 1 -type f -exec cp -t /carbide/target/bin {} + && \
   rm -rf /carbide/target/debug && \


### PR DESCRIPTION
## Description

Motivation: CI takes too long and big part of it is waiting while we build release and then run tests.

Move Rust test execution out of the release-container Docker image builds.  The release Dockerfiles now run the build/package-only cargo-make task, while a new x86 CI job runs the release-container service test flow inside the private build container.

Keep the existing combined cargo-make task for compatibility, add separate build and test tasks, and wire the new test job into build summary, notifications, and core-ci-pass gating.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

