### PR TITLE
fix: strongly type expected host NIC fixed gateways as IpAddr

### DIFF
--- a/crates/api-core/src/tests/expected_machine.rs
+++ b/crates/api-core/src/tests/expected_machine.rs
@@ -2181,6 +2181,60 @@ fn test_expected_machine_data_rejects_invalid_host_nic_fixed_ip() {
 }
 
 #[test]
+fn test_expected_machine_data_accepts_ipv6_host_nic_fixed_gateway() {
+    let expected_machine = rpc::forge::ExpectedMachine {
+        bmc_mac_address: "5A:5B:5C:5D:5E:65".to_string(),
+        bmc_username: "root".into(),
+        bmc_password: "testpass".into(),
+        chassis_serial_number: "IPV6-HOST-NIC-FIXED-GATEWAY".into(),
+        host_nics: vec![rpc::forge::ExpectedHostNic {
+            mac_address: "5A:5B:5C:5D:5E:66".to_string(),
+            fixed_gateway: Some("2001:db8::1".to_string()),
+            ..Default::default()
+        }],
+        metadata: Some(rpc::forge::Metadata::default()),
+        id: Some(::rpc::common::Uuid {
+            value: uuid::Uuid::new_v4().to_string(),
+        }),
+        ..Default::default()
+    };
+
+    let data = ExpectedMachineData::try_from(expected_machine).unwrap();
+
+    assert_eq!(
+        data.host_nics[0].fixed_gateway,
+        Some("2001:db8::1".parse().unwrap())
+    );
+}
+
+#[test]
+fn test_expected_machine_data_rejects_invalid_host_nic_fixed_gateway() {
+    let expected_machine = rpc::forge::ExpectedMachine {
+        bmc_mac_address: "5A:5B:5C:5D:5E:65".to_string(),
+        bmc_username: "root".into(),
+        bmc_password: "testpass".into(),
+        chassis_serial_number: "INVALID-HOST-NIC-FIXED-GATEWAY".into(),
+        host_nics: vec![rpc::forge::ExpectedHostNic {
+            mac_address: "5A:5B:5C:5D:5E:66".to_string(),
+            fixed_gateway: Some("not-a-valid-ip".to_string()),
+            ..Default::default()
+        }],
+        metadata: Some(rpc::forge::Metadata::default()),
+        id: Some(::rpc::common::Uuid {
+            value: uuid::Uuid::new_v4().to_string(),
+        }),
+        ..Default::default()
+    };
+
+    let err = match ExpectedMachineData::try_from(expected_machine) {
+        Ok(_) => panic!("invalid host NIC fixed gateway should fail conversion"),
+        Err(err) => err,
+    };
+
+    assert!(err.to_string().contains("Invalid fixed gateway"));
+}
+
+#[test]
 fn test_expected_machine_data_rejects_invalid_host_nic_mac_address() {
     let expected_machine = rpc::forge::ExpectedMachine {
         bmc_mac_address: "5A:5B:5C:5D:5E:65".to_string(),

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -96,7 +96,8 @@ pub struct ExpectedHostNic {
     pub nic_type: Option<String>,
     pub fixed_ip: Option<IpAddr>,
     pub fixed_mask: Option<String>,
-    pub fixed_gateway: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_ip_addr_lossy")]
+    pub fixed_gateway: Option<IpAddr>,
     /// When true, `primary` flags this NIC as the host's boot (primary)
     /// interface. At most one NIC per ExpectedMachine may be marked primary
     /// (which is enforced in the API). This ultimately propagates into the
@@ -106,6 +107,14 @@ pub struct ExpectedHostNic {
     /// interface accordingly).
     #[serde(default)]
     pub primary: Option<bool>,
+}
+
+fn deserialize_optional_ip_addr_lossy<'de, D>(deserializer: D) -> Result<Option<IpAddr>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<String>::deserialize(deserializer)?
+        .and_then(|address| address.parse::<IpAddr>().ok()))
 }
 
 // Important : new fields for expected machine should be Optional _and_ #[serde(default)],
@@ -371,6 +380,28 @@ mod tests {
         }"#;
         let em: ExpectedMachine = serde_json::from_str(json).unwrap();
         assert_eq!(em.data.host_lifecycle_profile.disable_lockdown, Some(true));
+    }
+
+    #[test]
+    fn expected_host_nic_deserializes_valid_fixed_gateway() {
+        let json = r#"{
+            "mac_address": "AA:BB:CC:DD:EE:FF",
+            "fixed_gateway": "2001:db8::1"
+        }"#;
+        let nic: ExpectedHostNic = serde_json::from_str(json).unwrap();
+
+        assert_eq!(nic.fixed_gateway, Some("2001:db8::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn expected_host_nic_drops_invalid_fixed_gateway_on_deserialize() {
+        let json = r#"{
+            "mac_address": "AA:BB:CC:DD:EE:FF",
+            "fixed_gateway": "not-an-ip"
+        }"#;
+        let nic: ExpectedHostNic = serde_json::from_str(json).unwrap();
+
+        assert_eq!(nic.fixed_gateway, None);
     }
 
     #[test]

--- a/crates/rpc/src/model/expected_machine.rs
+++ b/crates/rpc/src/model/expected_machine.rs
@@ -85,7 +85,7 @@ impl From<ExpectedHostNic> for rpc::forge::ExpectedHostNic {
             nic_type: expected_host_nic.nic_type,
             fixed_ip: expected_host_nic.fixed_ip.map(|ip| ip.to_string()),
             fixed_mask: expected_host_nic.fixed_mask,
-            fixed_gateway: expected_host_nic.fixed_gateway,
+            fixed_gateway: expected_host_nic.fixed_gateway.map(|ip| ip.to_string()),
             primary: expected_host_nic.primary,
         }
     }
@@ -109,7 +109,12 @@ impl TryFrom<rpc::forge::ExpectedHostNic> for ExpectedHostNic {
                 })?),
             },
             fixed_mask: expected_host_nic.fixed_mask,
-            fixed_gateway: expected_host_nic.fixed_gateway,
+            fixed_gateway: match expected_host_nic.fixed_gateway.as_deref() {
+                None | Some("") => None,
+                Some(ip) => Some(ip.parse::<IpAddr>().map_err(|_| {
+                    RpcDataConversionError::InvalidArgument(format!("Invalid fixed gateway: {ip}"))
+                })?),
+            },
             primary: expected_host_nic.primary,
         })
     }


### PR DESCRIPTION
## Description

This change parses `ExpectedHostNic.fixed_gateway` as `IpAddr` once it crosses the RPC boundary. This now matches the `fixed_ip` handling.

Test added!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

