### PR TITLE
test: add an async variant + better integrated error checking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,6 +1190,7 @@ dependencies = [
  "carbide-sqlx-testing",
  "carbide-state-controller-common",
  "carbide-switch-controller",
+ "carbide-test-support",
  "carbide-utils",
  "carbide-uuid",
  "carbide-version",
@@ -1227,7 +1228,6 @@ dependencies = [
  "mac_address",
  "mockito",
  "mqttea",
- "nico-test-support",
  "nras",
  "num_cpus",
  "nv-redfish",
@@ -1297,6 +1297,7 @@ dependencies = [
  "carbide-network",
  "carbide-secrets",
  "carbide-sqlx-testing",
+ "carbide-test-support",
  "carbide-utils",
  "carbide-uuid",
  "carbide-version",
@@ -1314,7 +1315,6 @@ dependencies = [
  "lazy_static",
  "mac_address",
  "names",
- "nico-test-support",
  "octseq",
  "regex",
  "rustc-hash",
@@ -1370,6 +1370,7 @@ dependencies = [
  "carbide-network",
  "carbide-secrets",
  "carbide-sqlx-testing",
+ "carbide-test-support",
  "carbide-utils",
  "carbide-uuid",
  "carbide-version",
@@ -1384,7 +1385,6 @@ dependencies = [
  "lazy_static",
  "libnmxm",
  "mac_address",
- "nico-test-support",
  "nras",
  "once_cell",
  "p256 0.14.0-rc.9",
@@ -2157,13 +2157,13 @@ dependencies = [
  "carbide-libmlx-model",
  "carbide-rpc",
  "carbide-ssh",
+ "carbide-test-support",
  "carbide-uuid",
  "chrono",
  "clap",
  "hex",
  "hostname",
  "mac_address",
- "nico-test-support",
  "once_cell",
  "prettytable-rs",
  "prost-types",
@@ -2814,6 +2814,7 @@ dependencies = [
  "carbide-rpc",
  "carbide-secrets",
  "carbide-test-harness",
+ "carbide-test-support",
  "carbide-utils",
  "carbide-uuid",
  "chrono",
@@ -2825,7 +2826,6 @@ dependencies = [
  "libredfish",
  "librms",
  "mac_address",
- "nico-test-support",
  "opentelemetry",
  "rand 0.10.1",
  "regex",
@@ -3023,6 +3023,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "carbide-test-support"
+version = "0.0.0"
+
+[[package]]
 name = "carbide-tls"
 version = "0.0.0"
 dependencies = [
@@ -3039,6 +3043,7 @@ version = "0.0.0"
 dependencies = [
  "byte-unit",
  "carbide-network",
+ "carbide-test-support",
  "chrono",
  "clap",
  "ipnetwork",
@@ -7201,10 +7206,6 @@ dependencies = [
  "x509-parser",
  "zip",
 ]
-
-[[package]]
-name = "nico-test-support"
-version = "0.0.0"
 
 [[package]]
 name = "nix"

--- a/crates/api-core/Cargo.toml
+++ b/crates/api-core/Cargo.toml
@@ -223,7 +223,7 @@ carbide-redfish = { path = "../redfish", features = ["test-support"] }
 carbide-rpc = { path = "../rpc", features = ["model", "sqlx", "test-support"] }
 carbide-secrets = { path = "../secrets", features = ["test-support"] }
 carbide-sqlx-testing = { path = "../sqlx-testing", default-features = false }
-nico-test-support = { path = "../test-support" }
+carbide-test-support = { path = "../test-support" }
 carbide-utils = { path = "../utils", features = ["test-support"] }
 prometheus-text-parser = { path = "../prometheus-text-parser" }
 state-controller = { path = "../state-controller", features = ["test-support"] }

--- a/crates/api-core/src/instance/mod.rs
+++ b/crates/api-core/src/instance/mod.rs
@@ -1408,8 +1408,8 @@ pub fn allocate_spx_port_mac(
 
 #[cfg(test)]
 mod tests {
-    use nico_test_support::Outcome::*;
-    use nico_test_support::{Case, check_cases};
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
 
     use super::*;
 

--- a/crates/api-core/src/machine_identity/token_exchange.rs
+++ b/crates/api-core/src/machine_identity/token_exchange.rs
@@ -201,56 +201,83 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn token_exchange_request_success_parses_json_response() {
-        let mut server = mockito::Server::new_async().await;
-        let _m = server
-            .mock("POST", "/token")
-            .match_header("content-type", "application/x-www-form-urlencoded")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(
-                r#"{"access_token":"exchanged","issued_token_type":"urn:ietf:params:oauth:token-type:jwt","token_type":"Bearer","expires_in":42}"#,
-            )
-            .create_async()
-            .await;
+    async fn token_exchange_request_maps_endpoint_response() {
+        use carbide_test_support::Outcome::*;
+        use carbide_test_support::{Case, check_cases_async};
 
-        let client = reqwest::Client::new();
-        let url = format!("{}/token", server.url());
-        let out = token_exchange_request(
-            &client,
-            &url,
-            "sub.jwt",
-            &["spiffe://workload".to_string()],
-            None,
+        // What the mocked `token_endpoint` returns for one request.
+        struct Reply {
+            status: usize,
+            body: &'static str,
+        }
+
+        // The four token fields we expect a 2xx response to parse into.
+        #[derive(Debug, PartialEq)]
+        struct Exchanged {
+            access_token: String,
+            issued_token_type: String,
+            token_type: String,
+            expires_in_sec: u32,
+        }
+
+        // The success row asserts the JSON parses into all four fields; the error
+        // row only asserts *that* a non-2xx fails — `Status` (the error) isn't
+        // `PartialEq`, so the closure maps it to `()` and the row uses `Fails`.
+        check_cases_async(
+            [
+                Case {
+                    scenario: "2xx JSON parses into the response fields",
+                    input: Reply {
+                        status: 200,
+                        body: r#"{"access_token":"exchanged","issued_token_type":"urn:ietf:params:oauth:token-type:jwt","token_type":"Bearer","expires_in":42}"#,
+                    },
+                    expect: Yields(Exchanged {
+                        access_token: "exchanged".to_string(),
+                        issued_token_type: "urn:ietf:params:oauth:token-type:jwt".to_string(),
+                        token_type: "Bearer".to_string(),
+                        expires_in_sec: 42,
+                    }),
+                },
+                Case {
+                    scenario: "non-2xx maps to an error",
+                    input: Reply {
+                        status: 401,
+                        body: r#"{"error":"invalid_client"}"#,
+                    },
+                    expect: Fails,
+                },
+            ],
+            |reply| async move {
+                let mut server = mockito::Server::new_async().await;
+                let _m = server
+                    .mock("POST", "/token")
+                    .match_header("content-type", "application/x-www-form-urlencoded")
+                    .with_status(reply.status)
+                    .with_header("content-type", "application/json")
+                    .with_body(reply.body)
+                    .create_async()
+                    .await;
+
+                let client = reqwest::Client::new();
+                let url = format!("{}/token", server.url());
+                token_exchange_request(
+                    &client,
+                    &url,
+                    "sub.jwt",
+                    &["spiffe://workload".to_string()],
+                    None,
+                )
+                .await
+                .map(|out| Exchanged {
+                    access_token: out.access_token,
+                    issued_token_type: out.issued_token_type,
+                    token_type: out.token_type,
+                    expires_in_sec: out.expires_in_sec,
+                })
+                .map_err(drop)
+            },
         )
-        .await
-        .unwrap();
-
-        assert_eq!(out.access_token, "exchanged");
-        assert_eq!(
-            out.issued_token_type,
-            "urn:ietf:params:oauth:token-type:jwt"
-        );
-        assert_eq!(out.token_type, "Bearer");
-        assert_eq!(out.expires_in_sec, 42);
-    }
-
-    #[tokio::test]
-    async fn token_exchange_request_http_error_maps_to_status() {
-        let mut server = mockito::Server::new_async().await;
-        let _m = server
-            .mock("POST", "/token")
-            .with_status(401)
-            .with_body(r#"{"error":"invalid_client"}"#)
-            .create_async()
-            .await;
-
-        let client = reqwest::Client::new();
-        let url = format!("{}/token", server.url());
-        let err = token_exchange_request(&client, &url, "sub.jwt", &["aud".to_string()], None)
-            .await
-            .unwrap_err();
-        assert!(err.message().contains("401"));
+        .await;
     }
 
     #[tokio::test]

--- a/crates/api-db/Cargo.toml
+++ b/crates/api-db/Cargo.toml
@@ -87,7 +87,7 @@ carbide-version = { path = "../version" }
 [dev-dependencies]
 base64 = { workspace = true }
 carbide-secrets = { path = "../secrets" }
-nico-test-support = { path = "../test-support" }
+carbide-test-support = { path = "../test-support" }
 lazy_static = { workspace = true }
 carbide-macros = { path = "../macros" }
 carbide-sqlx-testing = { path = "../sqlx-testing" }

--- a/crates/api-db/src/dns/mod.rs
+++ b/crates/api-db/src/dns/mod.rs
@@ -27,6 +27,8 @@ pub fn normalize_domain(name: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases_async};
     use sqlx::Row;
 
     #[test]
@@ -39,26 +41,48 @@ mod tests {
 
     #[crate::sqlx_test]
     async fn test_dns_hostname_from_ipv6_expands_to_rust_format(pool: sqlx::PgPool) {
-        let cases = [
-            ("192.168.1.2", "192-168-1-2"),
-            ("::", "0000-0000-0000-0000-0000-0000-0000-0000"),
-            ("::1", "0000-0000-0000-0000-0000-0000-0000-0001"),
-            ("2001:db8::2", "2001-0db8-0000-0000-0000-0000-0000-0002"),
-            (
-                "::ffff:192.0.2.128",
-                "0000-0000-0000-0000-0000-ffff-c000-0280",
-            ),
-        ];
-
-        for (address, expected_hostname) in cases {
-            let hostname: String = sqlx::query_scalar("SELECT nico_inet_to_dns_hostname($1::inet)")
-                .bind(address)
-                .fetch_one(&pool)
-                .await
-                .unwrap();
-
-            assert_eq!(hostname, expected_hostname);
-        }
+        check_cases_async(
+            [
+                Case {
+                    scenario: "ipv4 dotted-quad becomes dashed octets",
+                    input: "192.168.1.2",
+                    expect: Yields("192-168-1-2".to_string()),
+                },
+                Case {
+                    scenario: "unspecified address expands every hextet",
+                    input: "::",
+                    expect: Yields("0000-0000-0000-0000-0000-0000-0000-0000".to_string()),
+                },
+                Case {
+                    scenario: "loopback keeps the low hextet",
+                    input: "::1",
+                    expect: Yields("0000-0000-0000-0000-0000-0000-0000-0001".to_string()),
+                },
+                Case {
+                    scenario: "documentation prefix expands in full",
+                    input: "2001:db8::2",
+                    expect: Yields("2001-0db8-0000-0000-0000-0000-0000-0002".to_string()),
+                },
+                Case {
+                    scenario: "ipv4-mapped folds into the trailing hextets",
+                    input: "::ffff:192.0.2.128",
+                    expect: Yields("0000-0000-0000-0000-0000-ffff-c000-0280".to_string()),
+                },
+            ],
+            |address| {
+                // Clone the (Arc-backed) pool per case so the future owns it and
+                // the closure stays `Fn` — see check_cases_async's signature.
+                let pool = pool.clone();
+                async move {
+                    sqlx::query_scalar::<_, String>("SELECT nico_inet_to_dns_hostname($1::inet)")
+                        .bind(address)
+                        .fetch_one(&pool)
+                        .await
+                        .map_err(drop)
+                }
+            },
+        )
+        .await;
     }
 
     #[crate::sqlx_test]

--- a/crates/api-db/src/resource_pool.rs
+++ b/crates/api-db/src/resource_pool.rs
@@ -1030,8 +1030,8 @@ pub async fn create_common_pools(
 
 #[cfg(test)]
 mod tests {
-    use nico_test_support::Outcome::*;
-    use nico_test_support::{Case, check_cases};
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
 
     use super::*;
 

--- a/crates/api-model/Cargo.toml
+++ b/crates/api-model/Cargo.toml
@@ -91,7 +91,7 @@ carbide-version = { path = "../version" }
 [dev-dependencies]
 carbide-sqlx-testing = { path = "../sqlx-testing", default-features = false }
 carbide-secrets = { path = "../secrets" }
-nico-test-support = { path = "../test-support" }
+carbide-test-support = { path = "../test-support" }
 lazy_static = { workspace = true }
 p256 = { workspace = true }
 prost = { workspace = true }

--- a/crates/api-model/src/machine/upgrade_policy.rs
+++ b/crates/api-model/src/machine/upgrade_policy.rs
@@ -287,8 +287,8 @@ impl PartialOrd for BuildVersion<'_> {
 
 #[test]
 fn test_parse_version() {
-    use nico_test_support::Outcome::*;
-    use nico_test_support::{Case, check_cases};
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
 
     check_cases(
         [

--- a/crates/libmlx/Cargo.toml
+++ b/crates/libmlx/Cargo.toml
@@ -87,7 +87,7 @@ serde_yaml = "0.9"
 [dev-dependencies]
 carbide-libmlx-model = { path = "../libmlx-model", features = ["test-support"] }
 carbide-ssh = { path = "../ssh", features = ["test_support"] }
-nico-test-support = { path = "../test-support" }
+carbide-test-support = { path = "../test-support" }
 russh = { workspace = true }
 
 [features]

--- a/crates/libmlx/tests/variables/test_value.rs
+++ b/crates/libmlx/tests/variables/test_value.rs
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use libmlx::variables::spec::MlxVariableSpec;
 use libmlx::variables::value::{MlxValueError, MlxValueType};
 use libmlx::variables::variable::MlxConfigVariable;
-use nico_test_support::Outcome::*;
-use nico_test_support::{Case, check_cases};
 
 // create_test_variable creates a test variable with a given spec
 // to use for testing. This is leveraged for basically each test.
@@ -79,7 +79,7 @@ fn test_string_value_creation() {
 }
 
 // enum_values_validate_against_the_spec migrates the old hand-written enum test
-// onto nico-test-support: each row is a labeled input + an expected `Outcome`,
+// onto carbide-test-support: each row is a labeled input + an expected `Outcome`,
 // and `check_cases` runs the operation under test (`var.with`) over them. A valid
 // option yields an Enum value; an unknown option fails with the exact
 // InvalidEnumOption error — no `match … panic!` to read past.

--- a/crates/site-explorer/Cargo.toml
+++ b/crates/site-explorer/Cargo.toml
@@ -58,7 +58,7 @@ carbide-api-model = { path = "../api-model", default-features = false, features 
 carbide-test-harness = { path = "../test-harness" }
 carbide-redfish = { path = "../redfish", features = ["test-support"] }
 carbide-rpc = { path = "../rpc", features = ["test-support"] }
-nico-test-support = { path = "../test-support" }
+carbide-test-support = { path = "../test-support" }
 
 tokio = { workspace = true, features = ["macros", "rt"] }
 tonic = { workspace = true }

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -3142,10 +3142,10 @@ fn should_alert_power_state(power_state: PowerState) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
     use config_version::ConfigVersion;
     use model::site_explorer::PreingestionState;
-    use nico_test_support::Outcome::*;
-    use nico_test_support::{Case, check_cases};
 
     use super::*;
 

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -1455,9 +1455,11 @@ mod tests {
     use carbide_redfish::libredfish::test_support::RedfishSim;
     use carbide_redfish::nv_redfish::NvRedfishClientPool;
     use carbide_secrets::credentials::Credentials;
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases_async};
     use libredfish::model::service_root::RedfishVendor;
 
-    use super::RedfishClient;
+    use super::{EndpointExplorationError, RedfishClient};
 
     fn test_addr() -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 443)
@@ -1469,25 +1471,17 @@ mod tests {
         RedfishClient::new(sim, nv_pool)
     }
 
-    /// Test to check that when site-explorer rotates a BMC's root password,
-    /// it first uses an uninitialized client (`Some(RedfishVendor::Unknown)`)
-    /// to make the actual `change_password_by_id` call, and NOT a
-    /// vendor-specific client.
+    /// Rotate a BMC's root password against the sim and report the vendor
+    /// each `create_client` call was made with, in order.
     ///
-    /// The vendor-specific client triggers libredfish's full init path
-    /// (fetches `/Systems`, `/Managers`, `/Chassis`) which is unnecessary
-    /// just to PATCH `/AccountService`. Worse, factory BMCs like NVIDIA
-    /// GBx00 authenticate the supplied creds but return HTTP 403
-    /// `Base.1.18.1.PasswordChangeRequired` on `/Systems` until the
-    /// password is rotated -- so an init-first flow blocks the very PATCH
-    /// that would unblock it.
-    ///
-    /// Only the SECOND client (used to set the password policy after the
-    /// rotation has succeeded) should be vendor-specific so we get the right
-    /// `set_machine_password_policy` impl (e.g. Lite-On omits
-    /// `AccountLockoutCounterResetAfter`).
-    #[tokio::test]
-    async fn set_bmc_root_password_uses_unknown_vendor_for_password_change_client() {
+    /// This is what the password-rotation contract is asserted against: the
+    /// FIRST client (which makes the actual `change_password_by_id` PATCH to
+    /// `/AccountService`) must be uninitialized (`Some(RedfishVendor::Unknown)`),
+    /// and only the SECOND client (which sets the password policy afterward)
+    /// should carry the real `vendor`.
+    async fn password_change_client_vendors(
+        vendor: RedfishVendor,
+    ) -> Result<Vec<Option<RedfishVendor>>, EndpointExplorationError> {
         let sim = Arc::new(RedfishSim::default());
         sim.seed_user("root", "factory_pass");
 
@@ -1499,70 +1493,57 @@ mod tests {
         };
 
         redfish
-            .set_bmc_root_password(
-                test_addr(),
-                RedfishVendor::LiteOnPowerShelf,
-                factory_creds,
-                "site_pass".to_string(),
-            )
-            .await
-            .expect("set_bmc_root_password should succeed against the sim");
+            .set_bmc_root_password(test_addr(), vendor, factory_creds, "site_pass".to_string())
+            .await?;
 
-        let calls = sim.create_client_calls();
-        assert_eq!(
-            calls.len(),
-            2,
-            "expected exactly two create_client calls (one for password change, one for policy), got {calls:?}"
-        );
-        assert_eq!(
-            calls[0].vendor,
-            Some(RedfishVendor::Unknown),
-            "the FIRST client (password change) must be uninitialized (Unknown) so \
-             libredfish skips its /Systems, /Managers, /Chassis fetches. Passing the \
-             real vendor regresses to those fetches, which factory BMCs (e.g. NVIDIA \
-             GBx00) reject with HTTP 403 PasswordChangeRequired -- blocking the very \
-             PATCH that would unblock them. got: {:?}",
-            calls[0].vendor,
-        );
-        assert_eq!(
-            calls[1].vendor,
-            Some(RedfishVendor::LiteOnPowerShelf),
-            "the SECOND client (set_machine_password_policy) must use the real vendor \
-             so vendor-specific impls (e.g. Lite-On omitting AccountLockoutCounterResetAfter) \
-             are dispatched. got: {:?}",
-            calls[1].vendor,
-        );
+        Ok(sim
+            .create_client_calls()
+            .into_iter()
+            .map(|call| call.vendor)
+            .collect())
     }
 
-    /// Same regression guard, but for a non-Lite-On vendor that also needs
-    /// vendor dispatch on the second client (NvidiaDpu uses
-    /// `change_password_by_id`). Locks in that the Unknown-vs-vendor split
-    /// is consistent across vendors.
+    /// When site-explorer rotates a BMC's root password it must make the
+    /// rotation PATCH with an uninitialized `Unknown` client and only use the
+    /// real vendor on the follow-up policy client.
+    ///
+    /// The vendor-specific client triggers libredfish's full init path
+    /// (fetches `/Systems`, `/Managers`, `/Chassis`) which is unnecessary just
+    /// to PATCH `/AccountService`. Worse, factory BMCs like NVIDIA GBx00
+    /// authenticate the supplied creds but return HTTP 403
+    /// `Base.1.18.1.PasswordChangeRequired` on `/Systems` until the password is
+    /// rotated -- so an init-first flow blocks the very PATCH that would unblock
+    /// it. Only the SECOND client (set after the rotation succeeds) should be
+    /// vendor-specific, so `set_machine_password_policy` gets the right impl
+    /// (e.g. Lite-On omits `AccountLockoutCounterResetAfter`).
+    ///
+    /// Asserted as a table over vendors: each yields exactly two
+    /// `create_client` calls -- always `Unknown` first, then the real vendor --
+    /// which pins the call count, the uninitialized rotation client, and the
+    /// vendor-specific policy client all at once.
     #[tokio::test]
-    async fn set_bmc_root_password_uses_unknown_vendor_for_nvidia_dpu_too() {
-        let sim = Arc::new(RedfishSim::default());
-        sim.seed_user("root", "factory_pass");
-
-        let redfish = build_redfish_client(sim.clone());
-
-        let factory_creds = Credentials::UsernamePassword {
-            username: "root".to_string(),
-            password: "factory_pass".to_string(),
-        };
-
-        redfish
-            .set_bmc_root_password(
-                test_addr(),
-                RedfishVendor::NvidiaDpu,
-                factory_creds,
-                "site_pass".to_string(),
-            )
-            .await
-            .expect("set_bmc_root_password should succeed against the sim");
-
-        let calls = sim.create_client_calls();
-        assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0].vendor, Some(RedfishVendor::Unknown));
-        assert_eq!(calls[1].vendor, Some(RedfishVendor::NvidiaDpu));
+    async fn set_bmc_root_password_rotates_with_unknown_then_real_vendor() {
+        check_cases_async(
+            [
+                Case {
+                    scenario: "Lite-On power shelf gets a vendor-specific policy client",
+                    input: RedfishVendor::LiteOnPowerShelf,
+                    expect: Yields(vec![
+                        Some(RedfishVendor::Unknown),
+                        Some(RedfishVendor::LiteOnPowerShelf),
+                    ]),
+                },
+                Case {
+                    scenario: "NVIDIA DPU gets a vendor-specific policy client too",
+                    input: RedfishVendor::NvidiaDpu,
+                    expect: Yields(vec![
+                        Some(RedfishVendor::Unknown),
+                        Some(RedfishVendor::NvidiaDpu),
+                    ]),
+                },
+            ],
+            password_change_client_vendors,
+        )
+        .await;
     }
 }

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 [package]
-name = "nico-test-support"
+name = "carbide-test-support"
 version = "0.0.0"
 edition.workspace = true
 description = "A tiny, zero-dependency crate for making table-driven tests."
@@ -23,7 +23,7 @@ license.workspace = true
 authors.workspace = true
 
 [lib]
-name = "nico_test_support"
+name = "carbide_test_support"
 
 [lints]
 workspace = true

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -25,8 +25,8 @@
 //! # A table of cases
 //!
 //! ```
-//! use nico_test_support::Outcome::*;
-//! use nico_test_support::{Case, check_cases};
+//! use carbide_test_support::Outcome::*;
+//! use carbide_test_support::{Case, check_cases};
 //!
 //! check_cases(
 //!     [
@@ -57,8 +57,8 @@
 //! counterpart to [`check_cases`]:
 //!
 //! ```
-//! use nico_test_support::Case;
-//! use nico_test_support::Outcome::*;
+//! use carbide_test_support::Case;
+//! use carbide_test_support::Outcome::*;
 //!
 //! Case {
 //!     scenario: "in range",
@@ -66,6 +66,35 @@
 //!     expect: Yields(42),
 //! }
 //! .check(|s| s.parse::<u8>().map_err(|_| ()));
+//! ```
+//!
+//! # Async
+//!
+//! For an `async` operation, use [`check_cases_async`] (or [`Case::check_async`])
+//! and `.await` it — [`Outcome`], [`Case`], and the asserting are unchanged:
+//!
+//! ```
+//! use carbide_test_support::Outcome::*;
+//! use carbide_test_support::{Case, check_cases_async};
+//!
+//! # async fn example() {
+//! check_cases_async(
+//!     [
+//!         Case {
+//!             scenario: "doubles",
+//!             input: 2u8,
+//!             expect: Yields(4),
+//!         },
+//!         Case {
+//!             scenario: "overflows",
+//!             input: 200u8,
+//!             expect: Fails,
+//!         },
+//!     ],
+//!     |n| async move { n.checked_mul(2).ok_or(()) },
+//! )
+//! .await;
+//! # }
 //! ```
 //!
 //! # What's shared, and what stays a convention
@@ -79,6 +108,7 @@
 //! not a type.
 
 use std::fmt::Debug;
+use std::future::Future;
 
 /// The expected result of a fallible operation under test.
 ///
@@ -122,6 +152,17 @@ impl<I, T, E> Case<I, T, E> {
     {
         assert_outcome(run(self.input), self.expect, self.scenario);
     }
+
+    /// Async counterpart to [`check`](Case::check): runs an `async` operation and
+    /// awaits its result before asserting.
+    pub async fn check_async<Fut>(self, run: impl FnOnce(I) -> Fut)
+    where
+        Fut: Future<Output = Result<T, E>>,
+        T: PartialEq + Debug,
+        E: PartialEq + Debug,
+    {
+        assert_outcome(run(self.input).await, self.expect, self.scenario);
+    }
 }
 
 /// Run each case's `input` through `run` and assert its [`Outcome`]. `run` is the
@@ -135,6 +176,22 @@ pub fn check_cases<I, T, E>(
 {
     for case in cases {
         case.check(&run);
+    }
+}
+
+/// Async counterpart to [`check_cases`]: each case's `input` is run through the
+/// `async` operation `run` and its result awaited. Call it from an async test
+/// (e.g. `#[tokio::test]`) and `.await` it.
+pub async fn check_cases_async<I, T, E, Fut>(
+    cases: impl IntoIterator<Item = Case<I, T, E>>,
+    run: impl Fn(I) -> Fut,
+) where
+    Fut: Future<Output = Result<T, E>>,
+    T: PartialEq + Debug,
+    E: PartialEq + Debug,
+{
+    for case in cases {
+        case.check_async(&run).await;
     }
 }
 

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -51,5 +51,8 @@ sqlx = { workspace = true, features = ["postgres"], optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+
 [lints]
 workspace = true

--- a/crates/utils/src/host_port_pair.rs
+++ b/crates/utils/src/host_port_pair.rs
@@ -150,45 +150,63 @@ pub enum HostPortParseError {
 mod tests {
     use std::str::FromStr;
 
-    use crate::host_port_pair::{HostPortPair, HostPortParseError};
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
+    use crate::host_port_pair::HostPortPair;
+    use crate::host_port_pair::HostPortParseError::{EmptyString, InvalidPort, UriUnsupported};
 
     #[test]
     fn test_proxy_address_parsing() {
-        assert_eq!(
-            HostPortPair::from_str("proxyhost:1234"),
-            Ok(HostPortPair::HostAndPort("proxyhost".to_string(), 1234))
+        check_cases(
+            [
+                Case {
+                    scenario: "host and port",
+                    input: "proxyhost:1234",
+                    expect: Yields(HostPortPair::HostAndPort("proxyhost".to_string(), 1234)),
+                },
+                Case {
+                    scenario: "host only, no port",
+                    input: "proxyhost",
+                    expect: Yields(HostPortPair::HostOnly("proxyhost".to_string())),
+                },
+                Case {
+                    scenario: "port only, no host",
+                    input: ":1234",
+                    expect: Yields(HostPortPair::PortOnly(1234)),
+                },
+                Case {
+                    scenario: "empty port keeps the offending text in the error",
+                    input: "proxyhost:",
+                    expect: FailsWith(InvalidPort("".to_string())),
+                },
+                Case {
+                    scenario: "non-numeric port keeps the offending text in the error",
+                    input: "proxyhost:notaport",
+                    expect: FailsWith(InvalidPort("notaport".to_string())),
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: FailsWith(EmptyString),
+                },
+                Case {
+                    scenario: "a URI with a bad port is rejected as a URI, not a bad port",
+                    input: "https://proxyhost:notaport",
+                    expect: FailsWith(UriUnsupported),
+                },
+                Case {
+                    scenario: "a URI with a good port is still rejected",
+                    input: "https://proxyhost:1234",
+                    expect: FailsWith(UriUnsupported),
+                },
+                Case {
+                    scenario: "a URI with no port is still rejected",
+                    input: "https://proxyhost",
+                    expect: FailsWith(UriUnsupported),
+                },
+            ],
+            HostPortPair::from_str,
         );
-        assert_eq!(
-            HostPortPair::from_str("proxyhost"),
-            Ok(HostPortPair::HostOnly("proxyhost".to_string()))
-        );
-        assert_eq!(
-            HostPortPair::from_str(":1234"),
-            Ok(HostPortPair::PortOnly(1234))
-        );
-        assert!(matches!(
-            HostPortPair::from_str("proxyhost:"),
-            Err(HostPortParseError::InvalidPort(_)),
-        ));
-        assert!(matches!(
-            HostPortPair::from_str("proxyhost:notaport"),
-            Err(HostPortParseError::InvalidPort(_)),
-        ));
-        assert!(matches!(
-            HostPortPair::from_str(""),
-            Err(HostPortParseError::EmptyString),
-        ));
-        assert!(matches!(
-            HostPortPair::from_str("https://proxyhost:notaport"),
-            Err(HostPortParseError::UriUnsupported),
-        ));
-        assert!(matches!(
-            HostPortPair::from_str("https://proxyhost:1234"),
-            Err(HostPortParseError::UriUnsupported),
-        ));
-        assert!(matches!(
-            HostPortPair::from_str("https://proxyhost"),
-            Err(HostPortParseError::UriUnsupported),
-        ));
     }
 }


### PR DESCRIPTION
This supports #3914.

## Description

Follow-up to #2437 -- Ron asked for an async option, so here it is! This also renames from `nico-test-support` -> `carbide-test-support`.

Using it is the sync structuring, with `async`/`.await`:

```rust
async fn resolves() {
    check_cases_async(
        [
            Case { scenario: "known host", input: "web-01", expect: Yields(addr) },
            Case { scenario: "unknown",    input: "nope",   expect: Fails },
        ],
        |name| resolve(name),   // async fn -> a future, awaited per case
    )
    .await;
}
```

Primary callouts are:

- `check_cases_async` and `Case::check_async` -- async variants of `check_cases` and `check`. They take an async operation (a closure returning a future) and `.await` each case.
- `Outcome`, `Case`, and `assert_outcome` don't change at all -- the async runners just await and hand off to the same `assert_outcome`.
- Three async tests adopt it, each also folding a near-duplicate pair into one table:
    - `site-explorer` -- BMC password-rotation vendor sequence (pure async, Redfish sim)
    - `api-core` -- token-exchange endpoint mapping (pure async, mockito)
    - `api-db` -- IPv6-to-DNS hostname expansion (a `#[sqlx_test]`)

The `sqlx` one clones the `Arc`-backed pool per case, so the future owns it across the await -- just a little async-related callout.

The error-handling side got a little cleaner while I was in there, too. When a case only cares *that* something failed, the discard now reads as `.map_err(drop)` instead of `.map_err(|_| ())` -- same effect, it just says "drop the error". And then the other end, with `FailsWith` to check the error.

Tests updated!

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->