### PR TITLE
fix: IpAddr-typed explored endpoint addresses for linked expected components

### DIFF
--- a/crates/api-core/src/tests/expected_switch.rs
+++ b/crates/api-core/src/tests/expected_switch.rs
@@ -926,6 +926,40 @@ async fn test_find_all_linked_joins_on_bmc_mac(pool: sqlx::PgPool) {
     );
 }
 
+#[crate::sqlx_test]
+async fn test_find_one_linked_returns_explored_endpoint_address(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    create_expected_switches(&mut txn).await;
+
+    let linked = db::expected_switch::find_one_linked(&mut txn)
+        .await
+        .unwrap()
+        .expect("expected a linked switch row");
+    assert_eq!(linked.address, None);
+
+    let address =
+        db::machine_interface::lookup_bmc_ip_by_mac_address(&mut *txn, linked.bmc_mac_address)
+            .await
+            .unwrap()
+            .into_iter()
+            .next()
+            .expect("expected a BMC interface address");
+
+    db::explored_endpoints::insert(address, &Default::default(), false, &mut txn)
+        .await
+        .unwrap();
+
+    let linked = db::expected_switch::find_one_linked(&mut txn)
+        .await
+        .unwrap()
+        .expect("expected a linked switch row");
+    assert_eq!(linked.address, Some(address));
+
+    txn.commit().await.unwrap();
+}
+
 /// Verify that update persists nvos_mac_addresses.
 #[crate::sqlx_test]
 async fn test_update_persists_nvos_mac_addresses(pool: sqlx::PgPool) {

--- a/crates/api-db/src/expected_machine.rs
+++ b/crates/api-db/src/expected_machine.rs
@@ -113,7 +113,7 @@ pub async fn find_one_linked(
  em.serial_number,
  em.bmc_mac_address,
  mi.id AS interface_id,
- host(ee.address) AS address,
+ ee.address AS address,
  mi.machine_id,
  em.id AS expected_machine_id
 FROM expected_machines em
@@ -157,7 +157,7 @@ pub async fn find_all_linked(txn: impl DbReader<'_>) -> DatabaseResult<Vec<Linke
  em.serial_number,
  em.bmc_mac_address,
  mi.id AS interface_id,
- host(ee.address) AS address,
+ ee.address AS address,
  mi.machine_id,
  em.id AS expected_machine_id
 FROM expected_machines em

--- a/crates/api-db/src/expected_power_shelf.rs
+++ b/crates/api-db/src/expected_power_shelf.rs
@@ -115,7 +115,7 @@ pub async fn find_all_linked(
  eps.bmc_mac_address,
  ps.id AS power_shelf_id,
  eps.expected_power_shelf_id,
- host(ee.address) AS address,
+ ee.address AS address,
  eps.rack_id
 FROM expected_power_shelves eps
  LEFT JOIN power_shelves ps ON eps.serial_number = ps.config->>'name'

--- a/crates/api-db/src/expected_switch.rs
+++ b/crates/api-db/src/expected_switch.rs
@@ -149,7 +149,7 @@ pub async fn find_all_linked(txn: &mut PgConnection) -> DatabaseResult<Vec<Linke
   es.bmc_mac_address,
   s.id AS switch_id,
   es.expected_switch_id,
-  host(ee.address) AS address,
+  ee.address AS address,
   es.rack_id
  FROM expected_switches es
   LEFT JOIN switches s ON es.bmc_mac_address = s.bmc_mac_address
@@ -172,9 +172,21 @@ pub async fn find_one_linked(
   es.serial_number,
   es.bmc_mac_address,
   s.id AS switch_id,
-  es.expected_switch_id
+  es.expected_switch_id,
+  linked_endpoint.address AS address,
+  es.rack_id
  FROM expected_switches es
   LEFT JOIN switches s ON es.bmc_mac_address = s.bmc_mac_address
+  LEFT JOIN LATERAL (
+   SELECT ee.address
+   FROM machine_interfaces mi
+    JOIN machine_interface_addresses mia ON mi.id = mia.interface_id
+    JOIN explored_endpoints ee ON mia.address = ee.address
+   WHERE mi.mac_address = es.bmc_mac_address
+   -- Keep this single-row lookup deterministic if a MAC has multiple explored addresses.
+   ORDER BY ee.address
+   LIMIT 1
+  ) linked_endpoint ON true
   ORDER BY es.bmc_mac_address
  LIMIT 1
  "#;

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -225,7 +225,7 @@ pub struct LinkedExpectedMachine {
     pub serial_number: String,
     pub bmc_mac_address: MacAddress, // from expected_machines table
     pub interface_id: Option<MachineInterfaceId>, // from machine_interfaces table
-    pub address: Option<String>,     // The explored endpoint
+    pub address: Option<IpAddr>,     // The explored endpoint
     pub machine_id: Option<MachineId>, // The machine
     pub expected_machine_id: Option<Uuid>, // The expected machine ID
 }

--- a/crates/api-model/src/expected_power_shelf.rs
+++ b/crates/api-model/src/expected_power_shelf.rs
@@ -75,7 +75,7 @@ pub struct LinkedExpectedPowerShelf {
     pub bmc_mac_address: MacAddress, // from expected_power_shelves table
     pub power_shelf_id: Option<PowerShelfId>, // The power shelf
     pub expected_power_shelf_id: Option<Uuid>, // The expected power shelf ID
-    pub address: Option<String>,     // The explored BMC endpoint IP
+    pub address: Option<IpAddr>,     // The explored BMC endpoint IP
     pub rack_id: Option<RackId>,     // The rack this power shelf belongs to
 }
 

--- a/crates/api-model/src/expected_switch.rs
+++ b/crates/api-model/src/expected_switch.rs
@@ -93,7 +93,7 @@ pub struct LinkedExpectedSwitch {
     pub bmc_mac_address: MacAddress, // from expected_switches table
     pub switch_id: Option<SwitchId>, // The switch
     pub expected_switch_id: Option<Uuid>, // The expected switch ID
-    pub address: Option<String>,     // The explored BMC endpoint IP
+    pub address: Option<IpAddr>,     // The explored BMC endpoint IP
     pub rack_id: Option<RackId>,     // The rack this switch belongs to
 }
 

--- a/crates/rpc/src/model/expected_machine.rs
+++ b/crates/rpc/src/model/expected_machine.rs
@@ -172,7 +172,7 @@ impl From<LinkedExpectedMachine> for rpc::forge::LinkedExpectedMachine {
             chassis_serial_number: m.serial_number,
             bmc_mac_address: m.bmc_mac_address.to_string(),
             interface_id: m.interface_id.map(|u| u.to_string()),
-            explored_endpoint_address: m.address,
+            explored_endpoint_address: m.address.map(|addr| addr.to_string()),
             machine_id: m.machine_id,
             expected_machine_id: m.expected_machine_id.map(|id| crate::common::Uuid {
                 value: id.to_string(),

--- a/crates/rpc/src/model/expected_power_shelf.rs
+++ b/crates/rpc/src/model/expected_power_shelf.rs
@@ -118,7 +118,7 @@ impl From<LinkedExpectedPowerShelf> for rpc::forge::LinkedExpectedPowerShelf {
             expected_power_shelf_id: l.expected_power_shelf_id.map(|id| crate::common::Uuid {
                 value: id.to_string(),
             }),
-            explored_endpoint_address: l.address,
+            explored_endpoint_address: l.address.map(|addr| addr.to_string()),
             rack_id: l.rack_id,
         }
     }

--- a/crates/rpc/src/model/expected_switch.rs
+++ b/crates/rpc/src/model/expected_switch.rs
@@ -145,7 +145,7 @@ impl From<LinkedExpectedSwitch> for rpc::forge::LinkedExpectedSwitch {
             expected_switch_id: l.expected_switch_id.map(|id| crate::common::Uuid {
                 value: id.to_string(),
             }),
-            explored_endpoint_address: l.address,
+            explored_endpoint_address: l.address.map(|addr| addr.to_string()),
             rack_id: l.rack_id,
         }
     }


### PR DESCRIPTION
## Description

In doing some work to type linked endpoint addresses as `IpAddr`, I noticed `expected_switch::find_one_linked` did not return the explored endpoint address that `expected_machine::find_one_linked` and both variants of `find_all_linked` returns. This fixes that lookup while also keeping linked endpoint addresses typed as `IpAddr` after `sqlx` decodes the `inet` values.

RPC layer still converts them to strings for clients.

Primary callouts are:
- `LinkedExpectedMachine`, `LinkedExpectedPowerShelf`, and `LinkedExpectedSwitch` now have `IpAddr`-typed endpoint addresses.
- The linked lookup queries select `ee.address` directly so `sqlx` can decode the `inet` value (and give us `IpAddr`).
- `expected_switch::find_one_linked` now returns an explored endpoint address too, while still returning one switch row.

Tests added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

