### PR TITLE
fix(rest-api): share SQL IP address typing between nvswitch and powershelf

### DIFF
--- a/rest-api/common/pkg/sqltypes/ipaddr.go
+++ b/rest-api/common/pkg/sqltypes/ipaddr.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package sqltypes
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// IPAddr wraps net.IP to provide SQL driver support for PostgreSQL inet values.
+type IPAddr net.IP
+
+// Value implements driver.Valuer for IPAddr.
+// It converts the IP address to the string format PostgreSQL's inet type expects.
+func (ip IPAddr) Value() (driver.Value, error) {
+	if ip == nil {
+		return nil, nil
+	}
+	return net.IP(ip).String(), nil
+}
+
+// Scan implements sql.Scanner for IPAddr.
+// It handles both string and []byte inputs from PostgreSQL.
+func (ip *IPAddr) Scan(src interface{}) error {
+	if src == nil {
+		*ip = nil
+		return nil
+	}
+
+	var ipStr string
+	switch v := src.(type) {
+	case string:
+		ipStr = v
+	case []byte:
+		ipStr = string(v)
+	default:
+		return fmt.Errorf("cannot scan %T into IPAddr", src)
+	}
+
+	// PostgreSQL inet values may include CIDR notation. Strip it if present.
+	if i := strings.LastIndexByte(ipStr, '/'); i >= 0 {
+		ipStr = ipStr[:i]
+	}
+
+	parsed := net.ParseIP(ipStr)
+	if parsed == nil {
+		return fmt.Errorf("failed to parse IP address %q", ipStr)
+	}
+	*ip = IPAddr(parsed)
+	return nil
+}
+
+// IP returns the underlying net.IP.
+func (ip IPAddr) IP() net.IP {
+	return net.IP(ip)
+}
+
+// String returns the IP address as a string.
+func (ip IPAddr) String() string {
+	return net.IP(ip).String()
+}
+
+// Equal returns true if the two IPAddr values are equal.
+func (ip IPAddr) Equal(other IPAddr) bool {
+	return net.IP(ip).Equal(net.IP(other))
+}

