### PR TITLE
fix: Keep Flow mirror off in actual-sync inventory tests

### DIFF
--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory_test.go
@@ -61,11 +61,12 @@ func TestInventory(t *testing.T) {
 	err = c.Create(ctx, pool.DB)
 	assert.Nil(t, err)
 
-	// Pass expectedSyncEnabled=true so the mirror step runs against the
-	// empty mock (no-op via the safety guard) — matches the cycle layout
-	// production will have once the feature gate is flipped on, without
-	// changing what this test asserts about actual-sync outputs.
-	runInventoryOne(ctx, pool, grpcMock, true)
+	// expectedSyncEnabled=false: this test exercises actual-sync only. The
+	// mock carries no expected machines, so running the mirror would treat
+	// that as Core authoritatively reporting zero compute components and
+	// soft-delete serial2/serial4 before actual-sync runs. The mirror has
+	// its own coverage in expected_mirror_db_test.go.
+	runInventoryOne(ctx, pool, grpcMock, false)
 
 	rows, err := pool.DB.Query("SELECT serial_number, power_state FROM component;")
 	assert.NotNil(t, rows)
@@ -131,7 +132,10 @@ func TestSyncFirmwareVersion(t *testing.T) {
 	err = c2.Create(ctx, pool.DB)
 	assert.Nil(t, err)
 
-	runInventoryOne(ctx, pool, grpcMock, true)
+	// expectedSyncEnabled=false: actual-sync only. See TestInventory for why
+	// the mirror must stay off here (empty expected-mock would soft-delete
+	// the components this test relies on).
+	runInventoryOne(ctx, pool, grpcMock, false)
 
 	var updated1 model.Component
 	err = pool.DB.NewSelect().Model(&updated1).Where("id = ?", c1.ID).Scan(ctx)


### PR DESCRIPTION


## Description
TestInventory/TestSyncFirmwareVersion exercise actual-sync but ran the mirror with an empty expected-mock. With the empty-Core-is-authoritative delete semantics the mirror soft-deletes the seeded components before actual-sync runs, leaving power_state NULL and panicking on a nil *PowerState deref. The mirror has its own coverage in expected_mirror_db_test.go.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

