### PR TITLE
NICo infra fixes + blank site templates

### DIFF
--- a/helm-prereqs/clean.sh
+++ b/helm-prereqs/clean.sh
@@ -130,6 +130,14 @@ kubectl get clusterrole,clusterrolebinding -o name \
 kubectl delete validatingwebhookconfiguration externalsecret-validate secretstore-validate \
     --ignore-not-found 2>/dev/null || true
 
+# Prometheus Operator CRDs that setup.sh applies from operators/crds/ (servicemonitors,
+# podmonitors, prometheusrules, scrapeconfigs). Helm/kubectl-apply leave these behind, so
+# remove them for a complete wipe. NOTE: skip this if the cluster has its own cluster-level
+# Prometheus Operator that owns these CRDs.
+echo "Removing Prometheus Operator (monitoring.coreos.com) CRDs..."
+kubectl get crd -o name | grep monitoring.coreos.com \
+    | xargs kubectl delete --ignore-not-found 2>/dev/null || true
+
 # vault cluster-scoped RBAC and webhooks
 echo "Removing vault cluster-scoped RBAC and webhooks..."
 kubectl get clusterrole,clusterrolebinding -o name \

--- a/helm-prereqs/preflight.sh
+++ b/helm-prereqs/preflight.sh
@@ -68,6 +68,27 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _SOURCED=false
 [[ "${BASH_SOURCE[0]}" != "${0}" ]] && _SOURCED=true
 
+# ---------------------------------------------------------------------------
+# Standalone flags — when run directly (`./preflight.sh --skip-rest`) accept the
+# same skip flags as setup.sh so the checks match the install you intend to run.
+# When SOURCED by setup.sh these already arrive as exported SKIP_* env vars and
+# setup.sh has consumed its own args, so this block is a no-op there.
+# ---------------------------------------------------------------------------
+if ! ${_SOURCED}; then
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --skip-core)      SKIP_CORE=true ;;
+            --skip-rest)      SKIP_REST=true ;;
+            --skip-flow)      SKIP_FLOW=true ;;
+            -y|--yes)         AUTO_YES=true ;;
+            --core-values)    CORE_VALUES="$2"; shift ;;
+            --metallb-config) METALLB_CONFIG="$2"; shift ;;
+            *) ;;  # ignore unknown args when run standalone
+        esac
+        shift
+    done
+fi
+
 ERRORS=()
 WARNINGS=()
 
@@ -244,6 +265,163 @@ else
                 ERRORS+=("${_METALLB_CFG_LABEL}: ASN value is 0 — set a valid BGP ASN")
         fi
     done < <(printf '%s\n' "${_METALLB_RENDERED}")
