### PR TITLE
fix(dhcp): correctly type DHCP Option 50 as an IP address within Kea

### DIFF
--- a/crates/dhcp/src/discovery.rs
+++ b/crates/dhcp/src/discovery.rs
@@ -38,6 +38,7 @@ pub enum DiscoveryBuilderResult {
     FetchMachineError = 6,
     InvalidCircuitId = 7,
     TooManyFailuresError = 8,
+    InvalidDesiredAddress = 9,
 }
 
 #[unsafe(no_mangle)]
@@ -57,6 +58,7 @@ pub extern "C" fn discovery_builder_result_as_str(result: DiscoveryBuilderResult
             DiscoveryBuilderResult::FetchMachineError => "FetchMachineError\0",
             DiscoveryBuilderResult::InvalidCircuitId => "InvalidCircuitId\0",
             DiscoveryBuilderResult::TooManyFailuresError => "TooManyFailuresError\0",
+            DiscoveryBuilderResult::InvalidDesiredAddress => "InvalidDesiredAddress\0",
         }
         .as_bytes(),
     )
@@ -85,7 +87,7 @@ pub struct Discovery {
     pub(crate) remote_id: Option<String>,
 
     #[builder(setter(into, strip_option), default)]
-    pub(crate) desired_address: Option<String>,
+    pub(crate) desired_address: Option<Ipv4Addr>,
 }
 
 #[repr(C)]
@@ -198,7 +200,15 @@ pub unsafe extern "C" fn discovery_set_desired_address(
             Ok(string) => string.to_owned(),
             Err(error) => {
                 log::error!("Invalid UTF-8 byte string for desired_address: {error}");
-                return DiscoveryBuilderResult::InvalidVendorClass;
+                return DiscoveryBuilderResult::InvalidDesiredAddress;
+            }
+        };
+
+        let desired_address = match desired_address.parse::<Ipv4Addr>() {
+            Ok(ip) => ip,
+            Err(error) => {
+                log::error!("Invalid IP address for desired_address: {error}");
+                return DiscoveryBuilderResult::InvalidDesiredAddress;
             }
         };
 
@@ -361,7 +371,7 @@ unsafe fn discovery_fetch_machine_at(
             let mac_address = discovery.mac_address;
             let circuit_id = discovery.circuit_id.clone();
             let remote_id = discovery.remote_id.clone();
-            let desired_address = discovery.desired_address.clone();
+            let desired_address = discovery.desired_address;
             let addr_for_dhcp = IpAddr::V4(
                 discovery
                     .link_select_address
@@ -384,10 +394,9 @@ unsafe fn discovery_fetch_machine_at(
                 None => "",
             };
 
-            let desired_ip = match &desired_address {
-                Some(di) => di.as_str(),
-                None => "",
-            };
+            let desired_ip = desired_address
+                .map(|address| address.to_string())
+                .unwrap_or_default();
 
             let mut cache_entry_status = cache::CacheEntryStatus::DiscoveryFailing(0);
             if let Some(cache_entry) = cache::get(
@@ -511,6 +520,7 @@ pub unsafe extern "C" fn discovery_builder_free(ctx: *mut DiscoveryBuilderFFI) {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::CString;
     use std::ptr::null_mut;
     use std::thread;
 
@@ -644,6 +654,21 @@ mod tests {
         fn assert_send<T: Send>() {}
         assert_send::<Machine>();
         assert_send::<DiscoveryBuilderFFI>();
+    }
+
+    #[test]
+    fn test_discovery_set_desired_address_rejects_invalid_ip() {
+        let builder_ffi = discovery_builder_allocate();
+        let desired_address = CString::new("not-an-ip").unwrap();
+
+        let result =
+            unsafe { discovery_set_desired_address(builder_ffi, desired_address.as_ptr()) };
+
+        assert_eq!(result, DiscoveryBuilderResult::InvalidDesiredAddress);
+
+        unsafe {
+            discovery_builder_free(builder_ffi);
+        }
     }
 
     #[test]

--- a/crates/dhcp/src/kea/callouts.cc
+++ b/crates/dhcp/src/kea/callouts.cc
@@ -410,11 +410,14 @@ int pkt4_receive(CalloutHandle &handle) {
 
         auto desired = addr.toText();
 
-        discovery_set_desired_address(discovery.get(), desired.c_str());
+        builder_result =
+            discovery_set_desired_address(discovery.get(), desired.c_str());
 
-        LOG_INFO(logger,
-                "LOG_CARBIDE_PKT4_RECEIVE: Desired Address [%1] set")
-          .arg(desired);
+        if (builder_result == DiscoveryBuilderResult::Success) {
+          LOG_INFO(logger,
+                  "LOG_CARBIDE_PKT4_RECEIVE: Desired Address [%1] set")
+            .arg(desired);
+        }
       } else {
         LOG_ERROR(logger, "LOG_CARBIDE_PKT4_RECEIVE: Desired addr buf len wrong: [%1]")
           .arg(bufSize);

--- a/crates/dhcp/src/machine.rs
+++ b/crates/dhcp/src/machine.rs
@@ -55,7 +55,7 @@ impl Machine {
                     vendor_string: discovery.vendor_class.clone(),
                     circuit_id: discovery.circuit_id.clone(),
                     remote_id: discovery.remote_id.clone(),
-                    desired_address: discovery.desired_address.clone(),
+                    desired_address: discovery.desired_address.map(|addr| addr.to_string()),
                 });
 
                 client


### PR DESCRIPTION
## Description

This types the DHCP requested address (Option 50) as an `Ipv4Addr` after it crosses the Kea hook boundary. The Rust setter now rejects invalid desired-address strings before we send discovery data to `carbide-api`.

Tests included!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

