### PR TITLE
fix: secrets crate renaming conflicted with RMS changes

### DIFF
--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -2077,7 +2077,7 @@ mod tests {
     }
 
     fn make_ct_endpoint(bmc_ip: &str) -> ComputeTrayEndpoint {
-        use forge_secrets::credentials::Credentials;
+        use carbide_secrets::credentials::Credentials;
         ComputeTrayEndpoint {
             vendor: ComputeTrayVendor::Nvidia,
             bmc_ip: bmc_ip.parse().unwrap(),


### PR DESCRIPTION
## Description

RMS used old name of secrets crate.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

