### PR TITLE
fix: correctly type various service listen and endpoint addresses

### DIFF
--- a/crates/fmds/src/cfg.rs
+++ b/crates/fmds/src/cfg.rs
@@ -15,7 +15,10 @@
  * limitations under the License.
  */
 
+use std::net::SocketAddr;
+
 use clap::Parser;
+use ipnetwork::IpNetwork;
 
 #[derive(Parser)]
 #[clap(name = "carbide-fmds")]
@@ -27,15 +30,15 @@ pub struct Options {
     /// carbide-dpu-agent. The tenant should not be able to
     /// communicate with this address.
     #[clap(long, default_value = "0.0.0.0:50052")]
-    pub grpc_address: String,
+    pub grpc_address: SocketAddr,
 
     /// REST listen address for tenant OS metadata queries.
     #[clap(long, default_value = "0.0.0.0:80")]
-    pub rest_address: String,
+    pub rest_address: SocketAddr,
 
     /// Prometheus scrape address for `/metrics` (HTTP request stats for the REST metadata API).
     #[clap(long, default_value = "0.0.0.0:8888")]
-    pub metrics_address: String,
+    pub metrics_address: SocketAddr,
 
     /// Carbide API server address for phone_home.
     #[clap(long, default_value = "https://carbide-api.forge")]
@@ -66,7 +69,7 @@ pub struct Options {
         env = "FMDS_INTERFACE_CIDR",
         default_value = "169.254.169.254/30"
     )]
