### PR TITLE
feat: support attaching HostInband segments to VPCs

### DIFF
--- a/crates/admin-cli/src/network_segment/attach_vpc/args.rs
+++ b/crates/admin-cli/src/network_segment/attach_vpc/args.rs
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::network::NetworkSegmentId;
+use carbide_uuid::vpc::VpcId;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Attach a network segment to a VPC:
+    $ carbide-admin-cli network-segment attach-vpc --id 12345678-1234-5678-90ab-cdef01234567 \
+    --vpc-id abcdef01-2345-6789-abcd-ef0123456789
+
+Reassign a network segment from its current VPC:
+    $ carbide-admin-cli network-segment attach-vpc --id 12345678-1234-5678-90ab-cdef01234567 \
+    --vpc-id abcdef01-2345-6789-abcd-ef0123456789 --force
+
+")]
+pub struct Args {
+    #[clap(long, help = "Id of the network segment")]
+    pub id: NetworkSegmentId,
+
+    #[clap(long, help = "Id of the VPC")]
+    pub vpc_id: VpcId,
+
+    #[clap(
+        long,
+        help = "Allow reassigning a segment that is attached to another VPC"
+    )]
+    pub force: bool,
+}
+
+impl From<Args> for ::rpc::forge::AttachNetworkSegmentToVpcRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            network_segment_id: Some(args.id),
+            vpc_id: Some(args.vpc_id),
+            allow_replace: args.force,
+        }
+    }
+}

--- a/crates/admin-cli/src/network_segment/attach_vpc/cmd.rs
+++ b/crates/admin-cli/src/network_segment/attach_vpc/cmd.rs
@@ -15,27 +15,12 @@
  * limitations under the License.
  */
 
-mod attach_vpc;
-mod delete;
-mod show;
+use super::args::Args;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
-// Cross-module re-exports for jump module
-pub use show::args::Args as ShowNetworkSegment;
-pub use show::cmd::handle_show;
-
-#[cfg(test)]
-mod tests;
-
-use clap::Parser;
-
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Display Network Segment information")]
-    Show(show::Args),
-    #[clap(about = "Attach Network Segment to VPC")]
-    AttachVpc(attach_vpc::Args),
-    #[clap(about = "Delete Network Segment")]
-    Delete(delete::Args),
+pub async fn handle_attach_vpc(args: Args, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+    ctx.assert_cloud_unsafe_op_message()?;
+    ctx.api_client.0.attach_network_segment_to_vpc(args).await?;
+    Ok(())
 }

--- a/crates/admin-cli/src/network_segment/attach_vpc/mod.rs
+++ b/crates/admin-cli/src/network_segment/attach_vpc/mod.rs
@@ -15,27 +15,17 @@
  * limitations under the License.
  */
 
-mod attach_vpc;
-mod delete;
-mod show;
+pub mod args;
+pub mod cmd;
 
-// Cross-module re-exports for jump module
-pub use show::args::Args as ShowNetworkSegment;
-pub use show::cmd::handle_show;
+pub use args::Args;
 
-#[cfg(test)]
-mod tests;
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
 
-use clap::Parser;
-
-use crate::cfg::dispatch::Dispatch;
-
-#[derive(Parser, Debug, Dispatch)]
-pub enum Cmd {
-    #[clap(about = "Display Network Segment information")]
-    Show(show::Args),
-    #[clap(about = "Attach Network Segment to VPC")]
-    AttachVpc(attach_vpc::Args),
-    #[clap(about = "Delete Network Segment")]
-    Delete(delete::Args),
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::handle_attach_vpc(self, ctx).await
+    }
 }

--- a/crates/admin-cli/src/network_segment/tests.rs
+++ b/crates/admin-cli/src/network_segment/tests.rs
@@ -95,3 +95,69 @@ fn parse_delete_missing_id_fails() {
     let result = Cmd::try_parse_from(["network-segment", "delete"]);
     assert!(result.is_err(), "should fail without --id");
 }
