### PR TITLE
feat: add a separate site-wide credential for the SuperNIC Lockdown

### DIFF
--- a/crates/admin-cli/src/credential/add_nic_lockdown_ikm/args.rs
+++ b/crates/admin-cli/src/credential/add_nic_lockdown_ikm/args.rs
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+use rpc::{CredentialType, forge as forgerpc};
+
+use crate::credential::common::password_validator;
+use crate::errors::{CarbideCliError, CarbideCliResult};
+
+#[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Set the site-wide SuperNIC lockdown IKM (input key material):
+    $ carbide-admin-cli credential add-nic-lockdown-ikm --password mypassword
+
+")]
+pub struct Args {
+    #[clap(long, required(true), help = "The site-wide NIC lockdown IKM value")]
+    pub password: String,
+}
+
+impl TryFrom<Args> for forgerpc::CredentialCreationRequest {
+    type Error = CarbideCliError;
+    fn try_from(args: Args) -> CarbideCliResult<Self> {
+        let password = password_validator(args.password)?;
+        Ok(Self {
+            credential_type: CredentialType::SiteWideNicLockdownIkm.into(),
+            username: None,
+            password,
+            mac_address: None,
+            vendor: None,
+        })
+    }
+}

--- a/crates/admin-cli/src/credential/add_nic_lockdown_ikm/cmd.rs
+++ b/crates/admin-cli/src/credential/add_nic_lockdown_ikm/cmd.rs
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::forge as forgerpc;
+
+use super::args::Args;
+use crate::errors::CarbideCliResult;
+use crate::rpc::ApiClient;
+
+pub async fn add_nic_lockdown_ikm(data: Args, api_client: &ApiClient) -> CarbideCliResult<()> {
+    api_client
+        .0
+        .create_credential(forgerpc::CredentialCreationRequest::try_from(data)?)
+        .await?;
+    Ok(())
+}

--- a/crates/admin-cli/src/credential/add_nic_lockdown_ikm/mod.rs
+++ b/crates/admin-cli/src/credential/add_nic_lockdown_ikm/mod.rs
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::add_nic_lockdown_ikm(self, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/credential/mod.rs
+++ b/crates/admin-cli/src/credential/mod.rs
@@ -18,6 +18,7 @@
 mod add_bmc;
 mod add_dpu_factory_default;
 mod add_host_factory_default;
+mod add_nic_lockdown_ikm;
 mod add_nmxm;
 mod add_uefi;
 mod add_ufm;
@@ -48,6 +49,8 @@ pub enum Cmd {
     AddBMC(add_bmc::Args),
     #[clap(about = "Delete BMC credentials")]
     DeleteBMC(delete_bmc::Args),
+    #[clap(about = "Set the site-wide SuperNIC lockdown IKM (input key material)")]
+    AddNicLockdownIkm(add_nic_lockdown_ikm::Args),
     #[clap(
         about = "Add site-wide DPU UEFI default credential (NOTE: this parameter can be set only once)"
     )]

--- a/crates/admin-cli/src/credential/tests.rs
+++ b/crates/admin-cli/src/credential/tests.rs
@@ -158,6 +158,53 @@ fn parse_add_uefi() {
     }
 }
 