+fi
+
+# ---------------------------------------------------------------------------
+# 3b. Site values completeness — every site-specific value must be populated.
+#     Fails on leftover EXAMPLE/placeholder tokens in ACTIVE (non-comment) lines of
+#     values.yaml + values/nico-core.yaml + values/metallb-config.yaml, and on a few
+#     required keys. (Comment lines and inline `# …` comments are stripped first.)
+# ---------------------------------------------------------------------------
+_SITE_VALUES_CFG="${SCRIPT_DIR}/values.yaml"
+_PLACEHOLDER_RE='EXAMPLE|examplesite|example\.com|TMP_SITE|REPLACE_WITH|<your-registry>|<yoursite>|your-site|changeme|REPLACE_ME'
+for _vf in "${_SITE_VALUES_CFG}" "${_CORE_VALUES_CFG}" "${_METALLB_CFG}"; do
+    [[ -f "${_vf}" ]] || continue
+    _hits="$(sed -E 's/[[:space:]]+#.*$//; /^[[:space:]]*#/d' "${_vf}" | grep -nEi "${_PLACEHOLDER_RE}" || true)"
+    if [[ -n "${_hits}" ]]; then
+        ERRORS+=("${_vf##*/}: unpopulated placeholder value(s) — every site value must be set:"$'\n'"$(printf '%s\n' "${_hits}" | sed 's/^/          /')")
+    fi
+done
+
+# Empty-but-required site values — the committed templates ship BLANK (no site
+# data). Every active (uncommented) required value must be filled before install.
+# Comment lines + inline `# …` comments are stripped first.
+_strip_comments() { sed -E 's/[[:space:]]+#.*$//; /^[[:space:]]*#/d' "$1"; }
+
+if [[ "${SKIP_CORE:-false}" != "true" && -f "${_CORE_VALUES_CFG}" ]]; then
+    # nico-api.hostname must be a real external hostname
+    if _strip_comments "${_CORE_VALUES_CFG}" | grep -qE '^[[:space:]]*hostname:[[:space:]]*("")?[[:space:]]*$'; then
+        ERRORS+=("${_CORE_VALUES_LABEL}: nico-api.hostname is empty — set your external nico-api hostname")
+    fi
+    # Every enabled externalService needs a VIP from the MetalLB pool
+    if _strip_comments "${_CORE_VALUES_CFG}" | grep -qE 'loadBalancerIPs:[[:space:]]*("")?[[:space:]]*$'; then
+        ERRORS+=("${_CORE_VALUES_LABEL}: one or more loadBalancerIPs are empty — assign each enabled externalService a VIP from your MetalLB pool")
+    fi
+fi
+
+# MetalLB: a pool declared with no CIDR/range entries
+if [[ -f "${_METALLB_CFG}" && ! -d "${_METALLB_CFG}" ]]; then
+    if _strip_comments "${_METALLB_CFG}" | grep -qE '^kind:[[:space:]]*IPAddressPool' && \
+       ! _strip_comments "${_METALLB_CFG}" | grep -qE '^[[:space:]]*-[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'; then
+        ERRORS+=("${_METALLB_CFG_LABEL}: IPAddressPool has no addresses — add your VIP CIDR(s)/range(s)")
+    fi
+fi
+
+# siteName must be set and not the TMP_SITE default
+if [[ -f "${_SITE_VALUES_CFG}" ]]; then
+    _sn="$(grep -E '^siteName:' "${_SITE_VALUES_CFG}" | head -1 | sed -E 's/^siteName:[[:space:]]*//; s/["'\'' ]//g')"
+    [[ -z "${_sn}" || "${_sn}" == "TMP_SITE" ]] && \
+        ERRORS+=("values.yaml: siteName is not set (still '${_sn:-<empty>}')")
+fi
+
+# ---------------------------------------------------------------------------
+# 3c. IP / subnet validation — every service VIP must be a valid IPv4 that
+#     falls inside one of the MetalLB IPAddressPool CIDRs/ranges, and VIPs must
+#     not collide. Catches typos and pool/VIP mismatches before MetalLB silently
+#     fails to allocate (services stuck <pending>).
+# ---------------------------------------------------------------------------
+_ip2int() { local a b c d; IFS=. read -r a b c d <<<"$1"; echo $(( (a<<24)+(b<<16)+(c<<8)+d )); }
+_is_ipv4() {
+    local ip="$1" a b c d
+    [[ "$ip" =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]] || return 1
+    a=${BASH_REMATCH[1]}; b=${BASH_REMATCH[2]}; c=${BASH_REMATCH[3]}; d=${BASH_REMATCH[4]}
+    (( a<=255 && b<=255 && c<=255 && d<=255 ))
+}
+# Does $1 (ip) fall within $2 (CIDR "a.b.c.d/n" or range "a.b.c.d-a.b.c.d")?
+_ip_in_block() {
+    local ip="$1" block="$2" ipi neti maskbits m start end
+    ipi=$(_ip2int "$ip")
+    if [[ "$block" == */* ]]; then
+        neti=$(_ip2int "${block%/*}"); maskbits="${block#*/}"
+        [[ "$maskbits" =~ ^[0-9]+$ ]] || return 2
+        m=$(( 0xffffffff ^ ((1 << (32 - maskbits)) - 1) ))
+        (( (ipi & m) == (neti & m) ))
+    elif [[ "$block" == *-* ]]; then
+        start=$(_ip2int "${block%-*}"); end=$(_ip2int "${block#*-}")
+        (( ipi >= start && ipi <= end ))
+    else
+        return 2
+    fi
+}
+
+if [[ "${SKIP_CORE:-false}" != "true" && -f "${_CORE_VALUES_CFG}" ]]; then
+    # Collect the MetalLB pool blocks (CIDRs + ranges) from the rendered config.
+    _POOL_BLOCKS=()
+    if [[ -n "${_METALLB_RENDERED}" ]]; then
+        while IFS= read -r _blk; do
+            [[ -n "${_blk}" ]] && _POOL_BLOCKS+=("${_blk}")
+        done < <(printf '%s\n' "${_METALLB_RENDERED}" | sed -E 's/[[:space:]]+#.*$//; /^[[:space:]]*#/d' \
+                  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(/[0-9]+|-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)?' \
+                  | grep -E '/[0-9]+$|-' )
+    fi
+
+    # Collect every configured service VIP (non-empty loadBalancerIPs values).
+    _SEEN_VIPS=""
+    while IFS= read -r _vip; do
+        [[ -z "${_vip}" ]] && continue
+        if ! _is_ipv4 "${_vip}"; then
+            ERRORS+=("${_CORE_VALUES_LABEL}: loadBalancerIP '${_vip}' is not a valid IPv4 address")
+            continue
+        fi
+        # Duplicate VIP across services
+        if [[ " ${_SEEN_VIPS} " == *" ${_vip} "* ]]; then
+            WARNINGS+=("${_CORE_VALUES_LABEL}: VIP ${_vip} is assigned to more than one service — each service needs a unique IP")
+        fi
+        _SEEN_VIPS="${_SEEN_VIPS} ${_vip}"
+        # Containment in a MetalLB pool
+        if [[ ${#_POOL_BLOCKS[@]} -gt 0 ]]; then
+            _in_pool=false
+            for _blk in "${_POOL_BLOCKS[@]}"; do
+                if _ip_in_block "${_vip}" "${_blk}"; then _in_pool=true; break; fi
+            done
+            ${_in_pool} || \
+                ERRORS+=("${_CORE_VALUES_LABEL}: VIP ${_vip} is not within any MetalLB IPAddressPool (${_METALLB_CFG_LABEL}) — MetalLB cannot allocate it")
+        fi
+    done < <(sed -E 's/[[:space:]]+#.*$//; /^[[:space:]]*#/d' "${_CORE_VALUES_CFG}" \
+              | grep -E 'loadBalancerIPs:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' )
+
+    # kea DHCP hook IPs (nameservers / ntpServer / provisioningServer) are handed
+    # to DPUs at boot — validate format + pool-containment (no dup check: these
+    # intentionally mirror the unbound/ntp/pxe VIPs above).
+    while IFS= read -r _kip; do
+        [[ -z "${_kip}" ]] && continue
+        if ! _is_ipv4 "${_kip}"; then
+            ERRORS+=("${_CORE_VALUES_LABEL}: kea hookParameters IP '${_kip}' is not a valid IPv4 address")
+        elif [[ ${#_POOL_BLOCKS[@]} -gt 0 ]]; then
+            _in_pool=false
+            for _blk in "${_POOL_BLOCKS[@]}"; do
+                if _ip_in_block "${_kip}" "${_blk}"; then _in_pool=true; break; fi
+            done
+            ${_in_pool} || \
+                WARNINGS+=("${_CORE_VALUES_LABEL}: kea hookParameters IP ${_kip} is not within any MetalLB pool — DPUs will be told to use an unreachable DNS/NTP/PXE endpoint")
+        fi
+    done < <(sed -E 's/[[:space:]]+#.*$//; /^[[:space:]]*#/d' "${_CORE_VALUES_CFG}" \
+              | grep -E 'nameservers:|ntpServer:|provisioningServer:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' )
+
+    # Validate MetalLB pool blocks are well-formed CIDR/range.
+    for _blk in "${_POOL_BLOCKS[@]}"; do
+        _net="${_blk%%[-/]*}"
+        if ! _is_ipv4 "${_net}"; then
+            ERRORS+=("${_METALLB_CFG_LABEL}: pool entry '${_blk}' is not a valid CIDR/range")
+        elif [[ "${_blk}" == */* ]]; then
+            _bits="${_blk#*/}"
+            { [[ "${_bits}" =~ ^[0-9]+$ ]] && (( _bits >= 0 && _bits <= 32 )); } || \
+                ERRORS+=("${_METALLB_CFG_LABEL}: pool entry '${_blk}' has an invalid CIDR prefix length")
+        fi
+    done
+fi
+
+# nico-core: bootArtifactContainers must be populated or DPU/host HTTP boot 404s
+if [[ -f "${_CORE_VALUES_CFG}" ]]; then
+    if ! sed -E '/^[[:space:]]*#/d' "${_CORE_VALUES_CFG}" | grep -qE 'image:[[:space:]]*\S+.*boot-artifacts|boot-artifacts-'; then
+        WARNINGS+=("${_CORE_VALUES_LABEL}: bootArtifactContainers appears empty — DPU/host HTTP boot will 404 (set nico-pxe.bootArtifactContainers)")
+    fi
+    # If unbound is enabled, it must have localData and an external VIP for DPUs to resolve .forge
+    if sed -E '/^[[:space:]]*#/d' "${_CORE_VALUES_CFG}" | grep -qE '^[[:space:]]*enabled:[[:space:]]*true' && \
+       sed -E '/^[[:space:]]*#/d' "${_CORE_VALUES_CFG}" | grep -qE '^unbound:'; then
+        sed -E '/^[[:space:]]*#/d' "${_CORE_VALUES_CFG}" | grep -qE 'localData:' || \
+            WARNINGS+=("${_CORE_VALUES_LABEL}: unbound enabled but no localData (.forge records) set")
+    fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/helm-prereqs/templates/vault-config-job.yaml
+++ b/helm-prereqs/templates/vault-config-job.yaml
@@ -200,7 +200,7 @@ spec:
                 key_bits=256 \
                 ttl=1h \
                 max_ttl=12h \
-                ou={{ .Values.vault.nicoCliClientRole.name | quote }}{{ if .Values.vault.nicoCliClientRole.organization }} \
+                ou={{ .Values.vault.nicoCliClientRole.ou | default .Values.vault.nicoCliClientRole.name | quote }}{{ if .Values.vault.nicoCliClientRole.organization }} \
                 organization={{ .Values.vault.nicoCliClientRole.organization | quote }}{{ end }}
               {{ end }}
 

--- a/helm-prereqs/values.yaml
+++ b/helm-prereqs/values.yaml
@@ -6,7 +6,8 @@
 ## Site identifier - injected into postgres pods as TMP_SITE env var via
 ## the nico-pg-cluster-env ConfigMap.
 ## Override per site: --set siteName=<sitename>
-siteName: "TMP_SITE"
+## REQUIRED: set your short site identifier (preflight fails while empty/TMP_SITE).
+siteName: ""
 
 ## Target namespace — must match the namespace used for helm install nico
 namespace: nico-system
@@ -48,8 +49,13 @@ vault:
   pkiMount: "nicoca"
   pkiRole: "nico-cluster"
   nicoCliClientRole:
-    enabled: false
+    enabled: true                # create the admin-cli PKI client role at install
     name: "nico-cli-client"
+    ## SubjectOU stamped on issued CLI client certs = the ExternalUser "group" nico-api
+    ## authorizes. Must match the group the build's ForgeAdminCLI principal expects.
+    ## Empty = use `name`. (Current builds hardcode "Invalid" — set ou: "Invalid" until the
+    ## code fix lands; pair with nico-api auth.additionalIssuerCns: ["site-root"].)
+    ou: "Invalid"                # BUILD-SPECIFIC (not site): match this build's hardcoded ForgeAdminCLI group
     organization: ""
   ## Kubernetes auth role for nico-api to read and manage Vault KV
   ## credentials used by SiteExplorer and related credential flows.
@@ -75,6 +81,20 @@ vault:
         UsernamePassword:
           username: ""
           password: "bluefield"
+    ## site_default UEFI creds — seed these so site-explorer finds them. Without these,
+    ## `credential add-uefi` only writes Vault metadata (not the value) and preingestion
+    ## logs "Missing credential machines/all_{dpus,hosts}/site_default/uefi-metadata-items/auth".
+    ## SITE-SPECIFIC SECRET: blank the passwords before committing/MR; operator populates per site.
+    - path: "machines/all_dpus/site_default/uefi-metadata-items/auth"
+      data:
+        UsernamePassword:
+          username: ""
+          password: ""          # SITE SECRET: your DPU UEFI password — populate per site
+    - path: "machines/all_hosts/site_default/uefi-metadata-items/auth"
+      data:
+        UsernamePassword:
+          username: ""
+          password: ""          # SITE SECRET: your host UEFI password — populate per site
 
 certManager:
   siteRoot:

--- a/helm-prereqs/values/metallb-config.yaml
+++ b/helm-prereqs/values/metallb-config.yaml
@@ -3,21 +3,21 @@
 #
 # Applied by setup.sh Phase 1c after MetalLB is installed.
 #
-# IMPORTANT: Replace all placeholder values with your site's real config before
-# running setup.sh. The values below are worked examples — do NOT use them
-# for your site without updating every field marked EXAMPLE.
+# SITE TEMPLATE — every site-specific value below ships BLANK on purpose.
+# Fill in your VIP CIDRs and an advertisement mode (BGP or L2) before running
+# setup.sh. preflight.sh fails while the pools have no addresses or no
+# advertisement mode is configured.
 #
-# Fields you MUST change per site:
+# Fields you MUST set per site:
 #   IPAddressPool.spec.addresses   — your VIP CIDRs
 #   BGPPeer.spec.myASN             — your cluster-side ASN
 #   BGPPeer.spec.peerASN           — TOR router ASN per node (unique per node)
 #   BGPPeer.spec.peerAddress       — TOR switch IP reachable from that node
 #   BGPPeer.spec.nodeSelectors     — actual node hostnames in your cluster
-#   BGPAdvertisement.metadata.name — rename to match your site
 #
 # Advertisement mode — choose ONE:
-#   BGP (production): keep IPAddressPool + BGPPeer + BGPAdvertisement sections
-#   L2  (dev/test):   comment out BGPPeer + BGPAdvertisement, uncomment L2Advertisement
+#   BGP (production): uncomment + fill the BGPPeer + BGPAdvertisement section
+#   L2  (dev/test):   uncomment the L2Advertisement section
 # =============================================================================
 
 # ---------------------------------------------------------------------------
@@ -32,128 +32,73 @@
 # addresses: list of CIDRs or ranges:
 #   CIDR format:  "10.x.x.160/28"       (16 addresses: .160 – .175)
 #   Range format: "10.x.x.10-10.x.x.20" (11 addresses)
-#
-# EXAMPLE: internal pool = 10.180.126.160/28, external = 10.180.126.176/28
-# Replace with your site's VIP CIDRs.
 # ---------------------------------------------------------------------------
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
-  name: vip-pool-internal    # ← rename to vip-pool-int-<yoursite>
+  name: vip-pool-internal
   namespace: metallb-system
 spec:
-  addresses:
-    - 10.180.126.160/28      # EXAMPLE — replace with your internal VIP CIDR
+  addresses: []      # REQUIRED: your internal VIP CIDR(s)/range(s)
 
 ---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
-  name: vip-pool-external    # ← rename to vip-pool-ext-<yoursite>
+  name: vip-pool-external
   namespace: metallb-system
 spec:
-  addresses:
-    - 10.180.126.176/28      # EXAMPLE — replace with your external VIP CIDR
+  addresses: []      # REQUIRED: your external VIP CIDR(s)/range(s)
 
 ---
 # ---------------------------------------------------------------------------
-# BGP Peers
+# BGP Peers (production) — REQUIRED unless you use L2 mode below.
 #
-# One BGPPeer per (worker node, TOR router) pair.
-# Each node peers with the TOR switch it is physically connected to.
-# The MetalLB FRR speaker on that node establishes a BGP session with its TOR
-# and announces the VIP routes so traffic is routed to the right node.
+# One BGPPeer per (worker node, TOR router) pair. Each node peers with the TOR
+# switch it is physically connected to; the MetalLB FRR speaker announces the
+# VIP routes so traffic is routed to the right node.
 #
-# myASN:       cluster-side ASN — same for all nodes on this site.
-#              Allocated by your network team per cluster/rack.
-# peerASN:     router-side ASN — typically unique per TOR port / node.
-# peerAddress: TOR switch IP reachable from this node (usually OOB/mgmt subnet).
-# nodeSelectors: restricts this peer to the specific node by its hostname label.
-#   Run: kubectl get nodes -o wide   to list hostnames.
+#   myASN:       cluster-side ASN — same for all nodes on this site.
+#   peerASN:     router-side ASN — typically unique per TOR port / node.
+#   peerAddress: TOR switch IP reachable from this node (usually OOB/mgmt subnet).
+#   nodeSelectors: restricts this peer to a node by hostname (kubectl get nodes).
 #
-# EXAMPLE:
-#   myASN = 4244766850 (cluster ASN, allocated by your network team)
-#   3 worker nodes, each with its own TOR port and peerASN
+# Add or remove BGPPeer blocks to match your node count. Template per node:
 #
-# Add or remove BGPPeer blocks to match your node count.
+# apiVersion: metallb.io/v1beta2
+# kind: BGPPeer
+# metadata:
+#   name: <node-hostname>-bgp-peer
+#   namespace: metallb-system
+# spec:
+#   myASN: <cluster-asn>
+#   peerASN: <tor-asn-for-this-node>
+#   peerAddress: <tor-switch-ip-for-this-node>
+#   nodeSelectors:
+#     - matchExpressions:
+#         - key: kubernetes.io/hostname
+#           operator: In
+#           values:
+#             - <node-hostname>
+# ---
 # ---------------------------------------------------------------------------
-apiVersion: metallb.io/v1beta2
-kind: BGPPeer
-metadata:
-  name: rno1-m04-d04-cpu-1-bgp-peer    # EXAMPLE — rename to <node>-bgp-peer
-  namespace: metallb-system
-spec:
-  myASN: 4244766850      # EXAMPLE — replace with your cluster ASN
-  peerASN: 4244766851    # EXAMPLE — replace with TOR ASN for this node
-  peerAddress: 10.180.248.80    # EXAMPLE — replace with TOR switch IP for this node
-  nodeSelectors:
-    - matchExpressions:
-        - key: kubernetes.io/hostname
-          operator: In
-          values:
-            - rno1-m04-d04-cpu-1    # EXAMPLE — replace with your node hostname
-
----
-apiVersion: metallb.io/v1beta2
-kind: BGPPeer
-metadata:
-  name: rno1-m04-d04-cpu-2-bgp-peer    # EXAMPLE — rename to <node>-bgp-peer
-  namespace: metallb-system
-spec:
-  myASN: 4244766850      # same cluster ASN
-  peerASN: 4244766852    # EXAMPLE — unique per node
-  peerAddress: 10.180.248.82    # EXAMPLE — replace with TOR switch IP for this node
-  nodeSelectors:
-    - matchExpressions:
-        - key: kubernetes.io/hostname
-          operator: In
-          values:
-            - rno1-m04-d04-cpu-2    # EXAMPLE — replace with your node hostname
-
----
-apiVersion: metallb.io/v1beta2
-kind: BGPPeer
-metadata:
-  name: rno1-m04-d04-cpu-3-bgp-peer    # EXAMPLE — rename to <node>-bgp-peer
-  namespace: metallb-system
-spec:
-  myASN: 4244766850      # same cluster ASN
-  peerASN: 4244766853    # EXAMPLE — unique per node
-  peerAddress: 10.180.248.84    # EXAMPLE — replace with TOR switch IP for this node
-  nodeSelectors:
-    - matchExpressions:
-        - key: kubernetes.io/hostname
-          operator: In
-          values:
-            - rno1-m04-d04-cpu-3    # EXAMPLE — replace with your node hostname
----
+# BGP Advertisement (production)
+#
+# Empty spec = advertise ALL IPAddressPools to ALL BGPPeers. Uncomment when
+# using BGP mode; rename to match your site.
 # ---------------------------------------------------------------------------
-# BGP Advertisement
-#
-# Empty spec = advertise ALL IPAddressPools to ALL BGPPeers automatically.
-# This is the standard production configuration — no filtering needed when
-# all nodes peer with the same set of routers and all VIPs should be reachable
-# from both TOR switches.
-#
-# To restrict which pools are sent to which peers, add:
-#   spec:
-#     ipAddressPools: [vip-pool-internal]
-#     peers: [rno1-m04-d04-cpu-1-bgp-peer]
-#
-# Rename the advertisement to match your site (e.g. "prod-us-east", "lab-rno1").
-# ---------------------------------------------------------------------------
-apiVersion: metallb.io/v1beta1
-kind: BGPAdvertisement
-metadata:
-  name: my-site          # EXAMPLE — rename to your site name
-  namespace: metallb-system
+# apiVersion: metallb.io/v1beta1
+# kind: BGPAdvertisement
+# metadata:
+#   name: site-advertisement
+#   namespace: metallb-system
 
 # ---------------------------------------------------------------------------
 # L2 Advertisement — alternative to BGP for dev/test environments.
 #
 # Use this instead of BGPPeer + BGPAdvertisement when BGP routing is not
-# available (e.g. local dev clusters, Kind, or flat-network environments).
-# Comment out all BGPPeer and BGPAdvertisement sections above and uncomment:
+# available (e.g. local dev clusters, Kind, flat-network environments).
+# Uncomment and keep ONLY one mode active.
 # ---------------------------------------------------------------------------
 # apiVersion: metallb.io/v1beta1
 # kind: L2Advertisement

--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -1,6 +1,11 @@
 ## =============================================================================
 ## nico-core.yaml — values for: helm upgrade --install nico ./helm
 ##
+## SITE TEMPLATE — every site-specific value below ships BLANK on purpose.
+## Populate them for your site before running setup.sh; preflight.sh fails on
+## empty required values (hostname, VIPs, MetalLB pools) and on leftover
+## EXAMPLE/placeholder tokens.
+##
 ## Image registry and tag are injected at install time via --set flags:
 ##   --set global.image.repository=<your-registry>/nvmetal-carbide
 ##   --set global.image.tag=<tag>
@@ -13,8 +18,10 @@ global:
     tag: ""           # set via --set global.image.tag (NICO_CORE_IMAGE_TAG env var)
     pullPolicy: IfNotPresent
 
+  ## setup.sh creates a secret named `imagepullsecret` in nico-system from
+  ## REGISTRY_PULL_SECRET (host nvcr.io). Reference that name here.
   imagePullSecrets:
-    - name: nvcr-nico-dev
+    - name: imagepullsecret
 
   ## SPIFFE cert settings — vault-nico-issuer is configured by nico-prereqs
   certificate:
@@ -42,7 +49,14 @@ global:
 ##   what is available. Replace placeholder values with real site data.
 ## ---------------------------------------------------------------------------
 nico-api:
-  hostname: "api-examplesite.example.com"   # EXAMPLE - replace with your site's nico-api hostname
+  hostname: ""   # REQUIRED: external nico-api hostname (e.g. api-<site>.<domain>)
+
+  ## Trust admin-CLI client certs minted from the site CA (CN=site-root) so admin-cli works
+  ## with NO manual ConfigMap edit. Pair with helm-prereqs vault.nicoCliClientRole (ou: "Invalid").
+  ## "site-root" is the CN of the cert-manager site root created by nico-prereqs — generic, keep as-is.
+  auth:
+    additionalIssuerCns:
+      - "site-root"
 
   ## MetalLB VIP for the nico-api LoadBalancer service.
   ## Must be an IP within your external IPAddressPool (values/metallb-config.yaml).
@@ -50,7 +64,7 @@ nico-api:
   externalService:
     enabled: true    # must be explicitly enabled - defaults to false in chart
     annotations:
-      metallb.universe.tf/loadBalancerIPs: "10.180.126.177"  # EXAMPLE - nico-api external VIP
+      metallb.universe.tf/loadBalancerIPs: ""  # REQUIRED: nico-api external VIP
 
   ## TLS cert SANs.
   ##
@@ -63,48 +77,41 @@ nico-api:
   ## DNS (.forge zone)" for the full hostname list.
   certificate:
     extraDnsNames:
-      - "api-examplesite.example.com"  # EXAMPLE - your external hostname (match nico-api.hostname above)
+      - ""                             # REQUIRED: your external hostname (match nico-api.hostname above)
       - "carbide-api.forge"            # legacy hardcoded lookup in deployed DPU agents
+      - "nico-api.forge"               # renamed-binary alias (dual naming)
       - "carbide-api.forge-system.svc.cluster.local"  # legacy cluster-internal name from forged kustomize
 
   siteConfig:
     enabled: true
     nicoApiSiteConfig: |
       # -----------------------------------------------------------------------
-      # Site identity
+      # Site identity — REQUIRED: fill in your site's values.
       # -----------------------------------------------------------------------
-      sitename = "examplesite"                       # EXAMPLE - replace with your short site identifier
-      initial_domain_name = "examplesite.example.com" # EXAMPLE - replace with your base DNS domain
-      attestation_enabled = false                # enable TPM/DPU attestation
-      max_concurrent_machine_updates = 20        # cap parallel firmware/config pushes
-      vpc_peering_policy = "exclusive"           # "exclusive" | "shared"
+      sitename = ""                              # REQUIRED: short site identifier
+      initial_domain_name = ""                   # REQUIRED: base DNS domain for the site
+      attestation_enabled = false
+      max_concurrent_machine_updates = 20
 
       # -----------------------------------------------------------------------
-      # DHCP servers reachable from this site (empty list = no external DHCP)
+      # DHCP servers reachable from this site — REQUIRED: your nico-dhcp VIP(s).
       # -----------------------------------------------------------------------
-      dhcp_servers = ["10.180.126.160"]          # EXAMPLE — replace with your MetalLB VIP for DHCP service
+      dhcp_servers = []                          # REQUIRED: e.g. ["<dhcp-vip>"]
 
       # -----------------------------------------------------------------------
-      # BGP route servers (leave empty if not using BGP)
+      # BGP route servers — NICo Core has no FRR subchart; disabled by default.
+      # Re-enable + point at FRR VIPs if FRR is deployed out-of-band and DPU
+      # data-plane fabric BGP is required.
       # -----------------------------------------------------------------------
       route_servers = []
       enable_route_servers = false
-      # route_servers = ["10.0.0.1", "10.0.0.2"]
-      # enable_route_servers = true
 
       # -----------------------------------------------------------------------
-      # site_fabric_prefixes: prefixes that ARE part of the site fabric and
-      #   should be reachable between instances.
-      # deny_prefixes: prefixes that instances must NOT reach (OOB, control
-      #   plane, management networks, etc.).
+      # site_fabric_prefixes: prefixes that ARE part of the site fabric.
+      # deny_prefixes: prefixes instances must NOT reach (OOB, ctrl-plane, underlay).
       # -----------------------------------------------------------------------
-      site_fabric_prefixes = ["10.180.62.72/29"]   # EXAMPLE — replace with your fabric CIDRs
-
-      deny_prefixes = [                             # EXAMPLE — replace with your deny list
-        "10.180.62.64/29",    # EXAMPLE — admin/OOB network
-        "10.180.248.32/28",   # EXAMPLE — management network
-        "10.180.248.64/28",   # EXAMPLE — underlay TOR network
-      ]
+      site_fabric_prefixes = []                  # REQUIRED: your fabric CIDR(s)
+      deny_prefixes = []                         # your OOB / control-plane / underlay CIDRs
 
       # -----------------------------------------------------------------------
       # Site explorer — periodic background scan of site inventory
@@ -113,66 +120,56 @@ nico-api:
       run_interval = "30s"
 
       # -----------------------------------------------------------------------
-      # Host health monitoring
-      # Uncomment to override default behaviour.
+      # Machine + BOM validation
       # -----------------------------------------------------------------------
-      # [host_health]
-      # hardware_health_reports = "MonitorOnly"   # "MonitorOnly" | "Enforce"
+      [machine_validation_config]
+      enabled = true
+
+      [bom_validation]
+      enabled = true
+      ignore_unassigned_machines = true
 
       # -----------------------------------------------------------------------
-      # IP / integer pools — nico-api allocates from these ranges
-      #
-      # lo-ip:    loopback IPs assigned to bare-metal hosts
-      # vlan-id:  VLAN IDs for tenant networks
-      # vni:      VXLAN Network Identifiers
-      # vpc-vni:  VPC-level VNIs (set end=0 to disable)
+      # IP / integer pools — nico-api allocates from these ranges.
+      # REQUIRED: set the loopback (lo-ip) range to your site's pool.
       # -----------------------------------------------------------------------
       [pools.lo-ip]
       type = "ipv4"
-      ranges = [{ start = "10.180.62.84", end = "10.180.62.86" }]  # EXAMPLE — replace with your loopback pool
+      ranges = []                                # REQUIRED: e.g. [{ start = "...", end = "..." }]
 
       [pools.vlan-id]
       type = "integer"
-      ranges = [{ start = "100", end = "501" }]
+      ranges = []                                # REQUIRED: your VLAN ID range, e.g. [{ start = "100", end = "501" }]
 
       [pools.vni]
       type = "integer"
-      ranges = [{ start = "1024500", end = "1024800" }]
+      ranges = []                                # REQUIRED: your VXLAN VNI range, e.g. [{ start = "1024500", end = "1024800" }]
 
       [pools.vpc-vni]
       type = "integer"
-      ranges = [{ start = "0", end = "100" }]
+      ranges = []                                # REQUIRED: your VPC VNI range, e.g. [{ start = "0", end = "100" }]
 
       # -----------------------------------------------------------------------
-      # Networks — define named L3 segments visible to nico-api.
+      # Networks — named L3 segments visible to nico-api.
+      # REQUIRED: define your site's admin/OOB + underlay segments. Template:
       #
-      # type:          "admin" (OOB/management) | "underlay" (data-plane)
-      # prefix:        CIDR of the network
-      # gateway:       first-hop gateway IP
-      # mtu:           MTU (9000 for jumbo, 1500 for standard)
-      # reserve_first: number of IPs at the start of the prefix to skip
-      #                (gateway + infrastructure IPs)
+      #   [networks.admin]
+      #   type = "admin"
+      #   prefix = "<admin-cidr>"
+      #   gateway = "<admin-gateway>"
+      #   mtu = 9000
+      #   reserve_first = 5
       #
-      # Add one [networks.<name>] block per L3 segment at your site.
-      # The name is arbitrary but must be unique within this config.
+      #   [networks.<YOUR-UNDERLAY-SEGMENT-NAME>]
+      #   type = "underlay"
+      #   prefix = "<underlay-cidr>"
+      #   gateway = "<underlay-gateway>"
+      #   mtu = 1500
+      #   reserve_first = 2
       # -----------------------------------------------------------------------
-      [networks.admin]                             # EXAMPLE — your OOB/management network
-      type = "admin"
-      prefix = "10.180.62.64/29"    # EXAMPLE — replace with your admin CIDR
-      gateway = "10.180.62.65"      # EXAMPLE — replace with your admin gateway
-      mtu = 9000
-      reserve_first = 5
-
-      [networks.RNO1-M04-D04-IPMITOR-01]           # EXAMPLE — rename to your underlay segment name
-      type = "underlay"
-      prefix = "10.180.248.64/28"   # EXAMPLE — replace with your underlay CIDR
-      gateway = "10.180.248.65"     # EXAMPLE — replace with your underlay gateway
-      mtu = 1500
-      reserve_first = 5
-      # Add additional [networks.<name>] blocks here for each underlay segment at your site.
 
       # -----------------------------------------------------------------------
-      # InfiniBand (leave enabled=false if no IB fabric at this site)
+      # InfiniBand (disabled unless your site has an IB fabric)
       # -----------------------------------------------------------------------
       [ib_config]
       enabled = false
@@ -189,7 +186,6 @@ nico-api:
 
       # -----------------------------------------------------------------------
       # Machine state controller
-      # failure_retry_time: how long to wait before retrying a failed machine op
       # -----------------------------------------------------------------------
       [machine_state_controller]
       failure_retry_time = "90m"
@@ -208,46 +204,40 @@ nico-api:
 ##   - External pool (client-facing):  nico-api
 ##   - Each IP must be unique across all services
 ##   - The nico-api IP must resolve from external DNS to the hostname above
-##
-## These values mirror the kustomization patches that nicod applies via
-## site-controller. Without them the services come up with unpredictable IPs.
 ## ---------------------------------------------------------------------------
 
 nico-dhcp:
   externalService:
     enabled: true    # must be explicitly enabled - defaults to false in chart
     annotations:
-      metallb.universe.tf/loadBalancerIPs: "10.180.126.160"  # EXAMPLE - DHCP VIP (internal pool)
+      metallb.universe.tf/loadBalancerIPs: ""  # REQUIRED: DHCP VIP (internal pool)
 
   ## DHCP hook libraries' advertised IPs.
   ##
   ## Kea's libdhcp hook writes these IPs into the DHCP response that DPUs
   ## and bare-metal hosts receive on boot. They MUST be reachable on the
   ## PXE / management network the DPU comes up on, and they MUST match
-  ## the externalService VIPs assigned to nico-dns / nico-ntp / nico-pxe
-  ## above.
+  ## the externalService VIPs assigned to nico-dns / nico-ntp / nico-pxe.
   ##
-  ## Leaving the chart defaults (127.0.0.1) causes the symptoms reported
-  ## against helm-deployed sites — DPU pre-ingestion fails with clock
-  ## divergence (no NTP) and the DPU agent cannot reach the API endpoint
-  ## (no DNS).
+  ## Leaving the chart defaults (127.0.0.1) causes DPU pre-ingestion failures:
+  ## clock divergence (no NTP) and unreachable API endpoint (no DNS).
   ##
   ## Cross-check: each value below should equal the corresponding
   ## externalService loadBalancerIPs annotation in this file.
   ##
   ## DUAL-DEPLOYMENT NOTE (PR #2062): if the NICo API is installed under
   ## the legacy `carbide-api` name on this site, ALSO set
-  ## `nico-dhcp.apiServiceName: carbide-api` (uncomment the line below)
-  ## so the kea hook generates the right `nico-api-url` for DPUs. Without
-  ## this, the hook advertises https://nico-api.<ns>.svc.cluster.local
-  ## which will NXDOMAIN against a carbide-api-only deployment.
+  ## `nico-dhcp.apiServiceName: carbide-api` (uncomment below).
   # apiServiceName: carbide-api
   config:
     kea:
       hookParameters:
-        nameservers: "10.180.126.180"                      # EXAMPLE — must match nico-dns instance-0 VIP
-        ntpServer: "10.180.126.165,10.180.126.166,10.180.126.167"  # EXAMPLE — must match nico-ntp per-pod VIPs (comma-separated)
-        provisioningServer: "10.180.126.162"               # EXAMPLE — must match nico-pxe VIP
+        # DPUs need a resolver that serves the .forge zone (carbide-api.forge etc.).
+        # nico-dns is authoritative-only and does NOT serve .forge, so hand DPUs
+        # the unbound VIP (must equal unbound.externalService VIP below).
+        nameservers: ""           # REQUIRED: unbound VIP (must serve .forge)
+        ntpServer: ""             # REQUIRED: nico-ntp per-pod VIPs, comma-separated
+        provisioningServer: ""    # REQUIRED: nico-pxe VIP
 
 nico-dns:
   externalService:
@@ -256,14 +246,28 @@ nico-dns:
     ## The chart creates separate UDP + TCP services per pod and uses
     ## metallb.universe.tf/allow-shared-ip so both share the same IP.
     perPodAnnotations:
-      - metallb.universe.tf/loadBalancerIPs: "10.180.126.180"  # EXAMPLE - DNS instance-0 VIP (external pool)
-      - metallb.universe.tf/loadBalancerIPs: "10.180.126.179"  # EXAMPLE - DNS instance-1 VIP (external pool)
+      - metallb.universe.tf/loadBalancerIPs: ""  # REQUIRED: DNS instance-0 VIP (external pool)
+      - metallb.universe.tf/loadBalancerIPs: ""  # REQUIRED: DNS instance-1 VIP (external pool)
 
 nico-pxe:
   externalService:
     enabled: true    # must be explicitly enabled - defaults to false in chart
     annotations:
-      metallb.universe.tf/loadBalancerIPs: "10.180.126.162"  # EXAMPLE - PXE VIP (internal pool)
+      metallb.universe.tf/loadBalancerIPs: ""  # REQUIRED: PXE VIP (internal pool)
+
+  ## Boot artifacts (ipxe.efi, BFB, OS images) — REQUIRED or DPU/host HTTP boot 404s and
+  ## falls back to the local OS (never re-images). These init containers populate the
+  ## /boot-artifacts/blobs/internal volume that nico-pxe serves at /public/blobs/internal.
+  ## Pin the images to the same build/registry as nvmetal-carbide.
+  ## NOTE: the aarch64 image ships /aarch64 + /apt (NOT /firmware) — copying a missing dir crash-loops the init.
+  bootArtifactContainers: []
+  # bootArtifactContainers:
+  #   - name: boot-artifacts-x86-64
+  #     image: <your-registry>/boot-artifacts-x86_64:<tag>
+  #     command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
+  #   - name: boot-artifacts-aarch64
+  #     image: <your-registry>/boot-artifacts-aarch64:<tag>
+  #     command: ["sh", "-c", "cp -r /aarch64 /apt /boot-artifacts/blobs/internal"]
 
   ## TLS cert SANs — DPU agents are hardcoded to fetch boot artifacts from
   ## `carbide-pxe.forge` / `carbide-static-pxe.forge`. If the cert doesn't
@@ -271,14 +275,17 @@ nico-pxe:
   certificate:
     extraDnsNames:
       - "carbide-pxe.forge"            # legacy hardcoded lookup in deployed DPU agents
+      - "nico-pxe.forge"               # renamed-binary alias (dual naming)
       - "carbide-static-pxe.forge"     # legacy hardcoded lookup in host PXE loaders
       - "carbide-pxe.forge-system.svc.cluster.local"  # legacy cluster-internal name
 
 nico-ssh-console-rs:
+  ## imagePullSecrets now inherited from global.imagePullSecrets (chart fix: this subchart
+  ## falls back to global). No per-subchart override needed.
   externalService:
     enabled: true    # must be explicitly enabled - defaults to false in chart
     annotations:
-      metallb.universe.tf/loadBalancerIPs: "10.180.126.164"  # EXAMPLE - SSH console VIP (internal pool)
+      metallb.universe.tf/loadBalancerIPs: ""  # REQUIRED: SSH console VIP (internal pool)
 
 ## ---------------------------------------------------------------------------
 ## nico-ntp - chrony NTP servers
@@ -286,8 +293,7 @@ nico-ssh-console-rs:
 ## Deploys a 3-replica chrony StatefulSet plus per-pod LoadBalancer Services.
 ## Each replica gets a stable MetalLB VIP that DPUs and bare-metal hosts sync
 ## against (advertised to them via nico-dhcp.config.kea.hookParameters.ntpServer
-## above). Enabled by default — DPU pre-ingestion fails on clock divergence,
-## so the chart deploys NTP unless you disable it here.
+## above). Enabled by default — DPU pre-ingestion fails on clock divergence.
 ## ---------------------------------------------------------------------------
 nico-ntp:
   externalService:
@@ -295,9 +301,9 @@ nico-ntp:
     ## NTP uses perPodAnnotations - one VIP per replica so clients can reach
     ## each NTP instance at a stable IP regardless of pod scheduling.
     perPodAnnotations:
-      - metallb.universe.tf/loadBalancerIPs: "10.180.126.165"  # EXAMPLE - NTP instance-0 VIP (internal pool)
-      - metallb.universe.tf/loadBalancerIPs: "10.180.126.166"  # EXAMPLE - NTP instance-1 VIP (internal pool)
-      - metallb.universe.tf/loadBalancerIPs: "10.180.126.167"  # EXAMPLE - NTP instance-2 VIP (internal pool)
+      - metallb.universe.tf/loadBalancerIPs: ""  # REQUIRED: NTP instance-0 VIP (internal pool)
+      - metallb.universe.tf/loadBalancerIPs: ""  # REQUIRED: NTP instance-1 VIP (internal pool)
+      - metallb.universe.tf/loadBalancerIPs: ""  # REQUIRED: NTP instance-2 VIP (internal pool)
 
 ## ---------------------------------------------------------------------------
 ## nico-dsx-exchange-consumer - disabled until binary is included in image
@@ -318,36 +324,52 @@ nico-dsx-exchange-consumer:
 ## If you point your own external DNS at the same VIPs and serve the .forge
 ## records there, you can leave this disabled. Otherwise enable it and fill
 ## the VIPs to match the externalService.annotations entries above.
-##
-## Verify after install: `helm-prereqs/health-check.sh` reports per-record
-## status under the ".forge DNS Endpoint Reference" section.
 ## ---------------------------------------------------------------------------
 unbound:
-  enabled: false
-  # imagePullSecrets:
-  #   - name: nvcr-nvidian-nvforge
+  enabled: true
 
-  ## Uncomment + fill in VIPs to serve the DPU compatibility .forge zone.
-  ## The IPs below must match the loadBalancerIPs you set above (nico-api,
-  ## nico-pxe, nico-ntp). The unbound chart turns each entry into a
-  ## `local-data` line in `local_data.conf`. Existing DPU agents look up these
-  ## hostnames verbatim; the rename to .nico is deferred per the dual-
-  ## deployment POR, so we serve both old and new under the same VIPs.
-  # localData:
-  #   - name: carbide-api.forge        # nico-api external VIP — legacy DPU agent lookup
-  #     addresses: ["10.180.126.177"]
-  #   - name: nico-api.forge           # same VIP, renamed-binary alias
-  #     addresses: ["10.180.126.177"]
-  #   - name: carbide-pxe.forge        # nico-pxe VIP — hardcoded in DPU agent + boot images
-  #     addresses: ["10.180.126.162"]
-  #   - name: carbide-static-pxe.forge
-  #     addresses: ["10.180.126.162"]
-  #   - name: carbide-ntp.forge        # nico-ntp VIPs — hardcoded in DPU agent
-  #     addresses: ["10.180.126.165", "10.180.126.166", "10.180.126.167"]
-  #   - name: unbound.forge            # distributed to DPUs via DHCP option 6
-  #     addresses: ["10.180.126.180"]
-  #   # Optional: otel-receiver / socks if you run those services
-  #   # - name: otel-receiver.forge
-  #   #   addresses: ["10.180.126.181"]
-  #   # - name: socks.forge
-  #   #   addresses: ["10.180.126.182"]
+  ## unbound uses its own images (not global.image). These are fixed product
+  ## images (host nvcr.io, same `imagepullsecret` works) — set to the build
+  ## your site standardises on.
+  image:
+    repository: ""    # REQUIRED: unbound image repository
+    tag: ""           # REQUIRED: unbound image tag
+  exporterImage:
+    repository: ""    # REQUIRED: unbound_exporter image repository
+    tag: ""           # REQUIRED: unbound_exporter image tag
+
+  ## In-chart LoadBalancer VIP (chart fix) so DPUs reach unbound for .forge.
+  ## Must match nico-dhcp.config.kea.hookParameters.nameservers.
+  externalService:
+    enabled: true
+    annotations:
+      metallb.universe.tf/loadBalancerIPs: ""  # REQUIRED: unbound VIP (internal pool)
+
+  ## Upstream recursive forwarder. The chart default forwarders.conf is a broken
+  ## `patchme` placeholder; override it with your site's upstream resolver.
+  localConfig:
+    forwarders.conf: |
+      forward-zone:
+          name: .
+          forward-addr:       # REQUIRED: your upstream DNS resolver IP
+
+  ## DPU-compatibility .forge zone. Each entry becomes a `local-data ... IN A`
+  ## line. Serve both legacy carbide-* and new nico-* names under the same VIPs
+  ## (dual naming). Set every address to the matching service VIP above.
+  localData:
+    - name: carbide-api.forge
+      addresses: []          # REQUIRED: [nico-api VIP]
+    - name: nico-api.forge
+      addresses: []          # REQUIRED: [nico-api VIP]
+    - name: carbide-pxe.forge
+      addresses: []          # REQUIRED: [nico-pxe VIP]
+    - name: nico-pxe.forge
+      addresses: []          # REQUIRED: [nico-pxe VIP]
+    - name: carbide-static-pxe.forge
+      addresses: []          # REQUIRED: [nico-pxe VIP]
+    - name: carbide-ntp.forge
+      addresses: []          # REQUIRED: [nico-ntp VIPs]
+    - name: nico-ntp.forge
+      addresses: []          # REQUIRED: [nico-ntp VIPs]
+    - name: unbound.forge
+      addresses: []          # REQUIRED: [unbound VIP]

--- a/helm/charts/nico-api/files/carbide-api-config.toml
+++ b/helm/charts/nico-api/files/carbide-api-config.toml
@@ -53,10 +53,10 @@ algorithm = "ES256"               # must match tenant identity signing alg (ES25
 identity_pemfile_path = "/var/run/secrets/spiffe.io/tls.crt"
 identity_keyfile_path = "/var/run/secrets/spiffe.io/tls.key"
 root_cafile_path = "/var/run/secrets/spiffe.io/ca.crt"
-admin_root_cafile_path = "/etc/forge/carbide-api/site/admin_root_cert_pem"
+admin_root_cafile_path = "{{ .Values.auth.adminRootCafilePath | default "/etc/forge/carbide-api/site/admin_root_cert_pem" }}"
 
 [auth]
-permissive_mode = false
+permissive_mode = {{ .Values.auth.permissiveMode | default false }}
 casbin_policy_file = "/etc/forge/carbide-api/casbin-policy.csv"
 
 [auth.trust]
@@ -67,7 +67,7 @@ spiffe_service_base_paths = [
   "/elektra-site-agent/sa/",
 ]
 spiffe_machine_base_path = "/{{ .Values.auth.namespace | default (include "nico-api.namespace" .) }}/machine/"
-additional_issuer_cns = []
+additional_issuer_cns = [{{ range $i, $cn := .Values.auth.additionalIssuerCns }}{{ if $i }}, {{ end }}{{ $cn | quote }}{{ end }}]
 
 [machine_state_controller]
 failure_retry_time = "90m"

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -87,7 +87,8 @@ bootArtifactContainers: []
 #     command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
 #   - name: boot-artifacts-aarch64
 #     image: <your-registry>/boot-artifacts-aarch64:latest
-#     command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /boot-artifacts/blobs/internal"]
+#     # NOTE: the aarch64 image ships /aarch64 + /apt (NOT /firmware) — copying a missing dir crash-loops the init.
+#     command: ["sh", "-c", "cp -r /aarch64 /apt /boot-artifacts/blobs/internal"]
 #   - name: machine-validation-config
 #     image: <your-registry>/machine-validation-config:latest
 #     command: ["sh", "-c", "cp -r /machine-validation /boot-artifacts/blobs/internal"]
@@ -180,6 +181,15 @@ auth:
   principals:
     dhcp: nico-dhcp
     dns: nico-dns
+  ## [auth] permissive_mode — bypass the casbin policy layer. DEV ONLY. Note: this does
+  ## NOT bypass the internal RBAC handler, so it does not grant admin-CLI access by itself.
+  permissiveMode: false
+  ## [auth.trust] additional_issuer_cns — CNs of non-SPIFFE issuer CAs trusted as ExternalUser
+  ## principals (group = cert SubjectOU). Set to the site CA CN (e.g. ["site-root"]) to enable
+  ## admin-CLI client certs minted from the vault PKI without manual ConfigMap edits.
+  additionalIssuerCns: []
+  ## [tls] admin_root_cafile_path — CA bundle whose client certs are treated as admin ExternalUsers.
+  adminRootCafilePath: "/etc/forge/carbide-api/site/admin_root_cert_pem"
 
 ## Config files -- can be overridden with custom content
 configFiles:

--- a/helm/charts/nico-ntp/templates/statefulset.yaml
+++ b/helm/charts/nico-ntp/templates/statefulset.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         {{- include "nico-ntp.labels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with (.Values.imagePullSecrets | default .Values.global.imagePullSecrets) }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/charts/nico-pxe/values.yaml
+++ b/helm/charts/nico-pxe/values.yaml
@@ -50,17 +50,26 @@ initContainers: []
 
 ## Boot-artifact init containers
 ## Each entry is rendered as a Kubernetes init container with the boot-artifacts
-## volume automatically mounted at /boot-artifacts/blobs/internal.
+## volume automatically mounted at /boot-artifacts/blobs/internal, then served by
+## nico-pxe at /public/blobs/internal.
+##
+## REQUIRED for DPU and host HTTP boot: if empty, the DPU/host requests its bootloader
+## (e.g. /public/blobs/internal/aarch64/ipxe.efi) and gets HTTP 404, then falls back to
+## its local disk and never (re)provisions. Populate per site (extensible list).
+##
+## NOTE: copy ONLY directories that exist in the image. The boot-artifacts-aarch64 image
+## ships /aarch64 and /apt (NOT /firmware); copying a missing dir makes `cp` exit non-zero
+## and the init container crash-loops.
 bootArtifactContainers: []
 # bootArtifactContainers:
 #   - name: boot-artifacts-x86-64
-#     image: <your-registry>/boot-artifacts-x86_64:latest
+#     image: <your-registry>/boot-artifacts-x86_64:<tag>
 #     command: ["sh", "-c", "cp -r /x86_64 /boot-artifacts/blobs/internal"]
 #   - name: boot-artifacts-aarch64
-#     image: <your-registry>/boot-artifacts-aarch64:latest
-#     command: ["sh", "-c", "cp -r /aarch64 /apt /firmware /boot-artifacts/blobs/internal"]
+#     image: <your-registry>/boot-artifacts-aarch64:<tag>
+#     command: ["sh", "-c", "cp -r /aarch64 /apt /boot-artifacts/blobs/internal"]
 #   - name: machine-validation-config
-#     image: <your-registry>/machine-validation-config:latest
+#     image: <your-registry>/machine-validation-config:<tag>
 #     command: ["sh", "-c", "cp -r /machine-validation /boot-artifacts/blobs/internal"]
 
 ## Boot artifact serving configuration

--- a/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         {{- include "nico-ssh-console-rs.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "nico-ssh-console-rs.name" . }}
-      {{- with .Values.imagePullSecrets }}
+      {{- with (.Values.imagePullSecrets | default .Values.global.imagePullSecrets) }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/charts/unbound/templates/deployment.yaml
+++ b/helm/charts/unbound/templates/deployment.yaml
@@ -21,14 +21,22 @@ spec:
       labels:
         {{- include "unbound.podLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with (.Values.imagePullSecrets | default .Values.global.imagePullSecrets) }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: unbound
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ required "unbound.image.repository is required — set it in helm-prereqs/values/nico-core.yaml (unbound.image.repository)" .Values.image.repository }}:{{ required "unbound.image.tag is required — set it in helm-prereqs/values/nico-core.yaml (unbound.image.tag)" .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: dns-udp
               containerPort: 53
@@ -50,8 +58,9 @@ spec:
           envFrom:
             - configMapRef:
                 name: unbound-envvars
+        {{- if .Values.exporter.enabled }}
         - name: unbound-metrics
-          image: "{{ .Values.exporterImage.repository }}:{{ .Values.exporterImage.tag }}"
+          image: "{{ required "unbound.exporterImage.repository is required when exporter.enabled — set unbound.exporterImage.repository, or set unbound.exporter.enabled=false for a public/stock unbound image" .Values.exporterImage.repository }}:{{ required "unbound.exporterImage.tag is required when exporter.enabled — set unbound.exporterImage.tag" .Values.exporterImage.tag }}"
           imagePullPolicy: {{ .Values.exporterImage.pullPolicy }}
           env:
             - name: KEYS_DIR
@@ -64,6 +73,7 @@ spec:
             - name: metrics
               containerPort: 9167
               protocol: TCP
+        {{- end }}
       volumes:
         - name: local-config
           configMap:

--- a/helm/charts/unbound/templates/external-service.yaml
+++ b/helm/charts/unbound/templates/external-service.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.externalService.enabled }}
+{{- /*
+External LoadBalancer exposure for unbound (bare-metal / MetalLB). DPUs and bare-metal
+hosts use this VIP as their DHCP-advertised resolver to reach the .forge zone. Two Services
+(UDP + TCP on 53) share one VIP via metallb.universe.tf/allow-shared-ip. Set the VIP with:
+  externalService.annotations: { metallb.universe.tf/loadBalancerIPs: "10.x.x.x" }
+*/}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "unbound.name" . }}-external-udp
+  namespace: {{ include "unbound.namespace" . }}
+  labels:
+    {{- include "unbound.labels" . | nindent 4 }}
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "{{ include "unbound.name" . }}-external"
+    {{- with .Values.externalService.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.externalService.type | default "LoadBalancer" }}
+  {{- with .Values.externalService.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
+  selector:
+    {{- include "unbound.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: 53
+      targetPort: dns-udp
+      protocol: UDP
+      name: dns-udp
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "unbound.name" . }}-external-tcp
+  namespace: {{ include "unbound.namespace" . }}
+  labels:
+    {{- include "unbound.labels" . | nindent 4 }}
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "{{ include "unbound.name" . }}-external"
+    {{- with .Values.externalService.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.externalService.type | default "LoadBalancer" }}
+  {{- with .Values.externalService.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+  {{- end }}
+  selector:
+    {{- include "unbound.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: 53
+      targetPort: dns-tcp
+      protocol: TCP
+      name: dns-tcp
+{{- end }}

--- a/helm/charts/unbound/values.yaml
+++ b/helm/charts/unbound/values.yaml
@@ -15,10 +15,39 @@ exporterImage:
   tag: ""
   pullPolicy: IfNotPresent
 
+## Metrics sidecar (unbound_exporter). It needs unbound remote-control keys and the
+## default image is in a private registry — disable it when running a public/stock
+## unbound image that doesn't set up remote-control.
+exporter:
+  enabled: true
+
+## Optional container command/args override. Leave empty to use the image's own
+## entrypoint (the NVIDIA nvforge image, which loads /etc/unbound/local.conf.d and
+## sets up remote-control). Set these to run a PUBLIC/stock unbound image whose
+## entrypoint wouldn't otherwise include the chart's local.conf.d fragments, e.g.:
+##   command: ["/bin/sh", "-c"]
+##   args:
+##     - |
+##       printf 'server:\n  interface: 0.0.0.0\n  interface: ::0\n  access-control: 0.0.0.0/0 allow\ninclude: "/etc/unbound/local.conf.d/*.conf"\n' > /tmp/unbound.conf
+##       exec unbound -d -c /tmp/unbound.conf
+command: []
+args: []
+
 imagePullSecrets: []
 
 service:
   type: ClusterIP
+
+## External LoadBalancer Service (bare-metal / MetalLB). When enabled, renders two
+## Services (UDP+TCP on 53) sharing one VIP via metallb.universe.tf/allow-shared-ip, so
+## DPUs/hosts can use unbound as their DHCP-advertised resolver for the .forge zone.
+## Set the VIP via annotations, e.g.:
+##   annotations: { metallb.universe.tf/loadBalancerIPs: "10.x.x.x" }
+externalService:
+  enabled: false
+  type: LoadBalancer
+  externalTrafficPolicy: ""
+  annotations: {}
 
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
Overrideable infra fixes (no site data):
- imagePullSecrets: nico-ntp/ssh-console-rs/unbound fall back to global.imagePullSecrets
- unbound: in-chart externalService (dual UDP/TCP shared-VIP)
- nico-api: values-driven permissive_mode / additional_issuer_cns / admin_root_cafile_path
- nico-pxe + nico-api: fix bootArtifactContainers aarch64 example (drop nonexistent /firmware)
- helm-prereqs: site_default UEFI kvSeeds (blank secrets); nicoCliClientRole.ou override
- clean.sh: remove monitoring.coreos.com CRDs on teardown
- preflight.sh: standalone --skip-rest/--skip-core/--skip-flow flags; empty-required-value checks; IPv4/CIDR validation + service-VIP-in-MetalLB-pool containment + duplicate-VIP + kea hook IP checks

Site value files (values.yaml, values/nico-core.yaml, values/metallb-config.yaml) ship BLANK — every site-specific value is empty with a REQUIRED comment; operators populate per site and preflight.sh enforces population.

