### PR TITLE
fix(agent): strongly type NVUE config addresses as IpAddr (one case of Ipv4Addr)

### DIFF
--- a/crates/agent/src/command_line.rs
+++ b/crates/agent/src/command_line.rs
@@ -18,6 +18,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use carbide_network::ip::prefix::Ipv4Net;
 use carbide_network::virtualization::VpcVirtualizationType;
 use carbide_uuid::machine::MachineId;
 use clap::Parser;
@@ -118,10 +119,10 @@ pub struct NvueOptions {
     pub uplinks: Vec<String>,
 
     #[clap(long, use_value_delimiter = true, help = "Comma separated")]
-    pub route_servers: Vec<String>,
+    pub route_servers: Vec<IpAddr>,
 
     #[clap(long, use_value_delimiter = true, help = "Comma separated")]
-    pub dhcp_servers: Vec<String>,
+    pub dhcp_servers: Vec<IpAddr>,
 
     #[clap(
         long,
@@ -176,13 +177,13 @@ pub struct NvueOptions {
         long,
         help = "IP to be used for a local VTEP when configuring an additional overlay network"
     )]
-    pub secondary_overlay_vtep_ip: Option<String>,
+    pub secondary_overlay_vtep_ip: Option<IpAddr>,
 
     #[clap(
         long,
         help = "Prefix to be used for configuring a set of internal bridges to be used with advanced routing for traffic interception.  Prefix length is expected to be /29 or smaller (i.e., 8 or more IP addresses)."
     )]