+// parse_add_nic_lockdown_ikm ensures add-nic-lockdown-ikm parses with the
+// required password.
+#[test]
+fn parse_add_nic_lockdown_ikm() {
+    let cmd = Cmd::try_parse_from([
+        "credential",
+        "add-nic-lockdown-ikm",
+        "--password",
+        "ikm-secret",
+    ])
+    .expect("should parse add-nic-lockdown-ikm");
+
+    match cmd {
+        Cmd::AddNicLockdownIkm(args) => {
+            assert_eq!(args.password, "ikm-secret");
+        }
+        _ => panic!("expected AddNicLockdownIkm variant"),
+    }
+}
+
+// parse_add_nic_lockdown_ikm_missing_password_fails ensures the password is
+// required.
+#[test]
+fn parse_add_nic_lockdown_ikm_missing_password_fails() {
+    let result = Cmd::try_parse_from(["credential", "add-nic-lockdown-ikm"]);
+    assert!(result.is_err(), "should fail without required --password");
+}
+
+// add_nic_lockdown_ikm_maps_to_proto ensures the parsed args convert into a
+// CredentialCreationRequest carrying the SiteWideNicLockdownIkm type.
+#[test]
+fn add_nic_lockdown_ikm_maps_to_proto() {
+    use rpc::forge::{self as forgerpc, CredentialType};
+
+    let args = add_nic_lockdown_ikm::Args {
+        password: "ikm-secret".to_string(),
+    };
+    let req = forgerpc::CredentialCreationRequest::try_from(args).expect("convert");
+    assert_eq!(
+        req.credential_type,
+        CredentialType::SiteWideNicLockdownIkm as i32
+    );
+    assert_eq!(req.password, "ikm-secret");
+    assert!(req.username.is_none());
+    assert!(req.mac_address.is_none());
+}
+
 /////////////////////////////////////////////////////////////////////////////
 // Enum Conversions
 //

--- a/crates/api-core/src/dpa/lockdown.rs
+++ b/crates/api-core/src/dpa/lockdown.rs
@@ -16,12 +16,18 @@
  */
 
 use carbide_secrets::credentials::{
-    BmcCredentialType, CredentialKey, CredentialReader, Credentials,
+    BmcCredentialType, CredentialKey, CredentialManager, CredentialReader, Credentials,
+    NicLockdownIkm,
 };
 use carbide_uuid::dpa_interface::DpaInterfaceId;
 use hkdf::Hkdf;
 use sha2::Sha256;
 use sqlx::PgPool;
+
+// CURRENT_LOCKDOWN_IKM_VERSION is the site-wide lockdown IKM version the
+// lock/unlock flow currently derives keys from. We will leave it hardcoded to 0 until
+// we introduce rotation logic.
+pub const CURRENT_LOCKDOWN_IKM_VERSION: u32 = 0;
 
 // LOCKDOWN_KEY_LENGTH is the max length of the supported
 // key by a Mellanox device. As of now it's a 64-bit key,
@@ -130,21 +136,93 @@ async fn build_kdf_context(
     })
 }
 
-// fetch_kdf_secret fetches the site-wide root secret from Vault,
-// which is the IKM (Input Key Material) for the KDF.
+// lockdown_ikm_key returns the CredentialKey for the dedicated, versioned
+// site-wide lockdown IKM.
+fn lockdown_ikm_key(version: u32) -> CredentialKey {
+    CredentialKey::NicLockdownIkm {
+        credential_type: NicLockdownIkm::SiteWide { version },
+    }
+}
+
+// fetch_kdf_secret fetches the IKM for the KDF from the
+// dedicated site-wide lockdown credential, decoupled from the BMC root so the
+// two can be rotated independently.
 async fn fetch_kdf_secret(
     credential_reader: &dyn CredentialReader,
 ) -> Result<String, eyre::Report> {
-    let credential_key = CredentialKey::BmcCredentials {
-        credential_type: BmcCredentialType::SiteWideRoot,
-    };
+    let ikm_key = lockdown_ikm_key(CURRENT_LOCKDOWN_IKM_VERSION);
     let credentials = credential_reader
-        .get_credentials(&credential_key)
+        .get_credentials(&ikm_key)
         .await?
-        .ok_or_else(|| eyre::eyre!("SiteWideRoot credentials not found"))?;
+        .ok_or_else(|| {
+            eyre::eyre!("lockdown IKM v{CURRENT_LOCKDOWN_IKM_VERSION} not found; site not seeded")
+        })?;
     let Credentials::UsernamePassword { password, .. } = credentials;
 
     Ok(password)
+}
+
+// ensure_lockdown_ikm_seeded idempotently seeds the dedicated site-wide
+// lockdown IKM (v0) by copying the current site-wide BMC root. This lets
+// existing sites converge onto the decoupled lockdown key without operator
+// action; going forward the two credentials start identical but rotate
+// independently.
+//
+// Best-effort: if the BMC root is not yet configured (e.g. a brand-new site),
+// this is a no-op and the IKM is seeded on a later boot once the root exists.
+// Safe to run on every startup and concurrently across replicas (a lost
+// create race is treated as success).
+pub async fn ensure_lockdown_ikm_seeded(
+    credential_manager: &dyn CredentialManager,
+) -> Result<(), eyre::Report> {
+    let ikm_key = lockdown_ikm_key(CURRENT_LOCKDOWN_IKM_VERSION);
+    if credential_manager
+        .get_credentials(&ikm_key)
+        .await?
+        .is_some()
+    {
+        tracing::debug!(
+            version = CURRENT_LOCKDOWN_IKM_VERSION,
+            "lockdown IKM already seeded"
+        );
+        return Ok(());
+    }
+
+    let bmc_root_key = CredentialKey::BmcCredentials {
+        credential_type: BmcCredentialType::SiteWideRoot,
+    };
+    let Some(bmc_root) = credential_manager.get_credentials(&bmc_root_key).await? else {
+        tracing::warn!(
+            "site-wide BMC root not set; deferring lockdown IKM seed until it is configured"
+        );
+        return Ok(());
+    };
+
+    match credential_manager
+        .create_credentials(&ikm_key, &bmc_root)
+        .await
+    {
+        Ok(()) => {
+            tracing::info!(
+                version = CURRENT_LOCKDOWN_IKM_VERSION,
+                "seeded dedicated lockdown IKM from site-wide BMC root"
+            );
+            Ok(())
+        }
+        Err(e) => {
+            // Another replica may have seeded concurrently between our read and
+            // create; treat an already-present IKM as success.
+            if credential_manager
+                .get_credentials(&ikm_key)
+                .await?
+                .is_some()
+            {
+                Ok(())
+            } else {
+                Err(eyre::eyre!("failed to seed lockdown IKM: {e}"))
+            }
+        }
+    }
 }
 
 // build_supernic_lockdown_key builds a single lockdown key using