+
+#[test]
+fn parse_attach_vpc() {
+    let cmd = Cmd::try_parse_from([
+        "network-segment",
+        "attach-vpc",
+        "--id",
+        "12345678-1234-5678-90ab-cdef01234567",
+        "--vpc-id",
+        "abcdef01-2345-6789-abcd-ef0123456789",
+    ])
+    .expect("should parse attach-vpc");
+
+    match cmd {
+        Cmd::AttachVpc(args) => {
+            assert_eq!(args.id.to_string(), "12345678-1234-5678-90ab-cdef01234567");
+            assert_eq!(
+                args.vpc_id.to_string(),
+                "abcdef01-2345-6789-abcd-ef0123456789"
+            );
+            assert!(!args.force);
+        }
+        _ => panic!("expected AttachVpc variant"),
+    }
+}
+
+#[test]
+fn parse_attach_vpc_force() {
+    let cmd = Cmd::try_parse_from([
+        "network-segment",
+        "attach-vpc",
+        "--id",
+        "12345678-1234-5678-90ab-cdef01234567",
+        "--vpc-id",
+        "abcdef01-2345-6789-abcd-ef0123456789",
+        "--force",
+    ])
+    .expect("should parse attach-vpc with force");
+
+    match cmd {
+        Cmd::AttachVpc(args) => assert!(args.force),
+        _ => panic!("expected AttachVpc variant"),
+    }
+}
+
+#[test]
+fn parse_attach_vpc_missing_id_fails() {
+    let result = Cmd::try_parse_from([
+        "network-segment",
+        "attach-vpc",
+        "--vpc-id",
+        "abcdef01-2345-6789-abcd-ef0123456789",
+    ]);
+    assert!(result.is_err(), "should fail without --id");
+}
+
+#[test]
+fn parse_attach_vpc_missing_vpc_id_fails() {
+    let result = Cmd::try_parse_from([
+        "network-segment",
+        "attach-vpc",
+        "--id",
+        "12345678-1234-5678-90ab-cdef01234567",
+    ]);
+    assert!(result.is_err(), "should fail without --vpc-id");
+}

--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -446,6 +446,13 @@ impl Forge for Api {
         crate::handlers::network_segment::create(self, request).await
     }
 
