### PR TITLE
test: introduce nico-test-support (w/ some usage examples across a few crates)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,6 +1276,7 @@ dependencies = [
  "mac_address",
  "mockito",
  "mqttea",
+ "nico-test-support",
  "nras",
  "num_cpus",
  "nv-redfish",
@@ -1362,6 +1363,7 @@ dependencies = [
  "lazy_static",
  "mac_address",
  "names",
+ "nico-test-support",
  "octseq",
  "regex",
  "rustc-hash",
@@ -1431,6 +1433,7 @@ dependencies = [
  "lazy_static",
  "libnmxm",
  "mac_address",
+ "nico-test-support",
  "nras",
  "once_cell",
  "p256 0.14.0-rc.9",
@@ -2209,6 +2212,7 @@ dependencies = [
  "hex",
  "hostname",
  "mac_address",
+ "nico-test-support",
  "once_cell",
  "prettytable-rs",
  "prost-types",
@@ -2870,6 +2874,7 @@ dependencies = [
  "libredfish",
  "librms",
  "mac_address",
+ "nico-test-support",
  "opentelemetry",
  "rand 0.10.1",
  "regex",
@@ -7196,6 +7201,10 @@ dependencies = [
  "log",
  "tokio",
 ]
+
+[[package]]
+name = "nico-test-support"
+version = "0.0.0"
 
 [[package]]
 name = "nix"

--- a/crates/api-core/Cargo.toml
+++ b/crates/api-core/Cargo.toml
@@ -223,6 +223,7 @@ carbide-redfish = { path = "../redfish", features = ["test-support"] }
 carbide-rpc = { path = "../rpc", features = ["model", "sqlx", "test-support"] }
 carbide-secrets = { path = "../secrets", features = ["test-support"] }
 carbide-sqlx-testing = { path = "../sqlx-testing", default-features = false }
+nico-test-support = { path = "../test-support" }
 carbide-utils = { path = "../utils", features = ["test-support"] }
 prometheus-text-parser = { path = "../prometheus-text-parser" }
 state-controller = { path = "../state-controller", features = ["test-support"] }

--- a/crates/api-core/src/instance/mod.rs
+++ b/crates/api-core/src/instance/mod.rs
@@ -1408,41 +1408,44 @@ pub fn allocate_spx_port_mac(
 
 #[cfg(test)]
 mod tests {
+    use nico_test_support::Outcome::*;
+    use nico_test_support::{Case, check_cases};
+
     use super::*;
 
     #[test]
-    fn test_build_requested_linknet_prefix_valid_v4() {
-        // Host end of a /31 (odd address) should succeed.
-        let result = build_requested_linknet_prefix("10.0.0.1".parse().unwrap(), 31);
-        assert!(result.is_ok());
-        let prefix = result.unwrap();
-        assert_eq!(prefix.prefix(), 31);
-        assert_eq!(prefix.ip().to_string(), "10.0.0.1");
-    }
-
-    #[test]
-    fn test_build_requested_linknet_prefix_valid_v6() {
-        // Host end of a /127 (::1 address) should succeed.
-        let result = build_requested_linknet_prefix("2001:db8::1".parse().unwrap(), 127);
-        assert!(result.is_ok());
-        let prefix = result.unwrap();
-        assert_eq!(prefix.prefix(), 127);
-    }
-
-    #[test]
-    fn test_build_requested_linknet_prefix_rejects_dpu_end_v4() {
-        // DPU end of a /31 (even address) should be rejected.
-        let result = build_requested_linknet_prefix("10.0.0.0".parse().unwrap(), 31);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("host bit of 0"));
-    }
-
-    #[test]
-    fn test_build_requested_linknet_prefix_rejects_dpu_end_v6() {
-        // DPU end of a /127 (::0 address) should be rejected.
-        let result = build_requested_linknet_prefix("2001:db8::0".parse().unwrap(), 127);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("host bit of 0"));
+    fn build_requested_linknet_prefix_accepts_host_end_rejects_dpu_end() {
+        // The host must take the odd (::1) end of the linknet; the even end is the
+        // DPU's and is rejected. `CarbideError` isn't `PartialEq` (so it can't be the
+        // table's error type): error rows only assert *that* it fails via `Fails`, and
+        // the closure discards the error to `()` to satisfy `check_cases`.
+        check_cases(
+            [
+                Case {
+                    scenario: "host end of a /31 (odd v4)",
+                    input: ("10.0.0.1", 31),
+                    expect: Yields("10.0.0.1/31".parse().unwrap()),
+                },
+                Case {
+                    scenario: "host end of a /127 (::1 v6)",
+                    input: ("2001:db8::1", 127),
+                    expect: Yields("2001:db8::1/127".parse().unwrap()),
+                },
+                Case {
+                    scenario: "DPU end of a /31 (even v4) is rejected",
+                    input: ("10.0.0.0", 31),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "DPU end of a /127 (::0 v6) is rejected",
+                    input: ("2001:db8::0", 127),
+                    expect: Fails,
+                },
+            ],
+            |(ip, prefix_len)| {
+                build_requested_linknet_prefix(ip.parse().unwrap(), prefix_len).map_err(|_| ())
+            },
+        );
     }
 }
 

--- a/crates/api-db/Cargo.toml
+++ b/crates/api-db/Cargo.toml
@@ -87,6 +87,7 @@ carbide-version = { path = "../version" }
 [dev-dependencies]
 base64 = { workspace = true }
 carbide-secrets = { path = "../secrets" }
+nico-test-support = { path = "../test-support" }
 lazy_static = { workspace = true }
 carbide-macros = { path = "../macros" }
 carbide-sqlx-testing = { path = "../sqlx-testing" }

--- a/crates/api-db/src/resource_pool.rs
+++ b/crates/api-db/src/resource_pool.rs
@@ -1030,6 +1030,9 @@ pub async fn create_common_pools(
 
 #[cfg(test)]
 mod tests {
+    use nico_test_support::Outcome::*;
+    use nico_test_support::{Case, check_cases};
+
     use super::*;
 
     #[test]
@@ -1203,19 +1206,30 @@ mod tests {
 
     #[test]
     fn test_expand_ipv6_prefix_boundary() {
-        // A /111 == 2^17 = 131,072 addresses — under MAX_POOL_SIZE
-        // (which is currently 250k as of this writing).
-        let addrs = expand_ipv6_prefix("fd00::/111").unwrap();
-        assert_eq!(addrs.len(), 131_072);
-
-        // A /110 == 262,144 addresses — over MAX_POOL_SIZE, which
-        // is currently 250k as of this writing.
-        let result = expand_ipv6_prefix("fd00::/110");
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            DefineResourcePoolError::TooBig(_, _)
-        ));
+        // MAX_POOL_SIZE (currently 250k) is the dividing line: a prefix
+        // expands when its address count fits, and is rejected when it
+        // doesn't. We assert on that count; the rejection error
+        // (DefineResourcePoolError) isn't PartialEq, so the operation
+        // discards it and we only assert that the case `Fails`.
+        check_cases(
+            [
+                Case {
+                    scenario: "/111 fits: 2^17 = 131,072 addresses",
+                    input: "fd00::/111",
+                    expect: Yields(131_072),
+                },
+                Case {
+                    scenario: "/110 is too big: 2^18 = 262,144 addresses",
+                    input: "fd00::/110",
+                    expect: Fails,
+                },
+            ],
+            |network| {
+                expand_ipv6_prefix(network)
+                    .map(|addrs| addrs.len())
+                    .map_err(|_| ())
+            },
+        );
     }
 
     #[test]

--- a/crates/api-model/Cargo.toml
+++ b/crates/api-model/Cargo.toml
@@ -91,6 +91,7 @@ carbide-version = { path = "../version" }
 [dev-dependencies]
 carbide-sqlx-testing = { path = "../sqlx-testing", default-features = false }
 carbide-secrets = { path = "../secrets" }
+nico-test-support = { path = "../test-support" }
 lazy_static = { workspace = true }
 p256 = { workspace = true }
 prost = { workspace = true }

--- a/crates/api-model/src/machine/upgrade_policy.rs
+++ b/crates/api-model/src/machine/upgrade_policy.rs
@@ -286,82 +286,96 @@ impl PartialOrd for BuildVersion<'_> {
 }
 
 #[test]
-fn test_parse_version() -> eyre::Result<()> {
-    // Date-based versions
-    assert_eq!(
-        BuildVersion::try_from("v2023.08-92-g1b48e8b6")?,
-        BuildVersion {
-            version: "2023.08",
-            rc: "",
-            hotfix: 0,
-            commits: 92,
-            git_hash: "g1b48e8b6",
-        }
+fn test_parse_version() {
+    use nico_test_support::Outcome::*;
+    use nico_test_support::{Case, check_cases};
+
+    check_cases(
+        [
+            // Date-based versions
+            Case {
+                scenario: "date tag with commits and hash",
+                input: "v2023.08-92-g1b48e8b6",
+                expect: Yields(BuildVersion {
+                    version: "2023.08",
+                    rc: "",
+                    hotfix: 0,
+                    commits: 92,
+                    git_hash: "g1b48e8b6",
+                }),
+            },
+            Case {
+                scenario: "date tag with rc, commits and hash",
+                input: "v2023.09-rc1-27-gc3ce4d5d",
+                expect: Yields(BuildVersion {
+                    version: "2023.09",
+                    rc: "rc1",
+                    hotfix: 0,
+                    commits: 27,
+                    git_hash: "gc3ce4d5d",
+                }),
+            },
+            Case {
+                scenario: "bare date tag",
+                input: "v2023.08",
+                expect: Yields(BuildVersion {
+                    version: "2023.08",
+                    rc: "",
+                    hotfix: 0,
+                    commits: 0,
+                    git_hash: "",
+                }),
+            },
+            // Semver versions
+            Case {
+                scenario: "semver tag with rc, hotfix and hash",
+                input: "v0.0.4-rc4-0-g2a3c98cac",
+                expect: Yields(BuildVersion {
+                    version: "0.0.4",
+                    rc: "rc4",
+                    hotfix: 0,
+                    commits: 0,
+                    git_hash: "g2a3c98cac",
+                }),
+            },
+            Case {
+                scenario: "bare semver tag",
+                input: "v1.2.3",
+                expect: Yields(BuildVersion {
+                    version: "1.2.3",
+                    rc: "",
+                    hotfix: 0,
+                    commits: 0,
+                    git_hash: "",
+                }),
+            },
+            Case {
+                scenario: "semver tag with rc and hotfix",
+                input: "v0.0.4-rc1-0",
+                expect: Yields(BuildVersion {
+                    version: "0.0.4",
+                    rc: "rc1",
+                    hotfix: 0,
+                    commits: 0,
+                    git_hash: "",
+                }),
+            },
+            Case {
+                scenario: "too many dash-separated parts",
+                input: "v2023.08-rc1-0-3-g123eff-x",
+                expect: Fails,
+            },
+            Case {
+                scenario: "no version number after the 'v'",
+                input: "v-rc1",
+                expect: Fails,
+            },
+        ],
+        // The operation under test: parse a build-version string. The error type
+        // (eyre::Report) is not PartialEq, so failing rows assert only that it
+        // errors; we discard the report to keep the outcome comparable.
+        |s| BuildVersion::try_from(s).map_err(|_| ()),
     );
-
-    assert_eq!(
-        BuildVersion::try_from("v2023.09-rc1-27-gc3ce4d5d")?,
-        BuildVersion {
-            version: "2023.09",
-            rc: "rc1",
-            hotfix: 0,
-            commits: 27,
-            git_hash: "gc3ce4d5d",
-        }
-    );
-
-    assert_eq!(
-        BuildVersion::try_from("v2023.08")?,
-        BuildVersion {
-            version: "2023.08",
-            rc: "",
-            hotfix: 0,
-            commits: 0,
-            git_hash: "",
-        }
-    );
-
-    // Semver versions
-    assert_eq!(
-        BuildVersion::try_from("v0.0.4-rc4-0-g2a3c98cac")?,
-        BuildVersion {
-            version: "0.0.4",
-            rc: "rc4",
-            hotfix: 0,
-            commits: 0,
-            git_hash: "g2a3c98cac",
-        }
-    );
-
-    assert_eq!(
-        BuildVersion::try_from("v1.2.3")?,
-        BuildVersion {
-            version: "1.2.3",
-            rc: "",
-            hotfix: 0,
-            commits: 0,
-            git_hash: "",
-        }
-    );
-
-    assert_eq!(
-        BuildVersion::try_from("v0.0.4-rc1-0")?,
-        BuildVersion {
-            version: "0.0.4",
-            rc: "rc1",
-            hotfix: 0,
-            commits: 0,
-            git_hash: "",
-        }
-    );
-
-    // Too many dashes
-    assert!(BuildVersion::try_from("v2023.08-rc1-0-3-g123eff-x").is_err());
-
-    // No version
-    assert!(BuildVersion::try_from("v-rc1").is_err());
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/libmlx/Cargo.toml
+++ b/crates/libmlx/Cargo.toml
@@ -87,6 +87,7 @@ serde_yaml = "0.9"
 [dev-dependencies]
 carbide-libmlx-model = { path = "../libmlx-model", features = ["test-support"] }
 carbide-ssh = { path = "../ssh", features = ["test_support"] }
+nico-test-support = { path = "../test-support" }
 russh = { workspace = true }
 
 [features]

--- a/crates/libmlx/tests/variables/test_value.rs
+++ b/crates/libmlx/tests/variables/test_value.rs
@@ -18,6 +18,8 @@
 use libmlx::variables::spec::MlxVariableSpec;
 use libmlx::variables::value::{MlxValueError, MlxValueType};
 use libmlx::variables::variable::MlxConfigVariable;
+use nico_test_support::Outcome::*;
+use nico_test_support::{Case, check_cases};
 
 // create_test_variable creates a test variable with a given spec
 // to use for testing. This is leveraged for basically each test.
@@ -76,12 +78,13 @@ fn test_string_value_creation() {
     assert_eq!(value2.value, MlxValueType::String("world".to_string()));
 }
 
-// test_enum_value_validation creates a new variable called "test_enum"
-// with an enum spec, and then makes sure we can call `with`
-// on it with an enum, ensuring the IntoMlxValue trait is working
-// as expected for enums (among other things).
+// enum_values_validate_against_the_spec migrates the old hand-written enum test
+// onto nico-test-support: each row is a labeled input + an expected `Outcome`,
+// and `check_cases` runs the operation under test (`var.with`) over them. A valid
+// option yields an Enum value; an unknown option fails with the exact
+// InvalidEnumOption error — no `match … panic!` to read past.
 #[test]
-fn test_enum_value_validation() {
+fn enum_values_validate_against_the_spec() {
     let var = create_test_variable(
         "test_enum",
         MlxVariableSpec::Enum {
@@ -89,57 +92,82 @@ fn test_enum_value_validation() {
         },
     );
 
-    // Valid enum value - underlying logic it's an enum and validates.
-    let valid_value = var.with("medium").unwrap();
-    assert_eq!(valid_value.value, MlxValueType::Enum("medium".to_string()));
-
-    // Invalid enum value - still gets validated.
-    let invalid_result = var.with("invalid");
-    assert!(invalid_result.is_err());
-    match invalid_result.unwrap_err() {
-        MlxValueError::InvalidEnumOption { value, allowed } => {
-            assert_eq!(value, "invalid");
-            assert_eq!(allowed, vec!["low", "medium", "high"]);
-        }
-        _ => panic!("Expected InvalidEnumOption error"),
-    }
+    check_cases(
+        [
+            Case {
+                scenario: "a valid option",
+                input: "medium",
+                expect: Yields(MlxValueType::Enum("medium".to_string())),
+            },
+            Case {
+                scenario: "another valid option",
+                input: "high",
+                expect: Yields(MlxValueType::Enum("high".to_string())),
+            },
+            Case {
+                scenario: "an unknown option",
+                input: "invalid",
+                expect: FailsWith(MlxValueError::InvalidEnumOption {
+                    value: "invalid".to_string(),
+                    allowed: vec!["low".to_string(), "medium".to_string(), "high".to_string()],
+                }),
+            },
+        ],
+        |input| var.with(input).map(|v| v.value),
+    );
 }
 
-// test_preset_value creates a new variable called "test_preset"
-// with a preset spec, and then makes sure we can call `with`
-// on it with a preset, ensuring the IntoMlxValue trait is working
-// as expected for presets (among other things).
+// preset_values_respect_the_max migrates the old preset test onto `Outcome`: an
+// in-range u8 yields a Preset, an out-of-range one fails. We don't pin which error
+// the out-of-range case produces, so `Fails` says exactly that.
 #[test]
-fn test_preset_value() {
+fn preset_values_respect_the_max() {
     let var = create_test_variable("test_preset", MlxVariableSpec::Preset { max_preset: 5 });
 
-    // u8 gets automatically converted to preset with validation.
-    let valid_value = var.with(3u8).unwrap();
-    assert_eq!(valid_value.value, MlxValueType::Preset(3));
-
-    // Out of range preset.
-    let invalid_result = var.with(10u8);
-    assert!(invalid_result.is_err());
+    check_cases(
+        [
+            Case {
+                scenario: "in range",
+                input: 3u8,
+                expect: Yields(MlxValueType::Preset(3)),
+            },
+            Case {
+                scenario: "above the max",
+                input: 10u8,
+                expect: Fails,
+            },
+        ],
+        |input| var.with(input).map(|v| v.value),
+    );
 }
 
-// test_boolean_array_creation creates a new variable called "test_bool_array"
-// with a boolean array spec, and then makes sure we can call `with`
-// on it with a boolean array, ensuring the IntoMlxValue trait is working
-// as expected for boolean arrays (among other things).
+// boolean_arrays_validate_size_and_convert migrates the bool-array test onto
+// check_cases. The valid row shows `Yields` carrying real data — a dense Vec<bool>
+// is converted to the sparse BooleanArray form — while a wrong-sized input fails.
 #[test]
-fn test_boolean_array_creation() {
+fn boolean_arrays_validate_size_and_convert() {
     let var = create_test_variable("test_bool_array", MlxVariableSpec::BooleanArray { size: 4 });
 
-    // Vec<bool> gets automatically validated for size and converted to sparse format.
-    let valid_value = var.with(vec![true, false, true, false]).unwrap();
-    assert_eq!(
-        valid_value.value,
-        MlxValueType::BooleanArray(vec![Some(true), Some(false), Some(true), Some(false)])
+    check_cases(
+        [
+            Case {
+                scenario: "a right-sized Vec<bool> converts to the sparse form",
+                input: vec![true, false, true, false],
+                expect: Yields(MlxValueType::BooleanArray(vec![
+                    Some(true),
+                    Some(false),
+                    Some(true),
+                    Some(false),
+                ])),
+            },
+            Case {
+                scenario: "a wrong-sized input is rejected",
+                input: vec![true, false],
+                expect: Fails,
+            },
+        ],
+        |input| var.with(input).map(|v| v.value),
     );
-
-    // Wrong size gets caught.
-    let invalid_result = var.with(vec![true, false]);
-    assert!(invalid_result.is_err());
 }
 
 // test_sparse_boolean_array_creation tests creating sparse boolean arrays

--- a/crates/site-explorer/Cargo.toml
+++ b/crates/site-explorer/Cargo.toml
@@ -58,6 +58,7 @@ carbide-api-model = { path = "../api-model", default-features = false, features 
 carbide-test-harness = { path = "../test-harness" }
 carbide-redfish = { path = "../redfish", features = ["test-support"] }
 carbide-rpc = { path = "../rpc", features = ["test-support"] }
+nico-test-support = { path = "../test-support" }
 
 tokio = { workspace = true, features = ["macros", "rt"] }
 tonic = { workspace = true }

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -3144,6 +3144,8 @@ fn should_alert_power_state(power_state: PowerState) -> bool {
 mod tests {
     use config_version::ConfigVersion;
     use model::site_explorer::PreingestionState;
+    use nico_test_support::Outcome::*;
+    use nico_test_support::{Case, check_cases};
 
     use super::*;
 
@@ -3272,10 +3274,11 @@ mod tests {
 
     #[test]
     fn test_find_host_pf_mac_address() {
-        let ep_report: EndpointExplorationReport = load_bf2_ep_report();
-        let ep = ExploredEndpoint {
+        // A freshly-loaded BF2 endpoint; each case starts from one of these and
+        // perturbs the firmware inventory the legacy MAC lookup reads from.
+        let endpoint = || ExploredEndpoint {
             address: "10.217.132.202".parse().unwrap(),
-            report: ep_report,
+            report: load_bf2_ep_report(),
             report_version: ConfigVersion::initial(),
             preingestion_state: PreingestionState::Initial,
             waiting_for_explorer_refresh: false,
@@ -3290,73 +3293,72 @@ mod tests {
             boot_interface_id: None,
         };
 
-        assert_eq!(
-            find_host_pf_mac_address(&ep).unwrap(),
-            "B8:3F:D2:90:95:F4".parse().unwrap()
-        );
+        // Override the `DPU_SYS_IMAGE` firmware version the legacy path parses.
+        let with_sys_image = |version: &str| {
+            let mut ep = endpoint();
+            let inv = ep
+                .report
+                .service
+                .iter_mut()
+                .find(|s| s.id == "FirmwareInventory")
+                .unwrap()
+                .inventories
+                .iter_mut()
+                .find(|inv| inv.id == "DPU_SYS_IMAGE")
+                .unwrap();
+            inv.version = Some(version.to_string());
+            ep
+        };
 
-        // Invalid DPU_SYS_IMAGE field
-        let mut ep1 = ep.clone();
-        let update_service = ep1
-            .report
-            .service
-            .iter_mut()
-            .find(|s| s.id == "FirmwareInventory")
-            .unwrap();
-        let inv = update_service
-            .inventories
-            .iter_mut()
-            .find(|inv| inv.id == "DPU_SYS_IMAGE")
-            .unwrap();
-        inv.version = Some("b83f:d203:0090:95fz".to_string());
-        assert_eq!(
-            find_host_pf_mac_address(&ep1),
-            Err("Failed to build sanitized MAC from legacy/service MAC: Invalid stripped MAC length: 11 (input: b83fd29095fz, output: b83fd29095f) (source_mac: b83fd29095fz)".to_string())
-        );
+        // Drop the firmware-inventory entry whose `id` matches `inventory_id`.
+        let without_inventory = |inventory_id: &str| {
+            let mut ep = endpoint();
+            ep.report
+                .service
+                .iter_mut()
+                .find(|s| s.id == "FirmwareInventory")
+                .unwrap()
+                .inventories
+                .retain(|inv| inv.id != inventory_id);
+            ep
+        };
 
-        // Invalid DPU_SYS_IMAGE field
-        let mut ep1 = ep.clone();
-        let update_service = ep1
-            .report
-            .service
-            .iter_mut()
-            .find(|s| s.id == "FirmwareInventory")
-            .unwrap();
-        let inv = update_service
-            .inventories
-            .iter_mut()
-            .find(|inv| inv.id == "DPU_SYS_IMAGE")
-            .unwrap();
-        inv.version = Some("abc".to_string());
-        assert_eq!(
-            find_host_pf_mac_address(&ep1),
-            Err("Invalid sys_image_version length: 3 (abc)".to_string())
-        );
+        // Drop the whole `FirmwareInventory` service.
+        let without_firmware_inventory = || {
+            let mut ep = endpoint();
+            ep.report.service.retain(|s| s.id != "FirmwareInventory");
+            ep
+        };
 
-        // Missing DPU_SYS_IMAGE field
-        let mut ep1 = ep.clone();
-        let update_service = ep1
-            .report
-            .service
-            .iter_mut()
-            .find(|s| s.id == "FirmwareInventory")
-            .unwrap();
-        update_service
-            .inventories
-            .retain_mut(|inv| inv.id != "DPU_SYS_IMAGE");
-        assert_eq!(
-            find_host_pf_mac_address(&ep1),
-            Err("Missing DPU_SYS_IMAGE".to_string())
-        );
-
-        // Missing FirmwareInventory field
-        let mut ep1 = ep;
-        ep1.report
-            .service
-            .retain_mut(|inv| inv.id != "FirmwareInventory");
-        assert_eq!(
-            find_host_pf_mac_address(&ep1),
-            Err("Missing FirmwareInventory".to_string())
+        check_cases(
+            [
+                Case {
+                    scenario: "legacy sys-image MAC, sanitized",
+                    input: endpoint(),
+                    expect: Yields("B8:3F:D2:90:95:F4".parse().unwrap()),
+                },
+                Case {
+                    scenario: "legacy sys-image MAC fails sanitization",
+                    input: with_sys_image("b83f:d203:0090:95fz"),
+                    expect: FailsWith("Failed to build sanitized MAC from legacy/service MAC: Invalid stripped MAC length: 11 (input: b83fd29095fz, output: b83fd29095f) (source_mac: b83fd29095fz)".to_string()),
+                },
+                Case {
+                    scenario: "legacy sys-image is too short",
+                    input: with_sys_image("abc"),
+                    expect: FailsWith("Invalid sys_image_version length: 3 (abc)".to_string()),
+                },
+                Case {
+                    scenario: "no DPU_SYS_IMAGE inventory",
+                    input: without_inventory("DPU_SYS_IMAGE"),
+                    expect: FailsWith("Missing DPU_SYS_IMAGE".to_string()),
+                },
+                Case {
+                    scenario: "no FirmwareInventory service",
+                    input: without_firmware_inventory(),
+                    expect: FailsWith("Missing FirmwareInventory".to_string()),
+                },
+            ],
+            |ep| find_host_pf_mac_address(&ep),
         );
     }
 

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -1,0 +1,29 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+[package]
+name = "nico-test-support"
+version = "0.0.0"
+edition.workspace = true
+description = "A tiny, zero-dependency crate for making table-driven tests."
+license.workspace = true
+authors.workspace = true
+
+[lib]
+name = "nico_test_support"
+
+[lints]
+workspace = true

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -1,0 +1,224 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Tiny, zero-dependency helpers for making table-driven tests.
+//!
+//! Write a test as a list of labeled cases — each a `scenario`, an `input`, and an
+//! `expect`ed result — then run them all through one operation, written once.
+//! [`check_cases`] does the running and the asserting, [`Outcome`] is what a
+//! fallible operation should produce, and [`Case`] is one row.
+//!
+//! # A table of cases
+//!
+//! ```
+//! use nico_test_support::Outcome::*;
+//! use nico_test_support::{Case, check_cases};
+//!
+//! check_cases(
+//!     [
+//!         Case {
+//!             scenario: "valid",
+//!             input: "42",
+//!             expect: Yields(42),
+//!         },
+//!         Case {
+//!             scenario: "not numeric",
+//!             input: "x",
+//!             expect: Fails,
+//!         },
+//!         Case {
+//!             scenario: "out of range",
+//!             input: "999",
+//!             expect: FailsWith("bad byte: 999".to_string()),
+//!         },
+//!     ],
+//!     // the operation under test, written once:
+//!     |s| s.parse::<u8>().map_err(|_| format!("bad byte: {s}")),
+//! );
+//! ```
+//!
+//! # A single case
+//!
+//! A one-off test is just one [`Case`]; `.check(run)` is the single-row
+//! counterpart to [`check_cases`]:
+//!
+//! ```
+//! use nico_test_support::Case;
+//! use nico_test_support::Outcome::*;
+//!
+//! Case {
+//!     scenario: "in range",
+//!     input: "42",
+//!     expect: Yields(42),
+//! }
+//! .check(|s| s.parse::<u8>().map_err(|_| ()));
+//! ```
+//!
+//! # What's shared, and what stays a convention
+//!
+//! [`Outcome`] is the one piece worth sharing — every fallible test otherwise
+//! re-invents the same "succeeds / fails / fails-with-a-specific-error" enum. There
+//! is deliberately no macro: that's a last-mile crystallization, not a starting
+//! point. And when a row carries several inputs or expected values, a *local*
+//! `struct Case` with content-named fields plus [`assert_outcome`] reads better
+//! than forcing it through the generic [`Case`] here — so that stays a convention,
+//! not a type.
+
+use std::fmt::Debug;
+
+/// The expected result of a fallible operation under test.
+///
+/// Pick the most specific variant that still says what you mean: [`Fails`] when
+/// you only care *that* it errors, [`FailsWith`] when the exact error is part of
+/// the contract.
+///
+/// [`Fails`]: Outcome::Fails
+/// [`FailsWith`]: Outcome::FailsWith
+#[derive(Debug)]
+pub enum Outcome<T, E> {
+    /// Succeeds, yielding this value.
+    Yields(T),
+    /// Fails — the specific error doesn't matter to this case.
+    Fails,
+    /// Fails with exactly this error.
+    FailsWith(E),
+}
+
+/// One row of a table test: a labeled `input` and its expected [`Outcome`].
+///
+/// For rows with more than a single input (or several expected values), prefer a
+/// *local* `struct Case` whose fields are named for their contents.
+pub struct Case<I, T, E> {
+    /// What this row exercises; used as the failure label.
+    pub scenario: &'static str,
+    /// The input handed to the operation under test.
+    pub input: I,
+    /// What the operation should produce.
+    pub expect: Outcome<T, E>,
+}
+
+impl<I, T, E> Case<I, T, E> {
+    /// Run this case's `input` through `run` and assert its [`Outcome`], naming a
+    /// failure by `scenario`. The single-row counterpart to [`check_cases`] — for
+    /// a test that is one labeled input and one expected result.
+    pub fn check(self, run: impl FnOnce(I) -> Result<T, E>)
+    where
+        T: PartialEq + Debug,
+        E: PartialEq + Debug,
+    {
+        assert_outcome(run(self.input), self.expect, self.scenario);
+    }
+}
+
+/// Run each case's `input` through `run` and assert its [`Outcome`]. `run` is the
+/// operation under test, written once.
+pub fn check_cases<I, T, E>(
+    cases: impl IntoIterator<Item = Case<I, T, E>>,
+    run: impl Fn(I) -> Result<T, E>,
+) where
+    T: PartialEq + Debug,
+    E: PartialEq + Debug,
+{
+    for case in cases {
+        case.check(&run);
+    }
+}
+
+/// Assert that `got` matches the expected [`Outcome`], attributing any mismatch to
+/// `scenario`. This is the primitive [`Case::check`] and [`check_cases`] are built
+/// on — reach for it directly when a case needs a hand-written body.
+pub fn assert_outcome<T, E>(got: Result<T, E>, expect: Outcome<T, E>, scenario: &str)
+where
+    T: PartialEq + Debug,
+    E: PartialEq + Debug,
+{
+    use Outcome::*;
+    match (got, expect) {
+        (Ok(got), Yields(want)) => assert_eq!(got, want, "{scenario}"),
+        (Err(_), Fails) => {}
+        (Err(got), FailsWith(want)) => assert_eq!(got, want, "{scenario}"),
+        (got, expect) => panic!("{scenario}: got {got:?}, but expected {expect:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Outcome::*;
+    use super::{Case, assert_outcome, check_cases};
+
+    #[test]
+    fn check_runs_a_single_case() {
+        Case {
+            scenario: "doubles",
+            input: 21u8,
+            expect: Yields(42),
+        }
+        .check(|n| n.checked_mul(2).ok_or(()));
+    }
+
+    #[test]
+    fn check_cases_runs_every_row() {
+        check_cases(
+            [
+                Case {
+                    scenario: "doubles",
+                    input: 2u8,
+                    expect: Yields(4),
+                },
+                Case {
+                    scenario: "overflows",
+                    input: 200u8,
+                    expect: Fails,
+                },
+            ],
+            |n| n.checked_mul(2).ok_or("overflow"),
+        );
+    }
+
+    #[test]
+    fn assert_outcome_matches_each_variant() {
+        assert_outcome(Ok::<_, String>(7), Yields(7), "yields the value");
+        assert_outcome(Err::<u8, _>("boom".to_string()), Fails, "fails, any error");
+        assert_outcome(
+            Err::<u8, _>("nope".to_string()),
+            FailsWith("nope".to_string()),
+            "fails with the exact error",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "wanted a value")]
+    fn flags_an_unexpected_error() {
+        assert_outcome(Err::<u8, _>("x".to_string()), Yields(1), "wanted a value");
+    }
+
+    #[test]
+    #[should_panic(expected = "wanted a failure")]
+    fn flags_an_unexpected_success() {
+        assert_outcome(Ok::<_, String>(1), Fails, "wanted a failure");
+    }
+
+    #[test]
+    #[should_panic(expected = "wanted the other error")]
+    fn flags_the_wrong_error() {
+        assert_outcome(
+            Err::<u8, _>("a".to_string()),
+            FailsWith("b".to_string()),
+            "wanted the other error",
+        );
+    }
+}


### PR DESCRIPTION
This supports #3914.

## Description

This introduces a tiny (zero dependency!) crate called `nico-test-support` for making table-driven tests/test cases, with an example worked into each of five crates so the approach is easy to see.

We don't have to use it everywhere (or at all), but it might give us a platform

My hope here is that we can:
1. Cut down on the number of tests.
2. Make it easy to define/structure new tests.
3. Make useful tests.
4. Adopt this in a way that we maintain test coverage, and then use it to drive even better test coverage!

A test is a list of labeled cases. Each `Case` is `{ scenario, input, expect }`. `check_cases` feeds every input through ONE operation — written once, as a closure — and checks the result against that case's expected `Outcome`:

```
    each Case = { scenario, input, expect }

          input  →  run(input)  →  Result<value, error>
                                          │
                                          ▼
                                does it match `expect`?
                                          │
                        ✓ pass   /   ✗ fail   (labeled by scenario)
```

`Outcome<T, E>` is the one shared piece — every fallible test otherwise re-invents the same enum:

  - `Yields(value)`  — succeeds with this value
  - `Fails`          — fails, error unspecified
  - `FailsWith(err)` — fails with exactly this error

So a table reads like a spec:

```
    check_cases(
        [
            Case { scenario: "a valid option",    input: "medium",  expect: Yields(..) },
            Case { scenario: "an unknown option", input: "invalid", expect: FailsWith(..) },
        ],
        |input| var.with(input).map(|v| v.value),   // the operation under test, written once
    );
```

A one-off test is just one case — `.check` is the single-row form:

```
    Case { scenario: "in range", input: "42", expect: Yields(42) }
        .check(|s| s.parse::<u8>().map_err(|_| ()));
```

`Outcome` / `Case` / `check_cases` are plain generics. A macro is the last-mile crystallization, not the first PR. And when a row has several inputs or expected values, a *local* `struct Case` with content-named fields + `assert_outcome` (the primitive `check_cases` is built on) reads better than forcing it through the generic — so that stays a convention, not a type.

  - `libmlx`        — enum / preset / bool-array value validation
  - `api-model`     — BuildVersion parsing (`Yields` carrying parsed structs)
  - `api-core`      — linknet prefix host-end vs DPU-end validation
  - `api-db`        — IPv6 prefix expansion, size boundary
  - `site-explorer` — host PF MAC resolution (the full `Yields` + `FailsWith` demo)

Green: the crate's tests + doctests, and each adopter's flipped test.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->