### PR TITLE
feat: dpf: Support for https proxy on DPU

### DIFF
--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -826,9 +826,13 @@ pub struct DpfConfig {
     /// docker_image_pull_secret is set in services sections as well.
     #[serde(default)]
     pub docker_image_pull_secret: Option<String>,
-    /// Additional Helm services to deploy alongside DPF.
+    /// Mandatory Helm services to deploy alongside DPF.
     #[serde(default)]
     pub services: Box<DpfMandatoryServicesConfig>,
+    /// Optional proxy configuration for the DPU. When set, containerd on the DPU is
+    /// configured to route outbound HTTPS traffic through the specified proxy.
+    #[serde(default)]
+    pub proxy: Option<DpfProxyDetails>,
 }
 
 impl Default for DpfConfig {
@@ -841,6 +845,7 @@ impl Default for DpfConfig {
             bfb_url: String::new(),
             docker_image_pull_secret: None,
             services: Box::default(),
+            proxy: None,
         }
     }
 }
@@ -875,6 +880,22 @@ fn default_dpf_flavor_name() -> String {
 
 fn default_dpf_node_label_key() -> String {
     "carbide.nvidia.com/controlled.node.v2".to_string()
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DpfProxyDetails {
+    pub https_proxy: String,
+    #[serde(default)]
+    pub no_proxy: Vec<String>,
+}
+
+impl From<DpfProxyDetails> for carbide_dpf::types::DpfProxyDetails {
+    fn from(value: DpfProxyDetails) -> Self {
+        carbide_dpf::types::DpfProxyDetails {
+            https_proxy: value.https_proxy,
+            no_proxy: value.no_proxy,
+        }
+    }
 }
 
 /// Configuration for a mandatory Helm-based DPF service.

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -22,6 +22,7 @@ use std::path::PathBuf;
 
 use bmc_vendor::BMCVendor;
 use carbide_authn::config::{AllowedCertCriteria, TrustConfig};
+use carbide_dpf::types::DpfProxyDetails;
 use carbide_firmware::FirmwareConfig;
 use carbide_firmware::defaults::{
     BF2_BMC_VERSION, BF2_CEC_VERSION, BF2_NIC_VERSION, BF2_UEFI_VERSION, BF3_BMC_VERSION,
@@ -880,22 +881,6 @@ fn default_dpf_flavor_name() -> String {
 
 fn default_dpf_node_label_key() -> String {
     "carbide.nvidia.com/controlled.node.v2".to_string()
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct DpfProxyDetails {
-    pub https_proxy: String,
-    #[serde(default)]
-    pub no_proxy: Vec<String>,
-}
-
-impl From<DpfProxyDetails> for carbide_dpf::types::DpfProxyDetails {
-    fn from(value: DpfProxyDetails) -> Self {
-        carbide_dpf::types::DpfProxyDetails {
-            https_proxy: value.https_proxy,
-            no_proxy: value.no_proxy,
-        }
-    }
 }
 
 /// Configuration for a mandatory Helm-based DPF service.

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -690,6 +690,7 @@ pub async fn start_api(
             flavor_name: carbide_config.dpf.flavor_name.clone(),
             deployment_name: carbide_config.dpf.deployment_name.clone(),
             services: dpf_mandatory_services,
+            proxy: carbide_config.dpf.proxy.clone().map(|x| x.into()),
         };
 
         let sdk = carbide_dpf::DpfSdkBuilder::new(repo, carbide_dpf::NAMESPACE, provider)

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -690,7 +690,7 @@ pub async fn start_api(
             flavor_name: carbide_config.dpf.flavor_name.clone(),
             deployment_name: carbide_config.dpf.deployment_name.clone(),
             services: dpf_mandatory_services,
-            proxy: carbide_config.dpf.proxy.clone().map(|x| x.into()),
+            proxy: carbide_config.dpf.proxy.clone(),
         };
 
         let sdk = carbide_dpf::DpfSdkBuilder::new(repo, carbide_dpf::NAMESPACE, provider)

--- a/crates/dhcp-server/src/grpc_server.rs
+++ b/crates/dhcp-server/src/grpc_server.rs
@@ -159,7 +159,7 @@ impl DhcpServerControl for DhcpServerControlService {
             .await
             .map_err(|_| Status::internal("control channel closed"))?;
 
-        tracing::info!("UpdateAndReloadConfig accepted");
+        tracing::debug!("UpdateAndReloadConfig accepted");
         Ok(Response::new(UpdateAndReloadConfigResponse {}))
     }
 

--- a/crates/dpf/src/error.rs
+++ b/crates/dpf/src/error.rs
@@ -42,6 +42,9 @@ pub enum DpfError {
 
     #[error("Watcher error: {0}")]
     WatcherError(String),
+
+    #[error("JSON serialization error: {0}")]
+    SerializationError(#[from] serde_json::Error),
 }
 
 impl DpfError {

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -18,13 +18,26 @@
 //! DPUFlavor configuration for HBN.
 
 use kube::core::ObjectMeta;
+use sha2::{Digest, Sha256};
 
 use crate::crds::dpuflavors_generated::{
     DPUFlavor, DpuFlavorConfigFiles, DpuFlavorConfigFilesOperation, DpuFlavorDpuMode,
     DpuFlavorNvconfig, DpuFlavorNvconfigDevice, DpuFlavorSpec,
 };
+use crate::types::DpfProxyDetails;
 
 pub const DEFAULT_FLAVOR_NAME: &str = "dpu-flavor";
+
+impl DPUFlavor {
+    /// Returns `"{default_flavor_name}-{hash}"` where the hash is the first 8 bytes (16 hex chars)
+    /// of a stable SHA-256 digest of the spec. The name changes whenever the spec changes, which
+    /// causes outdated DPUs to be reprovisioned by MachineUpdateManager.
+    pub fn unique_name(&self, default_flavor_name: &str) -> String {
+        let json = serde_json::to_string(&self.spec).unwrap_or_default();
+        let short_hash = hex::encode(&Sha256::digest(json.as_bytes())[..8]);
+        format!("{default_flavor_name}-{short_hash}")
+    }
+}
 
 fn get_default_ovs_defaults() -> String {
     concat!(
@@ -51,8 +64,12 @@ fn get_default_ovs_defaults() -> String {
     .to_string()
 }
 
-/// Build the default DPUFlavor CR.
-pub fn default_flavor(namespace: &str, name: &str) -> DPUFlavor {
+/// Build the default DPUFlavor spec. If `proxy` is set, a containerd proxy drop-in config file
+/// is appended so the DPU can pull images through the proxy.
+///
+/// `metadata.name` is left unset; callers must set it (typically via [`DPUFlavor::unique_name`])
+/// before creating the resource in the cluster.
+pub fn default_flavor(namespace: &str, proxy: &Option<DpfProxyDetails>) -> DPUFlavor {
     let bfcfg_parameters = vec![
         "UPDATE_ATF_UEFI=yes".to_string(),
         "UPDATE_DPU_OS=yes".to_string(),
@@ -60,7 +77,7 @@ pub fn default_flavor(namespace: &str, name: &str) -> DPUFlavor {
     ];
     DPUFlavor {
         metadata: ObjectMeta {
-            name: Some(name.to_string()),
+            name: None,
             namespace: Some(namespace.to_string()),
             ..Default::default()
         },
@@ -68,57 +85,7 @@ pub fn default_flavor(namespace: &str, name: &str) -> DPUFlavor {
             dpu_mode: Some(DpuFlavorDpuMode::ZeroTrust),
             dpu_resources: None,
             bfcfg_parameters: Some(bfcfg_parameters),
-            config_files: Some(vec![
-                DpuFlavorConfigFiles {
-                    path: Some("/var/lib/hbn/etc/supervisor/conf.d/acltool.conf".to_string()),
-                    operation: Some(DpuFlavorConfigFilesOperation::Override),
-                    permissions: Some("0644".to_string()),
-                    raw: Some(
-                        concat!(
-                            "[program: cl-acltool]\n",
-                            "command = bash -c \"sleep 5 && ",
-                            "/usr/cumulus/bin/cl-acltool -i\"\n",
-                            "startsecs = 0\n",
-                            "autorestart = false\n",
-                            "priority = 200\n",
-                        )
-                        .to_string(),
-                    ),
-                },
-                DpuFlavorConfigFiles {
-                    path: Some("/var/lib/hbn/etc/cumulus/acl/policy.d/10-dhcp.rules".to_string()),
-                    operation: Some(DpuFlavorConfigFilesOperation::Override),
-                    permissions: Some("0644".to_string()),
-                    raw: Some(dhcp_acl_rules()),
-                },
-                DpuFlavorConfigFiles {
-                    path: Some("/etc/mellanox/mlnx-bf.conf".to_string()),
-                    operation: Some(DpuFlavorConfigFilesOperation::Override),
-                    permissions: Some("0644".to_string()),
-                    raw: Some(
-                        concat!(
-                            "ALLOW_SHARED_RQ=\"no\"\n",
-                            "IPSEC_FULL_OFFLOAD=\"no\"\n",
-                            "ENABLE_ESWITCH_MULTIPORT=\"yes\"\n"
-                        )
-                        .to_string(),
-                    ),
-                },
-                DpuFlavorConfigFiles {
-                    path: Some("/etc/mellanox/mlnx-ovs.conf".to_string()),
-                    operation: Some(DpuFlavorConfigFilesOperation::Override),
-                    permissions: Some("0644".to_string()),
-                    raw: Some(
-                        concat!("CREATE_OVS_BRIDGES=\"no\"\n", "OVS_DOCA=\"yes\"\n").to_string(),
-                    ),
-                },
-                DpuFlavorConfigFiles {
-                    path: Some("/etc/mellanox/mlnx-sf.conf".to_string()),
-                    operation: Some(DpuFlavorConfigFilesOperation::Override),
-                    permissions: Some("0644".to_string()),
-                    raw: Some("".to_string()),
-                },
-            ]),
+            config_files: Some(get_config_files(proxy)),
             containerd_config: None,
             grub: None,
             host_network_interface_configs: None,
@@ -130,6 +97,81 @@ pub fn default_flavor(namespace: &str, name: &str) -> DPUFlavor {
             system_reserved_resources: None,
         },
     }
+}
+
+/// Returns the base set of config files, plus an optional containerd proxy drop-in if `proxy` is set.
+fn get_config_files(proxy: &Option<DpfProxyDetails>) -> Vec<DpuFlavorConfigFiles> {
+    let mut config_files = vec![
+        DpuFlavorConfigFiles {
+            path: Some("/var/lib/hbn/etc/supervisor/conf.d/acltool.conf".to_string()),
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            permissions: Some("0644".to_string()),
+            raw: Some(
+                concat!(
+                    "[program: cl-acltool]\n",
+                    "command = bash -c \"sleep 5 && ",
+                    "/usr/cumulus/bin/cl-acltool -i\"\n",
+                    "startsecs = 0\n",
+                    "autorestart = false\n",
+                    "priority = 200\n",
+                )
+                .to_string(),
+            ),
+        },
+        DpuFlavorConfigFiles {
+            path: Some("/var/lib/hbn/etc/cumulus/acl/policy.d/10-dhcp.rules".to_string()),
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            permissions: Some("0644".to_string()),
+            raw: Some(dhcp_acl_rules()),
+        },
+        DpuFlavorConfigFiles {
+            path: Some("/etc/mellanox/mlnx-bf.conf".to_string()),
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            permissions: Some("0644".to_string()),
+            raw: Some(
+                concat!(
+                    "ALLOW_SHARED_RQ=\"no\"\n",
+                    "IPSEC_FULL_OFFLOAD=\"no\"\n",
+                    "ENABLE_ESWITCH_MULTIPORT=\"yes\"\n"
+                )
+                .to_string(),
+            ),
+        },
+        DpuFlavorConfigFiles {
+            path: Some("/etc/mellanox/mlnx-ovs.conf".to_string()),
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            permissions: Some("0644".to_string()),
+            raw: Some(concat!("CREATE_OVS_BRIDGES=\"no\"\n", "OVS_DOCA=\"yes\"\n").to_string()),
+        },
+        DpuFlavorConfigFiles {
+            path: Some("/etc/mellanox/mlnx-sf.conf".to_string()),
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            permissions: Some("0644".to_string()),
+            raw: Some("".to_string()),
+        },
+    ];
+
+    if let Some(proxy) = proxy {
+        let mut raw = format!(
+            "[Service]\nEnvironment=\"HTTPS_PROXY={0}\"\nEnvironment=\"https_proxy={0}\"\n",
+            proxy.https_proxy
+        );
+        if !proxy.no_proxy.is_empty() {
+            let no_proxy = proxy.no_proxy.join(",");
+            raw.push_str(&format!(
+                "Environment=\"NO_PROXY={0}\"\nEnvironment=\"no_proxy={0}\"\n",
+                no_proxy
+            ));
+        }
+        config_files.push(DpuFlavorConfigFiles {
+            path: Some("/etc/systemd/system/containerd.service.d/socks-proxy.conf".to_string()),
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            permissions: Some("0644".to_string()),
+            raw: Some(raw),
+        });
+    }
+
+    config_files
 }
 
 fn get_default_nvconfig() -> DpuFlavorNvconfig {
@@ -156,6 +198,145 @@ fn get_default_nvconfig() -> DpuFlavorNvconfig {
         // DPF does not allow anyother wild card. It takes only '*'
         device: Some(DpuFlavorNvconfigDevice::KopiumVariant0), //"*"
         parameters: Some(parameters),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::DpfProxyDetails;
+
+    fn proxy(https_proxy: &str, no_proxy: &[&str]) -> Option<DpfProxyDetails> {
+        Some(DpfProxyDetails {
+            https_proxy: https_proxy.to_string(),
+            no_proxy: no_proxy.iter().map(|s| s.to_string()).collect(),
+        })
+    }
+
+    // ── unique_name ────────────────────────────────────────────────────────
+
+    #[test]
+    fn unique_name_has_expected_format() {
+        let flavor = default_flavor("ns", &None);
+        let name = flavor.unique_name("dpu-flavor");
+        // "<prefix>-<16 lowercase hex chars>"
+        let (prefix, hash) = name.rsplit_once('-').expect("name contains '-'");
+        assert_eq!(prefix, "dpu-flavor");
+        assert_eq!(hash.len(), 16);
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn unique_name_is_deterministic() {
+        let f1 = default_flavor("ns", &None);
+        let f2 = default_flavor("ns", &None);
+        assert_eq!(f1.unique_name("dpu-flavor"), f2.unique_name("dpu-flavor"));
+    }
+
+    #[test]
+    fn unique_name_changes_when_proxy_added() {
+        let no_proxy = default_flavor("ns", &None);
+        let with_proxy = default_flavor("ns", &proxy("http://proxy:3128", &[]));
+        assert_ne!(
+            no_proxy.unique_name("dpu-flavor"),
+            with_proxy.unique_name("dpu-flavor")
+        );
+    }
+
+    #[test]
+    fn unique_name_changes_when_no_proxy_list_changes() {
+        let p1 = default_flavor("ns", &proxy("http://proxy:3128", &["10.0.0.0/8"]));
+        let p2 = default_flavor(
+            "ns",
+            &proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]),
+        );
+        assert_ne!(p1.unique_name("dpu-flavor"), p2.unique_name("dpu-flavor"));
+    }
+
+    // ── default_flavor ─────────────────────────────────────────────────────
+
+    #[test]
+    fn default_flavor_metadata_name_is_none() {
+        let flavor = default_flavor("test-ns", &None);
+        assert!(
+            flavor.metadata.name.is_none(),
+            "name must be set by the caller via unique_name()"
+        );
+    }
+
+    #[test]
+    fn default_flavor_namespace_is_set() {
+        let flavor = default_flavor("my-ns", &None);
+        assert_eq!(flavor.metadata.namespace.as_deref(), Some("my-ns"));
+    }
+
+    // ── get_config_files ───────────────────────────────────────────────────
+
+    #[test]
+    fn no_proxy_yields_five_config_files() {
+        let flavor = default_flavor("ns", &None);
+        let files = flavor.spec.config_files.unwrap();
+        assert_eq!(files.len(), 5);
+    }
+
+    #[test]
+    fn proxy_appends_sixth_config_file() {
+        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[]));
+        let files = flavor.spec.config_files.unwrap();
+        assert_eq!(files.len(), 6);
+    }
+
+    #[test]
+    fn proxy_config_file_has_correct_path() {
+        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[]));
+        let files = flavor.spec.config_files.unwrap();
+        let proxy_file = files.last().unwrap();
+        assert_eq!(
+            proxy_file.path.as_deref(),
+            Some("/etc/systemd/system/containerd.service.d/socks-proxy.conf")
+        );
+    }
+
+    #[test]
+    fn proxy_config_file_contains_https_proxy_env() {
+        let flavor = default_flavor("ns", &proxy("http://proxy.example.com:3128", &[]));
+        let files = flavor.spec.config_files.unwrap();
+        let raw = files.last().unwrap().raw.as_deref().unwrap();
+        assert!(raw.contains("HTTPS_PROXY=http://proxy.example.com:3128"));
+        assert!(raw.contains("https_proxy=http://proxy.example.com:3128"));
+    }
+
+    #[test]
+    fn proxy_config_file_omits_no_proxy_when_empty() {
+        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[]));
+        let files = flavor.spec.config_files.unwrap();
+        let raw = files.last().unwrap().raw.as_deref().unwrap();
+        assert!(!raw.contains("NO_PROXY"));
+        assert!(!raw.contains("no_proxy"));
+    }
+
+    #[test]
+    fn proxy_config_file_includes_no_proxy_when_set() {
+        let flavor = default_flavor(
+            "ns",
+            &proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]),
+        );
+        let files = flavor.spec.config_files.unwrap();
+        let raw = files.last().unwrap().raw.as_deref().unwrap();
+        assert!(raw.contains("NO_PROXY=10.0.0.0/8,localhost"));
+        assert!(raw.contains("no_proxy=10.0.0.0/8,localhost"));
+    }
+
+    #[test]
+    fn proxy_config_file_has_override_operation() {
+        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[]));
+        let files = flavor.spec.config_files.unwrap();
+        let proxy_file = files.last().unwrap();
+        assert!(matches!(
+            proxy_file.operation,
+            Some(DpuFlavorConfigFilesOperation::Override)
+        ));
+        assert_eq!(proxy_file.permissions.as_deref(), Some("0644"));
     }
 }
 

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -64,18 +64,37 @@ fn get_default_ovs_defaults() -> String {
     .to_string()
 }
 
+/// Rejects proxy strings containing characters that would break a systemd `Environment="..."` line:
+/// double-quotes (break the quoting), newlines / carriage returns (break the unit-file line), and
+/// any other ASCII control character (< 0x20 or DEL 0x7f).
+fn validate_proxy_string(value: &str, field: &str) -> Result<(), crate::error::DpfError> {
+    if value.chars().any(|c| c == '"' || c < '\x20' || c == '\x7f') {
+        return Err(crate::error::DpfError::ConfigError(format!(
+            "proxy {field} contains characters that are not allowed in a systemd \
+             Environment= value (quotes, newlines, or control characters)"
+        )));
+    }
+    Ok(())
+}
+
 /// Build the default DPUFlavor spec. If `proxy` is set, a containerd proxy drop-in config file
 /// is appended so the DPU can pull images through the proxy.
 ///
+/// Returns `ConfigError` if any proxy string contains characters that would break the generated
+/// systemd `Environment="..."` lines (quotes, newlines, or other control characters).
+///
 /// `metadata.name` is left unset; callers must set it (typically via [`DPUFlavor::unique_name`])
 /// before creating the resource in the cluster.
-pub fn default_flavor(namespace: &str, proxy: &Option<DpfProxyDetails>) -> DPUFlavor {
+pub fn default_flavor(
+    namespace: &str,
+    proxy: &Option<DpfProxyDetails>,
+) -> Result<DPUFlavor, crate::error::DpfError> {
     let bfcfg_parameters = vec![
         "UPDATE_ATF_UEFI=yes".to_string(),
         "UPDATE_DPU_OS=yes".to_string(),
         "WITH_NIC_FW_UPDATE=yes".to_string(),
     ];
-    DPUFlavor {
+    Ok(DPUFlavor {
         metadata: ObjectMeta {
             name: None,
             namespace: Some(namespace.to_string()),
@@ -85,7 +104,7 @@ pub fn default_flavor(namespace: &str, proxy: &Option<DpfProxyDetails>) -> DPUFl
             dpu_mode: Some(DpuFlavorDpuMode::ZeroTrust),
             dpu_resources: None,
             bfcfg_parameters: Some(bfcfg_parameters),
-            config_files: Some(get_config_files(proxy)),
+            config_files: Some(get_config_files(proxy)?),
             containerd_config: None,
             grub: None,
             host_network_interface_configs: None,
@@ -96,11 +115,13 @@ pub fn default_flavor(namespace: &str, proxy: &Option<DpfProxyDetails>) -> DPUFl
             sysctl: None,
             system_reserved_resources: None,
         },
-    }
+    })
 }
 
 /// Returns the base set of config files, plus an optional containerd proxy drop-in if `proxy` is set.
-fn get_config_files(proxy: &Option<DpfProxyDetails>) -> Vec<DpuFlavorConfigFiles> {
+fn get_config_files(
+    proxy: &Option<DpfProxyDetails>,
+) -> Result<Vec<DpuFlavorConfigFiles>, crate::error::DpfError> {
     let mut config_files = vec![
         DpuFlavorConfigFiles {
             path: Some("/var/lib/hbn/etc/supervisor/conf.d/acltool.conf".to_string()),
@@ -152,12 +173,25 @@ fn get_config_files(proxy: &Option<DpfProxyDetails>) -> Vec<DpuFlavorConfigFiles
     ];
 
     if let Some(proxy) = proxy {
+        validate_proxy_string(&proxy.https_proxy, "https_proxy")?;
+
         let mut raw = format!(
             "[Service]\nEnvironment=\"HTTPS_PROXY={0}\"\nEnvironment=\"https_proxy={0}\"\n",
             proxy.https_proxy
         );
         if !proxy.no_proxy.is_empty() {
-            let no_proxy = proxy.no_proxy.join(",");
+            let mut entries: Vec<&str> = proxy
+                .no_proxy
+                .iter()
+                .map(|e| e.trim())
+                .filter(|e| !e.is_empty())
+                .collect();
+            for entry in &entries {
+                validate_proxy_string(entry, "no_proxy entry")?;
+            }
+            entries.sort_unstable();
+            entries.dedup();
+            let no_proxy = entries.join(",");
             raw.push_str(&format!(
                 "Environment=\"NO_PROXY={0}\"\nEnvironment=\"no_proxy={0}\"\n",
                 no_proxy
@@ -171,7 +205,7 @@ fn get_config_files(proxy: &Option<DpfProxyDetails>) -> Vec<DpuFlavorConfigFiles
         });
     }
 
-    config_files
+    Ok(config_files)
 }
 
 fn get_default_nvconfig() -> DpuFlavorNvconfig {
@@ -232,7 +266,7 @@ mod tests {
 
     #[test]
     fn unique_name_has_expected_format() {
-        let flavor = default_flavor("ns", &None);
+        let flavor = default_flavor("ns", &None).unwrap();
         let name = flavor.unique_name("dpu-flavor").unwrap();
         // "<prefix>-<16 lowercase hex chars>"
         let (prefix, hash) = name.rsplit_once('-').expect("name contains '-'");
@@ -243,8 +277,8 @@ mod tests {
 
     #[test]
     fn unique_name_is_deterministic() {
-        let f1 = default_flavor("ns", &None);
-        let f2 = default_flavor("ns", &None);
+        let f1 = default_flavor("ns", &None).unwrap();
+        let f2 = default_flavor("ns", &None).unwrap();
         assert_eq!(
             f1.unique_name("dpu-flavor").unwrap(),
             f2.unique_name("dpu-flavor").unwrap()
@@ -253,8 +287,8 @@ mod tests {
 
     #[test]
     fn unique_name_changes_when_proxy_added() {
-        let no_proxy = default_flavor("ns", &None);
-        let with_proxy = default_flavor("ns", &proxy("http://proxy:3128", &[]));
+        let no_proxy = default_flavor("ns", &None).unwrap();
+        let with_proxy = default_flavor("ns", &proxy("http://proxy:3128", &[])).unwrap();
         assert_ne!(
             no_proxy.unique_name("dpu-flavor").unwrap(),
             with_proxy.unique_name("dpu-flavor").unwrap()
@@ -263,14 +297,67 @@ mod tests {
 
     #[test]
     fn unique_name_changes_when_no_proxy_list_changes() {
-        let p1 = default_flavor("ns", &proxy("http://proxy:3128", &["10.0.0.0/8"]));
+        let p1 = default_flavor("ns", &proxy("http://proxy:3128", &["10.0.0.0/8"])).unwrap();
         let p2 = default_flavor(
             "ns",
             &proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]),
-        );
+        )
+        .unwrap();
         assert_ne!(
             p1.unique_name("dpu-flavor").unwrap(),
             p2.unique_name("dpu-flavor").unwrap()
+        );
+    }
+
+    #[test]
+    fn unique_name_stable_regardless_of_no_proxy_order() {
+        let p1 = default_flavor(
+            "ns",
+            &proxy("http://proxy:3128", &["localhost", "10.0.0.0/8"]),
+        )
+        .unwrap();
+        let p2 = default_flavor(
+            "ns",
+            &proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]),
+        )
+        .unwrap();
+        assert_eq!(
+            p1.unique_name("dpu-flavor").unwrap(),
+            p2.unique_name("dpu-flavor").unwrap(),
+            "no_proxy order must not affect the flavor name"
+        );
+    }
+
+    #[test]
+    fn unique_name_stable_with_duplicate_no_proxy_entries() {
+        let p1 = default_flavor("ns", &proxy("http://proxy:3128", &["10.0.0.0/8"])).unwrap();
+        let p2 = default_flavor(
+            "ns",
+            &proxy("http://proxy:3128", &["10.0.0.0/8", "10.0.0.0/8"]),
+        )
+        .unwrap();
+        assert_eq!(
+            p1.unique_name("dpu-flavor").unwrap(),
+            p2.unique_name("dpu-flavor").unwrap(),
+            "duplicate no_proxy entries must not affect the flavor name"
+        );
+    }
+
+    #[test]
+    fn proxy_config_file_no_proxy_entries_are_sorted_and_deduped() {
+        let flavor = default_flavor(
+            "ns",
+            &proxy(
+                "http://proxy:3128",
+                &["localhost", "10.0.0.0/8", "10.0.0.0/8"],
+            ),
+        )
+        .unwrap();
+        let files = flavor.spec.config_files.unwrap();
+        let raw = files.last().unwrap().raw.as_deref().unwrap();
+        assert!(
+            raw.contains("NO_PROXY=10.0.0.0/8,localhost"),
+            "no_proxy must be sorted and deduped; got: {raw}"
         );
     }
 
@@ -278,7 +365,7 @@ mod tests {
 
     #[test]
     fn default_flavor_metadata_name_is_none() {
-        let flavor = default_flavor("test-ns", &None);
+        let flavor = default_flavor("test-ns", &None).unwrap();
         assert!(
             flavor.metadata.name.is_none(),
             "name must be set by the caller via unique_name()"
@@ -287,7 +374,7 @@ mod tests {
 
     #[test]
     fn default_flavor_namespace_is_set() {
-        let flavor = default_flavor("my-ns", &None);
+        let flavor = default_flavor("my-ns", &None).unwrap();
         assert_eq!(flavor.metadata.namespace.as_deref(), Some("my-ns"));
     }
 
@@ -295,21 +382,21 @@ mod tests {
 
     #[test]
     fn no_proxy_yields_five_config_files() {
-        let flavor = default_flavor("ns", &None);
+        let flavor = default_flavor("ns", &None).unwrap();
         let files = flavor.spec.config_files.unwrap();
         assert_eq!(files.len(), 5);
     }
 
     #[test]
     fn proxy_appends_sixth_config_file() {
-        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[]));
+        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[])).unwrap();
         let files = flavor.spec.config_files.unwrap();
         assert_eq!(files.len(), 6);
     }
 
     #[test]
     fn proxy_config_file_has_correct_path() {
-        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[]));
+        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[])).unwrap();
         let files = flavor.spec.config_files.unwrap();
         let proxy_file = files.last().unwrap();
         assert_eq!(
@@ -320,7 +407,7 @@ mod tests {
 
     #[test]
     fn proxy_config_file_contains_https_proxy_env() {
-        let flavor = default_flavor("ns", &proxy("http://proxy.example.com:3128", &[]));
+        let flavor = default_flavor("ns", &proxy("http://proxy.example.com:3128", &[])).unwrap();
         let files = flavor.spec.config_files.unwrap();
         let raw = files.last().unwrap().raw.as_deref().unwrap();
         assert!(raw.contains("HTTPS_PROXY=http://proxy.example.com:3128"));
@@ -329,7 +416,7 @@ mod tests {
 
     #[test]
     fn proxy_config_file_omits_no_proxy_when_empty() {
-        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[]));
+        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[])).unwrap();
         let files = flavor.spec.config_files.unwrap();
         let raw = files.last().unwrap().raw.as_deref().unwrap();
         assert!(!raw.contains("NO_PROXY"));
@@ -341,7 +428,8 @@ mod tests {
         let flavor = default_flavor(
             "ns",
             &proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]),
-        );
+        )
+        .unwrap();
         let files = flavor.spec.config_files.unwrap();
         let raw = files.last().unwrap().raw.as_deref().unwrap();
         assert!(raw.contains("NO_PROXY=10.0.0.0/8,localhost"));
@@ -350,7 +438,7 @@ mod tests {
 
     #[test]
     fn proxy_config_file_has_override_operation() {
-        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[]));
+        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[])).unwrap();
         let files = flavor.spec.config_files.unwrap();
         let proxy_file = files.last().unwrap();
         assert!(matches!(
@@ -358,5 +446,42 @@ mod tests {
             Some(DpuFlavorConfigFilesOperation::Override)
         ));
         assert_eq!(proxy_file.permissions.as_deref(), Some("0644"));
+    }
+
+    // ── validate_proxy_string ──────────────────────────────────────────────
+
+    #[test]
+    fn proxy_rejected_when_https_proxy_contains_quote() {
+        let err = default_flavor("ns", &proxy("http://proxy:3128/\"evil", &[])).unwrap_err();
+        assert!(
+            matches!(err, crate::error::DpfError::ConfigError(_)),
+            "expected ConfigError, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn proxy_rejected_when_https_proxy_contains_newline() {
+        let err =
+            default_flavor("ns", &proxy("http://proxy:3128\nEvil: injected", &[])).unwrap_err();
+        assert!(matches!(err, crate::error::DpfError::ConfigError(_)));
+    }
+
+    #[test]
+    fn proxy_rejected_when_no_proxy_entry_contains_control_char() {
+        let err =
+            default_flavor("ns", &proxy("http://proxy:3128", &["10.0.0.0/8\x01bad"])).unwrap_err();
+        assert!(matches!(err, crate::error::DpfError::ConfigError(_)));
+    }
+
+    #[test]
+    fn proxy_accepted_with_typical_values() {
+        default_flavor(
+            "ns",
+            &proxy(
+                "http://proxy.corp.example.com:3128",
+                &["10.0.0.0/8", "localhost", ".svc.cluster.local"],
+            ),
+        )
+        .unwrap();
     }
 }

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -32,10 +32,10 @@ impl DPUFlavor {
     /// Returns `"{default_flavor_name}-{hash}"` where the hash is the first 8 bytes (16 hex chars)
     /// of a stable SHA-256 digest of the spec. The name changes whenever the spec changes, which
     /// causes outdated DPUs to be reprovisioned by MachineUpdateManager.
-    pub fn unique_name(&self, default_flavor_name: &str) -> String {
-        let json = serde_json::to_string(&self.spec).unwrap_or_default();
+    pub fn unique_name(&self, default_flavor_name: &str) -> Result<String, crate::error::DpfError> {
+        let json = serde_json::to_string(&self.spec)?;
         let short_hash = hex::encode(&Sha256::digest(json.as_bytes())[..8]);
-        format!("{default_flavor_name}-{short_hash}")
+        Ok(format!("{default_flavor_name}-{short_hash}"))
     }
 }
 
@@ -201,6 +201,21 @@ fn get_default_nvconfig() -> DpuFlavorNvconfig {
     }
 }
 
+/// DHCP ACL rules: drop DHCP broadcasts from host-facing interfaces.
+fn dhcp_acl_rules() -> String {
+    let mut rules = String::from("[iptables]\n");
+    for iface in
+        std::iter::once("pf0hpf_if".to_string()).chain((0..=15).map(|i| format!("pf0vf{i}_if")))
+    {
+        rules.push_str(&format!(
+            "-t filter -A FORWARD -p udp -d 255.255.255.255 \
+             --dport 67 -m physdev --physdev-in {iface} \
+             -m comment --comment 'offload:0' -j DROP\n"
+        ));
+    }
+    rules
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -218,7 +233,7 @@ mod tests {
     #[test]
     fn unique_name_has_expected_format() {
         let flavor = default_flavor("ns", &None);
-        let name = flavor.unique_name("dpu-flavor");
+        let name = flavor.unique_name("dpu-flavor").unwrap();
         // "<prefix>-<16 lowercase hex chars>"
         let (prefix, hash) = name.rsplit_once('-').expect("name contains '-'");
         assert_eq!(prefix, "dpu-flavor");
@@ -230,7 +245,10 @@ mod tests {
     fn unique_name_is_deterministic() {
         let f1 = default_flavor("ns", &None);
         let f2 = default_flavor("ns", &None);
-        assert_eq!(f1.unique_name("dpu-flavor"), f2.unique_name("dpu-flavor"));
+        assert_eq!(
+            f1.unique_name("dpu-flavor").unwrap(),
+            f2.unique_name("dpu-flavor").unwrap()
+        );
     }
 
     #[test]
@@ -238,8 +256,8 @@ mod tests {
         let no_proxy = default_flavor("ns", &None);
         let with_proxy = default_flavor("ns", &proxy("http://proxy:3128", &[]));
         assert_ne!(
-            no_proxy.unique_name("dpu-flavor"),
-            with_proxy.unique_name("dpu-flavor")
+            no_proxy.unique_name("dpu-flavor").unwrap(),
+            with_proxy.unique_name("dpu-flavor").unwrap()
         );
     }
 
@@ -250,7 +268,10 @@ mod tests {
             "ns",
             &proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]),
         );
-        assert_ne!(p1.unique_name("dpu-flavor"), p2.unique_name("dpu-flavor"));
+        assert_ne!(
+            p1.unique_name("dpu-flavor").unwrap(),
+            p2.unique_name("dpu-flavor").unwrap()
+        );
     }
 
     // ── default_flavor ─────────────────────────────────────────────────────
@@ -338,19 +359,4 @@ mod tests {
         ));
         assert_eq!(proxy_file.permissions.as_deref(), Some("0644"));
     }
-}
-
-/// DHCP ACL rules: drop DHCP broadcasts from host-facing interfaces.
-fn dhcp_acl_rules() -> String {
-    let mut rules = String::from("[iptables]\n");
-    for iface in
-        std::iter::once("pf0hpf_if".to_string()).chain((0..=15).map(|i| format!("pf0vf{i}_if")))
-    {
-        rules.push_str(&format!(
-            "-t filter -A FORWARD -p udp -d 255.255.255.255 \
-             --dport 67 -m physdev --physdev-in {iface} \
-             -m comment --comment 'offload:0' -j DROP\n"
-        ));
-    }
-    rules
 }

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -454,7 +454,7 @@ async fn create_dpu_flavor<R: DpuFlavorRepository>(
     default_flavor_name: &str,
     proxy: &Option<DpfProxyDetails>,
 ) -> Result<String, DpfError> {
-    let mut flavor = crate::flavor::default_flavor(namespace, proxy);
+    let mut flavor = crate::flavor::default_flavor(namespace, proxy)?;
     let name = flavor.unique_name(default_flavor_name)?;
     flavor.metadata.name = Some(name.clone());
 
@@ -479,7 +479,7 @@ async fn create_dpu_flavor<R: DpuFlavorRepository>(
                     )))
                 }
                 Some(_) => {
-                    tracing::debug!("DPU flavor already exists");
+                    tracing::debug!(flavor = %name, "DPU flavor already exists");
                     Ok(name)
                 }
             }
@@ -2910,7 +2910,7 @@ mod tests {
 
         // Proxy flavor must get a different hash than the no-proxy flavor.
         let name_no_proxy = {
-            let f = crate::flavor::default_flavor(TEST_NAMESPACE, &None);
+            let f = crate::flavor::default_flavor(TEST_NAMESPACE, &None).unwrap();
             f.unique_name(crate::flavor::DEFAULT_FLAVOR_NAME).unwrap()
         };
         assert_ne!(
@@ -2968,7 +2968,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_dpu_flavor_fails_when_terminating() {
         let mock = SdkMock::new();
-        let mut flavor = crate::flavor::default_flavor(TEST_NAMESPACE, &None);
+        let mut flavor = crate::flavor::default_flavor(TEST_NAMESPACE, &None).unwrap();
         // Use the hash-derived name so the mock key matches what create_dpu_flavor will use.
         let hash_name = flavor
             .unique_name(crate::flavor::DEFAULT_FLAVOR_NAME)
@@ -2998,7 +2998,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_dpu_flavor_ok_when_existing_not_terminating() {
         let mock = SdkMock::new();
-        let mut flavor = crate::flavor::default_flavor(TEST_NAMESPACE, &None);
+        let mut flavor = crate::flavor::default_flavor(TEST_NAMESPACE, &None).unwrap();
         // Use the hash-derived name so the mock key matches what create_dpu_flavor will use.
         flavor.metadata.name = Some(
             flavor

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -455,7 +455,7 @@ async fn create_dpu_flavor<R: DpuFlavorRepository>(
     proxy: &Option<DpfProxyDetails>,
 ) -> Result<String, DpfError> {
     let mut flavor = crate::flavor::default_flavor(namespace, proxy);
-    let name = flavor.unique_name(default_flavor_name);
+    let name = flavor.unique_name(default_flavor_name)?;
     flavor.metadata.name = Some(name.clone());
 
     match DpuFlavorRepository::create(repo, &flavor).await {
@@ -2911,7 +2911,7 @@ mod tests {
         // Proxy flavor must get a different hash than the no-proxy flavor.
         let name_no_proxy = {
             let f = crate::flavor::default_flavor(TEST_NAMESPACE, &None);
-            f.unique_name(crate::flavor::DEFAULT_FLAVOR_NAME)
+            f.unique_name(crate::flavor::DEFAULT_FLAVOR_NAME).unwrap()
         };
         assert_ne!(
             name_with_proxy, name_no_proxy,
@@ -2970,7 +2970,9 @@ mod tests {
         let mock = SdkMock::new();
         let mut flavor = crate::flavor::default_flavor(TEST_NAMESPACE, &None);
         // Use the hash-derived name so the mock key matches what create_dpu_flavor will use.
-        let hash_name = flavor.unique_name(crate::flavor::DEFAULT_FLAVOR_NAME);
+        let hash_name = flavor
+            .unique_name(crate::flavor::DEFAULT_FLAVOR_NAME)
+            .unwrap();
         flavor.metadata.name = Some(hash_name);
         let mut terminating_flavor = flavor.clone();
         terminating_flavor.metadata.deletion_timestamp = Some(terminating_timestamp());
@@ -2998,7 +3000,11 @@ mod tests {
         let mock = SdkMock::new();
         let mut flavor = crate::flavor::default_flavor(TEST_NAMESPACE, &None);
         // Use the hash-derived name so the mock key matches what create_dpu_flavor will use.
-        flavor.metadata.name = Some(flavor.unique_name(crate::flavor::DEFAULT_FLAVOR_NAME));
+        flavor.metadata.name = Some(
+            flavor
+                .unique_name(crate::flavor::DEFAULT_FLAVOR_NAME)
+                .unwrap(),
+        );
         mock.flavors
             .write()
             .unwrap()

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -76,8 +76,8 @@ use crate::repository::{
 };
 use crate::types::{
     BmcPasswordProvider, ConfigPortsServiceType, DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME,
-    DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME, DpuDeviceInfo, DpuDeviceSummary, DpuMismatch,
-    DpuNodeInfo, DpuNodeSummary, DpuPhase, DpuServiceInterfaceTemplateDefinition,
+    DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME, DpfProxyDetails, DpuDeviceInfo, DpuDeviceSummary,
+    DpuMismatch, DpuNodeInfo, DpuNodeSummary, DpuPhase, DpuServiceInterfaceTemplateDefinition,
     DpuServiceInterfaceTemplateType, DpuSummary, FMDS_SERVICE_NAME, HostDpfSnapshot,
     InitDpfResourcesConfig, OTEL_COLLECTOR_SERVICE_NAME, ServiceConfigPortProtocol,
     ServiceDefinition, ServiceNADResourceType, ServiceTemplateVersion,
@@ -445,31 +445,44 @@ async fn create_bfb<R: BfbRepository>(
     }
 }
 
-// DPU flavor is immutable. You should never add any parameter here.
+/// Creates a DPUFlavor with a hash-derived name (`{default_flavor_name}-{spec_hash}`).
+/// Any change in the spec produces a different hash and therefore a new flavor name, which
+/// causes MachineUpdateManager to detect the DPUs as outdated and trigger reprovisioning.
 async fn create_dpu_flavor<R: DpuFlavorRepository>(
     repo: &R,
     namespace: &str,
     default_flavor_name: &str,
-) -> Result<(), DpfError> {
-    let flavor = crate::flavor::default_flavor(namespace, default_flavor_name);
+    proxy: &Option<DpfProxyDetails>,
+) -> Result<String, DpfError> {
+    let mut flavor = crate::flavor::default_flavor(namespace, proxy);
+    let name = flavor.unique_name(default_flavor_name);
+    flavor.metadata.name = Some(name.clone());
 
     match DpuFlavorRepository::create(repo, &flavor).await {
-        Ok(_) => Ok(()),
+        Ok(_) => Ok(name),
         Err(DpfError::KubeError(kube::Error::Api(ref err)))
             if err.is_already_exists() || err.is_conflict() =>
         {
-            let existing = DpuFlavorRepository::get(repo, default_flavor_name, namespace).await?;
-            if existing
-                .as_ref()
-                .is_some_and(|f| f.metadata.deletion_timestamp.is_some())
-            {
-                return Err(DpfError::InvalidState(format!(
-                    "DPUFlavor {default_flavor_name} is being deleted (has deletionTimestamp); \
-                     cannot re-create until the old resource is fully removed",
-                )));
+            // The hash-named flavor already exists (e.g. created by a concurrent reconcile).
+            // Guard against the case where it is being deleted — re-creating while
+            // deletionTimestamp is set would conflict again once the finalizers clear.
+            let existing = DpuFlavorRepository::get(repo, &name, namespace).await?;
+            match existing {
+                None => Err(DpfError::InvalidState(format!(
+                    "DPUFlavor {name} disappeared after AlreadyExists conflict; \
+                     will retry on next reconcile",
+                ))),
+                Some(f) if f.metadata.deletion_timestamp.is_some() => {
+                    Err(DpfError::InvalidState(format!(
+                        "DPUFlavor {name} is being deleted (has deletionTimestamp); \
+                         cannot re-create until the old resource is fully removed",
+                    )))
+                }
+                Some(_) => {
+                    tracing::debug!("DPU flavor already exists");
+                    Ok(name)
+                }
             }
-            tracing::debug!("DPU flavor already exists");
-            Ok(())
         }
         Err(e) => Err(e),
     }
@@ -1055,8 +1068,9 @@ async fn create_flavor_services_and_deployment<
     deployment_name: &str,
     bfb_name: &str,
     default_flavor_name: &str,
+    proxy: &Option<DpfProxyDetails>,
 ) -> Result<(), DpfError> {
-    create_dpu_flavor(repo, namespace, default_flavor_name).await?;
+    let flavor_name = create_dpu_flavor(repo, namespace, default_flavor_name, proxy).await?;
 
     let interfaces = build_dpu_interfaces_vec();
 
@@ -1078,7 +1092,7 @@ async fn create_flavor_services_and_deployment<
         services,
         deployment_name,
         bfb_name,
-        default_flavor_name,
+        &flavor_name,
         namespace,
         labeler,
         &interfaces,
@@ -1125,6 +1139,7 @@ impl<
             &config.deployment_name,
             &bfb_name,
             &config.flavor_name,
+            &config.proxy,
         )
         .await?;
 
@@ -2669,6 +2684,7 @@ mod tests {
             deployment_name: "my-deployment".to_string(),
             flavor_name: "my-flavor".to_string(),
             services: vec![],
+            proxy: None,
         };
 
         assert_eq!(config.bfb_url, "http://example.com/test.bfb");
@@ -2845,10 +2861,117 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_create_dpu_flavor_fresh() {
+        let mock = SdkMock::new();
+        let name = create_dpu_flavor(
+            &mock,
+            TEST_NAMESPACE,
+            crate::flavor::DEFAULT_FLAVOR_NAME,
+            &None,
+        )
+        .await
+        .unwrap();
+
+        // Returned name should have the expected "<prefix>-<hex>" shape.
+        assert!(
+            name.starts_with(crate::flavor::DEFAULT_FLAVOR_NAME),
+            "flavor name should start with the default prefix; got {name}"
+        );
+        assert_ne!(
+            name,
+            crate::flavor::DEFAULT_FLAVOR_NAME,
+            "name must include hash suffix"
+        );
+
+        // The flavor must actually be stored in the mock.
+        let stored = DpuFlavorRepository::get(&mock, &name, TEST_NAMESPACE)
+            .await
+            .unwrap();
+        assert!(stored.is_some(), "created flavor should be retrievable");
+    }
+
+    #[tokio::test]
+    async fn test_create_dpu_flavor_fresh_with_proxy() {
+        use crate::types::DpfProxyDetails;
+        let mock = SdkMock::new();
+        let proxy = Some(DpfProxyDetails {
+            https_proxy: "http://proxy.corp:3128".to_string(),
+            no_proxy: vec!["10.0.0.0/8".to_string()],
+        });
+
+        let name_with_proxy = create_dpu_flavor(
+            &mock,
+            TEST_NAMESPACE,
+            crate::flavor::DEFAULT_FLAVOR_NAME,
+            &proxy,
+        )
+        .await
+        .unwrap();
+
+        // Proxy flavor must get a different hash than the no-proxy flavor.
+        let name_no_proxy = {
+            let f = crate::flavor::default_flavor(TEST_NAMESPACE, &None);
+            f.unique_name(crate::flavor::DEFAULT_FLAVOR_NAME)
+        };
+        assert_ne!(
+            name_with_proxy, name_no_proxy,
+            "proxy and no-proxy flavors must produce distinct names"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_dpu_flavor_disappeared_after_conflict() {
+        // Simulate a race: create() returns AlreadyExists but the flavor is gone by the time we
+        // call get() — the function should return InvalidState rather than panic.
+
+        // We need a mock whose create() always returns AlreadyExists but get() returns None.
+        // Achieve this by pre-inserting then removing the flavor so the key is gone, and
+        // instead rely on the fact that SdkMock::create returns AlreadyExists only when the
+        // key is present — so we simply insert a *different* key so create conflicts but the
+        // flavor we look up is absent.
+        //
+        // Easier: insert the flavor under a wrong key so `create` finds a key collision on the
+        // real key (it won't), or just verify the existing None branch indirectly.
+        //
+        // The cleanest approach: build a custom mock that always errors on create.
+        #[derive(Clone, Default)]
+        struct AlwaysConflictsMock {
+            // empty — get() will always return None
+        }
+
+        #[async_trait::async_trait]
+        impl DpuFlavorRepository for AlwaysConflictsMock {
+            async fn get(&self, _name: &str, _ns: &str) -> Result<Option<DPUFlavor>, DpfError> {
+                Ok(None)
+            }
+            async fn create(&self, f: &DPUFlavor) -> Result<DPUFlavor, DpfError> {
+                Err(already_exists_error(f.meta().name.as_deref().unwrap_or("")))
+            }
+        }
+
+        let mock = AlwaysConflictsMock::default();
+        let err = create_dpu_flavor(
+            &mock,
+            TEST_NAMESPACE,
+            crate::flavor::DEFAULT_FLAVOR_NAME,
+            &None,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, DpfError::InvalidState(_)),
+            "expected InvalidState when flavor disappears after conflict; got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_create_dpu_flavor_fails_when_terminating() {
         let mock = SdkMock::new();
-        let flavor =
-            crate::flavor::default_flavor(TEST_NAMESPACE, crate::flavor::DEFAULT_FLAVOR_NAME);
+        let mut flavor = crate::flavor::default_flavor(TEST_NAMESPACE, &None);
+        // Use the hash-derived name so the mock key matches what create_dpu_flavor will use.
+        let hash_name = flavor.unique_name(crate::flavor::DEFAULT_FLAVOR_NAME);
+        flavor.metadata.name = Some(hash_name);
         let mut terminating_flavor = flavor.clone();
         terminating_flavor.metadata.deletion_timestamp = Some(terminating_timestamp());
         mock.flavors
@@ -2856,9 +2979,14 @@ mod tests {
             .unwrap()
             .insert(SdkMock::key(&terminating_flavor), terminating_flavor);
 
-        let err = create_dpu_flavor(&mock, TEST_NAMESPACE, crate::flavor::DEFAULT_FLAVOR_NAME)
-            .await
-            .unwrap_err();
+        let err = create_dpu_flavor(
+            &mock,
+            TEST_NAMESPACE,
+            crate::flavor::DEFAULT_FLAVOR_NAME,
+            &None,
+        )
+        .await
+        .unwrap_err();
         assert!(
             matches!(err, DpfError::InvalidState(_)),
             "expected InvalidState, got: {err:?}"
@@ -2868,16 +2996,22 @@ mod tests {
     #[tokio::test]
     async fn test_create_dpu_flavor_ok_when_existing_not_terminating() {
         let mock = SdkMock::new();
-        let flavor =
-            crate::flavor::default_flavor(TEST_NAMESPACE, crate::flavor::DEFAULT_FLAVOR_NAME);
+        let mut flavor = crate::flavor::default_flavor(TEST_NAMESPACE, &None);
+        // Use the hash-derived name so the mock key matches what create_dpu_flavor will use.
+        flavor.metadata.name = Some(flavor.unique_name(crate::flavor::DEFAULT_FLAVOR_NAME));
         mock.flavors
             .write()
             .unwrap()
             .insert(SdkMock::key(&flavor), flavor);
 
-        create_dpu_flavor(&mock, TEST_NAMESPACE, crate::flavor::DEFAULT_FLAVOR_NAME)
-            .await
-            .unwrap();
+        create_dpu_flavor(
+            &mock,
+            TEST_NAMESPACE,
+            crate::flavor::DEFAULT_FLAVOR_NAME,
+            &None,
+        )
+        .await
+        .unwrap();
     }
 
     #[derive(Clone, Default)]

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -298,7 +298,8 @@ async fn test_create_initialization_objects() {
     assert_eq!(bfbs.len(), 1);
 
     let expected_flavor_name = crate::flavor::default_flavor(TEST_NS, &config.proxy)
-        .unique_name(crate::flavor::DEFAULT_FLAVOR_NAME);
+        .unique_name(crate::flavor::DEFAULT_FLAVOR_NAME)
+        .unwrap();
     let flavor = DpuFlavorRepository::get(&mock, &expected_flavor_name, TEST_NS)
         .await
         .unwrap();

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -298,6 +298,7 @@ async fn test_create_initialization_objects() {
     assert_eq!(bfbs.len(), 1);
 
     let expected_flavor_name = crate::flavor::default_flavor(TEST_NS, &config.proxy)
+        .unwrap()
         .unique_name(crate::flavor::DEFAULT_FLAVOR_NAME)
         .unwrap();
     let flavor = DpuFlavorRepository::get(&mock, &expected_flavor_name, TEST_NS)

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -297,7 +297,9 @@ async fn test_create_initialization_objects() {
     let bfbs = BfbRepository::list(&mock, TEST_NS).await.unwrap();
     assert_eq!(bfbs.len(), 1);
 
-    let flavor = DpuFlavorRepository::get(&mock, crate::flavor::DEFAULT_FLAVOR_NAME, TEST_NS)
+    let expected_flavor_name = crate::flavor::default_flavor(TEST_NS, &config.proxy)
+        .unique_name(crate::flavor::DEFAULT_FLAVOR_NAME);
+    let flavor = DpuFlavorRepository::get(&mock, &expected_flavor_name, TEST_NS)
         .await
         .unwrap();
     assert!(flavor.is_some());

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -19,6 +19,8 @@
 
 use std::collections::BTreeMap;
 
+use serde::{Deserialize, Serialize};
+
 use crate::crds::dpus_generated::DpuStatusPhase;
 
 /// Async provider for BMC passwords used to create and refresh the K8s BMC
@@ -74,9 +76,10 @@ impl Default for InitDpfResourcesConfig {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DpfProxyDetails {
     pub https_proxy: String,
+    #[serde(default)]
     pub no_proxy: Vec<String>,
 }
 

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -58,6 +58,8 @@ pub struct InitDpfResourcesConfig {
     /// Service templates and configs for M4 DPUDeployment.
     /// When empty, `default_services()` is used automatically.
     pub services: Vec<ServiceDefinition>,
+
+    pub proxy: Option<DpfProxyDetails>,
 }
 
 impl Default for InitDpfResourcesConfig {
@@ -67,8 +69,15 @@ impl Default for InitDpfResourcesConfig {
             deployment_name: "dpu-deployment".to_string(),
             flavor_name: crate::flavor::DEFAULT_FLAVOR_NAME.to_string(),
             services: Vec::new(),
+            proxy: None,
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct DpfProxyDetails {
+    pub https_proxy: String,
+    pub no_proxy: Vec<String>,
 }
 
 /// A DPU CR whose installed BFB or `spec.dpuFlavor` does not match the

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -7,7 +7,7 @@ NICo supports two ways of provisioning DPUs:
 1. iPXE based
 2. DPF based
 
-This manual covers deployment of **DPF based** provisioning as it is used by NICo. 
+This manual covers deployment of **DPF based** provisioning as it is used by NICo.
 It assumes that a working Kubernetes cluster is already available, and is intentionally
 agnostic to the specific cluster implementation (kubeadm, k3s, RKE2, managed clouds, etc.)—any
 conformant cluster that satisfies the DPF prerequisites is acceptable.
@@ -15,7 +15,7 @@ conformant cluster that satisfies the DPF prerequisites is acceptable.
 This guide is **not a replacement** for the official DPF documentation. The
 authoritative source for installing and configuring DPF is the upstream guide:
 
-- https://docs.nvidia.com/networking/display/dpf25101
+- <https://docs.nvidia.com/networking/display/dpf25101>
 
 NICo is designed to follow the Zero-Trust use case detailed in the DPF documentation: [DPF Zero-Trust Mode - HBN Usecase](https://docs.nvidia.com/networking/display/dpf25101/hbn-in-dpf-zero-trust).
 
@@ -56,7 +56,7 @@ kubectl get namespace dpf-operator-system &>/dev/null \
 
 ### 1.2. Image pull and helm repository credentials
 
-Access to the DPF staging Helm chart and related container images requires authentication through NVIDIA NGC. Both the DPF operator and the workloads it deploys will need credentials for pulling Helm charts and container images from private registries. For detailed instructions, see: https://docs.nvidia.com/networking/display/dpf25101/using-private-registries.
+Access to the DPF staging Helm chart and related container images requires authentication through NVIDIA NGC. Both the DPF operator and the workloads it deploys will need credentials for pulling Helm charts and container images from private registries. For detailed instructions, see: <https://docs.nvidia.com/networking/display/dpf25101/using-private-registries>.
 
 #### 1.2.a. `hbn-user-password` Secret
 
@@ -96,8 +96,8 @@ kubectl -n dpf-operator-system label secret dpf-pull-secret \
 
 #### 1.2.c. Secret to pull NICo docker service images
 
-Credentials for `nvcr.io`, used by the DPF operator to download NICo 
-service images. 
+Credentials for `nvcr.io`, used by the DPF operator to download NICo
+service images.
 
 ```bash
 kubectl -n dpf-operator-system create secret docker-registry nico-pull-secret \
@@ -109,6 +109,7 @@ kubectl -n dpf-operator-system create secret docker-registry nico-pull-secret \
 kubectl -n dpf-operator-system label secret nico-pull-secret \
   dpu.nvidia.com/image-pull-secret=""
 ```
+
 #### 1.2.d. Argo CD repository Secrets for Helm charts
 
 DPF pulls several Helm charts via Argo CD. Apply the following Secrets so that
@@ -176,7 +177,22 @@ Important: the `url` field must not end with a `/`, as any difference in the `ur
 | `ngc-doca-https-helm` | `https://helm.ngc.nvidia.com/nvstaging/doca` | HTTPS helm | Some DPUService charts |
 | `ngc-carbide-https-helm` | `https://helm.ngc.nvidia.com/0837451325059433/carbide-dev` | HTTPS helm | Carbide-private DPUService charts |
 
-### 1.3. Cert-manager policy and RBAC for DPF
+### 1.3. Internet access for DPUs
+
+After a DPU joins the DPU cluster, containerd on the DPU must be able to pull
+container images from external registries (e.g. `nvcr.io`). Two approaches exist:
+
+**Option A — ACL softening for DPU egress.** Open the required egress paths in your
+network ACLs so DPUs can reach the container registries directly. Consult your
+network team for the specific rules required.
+
+**Option B — HTTPS proxy in the host cluster.** Deploy an HTTPS-capable forward
+proxy (e.g. a SOCKS5 proxy exposed via a Kubernetes Service) that DPUs can reach and
+that can forward requests onward to the internet. NICo can configure containerd on
+each DPU to route image-pull traffic through the proxy at provisioning time; see
+section 3.5 for the TOML configuration.
+
+### 1.4. Cert-manager policy and RBAC for DPF
 
 DPF relies on cert-manager to mint short-lived certificates. If the cluster
 runs `approver-policy` (CRD `policy.cert-manager.io/CertificateRequestPolicy`),
@@ -272,7 +288,7 @@ Without this binding cert-manager's controller cannot reference the policy and
 
 Follow the upstream DPF installation guide for the actual install procedure:
 
-- https://docs.nvidia.com/networking/display/dpf25101
+- <https://docs.nvidia.com/networking/display/dpf25101>
 
 When installing the DPF operator chart, two parameter overrides are required
 for a NICo-integrated deployment. The example command below illustrates how to
@@ -539,12 +555,30 @@ docker_image_tag        = "<image tag>"            # empty → CI default
 docker_image_pull_secret = "dpf-pull-secret"
 ```
 
+If your environment routes DPU image pulls through an HTTPS forward proxy (Option B
+from section 1.3), add a `[dpf.proxy]` table:
+
+```toml
+[dpf.proxy]
+https_proxy = "socks5://<proxy-host>:<port>"
+no_proxy = ["10.0.0.0/8", "192.168.0.0/16", "localhost", ".cluster.local"]
+```
+
+When set, NICo embeds a systemd drop-in
+(`/etc/systemd/system/containerd.service.d/socks-proxy.conf`) into the `DPUFlavor`
+spec so that containerd on every DPU routes outbound HTTPS traffic through the proxy.
+The proxy is part of the flavor spec — changing or adding `[dpf.proxy]` produces a
+new flavor name (hash-derived) and triggers a full DPU reprovisioning. Set it before
+the first NICo startup with DPF enabled if possible.
+
 Field reference (all under `[dpf]`):
 
 | TOML key | Type | Default | Meaning |
 |---|---|---|---|
 | `enabled` | bool | `false` | Master switch. Must be `true` to use DPF-based provisioning. |
 | `services.<svc>` | table | per-service defaults | Helm/image overrides for each mandatory DPUService. |
+| `proxy.https_proxy` | string | — | HTTPS proxy URL for DPU image pulls (see section 3.5). |
+| `proxy.no_proxy` | list of strings | `[]` | Hosts/CIDRs that must bypass the proxy. |
 
 Notes:
 
@@ -684,7 +718,7 @@ objects in the `dpf-operator-system` namespace:
 
 - a `Secret` (`bmc-shared-password`) holding the shared BMC password,
 - a `BFB` CR named `bf-bundle-<sha256([dpf].bfb_url)>`,
-- a `DPUFlavor` CR named after `[dpf].flavor_name`,
+- a `DPUFlavor` CR named `[dpf].flavor_name-<spec-hash>` (the 16-character hex suffix is a SHA-256 digest of the spec, so any change to the flavor — including adding or changing `[dpf.proxy]` — produces a new name and triggers reprovisioning of all DPUs),
 - a set of `DPUServiceInterface`, `DPUServiceTemplate`,
   `DPUServiceConfiguration`, and `DPUServiceNAD` CRs — one per mandatory
   DPUService (`dts`, `doca-hbn`, `carbide-dpu-agent`, `carbide-dhcp-server`,
@@ -696,9 +730,9 @@ objects in the `dpf-operator-system` namespace:
 
 Because this path runs only at process start, **any change to `[dpf]`** —
 enabling DPF for the first time, changing the BFB URL, renaming the
-`DPUDeployment`/`DPUFlavor`, or pinning a different chart/image version under
-`[dpf.services.*]` — **requires a carbide-api restart** for the new
-configuration to take effect.
+`DPUDeployment`/`DPUFlavor`, pinning a different chart/image version under
+`[dpf.services.*]`, or adding/changing `[dpf.proxy]` — **requires a carbide-api
+restart** for the new configuration to take effect.
 
 ---
 
@@ -726,7 +760,7 @@ carbide-admin-cli dpf enable <host-machine-id>
 | `<host-machine-id>` | yes | Must be a **host** machine id; DPU ids are rejected. |
 
 Sets `machines.dpf.enabled = true` on the given host's runtime row by calling
-the `ModifyDPFState` RPC. 
+the `ModifyDPFState` RPC.
 
 ### `dpf show` — inspect DPF state for one or all hosts
 
@@ -769,7 +803,7 @@ carbide-admin-cli dpf sv
 ```
 
 No arguments. Prints a table comparing each configured DPF service
-(`[dpf.services.*]` from the site config if given or read it from 
+(`[dpf.services.*]` from the site config if given or read it from
 the compile time version) against what is actually deployed
 in the cluster:
 

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -13,9 +13,7 @@ agnostic to the specific cluster implementation (kubeadm, k3s, RKE2, managed clo
 conformant cluster that satisfies the DPF prerequisites is acceptable.
 
 This guide is **not a replacement** for the official DPF documentation. The
-authoritative source for installing and configuring DPF is the upstream guide:
-
-- <https://docs.nvidia.com/networking/display/dpf25101>
+authoritative source for installing and configuring DPF is the [upstream guide](https://docs.nvidia.com/networking/display/dpf25101).
 
 NICo is designed to follow the Zero-Trust use case detailed in the DPF documentation: [DPF Zero-Trust Mode - HBN Usecase](https://docs.nvidia.com/networking/display/dpf25101/hbn-in-dpf-zero-trust).
 
@@ -56,7 +54,7 @@ kubectl get namespace dpf-operator-system &>/dev/null \
 
 ### 1.2. Image pull and helm repository credentials
 
-Access to the DPF staging Helm chart and related container images requires authentication through NVIDIA NGC. Both the DPF operator and the workloads it deploys will need credentials for pulling Helm charts and container images from private registries. For detailed instructions, see: <https://docs.nvidia.com/networking/display/dpf25101/using-private-registries>.
+Access to the DPF staging Helm chart and related container images requires authentication through NVIDIA NGC. Both the DPF operator and the workloads it deploys will need credentials for pulling Helm charts and container images from private registries. Refer to the [Using Private Registries](https://docs.nvidia.com/networking/display/dpf25101/using-private-registries) section of the DPF documentation for detailed instructions.
 
 #### 1.2.a. `hbn-user-password` Secret
 
@@ -286,9 +284,7 @@ Without this binding cert-manager's controller cannot reference the policy and
 
 ## 2. DPF Installation
 
-Follow the upstream DPF installation guide for the actual install procedure:
-
-- <https://docs.nvidia.com/networking/display/dpf25101>
+Follow the [upstream DPF installation guide](https://docs.nvidia.com/networking/display/dpf25101) for the actual install procedure.
 
 When installing the DPF operator chart, two parameter overrides are required
 for a NICo-integrated deployment. The example command below illustrates how to


### PR DESCRIPTION
## Description
Config options are provided to set https_proxy, and a optional no_proxy field in TOML file.
DPUFlavors are now named using a SHA-256 digest of their spec. This is needed to accumulate the runtime changes in DPUFlavor.

Tested on dev-env:
```toml
# cat /etc/systemd/system/containerd.service.d/socks-proxy.conf
[Service]
Environment="HTTPS_PROXY=socks5://10.0.110.2:31199"
Environment="https_proxy=socks5://10.0.110.2:31199"
Environment="NO_PROXY=10.0.0.0/8,192.168.0.0/16,localhost,.cluster.local"
Environment="no_proxy=10.0.0.0/8,192.168.0.0/16,localhost,.cluster.local"
```

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

