### PR TITLE
fix(machine-validation): skip reboot when disabled

### DIFF
--- a/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
@@ -68,8 +68,7 @@ use crate::tests::common::api_fixtures::network_segment::{
 };
 use crate::tests::common::api_fixtures::{
     TestEnv, TestManagedHost, forge_agent_control, get_machine_validation_runs,
-    machine_validation_completed, persist_machine_validation_result, reboot_completed,
-    update_machine_validation_run,
+    machine_validation_completed, persist_machine_validation_result, update_machine_validation_run,
 };
 use crate::tests::common::rpc_builder::DhcpDiscovery;
 
@@ -913,6 +912,10 @@ impl<'a> MockExploredHost<'a> {
                                         machine_validation:
                                             MachineValidatingState::MachineValidating { .. },
                                     },
+                                } | ManagedHostState::HostInit {
+                                    machine_state: MachineState::Discovered {
+                                        skip_reboot_wait: true,
+                                    },
                                 }
                             )
                     },
@@ -923,30 +926,43 @@ impl<'a> MockExploredHost<'a> {
             return self;
         }
 
-        if self.test_env.config.machine_validation_config.enabled {
-            machine_validation_completed(self.test_env, &host_machine_id, None).await;
-        } else {
-            // need to mark as reboot completed to move it to the next state
-            // even if machine validation is disabled
-            reboot_completed(self.test_env, host_machine_id).await;
-        }
-
-        let stop_state = self
-            .test_env
-            .run_machine_state_controller_iteration_until_state_condition(
-                &host_machine_id,
-                10,
-                |machine| {
-                    machine.current_state() == &expected_state
-                        || matches!(
-                            *machine.current_state(),
-                            ManagedHostState::HostInit {
-                                machine_state: MachineState::Discovered { .. },
-                            }
-                        )
+        let stop_state = if matches!(
+            stop_state,
+            ManagedHostState::Validation {
+                validation_state: ValidationState::MachineValidation {
+                    machine_validation: MachineValidatingState::MachineValidating { .. },
                 },
-            )
-            .await;
+            }
+        ) {
+            machine_validation_completed(self.test_env, &host_machine_id, None).await;
+
+            self.test_env
+                .run_machine_state_controller_iteration_until_state_condition(
+                    &host_machine_id,
+                    10,
+                    |machine| {
+                        machine.current_state() == &expected_state
+                            || matches!(
+                                *machine.current_state(),
+                                ManagedHostState::HostInit {
+                                    machine_state: MachineState::Discovered { .. },
+                                }
+                            )
+                    },
+                )
+                .await
+        } else if matches!(
+            stop_state,
+            ManagedHostState::HostInit {
+                machine_state: MachineState::Discovered {
+                    skip_reboot_wait: true,
+                },
+            }
+        ) {
+            stop_state
+        } else {
+            panic!("Unexpected state while handling machine validation: {stop_state}");
+        };
 
         if stop_state == expected_state {
             return self;
@@ -1046,26 +1062,48 @@ impl<'a> MockExploredHost<'a> {
         )
         .await;
 
-        self.test_env
-            .run_machine_state_controller_iteration_until_state_matches(
+        let expected_machine_validating_state = ManagedHostState::Validation {
+            validation_state: ValidationState::MachineValidation {
+                machine_validation: MachineValidatingState::MachineValidating {
+                    context: "Discovery".to_string(),
+                    id: MachineValidationId::new(),
+                    completed: 1,
+                    total: 1,
+                    is_enabled: true,
+                },
+            },
+        };
+        let stop_state = self
+            .test_env
+            .run_machine_state_controller_iteration_until_state_condition(
                 &host_machine_id,
                 10,
-                ManagedHostState::Validation {
-                    validation_state: ValidationState::MachineValidation {
-                        machine_validation: MachineValidatingState::MachineValidating {
-                            context: "Discovery".to_string(),
-                            id: MachineValidationId::new(),
-                            completed: 1,
-                            total: 1,
-                            is_enabled: self.test_env.config.machine_validation_config.enabled,
-                        },
-                    },
+                |machine| {
+                    let expected_machine_validating_state = self
+                        .test_env
+                        .fill_machine_information(&expected_machine_validating_state, machine);
+                    machine.current_state() == &expected_machine_validating_state
+                        || matches!(
+                            *machine.current_state(),
+                            ManagedHostState::HostInit {
+                                machine_state: MachineState::Discovered {
+                                    skip_reboot_wait: true,
+                                },
+                            }
+                        )
                 },
             )
             .await;
 
-        let response = forge_agent_control(self.test_env, host_machine_id).await;
-        if self.test_env.config.machine_validation_config.enabled {
+        if matches!(
+            stop_state,
+            ManagedHostState::Validation {
+                validation_state: ValidationState::MachineValidation {
+                    machine_validation: MachineValidatingState::MachineValidating { .. },
+                },
+            }
+        ) {
+            let response = forge_agent_control(self.test_env, host_machine_id).await;
             let uuid = &response.data.unwrap().pair[1].value;
             let validation_id: MachineValidationId = uuid.parse().unwrap();
             let success = update_machine_validation_run(
@@ -1178,22 +1216,14 @@ impl<'a> MockExploredHost<'a> {
                     )
                     .await;
             }
-        } else {
-            self.test_env
-                .run_machine_state_controller_iteration_until_state_matches(
-                    &host_machine_id,
-                    10,
-                    ManagedHostState::HostInit {
-                        machine_state: MachineState::Discovered {
-                            skip_reboot_wait: true,
-                        },
-                    },
-                )
-                .await;
-
-            // Note: no forge_agent_control/reboot_completed call happens here, since we're skipping
-            // machine validation and thus not doing an extra reboot.
-
+        } else if matches!(
+            stop_state,
+            ManagedHostState::HostInit {
+                machine_state: MachineState::Discovered {
+                    skip_reboot_wait: true,
+                },
+            }
+        ) {
             self.test_env
                 .run_machine_state_controller_iteration_until_state_matches(
                     &host_machine_id,
@@ -1201,6 +1231,8 @@ impl<'a> MockExploredHost<'a> {
                     ManagedHostState::Ready,
                 )
                 .await;
+        } else {
+            panic!("Unexpected state while handling machine validation: {stop_state}");
         }
 
         self

--- a/crates/api-core/src/tests/machine_validation.rs
+++ b/crates/api-core/src/tests/machine_validation.rs
@@ -21,6 +21,7 @@ use std::time::SystemTime;
 use carbide_machine_controller::config::machine_validation::{
     MachineValidationConfig, MachineValidationTestConfig, MachineValidationTestSelectionMode,
 };
+use carbide_machine_controller::handler::MachineStateHandlerBuilder;
 use carbide_uuid::machine_validation::MachineValidationId;
 use common::api_fixtures::{
     TestEnvOverrides, create_host_with_machine_validation, create_test_env,
@@ -604,6 +605,15 @@ async fn test_machine_validation_disabled(
 
     let machine = mh.host().rpc_machine().await;
     assert!(machine.health.as_ref().unwrap().alerts.is_empty());
+    let reboot_before = {
+        let mut txn = env.pool.begin().await?;
+        let machine = mh.host().db_machine(&mut txn).await;
+        let reboot = machine
+            .last_reboot_requested
+            .map(|last_reboot| (last_reboot.time, last_reboot.mode));
+        txn.commit().await?;
+        reboot
+    };
 
     let on_demand_response = on_demand_machine_validation(
         &env,
@@ -617,25 +627,25 @@ async fn test_machine_validation_disabled(
     env.run_machine_state_controller_iteration_until_state_matches(
         &mh.host().id,
         3,
-        ManagedHostState::Validation {
-            validation_state: ValidationState::MachineValidation {
-                machine_validation: MachineValidatingState::MachineValidating {
-                    context: "OnDemand".to_string(),
-                    id: MachineValidationId::new(),
-                    completed: 1,
-                    total: 1,
-                    is_enabled: env.config.machine_validation_config.enabled,
-                },
+        ManagedHostState::HostInit {
+            machine_state: MachineState::Discovered {
+                skip_reboot_wait: true,
             },
         },
     )
     .await;
-    let _ = mh.host().reboot_completed().await;
+    let reboot_after = {
+        let mut txn = env.pool.begin().await?;
+        let machine = mh.host().db_machine(&mut txn).await;
+        let reboot = machine
+            .last_reboot_requested
+            .map(|last_reboot| (last_reboot.time, last_reboot.mode));
+        txn.commit().await?;
+        reboot
+    };
+    assert_eq!(reboot_after, reboot_before);
 
     let runs = get_machine_validation_runs(&env, &mh.host().id, true).await;
-    let started_state_int = rpc::forge::machine_validation_status::MachineValidationState::Started(
-        rpc::forge::machine_validation_status::MachineValidationStarted::Started.into(),
-    );
     let mut status_asserted = false;
     for run in runs.runs {
         if run.validation_id.unwrap_or_default()
@@ -646,8 +656,8 @@ async fn test_machine_validation_disabled(
                 run.status
                     .unwrap_or_default()
                     .machine_validation_state
-                    .unwrap_or(started_state_int),
-                started_state_int
+                    .unwrap_or(skipped_state_int),
+                skipped_state_int
             );
         }
     }
@@ -677,6 +687,155 @@ async fn test_machine_validation_disabled(
         }
     }
     assert!(status_asserted);
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_machine_validation_disabled_waits_for_in_flight_reboot(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    let mh = create_host_with_machine_validation(&env, None, None).await;
+    let machine = mh.host().rpc_machine().await;
+    assert!(machine.health.as_ref().unwrap().alerts.is_empty());
+
+    let on_demand_response = on_demand_machine_validation(
+        &env,
+        machine.id.unwrap_or_default(),
+        Vec::new(),
+        Vec::new(),
+        false,
+        Vec::new(),
+    )
+    .await;
+    let validation_id = on_demand_response.validation_id.unwrap();
+
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.host().id,
+        1,
+        ManagedHostState::Validation {
+            validation_state: ValidationState::MachineValidation {
+                machine_validation: MachineValidatingState::RebootHost { validation_id },
+            },
+        },
+    )
+    .await;
+
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.host().id,
+        1,
+        ManagedHostState::Validation {
+            validation_state: ValidationState::MachineValidation {
+                machine_validation: MachineValidatingState::MachineValidating {
+                    context: "OnDemand".to_string(),
+                    id: validation_id,
+                    completed: 1,
+                    total: 1,
+                    is_enabled: env.config.machine_validation_config.enabled,
+                },
+            },
+        },
+    )
+    .await;
+
+    let reboot_request_before_wait = {
+        let mut txn = env.pool.begin().await?;
+        let machine = mh.host().db_machine(&mut txn).await;
+        let reboot = machine
+            .last_reboot_requested
+            .map(|last_reboot| (last_reboot.time, last_reboot.mode));
+        txn.commit().await?;
+        reboot
+    };
+
+    let mut machine_validation_config = env.config.machine_validation_config.clone();
+    machine_validation_config.enabled = false;
+    let handler = MachineStateHandlerBuilder::builder()
+        .hardware_models(env.config.get_firmware_config())
+        .reachability_params(env.reachability_params)
+        .attestation_enabled(env.attestation_enabled)
+        .common_pools(env.common_pools.clone())
+        .dpu_enable_secure_boot(env.config.dpu_config.dpu_enable_secure_boot)
+        .machine_validation_config(machine_validation_config)
+        .bom_validation(env.config.bom_validation)
+        .instance_autoreboot_period(
+            env.config
+                .machine_updater
+                .instance_autoreboot_period
+                .clone(),
+        )
+        .power_options_config(env.config.power_manager_options.clone().into())
+        .build();
+    env.override_machine_state_controller_handler(handler).await;
+
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.host().id,
+        1,
+        ManagedHostState::Validation {
+            validation_state: ValidationState::MachineValidation {
+                machine_validation: MachineValidatingState::MachineValidating {
+                    context: "OnDemand".to_string(),
+                    id: validation_id,
+                    completed: 1,
+                    total: 1,
+                    is_enabled: env.config.machine_validation_config.enabled,
+                },
+            },
+        },
+    )
+    .await;
+
+    let reboot_request_after_wait = {
+        let mut txn = env.pool.begin().await?;
+        let machine = mh.host().db_machine(&mut txn).await;
+        let reboot = machine
+            .last_reboot_requested
+            .map(|last_reboot| (last_reboot.time, last_reboot.mode));
+        txn.commit().await?;
+        reboot
+    };
+    assert_eq!(reboot_request_after_wait, reboot_request_before_wait);
+
+    mh.host().reboot_completed().await;
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.host().id,
+        1,
+        ManagedHostState::HostInit {
+            machine_state: MachineState::Discovered {
+                skip_reboot_wait: true,
+            },
+        },
+    )
+    .await;
+
+    let skipped_state_int =
+        rpc::forge::machine_validation_status::MachineValidationState::Completed(
+            rpc::forge::machine_validation_status::MachineValidationCompleted::Skipped.into(),
+        );
+    let runs = get_machine_validation_runs(&env, &mh.host().id, true).await;
+    let mut status_asserted = false;
+    for run in runs.runs {
+        if run.validation_id.unwrap_or_default() == validation_id {
+            status_asserted = true;
+            assert_eq!(
+                run.status
+                    .unwrap_or_default()
+                    .machine_validation_state
+                    .unwrap_or(skipped_state_int),
+                skipped_state_int
+            );
+        }
+    }
+    assert!(status_asserted);
+
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.host().id,
+        1,
+        ManagedHostState::Ready,
+    )
+    .await;
+
     Ok(())
 }
 

--- a/crates/machine-controller/src/handler/machine_validation.rs
+++ b/crates/machine-controller/src/handler/machine_validation.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use carbide_uuid::machine_validation::MachineValidationId;
 use libredfish::SystemPowerControl;
 use model::machine::{
     FailureCause, MachineState, MachineValidatingState, ManagedHostState, ManagedHostStateSnapshot,
@@ -28,6 +29,52 @@ use super::{HostHandlerParams, is_machine_validation_requested, machine_validati
 use crate::context::{MachineStateHandlerContextObjects, MachineStateHandlerServices};
 use crate::handler::{handler_host_power_control, rebooted, trigger_reboot_if_needed};
 
+async fn skip_machine_validation(
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    validation_id: &MachineValidationId,
+    mh_snapshot: &ManagedHostStateSnapshot,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    tracing::info!("Skipping Machine Validation");
+    let machine_id = mh_snapshot.host_snapshot.id;
+    let mut txn = ctx.services.db_pool.begin().await?;
+    let completed = db::machine_validation::mark_machine_validation_complete(
+        txn.as_mut(),
+        &machine_id,
+        validation_id,
+        MachineValidationStatus {
+            state: MachineValidationState::Skipped,
+            ..MachineValidationStatus::default()
+        },
+    )
+    .await?;
+    if !completed {
+        tracing::info!(
+            %machine_id,
+            machine_validation_id = %validation_id,
+            "skipped machine validation completion ignored because run is no longer active"
+        );
+        return Ok(StateHandlerOutcome::do_nothing().with_txn(txn));
+    }
+    let machine_validation = db::machine_validation::find_by_id(txn.as_mut(), validation_id)
+        .await
+        .map_err(|err| StateHandlerError::GenericError(err.into()))?;
+
+    *ctx.metrics
+        .last_machine_validation_list
+        .entry((
+            machine_validation.machine_id.to_string(),
+            machine_validation.context.unwrap_or_default(),
+        ))
+        .or_default() = 0_i32;
+
+    Ok(StateHandlerOutcome::transition(ManagedHostState::HostInit {
+        machine_state: MachineState::Discovered {
+            skip_reboot_wait: true,
+        },
+    })
+    .with_txn(txn))
+}
+
 pub(crate) async fn handle_machine_validation_state(
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     machine_validation: &MachineValidatingState,
@@ -36,6 +83,9 @@ pub(crate) async fn handle_machine_validation_state(
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     match machine_validation {
         MachineValidatingState::RebootHost { validation_id } => {
+            if !host_handler_params.machine_validation_config.enabled {
+                return skip_machine_validation(ctx, validation_id, mh_snapshot).await;
+            }
             // Handle reboot host case
             handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::ForceRestart).await?;
             let machine_validation =
@@ -83,50 +133,7 @@ pub(crate) async fn handle_machine_validation_state(
                 return Ok(StateHandlerOutcome::wait(status.status));
             }
             if !host_handler_params.machine_validation_config.enabled {
-                tracing::info!("Skipping Machine Validation");
-                let machine_id = mh_snapshot.host_snapshot.id;
-                let machine_validation_id = *id;
-                let mut txn = ctx.services.db_pool.begin().await?;
-                let completed = db::machine_validation::mark_machine_validation_complete(
-                    txn.as_mut(),
-                    &machine_id,
-                    &machine_validation_id,
-                    MachineValidationStatus {
-                        state: MachineValidationState::Skipped,
-                        ..MachineValidationStatus::default()
-                    },
-                )
-                .await?;
-                if !completed {
-                    tracing::info!(
-                        %machine_id,
-                        %machine_validation_id,
-                        "skipped machine validation completion ignored because run is no longer active"
-                    );
-                    return Ok(StateHandlerOutcome::do_nothing().with_txn(txn));
-                }
-                let machine_validation = db::machine_validation::find_by_id(txn.as_mut(), id)
-                    .await
-                    .map_err(|err| StateHandlerError::GenericError(err.into()))?;
-
-                *ctx.metrics
-                    .last_machine_validation_list
-                    .entry((
-                        machine_validation.machine_id.to_string(),
-                        machine_validation.context.unwrap_or_default(),
-                    ))
-                    .or_default() = 0_i32;
-
-                return Ok(StateHandlerOutcome::transition(ManagedHostState::HostInit {
-                    machine_state: MachineState::Discovered {
-                        // Since we're skipping machine validation, we don't need to
-                        // wait on *another* reboot. We already waited for the prior
-                        // reboot to complete above, so tell the Discovered state to
-                        // skip it.
-                        skip_reboot_wait: true,
-                    },
-                })
-                .with_txn(txn));
+                return skip_machine_validation(ctx, id, mh_snapshot).await;
             }
             // Host validation completed
             if machine_validation_completed(&mh_snapshot.host_snapshot) {


### PR DESCRIPTION
## Description

NICO currently enters the machine-validation reboot path even when machine validation is disabled, issuing an unnecessary host restart and increasing startup latency.

This change:

- skips disabled machine validation directly from `RebootHost`, before issuing a host reboot
- reuses one completion path for disabled validation from both `RebootHost` and `MachineValidating`
- preserves the existing wait when validation is disabled while a reboot is already in flight
- preserves the upstream guard for validation runs that are no longer active
- makes site-explorer fixtures branch on the observed machine state instead of the validation configuration
- adds regression coverage for both disabled-validation paths

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

Related to #2486 feat: skip machine validation reboot when validation is disabled


## Breaking Changes
- N/A

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validation performed against current `NVIDIA/infra-controller:main`:

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo test -p carbide-machine-controller` (19 passed)
- `cargo test -p carbide-api-core --no-default-features --no-run`

## Additional Notes

- N/A
