### PR TITLE
fix(rest-api): Validate MAC if provided in Expected Machine update request

### DIFF
--- a/rest-api/api/pkg/api/handler/expectedmachine_test.go
+++ b/rest-api/api/pkg/api/handler/expectedmachine_test.go
@@ -1300,6 +1300,19 @@ func TestUpdateExpectedMachineHandler_Handle(t *testing.T) {
 			},
 			expectedStatus: http.StatusUnprocessableEntity,
 		},
+		{
+			name: "invalid BMC MAC address returns 400",
+			id:   testEM.ID.String(),
+			requestBody: model.APIExpectedMachineUpdateRequest{
+				BmcMacAddress: cutil.GetPtr("INVALID-MAC"),
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, testEM.ID.String())
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
 	}
 
 	_ = infraProv // Ensure infraProv is used to avoid compiler warning

--- a/rest-api/api/pkg/api/model/expectedmachine.go
+++ b/rest-api/api/pkg/api/model/expectedmachine.go
@@ -164,6 +164,10 @@ func (emur *APIExpectedMachineUpdateRequest) Validate() error {
 	}
 
 	err := validation.ValidateStruct(emur,
+		validation.Field(&emur.BmcMacAddress,
+			validation.NilOrNotEmpty.Error("BmcMacAddress cannot be empty"),
+			validation.When(emur.BmcMacAddress != nil && *emur.BmcMacAddress != "",
+				validationis.MAC)),
 		validation.Field(&emur.DefaultBmcUsername,
 			validation.NilOrNotEmpty.Error("BMC Username cannot be empty"),
 			validation.When(emur.DefaultBmcUsername != nil && *emur.DefaultBmcUsername != "",


### PR DESCRIPTION

## Description
- Validate BMC Mac address if provided with Expected Machine and raise 400

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Fix** - Bug fixes


## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated

