### PR TITLE
fix(dpf): strongly type DPF BMC addresses as IpAddr

### DIFF
--- a/crates/dpf/src/bin/api_harness.rs
+++ b/crates/dpf/src/bin/api_harness.rs
@@ -21,6 +21,7 @@
 //! provisioning flows.
 
 use std::io::Read;
+use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -212,7 +213,7 @@ enum Commands {
 
 struct DpuConfig {
     device_name: String,
-    dpu_bmc_ip: String,
+    dpu_bmc_ip: IpAddr,
     serial_number: String,
 }
 
@@ -253,7 +254,9 @@ fn parse_dpus(dpus: &str) -> Result<Vec<DpuConfig>, String> {
             }
             Ok(DpuConfig {
                 device_name: parts[0].to_string(),
-                dpu_bmc_ip: parts[1].to_string(),
+                dpu_bmc_ip: parts[1]
+                    .parse()
+                    .map_err(|_| format!("Invalid DPU BMC IP '{}'", parts[1]))?,
                 serial_number: parts[2].to_string(),
             })
         })
@@ -702,6 +705,7 @@ async fn run_provisioning_flow(
     services: &[ServiceDefinition],
 ) -> Result<(), Box<dyn std::error::Error>> {
     let dpus = parse_dpus(dpus_str)?;
+    let host_bmc_ip_addr: IpAddr = host_bmc_ip.parse()?;
     let timeout = Duration::from_secs(timeout_secs);
 
     tracing::info!("=== DPF Provisioning Flow ===");
@@ -720,8 +724,8 @@ async fn run_provisioning_flow(
     for dpu in &dpus {
         let info = DpuDeviceInfo {
             device_id: dpu.device_name.clone(),
-            dpu_bmc_ip: dpu.dpu_bmc_ip.clone(),
-            host_bmc_ip: host_bmc_ip.to_string(),
+            dpu_bmc_ip: dpu.dpu_bmc_ip,
+            host_bmc_ip: host_bmc_ip_addr,
             serial_number: dpu.serial_number.clone(),
             dpu_machine_id: String::new(),
             is_primary: true,
@@ -733,7 +737,7 @@ async fn run_provisioning_flow(
     tracing::info!("[3/4] Registering DPU node...");
     let node_info = DpuNodeInfo {
         node_id: node_id.to_string(),
-        host_bmc_ip: host_bmc_ip.to_string(),
+        host_bmc_ip: host_bmc_ip_addr,
         device_ids: dpus.iter().map(|d| d.device_name.clone()).collect(),
     };
     sdk.register_dpu_node(node_info).await?;

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -1190,7 +1190,7 @@ impl<R: DpuDeviceRepository, L: ResourceLabeler> DpfSdk<R, L> {
                 ..Default::default()
             },
             spec: DpuDeviceSpec {
-                bmc_ip: Some(info.dpu_bmc_ip),
+                bmc_ip: Some(info.dpu_bmc_ip.to_string()),
                 bmc_port: Some(443),
                 number_of_p_fs: Some(1),
                 opn: None,
@@ -2139,8 +2139,8 @@ mod tests {
 
         let info = DpuDeviceInfo {
             device_id: "dpu-001".to_string(),
-            dpu_bmc_ip: "10.0.0.10".to_string(),
-            host_bmc_ip: "10.0.0.1".to_string(),
+            dpu_bmc_ip: "10.0.0.10".parse().unwrap(),
+            host_bmc_ip: "10.0.0.1".parse().unwrap(),
             serial_number: "SN123456".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
             is_primary: true,
@@ -2165,7 +2165,7 @@ mod tests {
 
         let info = DpuNodeInfo {
             node_id: "host-001".to_string(),
-            host_bmc_ip: "10.0.0.1".to_string(),
+            host_bmc_ip: "10.0.0.1".parse().unwrap(),
             device_ids: vec!["dpu-001".to_string(), "dpu-002".to_string()],
         };
 
@@ -2189,8 +2189,8 @@ mod tests {
 
         let info = DpuDeviceInfo {
             device_id: "dpu-001".to_string(),
-            dpu_bmc_ip: "10.0.0.10".to_string(),
-            host_bmc_ip: "10.0.0.1".to_string(),
+            dpu_bmc_ip: "10.0.0.10".parse().unwrap(),
+            host_bmc_ip: "10.0.0.1".parse().unwrap(),
             serial_number: "SN123456".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
             is_primary: true,
@@ -2221,7 +2221,7 @@ mod tests {
 
         let info = DpuNodeInfo {
             node_id: "host-001".to_string(),
-            host_bmc_ip: "10.0.0.1".to_string(),
+            host_bmc_ip: "10.0.0.1".parse().unwrap(),
             device_ids: vec!["dpu-001".to_string()],
         };
 
@@ -2246,7 +2246,7 @@ mod tests {
         fn device_labels(&self, info: &DpuDeviceInfo) -> BTreeMap<String, String> {
             BTreeMap::from([
                 ("test/device".to_string(), "true".to_string()),
-                ("test/host-bmc-ip".to_string(), info.host_bmc_ip.clone()),
+                ("test/host-bmc-ip".to_string(), info.host_bmc_ip.to_string()),
                 (
                     "test/dpu-machine-id".to_string(),
                     info.dpu_machine_id.clone(),
@@ -2274,8 +2274,8 @@ mod tests {
 
         let info = DpuDeviceInfo {
             device_id: "dpu-001".to_string(),
-            dpu_bmc_ip: "10.0.0.10".to_string(),
-            host_bmc_ip: "10.0.0.1".to_string(),
+            dpu_bmc_ip: "10.0.0.10".parse().unwrap(),
+            host_bmc_ip: "10.0.0.1".parse().unwrap(),
             serial_number: "SN123456".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
             is_primary: true,
@@ -2310,8 +2310,8 @@ mod tests {
 
         let info = DpuDeviceInfo {
             device_id: "dpu-001".to_string(),
-            dpu_bmc_ip: "10.0.0.10".to_string(),
-            host_bmc_ip: "10.0.0.1".to_string(),
+            dpu_bmc_ip: "10.0.0.10".parse().unwrap(),
+            host_bmc_ip: "10.0.0.1".parse().unwrap(),
             serial_number: "SN123456".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
             is_primary: true,
@@ -2337,7 +2337,7 @@ mod tests {
 
         let info = DpuNodeInfo {
             node_id: "host-001".to_string(),
-            host_bmc_ip: "10.0.0.1".to_string(),
+            host_bmc_ip: "10.0.0.1".parse().unwrap(),
             device_ids: vec!["dpu-001".to_string()],
         };
 
@@ -2362,7 +2362,7 @@ mod tests {
 
         let info = DpuNodeInfo {
             node_id: "host-001".to_string(),
-            host_bmc_ip: "10.0.0.1".to_string(),
+            host_bmc_ip: "10.0.0.1".parse().unwrap(),
             device_ids: vec!["dpu-001".to_string()],
         };
 
@@ -2427,8 +2427,8 @@ mod tests {
 
         let device_info = DpuDeviceInfo {
             device_id: "dpu-001".to_string(),
-            dpu_bmc_ip: "10.0.0.10".to_string(),
-            host_bmc_ip: "10.0.0.1".to_string(),
+            dpu_bmc_ip: "10.0.0.10".parse().unwrap(),
+            host_bmc_ip: "10.0.0.1".parse().unwrap(),
             serial_number: "SN123".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
             is_primary: true,
@@ -2524,8 +2524,8 @@ mod tests {
 
         let info1 = DpuDeviceInfo {
             device_id: "dpu-001".to_string(),
-            dpu_bmc_ip: "10.0.0.10".to_string(),
-            host_bmc_ip: "10.0.0.1".to_string(),
+            dpu_bmc_ip: "10.0.0.10".parse().unwrap(),
+            host_bmc_ip: "10.0.0.1".parse().unwrap(),
             serial_number: "SN111".to_string(),
             dpu_machine_id: "dpu-111".to_string(),
             is_primary: true,
@@ -2533,8 +2533,8 @@ mod tests {
 
         let info2 = DpuDeviceInfo {
             device_id: "dpu-002".to_string(),
-            dpu_bmc_ip: "10.0.0.20".to_string(),
-            host_bmc_ip: "10.0.0.2".to_string(),
+            dpu_bmc_ip: "10.0.0.20".parse().unwrap(),
+            host_bmc_ip: "10.0.0.2".parse().unwrap(),
             serial_number: "SN222".to_string(),
             dpu_machine_id: "dpu-222".to_string(),
             is_primary: false,
@@ -2715,8 +2715,8 @@ mod tests {
 
         let info = DpuDeviceInfo {
             device_id: "dpu-001".to_string(),
-            dpu_bmc_ip: "10.0.0.10".to_string(),
-            host_bmc_ip: "10.0.0.1".to_string(),
+            dpu_bmc_ip: "10.0.0.10".parse().unwrap(),
+            host_bmc_ip: "10.0.0.1".parse().unwrap(),
             serial_number: "SN123456".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
             is_primary: true,
@@ -2760,8 +2760,8 @@ mod tests {
 
         let info = DpuDeviceInfo {
             device_id: "dpu-001".to_string(),
-            dpu_bmc_ip: "10.0.0.10".to_string(),
-            host_bmc_ip: "10.0.0.1".to_string(),
+            dpu_bmc_ip: "10.0.0.10".parse().unwrap(),
+            host_bmc_ip: "10.0.0.1".parse().unwrap(),
             serial_number: "SN123456".to_string(),
             dpu_machine_id: "dpu-bbb".to_string(),
             is_primary: true,
@@ -2799,7 +2799,7 @@ mod tests {
 
         let info = DpuNodeInfo {
             node_id: "host-001".to_string(),
-            host_bmc_ip: "10.0.0.1".to_string(),
+            host_bmc_ip: "10.0.0.1".parse().unwrap(),
             device_ids: vec!["dpu-001".to_string()],
         };
         let err = sdk.register_dpu_node(info).await.unwrap_err();
@@ -2838,7 +2838,7 @@ mod tests {
 
         let info = DpuNodeInfo {
             node_id: "host-001".to_string(),
-            host_bmc_ip: "10.0.0.1".to_string(),
+            host_bmc_ip: "10.0.0.1".parse().unwrap(),
             device_ids: vec!["dpu-001".to_string()],
         };
         sdk.register_dpu_node(info).await.unwrap();
@@ -2999,7 +2999,7 @@ mod tests {
 
         let info = DpuNodeInfo {
             node_id: "host-001".to_string(),
-            host_bmc_ip: "10.0.0.1".to_string(),
+            host_bmc_ip: "10.0.0.1".parse().unwrap(),
             device_ids: vec!["dpu-001".to_string()],
         };
         sdk.register_dpu_node(info).await.unwrap();

--- a/crates/dpf/src/test/sdk_device_registration.rs
+++ b/crates/dpf/src/test/sdk_device_registration.rs
@@ -195,8 +195,8 @@ async fn test_register_devices_node_and_force_delete() {
     for i in 1..=2 {
         let info = DpuDeviceInfo {
             device_id: format!("dpu-{}", i),
-            dpu_bmc_ip: format!("192.168.1.{}", 100 + i),
-            host_bmc_ip: "192.168.1.1".to_string(),
+            dpu_bmc_ip: format!("192.168.1.{}", 100 + i).parse().unwrap(),
+            host_bmc_ip: "192.168.1.1".parse().unwrap(),
             serial_number: format!("SN-{}", i),
             dpu_machine_id: format!("dpu-{}-id", i),
             is_primary: true,
@@ -207,7 +207,7 @@ async fn test_register_devices_node_and_force_delete() {
     // Register node
     let node_info = DpuNodeInfo {
         node_id: "host-001".to_string(),
-        host_bmc_ip: "192.168.1.1".to_string(),
+        host_bmc_ip: "192.168.1.1".parse().unwrap(),
         device_ids: vec!["dpu-1".to_string(), "dpu-2".to_string()],
     };
     sdk.register_dpu_node(node_info).await.unwrap();

--- a/crates/dpf/src/test/sdk_reboot_annotation.rs
+++ b/crates/dpf/src/test/sdk_reboot_annotation.rs
@@ -145,7 +145,7 @@ async fn test_reboot_annotation_set_check_clear() {
     // Register a DPU node
     let node_info = DpuNodeInfo {
         node_id: "host-001".to_string(),
-        host_bmc_ip: "192.168.1.1".to_string(),
+        host_bmc_ip: "192.168.1.1".parse().unwrap(),
         device_ids: vec!["dpu-001".to_string()],
     };
     sdk.register_dpu_node(node_info).await.unwrap();

--- a/crates/dpf/src/test/watcher_reboot.rs
+++ b/crates/dpf/src/test/watcher_reboot.rs
@@ -97,5 +97,8 @@ async fn test_reboot_bmc_ip() {
     dpu.spec.bmc_ip = Some("10.0.0.42".into());
     m.emit_dpu(dpu);
     c.wait_for(1).await;
-    assert_eq!(c.get(0).unwrap().host_bmc_ip, "10.0.0.42");
+    assert_eq!(
+        c.get(0).unwrap().host_bmc_ip,
+        "10.0.0.42".parse::<std::net::IpAddr>().unwrap()
+    );
 }

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -18,6 +18,7 @@
 //! SDK types for the DPF SDK.
 
 use std::collections::BTreeMap;
+use std::net::IpAddr;
 
 use crate::crds::dpus_generated::DpuStatusPhase;
 
@@ -233,9 +234,9 @@ pub struct DpuDeviceInfo {
     /// Used as the DPUDevice CR name.
     pub device_id: String,
     /// BMC IP address for the DPU.
-    pub dpu_bmc_ip: String,
+    pub dpu_bmc_ip: IpAddr,
     /// BMC IP address for the host.
-    pub host_bmc_ip: String,
+    pub host_bmc_ip: IpAddr,
     /// Serial number of the DPU.
     pub serial_number: String,
     /// Caller-defined identifier for the DPU machine.
@@ -252,7 +253,7 @@ pub struct DpuNodeInfo {
     /// Used to build the DPUNode CR name via `dpu_node_cr_name()`.
     pub node_id: String,
     /// BMC IP of the host.
-    pub host_bmc_ip: String,
+    pub host_bmc_ip: IpAddr,
     /// Identifiers of each device attached to this node.
     pub device_ids: Vec<String>,
 }
@@ -351,7 +352,7 @@ pub struct RebootRequiredEvent {
     /// Name of the DPUNode resource.
     pub node_name: String,
     /// Host BMC IP.
-    pub host_bmc_ip: String,
+    pub host_bmc_ip: IpAddr,
 }
 
 /// Event emitted when a DPU is in the NodeEffect phase.

--- a/crates/dpf/src/watcher.rs
+++ b/crates/dpf/src/watcher.rs
@@ -367,10 +367,16 @@ where
             }
 
             if matches!(status.phase, DpuStatusPhase::Rebooting) {
+                let Some(host_bmc_ip) = dpu.spec.bmc_ip.as_deref().and_then(|ip| ip.parse().ok())
+                else {
+                    tracing::warn!(dpu = %dpu_name, "Skipping reboot event with missing or invalid BMC IP");
+                    return Ok(());
+                };
+
                 (cbs.reboot)(RebootRequiredEvent {
                     dpu_name: dpu_name.clone(),
                     node_name: node_name.clone(),
-                    host_bmc_ip: dpu.spec.bmc_ip.clone().unwrap_or_default(),
+                    host_bmc_ip,
                 })
                 .await?;
             }

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -174,7 +174,7 @@ impl ResourceLabeler for CarbideDPFLabeler {
             (CONTROLLED_DEVICE_LABEL.to_string(), "true".to_string()),
             (
                 "carbide.nvidia.com/host-bmc-ip".to_string(),
-                info.host_bmc_ip.clone(),
+                info.host_bmc_ip.to_string(),
             ),
             (
                 "carbide.nvidia.com/is-primary-dpu".to_string(),
@@ -200,7 +200,7 @@ impl ResourceLabeler for CarbideDPFLabeler {
     fn node_context_labels(&self, info: &DpuNodeInfo) -> BTreeMap<String, String> {
         BTreeMap::from([(
             "carbide.nvidia.com/host-bmc-ip".to_string(),
-            info.host_bmc_ip.clone(),
+            info.host_bmc_ip.to_string(),
         )])
     }
 

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -20,6 +20,8 @@
 //! 2. Wait for watcher callbacks (DPU ready, reboot required)
 //! 3. Handle cleanup on error/reprovisioning
 
+use std::net::IpAddr;
+
 use carbide_dpf::{DpfError, DpuPhase, dpu_node_cr_name};
 use carbide_uuid::machine::MachineId;
 use libredfish::SystemPowerControl;
@@ -40,8 +42,8 @@ fn dpf_error(error: DpfError) -> StateHandlerError {
     ExternalServiceError::with_source("dpf", "", error.to_string(), "dpf_error", error).into()
 }
 
-fn bmc_ip(machine: &Machine) -> Result<String, StateHandlerError> {
-    machine.bmc_info.ip.map(|ip| ip.to_string()).ok_or_else(|| {
+fn bmc_ip(machine: &Machine) -> Result<IpAddr, StateHandlerError> {
+    machine.bmc_info.ip.ok_or_else(|| {
         StateHandlerError::GenericError(eyre::eyre!("BMC IP is not set for machine {}", machine.id))
     })
 }


### PR DESCRIPTION
## Description

Small tweak to type DPF host and DPU BMC addresses as `IpAddr` through the SDK event and config paths.

K8s resources and labels still receive strings at the edge.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