-    pub internal_bridge_routing_prefix: Option<String>,
+    pub internal_bridge_routing_prefix: Option<Ipv4Net>,
 
     #[clap(
         long,

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -485,6 +485,32 @@ pub async fn update_nvue(
 
     let hostname = hostname().wrap_err("gethostname error")?;
     let is_dpu_os = matches!(update_flavor, NvueUpdateFlavor::StartupFile { .. });
+    let secondary_overlay_vtep_ip = nc
+        .traffic_intercept_config
+        .as_ref()
+        .and_then(|vc| vc.additional_overlay_vtep_ip.as_deref())
+        .map(str::parse)
+        .transpose()
+        .wrap_err("invalid secondary overlay VTEP IP")?;
+    let internal_bridge_routing_prefix = nc
+        .traffic_intercept_config
+        .as_ref()
+        .and_then(|vc| vc.bridging.as_ref())
+        .map(|b| b.internal_bridge_routing_prefix.parse::<Ipv4Net>())
+        .transpose()
+        .wrap_err("invalid internal bridge routing prefix")?;
+    let dhcp_servers = nc
+        .dhcp_servers
+        .iter()
+        .map(|ip| ip.parse::<IpAddr>())
+        .collect::<Result<Vec<_>, _>>()
+        .wrap_err("invalid DHCP server IP")?;
+    let route_servers = nc
+        .route_servers
+        .iter()
+        .map(|ip| ip.parse::<IpAddr>())
+        .collect::<Result<Vec<_>, _>>()
+        .wrap_err("invalid route server IP")?;
     let conf = nvue::NvueConfig {
         is_fnn: false,
         is_dpu_os,
@@ -512,15 +538,8 @@ pub async fn update_nvue(
                 .map(|b| b.vf_intercept_bridge_sf.clone())
         }),
         host_intercept_bridge_port_name: None,
-        secondary_overlay_vtep_ip: nc
-            .traffic_intercept_config
-            .as_ref()
-            .and_then(|vc| vc.additional_overlay_vtep_ip.clone()),
-        internal_bridge_routing_prefix: nc.traffic_intercept_config.as_ref().and_then(|vc| {
-            vc.bridging
-                .as_ref()
-                .map(|b| b.internal_bridge_routing_prefix.clone())
-        }),
+        secondary_overlay_vtep_ip,
+        internal_bridge_routing_prefix,
         traffic_intercept_public_prefixes: nc
             .traffic_intercept_config
             .as_ref()
@@ -550,8 +569,8 @@ pub async fn update_nvue(
             .into_iter()
             .map(String::from)
             .collect(),
-        dhcp_servers: nc.dhcp_servers.clone(),
-        route_servers: nc.route_servers.clone(),
+        dhcp_servers,
+        route_servers,
         ct_port_configs: networks,
         ct_vrf_name: format!("vpc_{}", nc.vpc_vni.unwrap_or_default()),
         ct_access_vlans: access_vlans,
@@ -686,8 +705,11 @@ pub async fn update_traffic_intercept_bridging(
     let Some(bridge_config) = traffic_intercept_config.bridging.as_ref() else {
         eyre::bail!("traffic_intercept bridging config not provided");
     };
-    let Some(secondary_overlay_vtep_ip) =
-        traffic_intercept_config.additional_overlay_vtep_ip.as_ref()
+    let Some(secondary_overlay_vtep_ip) = traffic_intercept_config
+        .additional_overlay_vtep_ip
+        .as_deref()
+        .map(str::parse)
+        .transpose()?
     else {
         eyre::bail!("secondary_overlay_vtep_ip required by traffic_intercept bridging not found");
     };
@@ -756,7 +778,7 @@ pub async fn update_traffic_intercept_bridging(
         .collect();
 
     let conf = traffic_intercept_bridging::TrafficInterceptBridgingConfig {
-        secondary_overlay_vtep_ip: secondary_overlay_vtep_ip.to_owned(),
+        secondary_overlay_vtep_ip,
         secondary_vtep_aggregate_prefixes: traffic_intercept_config
             .secondary_vtep_aggregate_prefixes
             .clone(),
@@ -3095,9 +3117,9 @@ mod tests {
             use_admin_network: true,
             tenancy_enabled: true,
             site_global_vpc_vni: None,
-            loopback_ip: "10.217.5.39".to_string(),
-            secondary_overlay_vtep_ip: Some("10.255.254.253".to_string()),
-            internal_bridge_routing_prefix: Some("10.255.255.0/29".to_string()),
+            loopback_ip: "10.217.5.39".parse().unwrap(),
+            secondary_overlay_vtep_ip: Some("10.255.254.253".parse().unwrap()),
+            internal_bridge_routing_prefix: Some("10.255.255.0/29".parse().unwrap()),
             vf_intercept_bridge_port_name: Some("pfdpu0".to_string()),
             vf_intercept_bridge_sf: Some("pf0dpu5".to_string()),
             host_intercept_bridge_port_name: Some("pfdpu1".to_string()),
@@ -3122,8 +3144,8 @@ mod tests {
                 .into_iter()
                 .map(String::from)
                 .collect(),
-            dhcp_servers: vec!["10.217.5.197".to_string()],
-            route_servers: vec!["172.43.0.1".to_string(), "172.43.0.2".to_string()],
+            dhcp_servers: vec!["10.217.5.197".parse().unwrap()],
+            route_servers: vec!["172.43.0.1".parse().unwrap(), "172.43.0.2".parse().unwrap()],
             deny_prefixes: vec![],
             use_vpc_isolation: false,
             site_fabric_prefixes: vec!["10.217.4.128/26".to_string()],

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -377,7 +377,7 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
                     hbn_version: opts.hbn_version,
                     use_admin_network: true,
                     tenancy_enabled: true,
-                    loopback_ip: opts.loopback_ip.to_string(),
+                    loopback_ip: opts.loopback_ip,
                     secondary_overlay_vtep_ip: opts.secondary_overlay_vtep_ip,
                     internal_bridge_routing_prefix: opts.internal_bridge_routing_prefix,
                     vf_intercept_bridge_port_name: opts.vf_intercept_bridge_port_name,

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -17,6 +17,7 @@
 
 use std::collections::HashMap;
 use std::fs;
+use std::net::IpAddr;
 use std::path::Path;
 
 use ::rpc::forge as rpc;
@@ -524,11 +525,7 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
         // IPv4 only for now. Internal HBN bridge plumbing uses 169.254.x.x
         // link-local addressing for DPU to HBN communication. An IPv6 equivalent
         // (fe80:: or similar) may be needed in the future for dual-stack bridging.
-    ) = if let Some(bridge_prefix) = conf
-        .internal_bridge_routing_prefix
-        .map(|p| p.parse::<Ipv4Net>())
-        .transpose()?
-    {
+    ) = if let Some(bridge_prefix) = conf.internal_bridge_routing_prefix {
         let prefix_len = bridge_prefix.prefix_len();
         let mut hosts = bridge_prefix.hosts();
 
@@ -596,12 +593,15 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
         HasBgpLeafSessionPassword: conf.bgp_leaf_session_password.is_some(),
         BgpLeafSessionPassword: conf.bgp_leaf_session_password.unwrap_or_default(),
         UseAdminNetwork: conf.use_admin_network,
-        LoopbackIP: conf.loopback_ip,
+        LoopbackIP: conf.loopback_ip.to_string(),
         HasSiteGlobalVpcVni: conf.site_global_vpc_vni.is_some(),
         SiteGlobalVpcVni: conf.site_global_vpc_vni.unwrap_or_default(),
         HasStaticAdvertisements: has_static_advertisements,
         HasSecondaryOverlayVTEP: conf.secondary_overlay_vtep_ip.is_some(),
-        SecondaryOverlayVtepIP: conf.secondary_overlay_vtep_ip.unwrap_or_default(),
+        SecondaryOverlayVtepIP: conf
+            .secondary_overlay_vtep_ip
+            .map(|ip| ip.to_string())
+            .unwrap_or_default(),
         HasInternalBridgeRouting: has_internal_bridging,
         VfInterceptBridgeIP: vf_intercept_bridge_ip,
         InterceptBridgePrefixLen: intercept_bridge_prefix_len,
@@ -632,8 +632,8 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
         DPUHostname: conf.dpu_hostname,
         SearchDomain: conf.dpu_search_domain,
         Uplinks: conf.uplinks.clone(),
-        RouteServers: conf.route_servers.clone(),
-        DHCPServers: conf.dhcp_servers.clone(),
+        RouteServers: conf.route_servers.iter().map(|ip| ip.to_string()).collect(),
+        DHCPServers: conf.dhcp_servers.iter().map(|ip| ip.to_string()).collect(),
         AnycastSitePrefixes: anycast_ipv4,
         AnycastSitePrefixesIpv6: anycast_ipv6,
         HasSiteFabricPrefixes: !site_fabric_ipv4.is_empty(),
@@ -1124,7 +1124,7 @@ pub struct NvueConfig {
     pub vpc_virtualization_type: VpcVirtualizationType,
     pub use_admin_network: bool,
     pub tenancy_enabled: bool,
-    pub loopback_ip: String,
+    pub loopback_ip: IpAddr,
     pub asn: u32,
     pub datacenter_asn: u32,
     pub site_global_vpc_vni: Option<u32>,
@@ -1132,19 +1132,19 @@ pub struct NvueConfig {
     pub additional_route_target_imports: Vec<RouteTargetConfig>,
     pub bgp_leaf_session_password: Option<String>,
 
-    pub secondary_overlay_vtep_ip: Option<String>,
+    pub secondary_overlay_vtep_ip: Option<IpAddr>,
     pub vf_intercept_bridge_port_name: Option<String>,
     pub vf_intercept_bridge_sf: Option<String>,
     pub host_intercept_bridge_port_name: Option<String>,
-    pub internal_bridge_routing_prefix: Option<String>,
+    pub internal_bridge_routing_prefix: Option<Ipv4Net>,
     pub traffic_intercept_public_prefixes: Vec<String>,
 
     pub dpu_hostname: String,
     pub dpu_search_domain: String,
     pub hbn_version: Option<String>,
     pub uplinks: Vec<String>,
-    pub route_servers: Vec<String>,
-    pub dhcp_servers: Vec<String>,
+    pub route_servers: Vec<IpAddr>,
+    pub dhcp_servers: Vec<IpAddr>,
     pub l3_domains: Vec<L3Domain>,
     pub deny_prefixes: Vec<String>,
     pub site_fabric_prefixes: Vec<String>,
@@ -1822,7 +1822,7 @@ mod tests {
             vpc_virtualization_type: VpcVirtualizationType::EthernetVirtualizer,
             use_admin_network: false,
             tenancy_enabled: true,
-            loopback_ip: "10.0.0.1".to_string(),
+            loopback_ip: "10.0.0.1".parse().unwrap(),
             asn: 65000,
             datacenter_asn: 11414,
             site_global_vpc_vni: None,

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -89,7 +89,7 @@ async fn test_traffic_intercept_bridging() -> eyre::Result<()> {
     let expected = include_str!("../../templates/tests/update_intercept_bridging.sh.expected");
     let bridging = traffic_intercept_bridging::build(
         traffic_intercept_bridging::TrafficInterceptBridgingConfig {
-            secondary_overlay_vtep_ip: "1.1.1.1".to_string(),
+            secondary_overlay_vtep_ip: "1.1.1.1".parse().unwrap(),
             secondary_vtep_aggregate_prefixes: vec!["1.1.1.0/24".to_string()],
             vf_intercept_bridge_ip: "10.10.10.2".to_string(),
             vf_intercept_bridge_name: "pfdpu000br-dpu".to_string(),

--- a/crates/agent/src/traffic_intercept_bridging.rs
+++ b/crates/agent/src/traffic_intercept_bridging.rs
@@ -16,6 +16,7 @@
  */
 
 use std::fs;
+use std::net::IpAddr;
 
 use eyre::WrapErr;
 use gtmpl_derive::Gtmpl;
@@ -26,7 +27,7 @@ const TMPL_BRIDGING: &str = include_str!("../templates/update_intercept_bridging
 
 // What we need for the commands to configure the bridge.
 pub struct TrafficInterceptBridgingConfig {
-    pub secondary_overlay_vtep_ip: String,
+    pub secondary_overlay_vtep_ip: IpAddr,
     pub secondary_vtep_aggregate_prefixes: Vec<String>,
     pub vf_intercept_bridge_ip: String,
     pub vf_intercept_bridge_name: String,
@@ -67,7 +68,7 @@ struct TmplTrafficInterceptBridging {
 
 pub fn build(conf: TrafficInterceptBridgingConfig) -> eyre::Result<String> {
     let params = TmplTrafficInterceptBridging {
-        SecondaryOverlayVtepIP: conf.secondary_overlay_vtep_ip,
+        SecondaryOverlayVtepIP: conf.secondary_overlay_vtep_ip.to_string(),
         SecondaryVtepAggregatePrefixes: conf.secondary_vtep_aggregate_prefixes,
         VfInterceptBridgeIP: conf.vf_intercept_bridge_ip,
         VfInterceptBridgeName: conf.vf_intercept_bridge_name,


### PR DESCRIPTION
## Description

Small tweak to keep NVUE config addresses typed until template rendering. RPC and CLI inputs still arrive as strings where needed, but route servers, DHCP servers, loopbacks, VTEPs, and bridge prefixes parse before building config. `internal_bridge_routing_prefix` specifically marked as `Ipv4Addr` for now -- we'll pick it up as part of the v6 support work.

Tests included.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