@@ -250,5 +328,131 @@ mod tests {
         let keys = derive_candidate_keys(root, &ctx).unwrap();
         assert_eq!(keys.len(), 1); // Only test against v1 for now.
         assert_eq!(keys[0].len(), 16);
+    }
+
+    use carbide_secrets::MemoryCredentialStore;
+    use carbide_secrets::credentials::CredentialWriter;
+
+    fn user_pass(password: &str) -> Credentials {
+        Credentials::UsernamePassword {
+            username: String::new(),
+            password: password.to_string(),
+        }
+    }
+
+    fn bmc_root_key() -> CredentialKey {
+        CredentialKey::BmcCredentials {
+            credential_type: BmcCredentialType::SiteWideRoot,
+        }
+    }
+
+    #[tokio::test]
+    async fn seed_copies_bmc_root_to_v0() {
+        let store = MemoryCredentialStore::default();
+        store
+            .set_credentials(&bmc_root_key(), &user_pass("root-pass"))
+            .await
+            .unwrap();
+
+        ensure_lockdown_ikm_seeded(&store).await.unwrap();
+
+        let seeded = store
+            .get_credentials(&lockdown_ikm_key(CURRENT_LOCKDOWN_IKM_VERSION))
+            .await
+            .unwrap();
+        assert_eq!(seeded, Some(user_pass("root-pass")));
+    }
+
+    #[tokio::test]
+    async fn seed_is_idempotent() {
+        let store = MemoryCredentialStore::default();
+        store
+            .set_credentials(&bmc_root_key(), &user_pass("root-pass"))
+            .await
+            .unwrap();
+
+        ensure_lockdown_ikm_seeded(&store).await.unwrap();
+        // A second run must not error (the IKM already exists) and must not
+        // change the value.
+        ensure_lockdown_ikm_seeded(&store).await.unwrap();
+
+        let seeded = store
+            .get_credentials(&lockdown_ikm_key(CURRENT_LOCKDOWN_IKM_VERSION))
+            .await
+            .unwrap();
+        assert_eq!(seeded, Some(user_pass("root-pass")));
+    }
+
+    #[tokio::test]
+    async fn seed_preserves_existing_lockdown_ikm() {
+        let store = MemoryCredentialStore::default();
+        // Both the BMC root and a (diverged) lockdown IKM already exist, e.g.
+        // the IKM was rotated independently after the initial seed.
+        store
+            .set_credentials(&bmc_root_key(), &user_pass("root-pass"))
+            .await
+            .unwrap();
+        store
+            .set_credentials(
+                &lockdown_ikm_key(CURRENT_LOCKDOWN_IKM_VERSION),
+                &user_pass("rotated-ikm"),
+            )
+            .await
+            .unwrap();
+
+        ensure_lockdown_ikm_seeded(&store).await.unwrap();
+
+        // Seeding must not clobber the existing IKM with the BMC root.
+        let seeded = store
+            .get_credentials(&lockdown_ikm_key(CURRENT_LOCKDOWN_IKM_VERSION))
+            .await
+            .unwrap();
+        assert_eq!(seeded, Some(user_pass("rotated-ikm")));
+    }
+
+    #[tokio::test]
+    async fn seed_defers_when_no_bmc_root() {
+        let store = MemoryCredentialStore::default();
+
+        // No BMC root configured yet: seeding is a no-op, not an error.
+        ensure_lockdown_ikm_seeded(&store).await.unwrap();
+
+        let seeded = store
+            .get_credentials(&lockdown_ikm_key(CURRENT_LOCKDOWN_IKM_VERSION))
+            .await
+            .unwrap();
+        assert!(seeded.is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_prefers_lockdown_ikm_over_bmc_root() {
+        let store = MemoryCredentialStore::default();
+        store
+            .set_credentials(&bmc_root_key(), &user_pass("root-pass"))
+            .await
+            .unwrap();
+        store
+            .set_credentials(
+                &lockdown_ikm_key(CURRENT_LOCKDOWN_IKM_VERSION),
+                &user_pass("ikm-pass"),
+            )
+            .await
+            .unwrap();
+
+        let secret = fetch_kdf_secret(&store).await.unwrap();
+        assert_eq!(secret, "ikm-pass");
+    }
+
+    #[tokio::test]
+    async fn fetch_errors_when_ikm_unseeded() {
+        let store = MemoryCredentialStore::default();
+        // The BMC root being present is not enough: without the seeded IKM the
+        // lock flow must error rather than derive from another secret.
+        store
+            .set_credentials(&bmc_root_key(), &user_pass("root-pass"))
+            .await
+            .unwrap();
+
+        assert!(fetch_kdf_secret(&store).await.is_err());
     }
 }

--- a/crates/api-core/src/handlers/credential.rs
+++ b/crates/api-core/src/handlers/credential.rs
@@ -24,6 +24,7 @@ use ::rpc::forge::{self as rpc};
 use carbide_nvlink_manager::DEFAULT_NMX_M_NAME;
 use carbide_secrets::credentials::{
     BgpCredentialType, BmcCredentialType, CredentialKey, CredentialType, Credentials,
+    NicLockdownIkm,
 };
 use mac_address::MacAddress;
 use model::ConfigValidationError;
@@ -76,6 +77,15 @@ pub(crate) async fn create_credential(
                 .map_err(|e| {
                     CarbideError::internal(format!(
                         "Error setting Site Wide BMC Root credentials: {e:?} "
+                    ))
+                })?;
+        }
+        rpc::CredentialType::SiteWideNicLockdownIkm => {
+            set_sitewide_nic_lockdown_ikm(api, password)
+                .await
+                .map_err(|e| {
+                    CarbideError::internal(format!(
+                        "Error setting Site Wide NIC lockdown IKM: {e:?} "
                     ))
                 })?;
         }
@@ -342,7 +352,9 @@ pub(crate) async fn delete_credential(
         | rpc::CredentialType::HostBmcFactoryDefault
         | rpc::CredentialType::DpuBmcFactoryDefault
         | rpc::CredentialType::BmcForgeAdminByMacAddress
-        | rpc::CredentialType::NmxM => {
+        | rpc::CredentialType::NmxM
+        // Deleting the lockdown IKM would break NIC unlock; rotate it instead.
+        | rpc::CredentialType::SiteWideNicLockdownIkm => {
             // Not support delete credential for these types
         }
         rpc::CredentialType::BgpSiteWideLeafPassword => {
@@ -567,6 +579,30 @@ async fn set_sitewide_bmc_root_credentials(
     };
 
     set_bmc_credentials(api, &credential_key, &credentials).await
+}
+
+// set_sitewide_nic_lockdown_ikm writes the dedicated site-wide SuperNIC
+// lockdown IKM. This lets an SRE configure (or rotate) the lockdown key
+// independently of the BMC root at site bring-up, mirroring how the site-wide
+// BMC root is set.
+async fn set_sitewide_nic_lockdown_ikm(api: &Api, password: String) -> Result<(), CarbideError> {
+    let credential_key = CredentialKey::NicLockdownIkm {
+        credential_type: NicLockdownIkm::SiteWide {
+            version: crate::dpa::lockdown::CURRENT_LOCKDOWN_IKM_VERSION,
+        },
+    };
+
+    let credentials = Credentials::UsernamePassword {
+        username: "".to_string(),
+        password,
+    };
+
+    api.credential_manager
+        .set_credentials(&credential_key, &credentials)
+        .await
+        .map_err(|e| {
+            CarbideError::internal(format!("Error setting NIC lockdown IKM credential: {e:?}"))
+        })
 }
 
 pub(crate) async fn delete_bmc_root_credentials_by_mac(

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -568,6 +568,12 @@ pub async fn start_api(
         .await?;
 
         txn.commit().await?;
+
+        // Idempotently seed the dedicated site-wide lockdown IKM (v0) from the
+        // site-wide BMC root, so existing sites converge onto the decoupled
+        // lockdown key without operator action. No-op once seeded or if the BMC
+        // root is not yet configured.
+        crate::dpa::lockdown::ensure_lockdown_ikm_seeded(&*credential_manager).await?;
     };
     let common_pools =
         db::resource_pool::create_common_pools(db_pool.clone(), ib_fabric_ids).await?;

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1266,6 +1266,7 @@ enum CredentialType {
   BmcForgeAdminByMacAddress = 9;
   NmxM = 10;
   BgpSiteWideLeafPassword = 11;
+  SiteWideNicLockdownIkm = 12;
 }
 
 message CredentialCreationRequest {

--- a/crates/secrets/src/credentials.rs
+++ b/crates/secrets/src/credentials.rs
@@ -250,6 +250,15 @@ pub enum BmcCredentialType {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum NicLockdownIkm {
+    /// Site-wide SuperNIC lockdown IKM (input key material), versioned for
+    /// rotation. This is the secret the per-NIC lock keys are derived from, not
+    /// a lock key itself. Derived keys are never stored; only this IKM lives in
+    /// Vault.
+    SiteWide { version: u32 },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum BgpCredentialType {
     // Site Wide Credentials
     SiteWideLeafPassword,
@@ -291,6 +300,9 @@ pub enum CredentialKey {
     BmcCredentials {
         credential_type: BmcCredentialType,
     },
+    NicLockdownIkm {
+        credential_type: NicLockdownIkm,
+    },
     ExtensionService {
         service_id: String,
         version: String,
@@ -329,6 +341,7 @@ pub enum CredentialPrefix {
     DpuUefi,
     HostUefi,
     BmcCredentials,
+    NicLockdownIkm,
     ExtensionService,
     NmxM,
     SwitchNvosAdmin,
@@ -351,6 +364,7 @@ impl CredentialPrefix {
             Self::DpuUefi => "machines/all_dpus/",
             Self::HostUefi => "machines/all_hosts/",
             Self::BmcCredentials => "machines/bmc/",
+            Self::NicLockdownIkm => "machines/nic_lockdown_ikm/",
             Self::ExtensionService => "machines/extension-services/",
             Self::NmxM => "nmxm/",
             Self::SwitchNvosAdmin => "switch_nvos/",
@@ -372,6 +386,7 @@ impl CredentialPrefix {
             Self::DpuUefi,
             Self::HostUefi,
             Self::BmcCredentials,
+            Self::NicLockdownIkm,
             Self::ExtensionService,
             Self::NmxM,
             Self::SwitchNvosAdmin,
@@ -396,6 +411,7 @@ impl CredentialKey {
             Self::DpuUefi { .. } => CredentialPrefix::DpuUefi,
             Self::HostUefi { .. } => CredentialPrefix::HostUefi,
             Self::BmcCredentials { .. } => CredentialPrefix::BmcCredentials,
+            Self::NicLockdownIkm { .. } => CredentialPrefix::NicLockdownIkm,
             Self::ExtensionService { .. } => CredentialPrefix::ExtensionService,
             Self::NmxM { .. } => CredentialPrefix::NmxM,
             Self::SwitchNvosAdmin { .. } => CredentialPrefix::SwitchNvosAdmin,
@@ -470,6 +486,11 @@ impl CredentialKey {
                     "machines/bmc/{bmc_mac_address}/forge-admin-account"
                 )),
             },
+            CredentialKey::NicLockdownIkm { credential_type } => match credential_type {
+                NicLockdownIkm::SiteWide { version } => {
+                    Cow::from(format!("machines/nic_lockdown_ikm/site/root/v{version}"))
+                }
+            },
             CredentialKey::ExtensionService {
                 service_id,
                 version,
@@ -532,6 +553,26 @@ mod tests {
         assert!(password.chars().any(|c| c.is_lowercase()));
         assert!(password.chars().any(|c| c.is_ascii_digit()));
         assert!(password.chars().all(|c| c.is_ascii_alphanumeric()));
+    }
+
+    // Pins the exact Vault path for the versioned lockdown IKM, including
+    // how the version is rendered (v{N}), since other components and the
+    // seed migration depend on this layout.
+    #[test]
+    fn lockdown_site_wide_path_is_versioned() {
+        let key = CredentialKey::NicLockdownIkm {
+            credential_type: NicLockdownIkm::SiteWide { version: 0 },
+        };
+        assert_eq!(key.to_key_str(), "machines/nic_lockdown_ikm/site/root/v0");
+        assert_eq!(key.prefix(), CredentialPrefix::NicLockdownIkm);
+
+        let key_v12 = CredentialKey::NicLockdownIkm {
+            credential_type: NicLockdownIkm::SiteWide { version: 12 },
+        };
+        assert_eq!(
+            key_v12.to_key_str(),
+            "machines/nic_lockdown_ikm/site/root/v12"
+        );
     }
 
     #[tokio::test]
@@ -682,6 +723,12 @@ mod tests {
                 "machines/bmc/",
             ),
             (
+                CredentialKey::NicLockdownIkm {
+                    credential_type: NicLockdownIkm::SiteWide { version: 0 },
+                },
+                "machines/nic_lockdown_ikm/",
+            ),
+            (
                 CredentialKey::ExtensionService {
                     service_id: "svc1".to_string(),
                     version: "v1".to_string(),
@@ -775,6 +822,9 @@ mod tests {
             CredentialKey::BmcCredentials {
                 credential_type: BmcCredentialType::SiteWideRoot,
             },
+            CredentialKey::NicLockdownIkm {
+                credential_type: NicLockdownIkm::SiteWide { version: 0 },
+            },
             CredentialKey::ExtensionService {
                 service_id: "s".to_string(),
                 version: "v".to_string(),
@@ -811,6 +861,6 @@ mod tests {
     #[test]
     fn prefix_all_is_complete() {
         let all = CredentialPrefix::all();
-        assert_eq!(all.len(), 15);
+        assert_eq!(all.len(), 16);
     }
 }


### PR DESCRIPTION
## Description

feat: add a separate site-wide credential for the SuperNIC Lockdown IKM. Today, we use the site-wide BMC password as the IKM. Although the two values can be the same, they should not share the same location in Vault so that the site-wide BMC password and the site-wide SuperNIC Lockdown IKM can be rotated indepedently. This is important because BMC passwords can be updated regardless of tenancy whereas NIC lockdown keys cannot be rotated during a tenancy (since the NIC needs to be unlocked in order to change the credential. The newly added location for the site-wide SuperNIC Lockdown IKM is 'machines/nic_lockdown_ikm/site/root/v0'

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