+    async fn attach_network_segment_to_vpc(
+        &self,
+        request: Request<rpc::AttachNetworkSegmentToVpcRequest>,
+    ) -> Result<Response<rpc::NetworkSegment>, Status> {
+        crate::handlers::network_segment::attach_to_vpc(self, request).await
+    }
+
     async fn delete_network_segment(
         &self,
         request: Request<rpc::NetworkSegmentDeletionRequest>,

--- a/crates/api-core/src/auth/internal_rbac_rules.rs
+++ b/crates/api-core/src/auth/internal_rbac_rules.rs
@@ -102,6 +102,7 @@ impl InternalRBACRules {
             vec![ForgeAdminCLI, Machineatron, SiteAgent],
         );
         x.perm("CreateNetworkSegment", vec![Machineatron, SiteAgent]);
+        x.perm("AttachNetworkSegmentToVpc", vec![ForgeAdminCLI]);
         x.perm(
             "DeleteNetworkSegment",
             vec![ForgeAdminCLI, Machineatron, SiteAgent],

--- a/crates/api-core/src/handlers/network_segment.rs
+++ b/crates/api-core/src/handlers/network_segment.rs
@@ -80,7 +80,7 @@ pub(crate) async fn find_by_ids(
 
     let mut result = Vec::with_capacity(segments.len());
     for seg in segments {
-        result.push(seg.try_into()?);
+        result.push(seg.into());
     }
     Ok(Response::new(rpc::NetworkSegmentList {
         network_segments: result,
@@ -158,9 +158,80 @@ pub(crate) async fn create(
 
     let network_segment = save(api, &mut txn, new_network_segment, false, allocate_svi_ip).await?;
 
-    let response = Ok(Response::new(network_segment.try_into()?));
     txn.commit().await?;
-    response
+
+    Ok(Response::new(network_segment.into()))
+}
+
+pub(crate) async fn attach_to_vpc(
+    api: &Api,
+    request: Request<rpc::AttachNetworkSegmentToVpcRequest>,
+) -> Result<Response<rpc::NetworkSegment>, Status> {
+    crate::api::log_request_data(&request);
+
+    let rpc::AttachNetworkSegmentToVpcRequest {
+        network_segment_id,
+        vpc_id,
+        allow_replace,
+        ..
+    } = request.into_inner();
+
+    let segment_id =
+        network_segment_id.ok_or(CarbideError::MissingArgument("network_segment_id"))?;
+    let vpc_id = vpc_id.ok_or(CarbideError::MissingArgument("vpc_id"))?;
+
+    let mut txn = api.txn_begin().await?;
+
+    let vpcs = db::vpc::find_by_with_lock(
+        txn.as_mut(),
+        ObjectColumnFilter::One(db::vpc::IdColumn, &vpc_id),
+        db::vpc::VpcRowLock::Mutation,
+    )
+    .await?;
+    let vpc = vpcs.first().ok_or_else(|| CarbideError::NotFoundError {
+        kind: "vpc",
+        id: vpc_id.to_string(),
+    })?;
+
+    let segment = db::network_segment::find_by(
+        &mut txn,
+        ObjectColumnFilter::One(network_segment::IdColumn, &segment_id),
+        NetworkSegmentSearchConfig::default(),
+    )
+    .await?
+    .into_iter()
+    .find(|segment| !segment.is_marked_as_deleted())
+    .ok_or_else(|| CarbideError::NotFoundError {
+        kind: "network segment",
+        id: segment_id.to_string(),
+    })?;
+
+    if segment.config.segment_type != NetworkSegmentType::HostInband {
+        return Err(CarbideError::InvalidArgument(format!(
+            "Only host_inband network segments can be attached to a VPC with this API, got {}",
+            segment.config.segment_type
+        ))
+        .into());
+    }
+
+    vpc.network_virtualization_type
+        .ensure_supports_segment(&segment)
+        .map_err(CarbideError::from)?;
+
+    let network_segment = match segment.config.vpc_id {
+        Some(current_vpc_id) if current_vpc_id == vpc_id => segment,
+        Some(current_vpc_id) if !allow_replace => {
+            return Err(CarbideError::FailedPrecondition(format!(
+                "Network segment {} is already attached to VPC {}",
+                segment.id, current_vpc_id
+            ))
+            .into());
+        }
+        _ => db::network_segment::attach_to_vpc(&segment, txn.as_mut(), vpc_id).await?,
+    };
+
+    txn.commit().await?;
+    Ok(Response::new(network_segment.into()))
 }
 
 pub(crate) async fn delete(
@@ -215,13 +286,9 @@ pub(crate) async fn for_vpc(
 
     let results = db::network_segment::for_vpc(&api.database_connection, uuid).await?;
 
-    let mut network_segments = Vec::with_capacity(results.len());
-
-    for result in results {
-        network_segments.push(result.try_into()?);
-    }
-
-    Ok(Response::new(rpc::NetworkSegmentList { network_segments }))
+    Ok(Response::new(rpc::NetworkSegmentList {
+        network_segments: results.into_iter().map(Into::into).collect(),
+    }))
 }
 
 pub(crate) async fn find_state_histories(

--- a/crates/api-core/src/tests/network_segment.rs
+++ b/crates/api-core/src/tests/network_segment.rs
@@ -24,6 +24,7 @@ use std::time::Duration;
 
 use carbide_network::virtualization::VpcVirtualizationType;
 use carbide_uuid::network::NetworkSegmentId;
+use carbide_uuid::vpc::VpcId;
 use common::network_segment::{
     NetworkSegmentHelper, create_network_segment_with_api, get_segment_state, get_segments,
     text_history,
@@ -1596,4 +1597,196 @@ async fn etv_vpc_rejects_host_inband_segment(
     );
 
     Ok(())
+}
+
+#[crate::sqlx_test]
+async fn attach_host_inband_segment_to_flat_vpc_succeeds(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(pool, TestEnvOverrides::no_network_segments()).await;
+    let (vpc_id, _vpc) =
+        common::api_fixtures::vpc::create_flat_vpc(&env, "flat".to_string(), None).await;
+    let segment = create_unattached_segment(
+        &env,
+        "ATTACH_HOST_INBAND",
+        "198.51.100.0/24",
+        "198.51.100.1",
+        rpc::forge::NetworkSegmentType::HostInband,
+    )
+    .await?;
+
+    let attached = attach_network_segment_to_vpc(&env, segment.id.unwrap(), vpc_id, false)
+        .await?
+        .into_inner();
+
+    assert_eq!(attached.config.unwrap().vpc_id, Some(vpc_id));
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn attach_host_inband_segment_to_same_vpc_is_idempotent(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(pool, TestEnvOverrides::no_network_segments()).await;
+    let (vpc_id, _vpc) =
+        common::api_fixtures::vpc::create_flat_vpc(&env, "flat".to_string(), None).await;
+    let segment = create_unattached_segment(
+        &env,
+        "ATTACH_HOST_INBAND_IDEMPOTENT",
+        "198.51.101.0/24",
+        "198.51.101.1",
+        rpc::forge::NetworkSegmentType::HostInband,
+    )
+    .await?;
+    let segment_id = segment.id.unwrap();
+
+    let first = attach_network_segment_to_vpc(&env, segment_id, vpc_id, false)
+        .await?
+        .into_inner();
+    let second = attach_network_segment_to_vpc(&env, segment_id, vpc_id, false)
+        .await?
+        .into_inner();
+
+    assert_eq!(second.config.unwrap().vpc_id, Some(vpc_id));
+    assert_eq!(second.version, first.version);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn attach_host_inband_segment_to_non_flat_vpc_fails(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(pool, TestEnvOverrides::no_network_segments()).await;
+    let (vpc_id, _vpc) =
+        common::api_fixtures::vpc::create_vpc(&env, "etv".to_string(), None, None).await;
+    let segment = create_unattached_segment(
+        &env,
+        "ATTACH_HOST_INBAND_TO_ETV",
+        "198.51.102.0/24",
+        "198.51.102.1",
+        rpc::forge::NetworkSegmentType::HostInband,
+    )
+    .await?;
+
+    let err = attach_network_segment_to_vpc(&env, segment.id.unwrap(), vpc_id, false)
+        .await
+        .expect_err("HostInband segments must not attach to non-Flat VPCs");
+
+    assert_eq!(err.code(), tonic::Code::InvalidArgument, "got: {err}");
+    assert!(
+        err.message().contains("etv") && err.message().contains("host_inband"),
+        "error should mention etv VPC rejecting host_inband segment, got: {}",
+        err.message()
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn attach_non_host_inband_segment_fails(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(pool, TestEnvOverrides::no_network_segments()).await;
+    let (vpc_id, _vpc) =
+        common::api_fixtures::vpc::create_flat_vpc(&env, "flat".to_string(), None).await;
+    let segment = create_unattached_segment(
+        &env,
+        "ATTACH_ADMIN_REJECTED",
+        "198.51.103.0/24",
+        "198.51.103.1",
+        rpc::forge::NetworkSegmentType::Admin,
+    )
+    .await?;
+
+    let err = attach_network_segment_to_vpc(&env, segment.id.unwrap(), vpc_id, false)
+        .await
+        .expect_err("non-HostInband segments must be rejected");
+
+    assert_eq!(err.code(), tonic::Code::InvalidArgument, "got: {err}");
+    assert!(
+        err.message().contains("host_inband"),
+        "error should mention host_inband validation, got: {}",
+        err.message()
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn attach_to_different_vpc_requires_force(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(pool, TestEnvOverrides::no_network_segments()).await;
+    let (first_vpc_id, _vpc) =
+        common::api_fixtures::vpc::create_flat_vpc(&env, "flat-1".to_string(), None).await;
+    let (second_vpc_id, _vpc) =
+        common::api_fixtures::vpc::create_flat_vpc(&env, "flat-2".to_string(), None).await;
+    let segment = create_unattached_segment(
+        &env,
+        "ATTACH_HOST_INBAND_REPLACE",
+        "198.51.104.0/24",
+        "198.51.104.1",
+        rpc::forge::NetworkSegmentType::HostInband,
+    )
+    .await?;
+    let segment_id = segment.id.unwrap();
+
+    attach_network_segment_to_vpc(&env, segment_id, first_vpc_id, false).await?;
+
+    let err = attach_network_segment_to_vpc(&env, segment_id, second_vpc_id, false)
+        .await
+        .expect_err("reassignment without force must fail");
+    assert_eq!(err.code(), tonic::Code::FailedPrecondition, "got: {err}");
+
+    let attached = attach_network_segment_to_vpc(&env, segment_id, second_vpc_id, true)
+        .await?
+        .into_inner();
+    assert_eq!(attached.config.unwrap().vpc_id, Some(second_vpc_id));
+
+    Ok(())
+}
+
+async fn create_unattached_segment(
+    env: &common::api_fixtures::TestEnv,
+    name: &str,
+    prefix: &str,
+    gateway: &str,
+    segment_type: rpc::forge::NetworkSegmentType,
+) -> Result<rpc::forge::NetworkSegment, tonic::Status> {
+    env.api
+        .create_network_segment(Request::new(rpc::forge::NetworkSegmentCreationRequest {
+            id: None,
+            mtu: Some(1500),
+            name: name.to_string(),
+            prefixes: vec![rpc::forge::NetworkPrefix {
+                id: None,
+                prefix: prefix.to_string(),
+                gateway: Some(gateway.to_string()),
+                reserve_first: 3,
+                free_ip_count: 0,
+                svi_ip: None,
+            }],
+            subdomain_id: None,
+            vpc_id: None,
+            segment_type: segment_type as i32,
+        }))
+        .await
+        .map(|response| response.into_inner())
+}
+
+async fn attach_network_segment_to_vpc(
+    env: &common::api_fixtures::TestEnv,
+    network_segment_id: NetworkSegmentId,
+    vpc_id: VpcId,
+    allow_replace: bool,
+) -> Result<tonic::Response<rpc::forge::NetworkSegment>, tonic::Status> {
+    env.api
+        .attach_network_segment_to_vpc(Request::new(rpc::forge::AttachNetworkSegmentToVpcRequest {
+            network_segment_id: Some(network_segment_id),
+            vpc_id: Some(vpc_id),
+            allow_replace,
+        }))
+        .await
 }

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -715,6 +715,46 @@ pub async fn set_vpc_id_and_can_stretch(
     Ok(())
 }
 
+pub async fn attach_to_vpc(
+    value: &NetworkSegment,
+    txn: &mut PgConnection,
+    vpc_id: VpcId,
+) -> Result<NetworkSegment, DatabaseError> {
+    let next_version = value.version.increment();
+    let query = "UPDATE network_segments
+            SET vpc_id=$1, version=$2, updated=NOW()
+            WHERE id=$3 AND version=$4 AND deleted IS NULL
+            RETURNING id";
+    let updated_id: NetworkSegmentId = sqlx::query_as(query)
+        .bind(vpc_id)
+        .bind(next_version)
+        .bind(value.id)
+        .bind(value.version)
+        .fetch_one(&mut *txn)
+        .await
+        .map_err(|e| match e {
+            sqlx::Error::RowNotFound => DatabaseError::ConcurrentModificationError(
+                "network_segment",
+                value.version.to_string(),
+            ),
+            e => DatabaseError::query(query, e),
+        })?;
+
+    find_by(
+        txn,
+        ObjectColumnFilter::One(IdColumn, &updated_id),
+        NetworkSegmentSearchConfig::default(),
+    )
+    .await?
+    .pop()
+    .ok_or_else(|| {
+        DatabaseError::new(
+            "finding just-attached network segment",
+            sqlx::Error::RowNotFound,
+        )
+    })
+}
+
 pub async fn mark_as_deleted(
     value: &NetworkSegment,
     txn: &mut PgConnection,

--- a/crates/api-model/src/network_prefix.rs
+++ b/crates/api-model/src/network_prefix.rs
@@ -44,6 +44,16 @@ pub struct NewNetworkPrefix {
     pub num_reserved: i32,
 }
 
+impl From<NetworkPrefix> for NewNetworkPrefix {
+    fn from(prefix: NetworkPrefix) -> Self {
+        Self {
+            prefix: prefix.prefix,
+            gateway: prefix.gateway,
+            num_reserved: prefix.num_reserved,
+        }
+    }
+}
+
 impl<'r> FromRow<'r, PgRow> for NetworkPrefix {
     fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
         Ok(NetworkPrefix {

--- a/crates/api-model/src/vpc/capability.rs
+++ b/crates/api-model/src/vpc/capability.rs
@@ -51,8 +51,9 @@
 use std::fmt;
 
 use carbide_network::virtualization::VpcVirtualizationType;
+use ipnetwork::IpNetwork;
 
-use crate::network_segment::{NetworkSegmentType, NewNetworkSegment};
+use crate::network_segment::{NetworkSegment, NetworkSegmentType, NewNetworkSegment};
 
 /// Which host-side fabric interface kind a VPC virtualization type
 /// attaches to. Used at instance-allocation time to decide which hosts
@@ -311,7 +312,7 @@ pub trait VpcVirtualizationTypeCapabilities {
     /// per-address-family prefix checks ([`Self::supports_ipv4_prefix`]
     /// and [`Self::supports_ipv6_prefix`]) for any prefixes the segment
     /// carries.
-    fn supports_segment(self, segment: &NewNetworkSegment) -> bool;
+    fn supports_segment(self, segment: impl NetworkSegmentProperties) -> bool;
 
     /// Whether this type can have IPv4 network prefixes.
     fn supports_ipv4_prefix(self) -> bool;
@@ -335,7 +336,7 @@ pub trait VpcVirtualizationTypeCapabilities {
     /// `can_stretch` opt-in -- a SVI is only allocated on stretched-L2
     /// segments in a SVI-capable VPC type. Tenant /31 link segments
     /// (`can_stretch = false`) don't get one even on FNN.
-    fn allocates_svi_for(self, segment: &NewNetworkSegment) -> bool;
+    fn allocates_svi_for(self, segment: impl NetworkSegmentProperties) -> bool;
 
     /// Whether this type's DPU agent imports peer VPCs' VNIs into the
     /// local VRF for EVPN-style route exchange. See
@@ -359,12 +360,51 @@ pub trait VpcVirtualizationTypeCapabilities {
     ) -> Result<(), VpcCapabilityError>;
     /// Validates segment-type compatibility plus per-address-family
     /// support for any prefixes the segment carries.
-    fn ensure_supports_segment(self, segment: &NewNetworkSegment)
-    -> Result<(), VpcCapabilityError>;
+    fn ensure_supports_segment(
+        self,
+        segment: impl NetworkSegmentProperties,
+    ) -> Result<(), VpcCapabilityError>;
     fn ensure_supports_ipv4_prefix(self) -> Result<(), VpcCapabilityError>;
     fn ensure_supports_ipv6_prefix(self) -> Result<(), VpcCapabilityError>;
     fn ensure_supports_routing_profiles(self) -> Result<(), VpcCapabilityError>;
     fn ensure_can_peer_with(self, other: VpcVirtualizationType) -> Result<(), VpcCapabilityError>;
+}
+
+/// Trait representing the information we need from a NetworkSegment to perform validation. Included
+/// so that you can pass a `&NewNetworkSegment` or a `&NetworkSegment` to
+/// VpcVirtualizationTypeCapabilities.
+pub trait NetworkSegmentProperties {
+    fn segment_type(&self) -> NetworkSegmentType;
+    fn prefixes(&self) -> impl Iterator<Item = IpNetwork>;
+    fn can_stretch(&self) -> Option<bool>;
+}
+
+impl NetworkSegmentProperties for &NewNetworkSegment {
+    fn segment_type(&self) -> NetworkSegmentType {
+        self.segment_type
+    }
+
+    fn prefixes(&self) -> impl Iterator<Item = IpNetwork> {
+        self.prefixes.iter().map(|p| p.prefix)
+    }
+
+    fn can_stretch(&self) -> Option<bool> {
+        self.can_stretch
+    }
+}
+
+impl NetworkSegmentProperties for &NetworkSegment {
+    fn segment_type(&self) -> NetworkSegmentType {
+        self.config.segment_type
+    }
+
+    fn prefixes(&self) -> impl Iterator<Item = IpNetwork> {
+        self.prefixes.iter().map(|p| p.prefix)
+    }
+
+    fn can_stretch(&self) -> Option<bool> {
+        self.status.can_stretch
+    }
 }
 
 impl VpcVirtualizationTypeCapabilities for VpcVirtualizationType {
@@ -386,12 +426,12 @@ impl VpcVirtualizationTypeCapabilities for VpcVirtualizationType {
             .contains(&segment_type)
     }
 
-    fn supports_segment(self, segment: &NewNetworkSegment) -> bool {
-        if !self.supports_segment_type(segment.segment_type) {
+    fn supports_segment(self, segment: impl NetworkSegmentProperties) -> bool {
+        if !self.supports_segment_type(segment.segment_type()) {
             return false;
         }
-        let has_ipv4_prefix = segment.prefixes.iter().any(|p| p.prefix.is_ipv4());
-        let has_ipv6_prefix = segment.prefixes.iter().any(|p| p.prefix.is_ipv6());
+        let has_ipv4_prefix = segment.prefixes().any(|p| p.is_ipv4());
+        let has_ipv6_prefix = segment.prefixes().any(|p| p.is_ipv6());
         (!has_ipv4_prefix || self.supports_ipv4_prefix())
             && (!has_ipv6_prefix || self.supports_ipv6_prefix())
     }
@@ -412,8 +452,8 @@ impl VpcVirtualizationTypeCapabilities for VpcVirtualizationType {
         self.capabilities().data_plane.allocates_svi_ip()
     }
 
-    fn allocates_svi_for(self, segment: &NewNetworkSegment) -> bool {
-        segment.can_stretch.unwrap_or(true) && self.allocates_svi_ip()
+    fn allocates_svi_for(self, segment: impl NetworkSegmentProperties) -> bool {
+        segment.can_stretch().unwrap_or(true) && self.allocates_svi_ip()
     }
 
     fn imports_peer_vnis_into_overlay(self) -> bool {
@@ -446,13 +486,13 @@ impl VpcVirtualizationTypeCapabilities for VpcVirtualizationType {
 
     fn ensure_supports_segment(
         self,
-        segment: &NewNetworkSegment,
+        segment: impl NetworkSegmentProperties,
     ) -> Result<(), VpcCapabilityError> {
-        self.ensure_supports_segment_type(segment.segment_type)?;
-        if segment.prefixes.iter().any(|p| p.prefix.is_ipv4()) {
+        self.ensure_supports_segment_type(segment.segment_type())?;
+        if segment.prefixes().any(|p| p.is_ipv4()) {
             self.ensure_supports_ipv4_prefix()?;
         }
-        if segment.prefixes.iter().any(|p| p.prefix.is_ipv6()) {
+        if segment.prefixes().any(|p| p.is_ipv6()) {
             self.ensure_supports_ipv6_prefix()?;
         }
         Ok(())

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -331,6 +331,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .type_attribute("forge.NetworkSegmentConfig", "#[derive(serde::Serialize)]")
         .type_attribute("forge.NetworkSegmentStatus", "#[derive(serde::Serialize)]")
         .type_attribute("forge.NetworkSegment", "#[derive(serde::Serialize)]")
+        .type_attribute(
+            "forge.AttachNetworkSegmentToVpcRequest",
+            "#[derive(serde::Serialize)]",
+        )
         .type_attribute("forge.IBPartitionConfig", "#[derive(serde::Serialize)]")
         .type_attribute("forge.SpxPartitionConfig", "#[derive(serde::Serialize)]")
         .type_attribute("forge.IBPartitionStatus", "#[derive(serde::Serialize)]")

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -75,6 +75,7 @@ service Forge {
   rpc FindNetworkSegmentIds(NetworkSegmentSearchFilter) returns (NetworkSegmentIdList);
   rpc FindNetworkSegmentsByIds(NetworkSegmentsByIdsRequest) returns (NetworkSegmentList);
   rpc CreateNetworkSegment(NetworkSegmentCreationRequest) returns (NetworkSegment);
+  rpc AttachNetworkSegmentToVpc(AttachNetworkSegmentToVpcRequest) returns (NetworkSegment);
   rpc DeleteNetworkSegment(NetworkSegmentDeletionRequest) returns (NetworkSegmentDeletionResult);
   // TODO: This functionality should get integrated into NetworkSegmentSearchFilter
   rpc NetworkSegmentsForVpc(VpcSearchQuery) returns (NetworkSegmentList);
@@ -2439,6 +2440,12 @@ message NetworkSegmentCreationRequest {
 
 message NetworkSegmentDeletionRequest {
   common.NetworkSegmentId id = 1;
+}
+
+message AttachNetworkSegmentToVpcRequest {
+  common.NetworkSegmentId network_segment_id = 1;
+  common.VpcId vpc_id = 2;
+  bool allow_replace = 3;
 }
 
 message NetworkSegmentDeletionResult {

--- a/crates/rpc/src/model/network_segment.rs
+++ b/crates/rpc/src/model/network_segment.rs
@@ -130,9 +130,8 @@ impl TryFrom<rpc::forge::NetworkSegmentCreationRequest> for NewNetworkSegment {
 ///
 /// subdomain_id - Rust UUID -> ProtoBuf UUID(String) cannot fail, so convert it or return None
 #[allow(deprecated)]
-impl TryFrom<NetworkSegment> for rpc::NetworkSegment {
-    type Error = RpcDataConversionError;
-    fn try_from(src: NetworkSegment) -> Result<Self, Self::Error> {
+impl From<NetworkSegment> for rpc::NetworkSegment {
+    fn from(src: NetworkSegment) -> Self {
         // Deprecated TenantState mapping - kept to populate the backward-compat flat field.
         // Note that even though the segment might already be ready,
         // we only return `Ready` after the state machine also noticed that.
@@ -199,7 +198,7 @@ impl TryFrom<NetworkSegment> for rpc::NetworkSegment {
 
         let version = src.version.version_string();
 
-        Ok(rpc::NetworkSegment {
+        rpc::NetworkSegment {
             id: Some(src.id),
             created: Some(src.created.into()),
             updated: Some(src.updated.into()),
@@ -247,7 +246,7 @@ impl TryFrom<NetworkSegment> for rpc::NetworkSegment {
             history,
             state_reason,
             state_sla: Some(sla),
-        })
+        }
     }
 }
 


### PR DESCRIPTION
## Description
In cases where we've seeded data with initial HostInband network segments, but don't have coresponding VPC objects, add a command to associate a network segment with a VPC after the fact. This is because a host-inband segment needs to exist for machines to even DHCP in a zero-dpu environment, before any instances are allocated. But once you do want to allocate instances, and you have a VPC created for them, the network segment the hosts have already DHCP'd into needs to be associated with that VPC.

## Type of Change
- [X] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
#2337

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated  
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes



Closes #2337