-    pub interface_cidr: String,
+    pub interface_cidr: IpNetwork,
 }
 
 impl Options {

--- a/crates/fmds/src/main.rs
+++ b/crates/fmds/src/main.rs
@@ -69,9 +69,8 @@ async fn main() -> eyre::Result<()> {
         "Starting carbide-fmds"
     );
 
-    let interface_cidr: ipnetwork::IpNetwork = options.interface_cidr.parse()?;
-    nic_init::assign_address(&options.interface_name, interface_cidr).await?;
-    nic_init::setup_metadata_routing(&options.interface_name, interface_cidr).await?;
+    nic_init::assign_address(&options.interface_name, options.interface_cidr).await?;
+    nic_init::setup_metadata_routing(&options.interface_name, options.interface_cidr).await?;
 
     // Build ForgeClientConfig for phone_home if cert paths are provided
     let forge_client_config = match (&options.root_ca, &options.client_cert, &options.client_key) {
@@ -100,16 +99,15 @@ async fn main() -> eyre::Result<()> {
     let (prometheus_registry, http_request_metrics_state) = http_request_metrics::init()?;
     let http_request_metrics_state = Arc::new(http_request_metrics_state);
 
-    let metrics_address = options.metrics_address.clone();
+    let metrics_address = options.metrics_address;
     let registry_for_metrics = prometheus_registry.clone();
     tokio::spawn(async move {
         let router = axum::Router::new().nest(
             "/metrics",
             http_request_metrics::metrics_router(registry_for_metrics),
         );
-        let addr: std::net::SocketAddr = metrics_address.parse().expect("invalid metrics address");
-        let server = axum_server::Server::bind(addr);
-        tracing::info!(%addr, "Prometheus /metrics listening");
+        let server = axum_server::Server::bind(metrics_address);
+        tracing::info!(%metrics_address, "Prometheus /metrics listening");
         if let Err(err) = server.serve(router.into_make_service()).await {
             tracing::error!("Prometheus metrics server error: {err}");
         }
@@ -117,7 +115,7 @@ async fn main() -> eyre::Result<()> {
 
     // Start REST server for tenant metadata queries
     let rest_state = state.clone();
-    let rest_address = options.rest_address.clone();
+    let rest_address = options.rest_address;
     let rest_http_metrics = http_request_metrics_state.clone();
     tokio::spawn(async move {
         // We serve metadata under both /latest and /2009-04-04 for
@@ -128,25 +126,21 @@ async fn main() -> eyre::Result<()> {
             .nest("/2009-04-04", get_fmds_router(rest_state));
         let router = http_request_metrics::with_http_request_trace_layer(router, rest_http_metrics);
 
-        let addr: std::net::SocketAddr = rest_address.parse().expect("invalid REST address");
-        let server = axum_server::Server::bind(addr);
+        let server = axum_server::Server::bind(rest_address);
 
-        tracing::info!(%addr, "REST server listening");
+        tracing::info!(%rest_address, "REST server listening");
         if let Err(err) = server.serve(router.into_make_service()).await {
             tracing::error!("REST server error: {err}");
         }
     });
 
     // Start gRPC server for receiving config updates from agent
-    let grpc_address: std::net::SocketAddr =
-        options.grpc_address.parse().expect("invalid gRPC address");
-
     let grpc_server = FmdsGrpcServer::new(state);
 
-    tracing::info!(%grpc_address, "gRPC server listening");
+    tracing::info!(%options.grpc_address, "gRPC server listening");
     tonic::transport::Server::builder()
         .add_service(FmdsConfigServiceServer::new(grpc_server))
-        .serve(grpc_address)
+        .serve(options.grpc_address)
         .await?;
 
     Ok(())

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -16,7 +16,7 @@
  */
 
 use std::fmt::Debug;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::path::Path;
 use std::time::Duration;
 
@@ -94,7 +94,7 @@ impl Default for EndpointSourcesConfig {
 #[derive(Clone, serde::Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StaticBmcEndpoint {
-    pub ip: String,
+    pub ip: IpAddr,
     #[serde(default)]
     pub port: Option<u16>,
     pub mac: String,
@@ -1309,7 +1309,7 @@ cache_size = 50
         assert_eq!(config.endpoint_sources.static_bmc_endpoints.len(), 1);
         assert_eq!(
             config.endpoint_sources.static_bmc_endpoints[0].ip,
-            "192.168.1.100"
+            "192.168.1.100".parse::<IpAddr>().unwrap()
         );
         assert_eq!(
             config.endpoint_sources.static_bmc_endpoints[0].mac,
@@ -1341,6 +1341,23 @@ cache_size = 50
         assert!(config.processors.leak_detection.is_enabled());
 
         config.validate().expect("config should be valid");
+    }
+
+    #[test]
+    fn test_static_endpoint_config_rejects_invalid_ip() {
+        let toml_content = r#"
+[[endpoint_sources.static_bmc_endpoints]]
+ip = "not-an-ip"
+mac = "00:11:22:33:44:55"
+username = "root"
+"#;
+
+        let result = Figment::new()
+            .merge(Serialized::defaults(Config::default()))
+            .merge(Toml::string(toml_content))
+            .extract::<Config>();
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/health/src/endpoint/sources.rs
+++ b/crates/health/src/endpoint/sources.rs
@@ -52,14 +52,6 @@ impl StaticEndpointSource {
         let mut endpoints = Vec::with_capacity(configs.len());
 
         for cfg in configs {
-            let ip = match cfg.ip.parse() {
-                Ok(ip) => ip,
-                Err(error) => {
-                    tracing::warn!(?error, ip = ?cfg.ip, "Invalid IP in static endpoint config");
-                    continue;
-                }
-            };
-
             let mac = match MacAddress::from_str(&cfg.mac) {
                 Ok(mac) => mac,
                 Err(error) => {
@@ -158,7 +150,7 @@ impl StaticEndpointSource {
             };
 
             let addr = BmcAddr {
-                ip,
+                ip: cfg.ip,
                 port: cfg.port,
                 mac,
             };
@@ -267,11 +259,15 @@ mod tests {
         )
     }
 
+    fn ip(addr: &str) -> std::net::IpAddr {
+        addr.parse().unwrap()
+    }
+
     #[tokio::test]
-    async fn test_static_endpoint_source_filters_invalid_ip() {
+    async fn test_static_endpoint_source_filters_invalid_mac() {
         let configs = vec![
             StaticBmcEndpoint {
-                ip: "10.0.0.1".to_string(),
+                ip: ip("10.0.0.1"),
                 port: Some(443),
                 mac: "00:11:22:33:44:55".to_string(),
                 username: "admin".to_string(),
@@ -282,9 +278,9 @@ mod tests {
                 rack_id: None,
             },
             StaticBmcEndpoint {
-                ip: "not-an-ip".to_string(),
+                ip: ip("10.0.0.2"),
                 port: Some(443),
-                mac: "aa:bb:cc:dd:ee:ff".to_string(),
+                mac: "not-a-mac".to_string(),
                 username: "admin".to_string(),
                 password: Some("pass".to_string()),
                 machine: None,
@@ -308,7 +304,7 @@ mod tests {
     async fn test_static_endpoint_with_switch_serial_sets_metadata() {
         let switch_id = test_switch_id("switch-a");
         let configs = vec![StaticBmcEndpoint {
-            ip: "10.0.1.1".to_string(),
+            ip: ip("10.0.1.1"),
             port: Some(443),
             mac: "11:22:33:44:55:66".to_string(),
             username: "cumulus".to_string(),
@@ -349,7 +345,7 @@ mod tests {
     async fn test_static_endpoint_with_power_shelf_metadata() {
         let power_shelf_id = test_power_shelf_id("power-shelf-a");
         let configs = vec![StaticBmcEndpoint {
-            ip: "10.0.2.1".to_string(),
+            ip: ip("10.0.2.1"),
             port: Some(443),
             mac: "22:33:44:55:66:77".to_string(),
             username: "admin".to_string(),
@@ -385,7 +381,7 @@ mod tests {
             .parse()
             .expect("valid NVLink domain UUID");
         let configs = vec![StaticBmcEndpoint {
-            ip: "10.0.1.2".to_string(),
+            ip: ip("10.0.1.2"),
             port: Some(443),
             mac: "11:22:33:44:55:11".to_string(),
             username: "admin".to_string(),
@@ -428,7 +424,7 @@ mod tests {
     #[tokio::test]
     async fn test_static_endpoint_without_switch_serial_has_no_metadata() {
         let configs = vec![StaticBmcEndpoint {
-            ip: "10.0.0.1".to_string(),
+            ip: ip("10.0.0.1"),
             port: Some(443),
             mac: "aa:bb:cc:dd:ee:ff".to_string(),
             username: "admin".to_string(),

--- a/crates/pxe/src/config.rs
+++ b/crates/pxe/src/config.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use std::env;
+use std::net::IpAddr;
 
 #[derive(Clone, Debug)]
 pub(crate) struct RuntimeConfig {
@@ -25,7 +26,7 @@ pub(crate) struct RuntimeConfig {
     pub forge_root_ca_path: String,
     pub server_cert_path: String,
     pub server_key_path: String,
-    pub bind_address: String,
+    pub bind_address: IpAddr,
     pub bind_port: u16,
     pub template_directory: String,
 }
@@ -51,7 +52,10 @@ impl RuntimeConfig {
             server_key_path: env::var("FORGE_CLIENT_KEY_PATH").map_err(|_| {
                 "Could not extract FORGE_CLIENT_KEY_PATH from environment".to_string()
             })?,
-            bind_address: env::var("PXE_BIND_ADDRESS").unwrap_or_else(|_| "0.0.0.0".to_string()),
+            bind_address: env::var("PXE_BIND_ADDRESS")
+                .unwrap_or_else(|_| "0.0.0.0".to_string())
+                .parse()
+                .map_err(|_| "not a parsable bind address for runtime config?".to_string())?,
             bind_port: env::var("PXE_BIND_PORT")
                 .unwrap_or_else(|_| "8080".to_string())
                 .parse::<u16>()

--- a/crates/pxe/src/main.rs
+++ b/crates/pxe/src/main.rs
@@ -16,7 +16,6 @@
  */
 use std::fmt::Debug;
 use std::net::SocketAddr;
-use std::str::FromStr;
 
 use axum::middleware::{map_request, map_response};
 use axum::{Router, ServiceExt};
@@ -74,14 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let tera = Tera::new(format!("{}/**/*", runtime_config.template_directory).as_str())
         .expect("unable to build templating engine?");
-    let socket_addr = SocketAddr::from_str(
-        format!(
-            "{}:{}",
-            runtime_config.bind_address, runtime_config.bind_port
-        )
-        .as_str(),
-    )
-    .expect("unable to construct socket address from runtime config?");
+    let socket_addr = SocketAddr::new(runtime_config.bind_address, runtime_config.bind_port);
 
     let app_state = AppState {
         engine: Engine::from(tera),

--- a/crates/pxe/src/routes/cloud_init.rs
+++ b/crates/pxe/src/routes/cloud_init.rs
@@ -315,7 +315,7 @@ mod tests {
                 forge_root_ca_path: String::new(),
                 server_cert_path: String::new(),
                 server_key_path: String::new(),
-                bind_address: "0.0.0.0".to_string(),
+                bind_address: "0.0.0.0".parse().unwrap(),
                 bind_port: 8080,
                 template_directory: String::new(),
             },


### PR DESCRIPTION
## Description

This makes a small pass over service parameters so static health endpoints, FMDS listeners, FMDS metadata CIDRs, and PXE bind addresses parse into typed values up front (including `SocketAddr`).

Tests added.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

