### PR TITLE
chore: type the api-side DHCP server list as Ipv4Addr

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -19,7 +19,7 @@ applicable.
 | `max_database_connections` | `u32` | `1000` | Maximum database connection pool size. |
 | `ib_config` | `Option<IBFabricConfig>` | — | InfiniBand fabric configuration (see [IBFabricConfig](#ibfabricconfig)). |
 | `asn` | `u32` | **required** | Autonomous System Number, fixed per environment. Used by nico-dpu-agent for `frr.conf` BGP routing. |
-| `dhcp_servers` | `Vec<String>` | `[]` | DHCP server addresses announced to DPUs during network provisioning. |
+| `dhcp_servers` | `Vec<Ipv4Addr>` | `[]` | DHCP server addresses announced to DPUs during network provisioning. |
 | `route_servers` | `Vec<String>` | `[]` | Route server IPs for L2VPN Ethernet Virtual network support. |
 | `enable_route_servers` | `bool` | `false` | Enables route server injection into DPU FRR configs for L2VPN. |
 | `deny_prefixes` | `Vec<Ipv4Network>` | `[]` | IPv4 CIDR prefixes that tenant instances are blocked from reaching. Generates iptables DROP rules and nvue ACL policies. |

--- a/crates/api-core/src/ethernet_virtualization.rs
+++ b/crates/api-core/src/ethernet_virtualization.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 
 use ::rpc::forge as rpc;
 use carbide_network::virtualization::{VpcVirtualizationType, get_svi_ip};
@@ -46,7 +46,7 @@ use crate::cfg::file::{FnnConfig, FnnRoutingProfileConfig, VpcPeeringPolicy};
 #[derive(Default, Clone)]
 pub struct EthVirtData {
     pub asn: u32,
-    pub dhcp_servers: Vec<String>,
+    pub dhcp_servers: Vec<Ipv4Addr>,
     pub deny_prefixes: Vec<Ipv4Network>,
     pub site_fabric_prefixes: Option<SiteFabricPrefixList>,
 }

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -588,7 +588,12 @@ pub(crate) async fn get_managed_host_network_config_inner(
     let resp = rpc::ManagedHostNetworkConfigResponse {
         instance_id: snapshot.instance.as_ref().map(|instance| instance.id),
         asn,
-        dhcp_servers: api.eth_data.dhcp_servers.clone(),
+        dhcp_servers: api
+            .eth_data
+            .dhcp_servers
+            .iter()
+            .map(|addr| addr.to_string())
+            .collect(),
         route_servers,
         // TODO: Automatically add the prefix(es?) from the IPv4 loopback
         // pool to deny_prefixes. The database stores the pool in an

--- a/crates/api-core/src/handlers/finder.rs
+++ b/crates/api-core/src/handlers/finder.rs
@@ -226,11 +226,11 @@ async fn search(
             api.eth_data
                 .dhcp_servers
                 .iter()
-                .find(|&dhcp| ip == *dhcp)
-                .map(|ip| rpc::IpAddressMatch {
+                .find(|&&dhcp| addr == IpAddr::V4(dhcp))
+                .map(|dhcp| rpc::IpAddressMatch {
                     ip_type: rpc::IpType::StaticDataDhcpServer as i32,
                     owner_id: None,
-                    message: format!("{ip} is a static DHCP server"),
+                    message: format!("{dhcp} is a static DHCP server"),
                 })
         }),
 

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -604,11 +604,7 @@ pub async fn start_api(
 
     let eth_data = ethernet_virtualization::EthVirtData {
         asn: carbide_config.asn,
-        dhcp_servers: carbide_config
-            .dhcp_servers
-            .iter()
-            .map(|addr| addr.to_string())
-            .collect(),
+        dhcp_servers: carbide_config.dhcp_servers.clone(),
         deny_prefixes: carbide_config.deny_prefixes.clone(),
         site_fabric_prefixes,
     };

--- a/crates/api-core/src/test_support/network.rs
+++ b/crates/api-core/src/test_support/network.rs
@@ -108,7 +108,7 @@ pub fn default_test_eth_virt_data() -> EthVirtData {
     let site_fabric_prefixes = { SiteFabricPrefixList::from_ipnetwork_vec(site_fabric_networks) };
     EthVirtData {
         asn: 65535,
-        dhcp_servers: vec![FIXTURE_DHCP_RELAY_ADDRESS.to_string()],
+        dhcp_servers: vec![FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap()],
         deny_prefixes: vec![],
         site_fabric_prefixes,
     }

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -1179,7 +1179,7 @@ pub async fn create_test_env_with_overrides(
 
     let eth_virt_data = EthVirtData {
         asn: 65535,
-        dhcp_servers: vec![FIXTURE_DHCP_RELAY_ADDRESS.to_string()],
+        dhcp_servers: vec![FIXTURE_DHCP_RELAY_ADDRESS.parse().unwrap()],
         deny_prefixes: vec![],
         site_fabric_prefixes,
     };


### PR DESCRIPTION
## Description

Small tweak to type configured DHCP server addresses through the API layer as `Ipv4Addr`. Can adjust to `IpAddr` later (we'll pick it up w/ the v6 work anyway).

Tests updated!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

