### PR TITLE
fix: strongly type LLDP management addresses as IpAddr

### DIFF
--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -19,6 +19,7 @@
 
 use std::fmt;
 use std::fmt::{Display, Formatter};
+use std::net::IpAddr;
 use std::str::FromStr;
 
 use base64::prelude::*;
@@ -159,10 +160,25 @@ pub struct LldpSwitchData {
     pub description: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub local_port: String,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub ip_address: Vec<String>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_ip_addr_vec_lossy",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub ip_address: Vec<IpAddr>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub remote_port: String,
+}
+
+fn deserialize_ip_addr_vec_lossy<'de, D>(deserializer: D) -> Result<Vec<IpAddr>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<Vec<String>>::deserialize(deserializer)?
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|address| address.parse::<IpAddr>().ok())
+        .collect())
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -407,6 +423,33 @@ mod tests {
             json,
             r#"{"components":[{"name":"foo","version":"1.0","url":""},{"name":"bar","version":"2.0","url":"nvidia.com"}]}"#
         );
+    }
+
+    #[test]
+    fn lldp_switch_data_filters_invalid_management_addresses() {
+        let json = r#"{
+            "ip_address": [
+                "192.0.2.10",
+                "not-an-ip",
+                "2001:db8::1"
+            ]
+        }"#;
+        let switch: LldpSwitchData = serde_json::from_str(json).unwrap();
+
+        assert_eq!(
+            switch.ip_address,
+            vec![
+                "192.0.2.10".parse::<IpAddr>().unwrap(),
+                "2001:db8::1".parse::<IpAddr>().unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn lldp_switch_data_defaults_null_management_addresses() {
+        let switch: LldpSwitchData = serde_json::from_str(r#"{"ip_address":null}"#).unwrap();
+
+        assert!(switch.ip_address.is_empty());
     }
 
     #[test]

--- a/crates/host-support/src/hardware_enumeration/dpu.rs
+++ b/crates/host-support/src/hardware_enumeration/dpu.rs
@@ -16,6 +16,7 @@
  */
 
 use std::collections::HashMap;
+use std::net::IpAddr;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
@@ -63,7 +64,7 @@ pub struct LldpChassisData {
     pub descr: String,
     #[serde(rename = "mgmt-ip", default)]
     #[serde_as(as = "OneOrMany<_>")]
-    pub management_ip_address: Vec<String>, // we get an array with ipv4 and ipv6 addresses
+    pub management_ip_address: Vec<IpAddr>, // we get an array with ipv4 and ipv6 addresses
     #[serde(default)]
     pub capability: Vec<LldpCapabilityData>,
 }
@@ -178,7 +179,11 @@ pub fn get_port_lldp_info(port: &str) -> Result<LldpSwitchData, DpuEnumerationEr
             lldp_info.local_port = port.to_string();
 
             // management_ip_address if missing we just replace it with empty list.
-            lldp_info.ip_address = tor_data.management_ip_address.clone();
+            lldp_info.ip_address = tor_data
+                .management_ip_address
+                .iter()
+                .map(|ip| ip.to_string())
+                .collect();
         }
         lldp_info.remote_port =
             format!("{}={}", lldp_data.port.id.id_type, lldp_data.port.id.value);

--- a/crates/rpc/src/model/hardware_info.rs
+++ b/crates/rpc/src/model/hardware_info.rs
@@ -183,7 +183,14 @@ impl TryFrom<rpc::machine_discovery::LldpSwitchData> for LldpSwitchData {
             id: data.id,
             description: data.description,
             local_port: data.local_port,
-            ip_address: data.ip_address,
+            ip_address: data
+                .ip_address
+                .into_iter()
+                .map(|ip| {
+                    ip.parse()
+                        .map_err(|_| RpcDataConversionError::InvalidIpAddress(ip))
+                })
+                .collect::<Result<Vec<_>, _>>()?,
             remote_port: data.remote_port,
         })
     }
@@ -198,7 +205,11 @@ impl TryFrom<LldpSwitchData> for rpc::machine_discovery::LldpSwitchData {
             id: data.id,
             description: data.description,
             local_port: data.local_port,
-            ip_address: data.ip_address,
+            ip_address: data
+                .ip_address
+                .into_iter()
+                .map(|ip| ip.to_string())
+                .collect(),
             remote_port: data.remote_port,
         })
     }


### PR DESCRIPTION
## Description

This parses LLDP management addresses into `IpAddr` when we deserialize LLDP data and keeps the API model typed. The generated protobuf remains string-based for discovery reports.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