--- a/rest-api/common/pkg/sqltypes/ipaddr_test.go
+++ b/rest-api/common/pkg/sqltypes/ipaddr_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package model
+package sqltypes
 
 import (
 	"testing"
@@ -12,7 +12,7 @@ import (
 // TestIPAddrScan covers (*IPAddr).Scan, with emphasis on the CIDR-notation
 // stripping that PostgreSQL's inet type can return (e.g. "192.168.1.100/24").
 // The strip is implemented with strings.LastIndexByte, so these cases pin that
-// behavior — including the IPv6 path (a single '/' prefix delimiter, never a
+// behavior, including the IPv6 path (a single '/' prefix delimiter, never a
 // colon) and the bare "/" edge case, which strips to "" and is then rejected
 // by net.ParseIP.
 func TestIPAddrScan(t *testing.T) {

--- a/rest-api/nvswitch-manager/pkg/nvswitchregistry/postgres.go
+++ b/rest-api/nvswitch-manager/pkg/nvswitchregistry/postgres.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/sqltypes"
 	"github.com/NVIDIA/infra-controller/rest-api/nvswitch-manager/pkg/common/vendor"
 	"github.com/NVIDIA/infra-controller/rest-api/nvswitch-manager/pkg/objects/bmc"
 	"github.com/NVIDIA/infra-controller/rest-api/nvswitch-manager/pkg/objects/nvos"
@@ -36,15 +37,15 @@ func NewPostgresRegistry(db *bun.DB) *PostgresRegistry {
 type NVSwitchModel struct {
 	bun.BaseModel `bun:"table:nvswitch,alias:ns"`
 
-	UUID           uuid.UUID `bun:"uuid,pk,type:uuid"`
-	Vendor         int       `bun:"vendor,notnull"`
-	BMCMACAddress  string    `bun:"bmc_mac_address,notnull"`
-	BMCIPAddress   string    `bun:"bmc_ip_address,notnull"`
-	BMCPort        int       `bun:"bmc_port,notnull,default:443"`
-	NVOSMACAddress string    `bun:"nvos_mac_address,notnull"`
-	NVOSIPAddress  string    `bun:"nvos_ip_address,notnull"`
-	NVOSPort       int       `bun:"nvos_port,notnull,default:22"`
-	RackID         string    `bun:"rack_id"`
+	UUID           uuid.UUID       `bun:"uuid,pk,type:uuid"`
+	Vendor         int             `bun:"vendor,notnull"`
+	BMCMACAddress  string          `bun:"bmc_mac_address,notnull"`
+	BMCIPAddress   sqltypes.IPAddr `bun:"bmc_ip_address,notnull,type:inet"`
+	BMCPort        int             `bun:"bmc_port,notnull,default:443"`
+	NVOSMACAddress string          `bun:"nvos_mac_address,notnull"`
+	NVOSIPAddress  sqltypes.IPAddr `bun:"nvos_ip_address,notnull,type:inet"`
+	NVOSPort       int             `bun:"nvos_port,notnull,default:22"`
+	RackID         string          `bun:"rack_id"`
 }
 
 // Start initializes the registry.
@@ -89,10 +90,10 @@ func (r *PostgresRegistry) Register(ctx context.Context, tray *nvswitch.NVSwitch
 		if err == nil {
 			// Update existing entry
 			existing.Vendor = int(tray.Vendor.Code)
-			existing.BMCIPAddress = tray.BMC.IP.String()
+			existing.BMCIPAddress = sqltypes.IPAddr(tray.BMC.IP)
 			existing.BMCPort = tray.BMC.GetPort()
 			existing.NVOSMACAddress = tray.NVOS.MAC.String()
-			existing.NVOSIPAddress = tray.NVOS.IP.String()
+			existing.NVOSIPAddress = sqltypes.IPAddr(tray.NVOS.IP)
 			existing.NVOSPort = tray.NVOS.GetPort()
 			existing.RackID = tray.RackID
 
@@ -122,10 +123,10 @@ func (r *PostgresRegistry) Register(ctx context.Context, tray *nvswitch.NVSwitch
 			UUID:           tray.UUID,
 			Vendor:         int(tray.Vendor.Code),
 			BMCMACAddress:  bmcMAC,
-			BMCIPAddress:   tray.BMC.IP.String(),
+			BMCIPAddress:   sqltypes.IPAddr(tray.BMC.IP),
 			BMCPort:        tray.BMC.GetPort(),
 			NVOSMACAddress: tray.NVOS.MAC.String(),
-			NVOSIPAddress:  tray.NVOS.IP.String(),
+			NVOSIPAddress:  sqltypes.IPAddr(tray.NVOS.IP),
 			NVOSPort:       tray.NVOS.GetPort(),
 			RackID:         tray.RackID,
 		}
@@ -234,9 +235,9 @@ func modelToTray(m *NVSwitchModel) (*nvswitch.NVSwitchTray, error) {
 		return nil, fmt.Errorf("invalid BMC MAC address %s: %w", m.BMCMACAddress, err)
 	}
 
-	bmcIP := net.ParseIP(m.BMCIPAddress)
+	bmcIP := m.BMCIPAddress.IP()
 	if bmcIP == nil {
-		return nil, fmt.Errorf("invalid BMC IP address: %s", m.BMCIPAddress)
+		return nil, fmt.Errorf("invalid BMC IP address: %s", m.BMCIPAddress.String())
 	}
 
 	nvosMAC, err := net.ParseMAC(m.NVOSMACAddress)
@@ -244,9 +245,9 @@ func modelToTray(m *NVSwitchModel) (*nvswitch.NVSwitchTray, error) {
 		return nil, fmt.Errorf("invalid NVOS MAC address %s: %w", m.NVOSMACAddress, err)
 	}
 
-	nvosIP := net.ParseIP(m.NVOSIPAddress)
+	nvosIP := m.NVOSIPAddress.IP()
 	if nvosIP == nil {
-		return nil, fmt.Errorf("invalid NVOS IP address: %s", m.NVOSIPAddress)
+		return nil, fmt.Errorf("invalid NVOS IP address: %s", m.NVOSIPAddress.String())
 	}
 
 	bmcObj, err := bmc.NewFromAddr(bmcMAC, bmcIP, nil)

--- a/rest-api/powershelf-manager/pkg/converter/dao/converter.go
+++ b/rest-api/powershelf-manager/pkg/converter/dao/converter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/sqltypes"
 	"github.com/NVIDIA/infra-controller/rest-api/powershelf-manager/pkg/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/powershelf-manager/pkg/objects/pmc"
 	"github.com/NVIDIA/infra-controller/rest-api/powershelf-manager/pkg/objects/powershelf"
@@ -20,7 +21,7 @@ func PmcTo(pmc *pmc.PMC) *model.PMC {
 
 	return &model.PMC{
 		MacAddress: model.MacAddr(pmc.GetMac()),
-		IPAddress:  model.IPAddr(pmc.GetIp()),
+		IPAddress:  sqltypes.IPAddr(pmc.GetIp()),
 		Vendor:     pmc.GetVendor().Code,
 	}
 }

--- a/rest-api/powershelf-manager/pkg/converter/dao/converter_test.go
+++ b/rest-api/powershelf-manager/pkg/converter/dao/converter_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/sqltypes"
 	"github.com/NVIDIA/infra-controller/rest-api/powershelf-manager/pkg/common/vendor"
 	"github.com/NVIDIA/infra-controller/rest-api/powershelf-manager/pkg/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/powershelf-manager/pkg/objects/pmc"
@@ -41,14 +42,14 @@ func mustParseMAC(t *testing.T, s string) model.MacAddr {
 	return model.MacAddr(mac)
 }
 
-// Helper to parse IP address and return model.IPAddr
-func mustParseIP(t *testing.T, s string) model.IPAddr {
+// Helper to parse IP address and return sqltypes.IPAddr
+func mustParseIP(t *testing.T, s string) sqltypes.IPAddr {
 	t.Helper()
 	ip := net.ParseIP(s)
 	if ip == nil {
 		t.Fatalf("mustParseIP(%q): invalid IP", s)
 	}
-	return model.IPAddr(ip)
+	return sqltypes.IPAddr(ip)
 }
 
 func TestPmcTo(t *testing.T) {

--- a/rest-api/powershelf-manager/pkg/db/model/integration_test.go
+++ b/rest-api/powershelf-manager/pkg/db/model/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/sqltypes"
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	dbtestutil "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/testutil"
 	"github.com/NVIDIA/infra-controller/rest-api/powershelf-manager/pkg/common/vendor"
@@ -61,11 +62,11 @@ func parseMac(t *testing.T, s string) MacAddr {
 }
 
 // parseIP is a test helper that parses an IP address and converts to IPAddr
-func parseIP(t *testing.T, s string) IPAddr {
+func parseIP(t *testing.T, s string) sqltypes.IPAddr {
 	t.Helper()
 	ip := net.ParseIP(s)
 	require.NotNil(t, ip)
-	return IPAddr(ip)
+	return sqltypes.IPAddr(ip)
 }
 
 func TestIntegration_PMC_CreateAndGet(t *testing.T) {

--- a/rest-api/powershelf-manager/pkg/db/model/pmc.go
+++ b/rest-api/powershelf-manager/pkg/db/model/pmc.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/sqltypes"
 	"github.com/NVIDIA/infra-controller/rest-api/powershelf-manager/pkg/common/vendor"
 
 	"github.com/uptrace/bun"
@@ -18,7 +19,7 @@ type PMC struct {
 
 	MacAddress MacAddr           `bun:"mac_address,pk,unique,notnull,type:macaddr"`
 	Vendor     vendor.VendorCode `bun:"vendor,notnull"`
-	IPAddress  IPAddr            `bun:"ip_address,unique,notnull,type:inet"`
+	IPAddress  sqltypes.IPAddr   `bun:"ip_address,unique,notnull,type:inet"`
 }
 
 // Create inserts a new PMC row.

--- a/rest-api/powershelf-manager/pkg/db/model/pmc_test.go
+++ b/rest-api/powershelf-manager/pkg/db/model/pmc_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/sqltypes"
 	"github.com/NVIDIA/infra-controller/rest-api/powershelf-manager/pkg/common/vendor"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -30,11 +31,11 @@ func mustParseMAC(s string) MacAddr {
 }
 
 // Helper to parse IP address
-func mustParseIP(s string) IPAddr {
+func mustParseIP(s string) sqltypes.IPAddr {
 	if s == "" {
 		return nil
 	}
-	return IPAddr(net.ParseIP(s))
+	return sqltypes.IPAddr(net.ParseIP(s))
 }
 
 type testPMC struct {

--- a/rest-api/powershelf-manager/pkg/db/model/types.go
+++ b/rest-api/powershelf-manager/pkg/db/model/types.go
@@ -7,7 +7,6 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"net"
-	"strings"
 )
 
 // MacAddr wraps net.HardwareAddr to provide proper SQL driver support for PostgreSQL macaddr type.
@@ -56,62 +55,4 @@ func (m MacAddr) HardwareAddr() net.HardwareAddr {
 // String returns the MAC address as a string.
 func (m MacAddr) String() string {
 	return net.HardwareAddr(m).String()
-}
-
-// IPAddr wraps net.IP to provide proper SQL driver support for PostgreSQL inet type.
-type IPAddr net.IP
-
-// Value implements driver.Valuer for IPAddr.
-// Converts the IP address to a string format that PostgreSQL's inet type expects.
-func (ip IPAddr) Value() (driver.Value, error) {
-	if ip == nil {
-		return nil, nil
-	}
-	return net.IP(ip).String(), nil
-}
-
-// Scan implements sql.Scanner for IPAddr.
-// Handles both string and []byte inputs from PostgreSQL.
-func (ip *IPAddr) Scan(src interface{}) error {
-	if src == nil {
-		*ip = nil
-		return nil
-	}
-
-	var ipStr string
-	switch v := src.(type) {
-	case string:
-		ipStr = v
-	case []byte:
-		ipStr = string(v)
-	default:
-		return fmt.Errorf("cannot scan %T into IPAddr", src)
-	}
-
-	// PostgreSQL inet type may include CIDR notation, strip it if present
-	if i := strings.LastIndexByte(ipStr, '/'); i >= 0 {
-		ipStr = ipStr[:i]
-	}
-
-	parsed := net.ParseIP(ipStr)
-	if parsed == nil {
-		return fmt.Errorf("failed to parse IP address %q", ipStr)
-	}
-	*ip = IPAddr(parsed)
-	return nil
-}
-
-// IP returns the underlying net.IP.
-func (ip IPAddr) IP() net.IP {
-	return net.IP(ip)
-}
-
-// String returns the IP address as a string.
-func (ip IPAddr) String() string {
-	return net.IP(ip).String()
-}
-
-// Equal returns true if the two IPAddr are equal.
-func (ip IPAddr) Equal(other IPAddr) bool {
-	return net.IP(ip).Equal(net.IP(other))
 }

--- a/rest-api/powershelf-manager/pkg/firmwaremanager/firmware_manager_integration_test.go
+++ b/rest-api/powershelf-manager/pkg/firmwaremanager/firmware_manager_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/credential"
+	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/sqltypes"
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	dbtestutil "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db/testutil"
 	"github.com/NVIDIA/infra-controller/rest-api/powershelf-manager/pkg/common/vendor"
@@ -156,7 +157,7 @@ func TestIntegration_FirmwareManager_SetUpdateState(t *testing.T) {
 	pmcModel := &model.PMC{
 		MacAddress: model.MacAddr(testPmc.GetMac()),
 		Vendor:     testPmc.GetVendor().Code,
-		IPAddress:  model.IPAddr(testPmc.GetIp()),
+		IPAddress:  sqltypes.IPAddr(testPmc.GetIp()),
 	}
 	tx, err := session.BeginTx(ctx)
 	require.NoError(t, err)
@@ -213,7 +214,7 @@ func TestIntegration_FirmwareManager_SetUpdateState_WithError(t *testing.T) {
 	pmcModel := &model.PMC{
 		MacAddress: model.MacAddr(testPmc.GetMac()),
 		Vendor:     testPmc.GetVendor().Code,
-		IPAddress:  model.IPAddr(testPmc.GetIp()),
+		IPAddress:  sqltypes.IPAddr(testPmc.GetIp()),
 	}
 	tx, err := session.BeginTx(ctx)
 	require.NoError(t, err)
@@ -266,7 +267,7 @@ func TestIntegration_FirmwareManager_GetPendingUpdates(t *testing.T) {
 		pmcModel := &model.PMC{
 			MacAddress: model.MacAddr(p.GetMac()),
 			Vendor:     p.GetVendor().Code,
-			IPAddress:  model.IPAddr(p.GetIp()),
+			IPAddress:  sqltypes.IPAddr(p.GetIp()),
 		}
 		tx, err := session.BeginTx(ctx)
 		require.NoError(t, err)
@@ -331,7 +332,7 @@ func TestIntegration_FirmwareManager_BlockDuplicateUpdate(t *testing.T) {
 	pmcModel := &model.PMC{
 		MacAddress: model.MacAddr(testPmc.GetMac()),
 		Vendor:     testPmc.GetVendor().Code,
-		IPAddress:  model.IPAddr(testPmc.GetIp()),
+		IPAddress:  sqltypes.IPAddr(testPmc.GetIp()),
 	}
 	tx, err := session.BeginTx(ctx)
 	require.NoError(t, err)
@@ -380,7 +381,7 @@ func TestIntegration_FirmwareManager_MultipleComponents(t *testing.T) {
 	pmcModel := &model.PMC{
 		MacAddress: model.MacAddr(testPmc.GetMac()),
 		Vendor:     testPmc.GetVendor().Code,
-		IPAddress:  model.IPAddr(testPmc.GetIp()),
+		IPAddress:  sqltypes.IPAddr(testPmc.GetIp()),
 	}
 	tx, err := session.BeginTx(ctx)
 	require.NoError(t, err)
@@ -438,7 +439,7 @@ func TestIntegration_FirmwareManager_StateTransitionTimestamps(t *testing.T) {
 	pmcModel := &model.PMC{
 		MacAddress: model.MacAddr(testPmc.GetMac()),
 		Vendor:     testPmc.GetVendor().Code,
-		IPAddress:  model.IPAddr(testPmc.GetIp()),
+		IPAddress:  sqltypes.IPAddr(testPmc.GetIp()),
 	}
 	tx, err := session.BeginTx(ctx)
 	require.NoError(t, err)
@@ -513,7 +514,7 @@ func TestIntegration_FirmwareManager_TerminalStateCheck(t *testing.T) {
 			pmcModel := &model.PMC{
 				MacAddress: model.MacAddr(testPmc.GetMac()),
 				Vendor:     testPmc.GetVendor().Code,
-				IPAddress:  model.IPAddr(testPmc.GetIp()),
+				IPAddress:  sqltypes.IPAddr(testPmc.GetIp()),
 			}
 			tx, err := session.BeginTx(ctx)
 			require.NoError(t, err)


### PR DESCRIPTION
## Description

Moves the REST-side Postgres `inet` scanner/valuer into common code. NVSwitch registry gets typed IP storage, and power shelf uses the same helper instead of using its own copy.

Primary callouts are:
- `sqltypes.IPAddr` owns the `inet` Scan/Value behavior, including CIDR stripping from Postgres values.
- `NVSwitchModel` stores BMC and NVOS addresses as `sqltypes.IPAddr`.
- `model.PMC` uses `sqltypes.IPAddr` for the power shelf PMC address.
- No duplicate NVSwitch and power shelf local IP helpers -- they share the same one.

Tests updated!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

