### PR TITLE
test(libmlx): fold tests onto carbide-test-support modeling

### DIFF
--- a/crates/libmlx/tests/device/test_discovery.rs
+++ b/crates/libmlx/tests/device/test_discovery.rs
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, Check, check_cases, check_values};
 use libmlx::device::discovery::{convert_pci_name_to_address, parse_mlxfwmanager_xml};
 
 // Test XML to use for a single DPU with failed access due to lockdown.
@@ -182,47 +184,46 @@ fn test_parse_mixed_devices() {
     assert!(third_device.base_mac.is_some());
 }
 
+// convert_pci_name_to_address strips a single leading "0000:" domain prefix from a
+// PCI name and passes everything else (clean addresses, mst paths, arbitrary
+// strings) through untouched.
 #[test]
-fn test_convert_pci_name_removes_domain_prefix() {
-    let input = "0000:01:00.0";
-    let result = convert_pci_name_to_address(input).unwrap();
-    assert_eq!(result, "01:00.0");
-}
-
-#[test]
-fn test_convert_pci_name_passthrough_clean_address() {
-    let input = "01:00.0";
-    let result = convert_pci_name_to_address(input).unwrap();
-    assert_eq!(result, "01:00.0");
-}
-
-#[test]
-fn test_convert_pci_name_passthrough_mst_path() {
-    let input = "/dev/mst/mt41692_pciconf0";
-    let result = convert_pci_name_to_address(input).unwrap();
-    assert_eq!(result, "/dev/mst/mt41692_pciconf0");
-}
-
-#[test]
-fn test_convert_pci_name_passthrough_other_format() {
-    let input = "custom_device_path";
-    let result = convert_pci_name_to_address(input).unwrap();
-    assert_eq!(result, "custom_device_path");
-}
-
-#[test]
-fn test_convert_pci_name_multiple_domain_prefixes() {
-    let input = "0000:0000:01:00.0";
-    let result = convert_pci_name_to_address(input).unwrap();
-    // Should only remove the first "0000:" prefix
-    assert_eq!(result, "0000:01:00.0");
-}
-
-#[test]
-fn test_convert_pci_name_empty_string() {
-    let input = "";
-    let result = convert_pci_name_to_address(input).unwrap();
-    assert_eq!(result, "");
+fn test_convert_pci_name_to_address() {
+    check_cases(
+        [
+            Case {
+                scenario: "removes domain prefix",
+                input: "0000:01:00.0",
+                expect: Yields("01:00.0".to_string()),
+            },
+            Case {
+                scenario: "passes through a clean address",
+                input: "01:00.0",
+                expect: Yields("01:00.0".to_string()),
+            },
+            Case {
+                scenario: "passes through an mst path",
+                input: "/dev/mst/mt41692_pciconf0",
+                expect: Yields("/dev/mst/mt41692_pciconf0".to_string()),
+            },
+            Case {
+                scenario: "passes through an unrelated format",
+                input: "custom_device_path",
+                expect: Yields("custom_device_path".to_string()),
+            },
+            Case {
+                scenario: "removes only the first of multiple domain prefixes",
+                input: "0000:0000:01:00.0",
+                expect: Yields("0000:01:00.0".to_string()),
+            },
+            Case {
+                scenario: "passes through an empty string",
+                input: "",
+                expect: Yields("".to_string()),
+            },
+        ],
+        convert_pci_name_to_address,
+    );
 }
 
 #[test]
@@ -239,19 +240,52 @@ fn test_mac_address_parsing() {
     );
 }
 
+// get_field_value renders a None optional field as "--" and returns the value of a
+// present field. Exercised against the failed-DPU device, whose optionals are all
+// absent while pci_name/device_type/status are set.
 #[test]
 fn test_optional_field_handling() {
     let devices = parse_mlxfwmanager_xml(DPU_FAILED_XML).unwrap();
     let device = &devices[0];
 
-    // Test that get_field_value handles None values correctly
-    assert_eq!(device.get_field_value("psid"), "--");
-    assert_eq!(device.get_field_value("part_number"), "--");
-    assert_eq!(device.get_field_value("base_mac"), "--");
-    assert_eq!(device.get_field_value("fw_version_current"), "--");
-
-    // Test that non-None fields work correctly
-    assert_eq!(device.get_field_value("pci_name"), "b4:00.0");
-    assert_eq!(device.get_field_value("device_type"), "BlueField3");
-    assert_eq!(device.get_field_value("status"), "Failed to open device");
+    check_values(
+        [
+            Check {
+                scenario: "None psid renders as --",
+                input: "psid",
+                expect: "--".to_string(),
+            },
+            Check {
+                scenario: "None part_number renders as --",
+                input: "part_number",
+                expect: "--".to_string(),
+            },
+            Check {
+                scenario: "None base_mac renders as --",
+                input: "base_mac",
+                expect: "--".to_string(),
+            },
+            Check {
+                scenario: "None fw_version_current renders as --",
+                input: "fw_version_current",
+                expect: "--".to_string(),
+            },
+            Check {
+                scenario: "present pci_name",
+                input: "pci_name",
+                expect: "b4:00.0".to_string(),
+            },
+            Check {
+                scenario: "present device_type",
+                input: "device_type",
+                expect: "BlueField3".to_string(),
+            },
+            Check {
+                scenario: "present status",
+                input: "status",
+                expect: "Failed to open device".to_string(),
+            },
+        ],
+        |field| device.get_field_value(field),
+    );
 }

--- a/crates/libmlx/tests/device/test_filters.rs
+++ b/crates/libmlx/tests/device/test_filters.rs
@@ -17,7 +17,127 @@
 use std::str::FromStr;
 
 use carbide_libmlx_model::device::info::MlxDeviceInfo;
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, Check, check_cases, check_values};
 use libmlx::device::filters::{DeviceField, DeviceFilter, DeviceFilterSet, MatchMode};
+
+// A single filter against the fully-populated test device should match across
+// every field and match mode -- device type (exact/prefix/regex/complex regex),
+// part number, firmware, MAC, and the case-insensitive/substring description
+// paths -- plus the OR-logic case where any one of several values matches.
+#[test]
+fn filter_matches_complete_device() {
+    let device = MlxDeviceInfo::create_test_device();
+
+    check_values(
+        [
+            Check {
+                scenario: "device_type exact \"ConnectX-6 Dx\"",
+                input: DeviceFilter::device_type(
+                    vec!["ConnectX-6 Dx".to_string()],
+                    MatchMode::Exact,
+                ),
+                expect: true,
+            },
+            Check {
+                scenario: "device_type prefix \"ConnectX\"",
+                input: DeviceFilter::device_type(vec!["ConnectX".to_string()], MatchMode::Prefix),
+                expect: true,
+            },
+            Check {
+                scenario: "device_type regex \"Connect.*\"",
+                input: DeviceFilter::device_type(vec!["Connect.*".to_string()], MatchMode::Regex),
+                expect: true,
+            },
+            Check {
+                scenario: "device_type complex regex \".*X-6.*\"",
+                input: DeviceFilter::device_type(vec![".*X-6.*".to_string()], MatchMode::Regex),
+                expect: true,
+            },
+            Check {
+                scenario: "part_number prefix \"MCX623\"",
+                input: DeviceFilter::part_number(vec!["MCX623".to_string()], MatchMode::Prefix),
+                expect: true,
+            },
+            Check {
+                scenario: "firmware_version prefix \"22.32\"",
+                input: DeviceFilter::firmware_version(vec!["22.32".to_string()], MatchMode::Prefix),
+                expect: true,
+            },
+            Check {
+                scenario: "mac_address prefix \"b8:3f:d2\"",
+                input: DeviceFilter::mac_address(vec!["b8:3f:d2".to_string()], MatchMode::Prefix),
+                expect: true,
+            },
+            Check {
+                scenario: "description regex substring \".*100GbE.*\"",
+                input: DeviceFilter::description(vec![".*100GbE.*".to_string()], MatchMode::Regex),
+                expect: true,
+            },
+            Check {
+                scenario: "description case-insensitive prefix \"mellanox\"",
+                input: DeviceFilter::description(vec!["mellanox".to_string()], MatchMode::Prefix),
+                expect: true,
+            },
+            Check {
+                scenario: "multiple values, OR logic (one value matches)",
+                input: DeviceFilter::device_type(
+                    vec!["ConnectX-7".to_string(), "ConnectX-6 Dx".to_string()],
+                    MatchMode::Exact,
+                ),
+                expect: true,
+            },
+        ],
+        |filter| filter.matches(&device),
+    );
+}
+
+// The device with missing data has only its device type and status populated.
+// Filters on present fields match (status, device type); filters on absent
+// fields (part number, firmware, MAC) do not.
+#[test]
+fn filter_matches_device_with_missing_data() {
+    let device = MlxDeviceInfo::create_test_device_with_missing_data();
+
+    check_values(
+        [
+            Check {
+                scenario: "status exact \"Failed to open device\" present",
+                input: DeviceFilter::status(
+                    vec!["Failed to open device".to_string()],
+                    MatchMode::Exact,
+                ),
+                expect: true,
+            },
+            Check {
+                scenario: "status prefix \"Failed\" present",
+                input: DeviceFilter::status(vec!["Failed".to_string()], MatchMode::Prefix),
+                expect: true,
+            },
+            Check {
+                scenario: "device_type prefix \"BlueField\" present",
+                input: DeviceFilter::device_type(vec!["BlueField".to_string()], MatchMode::Prefix),
+                expect: true,
+            },
+            Check {
+                scenario: "part_number prefix \"MCX\" absent",
+                input: DeviceFilter::part_number(vec!["MCX".to_string()], MatchMode::Prefix),
+                expect: false,
+            },
+            Check {
+                scenario: "firmware_version prefix \"22.32\" absent",
+                input: DeviceFilter::firmware_version(vec!["22.32".to_string()], MatchMode::Prefix),
+                expect: false,
+            },
+            Check {
+                scenario: "mac_address prefix \"b8:3f\" absent",
+                input: DeviceFilter::mac_address(vec!["b8:3f".to_string()], MatchMode::Prefix),
+                expect: false,
+            },
+        ],
+        |filter| filter.matches(&device),
+    );
+}
 
 #[test]
 fn test_device_filter_set_no_filters_matches_all() {
@@ -26,86 +146,6 @@ fn test_device_filter_set_no_filters_matches_all() {
 
     assert!(filter_set.matches(&device));
     assert!(!filter_set.has_filters());
-}
-
-#[test]
-fn test_device_filter_device_type_exact_match() {
-    let device = MlxDeviceInfo::create_test_device();
-    let filter = DeviceFilter::device_type(vec!["ConnectX-6 Dx".to_string()], MatchMode::Exact);
-
-    assert!(filter.matches(&device));
-}
-
-#[test]
-fn test_device_filter_device_type_prefix_match() {
-    let device = MlxDeviceInfo::create_test_device();
-    let filter = DeviceFilter::device_type(vec!["ConnectX".to_string()], MatchMode::Prefix);
-
-    assert!(filter.matches(&device));
-}
-
-#[test]
-fn test_device_filter_device_type_regex_match() {
-    let device = MlxDeviceInfo::create_test_device();
-    let filter = DeviceFilter::device_type(vec!["Connect.*".to_string()], MatchMode::Regex);
-
-    assert!(filter.matches(&device));
-}
-
-#[test]
-fn test_device_filter_device_type_complex_regex() {
-    let device = MlxDeviceInfo::create_test_device();
-    let filter = DeviceFilter::device_type(vec![".*X-6.*".to_string()], MatchMode::Regex);
-
-    assert!(filter.matches(&device));
-}
-
-#[test]
-fn test_device_filter_part_number_match() {
-    let device = MlxDeviceInfo::create_test_device();
-    let filter = DeviceFilter::part_number(vec!["MCX623".to_string()], MatchMode::Prefix);
-
-    assert!(filter.matches(&device));
-}
-
-#[test]
-fn test_device_filter_firmware_version_match() {
-    let device = MlxDeviceInfo::create_test_device();
-    let filter = DeviceFilter::firmware_version(vec!["22.32".to_string()], MatchMode::Prefix);
-
-    assert!(filter.matches(&device));
-}
-
-#[test]
-fn test_device_filter_mac_address_match() {
-    let device = MlxDeviceInfo::create_test_device();
-    let filter = DeviceFilter::mac_address(vec!["b8:3f:d2".to_string()], MatchMode::Prefix);
-
-    assert!(filter.matches(&device));
-}
-
-#[test]
-fn test_device_filter_description_substring_match() {
-    let device = MlxDeviceInfo::create_test_device();
-    let filter = DeviceFilter::description(vec![".*100GbE.*".to_string()], MatchMode::Regex);
-
-    assert!(filter.matches(&device));
-}
-
-#[test]
-fn test_device_filter_description_case_insensitive() {
-    let device = MlxDeviceInfo::create_test_device();
-    let filter = DeviceFilter::description(vec!["mellanox".to_string()], MatchMode::Prefix);
-
-    assert!(filter.matches(&device));
-}
-
-#[test]
-fn test_device_filter_status_match() {
-    let device = MlxDeviceInfo::create_test_device_with_missing_data();
-    let filter = DeviceFilter::status(vec!["Failed to open device".to_string()], MatchMode::Exact);
-
-    assert!(filter.matches(&device));
 }
 
 #[test]
@@ -175,124 +215,134 @@ fn test_device_filter_set_summary_with_filters() {
     assert!(summary_vec.iter().any(|s| s.contains("part_number")));
 }
 
+// DeviceFilter::from_str parses "field:values[:match_mode]". The field and the
+// (comma-split) values are required; an omitted match mode defaults to Regex.
+// Each row pins the full parsed triple (field, values, match_mode).
 #[test]
-fn test_device_filter_from_str_simple() {
-    let filter_str = "device_type:ConnectX";
-    let filter = DeviceFilter::from_str(filter_str).unwrap();
-
-    assert_eq!(filter.field, DeviceField::DeviceType);
-    assert_eq!(filter.values, vec!["ConnectX".to_string()]);
-    assert_eq!(filter.match_mode, MatchMode::Regex);
+fn device_filter_from_str_parses_field_values_and_mode() {
+    check_cases(
+        [
+            Case {
+                scenario: "\"device_type:ConnectX\" defaults to regex",
+                input: "device_type:ConnectX",
+                expect: Yields((
+                    DeviceField::DeviceType,
+                    vec!["ConnectX".to_string()],
+                    MatchMode::Regex,
+                )),
+            },
+            Case {
+                scenario: "\"part_number:MCX623:exact\" with explicit mode",
+                input: "part_number:MCX623:exact",
+                expect: Yields((
+                    DeviceField::PartNumber,
+                    vec!["MCX623".to_string()],
+                    MatchMode::Exact,
+                )),
+            },
+            Case {
+                scenario: "\"device_type:ConnectX-6,ConnectX-7:prefix\" splits values",
+                input: "device_type:ConnectX-6,ConnectX-7:prefix",
+                expect: Yields((
+                    DeviceField::DeviceType,
+                    vec!["ConnectX-6".to_string(), "ConnectX-7".to_string()],
+                    MatchMode::Prefix,
+                )),
+            },
+        ],
+        |s| {
+            DeviceFilter::from_str(s)
+                .map(|f| (f.field, f.values, f.match_mode))
+                .map_err(drop)
+        },
+    );
 }
 
+// MatchMode::from_str accepts the three mode names case-insensitively and
+// rejects anything else.
 #[test]
-fn test_device_filter_from_str_with_match_mode() {
-    let filter_str = "part_number:MCX623:exact";
-    let filter = DeviceFilter::from_str(filter_str).unwrap();
-
-    assert_eq!(filter.field, DeviceField::PartNumber);
-    assert_eq!(filter.values, vec!["MCX623".to_string()]);
-    assert_eq!(filter.match_mode, MatchMode::Exact);
+fn match_mode_from_str_parses_known_modes() {
+    check_cases(
+        [
+            Case {
+                scenario: "\"regex\"",
+                input: "regex",
+                expect: Yields(MatchMode::Regex),
+            },
+            Case {
+                scenario: "\"exact\"",
+                input: "exact",
+                expect: Yields(MatchMode::Exact),
+            },
+            Case {
+                scenario: "\"prefix\"",
+                input: "prefix",
+                expect: Yields(MatchMode::Prefix),
+            },
+            Case {
+                scenario: "\"REGEX\" is case-insensitive",
+                input: "REGEX",
+                expect: Yields(MatchMode::Regex),
+            },
+            Case {
+                scenario: "\"invalid\" is rejected",
+                input: "invalid",
+                expect: Fails,
+            },
+        ],
+        |s| MatchMode::from_str(s).map_err(drop),
+    );
 }
 
+// DeviceField::from_str accepts each field's full name and its short alias, and
+// rejects anything else.
 #[test]
-fn test_device_filter_from_str_multiple_values() {
-    let filter_str = "device_type:ConnectX-6,ConnectX-7:prefix";
-    let filter = DeviceFilter::from_str(filter_str).unwrap();
-
-    assert_eq!(filter.field, DeviceField::DeviceType);
-    assert_eq!(
-        filter.values,
-        vec!["ConnectX-6".to_string(), "ConnectX-7".to_string()]
+fn device_field_from_str_parses_names_and_aliases() {
+    check_cases(
+        [
+            Case {
+                scenario: "\"device_type\"",
+                input: "device_type",
+                expect: Yields(DeviceField::DeviceType),
+            },
+            Case {
+                scenario: "\"type\" alias",
+                input: "type",
+                expect: Yields(DeviceField::DeviceType),
+            },
+            Case {
+                scenario: "\"part_number\"",
+                input: "part_number",
+                expect: Yields(DeviceField::PartNumber),
+            },
+            Case {
+                scenario: "\"part\" alias",
+                input: "part",
+                expect: Yields(DeviceField::PartNumber),
+            },
+            Case {
+                scenario: "\"firmware_version\"",
+                input: "firmware_version",
+                expect: Yields(DeviceField::FirmwareVersion),
+            },
+            Case {
+                scenario: "\"fw\" alias",
+                input: "fw",
+                expect: Yields(DeviceField::FirmwareVersion),
+            },
+            Case {
+                scenario: "\"status\"",
+                input: "status",
+                expect: Yields(DeviceField::Status),
+            },
+            Case {
+                scenario: "\"invalid\" is rejected",
+                input: "invalid",
+                expect: Fails,
+            },
+        ],
+        |s| DeviceField::from_str(s).map_err(drop),
     );
-    assert_eq!(filter.match_mode, MatchMode::Prefix);
-}
-
-#[test]
-fn test_device_filter_multiple_values_or_logic() {
-    let device = MlxDeviceInfo::create_test_device();
-    let filter = DeviceFilter::device_type(
-        vec!["ConnectX-7".to_string(), "ConnectX-6 Dx".to_string()],
-        MatchMode::Exact,
-    );
-
-    // Should match because one of the values matches (ConnectX-6 Dx)
-    assert!(filter.matches(&device));
-}
-
-#[test]
-fn test_device_filter_with_missing_data() {
-    let device = MlxDeviceInfo::create_test_device_with_missing_data();
-
-    // Filtering on missing data should not match
-    let part_filter = DeviceFilter::part_number(vec!["MCX".to_string()], MatchMode::Prefix);
-    assert!(!part_filter.matches(&device));
-
-    // But filtering on device type should still work
-    let type_filter = DeviceFilter::device_type(vec!["BlueField".to_string()], MatchMode::Prefix);
-    assert!(type_filter.matches(&device));
-
-    // Status filtering should work
-    let status_filter = DeviceFilter::status(vec!["Failed".to_string()], MatchMode::Prefix);
-    assert!(status_filter.matches(&device));
-}
-
-#[test]
-fn test_match_mode_from_str() {
-    assert_eq!(MatchMode::from_str("regex").unwrap(), MatchMode::Regex);
-    assert_eq!(MatchMode::from_str("exact").unwrap(), MatchMode::Exact);
-    assert_eq!(MatchMode::from_str("prefix").unwrap(), MatchMode::Prefix);
-    assert_eq!(MatchMode::from_str("REGEX").unwrap(), MatchMode::Regex);
-    assert!(MatchMode::from_str("invalid").is_err());
-}
-
-#[test]
-fn test_device_field_from_str() {
-    assert_eq!(
-        DeviceField::from_str("device_type").unwrap(),
-        DeviceField::DeviceType
-    );
-    assert_eq!(
-        DeviceField::from_str("type").unwrap(),
-        DeviceField::DeviceType
-    );
-    assert_eq!(
-        DeviceField::from_str("part_number").unwrap(),
-        DeviceField::PartNumber
-    );
-    assert_eq!(
-        DeviceField::from_str("part").unwrap(),
-        DeviceField::PartNumber
-    );
-    assert_eq!(
-        DeviceField::from_str("firmware_version").unwrap(),
-        DeviceField::FirmwareVersion
-    );
-    assert_eq!(
-        DeviceField::from_str("fw").unwrap(),
-        DeviceField::FirmwareVersion
-    );
-    assert_eq!(
-        DeviceField::from_str("status").unwrap(),
-        DeviceField::Status
-    );
-    assert!(DeviceField::from_str("invalid").is_err());
-}
-
-#[test]
-fn test_empty_field_filtering() {
-    let device = MlxDeviceInfo::create_test_device_with_missing_data();
-
-    // Test that empty fields don't match regular filters
-    let fw_filter = DeviceFilter::firmware_version(vec!["22.32".to_string()], MatchMode::Prefix);
-    assert!(!fw_filter.matches(&device));
-
-    let mac_filter = DeviceFilter::mac_address(vec!["b8:3f".to_string()], MatchMode::Prefix);
-    assert!(!mac_filter.matches(&device));
-
-    // But device type should still match since it's always present
-    let type_filter = DeviceFilter::device_type(vec!["BlueField".to_string()], MatchMode::Prefix);
-    assert!(type_filter.matches(&device));
 }
 
 #[test]
@@ -305,12 +355,12 @@ fn test_mixed_device_filtering() {
     assert!(part_filter.matches(&complete_device));
     assert!(!part_filter.matches(&partial_device));
 
-    // Filter that should match both
+    // A ".*" regex on device type matches both, since device type is always present
     let type_filter = DeviceFilter::device_type(vec![".*".to_string()], MatchMode::Regex);
     assert!(type_filter.matches(&complete_device)); // ConnectX-6 Dx
-    assert!(type_filter.matches(&partial_device)); // BlueField3 -> no match actually
+    assert!(type_filter.matches(&partial_device)); // BlueField3
 
-    // Actually fix the regex to match both
+    // An explicit alternation matches both device types too
     let broad_filter =
         DeviceFilter::device_type(vec!["Connect.*|Blue.*".to_string()], MatchMode::Regex);
     assert!(broad_filter.matches(&complete_device));

--- a/crates/libmlx/tests/firmware/test_config.rs
+++ b/crates/libmlx/tests/firmware/test_config.rs
@@ -15,7 +15,14 @@
  * limitations under the License.
  */
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, Check, check_cases, check_values};
 use libmlx::firmware::config::FirmwareFlasherProfile;
+
+// Parse `toml` into a profile, panicking with the scenario label if it doesn't.
+fn profile(scenario: &str, toml: &str) -> FirmwareFlasherProfile {
+    FirmwareFlasherProfile::from_toml(toml).unwrap_or_else(|e| panic!("{scenario}: {e}"))
+}
 
 #[test]
 fn test_minimal_config() {
@@ -59,9 +66,15 @@ verify_version = true
     assert_eq!(profile.flash_options.reset_level, 3); // default
 }
 
+// Every credential block parses into a present `firmware_credentials`, regardless
+// of auth scheme (bearer token, basic auth, SSH key, SSH agent).
 #[test]
-fn test_config_with_bearer_token() {
-    let toml = r#"
+fn credentials_block_populates_firmware_credentials() {
+    check_values(
+        [
+            Check {
+                scenario: "bearer token",
+                input: r#"
 part_number = "900-9D3B4-00CV-TA0"
 psid = "MT_0000000884"
 version = "32.43.1014"
@@ -70,18 +83,12 @@ firmware_url = "https://artifacts.example.com/fw/prod.signed.bin"
 [firmware_credentials]
 type = "bearer_token"
 token = "my-secret-token"
-"#;
-
-    let profile = FirmwareFlasherProfile::from_toml(toml).unwrap();
-    assert!(profile.flash_spec.firmware_credentials.is_some());
-
-    let source = profile.flash_spec.build_firmware_source().unwrap();
-    assert!(source.description().contains("http:"));
-}
-
-#[test]
-fn test_config_with_basic_auth() {
-    let toml = r#"
+"#,
+                expect: true,
+            },
+            Check {
+                scenario: "basic auth",
+                input: r#"
 part_number = "900-9D3B4-00CV-TA0"
 psid = "MT_0000000884"
 version = "32.43.1014"
@@ -91,15 +98,12 @@ firmware_url = "https://internal.example.com/fw/prod.signed.bin"
 type = "basic_auth"
 username = "deploy"
 password = "s3cret"
-"#;
-
-    let profile = FirmwareFlasherProfile::from_toml(toml).unwrap();
-    assert!(profile.flash_spec.firmware_credentials.is_some());
-}
-
-#[test]
-fn test_config_with_ssh_key() {
-    let toml = r#"
+"#,
+                expect: true,
+            },
+            Check {
+                scenario: "ssh key",
+                input: r#"
 part_number = "900-9D3B4-00CV-TA0"
 psid = "MT_0000000884"
 version = "32.43.1014"
@@ -108,18 +112,12 @@ firmware_url = "ssh://deploy@build-server.example.com:builds/fw/prod.signed.bin"
 [firmware_credentials]
 type = "ssh_key"
 path = "/home/deploy/.ssh/id_ed25519"
-"#;
-
-    let profile = FirmwareFlasherProfile::from_toml(toml).unwrap();
-    assert!(profile.flash_spec.firmware_credentials.is_some());
-
-    let source = profile.flash_spec.build_firmware_source().unwrap();
-    assert!(source.description().contains("ssh://"));
-}
-
-#[test]
-fn test_config_with_ssh_agent() {
-    let toml = r#"
+"#,
+                expect: true,
+            },
+            Check {
+                scenario: "ssh agent",
+                input: r#"
 part_number = "900-9D3B4-00CV-TA0"
 psid = "MT_0000000884"
 version = "32.43.1014"
@@ -127,10 +125,70 @@ firmware_url = "ssh://deploy@build-server.example.com:builds/fw/prod.signed.bin"
 
 [firmware_credentials]
 type = "ssh_agent"
-"#;
+"#,
+                expect: true,
+            },
+        ],
+        |toml| {
+            profile("credentials", toml)
+                .flash_spec
+                .firmware_credentials
+                .is_some()
+        },
+    );
+}
 
-    let profile = FirmwareFlasherProfile::from_toml(toml).unwrap();
-    assert!(profile.flash_spec.firmware_credentials.is_some());
+// The firmware source built from the flash spec describes the transport scheme of
+// its `firmware_url` -- http for an https URL, ssh for an ssh URL. Each row pairs a
+// config with the scheme its source description must contain.
+#[test]
+fn firmware_source_describes_its_transport_scheme() {
+    check_values(
+        [
+            Check {
+                scenario: "https url -> http source",
+                input: (
+                    r#"
+part_number = "900-9D3B4-00CV-TA0"
+psid = "MT_0000000884"
+version = "32.43.1014"
+firmware_url = "https://artifacts.example.com/fw/prod.signed.bin"
+
+[firmware_credentials]
+type = "bearer_token"
+token = "my-secret-token"
+"#,
+                    "http:",
+                ),
+                expect: true,
+            },
+            Check {
+                scenario: "ssh url -> ssh source",
+                input: (
+                    r#"
+part_number = "900-9D3B4-00CV-TA0"
+psid = "MT_0000000884"
+version = "32.43.1014"
+firmware_url = "ssh://deploy@build-server.example.com:builds/fw/prod.signed.bin"
+
+[firmware_credentials]
+type = "ssh_key"
+path = "/home/deploy/.ssh/id_ed25519"
+"#,
+                    "ssh://",
+                ),
+                expect: true,
+            },
+        ],
+        |(toml, scheme)| {
+            profile("transport scheme", toml)
+                .flash_spec
+                .build_firmware_source()
+                .unwrap()
+                .description()
+                .contains(scheme)
+        },
+    );
 }
 
 #[test]
@@ -180,24 +238,32 @@ firmware_url = "/opt/firmware/prod.signed.bin"
     assert!(conf_source.is_none());
 }
 
+// Malformed or incomplete TOML is rejected by `from_toml`.
 #[test]
-fn test_config_invalid_toml() {
-    let toml = r#"
+fn from_toml_rejects_malformed_or_incomplete_input() {
+    check_cases(
+        [
+            Case {
+                scenario: "unterminated string literal",
+                input: r#"
 firmware_url = "missing closing quote
-"#;
-
-    let result = FirmwareFlasherProfile::from_toml(toml);
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_config_missing_required_field() {
-    let toml = r#"
+"#,
+                expect: Fails,
+            },
+            Case {
+                scenario: "missing required firmware_url",
+                input: r#"
 part_number = "900-9D3B4-00CV-TA0"
 psid = "MT_0000000884"
 version = "32.43.1014"
-"#;
-
-    let result = FirmwareFlasherProfile::from_toml(toml);
-    assert!(result.is_err());
+"#,
+                expect: Fails,
+            },
+        ],
+        |toml| {
+            FirmwareFlasherProfile::from_toml(toml)
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/libmlx/tests/firmware/test_credentials.rs
+++ b/crates/libmlx/tests/firmware/test_credentials.rs
@@ -15,70 +15,83 @@
  * limitations under the License.
  */
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use libmlx::firmware::credentials::Credentials;
 
 // -- validate_http --
 
 #[test]
-fn test_bearer_token_valid_for_http() {
-    let cred = Credentials::bearer_token("my-token");
-    assert!(cred.validate_http().is_ok());
-}
-
-#[test]
-fn test_basic_auth_valid_for_http() {
-    let cred = Credentials::basic_auth("user", "pass");
-    assert!(cred.validate_http().is_ok());
-}
-
-#[test]
-fn test_header_valid_for_http() {
-    let cred = Credentials::header("X-API-Key", "abc123");
-    assert!(cred.validate_http().is_ok());
-}
-
-#[test]
-fn test_ssh_key_invalid_for_http() {
-    let cred = Credentials::ssh_key("/home/user/.ssh/id_rsa");
-    assert!(cred.validate_http().is_err());
-}
-
-#[test]
-fn test_ssh_agent_invalid_for_http() {
-    let cred = Credentials::ssh_agent();
-    assert!(cred.validate_http().is_err());
+fn validate_http_accepts_http_creds_and_rejects_ssh_creds() {
+    check_cases(
+        [
+            Case {
+                scenario: "bearer token is valid for http",
+                input: Credentials::bearer_token("my-token"),
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "basic auth is valid for http",
+                input: Credentials::basic_auth("user", "pass"),
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "header is valid for http",
+                input: Credentials::header("X-API-Key", "abc123"),
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "ssh key is invalid for http",
+                input: Credentials::ssh_key("/home/user/.ssh/id_rsa"),
+                expect: Fails,
+            },
+            Case {
+                scenario: "ssh agent is invalid for http",
+                input: Credentials::ssh_agent(),
+                expect: Fails,
+            },
+        ],
+        |cred| cred.validate_http().map_err(drop),
+    );
 }
 
 // -- validate_ssh --
 
 #[test]
-fn test_ssh_key_valid_for_ssh() {
-    let cred = Credentials::ssh_key("/home/user/.ssh/id_rsa");
-    assert!(cred.validate_ssh().is_ok());
-}
-
-#[test]
-fn test_ssh_key_with_passphrase_valid_for_ssh() {
-    let cred = Credentials::ssh_key_with_passphrase("/home/user/.ssh/id_rsa", "my-passphrase");
-    assert!(cred.validate_ssh().is_ok());
-}
-
-#[test]
-fn test_ssh_agent_valid_for_ssh() {
-    let cred = Credentials::ssh_agent();
-    assert!(cred.validate_ssh().is_ok());
-}
-
-#[test]
-fn test_bearer_token_invalid_for_ssh() {
-    let cred = Credentials::bearer_token("my-token");
-    assert!(cred.validate_ssh().is_err());
-}
-
-#[test]
-fn test_basic_auth_invalid_for_ssh() {
-    let cred = Credentials::basic_auth("user", "pass");
-    assert!(cred.validate_ssh().is_err());
+fn validate_ssh_accepts_ssh_creds_and_rejects_http_creds() {
+    check_cases(
+        [
+            Case {
+                scenario: "ssh key is valid for ssh",
+                input: Credentials::ssh_key("/home/user/.ssh/id_rsa"),
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "ssh key with passphrase is valid for ssh",
+                input: Credentials::ssh_key_with_passphrase(
+                    "/home/user/.ssh/id_rsa",
+                    "my-passphrase",
+                ),
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "ssh agent is valid for ssh",
+                input: Credentials::ssh_agent(),
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "bearer token is invalid for ssh",
+                input: Credentials::bearer_token("my-token"),
+                expect: Fails,
+            },
+            Case {
+                scenario: "basic auth is invalid for ssh",
+                input: Credentials::basic_auth("user", "pass"),
+                expect: Fails,
+            },
+        ],
+        |cred| cred.validate_ssh().map_err(drop),
+    );
 }
 
 // -- serde roundtrip --

--- a/crates/libmlx/tests/firmware/test_source.rs
+++ b/crates/libmlx/tests/firmware/test_source.rs
@@ -15,110 +15,106 @@
  * limitations under the License.
  */
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use libmlx::firmware::source::FirmwareSource;
 
-// -- from_url: local paths --
-
+// from_url classifies a URL into a FirmwareSource whose `description()` records the
+// scheme it picked. Local paths (bare or `file://`) become `local:`, HTTP(S) stays
+// `http:<url>`, and an SCP-style `ssh://` URL renders host:port:path. A malformed
+// ssh URL (no path, empty path, no host) is rejected. Each row maps the parsed
+// source straight to its description, so one table folds every exact-description and
+// every rejection case. (The no-user ssh case asserts a substring, so it stays
+// standalone below.)
 #[test]
-fn test_from_url_absolute_path() {
-    let source = FirmwareSource::from_url("/opt/firmware/prod.signed.bin").unwrap();
-    assert_eq!(source.description(), "local:/opt/firmware/prod.signed.bin");
-}
-
-#[test]
-fn test_from_url_relative_path() {
-    let source = FirmwareSource::from_url("firmware/prod.signed.bin").unwrap();
-    assert_eq!(source.description(), "local:firmware/prod.signed.bin");
-}
-
-#[test]
-fn test_from_url_file_prefix() {
-    let source = FirmwareSource::from_url("file:///opt/firmware/prod.signed.bin").unwrap();
-    assert_eq!(source.description(), "local:/opt/firmware/prod.signed.bin");
-}
-
-#[test]
-fn test_from_url_file_prefix_relative() {
-    let source = FirmwareSource::from_url("file://firmware/prod.signed.bin").unwrap();
-    assert_eq!(source.description(), "local:firmware/prod.signed.bin");
-}
-
-// -- from_url: HTTP(S) --
-
-#[test]
-fn test_from_url_https() {
-    let source =
-        FirmwareSource::from_url("https://artifacts.example.com/fw/prod.signed.bin").unwrap();
-    assert_eq!(
-        source.description(),
-        "http:https://artifacts.example.com/fw/prod.signed.bin"
+fn from_url_classifies_by_scheme() {
+    check_cases(
+        [
+            Case {
+                scenario: "absolute local path",
+                input: "/opt/firmware/prod.signed.bin",
+                expect: Yields("local:/opt/firmware/prod.signed.bin".to_string()),
+            },
+            Case {
+                scenario: "relative local path",
+                input: "firmware/prod.signed.bin",
+                expect: Yields("local:firmware/prod.signed.bin".to_string()),
+            },
+            Case {
+                scenario: "file:// absolute path",
+                input: "file:///opt/firmware/prod.signed.bin",
+                expect: Yields("local:/opt/firmware/prod.signed.bin".to_string()),
+            },
+            Case {
+                scenario: "file:// relative path",
+                input: "file://firmware/prod.signed.bin",
+                expect: Yields("local:firmware/prod.signed.bin".to_string()),
+            },
+            Case {
+                scenario: "https URL",
+                input: "https://artifacts.example.com/fw/prod.signed.bin",
+                expect: Yields("http:https://artifacts.example.com/fw/prod.signed.bin".to_string()),
+            },
+            Case {
+                scenario: "http URL",
+                input: "http://internal.example.com/fw/prod.signed.bin",
+                expect: Yields("http:http://internal.example.com/fw/prod.signed.bin".to_string()),
+            },
+            Case {
+                scenario: "ssh with user and relative path",
+                input: "ssh://deploy@build-server.example.com:builds/fw/prod.signed.bin",
+                expect: Yields(
+                    "ssh://deploy@build-server.example.com:22:builds/fw/prod.signed.bin"
+                        .to_string(),
+                ),
+            },
+            Case {
+                scenario: "ssh with user and absolute path",
+                input: "ssh://deploy@build-server.example.com:/opt/fw/prod.signed.bin",
+                expect: Yields(
+                    "ssh://deploy@build-server.example.com:22:/opt/fw/prod.signed.bin".to_string(),
+                ),
+            },
+            Case {
+                scenario: "ssh missing path is rejected",
+                input: "ssh://deploy@build-server.example.com",
+                expect: Fails,
+            },
+            Case {
+                scenario: "ssh empty path is rejected",
+                input: "ssh://deploy@build-server.example.com:",
+                expect: Fails,
+            },
+            Case {
+                scenario: "ssh missing host is rejected",
+                input: "ssh://:path/to/file",
+                expect: Fails,
+            },
+        ],
+        |url| {
+            FirmwareSource::from_url(url)
+                .map(|s| s.description())
+                .map_err(drop)
+        },
     );
 }
 
-#[test]
-fn test_from_url_http() {
-    let source =
-        FirmwareSource::from_url("http://internal.example.com/fw/prod.signed.bin").unwrap();
-    assert_eq!(
-        source.description(),
-        "http:http://internal.example.com/fw/prod.signed.bin"
-    );
-}
-
-// -- from_url: SSH (SCP-style) --
-
-#[test]
-fn test_from_url_ssh_with_user_and_path() {
-    let source =
-        FirmwareSource::from_url("ssh://deploy@build-server.example.com:builds/fw/prod.signed.bin")
-            .unwrap();
-    assert_eq!(
-        source.description(),
-        "ssh://deploy@build-server.example.com:22:builds/fw/prod.signed.bin"
-    );
-}
-
-#[test]
-fn test_from_url_ssh_absolute_path() {
-    let source =
-        FirmwareSource::from_url("ssh://deploy@build-server.example.com:/opt/fw/prod.signed.bin")
-            .unwrap();
-    assert_eq!(
-        source.description(),
-        "ssh://deploy@build-server.example.com:22:/opt/fw/prod.signed.bin"
-    );
-}
-
+// With no user in the ssh URL, the username defaults to the current user or "root",
+// so we can only pin the host:port:path tail -- a substring assertion, not the exact
+// equality the table above relies on.
 #[test]
 fn test_from_url_ssh_no_user() {
     let source =
         FirmwareSource::from_url("ssh://build-server.example.com:builds/fw/prod.signed.bin")
             .unwrap();
-    // Username defaults to current user or "root".
     let desc = source.description();
     assert!(desc.contains("build-server.example.com:22:builds/fw/prod.signed.bin"));
 }
 
-#[test]
-fn test_from_url_ssh_missing_path() {
-    let result = FirmwareSource::from_url("ssh://deploy@build-server.example.com");
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_from_url_ssh_empty_path() {
-    let result = FirmwareSource::from_url("ssh://deploy@build-server.example.com:");
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_from_url_ssh_missing_host() {
-    let result = FirmwareSource::from_url("ssh://:path/to/file");
-    assert!(result.is_err());
-}
-
 // -- direct constructors --
 
+// The local() and http() constructors record their scheme in `description()` just as
+// from_url does, but take a path/URL directly rather than classifying one.
 #[test]
 fn test_local_constructor() {
     let source = FirmwareSource::local("/path/to/firmware.bin");

--- a/crates/libmlx/tests/lockdown/test_cmd.rs
+++ b/crates/libmlx/tests/lockdown/test_cmd.rs
@@ -15,9 +15,31 @@
  * limitations under the License.
  */
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, Check, check_cases, check_values};
 use clap::Parser;
 use libmlx::lockdown::cmd::args::{Cli, Commands, LockdownAction, OutputFormat};
 use libmlx::lockdown::cmd::cmds::run_cli;
+
+// Parse a fully-formed argv into its LockdownAction, panicking on a parse error
+// (every caller below hands it a valid command line). The outer `Commands` enum
+// has the one `Lockdown` variant, so the destructure is irrefutable.
+fn action_of(args: &[&str]) -> LockdownAction {
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Commands::Lockdown { action } = cli.command;
+    action
+}
+
+// Name the parsed action's variant -- LockdownAction isn't PartialEq, so a table
+// pins the variant by this discriminant rather than by equality.
+fn action_kind(action: &LockdownAction) -> &'static str {
+    match action {
+        LockdownAction::Lock { .. } => "lock",
+        LockdownAction::Unlock { .. } => "unlock",
+        LockdownAction::Status { .. } => "status",
+        LockdownAction::SetKey { .. } => "set-key",
+    }
+}
 
 #[test]
 fn test_cli_parsing() {
@@ -30,217 +52,235 @@ fn test_cli_parsing() {
 
 #[test]
 fn test_cli_help() {
-    // Test that help works without panicking
+    // Help exits with an error code, which clap surfaces as Err -- that's expected.
     let result = Cli::try_parse_from(["mlxconfig-lockdown", "--help"]);
-    assert!(result.is_err()); // Help exits with error code, but that's expected
+    assert!(result.is_err());
 }
 
+// Each lockdown subcommand parses to its matching action variant. Folds the
+// per-subcommand parse-and-`matches!` blocks into one table over `action_kind`.
 #[test]
-fn test_lockdown_subcommands() {
-    let cli = Cli::try_parse_from([
-        "mlxconfig-lockdown",
-        "lockdown",
-        "lock",
-        "04:00.0",
-        "12345678",
-    ])
-    .unwrap();
-
-    let Commands::Lockdown { action } = cli.command;
-    assert!(matches!(action, LockdownAction::Lock { .. }));
-
-    // Test unlock subcommand
-    let cli = Cli::try_parse_from([
-        "mlxconfig-lockdown",
-        "lockdown",
-        "unlock",
-        "04:00.0",
-        "12345678",
-    ])
-    .unwrap();
-
-    let Commands::Lockdown { action } = cli.command;
-    assert!(matches!(action, LockdownAction::Unlock { .. }));
-
-    // Test set-key subcommand
-    let cli = Cli::try_parse_from([
-        "mlxconfig-lockdown",
-        "lockdown",
-        "set-key",
-        "04:00.0",
-        "12345678",
-    ])
-    .unwrap();
-
-    let Commands::Lockdown { action } = cli.command;
-    assert!(matches!(action, LockdownAction::SetKey { .. }));
+fn lockdown_subcommands_parse_to_their_action_variant() {
+    check_values(
+        [
+            Check {
+                scenario: "lock",
+                input: vec![
+                    "mlxconfig-lockdown",
+                    "lockdown",
+                    "lock",
+                    "04:00.0",
+                    "12345678",
+                ],
+                expect: "lock",
+            },
+            Check {
+                scenario: "unlock",
+                input: vec![
+                    "mlxconfig-lockdown",
+                    "lockdown",
+                    "unlock",
+                    "04:00.0",
+                    "12345678",
+                ],
+                expect: "unlock",
+            },
+            Check {
+                scenario: "set-key",
+                input: vec![
+                    "mlxconfig-lockdown",
+                    "lockdown",
+                    "set-key",
+                    "04:00.0",
+                    "12345678",
+                ],
+                expect: "set-key",
+            },
+            Check {
+                scenario: "status",
+                input: vec!["mlxconfig-lockdown", "lockdown", "status", "04:00.0"],
+                expect: "status",
+            },
+        ],
+        |args| action_kind(&action_of(&args)),
+    );
 }
 
 #[test]
 fn test_dry_run_flag_parsing() {
     // Test that dry-run flag is parsed correctly
-    let cli = Cli::try_parse_from([
+    let LockdownAction::Status { dry_run, .. } = action_of(&[
         "mlxconfig-lockdown",
         "lockdown",
         "status",
         "04:00.0",
         "--dry-run",
-    ])
-    .unwrap();
-
-    let Commands::Lockdown { action } = cli.command;
-    if let LockdownAction::Status { dry_run, .. } = action {
-        assert!(dry_run);
-    }
+    ]) else {
+        panic!("expected a Status action");
+    };
+    assert!(dry_run);
 }
 
+// `--format json` / `--format yaml` parse to the matching OutputFormat. The format
+// enum isn't PartialEq, so each row pins it by a discriminant name.
 #[test]
-fn test_output_formats() {
-    // Test JSON format
-    let cli = Cli::try_parse_from([
-        "mlxconfig-lockdown",
-        "lockdown",
-        "status",
-        "04:00.0",
-        "--format",
-        "json",
-    ])
-    .unwrap();
-
-    let Commands::Lockdown { action } = cli.command;
-    if let LockdownAction::Status { format, .. } = action {
-        assert!(matches!(format, OutputFormat::Json));
+fn output_format_flag_parses_to_the_named_format() {
+    fn status_format(args: &[&str]) -> &'static str {
+        let LockdownAction::Status { format, .. } = action_of(args) else {
+            panic!("expected a Status action");
+        };
+        match format {
+            OutputFormat::Text => "text",
+            OutputFormat::Json => "json",
+            OutputFormat::Yaml => "yaml",
+        }
     }
 
-    // Test YAML format
-    let cli = Cli::try_parse_from([
-        "mlxconfig-lockdown",
-        "lockdown",
-        "status",
-        "04:00.0",
-        "--format",
-        "yaml",
-    ])
-    .unwrap();
-
-    let Commands::Lockdown { action } = cli.command;
-    if let LockdownAction::Status { format, .. } = action {
-        assert!(matches!(format, OutputFormat::Yaml));
-    }
+    check_values(
+        [
+            Check {
+                scenario: "--format json",
+                input: vec![
+                    "mlxconfig-lockdown",
+                    "lockdown",
+                    "status",
+                    "04:00.0",
+                    "--format",
+                    "json",
+                ],
+                expect: "json",
+            },
+            Check {
+                scenario: "--format yaml",
+                input: vec![
+                    "mlxconfig-lockdown",
+                    "lockdown",
+                    "status",
+                    "04:00.0",
+                    "--format",
+                    "yaml",
+                ],
+                expect: "yaml",
+            },
+        ],
+        |args| status_format(&args),
+    );
 }
 
+// device_id and key are parsed as positional arguments, in order. The (device_id,
+// key) pair is PartialEq, so the table pins both at once.
 #[test]
-fn test_positional_arguments() {
-    // Test that device_id is parsed as positional argument.
-    let cli = Cli::try_parse_from([
-        "mlxconfig-lockdown",
-        "lockdown",
-        "lock",
-        "test:device:id",
-        "12345678",
-    ])
-    .unwrap();
-
-    let Commands::Lockdown { action } = cli.command;
-    if let LockdownAction::Lock { device_id, key, .. } = action {
-        assert_eq!(device_id, "test:device:id");
-        assert_eq!(key, "12345678");
+fn positional_arguments_become_device_id_and_key() {
+    fn device_and_key(args: &[&str]) -> (String, String) {
+        match action_of(args) {
+            LockdownAction::Lock { device_id, key, .. }
+            | LockdownAction::Unlock { device_id, key, .. }
+            | LockdownAction::SetKey { device_id, key, .. } => (device_id, key),
+            LockdownAction::Status { .. } => panic!("expected a keyed action"),
+        }
     }
 
-    // Test that key is parsed as positional argument
-    let cli = Cli::try_parse_from([
-        "mlxconfig-lockdown",
-        "lockdown",
-        "unlock",
-        "04:00.0",
-        "abcdef01",
-    ])
-    .unwrap();
-
-    let Commands::Lockdown { action } = cli.command;
-    if let LockdownAction::Unlock { device_id, key, .. } = action {
-        assert_eq!(device_id, "04:00.0");
-        assert_eq!(key, "abcdef01");
-    }
+    check_values(
+        [
+            Check {
+                scenario: "lock keeps an mst-style device id",
+                input: vec![
+                    "mlxconfig-lockdown",
+                    "lockdown",
+                    "lock",
+                    "test:device:id",
+                    "12345678",
+                ],
+                expect: ("test:device:id".to_string(), "12345678".to_string()),
+            },
+            Check {
+                scenario: "unlock keeps a PCI device id",
+                input: vec![
+                    "mlxconfig-lockdown",
+                    "lockdown",
+                    "unlock",
+                    "04:00.0",
+                    "abcdef01",
+                ],
+                expect: ("04:00.0".to_string(), "abcdef01".to_string()),
+            },
+        ],
+        |args| device_and_key(&args),
+    );
 }
 
 #[cfg(test)]
 mod integration_tests {
     use super::*;
 
-    #[test]
-    fn test_run_cli_with_dry_run() {
-        // Test that dry-run commands work end-to-end
-        let cli = Cli::try_parse_from([
-            "mlxconfig-lockdown",
-            "lockdown",
-            "status",
-            "fake_device",
-            "--dry-run",
-        ])
-        .unwrap();
-
-        // This should succeed because dry-run just prints what would be executed
-        let result = run_cli(cli);
-        assert!(result.is_ok());
+    // run_cli over a parsed command line, dropping the (non-PartialEq) error so the
+    // outcome rows only assert succeeds/fails.
+    fn run(args: &[&str]) -> Result<(), ()> {
+        run_cli(Cli::try_parse_from(args).unwrap()).map_err(drop)
     }
 
+    // Every dry-run command succeeds end-to-end (it just prints what it would run),
+    // while a real status against a device flint can't reach fails. Folds the
+    // single-command dry-run/fake-device tests and the per-subcommand dry-run loop
+    // into one outcome table.
     #[test]
-    fn test_run_cli_with_fake_device() {
-        // This will fail since we don't have flint set up, but we can test
-        // that the CLI structure works
-        let cli = Cli::try_parse_from(["mlxconfig-lockdown", "lockdown", "status", "fake_device"])
-            .unwrap();
-
-        // This should fail with some kind of error, not a parsing error
-        let result = run_cli(cli);
-        assert!(result.is_err());
-
-        // Should be some kind of flint-related error (could be CommandFailed, FlintNotFound, or others)
-        assert!(result.is_err(), "Expected an error when using fake device");
-    }
-
-    #[test]
-    fn test_all_subcommands_with_fake_device() {
-        let test_cases = vec![
-            vec![
-                "mlxconfig-lockdown",
-                "lockdown",
-                "lock",
-                "fake_device",
-                "12345678",
-                "--dry-run",
+    fn run_cli_dry_runs_succeed_and_real_lookups_fail() {
+        check_cases(
+            [
+                Case {
+                    scenario: "status dry-run prints and succeeds",
+                    input: vec![
+                        "mlxconfig-lockdown",
+                        "lockdown",
+                        "status",
+                        "fake_device",
+                        "--dry-run",
+                    ],
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "lock dry-run prints and succeeds",
+                    input: vec![
+                        "mlxconfig-lockdown",
+                        "lockdown",
+                        "lock",
+                        "fake_device",
+                        "12345678",
+                        "--dry-run",
+                    ],
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "unlock dry-run prints and succeeds",
+                    input: vec![
+                        "mlxconfig-lockdown",
+                        "lockdown",
+                        "unlock",
+                        "fake_device",
+                        "12345678",
+                        "--dry-run",
+                    ],
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "set-key dry-run prints and succeeds",
+                    input: vec![
+                        "mlxconfig-lockdown",
+                        "lockdown",
+                        "set-key",
+                        "fake_device",
+                        "12345678",
+                        "--dry-run",
+                    ],
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "real status against a fake device fails (no flint)",
+                    input: vec!["mlxconfig-lockdown", "lockdown", "status", "fake_device"],
+                    expect: Fails,
+                },
             ],
-            vec![
-                "mlxconfig-lockdown",
-                "lockdown",
-                "unlock",
-                "fake_device",
-                "12345678",
-                "--dry-run",
-            ],
-            vec![
-                "mlxconfig-lockdown",
-                "lockdown",
-                "status",
-                "fake_device",
-                "--dry-run",
-            ],
-            vec![
-                "mlxconfig-lockdown",
-                "lockdown",
-                "set-key",
-                "fake_device",
-                "12345678",
-                "--dry-run",
-            ],
-        ];
-
-        for args in test_cases {
-            let cli = Cli::try_parse_from(args.clone()).unwrap();
-            let result = run_cli(cli);
-            // Dry-run commands should succeed (they just print to stdout)
-            assert!(result.is_ok(), "Failed for args: {args:?}");
-        }
+            |args| run(&args),
+        );
     }
 }

--- a/crates/libmlx/tests/lockdown/test_error.rs
+++ b/crates/libmlx/tests/lockdown/test_error.rs
@@ -15,21 +15,87 @@
  * limitations under the License.
  */
 
+use carbide_test_support::{Check, check_values};
 use libmlx::lockdown::error::{MlxError, MlxResult};
 
+// Every MlxError variant renders to an exact, contract-bearing string via its
+// thiserror `#[error(...)]` Display impl. This one table is the single source of
+// truth for that mapping -- it folds the old per-variant display tests (the
+// DeviceNotFound and DryRun spot-checks, the IoError chain check) and subsumes the
+// old "can every variant be displayed without panic" loop, since asserting the
+// exact text exercises Display for each variant. The IoError row pins the full
+// rendered string rather than the old `.contains` check -- a strictly stronger
+// assertion. (SerializationError is omitted: constructing a serde_json::Error
+// inline is awkward and the old loop didn't cover it either.)
 #[test]
-fn test_error_display() {
-    let error = MlxError::DeviceNotFound("test_device".to_string());
-    assert_eq!(error.to_string(), "Device not found: test_device");
+fn error_variants_display_their_contract_strings() {
+    check_values(
+        [
+            Check {
+                scenario: "CommandFailed",
+                input: MlxError::CommandFailed("test".to_string()),
+                expect: "Command execution failed: test".to_string(),
+            },
+            Check {
+                scenario: "DeviceNotFound",
+                input: MlxError::DeviceNotFound("test_device".to_string()),
+                expect: "Device not found: test_device".to_string(),
+            },
+            Check {
+                scenario: "InvalidDeviceId",
+                input: MlxError::InvalidDeviceId("invalid".to_string()),
+                expect: "Invalid device ID format: invalid".to_string(),
+            },
+            Check {
+                scenario: "AlreadyLocked",
+                input: MlxError::AlreadyLocked,
+                expect: "Hardware access is already disabled".to_string(),
+            },
+            Check {
+                scenario: "AlreadyUnlocked",
+                input: MlxError::AlreadyUnlocked,
+                expect: "Hardware access is already enabled".to_string(),
+            },
+            Check {
+                scenario: "InvalidKey",
+                input: MlxError::InvalidKey,
+                expect: "Invalid key format or length".to_string(),
+            },
+            Check {
+                scenario: "PermissionDenied",
+                input: MlxError::PermissionDenied,
+                expect: "Permission denied - requires root privileges".to_string(),
+            },
+            Check {
+                scenario: "FlintNotFound",
+                input: MlxError::FlintNotFound,
+                expect: "flint tool not found or not executable".to_string(),
+            },
+            Check {
+                scenario: "ParseError",
+                input: MlxError::ParseError("parse error".to_string()),
+                expect: "Failed to parse command output: parse error".to_string(),
+            },
+            Check {
+                scenario: "DryRun",
+                input: MlxError::DryRun("flint -d 04:00.0 q".to_string()),
+                expect: "Dry run - would have executed: flint -d 04:00.0 q".to_string(),
+            },
+            Check {
+                scenario: "IoError wraps the inner message",
+                input: MlxError::IoError(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "file not found",
+                )),
+                expect: "I/O error: file not found".to_string(),
+            },
+        ],
+        |error| error.to_string(),
+    );
 }
 
-#[test]
-fn test_error_chain() {
-    let io_error = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
-    let mlx_error = MlxError::IoError(io_error);
-    assert!(mlx_error.to_string().contains("file not found"));
-}
-
+// The MlxResult<T> alias is just Result<T, MlxError> -- this keeps a standalone
+// guard that an Ok flows through it unchanged.
 #[test]
 fn test_result_type() {
     fn test_function() -> MlxResult<i32> {
@@ -37,35 +103,4 @@ fn test_result_type() {
     }
 
     assert_eq!(test_function().unwrap(), 42);
-}
-
-#[test]
-fn test_dry_run_error() {
-    let cmd = "flint -d 04:00.0 q";
-    let error = MlxError::DryRun(cmd.to_string());
-    assert_eq!(
-        error.to_string(),
-        "Dry run - would have executed: flint -d 04:00.0 q"
-    );
-}
-
-#[test]
-fn test_all_error_variants() {
-    let errors = vec![
-        MlxError::CommandFailed("test".to_string()),
-        MlxError::DeviceNotFound("device".to_string()),
-        MlxError::InvalidDeviceId("invalid".to_string()),
-        MlxError::AlreadyLocked,
-        MlxError::AlreadyUnlocked,
-        MlxError::InvalidKey,
-        MlxError::PermissionDenied,
-        MlxError::FlintNotFound,
-        MlxError::ParseError("parse error".to_string()),
-        MlxError::DryRun("cmd".to_string()),
-    ];
-
-    for error in errors {
-        // Just ensure they can be displayed without panic
-        let _ = error.to_string();
-    }
 }

--- a/crates/libmlx/tests/lockdown/test_lockdown.rs
+++ b/crates/libmlx/tests/lockdown/test_lockdown.rs
@@ -15,15 +15,47 @@
  * limitations under the License.
  */
 
+use carbide_test_support::{Check, check_values};
 use libmlx::lockdown::error::MlxError;
 use libmlx::lockdown::lockdown::{LockStatus, LockdownManager, StatusReport};
 use libmlx::lockdown::runner::FlintRunner;
 
+// MlxError is not PartialEq, so we can't pin it with Outcome::FailsWith. Map a
+// result to a stable token naming its error variant (or "ok") so a table can
+// assert the variant that IS the contract via plain string equality.
+fn error_kind<T>(result: Result<T, MlxError>) -> &'static str {
+    match result {
+        Ok(_) => "ok",
+        Err(MlxError::CommandFailed(_)) => "CommandFailed",
+        Err(MlxError::DryRun(_)) => "DryRun",
+        Err(MlxError::AlreadyLocked) => "AlreadyLocked",
+        Err(MlxError::AlreadyUnlocked) => "AlreadyUnlocked",
+        Err(_) => "other",
+    }
+}
+
 #[test]
-fn test_lock_status_display() {
-    assert_eq!(LockStatus::Locked.to_string(), "locked");
-    assert_eq!(LockStatus::Unlocked.to_string(), "unlocked");
-    assert_eq!(LockStatus::Unknown.to_string(), "unknown");
+fn lock_status_displays_lowercase_name() {
+    check_values(
+        [
+            Check {
+                scenario: "locked",
+                input: LockStatus::Locked,
+                expect: "locked".to_string(),
+            },
+            Check {
+                scenario: "unlocked",
+                input: LockStatus::Unlocked,
+                expect: "unlocked".to_string(),
+            },
+            Check {
+                scenario: "unknown",
+                input: LockStatus::Unknown,
+                expect: "unknown".to_string(),
+            },
+        ],
+        |status| status.to_string(),
+    );
 }
 
 #[test]
@@ -102,76 +134,106 @@ fn test_device_validation_in_manager() {
     assert!(result.is_err());
 }
 
+// With a fake flint path every operation fails when it tries to execute the tool,
+// surfacing as CommandFailed. Each manager method has its own signature, so the
+// rows feed pre-computed outcomes (mapped to their error variant) through identity.
 #[test]
 fn test_manager_error_handling() {
     let runner = FlintRunner::with_path("/fake/flint");
     let manager = LockdownManager::with_runner(runner);
 
-    // These operations should fail with CommandFailed since we're using a fake runner
-    let lock_result = manager.lock_device("fake_device", "12345678");
-    assert!(matches!(lock_result, Err(MlxError::CommandFailed(_))));
-
-    let unlock_result = manager.unlock_device("fake_device", "12345678");
-    assert!(matches!(unlock_result, Err(MlxError::CommandFailed(_))));
-
-    let status_result = manager.get_status("fake_device");
-    assert!(matches!(status_result, Err(MlxError::CommandFailed(_))));
-
-    let set_key_result = manager.set_device_key("fake_device", "12345678");
-    assert!(matches!(set_key_result, Err(MlxError::CommandFailed(_))));
+    check_values(
+        [
+            Check {
+                scenario: "lock_device",
+                input: error_kind(manager.lock_device("fake_device", "12345678")),
+                expect: "CommandFailed",
+            },
+            Check {
+                scenario: "unlock_device",
+                input: error_kind(manager.unlock_device("fake_device", "12345678")),
+                expect: "CommandFailed",
+            },
+            Check {
+                scenario: "get_status",
+                input: error_kind(manager.get_status("fake_device")),
+                expect: "CommandFailed",
+            },
+            Check {
+                scenario: "set_device_key",
+                input: error_kind(manager.set_device_key("fake_device", "12345678")),
+                expect: "CommandFailed",
+            },
+        ],
+        |kind| kind,
+    );
 }
 
 #[cfg(test)]
 mod dry_run_tests {
     use super::*;
 
+    // A dry-run runner short-circuits every operation with DryRun before touching
+    // flint. Same per-method-signature shape as test_manager_error_handling.
     #[test]
     fn test_dry_run_manager_operations() {
         let runner = FlintRunner::with_path("/fake/flint").with_dry_run(true);
         let manager = LockdownManager::with_runner(runner);
 
-        // Test that all operations return DryRun errors
-        assert!(matches!(
-            manager.lock_device("test_device", "12345678"),
-            Err(MlxError::DryRun(_))
-        ));
-
-        assert!(matches!(
-            manager.unlock_device("test_device", "12345678"),
-            Err(MlxError::DryRun(_))
-        ));
-
-        assert!(matches!(
-            manager.get_status("test_device"),
-            Err(MlxError::DryRun(_))
-        ));
-
-        assert!(matches!(
-            manager.set_device_key("test_device", "12345678"),
-            Err(MlxError::DryRun(_))
-        ));
+        check_values(
+            [
+                Check {
+                    scenario: "lock_device",
+                    input: error_kind(manager.lock_device("test_device", "12345678")),
+                    expect: "DryRun",
+                },
+                Check {
+                    scenario: "unlock_device",
+                    input: error_kind(manager.unlock_device("test_device", "12345678")),
+                    expect: "DryRun",
+                },
+                Check {
+                    scenario: "get_status",
+                    input: error_kind(manager.get_status("test_device")),
+                    expect: "DryRun",
+                },
+                Check {
+                    scenario: "set_device_key",
+                    input: error_kind(manager.set_device_key("test_device", "12345678")),
+                    expect: "DryRun",
+                },
+            ],
+            |kind| kind,
+        );
     }
 
+    // The DryRun error carries the command string that would have run; each
+    // operation's command must mention the flint sub-command plus the arguments
+    // it was handed. A helper pulls the command out of the expected DryRun error.
     #[test]
     fn test_dry_run_commands_contain_expected_parts() {
         let runner = FlintRunner::with_path("/test/flint").with_dry_run(true);
         let manager = LockdownManager::with_runner(runner);
 
-        if let Err(MlxError::DryRun(cmd)) = manager.lock_device("test_device", "12345678") {
-            assert!(cmd.contains("hw_access disable"));
-            assert!(cmd.contains("test_device"));
-            assert!(cmd.contains("12345678"));
+        fn dry_run_command<T: std::fmt::Debug>(result: Result<T, MlxError>) -> String {
+            match result {
+                Err(MlxError::DryRun(cmd)) => cmd,
+                other => panic!("expected DryRun, got {other:?}"),
+            }
         }
 
-        if let Err(MlxError::DryRun(cmd)) = manager.unlock_device("test_device", "abcdef01") {
-            assert!(cmd.contains("hw_access enable"));
-            assert!(cmd.contains("abcdef01"));
-        }
+        let lock_cmd = dry_run_command(manager.lock_device("test_device", "12345678"));
+        assert!(lock_cmd.contains("hw_access disable"));
+        assert!(lock_cmd.contains("test_device"));
+        assert!(lock_cmd.contains("12345678"));
 
-        if let Err(MlxError::DryRun(cmd)) = manager.set_device_key("test_device", "12345678") {
-            assert!(cmd.contains("set_key"));
-            assert!(cmd.contains("12345678"));
-        }
+        let unlock_cmd = dry_run_command(manager.unlock_device("test_device", "abcdef01"));
+        assert!(unlock_cmd.contains("hw_access enable"));
+        assert!(unlock_cmd.contains("abcdef01"));
+
+        let set_key_cmd = dry_run_command(manager.set_device_key("test_device", "12345678"));
+        assert!(set_key_cmd.contains("set_key"));
+        assert!(set_key_cmd.contains("12345678"));
     }
 }
 
@@ -218,33 +280,46 @@ mod mock_runner_tests {
         }
     }
 
+    // disable_hw_access / enable_hw_access succeed by default and surface the
+    // matching "already" error only when the mock is primed for that state.
     #[test]
-    fn test_already_locked_behavior() {
-        // Test that when flint returns "already disabled", we get an AlreadyLocked error
-        let mock_runner = MockRunner::new().with_already_locked();
-
-        let result = mock_runner.disable_hw_access("test_device", "12345678");
-        assert!(matches!(result, Err(MlxError::AlreadyLocked)));
-    }
-
-    #[test]
-    fn test_already_unlocked_behavior() {
-        // Test that when flint returns "already enabled", we get an AlreadyUnlocked error
-        let mock_runner = MockRunner::new().with_already_unlocked();
-
-        let result = mock_runner.enable_hw_access("test_device", "12345678");
-        assert!(matches!(result, Err(MlxError::AlreadyUnlocked)));
-    }
-
-    #[test]
-    fn test_successful_operations() {
-        // Test that normal operations succeed
-        let mock_runner = MockRunner::new();
-
-        let lock_result = mock_runner.disable_hw_access("test_device", "12345678");
-        assert!(lock_result.is_ok());
-
-        let unlock_result = mock_runner.enable_hw_access("test_device", "12345678");
-        assert!(unlock_result.is_ok());
+    fn mock_runner_reports_already_state_else_succeeds() {
+        check_values(
+            [
+                Check {
+                    scenario: "disable on a primed-locked device is AlreadyLocked",
+                    input: error_kind(
+                        MockRunner::new()
+                            .with_already_locked()
+                            .disable_hw_access("test_device", "12345678"),
+                    ),
+                    expect: "AlreadyLocked",
+                },
+                Check {
+                    scenario: "enable on a primed-unlocked device is AlreadyUnlocked",
+                    input: error_kind(
+                        MockRunner::new()
+                            .with_already_unlocked()
+                            .enable_hw_access("test_device", "12345678"),
+                    ),
+                    expect: "AlreadyUnlocked",
+                },
+                Check {
+                    scenario: "disable on a fresh device succeeds",
+                    input: error_kind(
+                        MockRunner::new().disable_hw_access("test_device", "12345678"),
+                    ),
+                    expect: "ok",
+                },
+                Check {
+                    scenario: "enable on a fresh device succeeds",
+                    input: error_kind(
+                        MockRunner::new().enable_hw_access("test_device", "12345678"),
+                    ),
+                    expect: "ok",
+                },
+            ],
+            |kind| kind,
+        );
     }
 }

--- a/crates/libmlx/tests/lockdown/test_runner.rs
+++ b/crates/libmlx/tests/lockdown/test_runner.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, Check, check_cases, check_values};
 use libmlx::lockdown::error::MlxError;
 use libmlx::lockdown::runner::FlintRunner;
 
@@ -24,78 +26,131 @@ fn test_runner_creation_with_path() {
     // Just ensure it can be created without errors
 }
 
+// validate_device_id accepts PCI addresses, device paths, and names, and rejects
+// the empty string and anything with spaces. MlxError isn't PartialEq, so each row
+// pins the rejection by its variant name rather than the whole error.
 #[test]
 fn test_device_id_validation() {
-    // Valid device IDs
-    assert!(FlintRunner::validate_device_id("04:00.0").is_ok());
-    assert!(FlintRunner::validate_device_id("/dev/mst/mt4099_pci_cr0").is_ok());
-    assert!(FlintRunner::validate_device_id("mlx5_0").is_ok());
+    fn validated(device_id: &str) -> Result<(), &'static str> {
+        FlintRunner::validate_device_id(device_id).map_err(|e| match e {
+            MlxError::InvalidDeviceId(_) => "InvalidDeviceId",
+            _ => "other",
+        })
+    }
 
-    // Invalid device IDs
-    assert!(matches!(
-        FlintRunner::validate_device_id(""),
-        Err(MlxError::InvalidDeviceId(_))
-    ));
-
-    assert!(matches!(
-        FlintRunner::validate_device_id("device with spaces"),
-        Err(MlxError::InvalidDeviceId(_))
-    ));
+    check_cases(
+        [
+            Case {
+                scenario: "PCI address",
+                input: "04:00.0",
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "device path",
+                input: "/dev/mst/mt4099_pci_cr0",
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "device name",
+                input: "mlx5_0",
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "empty string is rejected",
+                input: "",
+                expect: FailsWith("InvalidDeviceId"),
+            },
+            Case {
+                scenario: "spaces are rejected",
+                input: "device with spaces",
+                expect: FailsWith("InvalidDeviceId"),
+            },
+        ],
+        validated,
+    );
 }
 
+// With dry-run enabled, every mutating/querying call returns DryRun(cmd) instead of
+// shelling out; this checks the command string each one would have run. The exact
+// string is the contract, so each row pins it; `dry_run_cmd` pulls the string out
+// of the DryRun error (and panics loudly if a call unexpectedly didn't dry-run).
 #[test]
-fn test_dry_run_functionality() {
-    let runner = FlintRunner::with_path("/fake/flint").with_dry_run(true);
+fn test_dry_run_command_strings() {
+    let runner = FlintRunner::with_path("/test/flint").with_dry_run(true);
 
-    // Test dry run for query
-    let result = runner.query_device("fake_device");
-    assert!(matches!(result, Err(MlxError::DryRun(_))));
-    if let Err(MlxError::DryRun(cmd)) = result {
-        assert!(cmd.contains("fake_device"));
-        assert!(cmd.contains("/fake/flint"));
+    fn dry_run_cmd<T: std::fmt::Debug>(result: Result<T, MlxError>) -> String {
+        match result {
+            Err(MlxError::DryRun(cmd)) => cmd,
+            other => panic!("expected DryRun, got {other:?}"),
+        }
     }
 
-    // Test dry run for disable
-    let result = runner.disable_hw_access("fake_device", "12345678");
-    assert!(matches!(result, Err(MlxError::DryRun(_))));
-    if let Err(MlxError::DryRun(cmd)) = result {
-        assert!(cmd.contains("hw_access disable"));
-        assert!(cmd.contains("12345678"));
-    }
-
-    // Test dry run for enable
-    let result = runner.enable_hw_access("fake_device", "12345678");
-    assert!(matches!(result, Err(MlxError::DryRun(_))));
-    if let Err(MlxError::DryRun(cmd)) = result {
-        assert!(cmd.contains("hw_access enable"));
-        assert!(cmd.contains("12345678"));
-    }
-
-    // Test dry run for set_key
-    let result = runner.set_key("fake_device", "12345678");
-    assert!(matches!(result, Err(MlxError::DryRun(_))));
-    if let Err(MlxError::DryRun(cmd)) = result {
-        assert!(cmd.contains("set_key"));
-    }
+    check_values(
+        [
+            Check {
+                scenario: "query",
+                input: dry_run_cmd(runner.query_device("test_device")),
+                expect: "/test/flint -d test_device q".to_string(),
+            },
+            Check {
+                scenario: "disable hw_access",
+                input: dry_run_cmd(runner.disable_hw_access("test_device", "abcdef01")),
+                expect: "/test/flint -d test_device hw_access disable abcdef01".to_string(),
+            },
+            Check {
+                scenario: "enable hw_access",
+                input: dry_run_cmd(runner.enable_hw_access("test_device", "abcdef01")),
+                expect: "/test/flint -d test_device hw_access enable abcdef01".to_string(),
+            },
+            Check {
+                scenario: "set_key",
+                input: dry_run_cmd(runner.set_key("test_device", "12345678")),
+                expect: "/test/flint -d test_device set_key 12345678".to_string(),
+            },
+        ],
+        |cmd| cmd,
+    );
 }
 
+// Keys must be exactly 8 hex digits; set_key and enable_hw_access both reject a
+// malformed key with InvalidKey before any command is built. MlxError isn't
+// PartialEq, so each row pins the rejection by variant name.
 #[test]
 fn test_key_validation() {
     let runner = FlintRunner::with_path("/fake/flint");
 
-    // Test with invalid keys that should fail validation
-    let result = runner.set_key("fake_device", "invalid_key");
-    assert!(matches!(result, Err(MlxError::InvalidKey)));
+    fn key_error(result: Result<(), MlxError>) -> Result<(), &'static str> {
+        result.map_err(|e| match e {
+            MlxError::InvalidKey => "InvalidKey",
+            _ => "other",
+        })
+    }
 
-    let result = runner.set_key("fake_device", "123");
-    assert!(matches!(result, Err(MlxError::InvalidKey)));
-
-    let result = runner.set_key("fake_device", "1234567g");
-    assert!(matches!(result, Err(MlxError::InvalidKey)));
-
-    // Test enable_hw_access with invalid key
-    let result = runner.enable_hw_access("fake_device", "toolong123");
-    assert!(matches!(result, Err(MlxError::InvalidKey)));
+    check_cases(
+        [
+            Case {
+                scenario: "set_key with non-hex key",
+                input: key_error(runner.set_key("fake_device", "invalid_key")),
+                expect: FailsWith("InvalidKey"),
+            },
+            Case {
+                scenario: "set_key with too-short key",
+                input: key_error(runner.set_key("fake_device", "123")),
+                expect: FailsWith("InvalidKey"),
+            },
+            Case {
+                scenario: "set_key with a non-hex digit",
+                input: key_error(runner.set_key("fake_device", "1234567g")),
+                expect: FailsWith("InvalidKey"),
+            },
+            Case {
+                scenario: "enable_hw_access with too-long key",
+                input: key_error(runner.enable_hw_access("fake_device", "toolong123")),
+                expect: FailsWith("InvalidKey"),
+            },
+        ],
+        |result| result,
+    );
 }
 
 #[test]
@@ -104,85 +159,75 @@ fn test_runner_default() {
     // Should not panic even if flint is not found
 }
 
-#[test]
-fn test_command_building() {
-    let runner = FlintRunner::with_path("/test/flint").with_dry_run(true);
-
-    // Test that dry run produces expected command strings
-    if let Err(MlxError::DryRun(cmd)) = runner.query_device("test_device") {
-        assert_eq!(cmd, "/test/flint -d test_device q");
-    }
-
-    if let Err(MlxError::DryRun(cmd)) = runner.disable_hw_access("test_device", "abcdef01") {
-        assert_eq!(cmd, "/test/flint -d test_device hw_access disable abcdef01");
-    }
-
-    if let Err(MlxError::DryRun(cmd)) = runner.enable_hw_access("test_device", "abcdef01") {
-        assert_eq!(cmd, "/test/flint -d test_device hw_access enable abcdef01");
-    }
-
-    if let Err(MlxError::DryRun(cmd)) = runner.set_key("test_device", "12345678") {
-        assert_eq!(cmd, "/test/flint -d test_device set_key 12345678");
-    }
-}
-
 // These tests verify the output parsing logic without requiring actual flint execution
 #[cfg(test)]
 mod output_parsing_tests {
+    use carbide_test_support::{Check, check_values};
 
+    // FlintRunner's output parsing keys off substrings; this walks the marker
+    // strings flint emits (bare, with the -I-/Error prefixes, and embedded in
+    // surrounding lines) and confirms each substring is detected. Folds the three
+    // per-marker loops into one table over `(haystack, needle)`.
     #[test]
-    fn test_already_disabled_parsing() {
-        // Test that our code would correctly identify "already disabled" messages
-        let already_disabled_outputs = vec![
-            "HW access already disabled",
-            "-I- HW access already disabled",
-            "some other text\nHW access already disabled\nmore text",
-        ];
-
-        for output in already_disabled_outputs {
-            // This simulates what our parsing logic does in FlintRunner
-            let contains_already_disabled = output.contains("already disabled");
-            assert!(
-                contains_already_disabled,
-                "Should detect 'already disabled' in: {output}"
-            );
-        }
-    }
-
-    #[test]
-    fn test_already_enabled_parsing() {
-        // Test that our code would correctly identify "already enabled" messages
-        let already_enabled_outputs = vec![
-            "HW access already enabled",
-            "-I- HW access already enabled",
-            "some other text\nHW access already enabled\nmore text",
-        ];
-
-        for output in already_enabled_outputs {
-            // This simulates what our parsing logic does in FlintRunner
-            let contains_already_enabled = output.contains("already enabled");
-            assert!(
-                contains_already_enabled,
-                "Should detect 'already enabled' in: {output}"
-            );
-        }
-    }
-
-    #[test]
-    fn test_hw_access_disabled_parsing() {
-        // Test parsing of "HW access is disabled" messages
-        let hw_disabled_outputs = vec![
-            "HW access is disabled",
-            "Error: HW access is disabled",
-            "some text\nHW access is disabled\nmore text",
-        ];
-
-        for output in hw_disabled_outputs {
-            let contains_hw_disabled = output.contains("HW access is disabled");
-            assert!(
-                contains_hw_disabled,
-                "Should detect 'HW access is disabled' in: {output}"
-            );
-        }
+    fn detects_status_substrings_in_output() {
+        check_values(
+            [
+                Check {
+                    scenario: "already disabled, bare",
+                    input: ("HW access already disabled", "already disabled"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "already disabled, -I- prefix",
+                    input: ("-I- HW access already disabled", "already disabled"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "already disabled, embedded in surrounding lines",
+                    input: (
+                        "some other text\nHW access already disabled\nmore text",
+                        "already disabled",
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "already enabled, bare",
+                    input: ("HW access already enabled", "already enabled"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "already enabled, -I- prefix",
+                    input: ("-I- HW access already enabled", "already enabled"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "already enabled, embedded in surrounding lines",
+                    input: (
+                        "some other text\nHW access already enabled\nmore text",
+                        "already enabled",
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "HW access is disabled, bare",
+                    input: ("HW access is disabled", "HW access is disabled"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "HW access is disabled, Error prefix",
+                    input: ("Error: HW access is disabled", "HW access is disabled"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "HW access is disabled, embedded in surrounding lines",
+                    input: (
+                        "some text\nHW access is disabled\nmore text",
+                        "HW access is disabled",
+                    ),
+                    expect: true,
+                },
+            ],
+            |(output, needle)| output.contains(needle),
+        );
     }
 }

--- a/crates/libmlx/tests/profile/test_serialization.rs
+++ b/crates/libmlx/tests/profile/test_serialization.rs
@@ -17,6 +17,7 @@
 
 use std::collections::HashMap;
 
+use carbide_test_support::{Check, check_values};
 use libmlx::profile::error::MlxProfileError;
 use libmlx::profile::profile::MlxConfigProfile;
 use libmlx::profile::serialization::{
@@ -25,6 +26,59 @@ use libmlx::profile::serialization::{
 use libmlx::registry::registries;
 use rpc::protos::mlx_device::SerializableMlxConfigProfile as SerializableMlxConfigProfilePb;
 use serde::{Deserialize, Serialize};
+
+// assert_same_profile checks the four identity fields (name, registry, description,
+// and the config size) line up between two profiles. Every roundtrip test below --
+// YAML/JSON/TOML, file or string, protobuf -- ends with this same comparison, so it
+// lives here once.
+fn assert_same_profile(got: &SerializableProfile, want: &SerializableProfile) {
+    assert_eq!(got.name, want.name);
+    assert_eq!(got.registry_name, want.registry_name);
+    assert_eq!(got.description, want.description);
+    assert_eq!(got.config.len(), want.config.len());
+}
+
+// to_proto mirrors the TryInto conversion: each YAML config value is serialized to a
+// trimmed string. The real conversion lives in the crate; the tests re-create it so
+// they can assert the wire shape independently.
+fn to_proto(profile: &SerializableProfile) -> SerializableMlxConfigProfilePb {
+    let config = profile
+        .config
+        .iter()
+        .map(|(key, yaml_value)| {
+            let value_str = serde_yaml::to_string(yaml_value).expect("Should serialize YAML value");
+            (key.clone(), value_str.trim().to_string())
+        })
+        .collect();
+
+    SerializableMlxConfigProfilePb {
+        name: profile.name.clone(),
+        registry_name: profile.registry_name.clone(),
+        description: profile.description.clone(),
+        config,
+    }
+}
+
+// from_proto mirrors the TryFrom conversion: each stringified config value is parsed
+// back into a YAML value.
+fn from_proto(proto: SerializableMlxConfigProfilePb) -> SerializableProfile {
+    let config = proto
+        .config
+        .into_iter()
+        .map(|(key, value_str)| {
+            let yaml_value: serde_yaml::Value =
+                serde_yaml::from_str(&value_str).expect("Should parse YAML value");
+            (key, yaml_value)
+        })
+        .collect();
+
+    SerializableProfile {
+        name: proto.name,
+        registry_name: proto.registry_name,
+        description: proto.description,
+        config,
+    }
+}
 
 #[test]
 fn test_serializable_profile_creation() {
@@ -62,14 +116,9 @@ fn test_yaml_serialization_roundtrip() {
     assert!(yaml.contains("INT_VAR: 123"));
     assert!(yaml.contains("STRING_VAR: hello"));
 
-    // Deserialize back from YAML
+    // Deserialize back from YAML and verify round-trip integrity
     let deserialized = SerializableProfile::from_yaml(&yaml).expect("Should deserialize from YAML");
-
-    // Verify round-trip integrity
-    assert_eq!(deserialized.name, original.name);
-    assert_eq!(deserialized.registry_name, original.registry_name);
-    assert_eq!(deserialized.description, original.description);
-    assert_eq!(deserialized.config.len(), original.config.len());
+    assert_same_profile(&deserialized, &original);
 }
 
 #[test]
@@ -87,13 +136,9 @@ fn test_json_serialization_roundtrip() {
     assert!(json.contains(r#""BOOL_VAR": false"#));
     assert!(json.contains(r#""INT_VAR": 456"#));
 
-    // Deserialize back from JSON
+    // Deserialize back from JSON and verify round-trip integrity
     let deserialized = SerializableProfile::from_json(&json).expect("Should deserialize from JSON");
-
-    // Verify round-trip integrity
-    assert_eq!(deserialized.name, original.name);
-    assert_eq!(deserialized.registry_name, original.registry_name);
-    assert_eq!(deserialized.config.len(), original.config.len());
+    assert_same_profile(&deserialized, &original);
 }
 
 #[test]
@@ -159,11 +204,7 @@ this is not valid yaml: [
 "#;
 
     let result = SerializableProfile::from_yaml(invalid_yaml);
-    assert!(result.is_err());
-    assert!(matches!(
-        result.unwrap_err(),
-        MlxProfileError::YamlParsing { .. }
-    ));
+    assert!(matches!(result, Err(MlxProfileError::YamlParsing { .. })));
 }
 
 #[test]
@@ -171,11 +212,7 @@ fn test_invalid_json() {
     let invalid_json = r#"{"name": "broken", "missing_comma" "value"}"#;
 
     let result = SerializableProfile::from_json(invalid_json);
-    assert!(result.is_err());
-    assert!(matches!(
-        result.unwrap_err(),
-        MlxProfileError::JsonParsing { .. }
-    ));
+    assert!(matches!(result, Err(MlxProfileError::JsonParsing { .. })));
 }
 
 #[test]
@@ -194,20 +231,7 @@ fn test_try_from_protobuf_basic() {
         config: proto_config,
     };
 
-    // Simulate the TryFrom conversion logic
-    let mut config = HashMap::new();
-    for (key, value_str) in proto.config {
-        let yaml_value: serde_yaml::Value =
-            serde_yaml::from_str(&value_str).expect("Should parse YAML value");
-        config.insert(key, yaml_value);
-    }
-
-    let profile = SerializableProfile {
-        name: proto.name,
-        registry_name: proto.registry_name,
-        description: proto.description, // Both are Option<String> now
-        config,
-    };
+    let profile = from_proto(proto);
 
     assert_eq!(profile.name, "proto_test");
     assert_eq!(profile.registry_name, "test_registry");
@@ -217,19 +241,35 @@ fn test_try_from_protobuf_basic() {
     );
     assert_eq!(profile.config.len(), 3);
 
-    // Verify the config values were parsed correctly
-    assert!(matches!(
-        profile.config.get("BOOL_VAR"),
-        Some(serde_yaml::Value::Bool(true))
-    ));
-    assert!(matches!(
-        profile.config.get("INT_VAR"),
-        Some(serde_yaml::Value::Number(_))
-    ));
-    assert!(matches!(
-        profile.config.get("STRING_VAR"),
-        Some(serde_yaml::Value::String(_))
-    ));
+    // Each config string parses into the YAML value variant its content implies.
+    fn variant(value: Option<&serde_yaml::Value>) -> &'static str {
+        match value {
+            Some(serde_yaml::Value::Bool(_)) => "bool",
+            Some(serde_yaml::Value::Number(_)) => "number",
+            Some(serde_yaml::Value::String(_)) => "string",
+            _ => "other",
+        }
+    }
+    check_values(
+        [
+            Check {
+                scenario: "BOOL_VAR parses to a bool",
+                input: "BOOL_VAR",
+                expect: "bool",
+            },
+            Check {
+                scenario: "INT_VAR parses to a number",
+                input: "INT_VAR",
+                expect: "number",
+            },
+            Check {
+                scenario: "STRING_VAR parses to a string",
+                input: "STRING_VAR",
+                expect: "string",
+            },
+        ],
+        |key| variant(profile.config.get(key)),
+    );
 }
 
 #[test]
@@ -240,19 +280,7 @@ fn test_try_into_protobuf_basic() {
         .with_config("INT_VAR", 789)
         .with_config("STRING_VAR", "proto_value");
 
-    // Simulate the TryInto conversion logic
-    let mut config = HashMap::new();
-    for (key, yaml_value) in &original.config {
-        let value_str = serde_yaml::to_string(yaml_value).expect("Should serialize YAML value");
-        config.insert(key.clone(), value_str.trim().to_string());
-    }
-
-    let proto = SerializableMlxConfigProfilePb {
-        name: original.name.clone(),
-        registry_name: original.registry_name.clone(),
-        description: original.description.clone(),
-        config,
-    };
+    let proto = to_proto(&original);
 
     assert_eq!(proto.name, "proto_test");
     assert_eq!(proto.registry_name, "test_registry");
@@ -279,40 +307,9 @@ fn test_protobuf_roundtrip() {
         .with_config("INT_VAR", 42)
         .with_config("STRING_VAR", "test_value");
 
-    // Convert to protobuf (TryInto simulation)
-    let mut proto_config = HashMap::new();
-    for (key, yaml_value) in &original.config {
-        let value_str = serde_yaml::to_string(yaml_value).expect("Should serialize");
-        proto_config.insert(key.clone(), value_str.trim().to_string());
-    }
-
-    let proto = SerializableMlxConfigProfilePb {
-        name: original.name.clone(),
-        registry_name: original.registry_name.clone(),
-        description: original.description.clone(),
-        config: proto_config,
-    };
-
-    // Convert back from protobuf (TryFrom simulation)
-    let mut config = HashMap::new();
-    for (key, value_str) in proto.config {
-        let yaml_value: serde_yaml::Value =
-            serde_yaml::from_str(&value_str).expect("Should deserialize");
-        config.insert(key, yaml_value);
-    }
-
-    let roundtrip = SerializableProfile {
-        name: proto.name,
-        registry_name: proto.registry_name,
-        description: proto.description, // Both are Option<String>
-        config,
-    };
-
-    // Verify roundtrip integrity
-    assert_eq!(roundtrip.name, original.name);
-    assert_eq!(roundtrip.registry_name, original.registry_name);
-    assert_eq!(roundtrip.description, original.description);
-    assert_eq!(roundtrip.config.len(), original.config.len());
+    // Convert to protobuf and back, then verify roundtrip integrity.
+    let roundtrip = from_proto(to_proto(&original));
+    assert_same_profile(&roundtrip, &original);
 }
 
 #[test]
@@ -398,29 +395,18 @@ fn test_protobuf_with_sparse_arrays() {
 
 #[test]
 fn test_protobuf_empty_description() {
-    let original =
-        SerializableProfile::new("no_desc_test", "test_registry").with_config("VAR", "value");
-    // Note: no description set, so it should be None
-
-    // Convert to protobuf format
     let proto = SerializableMlxConfigProfilePb {
-        name: original.name.clone(),
-        registry_name: original.registry_name.clone(),
+        name: "no_desc_test".to_string(),
+        registry_name: "test_registry".to_string(),
         description: None,      // No description set, so it should be None
         config: HashMap::new(), // Simplified for this test
     };
 
     assert_eq!(proto.description, None); // None in protobuf
 
-    // Convert back from protobuf
-    let converted_back = SerializableProfile {
-        name: proto.name,
-        registry_name: proto.registry_name,
-        description: proto.description, // Both are Option<String>
-        config: HashMap::new(),
-    };
-
-    assert_eq!(converted_back.description, None); // Should still be None
+    // Convert back from protobuf -- None should survive the round trip.
+    let converted_back = from_proto(proto);
+    assert_eq!(converted_back.description, None);
 }
 
 #[test]
@@ -437,12 +423,11 @@ fn test_edge_cases() {
     let yaml = no_desc.to_yaml().expect("Should serialize");
     assert!(!yaml.contains("description:"));
 
-    // Test profile with empty description (should be treated as None)
+    // An explicitly-empty description is retained as Some("") on the profile.
     let empty_desc = SerializableProfile::new("empty_desc", "registry")
         .with_description("")
         .with_config("VAR", "value");
-    // Empty descriptions should be skipped in serialization
-    assert!(empty_desc.description == Some("".to_string()));
+    assert_eq!(empty_desc.description, Some("".to_string()));
 }
 
 #[test]
@@ -467,14 +452,9 @@ fn test_toml_serialization_roundtrip() {
     assert!(toml.contains("INT_VAR = 123"));
     assert!(toml.contains(r#"STRING_VAR = "hello""#));
 
-    // Deserialize back from TOML
+    // Deserialize back from TOML and verify round-trip integrity
     let deserialized = SerializableProfile::from_toml(&toml).expect("Should deserialize from TOML");
-
-    // Verify round-trip integrity
-    assert_eq!(deserialized.name, original.name);
-    assert_eq!(deserialized.registry_name, original.registry_name);
-    assert_eq!(deserialized.description, original.description);
-    assert_eq!(deserialized.config.len(), original.config.len());
+    assert_same_profile(&deserialized, &original);
 }
 
 #[test]
@@ -784,14 +764,9 @@ this is not valid toml syntax [
 missing quotes and brackets
 "#;
 
-    let result = SerializableProfile::from_toml(invalid_toml);
-    assert!(result.is_err());
     // TOML errors get wrapped in MlxProfileError::Serialization
-    if let Err(MlxProfileError::Serialization { .. }) = result {
-        // This is what we expect
-    } else {
-        panic!("Expected MlxProfileError::Serialization for invalid TOML");
-    }
+    let result = SerializableProfile::from_toml(invalid_toml);
+    assert!(matches!(result, Err(MlxProfileError::Serialization { .. })));
 }
 
 #[test]
@@ -813,10 +788,7 @@ fn test_toml_file_operations() {
 
     let loaded_toml =
         SerializableProfile::from_toml_file(&toml_path).expect("Should read TOML file");
-    assert_eq!(loaded_toml.name, profile.name);
-    assert_eq!(loaded_toml.registry_name, profile.registry_name);
-    assert_eq!(loaded_toml.description, profile.description);
-    assert_eq!(loaded_toml.config.len(), profile.config.len());
+    assert_same_profile(&loaded_toml, &profile);
 }
 
 #[test]
@@ -837,17 +809,10 @@ fn test_toml_vs_yaml_compatibility() {
     let from_yaml =
         SerializableProfile::from_yaml(&yaml_str).expect("Should deserialize from YAML");
 
-    // Both should be equivalent to original
-    assert_eq!(from_toml.name, original.name);
-    assert_eq!(from_yaml.name, original.name);
-    assert_eq!(from_toml.config.len(), original.config.len());
-    assert_eq!(from_yaml.config.len(), original.config.len());
-
-    // And equivalent to each other
-    assert_eq!(from_toml.name, from_yaml.name);
-    assert_eq!(from_toml.registry_name, from_yaml.registry_name);
-    assert_eq!(from_toml.description, from_yaml.description);
-    assert_eq!(from_toml.config.len(), from_yaml.config.len());
+    // Both should be equivalent to original, and so to each other.
+    assert_same_profile(&from_toml, &original);
+    assert_same_profile(&from_yaml, &original);
+    assert_same_profile(&from_toml, &from_yaml);
 }
 
 #[test]
@@ -874,15 +839,10 @@ fn test_yaml_file_operations() {
     assert!(file_content.contains("name: yaml_file_test"));
     assert!(file_content.contains("BOOL_VAR: true"));
 
-    // Load back from file
+    // Load back from file and verify round-trip integrity
     let loaded_profile =
         SerializableProfile::from_yaml_file(&yaml_path).expect("Should read YAML file");
-
-    // Verify round-trip integrity
-    assert_eq!(loaded_profile.name, profile.name);
-    assert_eq!(loaded_profile.registry_name, profile.registry_name);
-    assert_eq!(loaded_profile.description, profile.description);
-    assert_eq!(loaded_profile.config.len(), profile.config.len());
+    assert_same_profile(&loaded_profile, &profile);
 
     // Verify specific config values
     assert!(loaded_profile.config.contains_key("BOOL_VAR"));
@@ -914,15 +874,10 @@ fn test_json_file_operations() {
     assert!(file_content.contains(r#""name": "json_file_test""#));
     assert!(file_content.contains(r#""BOOL_VAR": false"#));
 
-    // Load back from file
+    // Load back from file and verify round-trip integrity
     let loaded_profile =
         SerializableProfile::from_json_file(&json_path).expect("Should read JSON file");
-
-    // Verify round-trip integrity
-    assert_eq!(loaded_profile.name, profile.name);
-    assert_eq!(loaded_profile.registry_name, profile.registry_name);
-    assert_eq!(loaded_profile.description, profile.description);
-    assert_eq!(loaded_profile.config.len(), profile.config.len());
+    assert_same_profile(&loaded_profile, &profile);
 
     // Verify specific config values
     assert!(loaded_profile.config.contains_key("BOOL_VAR"));
@@ -972,19 +927,13 @@ fn test_all_file_formats_compatibility() {
     // All should be equivalent to original
     let profiles = [&from_yaml, &from_json, &from_toml];
     for profile in &profiles {
-        assert_eq!(profile.name, original.name);
-        assert_eq!(profile.registry_name, original.registry_name);
-        assert_eq!(profile.description, original.description);
-        assert_eq!(profile.config.len(), original.config.len());
+        assert_same_profile(profile, &original);
     }
 
     // All should be equivalent to each other
     for (i, profile1) in profiles.iter().enumerate() {
         for profile2 in profiles.iter().skip(i + 1) {
-            assert_eq!(profile1.name, profile2.name);
-            assert_eq!(profile1.registry_name, profile2.registry_name);
-            assert_eq!(profile1.description, profile2.description);
-            assert_eq!(profile1.config.len(), profile2.config.len());
+            assert_same_profile(profile1, profile2);
         }
     }
 }
@@ -1075,10 +1024,7 @@ fn test_file_error_handling() {
     assert!(SerializableProfile::from_json_file(&missing_json).is_err());
     assert!(SerializableProfile::from_toml_file(&missing_toml).is_err());
 
-    // Test writing to invalid paths (read-only directory)
-    // Note: This test might be platform-specific, so we'll create a simple version
-
-    // Create files with invalid content and test parsing
+    // Create files with invalid content and confirm parsing fails.
     let invalid_yaml = temp_dir.path().join("invalid.yaml");
     let invalid_json = temp_dir.path().join("invalid.json");
     let invalid_toml = temp_dir.path().join("invalid.toml");
@@ -1089,7 +1035,6 @@ fn test_file_error_handling() {
         .expect("Should write invalid JSON");
     std::fs::write(&invalid_toml, "invalid = toml content [[[").expect("Should write invalid TOML");
 
-    // These should all fail to parse
     assert!(SerializableProfile::from_yaml_file(&invalid_yaml).is_err());
     assert!(SerializableProfile::from_json_file(&invalid_json).is_err());
     assert!(SerializableProfile::from_toml_file(&invalid_toml).is_err());

--- a/crates/libmlx/tests/runner/command_builder_tests.rs
+++ b/crates/libmlx/tests/runner/command_builder_tests.rs
@@ -20,18 +20,23 @@
 
 use std::path::Path;
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, Check, check_cases, check_values};
 use libmlx::runner::command_builder::{CommandBuilder, CommandSpec};
 use libmlx::runner::exec_options::ExecOptions;
 
 use super::common;
 
+// A CommandBuilder over `device` with the given options -- the struct-literal dance
+// every test below would otherwise repeat.
+fn builder<'a>(options: &'a ExecOptions, device: &'a str) -> CommandBuilder<'a> {
+    CommandBuilder { device, options }
+}
+
 #[test]
 fn test_build_query_command_spec_basic() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
+    let builder = builder(&options, "01:00.0");
 
     let temp_file = Path::new("/tmp/test.json");
     let variables = vec!["SRIOV_EN".to_string(), "NUM_OF_VFS".to_string()];
@@ -57,10 +62,7 @@ fn test_build_query_command_spec_basic() {
 #[test]
 fn test_build_query_command_spec_empty_variables() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "02:00.0",
-        options: &options,
-    };
+    let builder = builder(&options, "02:00.0");
 
     let temp_file = Path::new("/tmp/test_empty.json");
     let variables: Vec<String> = vec![];
@@ -79,10 +81,7 @@ fn test_build_query_command_spec_empty_variables() {
 #[test]
 fn test_build_query_command_spec_many_variables() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
+    let builder = builder(&options, "01:00.0");
 
     let temp_file = Path::new("/tmp/test_many.json");
     let variables = vec![
@@ -103,10 +102,7 @@ fn test_build_query_command_spec_many_variables() {
 #[test]
 fn test_build_set_command_spec_basic() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
+    let builder = builder(&options, "01:00.0");
 
     let assignments = vec!["SRIOV_EN=true".to_string(), "NUM_OF_VFS=16".to_string()];
 
@@ -124,10 +120,7 @@ fn test_build_set_command_spec_basic() {
 #[test]
 fn test_build_set_command_spec_empty_assignments() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
+    let builder = builder(&options, "01:00.0");
 
     let assignments: Vec<String> = vec![];
 
@@ -140,23 +133,29 @@ fn test_build_set_command_spec_empty_assignments() {
     assert!(command_spec.args.contains(&"set".to_string()));
 }
 
+// CommandSpec's Display joins the program and its args with spaces; an arg-less
+// spec is just the program.
 #[test]
-fn test_command_spec_display_trait() {
-    let spec = CommandSpec::new("mlxconfig")
-        .arg("-d")
-        .arg("01:00.0")
-        .arg("q")
-        .arg("SRIOV_EN");
-
-    let display_str = format!("{spec}");
-    assert_eq!(display_str, "mlxconfig -d 01:00.0 q SRIOV_EN");
-}
-
-#[test]
-fn test_command_spec_display_trait_no_args() {
-    let spec = CommandSpec::new("mlxconfig");
-    let display_str = format!("{spec}");
-    assert_eq!(display_str, "mlxconfig");
+fn command_spec_displays_program_then_args() {
+    check_values(
+        [
+            Check {
+                scenario: "program with args",
+                input: CommandSpec::new("mlxconfig")
+                    .arg("-d")
+                    .arg("01:00.0")
+                    .arg("q")
+                    .arg("SRIOV_EN"),
+                expect: "mlxconfig -d 01:00.0 q SRIOV_EN".to_string(),
+            },
+            Check {
+                scenario: "program with no args",
+                input: CommandSpec::new("mlxconfig"),
+                expect: "mlxconfig".to_string(),
+            },
+        ],
+        |spec| format!("{spec}"),
+    );
 }
 
 #[test]
@@ -176,233 +175,141 @@ fn test_command_spec_builder_pattern() {
     assert_eq!(spec.args[7], "VAR2");
 }
 
+// build_set_assignments turns each MlxConfigValue into one or more `VAR=value`
+// (or `VAR[index]=value`) strings, in input order, skipping the None slots of a
+// sparse array. The assignments come back in a deterministic order, so each row
+// pins the exact Vec<String>. Scalars, every array variant (dense and sparse),
+// binary hex encoding, multiple variables, and the empty case all fold here; the
+// per-row config values are pre-built from the shared test registry.
 #[test]
-fn test_build_set_assignments_boolean() {
+fn build_set_assignments_formats_each_value() {
     let registry = common::create_test_registry();
-    let sriov_var = registry.get_variable("SRIOV_EN").unwrap();
-    let config_value = sriov_var.with(true).unwrap();
+    // Pull a registry variable by name; each row then `.with(...)`s a concrete value.
+    let var = |name: &str| registry.get_variable(name).unwrap();
 
     let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
+    let builder = builder(&options, "01:00.0");
 
-    let assignments = builder.build_set_assignments(&[config_value]).unwrap();
-
-    assert_eq!(assignments.len(), 1);
-    assert_eq!(assignments[0], "SRIOV_EN=true");
-}
-
-#[test]
-fn test_build_set_assignments_integer() {
-    let registry = common::create_test_registry();
-    let vfs_var = registry.get_variable("NUM_OF_VFS").unwrap();
-    let config_value = vfs_var.with(32i64).unwrap();
-
-    let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
-
-    let assignments = builder.build_set_assignments(&[config_value]).unwrap();
-
-    assert_eq!(assignments.len(), 1);
-    assert_eq!(assignments[0], "NUM_OF_VFS=32");
-}
-
-#[test]
-fn test_build_set_assignments_enum() {
-    let registry = common::create_test_registry();
-    let power_var = registry.get_variable("POWER_MODE").unwrap();
-    let config_value = power_var.with("HIGH").unwrap();
-
-    let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
-
-    let assignments = builder.build_set_assignments(&[config_value]).unwrap();
-
-    assert_eq!(assignments.len(), 1);
-    assert_eq!(assignments[0], "POWER_MODE=HIGH");
-}
-
-#[test]
-fn test_build_set_assignments_preset() {
-    let registry = common::create_test_registry();
-    let preset_var = registry.get_variable("PERFORMANCE_PRESET").unwrap();
-    let config_value = preset_var.with(7u8).unwrap();
-
-    let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
-
-    let assignments = builder.build_set_assignments(&[config_value]).unwrap();
-
-    assert_eq!(assignments.len(), 1);
-    assert_eq!(assignments[0], "PERFORMANCE_PRESET=7");
-}
-
-#[test]
-fn test_build_set_assignments_boolean_array_dense() {
-    let registry = common::create_test_registry();
-    let gpio_var = registry.get_variable("GPIO_ENABLED").unwrap();
-    let config_value = gpio_var.with(vec![true, false, true, false]).unwrap();
-
-    let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
-
-    let assignments = builder.build_set_assignments(&[config_value]).unwrap();
-
-    assert_eq!(assignments.len(), 4);
-    assert!(assignments.contains(&"GPIO_ENABLED[0]=true".to_string()));
-    assert!(assignments.contains(&"GPIO_ENABLED[1]=false".to_string()));
-    assert!(assignments.contains(&"GPIO_ENABLED[2]=true".to_string()));
-    assert!(assignments.contains(&"GPIO_ENABLED[3]=false".to_string()));
-}
-
-#[test]
-fn test_build_set_assignments_boolean_array_sparse() {
-    let registry = common::create_test_registry();
-    let gpio_var = registry.get_variable("GPIO_ENABLED").unwrap();
-    let sparse_values = vec![Some(true), None, Some(false), None];
-    let config_value = gpio_var.with(sparse_values).unwrap();
-
-    let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
-
-    let assignments = builder.build_set_assignments(&[config_value]).unwrap();
-
-    // Should only have assignments for non-None values
-    assert_eq!(assignments.len(), 2);
-    assert!(assignments.contains(&"GPIO_ENABLED[0]=true".to_string()));
-    assert!(assignments.contains(&"GPIO_ENABLED[2]=false".to_string()));
-    assert!(!assignments.iter().any(|a| a.contains("GPIO_ENABLED[1]")));
-    assert!(!assignments.iter().any(|a| a.contains("GPIO_ENABLED[3]")));
-}
-
-#[test]
-fn test_build_set_assignments_integer_array_sparse() {
-    let registry = common::create_test_registry();
-    let thermal_var = registry.get_variable("THERMAL_SENSORS").unwrap();
-    let sparse_values = vec![Some(45i64), None, Some(42i64), None, Some(39i64), None];
-    let config_value = thermal_var.with(sparse_values).unwrap();
-
-    let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
-
-    let assignments = builder.build_set_assignments(&[config_value]).unwrap();
-
-    // Should only have assignments for non-None values
-    assert_eq!(assignments.len(), 3);
-    assert!(assignments.contains(&"THERMAL_SENSORS[0]=45".to_string()));
-    assert!(assignments.contains(&"THERMAL_SENSORS[2]=42".to_string()));
-    assert!(assignments.contains(&"THERMAL_SENSORS[4]=39".to_string()));
-}
-
-#[test]
-fn test_build_set_assignments_enum_array_sparse() {
-    let registry = common::create_test_registry();
-    let gpio_modes_var = registry.get_variable("GPIO_MODES").unwrap();
-    let sparse_values = vec![
-        Some("input".to_string()),
-        Some("output".to_string()),
-        None,
-        Some("bidirectional".to_string()),
-        None,
-        None,
-        None,
-        None,
-    ];
-    let config_value = gpio_modes_var.with(sparse_values).unwrap();
-
-    let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
-
-    let assignments = builder.build_set_assignments(&[config_value]).unwrap();
-
-    // Should only have assignments for non-None values
-    assert_eq!(assignments.len(), 3);
-    assert!(assignments.contains(&"GPIO_MODES[0]=input".to_string()));
-    assert!(assignments.contains(&"GPIO_MODES[1]=output".to_string()));
-    assert!(assignments.contains(&"GPIO_MODES[3]=bidirectional".to_string()));
-}
-
-#[test]
-fn test_build_set_assignments_binary_hex() {
-    let registry = common::create_test_registry();
-    let uuid_var = registry.get_variable("DEVICE_UUID").unwrap();
-    let binary_data = vec![0x1au8, 0x2bu8, 0x3cu8, 0x4du8];
-    let config_value = uuid_var.with(binary_data).unwrap();
-
-    let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
-
-    let assignments = builder.build_set_assignments(&[config_value]).unwrap();
-
-    assert_eq!(assignments.len(), 1);
-    assert_eq!(assignments[0], "DEVICE_UUID=0x1a2b3c4d");
-}
-
-#[test]
-fn test_build_set_assignments_multiple_variables() {
-    let registry = common::create_test_registry();
-
-    let sriov_var = registry.get_variable("SRIOV_EN").unwrap();
-    let vfs_var = registry.get_variable("NUM_OF_VFS").unwrap();
-    let power_var = registry.get_variable("POWER_MODE").unwrap();
-
-    let config_values = vec![
-        sriov_var.with(true).unwrap(),
-        vfs_var.with(16i64).unwrap(),
-        power_var.with("HIGH").unwrap(),
-    ];
-
-    let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
-
-    let assignments = builder.build_set_assignments(&config_values).unwrap();
-
-    assert_eq!(assignments.len(), 3);
-    assert!(assignments.contains(&"SRIOV_EN=true".to_string()));
-    assert!(assignments.contains(&"NUM_OF_VFS=16".to_string()));
-    assert!(assignments.contains(&"POWER_MODE=HIGH".to_string()));
-}
-
-#[test]
-fn test_build_set_assignments_empty() {
-    let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
-
-    let assignments = builder.build_set_assignments(&[]).unwrap();
-
-    assert!(assignments.is_empty());
+    check_cases(
+        [
+            Case {
+                scenario: "boolean scalar",
+                input: vec![var("SRIOV_EN").with(true).unwrap()],
+                expect: Yields(vec!["SRIOV_EN=true".to_string()]),
+            },
+            Case {
+                scenario: "integer scalar",
+                input: vec![var("NUM_OF_VFS").with(32i64).unwrap()],
+                expect: Yields(vec!["NUM_OF_VFS=32".to_string()]),
+            },
+            Case {
+                scenario: "enum scalar",
+                input: vec![var("POWER_MODE").with("HIGH").unwrap()],
+                expect: Yields(vec!["POWER_MODE=HIGH".to_string()]),
+            },
+            Case {
+                scenario: "preset scalar",
+                input: vec![var("PERFORMANCE_PRESET").with(7u8).unwrap()],
+                expect: Yields(vec!["PERFORMANCE_PRESET=7".to_string()]),
+            },
+            Case {
+                scenario: "binary scalar is hex-encoded",
+                input: vec![
+                    var("DEVICE_UUID")
+                        .with(vec![0x1au8, 0x2bu8, 0x3cu8, 0x4du8])
+                        .unwrap(),
+                ],
+                expect: Yields(vec!["DEVICE_UUID=0x1a2b3c4d".to_string()]),
+            },
+            Case {
+                scenario: "dense boolean array sets every index",
+                input: vec![
+                    var("GPIO_ENABLED")
+                        .with(vec![true, false, true, false])
+                        .unwrap(),
+                ],
+                expect: Yields(vec![
+                    "GPIO_ENABLED[0]=true".to_string(),
+                    "GPIO_ENABLED[1]=false".to_string(),
+                    "GPIO_ENABLED[2]=true".to_string(),
+                    "GPIO_ENABLED[3]=false".to_string(),
+                ]),
+            },
+            Case {
+                scenario: "sparse boolean array skips None slots",
+                input: vec![
+                    var("GPIO_ENABLED")
+                        .with(vec![Some(true), None, Some(false), None])
+                        .unwrap(),
+                ],
+                expect: Yields(vec![
+                    "GPIO_ENABLED[0]=true".to_string(),
+                    "GPIO_ENABLED[2]=false".to_string(),
+                ]),
+            },
+            Case {
+                scenario: "sparse integer array skips None slots",
+                input: vec![
+                    var("THERMAL_SENSORS")
+                        .with(vec![
+                            Some(45i64),
+                            None,
+                            Some(42i64),
+                            None,
+                            Some(39i64),
+                            None,
+                        ])
+                        .unwrap(),
+                ],
+                expect: Yields(vec![
+                    "THERMAL_SENSORS[0]=45".to_string(),
+                    "THERMAL_SENSORS[2]=42".to_string(),
+                    "THERMAL_SENSORS[4]=39".to_string(),
+                ]),
+            },
+            Case {
+                scenario: "sparse enum array skips None slots",
+                input: vec![
+                    var("GPIO_MODES")
+                        .with(vec![
+                            Some("input".to_string()),
+                            Some("output".to_string()),
+                            None,
+                            Some("bidirectional".to_string()),
+                            None,
+                            None,
+                            None,
+                            None,
+                        ])
+                        .unwrap(),
+                ],
+                expect: Yields(vec![
+                    "GPIO_MODES[0]=input".to_string(),
+                    "GPIO_MODES[1]=output".to_string(),
+                    "GPIO_MODES[3]=bidirectional".to_string(),
+                ]),
+            },
+            Case {
+                scenario: "multiple variables, each in input order",
+                input: vec![
+                    var("SRIOV_EN").with(true).unwrap(),
+                    var("NUM_OF_VFS").with(16i64).unwrap(),
+                    var("POWER_MODE").with("HIGH").unwrap(),
+                ],
+                expect: Yields(vec![
+                    "SRIOV_EN=true".to_string(),
+                    "NUM_OF_VFS=16".to_string(),
+                    "POWER_MODE=HIGH".to_string(),
+                ]),
+            },
+            Case {
+                scenario: "no values yields no assignments",
+                input: vec![],
+                expect: Yields(vec![]),
+            },
+        ],
+        |config_values| builder.build_set_assignments(&config_values).map_err(drop),
+    );
 }
 
 #[test]
@@ -413,10 +320,7 @@ fn test_different_devices() {
     let devices = ["01:00.0", "02:00.0", "03:00.1", "0000:01:00.0"];
 
     for device in &devices {
-        let builder = CommandBuilder {
-            device,
-            options: &options,
-        };
+        let builder = builder(&options, device);
         let temp_file = Path::new("/tmp/test.json");
         let variables = vec!["TEST_VAR".to_string()];
 
@@ -428,10 +332,7 @@ fn test_different_devices() {
 #[test]
 fn test_verbose_logging() {
     let options = ExecOptions::new().with_verbose(true);
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
+    let builder = builder(&options, "01:00.0");
 
     let temp_file = Path::new("/tmp/test.json");
     let variables = vec!["TEST_VAR".to_string()];
@@ -458,10 +359,7 @@ fn test_command_spec_to_command_conversion() {
 #[test]
 fn test_realistic_mlxconfig_query_spec() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
+    let builder = builder(&options, "01:00.0");
 
     let variables = vec![
         "SRIOV_EN".to_string(),
@@ -481,10 +379,7 @@ fn test_realistic_mlxconfig_query_spec() {
 #[test]
 fn test_realistic_mlxconfig_set_spec() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
+    let builder = builder(&options, "01:00.0");
 
     let assignments = vec!["SRIOV_EN=true".to_string(), "NUM_OF_VFS=16".to_string()];
 
@@ -497,10 +392,7 @@ fn test_realistic_mlxconfig_set_spec() {
 #[test]
 fn test_command_spec_args_order() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
+    let builder = builder(&options, "01:00.0");
 
     let variables = vec!["VAR1".to_string(), "VAR2".to_string()];
     let temp_file = Path::new("/tmp/test.json");
@@ -523,10 +415,7 @@ fn test_command_spec_args_order() {
 #[test]
 fn test_command_spec_complex_path() {
     let options = ExecOptions::default();
-    let builder = CommandBuilder {
-        device: "01:00.0",
-        options: &options,
-    };
+    let builder = builder(&options, "01:00.0");
 
     let temp_file = Path::new("/tmp/very/deep/directory/structure/test.json");
     let variables = vec!["TEST_VAR".to_string()];

--- a/crates/libmlx/tests/runner/exec_options_tests.rs
+++ b/crates/libmlx/tests/runner/exec_options_tests.rs
@@ -20,12 +20,12 @@
 
 use std::time::Duration;
 
+use carbide_test_support::{Check, check_values};
 use libmlx::runner::exec_options::{ExecOptions, is_destructive_variable};
 
-#[test]
-fn test_default_exec_options() {
-    let options = ExecOptions::default();
-
+// Assert `options` holds the documented default configuration. `new()` is meant to
+// be identical to `default()`, so both constructors are checked through here.
+fn assert_default_options(options: &ExecOptions) {
     assert_eq!(options.timeout, Some(Duration::from_secs(30)));
     assert_eq!(options.retries, 3);
     assert_eq!(options.retry_delay, Duration::from_millis(500));
@@ -38,19 +38,14 @@ fn test_default_exec_options() {
 }
 
 #[test]
-fn test_new_exec_options() {
-    let options = ExecOptions::new();
+fn test_default_exec_options() {
+    assert_default_options(&ExecOptions::default());
+}
 
-    // Should be identical to default
-    assert_eq!(options.timeout, Some(Duration::from_secs(30)));
-    assert_eq!(options.retries, 3);
-    assert_eq!(options.retry_delay, Duration::from_millis(500));
-    assert_eq!(options.max_retry_delay, Duration::from_secs(60));
-    assert_eq!(options.retry_multiplier, 2.0);
-    assert!(!options.dry_run);
-    assert!(!options.verbose);
-    assert!(!options.log_json_output);
-    assert!(!options.confirm_destructive);
+#[test]
+fn test_new_exec_options() {
+    // new() should be identical to default().
+    assert_default_options(&ExecOptions::new());
 }
 
 #[test]
@@ -101,48 +96,73 @@ fn test_builder_pattern_retry_multiplier() {
     assert_eq!(conservative_options.retry_multiplier, 1.1);
 }
 
+// Each boolean setter round-trips the flag it sets and touches nothing else. The
+// `set` closure applies the setter and `get` reads its field back, so one table
+// covers every flag in both states.
 #[test]
-fn test_builder_pattern_dry_run() {
-    let options = ExecOptions::new().with_dry_run(true);
+fn test_builder_pattern_boolean_flags() {
+    struct BoolFlag {
+        scenario: &'static str,
+        value: bool,
+        set: fn(ExecOptions, bool) -> ExecOptions,
+        get: fn(&ExecOptions) -> bool,
+    }
 
-    assert!(options.dry_run);
+    let flags = [
+        BoolFlag {
+            scenario: "dry_run set true",
+            value: true,
+            set: |o, v| o.with_dry_run(v),
+            get: |o| o.dry_run,
+        },
+        BoolFlag {
+            scenario: "dry_run set false",
+            value: false,
+            set: |o, v| o.with_dry_run(v),
+            get: |o| o.dry_run,
+        },
+        BoolFlag {
+            scenario: "verbose set true",
+            value: true,
+            set: |o, v| o.with_verbose(v),
+            get: |o| o.verbose,
+        },
+        BoolFlag {
+            scenario: "verbose set false",
+            value: false,
+            set: |o, v| o.with_verbose(v),
+            get: |o| o.verbose,
+        },
+        BoolFlag {
+            scenario: "log_json_output set true",
+            value: true,
+            set: |o, v| o.with_log_json_output(v),
+            get: |o| o.log_json_output,
+        },
+        BoolFlag {
+            scenario: "log_json_output set false",
+            value: false,
+            set: |o, v| o.with_log_json_output(v),
+            get: |o| o.log_json_output,
+        },
+        BoolFlag {
+            scenario: "confirm_destructive set true",
+            value: true,
+            set: |o, v| o.with_confirm_destructive(v),
+            get: |o| o.confirm_destructive,
+        },
+        BoolFlag {
+            scenario: "confirm_destructive set false",
+            value: false,
+            set: |o, v| o.with_confirm_destructive(v),
+            get: |o| o.confirm_destructive,
+        },
+    ];
 
-    let options_false = ExecOptions::new().with_dry_run(false);
-
-    assert!(!options_false.dry_run);
-}
-
-#[test]
-fn test_builder_pattern_verbose() {
-    let options = ExecOptions::new().with_verbose(true);
-
-    assert!(options.verbose);
-
-    let options_false = ExecOptions::new().with_verbose(false);
-
-    assert!(!options_false.verbose);
-}
-
-#[test]
-fn test_builder_pattern_log_json_output() {
-    let options = ExecOptions::new().with_log_json_output(true);
-
-    assert!(options.log_json_output);
-
-    let options_false = ExecOptions::new().with_log_json_output(false);
-
-    assert!(!options_false.log_json_output);
-}
-
-#[test]
-fn test_builder_pattern_confirm_destructive() {
-    let options = ExecOptions::new().with_confirm_destructive(true);
-
-    assert!(options.confirm_destructive);
-
-    let options_false = ExecOptions::new().with_confirm_destructive(false);
-
-    assert!(!options_false.confirm_destructive);
+    for flag in flags {
+        let options = (flag.set)(ExecOptions::new(), flag.value);
+        assert_eq!((flag.get)(&options), flag.value, "{}", flag.scenario);
+    }
 }
 
 #[test]
@@ -205,20 +225,50 @@ fn test_backoff_edge_cases() {
     assert_eq!(aggressive_growth_options.retry_multiplier, 10.0);
 }
 
+// Only the exact, case-sensitive name `OH_MY_DPU` is treated as destructive;
+// everything else (other variables, the empty string, mismatched casing) is not.
 #[test]
 fn test_is_destructive_variable() {
-    // Test the predefined destructive variable
-    assert!(is_destructive_variable("OH_MY_DPU"));
-
-    // Test non-destructive variables
-    assert!(!is_destructive_variable("SRIOV_EN"));
-    assert!(!is_destructive_variable("NUM_OF_VFS"));
-    assert!(!is_destructive_variable("POWER_MODE"));
-    assert!(!is_destructive_variable(""));
-
-    // Test case sensitivity
-    assert!(!is_destructive_variable("oh_my_dpu"));
-    assert!(!is_destructive_variable("Oh_My_Dpu"));
+    check_values(
+        [
+            Check {
+                scenario: "the predefined destructive variable",
+                input: "OH_MY_DPU",
+                expect: true,
+            },
+            Check {
+                scenario: "SRIOV_EN is not destructive",
+                input: "SRIOV_EN",
+                expect: false,
+            },
+            Check {
+                scenario: "NUM_OF_VFS is not destructive",
+                input: "NUM_OF_VFS",
+                expect: false,
+            },
+            Check {
+                scenario: "POWER_MODE is not destructive",
+                input: "POWER_MODE",
+                expect: false,
+            },
+            Check {
+                scenario: "the empty string is not destructive",
+                input: "",
+                expect: false,
+            },
+            Check {
+                scenario: "lowercase does not match",
+                input: "oh_my_dpu",
+                expect: false,
+            },
+            Check {
+                scenario: "mixed case does not match",
+                input: "Oh_My_Dpu",
+                expect: false,
+            },
+        ],
+        is_destructive_variable,
+    );
 }
 
 #[test]

--- a/crates/libmlx/tests/runner/executor_tests.rs
+++ b/crates/libmlx/tests/runner/executor_tests.rs
@@ -22,6 +22,7 @@ use std::fs;
 use std::path::Path;
 use std::time::Duration;
 
+use carbide_test_support::{Check, check_values};
 use libmlx::runner::command_builder::{CommandBuilder, CommandSpec};
 use libmlx::runner::error::MlxRunnerError;
 use libmlx::runner::exec_options::ExecOptions;
@@ -84,32 +85,46 @@ fn test_cleanup_temp_file_nonexistent() {
 
 #[test]
 fn test_is_dry_run() {
-    let dry_run_options = ExecOptions::new().with_dry_run(true);
-    let executor = CommandExecutor {
-        options: &dry_run_options,
-    };
-    assert!(executor.is_dry_run());
-
-    let normal_options = ExecOptions::new().with_dry_run(false);
-    let executor = CommandExecutor {
-        options: &normal_options,
-    };
-    assert!(!executor.is_dry_run());
+    check_values(
+        [
+            Check {
+                scenario: "dry-run on",
+                input: true,
+                expect: true,
+            },
+            Check {
+                scenario: "dry-run off",
+                input: false,
+                expect: false,
+            },
+        ],
+        |dry_run| {
+            let options = ExecOptions::new().with_dry_run(dry_run);
+            CommandExecutor { options: &options }.is_dry_run()
+        },
+    );
 }
 
 #[test]
 fn test_is_verbose() {
-    let verbose_options = ExecOptions::new().with_verbose(true);
-    let executor = CommandExecutor {
-        options: &verbose_options,
-    };
-    assert!(executor.is_verbose());
-
-    let quiet_options = ExecOptions::new().with_verbose(false);
-    let executor = CommandExecutor {
-        options: &quiet_options,
-    };
-    assert!(!executor.is_verbose());
+    check_values(
+        [
+            Check {
+                scenario: "verbose on",
+                input: true,
+                expect: true,
+            },
+            Check {
+                scenario: "verbose off",
+                input: false,
+                expect: false,
+            },
+        ],
+        |verbose| {
+            let options = ExecOptions::new().with_verbose(verbose);
+            CommandExecutor { options: &options }.is_verbose()
+        },
+    );
 }
 
 #[test]
@@ -209,53 +224,117 @@ fn test_no_timeout_successful_execution() {
     );
 }
 
+// `should_retry_error` splits every `MlxRunnerError` variant into transient (retry
+// — expect true) and permanent (give up — expect false). One table over the whole
+// error taxonomy, replacing the three hand-written classification tests.
 #[test]
 fn test_should_retry_error_classification() {
-    let options = ExecOptions::default();
-    let executor = CommandExecutor { options: &options };
-
-    // Permanent errors should not be retried.
-    assert!(
-        !executor.should_retry_error(&MlxRunnerError::VariableNotFound {
-            variable_name: "TEST".to_string()
-        })
-    );
-
-    assert!(
-        !executor.should_retry_error(&MlxRunnerError::ArraySizeMismatch {
-            variable_name: "TEST".to_string(),
-            expected: 4,
-            found: 6,
-        })
-    );
-
-    assert!(
-        !executor.should_retry_error(&MlxRunnerError::DeviceMismatch {
-            expected: "01:00.0".to_string(),
-            actual: "02:00.0".to_string(),
-        })
-    );
-
-    // Transient errors should be retried
-    assert!(executor.should_retry_error(&MlxRunnerError::Timeout {
-        command: "test".to_string(),
-        duration: Duration::from_secs(1)
-    }));
-
-    assert!(
-        executor.should_retry_error(&MlxRunnerError::CommandExecution {
-            command: "test".to_string(),
-            exit_code: Some(1),
-            stdout: "".to_string(),
-            stderr: "error".to_string(),
-        })
-    );
-
-    assert!(
-        executor.should_retry_error(&MlxRunnerError::Io(std::io::Error::new(
-            std::io::ErrorKind::ConnectionRefused,
-            "test"
-        )))
+    check_values(
+        [
+            // Permanent: a bad request won't get better on retry.
+            Check {
+                scenario: "VariableNotFound",
+                input: MlxRunnerError::VariableNotFound {
+                    variable_name: "TEST".to_string(),
+                },
+                expect: false,
+            },
+            Check {
+                scenario: "ArraySizeMismatch",
+                input: MlxRunnerError::ArraySizeMismatch {
+                    variable_name: "TEST".to_string(),
+                    expected: 4,
+                    found: 6,
+                },
+                expect: false,
+            },
+            Check {
+                scenario: "ValueConversion",
+                input: MlxRunnerError::ValueConversion {
+                    variable_name: "TEST".to_string(),
+                    value: "test".to_string(),
+                    error: libmlx::variables::value::MlxValueError::TypeMismatch {
+                        expected: "int".to_string(),
+                        got: "string".to_string(),
+                    },
+                },
+                expect: false,
+            },
+            Check {
+                scenario: "InvalidArrayIndex",
+                input: MlxRunnerError::InvalidArrayIndex {
+                    variable_name: "TEST[invalid]".to_string(),
+                },
+                expect: false,
+            },
+            Check {
+                scenario: "DeviceMismatch",
+                input: MlxRunnerError::DeviceMismatch {
+                    expected: "01:00.0".to_string(),
+                    actual: "02:00.0".to_string(),
+                },
+                expect: false,
+            },
+            Check {
+                scenario: "NoDeviceFound",
+                input: MlxRunnerError::NoDeviceFound,
+                expect: false,
+            },
+            Check {
+                scenario: "ConfirmationDeclined",
+                input: MlxRunnerError::ConfirmationDeclined {
+                    variables: vec!["TEST".to_string()],
+                },
+                expect: false,
+            },
+            Check {
+                scenario: "JsonParsing",
+                input: MlxRunnerError::JsonParsing {
+                    content: "{}".to_string(),
+                    error: serde_json::from_str::<serde_json::Value>("invalid json{").unwrap_err(),
+                },
+                expect: false,
+            },
+            // Transient: worth another attempt.
+            Check {
+                scenario: "CommandExecution",
+                input: MlxRunnerError::CommandExecution {
+                    command: "test".to_string(),
+                    exit_code: Some(1),
+                    stdout: "".to_string(),
+                    stderr: "error".to_string(),
+                },
+                expect: true,
+            },
+            Check {
+                scenario: "TempFileError",
+                input: MlxRunnerError::TempFileError {
+                    path: std::path::PathBuf::from("/tmp/test"),
+                    error: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "test"),
+                },
+                expect: true,
+            },
+            Check {
+                scenario: "Timeout",
+                input: MlxRunnerError::Timeout {
+                    command: "test".to_string(),
+                    duration: Duration::from_secs(1),
+                },
+                expect: true,
+            },
+            Check {
+                scenario: "Io",
+                input: MlxRunnerError::Io(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    "test",
+                )),
+                expect: true,
+            },
+        ],
+        |error| {
+            let options = ExecOptions::default();
+            CommandExecutor { options: &options }.should_retry_error(&error)
+        },
     );
 }
 
@@ -721,91 +800,8 @@ mod integration_tests {
 }
 
 #[cfg(test)]
-mod error_classification_tests {
+mod backoff_edge_case_tests {
     use super::*;
-
-    #[test]
-    fn test_all_permanent_errors() {
-        let options = ExecOptions::default();
-        let executor = CommandExecutor { options: &options };
-
-        // Test all permanent error types
-        let permanent_errors = vec![
-            MlxRunnerError::VariableNotFound {
-                variable_name: "TEST".to_string(),
-            },
-            MlxRunnerError::ArraySizeMismatch {
-                variable_name: "TEST".to_string(),
-                expected: 4,
-                found: 6,
-            },
-            MlxRunnerError::ValueConversion {
-                variable_name: "TEST".to_string(),
-                value: "test".to_string(),
-                error: libmlx::variables::value::MlxValueError::TypeMismatch {
-                    expected: "int".to_string(),
-                    got: "string".to_string(),
-                },
-            },
-            MlxRunnerError::InvalidArrayIndex {
-                variable_name: "TEST[invalid]".to_string(),
-            },
-            MlxRunnerError::DeviceMismatch {
-                expected: "01:00.0".to_string(),
-                actual: "02:00.0".to_string(),
-            },
-            MlxRunnerError::NoDeviceFound,
-            MlxRunnerError::ConfirmationDeclined {
-                variables: vec!["TEST".to_string()],
-            },
-            MlxRunnerError::JsonParsing {
-                content: "{}".to_string(),
-                error: serde_json::from_str::<serde_json::Value>("invalid json{").unwrap_err(),
-            },
-        ];
-
-        for error in permanent_errors {
-            assert!(
-                !executor.should_retry_error(&error),
-                "Error should be permanent: {error:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn test_all_transient_errors() {
-        let options = ExecOptions::default();
-        let executor = CommandExecutor { options: &options };
-
-        // Test all transient error types
-        let transient_errors = vec![
-            MlxRunnerError::CommandExecution {
-                command: "test".to_string(),
-                exit_code: Some(1),
-                stdout: "".to_string(),
-                stderr: "error".to_string(),
-            },
-            MlxRunnerError::TempFileError {
-                path: std::path::PathBuf::from("/tmp/test"),
-                error: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "test"),
-            },
-            MlxRunnerError::Timeout {
-                command: "test".to_string(),
-                duration: Duration::from_secs(1),
-            },
-            MlxRunnerError::Io(std::io::Error::new(
-                std::io::ErrorKind::ConnectionRefused,
-                "test",
-            )),
-        ];
-
-        for error in transient_errors {
-            assert!(
-                executor.should_retry_error(&error),
-                "Error should be transient: {error:?}"
-            );
-        }
-    }
 
     #[test]
     fn test_edge_case_backoff_configurations() {

--- a/crates/libmlx/tests/runner/json_parser_tests.rs
+++ b/crates/libmlx/tests/runner/json_parser_tests.rs
@@ -20,32 +20,48 @@
 
 use std::fs;
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
+use libmlx::runner::error::MlxRunnerError;
 use libmlx::runner::exec_options::ExecOptions;
 use libmlx::runner::json_parser::JsonResponseParser;
+use libmlx::runner::result_types::QueryResult;
+use libmlx::variables::registry::MlxVariableRegistry;
 use libmlx::variables::value::MlxValueType;
 use serde_json::json;
 
 use super::common;
 
+// Build a parser over `registry`, write `json` to a temp file, and parse it for
+// `device`. The temp-file/parser dance was copy-pasted into every test below.
+fn parse(
+    registry: &MlxVariableRegistry,
+    json: serde_json::Value,
+    device: &str,
+) -> Result<QueryResult, MlxRunnerError> {
+    let options = ExecOptions::default();
+    let parser = JsonResponseParser {
+        registry,
+        options: &options,
+    };
+    let temp_file = tempfile::NamedTempFile::new().unwrap();
+    fs::write(
+        temp_file.path(),
+        serde_json::to_string_pretty(&json).unwrap(),
+    )
+    .unwrap();
+    parser.parse_json_response(temp_file.path(), device)
+}
+
 #[test]
 fn test_parse_basic_json_response() {
     let registry = common::create_test_registry();
-    let options = ExecOptions::default();
-    let parser = JsonResponseParser {
-        registry: &registry,
-        options: &options,
-    };
-
-    let json_data = common::create_sample_json_response("01:00.0");
-
-    // Write JSON to temp file
-    let temp_file = tempfile::NamedTempFile::new().unwrap();
-    let json_string = serde_json::to_string_pretty(&json_data).unwrap();
-    fs::write(temp_file.path(), json_string).unwrap();
-
-    let result = parser
-        .parse_json_response(temp_file.path(), "01:00.0")
-        .unwrap();
+    let result = parse(
+        &registry,
+        common::create_sample_json_response("01:00.0"),
+        "01:00.0",
+    )
+    .unwrap();
 
     // Verify device info
     assert_eq!(
@@ -77,22 +93,12 @@ fn test_parse_basic_json_response() {
 #[test]
 fn test_parse_array_variables() {
     let registry = common::create_test_registry();
-    let options = ExecOptions::default();
-    let parser = JsonResponseParser {
-        registry: &registry,
-        options: &options,
-    };
-
-    let json_data = common::create_array_json_response("01:00.0");
-
-    // Write JSON to temp file
-    let temp_file = tempfile::NamedTempFile::new().unwrap();
-    let json_string = serde_json::to_string_pretty(&json_data).unwrap();
-    fs::write(temp_file.path(), json_string).unwrap();
-
-    let result = parser
-        .parse_json_response(temp_file.path(), "01:00.0")
-        .unwrap();
+    let result = parse(
+        &registry,
+        common::create_array_json_response("01:00.0"),
+        "01:00.0",
+    )
+    .unwrap();
 
     // Find GPIO_ENABLED boolean array
     let gpio_enabled = result
@@ -155,21 +161,12 @@ fn test_parse_array_variables() {
 #[test]
 fn test_device_mismatch_error() {
     let registry = common::create_test_registry();
-    let options = ExecOptions::default();
-    let parser = JsonResponseParser {
-        registry: &registry,
-        options: &options,
-    };
-
-    let json_data = common::create_sample_json_response("01:00.0");
-
-    // Write JSON to temp file
-    let temp_file = tempfile::NamedTempFile::new().unwrap();
-    let json_string = serde_json::to_string_pretty(&json_data).unwrap();
-    fs::write(temp_file.path(), json_string).unwrap();
-
-    // Try to parse with different expected device
-    let result = parser.parse_json_response(temp_file.path(), "02:00.0");
+    // Try to parse with a different expected device.
+    let result = parse(
+        &registry,
+        common::create_sample_json_response("01:00.0"),
+        "02:00.0",
+    );
 
     assert!(result.is_err());
     if let Err(libmlx::runner::error::MlxRunnerError::DeviceMismatch { expected, actual }) = result
@@ -215,60 +212,64 @@ fn test_missing_file() {
     assert!(result.is_err());
 }
 
+// The boolean spellings mlxconfig might hand back, parsed for TEST_BOOL.
 #[test]
 fn test_boolean_parsing_variations() {
     let registry = common::create_minimal_test_registry();
-    let options = ExecOptions::default();
-    let parser = JsonResponseParser {
-        registry: &registry,
-        options: &options,
-    };
-
-    // Test different boolean formats that mlxconfig might return
-    let test_cases = vec![
-        ("True(1)", true),
-        ("False(0)", false),
-        ("TRUE", true),
-        ("FALSE", false),
-    ];
-
-    for (input_value, expected_bool) in test_cases {
-        let json_data = json!({
-            "Device #1": {
-                "description": "Test Device",
-                "device": "01:00.0",
-                "device_type": "Test",
-                "name": "Test",
-                "tlv_configuration": {
-                    "TEST_BOOL": {
-                        "current_value": input_value,
-                        "default_value": "False(0)",
-                        "modified": false,
-                        "next_value": input_value,
-                        "read_only": false
+    check_cases(
+        [
+            Case {
+                scenario: "True(1)",
+                input: "True(1)",
+                expect: Yields(MlxValueType::Boolean(true)),
+            },
+            Case {
+                scenario: "False(0)",
+                input: "False(0)",
+                expect: Yields(MlxValueType::Boolean(false)),
+            },
+            Case {
+                scenario: "TRUE",
+                input: "TRUE",
+                expect: Yields(MlxValueType::Boolean(true)),
+            },
+            Case {
+                scenario: "FALSE",
+                input: "FALSE",
+                expect: Yields(MlxValueType::Boolean(false)),
+            },
+        ],
+        |raw| {
+            let json = json!({
+                "Device #1": {
+                    "description": "Test Device",
+                    "device": "01:00.0",
+                    "device_type": "Test",
+                    "name": "Test",
+                    "tlv_configuration": {
+                        "TEST_BOOL": {
+                            "current_value": raw,
+                            "default_value": "False(0)",
+                            "modified": false,
+                            "next_value": raw,
+                            "read_only": false
+                        }
                     }
                 }
-            }
-        });
-
-        let temp_file = tempfile::NamedTempFile::new().unwrap();
-        let json_string = serde_json::to_string_pretty(&json_data).unwrap();
-        fs::write(temp_file.path(), json_string).unwrap();
-
-        let result = parser
-            .parse_json_response(temp_file.path(), "01:00.0")
-            .unwrap();
-        let test_var = result
-            .variables
-            .iter()
-            .find(|v| v.name() == "TEST_BOOL")
-            .unwrap();
-
-        assert_eq!(
-            test_var.current_value.value,
-            MlxValueType::Boolean(expected_bool)
-        );
-    }
+            });
+            parse(&registry, json, "01:00.0")
+                .map(|r| {
+                    r.variables
+                        .iter()
+                        .find(|v| v.name() == "TEST_BOOL")
+                        .unwrap()
+                        .current_value
+                        .value
+                        .clone()
+                })
+                .map_err(drop)
+        },
+    );
 }
 
 #[test]

--- a/crates/libmlx/tests/runner/result_types_tests.rs
+++ b/crates/libmlx/tests/runner/result_types_tests.rs
@@ -20,6 +20,7 @@
 
 use std::time::Duration;
 
+use carbide_test_support::{Check, check_values};
 use libmlx::runner::result_types::{
     ComparisonResult, PlannedChange, QueriedDeviceInfo, QueriedVariable, QueryResult, SyncResult,
     VariableChange,
@@ -55,42 +56,50 @@ fn test_queried_variable_construction() {
     assert!(!queried_var.read_only);
 }
 
+// is_pending_change is true exactly when current_value differs from next_value.
+// Each row sets a (current, next) bool pair on a QueriedVariable and asserts the
+// predicate; the rest of the struct is held constant.
 #[test]
 fn test_queried_variable_pending_change_detection() {
+    struct Values {
+        current: bool,
+        next: bool,
+    }
+
     let registry = common::create_test_registry();
     let sriov_var = registry.get_variable("SRIOV_EN").unwrap().clone();
 
-    // Test case where current != next (pending change)
-    let current_value = sriov_var.with(false).unwrap();
-    let default_value = sriov_var.with(false).unwrap();
-    let next_value = sriov_var.with(true).unwrap();
-
-    let queried_var_with_pending = QueriedVariable {
-        variable: sriov_var.clone(),
-        current_value,
-        default_value,
-        next_value,
-        modified: true,
-        read_only: false,
-    };
-
-    assert!(queried_var_with_pending.is_pending_change());
-
-    // Test case where current == next (no pending change)
-    let current_value = sriov_var.with(true).unwrap();
-    let next_value = sriov_var.with(true).unwrap();
-    let default_value = sriov_var.with(false).unwrap();
-
-    let queried_var_no_pending = QueriedVariable {
-        variable: sriov_var,
-        current_value,
-        default_value,
-        next_value,
-        modified: true,
-        read_only: false,
-    };
-
-    assert!(!queried_var_no_pending.is_pending_change());
+    check_values(
+        [
+            Check {
+                scenario: "current != next is a pending change",
+                input: Values {
+                    current: false,
+                    next: true,
+                },
+                expect: true,
+            },
+            Check {
+                scenario: "current == next is not a pending change",
+                input: Values {
+                    current: true,
+                    next: true,
+                },
+                expect: false,
+            },
+        ],
+        |Values { current, next }| {
+            QueriedVariable {
+                variable: sriov_var.clone(),
+                current_value: sriov_var.with(current).unwrap(),
+                default_value: sriov_var.with(false).unwrap(),
+                next_value: sriov_var.with(next).unwrap(),
+                modified: true,
+                read_only: false,
+            }
+            .is_pending_change()
+        },
+    );
 }
 
 #[test]

--- a/crates/libmlx/tests/runner/runner_integration_tests.rs
+++ b/crates/libmlx/tests/runner/runner_integration_tests.rs
@@ -21,6 +21,9 @@
 use std::fs;
 use std::time::Duration;
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
+use libmlx::runner::error::MlxRunnerError;
 use libmlx::runner::exec_options::ExecOptions;
 use libmlx::runner::runner::MlxConfigRunner;
 
@@ -29,6 +32,27 @@ use super::common;
 // Note: These tests focus on the runner's internal logic and error handling
 // rather than actually executing mlxconfig commands, since we can't rely on
 // mlxconfig being available or specific hardware being present in test environments.
+
+// A dry-run runner over a fresh test registry, targeting `01:00.0`. Dry run keeps
+// these tests off any real mlxconfig binary; the construction was copy-pasted into
+// almost every test below.
+fn dry_run_runner() -> MlxConfigRunner {
+    let registry = common::create_test_registry();
+    let options = ExecOptions::new().with_dry_run(true);
+    MlxConfigRunner::with_options("01:00.0".to_string(), registry, options)
+}
+
+// Runs `set` on a fresh dry-run runner and distills the error to a comparable
+// shape: a `VariableNotFound` becomes its offending variable name (the part of the
+// error that is the contract), any other failure becomes a generic marker. Lets one
+// `check_cases` table both pin the not-found name (`FailsWith`) and assert plain
+// rejection (`Fails`) for the validation failures.
+fn set_outcome(assignments: &[(&str, &str)]) -> Result<(), String> {
+    dry_run_runner().set(assignments).map_err(|err| match err {
+        MlxRunnerError::VariableNotFound { variable_name } => variable_name,
+        other => format!("other: {other:?}"),
+    })
+}
 
 #[test]
 fn test_runner_temp_file_prefix() {
@@ -39,261 +63,69 @@ fn test_runner_temp_file_prefix() {
     runner.set_temp_file_prefix("/custom/tmp");
 }
 
+// Every invalid `set` assignment is rejected before any mlxconfig command runs.
+// The not-found rows pin the offending variable name (it's the contract, and the
+// runner reports the *first* invalid variable); the enum / boolean / array-bounds /
+// preset-range rows just assert rejection.
 #[test]
-fn test_sync_with_no_changes_needed() {
-    let registry = common::create_test_registry();
-    let options = ExecOptions::new().with_dry_run(true); // Use dry run to avoid actual execution
-    let runner = MlxConfigRunner::with_options("01:00.0".to_string(), registry, options);
-
-    // Create a mock JSON response file that matches our desired values
-    let json_data = common::create_sample_json_response("01:00.0");
-    let temp_file = tempfile::NamedTempFile::new().unwrap();
-    let json_string = serde_json::to_string_pretty(&json_data).unwrap();
-    fs::write(temp_file.path(), json_string).unwrap();
-
-    // Since we're in dry_run mode, the sync operation will attempt to parse
-    // but won't actually execute mlxconfig commands
-    let assignments = &[
-        ("SRIOV_EN", "true"), // Already true in mock JSON
-        ("NUM_OF_VFS", "16"), // Already 16 in mock JSON
-    ];
-
-    // This will fail because we can't mock the mlxconfig command execution easily,
-    // but it tests the basic sync flow setup
-    let result = runner.sync(assignments);
-
-    // In dry run mode with no actual mlxconfig, this will likely error
-    // but the sync logic path gets exercised
-    // We could make this more sophisticated with better mocking
-    assert!(result.is_err() || result.is_ok());
-}
-
-#[test]
-fn test_compare_operation() {
-    let registry = common::create_test_registry();
-    let options = ExecOptions::new().with_dry_run(true);
-    let runner = MlxConfigRunner::with_options("01:00.0".to_string(), registry, options);
-
-    let assignments = &[
-        ("SRIOV_EN", "false"), // Different from mock JSON (which has true)
-        ("NUM_OF_VFS", "32"),  // Different from mock JSON (which has 16)
-        ("POWER_MODE", "LOW"), // Different from mock JSON (which has HIGH)
-    ];
-
-    // This will fail in the query phase since we can't mock mlxconfig,
-    // but it tests the compare flow setup
-    let result = runner.compare(assignments);
-    assert!(result.is_err() || result.is_ok());
-}
-
-#[test]
-fn test_set_with_array_variables() {
-    let registry = common::create_test_registry();
-    let options = ExecOptions::new().with_dry_run(true);
-    let runner = MlxConfigRunner::with_options("01:00.0".to_string(), registry, options);
-
-    // Test sparse array assignments
-    let assignments = &[
-        ("GPIO_ENABLED[0]", "true"),
-        ("GPIO_ENABLED[2]", "false"),
-        ("GPIO_MODES[1]", "output"),
-        ("GPIO_MODES[3]", "bidirectional"),
-    ];
-
-    // In dry run mode, this should process the assignments and build the command
-    // but not actually execute it
-    let result = runner.set(assignments);
-    assert!(result.is_err() || result.is_ok());
-}
-
-#[test]
-fn test_set_with_invalid_variable() {
-    let registry = common::create_test_registry();
-    let options = ExecOptions::new().with_dry_run(true);
-    let runner = MlxConfigRunner::with_options("01:00.0".to_string(), registry, options);
-
-    let assignments = &[("SRIOV_EN", "true"), ("NONEXISTENT_VAR", "value")];
-
-    let result = runner.set(assignments);
-    assert!(result.is_err());
-
-    if let Err(libmlx::runner::error::MlxRunnerError::VariableNotFound { variable_name }) = result {
-        assert_eq!(variable_name, "NONEXISTENT_VAR");
-    } else {
-        panic!("Expected VariableNotFound error, got: {result:?}");
-    }
-}
-
-#[test]
-fn test_set_with_invalid_enum_value() {
-    let registry = common::create_test_registry();
-    let options = ExecOptions::new().with_dry_run(true);
-    let runner = MlxConfigRunner::with_options("01:00.0".to_string(), registry, options);
-
-    let assignments = &[
-        ("POWER_MODE", "INVALID_POWER_MODE"), // Not in allowed options: LOW, MEDIUM, HIGH
-    ];
-
-    let result = runner.set(assignments);
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_set_with_invalid_boolean_value() {
-    let registry = common::create_test_registry();
-    let options = ExecOptions::new().with_dry_run(true);
-    let runner = MlxConfigRunner::with_options("01:00.0".to_string(), registry, options);
-
-    let assignments = &[
-        ("SRIOV_EN", "maybe"), // Invalid boolean value
-    ];
-
-    let result = runner.set(assignments);
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_set_with_array_out_of_bounds() {
-    let registry = common::create_test_registry();
-    let options = ExecOptions::new().with_dry_run(true);
-    let runner = MlxConfigRunner::with_options("01:00.0".to_string(), registry, options);
-
-    let assignments = &[
-        ("GPIO_ENABLED[10]", "true"), // GPIO_ENABLED array size is 4, so index 10 is invalid
-    ];
-
-    let result = runner.set(assignments);
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_set_with_preset_out_of_range() {
-    let registry = common::create_test_registry();
-    let options = ExecOptions::new().with_dry_run(true);
-    let runner = MlxConfigRunner::with_options("01:00.0".to_string(), registry, options);
-
-    let assignments = &[
-        ("PERFORMANCE_PRESET", "20"), // Max preset is 10, so 20 is invalid
-    ];
-
-    let result = runner.set(assignments);
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_query_all_variables() {
-    let registry = common::create_test_registry();
-    let options = ExecOptions::new().with_dry_run(true);
-    let runner = MlxConfigRunner::with_options("01:00.0".to_string(), registry, options);
-
-    // This will fail because we can't actually execute mlxconfig,
-    // but it tests the query_all flow
-    let result = runner.query_all();
-    assert!(result.is_err() || result.is_ok());
-}
-
-#[test]
-fn test_query_specific_variables() {
-    let registry = common::create_test_registry();
-    let options = ExecOptions::new().with_dry_run(true);
-    let runner = MlxConfigRunner::with_options("01:00.0".to_string(), registry, options);
-
-    let variables = &["SRIOV_EN", "NUM_OF_VFS"];
-
-    // This will fail because we can't actually execute mlxconfig,
-    // but it tests the query flow
-    let result = runner.query(variables);
-    assert!(result.is_err() || result.is_ok());
-}
-
-#[test]
-fn test_query_array_variables() {
-    let registry = common::create_test_registry();
-    let options = ExecOptions::new().with_dry_run(true);
-    let runner = MlxConfigRunner::with_options("01:00.0".to_string(), registry, options);
-
-    // Query array variables - should expand to individual indices
-    let variables = &["GPIO_ENABLED", "THERMAL_SENSORS"];
-
-    let result = runner.query(variables);
-    assert!(result.is_err() || result.is_ok());
+fn invalid_set_assignments_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "unknown variable names itself",
+                input: &[("SRIOV_EN", "true"), ("NONEXISTENT_VAR", "value")][..],
+                expect: FailsWith("NONEXISTENT_VAR".to_string()),
+            },
+            Case {
+                scenario: "first invalid variable wins over later invalid values",
+                input: &[
+                    ("NONEXISTENT_VAR", "value"),   // Variable not found
+                    ("POWER_MODE", "INVALID_MODE"), // Invalid enum value
+                    ("GPIO_ENABLED[100]", "true"),  // Array index out of bounds
+                ][..],
+                expect: FailsWith("NONEXISTENT_VAR".to_string()),
+            },
+            Case {
+                scenario: "enum value outside allowed options (LOW/MEDIUM/HIGH)",
+                input: &[("POWER_MODE", "INVALID_POWER_MODE")][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "non-boolean value for a boolean variable",
+                input: &[("SRIOV_EN", "maybe")][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "array index past the registry size of 4",
+                input: &[("GPIO_ENABLED[10]", "true")][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "preset above the max of 10",
+                input: &[("PERFORMANCE_PRESET", "20")][..],
+                expect: Fails,
+            },
+        ],
+        set_outcome,
+    );
 }
 
 #[test]
 fn test_query_nonexistent_variable() {
-    let registry = common::create_test_registry();
-    let options = ExecOptions::new().with_dry_run(true);
-    let runner = MlxConfigRunner::with_options("01:00.0".to_string(), registry, options);
+    let runner = dry_run_runner();
+    let result = runner.query(["NONEXISTENT_VAR"]);
 
-    let variables = &["NONEXISTENT_VAR"];
-
-    let result = runner.query(variables);
     assert!(result.is_err());
-
-    if let Err(libmlx::runner::error::MlxRunnerError::VariableNotFound { variable_name }) = result {
+    if let Err(MlxRunnerError::VariableNotFound { variable_name }) = result {
         assert_eq!(variable_name, "NONEXISTENT_VAR");
     } else {
         panic!("Expected VariableNotFound error, got: {result:?}");
-    }
-}
-
-#[test]
-fn test_different_device_identifiers() {
-    let registry = common::create_test_registry();
-
-    let devices = [
-        "01:00.0",
-        "02:00.0",
-        "03:00.1",
-        "0000:01:00.0",
-        "0000:0a:00.0",
-    ];
-
-    for device in &devices {
-        // Should be able to create runners for different device formats
-        // Basic smoke test - construction should succeed.
-        let options = ExecOptions::new().with_dry_run(true);
-        let runner_with_options =
-            MlxConfigRunner::with_options(device.to_string(), registry.clone(), options);
-
-        // Test a basic operation
-        let result = runner_with_options.set([("SRIOV_EN", "true")]);
-        assert!(result.is_err() || result.is_ok());
-    }
-}
-
-#[test]
-fn test_execution_options_propagation() {
-    let registry = common::create_test_registry();
-
-    // Test various option combinations
-    let test_cases = vec![
-        ExecOptions::new().with_verbose(true),
-        ExecOptions::new().with_dry_run(true),
-        ExecOptions::new().with_retries(5),
-        ExecOptions::new().with_timeout(Some(Duration::from_secs(60))),
-        ExecOptions::new()
-            .with_verbose(true)
-            .with_dry_run(true)
-            .with_retries(3)
-            .with_confirm_destructive(true),
-    ];
-
-    for options in test_cases {
-        let runner =
-            MlxConfigRunner::with_options("01:00.0".to_string(), registry.clone(), options);
-
-        // Test that runner can be created with different option combinations
-        let result = runner.set([("SRIOV_EN", "true")]);
-        assert!(result.is_err() || result.is_ok());
     }
 }
 
 #[test]
 fn test_empty_assignments() {
-    let registry = common::create_test_registry();
-    let options = ExecOptions::new().with_dry_run(true);
-    let runner = MlxConfigRunner::with_options("01:00.0".to_string(), registry, options);
+    let runner = dry_run_runner();
 
     // Empty assignments array should be handled gracefully
     let empty_assignments: &[(&str, &str)] = &[];
@@ -316,60 +148,144 @@ fn test_temp_file_prefix_setting() {
     // Should not panic or error
 }
 
-#[cfg(test)]
-mod error_handling_tests {
-    use super::*;
+// The smoke tests below can't pin an outcome: without a mockable mlxconfig binary
+// the operation may succeed or fail depending on the host. Each one asserts the
+// weaker contract that the flow runs to completion without panicking. They stay
+// standalone (no outcome to fold into a table) but share `dry_run_runner`.
 
-    #[test]
-    fn test_multiple_error_conditions() {
-        let registry = common::create_test_registry();
+#[test]
+fn test_sync_with_no_changes_needed() {
+    let runner = dry_run_runner();
+
+    // Create a mock JSON response file that matches our desired values
+    let json_data = common::create_sample_json_response("01:00.0");
+    let temp_file = tempfile::NamedTempFile::new().unwrap();
+    let json_string = serde_json::to_string_pretty(&json_data).unwrap();
+    fs::write(temp_file.path(), json_string).unwrap();
+
+    // Since we're in dry_run mode, the sync operation will attempt to parse
+    // but won't actually execute mlxconfig commands. We can't mock the command
+    // execution easily, but this exercises the basic sync flow setup.
+    let assignments = &[
+        ("SRIOV_EN", "true"), // Already true in mock JSON
+        ("NUM_OF_VFS", "16"), // Already 16 in mock JSON
+    ];
+
+    let _ = runner.sync(assignments);
+}
+
+#[test]
+fn test_compare_operation() {
+    let runner = dry_run_runner();
+
+    let assignments = &[
+        ("SRIOV_EN", "false"), // Different from mock JSON (which has true)
+        ("NUM_OF_VFS", "32"),  // Different from mock JSON (which has 16)
+        ("POWER_MODE", "LOW"), // Different from mock JSON (which has HIGH)
+    ];
+
+    // Fails in the query phase (no mockable mlxconfig); exercises the compare setup.
+    let _ = runner.compare(assignments);
+}
+
+#[test]
+fn test_set_with_array_variables() {
+    let runner = dry_run_runner();
+
+    // Test sparse array assignments
+    let assignments = &[
+        ("GPIO_ENABLED[0]", "true"),
+        ("GPIO_ENABLED[2]", "false"),
+        ("GPIO_MODES[1]", "output"),
+        ("GPIO_MODES[3]", "bidirectional"),
+    ];
+
+    // In dry run mode, this should process the assignments and build the command
+    // but not actually execute it.
+    let _ = runner.set(assignments);
+}
+
+#[test]
+fn test_query_all_variables() {
+    let runner = dry_run_runner();
+
+    // Exercises the query_all flow (no mockable mlxconfig to actually execute).
+    let _ = runner.query_all();
+}
+
+#[test]
+fn test_query_specific_variables() {
+    let runner = dry_run_runner();
+
+    // Exercises the query flow (no mockable mlxconfig to actually execute).
+    let _ = runner.query(["SRIOV_EN", "NUM_OF_VFS"]);
+}
+
+#[test]
+fn test_query_array_variables() {
+    let runner = dry_run_runner();
+
+    // Query array variables - should expand to individual indices.
+    let _ = runner.query(["GPIO_ENABLED", "THERMAL_SENSORS"]);
+}
+
+#[test]
+fn test_sync_vs_set_vs_compare_consistency() {
+    let runner = dry_run_runner();
+
+    let assignments = &[("SRIOV_EN", "true"), ("NUM_OF_VFS", "32")];
+
+    // All three operations accept the same assignments and run to completion without
+    // panicking. We can't pin their outcome (no mockable mlxconfig), and the original
+    // test deliberately tolerated mixed success/failure across the three.
+    let _ = runner.set(assignments);
+    let _ = runner.sync(assignments);
+    let _ = runner.compare(assignments);
+}
+
+#[test]
+fn test_different_device_identifiers() {
+    let registry = common::create_test_registry();
+
+    let devices = [
+        "01:00.0",
+        "02:00.0",
+        "03:00.1",
+        "0000:01:00.0",
+        "0000:0a:00.0",
+    ];
+
+    for device in &devices {
+        // Construction should succeed for every device format, and a basic operation
+        // should run without panicking.
         let options = ExecOptions::new().with_dry_run(true);
-        let runner = MlxConfigRunner::with_options("01:00.0".to_string(), registry, options);
-
-        // Test multiple invalid conditions at once
-        let assignments = &[
-            ("NONEXISTENT_VAR", "value"),   // Variable not found
-            ("POWER_MODE", "INVALID_MODE"), // Invalid enum value
-            ("GPIO_ENABLED[100]", "true"),  // Array index out of bounds
-        ];
-
-        let result = runner.set(assignments);
-        assert!(result.is_err());
-
-        // Should get the first error encountered (variable not found)
-        if let Err(libmlx::runner::error::MlxRunnerError::VariableNotFound { variable_name }) =
-            result
-        {
-            assert_eq!(variable_name, "NONEXISTENT_VAR");
-        } else {
-            panic!("Expected VariableNotFound error for first invalid variable");
-        }
+        let runner = MlxConfigRunner::with_options(device.to_string(), registry.clone(), options);
+        let _ = runner.set([("SRIOV_EN", "true")]);
     }
+}
 
-    #[test]
-    fn test_sync_vs_set_vs_compare_consistency() {
-        let registry = common::create_test_registry();
-        let options = ExecOptions::new().with_dry_run(true);
-        let runner = MlxConfigRunner::with_options("01:00.0".to_string(), registry, options);
+#[test]
+fn test_execution_options_propagation() {
+    let registry = common::create_test_registry();
 
-        let assignments = &[("SRIOV_EN", "true"), ("NUM_OF_VFS", "32")];
+    // Test various option combinations
+    let test_cases = vec![
+        ExecOptions::new().with_verbose(true),
+        ExecOptions::new().with_dry_run(true),
+        ExecOptions::new().with_retries(5),
+        ExecOptions::new().with_timeout(Some(Duration::from_secs(60))),
+        ExecOptions::new()
+            .with_verbose(true)
+            .with_dry_run(true)
+            .with_retries(3)
+            .with_confirm_destructive(true),
+    ];
 
-        // All three operations should handle the same assignments consistently
-        // (Even though they'll fail due to no mlxconfig, they should fail in the same way)
-
-        let set_result = runner.set(assignments);
-        let sync_result = runner.sync(assignments);
-        let compare_result = runner.compare(assignments);
-
-        // All should either succeed or fail with similar error patterns
-        match (&set_result, &sync_result, &compare_result) {
-            (Ok(_), Ok(_), Ok(_)) => {}    // All succeeded
-            (Err(_), Err(_), Err(_)) => {} // All failed (expected in test environment)
-            _ => {
-                // Mixed results might indicate inconsistent handling
-                // But we'll allow it since mocking is complex
-            }
-        }
+    for options in test_cases {
+        // The runner builds with each option combination and runs without panicking.
+        let runner =
+            MlxConfigRunner::with_options("01:00.0".to_string(), registry.clone(), options);
+        let _ = runner.set([("SRIOV_EN", "true")]);
     }
 }
 
@@ -390,15 +306,12 @@ mod realistic_scenarios {
         // Typical SRIOV configuration
         let sriov_config = &[("SRIOV_EN", "true"), ("NUM_OF_VFS", "8")];
 
-        let result = runner.set(sriov_config);
-        assert!(result.is_err() || result.is_ok());
+        let _ = runner.set(sriov_config);
     }
 
     #[test]
     fn test_gpio_array_configuration() {
-        let registry = common::create_test_registry();
-        let options = ExecOptions::new().with_dry_run(true);
-        let runner = MlxConfigRunner::with_options("01:00.0".to_string(), registry, options);
+        let runner = dry_run_runner();
 
         // Configure GPIO pins with mixed modes
         let gpio_config = &[
@@ -411,8 +324,7 @@ mod realistic_scenarios {
             ("GPIO_MODES[3]", "bidirectional"),
         ];
 
-        let result = runner.set(gpio_config);
-        assert!(result.is_err() || result.is_ok());
+        let _ = runner.set(gpio_config);
     }
 
     #[test]
@@ -430,7 +342,6 @@ mod realistic_scenarios {
             ("PERFORMANCE_PRESET", "8"),
         ];
 
-        let result = runner.sync(perf_config);
-        assert!(result.is_err() || result.is_ok());
+        let _ = runner.sync(perf_config);
     }
 }

--- a/crates/libmlx/tests/runner/traits_tests.rs
+++ b/crates/libmlx/tests/runner/traits_tests.rs
@@ -18,6 +18,8 @@
 // tests/traits_tests.rs
 // Tests for MlxConfigSettable and MlxConfigQueryable traits
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use libmlx::runner::traits::{self, MlxConfigQueryable, MlxConfigSettable};
 use libmlx::variables::value::MlxValueType;
 
@@ -377,34 +379,57 @@ fn test_mlx_config_queryable_vec_variables() {
     assert!(result.contains(&"NUM_OF_VFS".to_string()));
 }
 
+// `parse_array_index` splits a `NAME[idx]` string into its base name and index,
+// returns None for a plain (non-indexed) name, and errors on a malformed index.
+// The runner error isn't PartialEq, so the malformed rows use `Fails`; the rest
+// pin the exact `Option<(name, index)>` the parse should yield.
 #[test]
-fn test_parse_array_index() {
-    // Test valid array index formats
-    let result = traits::parse_array_index("ARRAY_VAR[0]").unwrap();
-    assert_eq!(result, Some(("ARRAY_VAR".to_string(), 0)));
-
-    let result = traits::parse_array_index("GPIO_ENABLED[15]").unwrap();
-    assert_eq!(result, Some(("GPIO_ENABLED".to_string(), 15)));
-
-    let result = traits::parse_array_index("COMPLEX_ARRAY_NAME[999]").unwrap();
-    assert_eq!(result, Some(("COMPLEX_ARRAY_NAME".to_string(), 999)));
-
-    // Test non-array format
-    let result = traits::parse_array_index("SRIOV_EN").unwrap();
-    assert_eq!(result, None);
-
-    let result = traits::parse_array_index("POWER_MODE").unwrap();
-    assert_eq!(result, None);
-
-    // Test invalid formats
-    let result = traits::parse_array_index("INVALID[]");
-    assert!(result.is_err());
-
-    let result = traits::parse_array_index("invalid[0]");
-    assert!(result.unwrap().is_none());
-
-    let result = traits::parse_array_index("VAR[not_a_number]");
-    assert!(result.is_err());
+fn parse_array_index_splits_name_and_index() {
+    check_cases(
+        [
+            Case {
+                scenario: "'ARRAY_VAR[0]'",
+                input: "ARRAY_VAR[0]",
+                expect: Yields(Some(("ARRAY_VAR".to_string(), 0))),
+            },
+            Case {
+                scenario: "'GPIO_ENABLED[15]'",
+                input: "GPIO_ENABLED[15]",
+                expect: Yields(Some(("GPIO_ENABLED".to_string(), 15))),
+            },
+            Case {
+                scenario: "'COMPLEX_ARRAY_NAME[999]'",
+                input: "COMPLEX_ARRAY_NAME[999]",
+                expect: Yields(Some(("COMPLEX_ARRAY_NAME".to_string(), 999))),
+            },
+            Case {
+                scenario: "'SRIOV_EN' is not an indexed name",
+                input: "SRIOV_EN",
+                expect: Yields(None),
+            },
+            Case {
+                scenario: "'POWER_MODE' is not an indexed name",
+                input: "POWER_MODE",
+                expect: Yields(None),
+            },
+            Case {
+                scenario: "'invalid[0]' lowercase name is not an index",
+                input: "invalid[0]",
+                expect: Yields(None),
+            },
+            Case {
+                scenario: "'INVALID[]' has an empty index",
+                input: "INVALID[]",
+                expect: Fails,
+            },
+            Case {
+                scenario: "'VAR[not_a_number]' has a non-numeric index",
+                input: "VAR[not_a_number]",
+                expect: Fails,
+            },
+        ],
+        |name| traits::parse_array_index(name).map_err(drop),
+    );
 }
 
 #[test]
@@ -546,47 +571,56 @@ fn test_build_sparse_array_value_invalid_enum() {
     assert!(result.is_err());
 }
 
+// `get_array_size_from_spec` reads the declared size off any array spec and errors
+// on a scalar spec. One row per array variant plus the scalar rejection. The runner
+// error isn't PartialEq, so the scalar case uses `Fails`.
 #[test]
-fn test_get_array_size_from_spec() {
+fn get_array_size_from_spec_reads_array_sizes() {
     use libmlx::variables::spec::MlxVariableSpec;
 
-    // Test boolean array
-    let spec = MlxVariableSpec::builder()
-        .boolean_array()
-        .with_size(4)
-        .build();
-    let size = traits::get_array_size_from_spec(&spec).unwrap();
-    assert_eq!(size, 4);
-
-    // Test integer array
-    let spec = MlxVariableSpec::builder()
-        .integer_array()
-        .with_size(6)
-        .build();
-    let size = traits::get_array_size_from_spec(&spec).unwrap();
-    assert_eq!(size, 6);
-
-    // Test enum array
-    let spec = MlxVariableSpec::builder()
-        .enum_array()
-        .with_options(vec!["a".to_string(), "b".to_string()])
-        .with_size(8)
-        .build();
-    let size = traits::get_array_size_from_spec(&spec).unwrap();
-    assert_eq!(size, 8);
-
-    // Test binary array
-    let spec = MlxVariableSpec::builder()
-        .binary_array()
-        .with_size(2)
-        .build();
-    let size = traits::get_array_size_from_spec(&spec).unwrap();
-    assert_eq!(size, 2);
-
-    // Test non-array spec should error
-    let spec = MlxVariableSpec::builder().boolean().build();
-    let result = traits::get_array_size_from_spec(&spec);
-    assert!(result.is_err());
+    check_cases(
+        [
+            Case {
+                scenario: "boolean array",
+                input: MlxVariableSpec::builder()
+                    .boolean_array()
+                    .with_size(4)
+                    .build(),
+                expect: Yields(4),
+            },
+            Case {
+                scenario: "integer array",
+                input: MlxVariableSpec::builder()
+                    .integer_array()
+                    .with_size(6)
+                    .build(),
+                expect: Yields(6),
+            },
+            Case {
+                scenario: "enum array",
+                input: MlxVariableSpec::builder()
+                    .enum_array()
+                    .with_options(vec!["a".to_string(), "b".to_string()])
+                    .with_size(8)
+                    .build(),
+                expect: Yields(8),
+            },
+            Case {
+                scenario: "binary array",
+                input: MlxVariableSpec::builder()
+                    .binary_array()
+                    .with_size(2)
+                    .build(),
+                expect: Yields(2),
+            },
+            Case {
+                scenario: "a scalar spec has no array size",
+                input: MlxVariableSpec::builder().boolean().build(),
+                expect: Fails,
+            },
+        ],
+        |spec| traits::get_array_size_from_spec(&spec).map_err(drop),
+    );
 }
 
 #[test]
@@ -730,34 +764,61 @@ fn test_mlx_config_queryable_array_index_base_variable_not_found() {
     }
 }
 
+// Querying a single explicit array index validates that index against the array's
+// size from the registry spec: an in-bounds index is preserved verbatim (size 1,
+// the name unchanged), an out-of-bounds one is rejected. Folds the per-type
+// validation cases and the boundary edge cases into one table. The runner error
+// isn't PartialEq, so rejections use `Fails`; a success yields the single-name vec,
+// which pins both the length and the preserved name.
 #[test]
-fn test_mlx_config_queryable_array_index_validation() {
+fn array_index_query_validates_against_spec_size() {
     let registry = common::create_test_registry();
 
-    // Test that array index validation works for different array types
-    let test_cases = vec![
-        ("GPIO_ENABLED[0]", true),     // BooleanArray size 4, index 0 valid
-        ("GPIO_ENABLED[3]", true),     // BooleanArray size 4, index 3 valid
-        ("GPIO_ENABLED[4]", false),    // BooleanArray size 4, index 4 invalid
-        ("THERMAL_SENSORS[5]", true),  // IntegerArray size 6, index 5 valid
-        ("THERMAL_SENSORS[6]", false), // IntegerArray size 6, index 6 invalid
-        ("GPIO_MODES[7]", true),       // EnumArray size 8, index 7 valid
-        ("GPIO_MODES[8]", false),      // EnumArray size 8, index 8 invalid
-    ];
-
-    for (var_name, should_succeed) in test_cases {
-        let variables = &[var_name];
-        let result = variables.to_variable_names(&registry);
-
-        if should_succeed {
-            assert!(result.is_ok(), "Expected {var_name} to succeed");
-            let names = result.unwrap();
-            assert_eq!(names.len(), 1);
-            assert_eq!(names[0], var_name);
-        } else {
-            assert!(result.is_err(), "Expected {var_name} to fail");
-        }
-    }
+    check_cases(
+        [
+            Case {
+                scenario: "GPIO_ENABLED[0]: boolean array size 4, first index",
+                input: "GPIO_ENABLED[0]",
+                expect: Yields(vec!["GPIO_ENABLED[0]".to_string()]),
+            },
+            Case {
+                scenario: "GPIO_ENABLED[3]: boolean array size 4, last valid index",
+                input: "GPIO_ENABLED[3]",
+                expect: Yields(vec!["GPIO_ENABLED[3]".to_string()]),
+            },
+            Case {
+                scenario: "GPIO_ENABLED[4]: boolean array size 4, out of bounds",
+                input: "GPIO_ENABLED[4]",
+                expect: Fails,
+            },
+            Case {
+                scenario: "THERMAL_SENSORS[5]: integer array size 6, last valid index",
+                input: "THERMAL_SENSORS[5]",
+                expect: Yields(vec!["THERMAL_SENSORS[5]".to_string()]),
+            },
+            Case {
+                scenario: "THERMAL_SENSORS[6]: integer array size 6, out of bounds",
+                input: "THERMAL_SENSORS[6]",
+                expect: Fails,
+            },
+            Case {
+                scenario: "GPIO_MODES[0]: enum array size 8, first index",
+                input: "GPIO_MODES[0]",
+                expect: Yields(vec!["GPIO_MODES[0]".to_string()]),
+            },
+            Case {
+                scenario: "GPIO_MODES[7]: enum array size 8, last valid index",
+                input: "GPIO_MODES[7]",
+                expect: Yields(vec!["GPIO_MODES[7]".to_string()]),
+            },
+            Case {
+                scenario: "GPIO_MODES[8]: enum array size 8, out of bounds",
+                input: "GPIO_MODES[8]",
+                expect: Fails,
+            },
+        ],
+        |var_name| (&[var_name]).to_variable_names(&registry).map_err(drop),
+    );
 }
 
 #[test]
@@ -792,31 +853,4 @@ fn test_mlx_config_queryable_preserve_vs_expand_behavior() {
     assert!(index_result.contains(&"GPIO_ENABLED[3]".to_string()));
     assert!(!index_result.contains(&"GPIO_ENABLED[0]".to_string()));
     assert!(!index_result.contains(&"GPIO_ENABLED[2]".to_string()));
-}
-
-#[test]
-fn test_mlx_config_queryable_array_index_edge_cases() {
-    let registry = common::create_test_registry();
-
-    // Test edge cases for array index parsing and validation
-    let test_cases = vec![
-        ("GPIO_ENABLED[0]", true),    // First index
-        ("THERMAL_SENSORS[5]", true), // Last valid index (size 6, so 0-5 valid)
-        ("GPIO_MODES[0]", true),      // First index of larger array
-        ("GPIO_MODES[7]", true),      // Last valid index (size 8, so 0-7 valid)
-    ];
-
-    for (var_name, should_succeed) in test_cases {
-        let variables = &[var_name];
-        let result = variables.to_variable_names(&registry);
-
-        if should_succeed {
-            assert!(result.is_ok(), "Expected {var_name} to succeed");
-            let names = result.unwrap();
-            assert_eq!(names.len(), 1);
-            assert_eq!(names[0], var_name);
-        } else {
-            assert!(result.is_err(), "Expected {var_name} to fail");
-        }
-    }
 }

--- a/crates/libmlx/tests/variables/test_registry.rs
+++ b/crates/libmlx/tests/variables/test_registry.rs
@@ -16,6 +16,7 @@
  */
 
 use carbide_libmlx_model::device::info::MlxDeviceInfo;
+use carbide_test_support::{Check, check_values};
 use libmlx::device::filters::{DeviceField, DeviceFilter, DeviceFilterSet, MatchMode};
 use libmlx::variables::registry::MlxVariableRegistry;
 use libmlx::variables::spec::MlxVariableSpec;
@@ -236,17 +237,26 @@ fn test_registry_device_matching_with_filters() {
             match_mode: MatchMode::Regex,
         });
 
-    // Device that matches both filters
-    let matching_device = create_test_device("BlueField3", "MCX623106AS-CDAT", "28.38.1010");
-    assert!(registry.matches_device(&matching_device));
-
-    // Device that matches only first filter
-    let partial_match_device = create_test_device("BlueField3", "MT40354", "28.38.1010");
-    assert!(!registry.matches_device(&partial_match_device));
-
-    // Device that matches no filters
-    let non_matching_device = create_test_device("ConnectX-6", "MT40354", "28.38.1010");
-    assert!(!registry.matches_device(&non_matching_device));
+    check_values(
+        [
+            Check {
+                scenario: "matches both filters",
+                input: create_test_device("BlueField3", "MCX623106AS-CDAT", "28.38.1010"),
+                expect: true,
+            },
+            Check {
+                scenario: "matches only the device-type filter",
+                input: create_test_device("BlueField3", "MT40354", "28.38.1010"),
+                expect: false,
+            },
+            Check {
+                scenario: "matches neither filter",
+                input: create_test_device("ConnectX-6", "MT40354", "28.38.1010"),
+                expect: false,
+            },
+        ],
+        |device| registry.matches_device(&device),
+    );
 }
 
 #[test]

--- a/crates/libmlx/tests/variables/test_spec.rs
+++ b/crates/libmlx/tests/variables/test_spec.rs
@@ -15,30 +15,56 @@
  * limitations under the License.
  */
 
+use std::mem::discriminant;
+
+use carbide_test_support::{Check, check_values};
 use libmlx::variables::spec::MlxVariableSpec;
 
+// Each builder method produces its matching variant. The old version called
+// `matches!` without asserting -- the booleans were discarded, so it checked
+// nothing. Comparing discriminants restores the check (variant only, no payload).
 #[test]
 fn test_simple_variable_specs() {
-    let boolean_spec = MlxVariableSpec::builder().boolean().build();
-    matches!(boolean_spec, MlxVariableSpec::Boolean);
-
-    let integer_spec = MlxVariableSpec::builder().integer().build();
-    matches!(integer_spec, MlxVariableSpec::Integer);
-
-    let string_spec = MlxVariableSpec::builder().string().build();
-    matches!(string_spec, MlxVariableSpec::String);
-
-    let binary_spec = MlxVariableSpec::builder().binary().build();
-    matches!(binary_spec, MlxVariableSpec::Binary);
-
-    let bytes_spec = MlxVariableSpec::builder().bytes().build();
-    matches!(bytes_spec, MlxVariableSpec::Bytes);
-
-    let array_spec = MlxVariableSpec::builder().array().build();
-    matches!(array_spec, MlxVariableSpec::Array);
-
-    let opaque_spec = MlxVariableSpec::builder().opaque().build();
-    matches!(opaque_spec, MlxVariableSpec::Opaque);
+    check_values(
+        [
+            Check {
+                scenario: "boolean",
+                input: MlxVariableSpec::builder().boolean().build(),
+                expect: discriminant(&MlxVariableSpec::Boolean),
+            },
+            Check {
+                scenario: "integer",
+                input: MlxVariableSpec::builder().integer().build(),
+                expect: discriminant(&MlxVariableSpec::Integer),
+            },
+            Check {
+                scenario: "string",
+                input: MlxVariableSpec::builder().string().build(),
+                expect: discriminant(&MlxVariableSpec::String),
+            },
+            Check {
+                scenario: "binary",
+                input: MlxVariableSpec::builder().binary().build(),
+                expect: discriminant(&MlxVariableSpec::Binary),
+            },
+            Check {
+                scenario: "bytes",
+                input: MlxVariableSpec::builder().bytes().build(),
+                expect: discriminant(&MlxVariableSpec::Bytes),
+            },
+            Check {
+                scenario: "array",
+                input: MlxVariableSpec::builder().array().build(),
+                expect: discriminant(&MlxVariableSpec::Array),
+            },
+            Check {
+                scenario: "opaque",
+                input: MlxVariableSpec::builder().opaque().build(),
+                expect: discriminant(&MlxVariableSpec::Opaque),
+            },
+        ],
+        |spec| discriminant(&spec),
+    );
 }
 
 #[test]

--- a/crates/libmlx/tests/variables/test_value.rs
+++ b/crates/libmlx/tests/variables/test_value.rs
@@ -16,7 +16,7 @@
  */
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::{Case, Check, check_cases, check_values};
 use libmlx::variables::spec::MlxVariableSpec;
 use libmlx::variables::value::{MlxValueError, MlxValueType};
 use libmlx::variables::variable::MlxConfigVariable;
@@ -378,267 +378,328 @@ fn test_contextual_string_handling() {
     assert_eq!(enum_value.value, MlxValueType::Enum("medium".to_string()));
 }
 
-// test_string_parsing_for_single_values is one big test
-// that makes sure all of the string -> spec parsing works
-// as expected. mlxconfig returns all values as strings when
-// working with --json, so we need to make sure this works
-// as part of deserializing the JSON payloads. This one is
-// specifically for testing single values.
+// mlxconfig hands every value back as a string (via `--json`), so `with` has to
+// parse a string into each spec. This walks every single-value spec, grouped by
+// spec; `parsed` pulls the value out and drops the error, since the rejection rows
+// only assert *that* a bad string fails.
 #[test]
 fn test_string_parsing_for_single_values() {
-    // Boolean parsing.
+    fn parsed(var: &MlxConfigVariable, raw: &str) -> Result<MlxValueType, ()> {
+        var.with(raw.to_string()).map(|v| v.value).map_err(drop)
+    }
+
     let bool_var = create_test_variable("test_bool", MlxVariableSpec::Boolean);
-    assert_eq!(
-        bool_var.with("true".to_string()).unwrap().value,
-        MlxValueType::Boolean(true)
+    check_cases(
+        [
+            Case {
+                scenario: "'true'",
+                input: "true",
+                expect: Yields(MlxValueType::Boolean(true)),
+            },
+            Case {
+                scenario: "'1'",
+                input: "1",
+                expect: Yields(MlxValueType::Boolean(true)),
+            },
+            Case {
+                scenario: "'YES'",
+                input: "YES",
+                expect: Yields(MlxValueType::Boolean(true)),
+            },
+            Case {
+                scenario: "'enabled'",
+                input: "enabled",
+                expect: Yields(MlxValueType::Boolean(true)),
+            },
+            Case {
+                scenario: "'on'",
+                input: "on",
+                expect: Yields(MlxValueType::Boolean(true)),
+            },
+            Case {
+                scenario: "'false'",
+                input: "false",
+                expect: Yields(MlxValueType::Boolean(false)),
+            },
+            Case {
+                scenario: "'0'",
+                input: "0",
+                expect: Yields(MlxValueType::Boolean(false)),
+            },
+            Case {
+                scenario: "'NO'",
+                input: "NO",
+                expect: Yields(MlxValueType::Boolean(false)),
+            },
+            Case {
+                scenario: "'disabled'",
+                input: "disabled",
+                expect: Yields(MlxValueType::Boolean(false)),
+            },
+            Case {
+                scenario: "'off'",
+                input: "off",
+                expect: Yields(MlxValueType::Boolean(false)),
+            },
+            Case {
+                scenario: "'maybe' is not a boolean",
+                input: "maybe",
+                expect: Fails,
+            },
+        ],
+        |raw| parsed(&bool_var, raw),
     );
-    assert_eq!(
-        bool_var.with("1".to_string()).unwrap().value,
-        MlxValueType::Boolean(true)
-    );
-    assert_eq!(
-        bool_var.with("YES".to_string()).unwrap().value,
-        MlxValueType::Boolean(true)
-    );
-    assert_eq!(
-        bool_var.with("enabled".to_string()).unwrap().value,
-        MlxValueType::Boolean(true)
-    );
-    assert_eq!(
-        bool_var.with("on".to_string()).unwrap().value,
-        MlxValueType::Boolean(true)
-    );
-    assert_eq!(
-        bool_var.with("false".to_string()).unwrap().value,
-        MlxValueType::Boolean(false)
-    );
-    assert_eq!(
-        bool_var.with("0".to_string()).unwrap().value,
-        MlxValueType::Boolean(false)
-    );
-    assert_eq!(
-        bool_var.with("NO".to_string()).unwrap().value,
-        MlxValueType::Boolean(false)
-    );
-    assert_eq!(
-        bool_var.with("disabled".to_string()).unwrap().value,
-        MlxValueType::Boolean(false)
-    );
-    assert_eq!(
-        bool_var.with("off".to_string()).unwrap().value,
-        MlxValueType::Boolean(false)
-    );
-    assert!(bool_var.with("maybe".to_string()).is_err());
 
-    // Integer parsing.
     let int_var = create_test_variable("test_int", MlxVariableSpec::Integer);
-    assert_eq!(
-        int_var.with("42".to_string()).unwrap().value,
-        MlxValueType::Integer(42)
+    check_cases(
+        [
+            Case {
+                scenario: "positive",
+                input: "42",
+                expect: Yields(MlxValueType::Integer(42)),
+            },
+            Case {
+                scenario: "negative",
+                input: "-123",
+                expect: Yields(MlxValueType::Integer(-123)),
+            },
+            Case {
+                scenario: "zero",
+                input: "0",
+                expect: Yields(MlxValueType::Integer(0)),
+            },
+            Case {
+                scenario: "non-number is rejected",
+                input: "not_a_number",
+                expect: Fails,
+            },
+        ],
+        |raw| parsed(&int_var, raw),
     );
-    assert_eq!(
-        int_var.with("-123".to_string()).unwrap().value,
-        MlxValueType::Integer(-123)
-    );
-    assert_eq!(
-        int_var.with("0".to_string()).unwrap().value,
-        MlxValueType::Integer(0)
-    );
-    assert!(int_var.with("not_a_number".to_string()).is_err());
 
-    // String parsing (trivial but good to test).
     let str_var = create_test_variable("test_string", MlxVariableSpec::String);
-    assert_eq!(
-        str_var.with("hello world".to_string()).unwrap().value,
-        MlxValueType::String("hello world".to_string())
-    );
-    assert_eq!(
-        str_var.with("  trimmed  ".to_string()).unwrap().value,
-        MlxValueType::String("trimmed".to_string())
+    check_cases(
+        [
+            Case {
+                scenario: "stored as-is",
+                input: "hello world",
+                expect: Yields(MlxValueType::String("hello world".to_string())),
+            },
+            Case {
+                scenario: "surrounding whitespace trimmed",
+                input: "  trimmed  ",
+                expect: Yields(MlxValueType::String("trimmed".to_string())),
+            },
+        ],
+        |raw| parsed(&str_var, raw),
     );
 
-    // Enum parsing with validation.
     let enum_var = create_test_variable(
         "test_enum",
         MlxVariableSpec::Enum {
             options: vec!["low".to_string(), "medium".to_string(), "high".to_string()],
         },
     );
-    assert_eq!(
-        enum_var.with("medium".to_string()).unwrap().value,
-        MlxValueType::Enum("medium".to_string())
+    check_cases(
+        [
+            Case {
+                scenario: "a valid option",
+                input: "medium",
+                expect: Yields(MlxValueType::Enum("medium".to_string())),
+            },
+            Case {
+                scenario: "another valid option",
+                input: "high",
+                expect: Yields(MlxValueType::Enum("high".to_string())),
+            },
+            Case {
+                scenario: "trimmed before matching",
+                input: " low ",
+                expect: Yields(MlxValueType::Enum("low".to_string())),
+            },
+            Case {
+                scenario: "an unknown option is rejected",
+                input: "invalid",
+                expect: Fails,
+            },
+        ],
+        |raw| parsed(&enum_var, raw),
     );
-    assert_eq!(
-        enum_var.with("high".to_string()).unwrap().value,
-        MlxValueType::Enum("high".to_string())
-    );
-    assert_eq!(
-        enum_var.with(" low ".to_string()).unwrap().value,
-        MlxValueType::Enum("low".to_string())
-    ); // trimmed
-    assert!(enum_var.with("invalid".to_string()).is_err());
 
-    // Preset parsing.
     let preset_var =
         create_test_variable("test_preset", MlxVariableSpec::Preset { max_preset: 10 });
-    assert_eq!(
-        preset_var.with("5".to_string()).unwrap().value,
-        MlxValueType::Preset(5)
+    check_cases(
+        [
+            Case {
+                scenario: "mid-range",
+                input: "5",
+                expect: Yields(MlxValueType::Preset(5)),
+            },
+            Case {
+                scenario: "the floor",
+                input: "0",
+                expect: Yields(MlxValueType::Preset(0)),
+            },
+            Case {
+                scenario: "the ceiling",
+                input: "10",
+                expect: Yields(MlxValueType::Preset(10)),
+            },
+            Case {
+                scenario: "above the max is rejected",
+                input: "15",
+                expect: Fails,
+            },
+            Case {
+                scenario: "non-number is rejected",
+                input: "not_a_number",
+                expect: Fails,
+            },
+        ],
+        |raw| parsed(&preset_var, raw),
     );
-    assert_eq!(
-        preset_var.with("0".to_string()).unwrap().value,
-        MlxValueType::Preset(0)
-    );
-    assert_eq!(
-        preset_var.with("10".to_string()).unwrap().value,
-        MlxValueType::Preset(10)
-    );
-    assert!(preset_var.with("15".to_string()).is_err()); // out of range
-    assert!(preset_var.with("not_a_number".to_string()).is_err());
 
-    // Hex parsing for Binary, Bytes, and Opaque.
+    // Binary, Bytes, and Opaque all parse hex -- with or without an 0x/0X prefix.
     let binary_var = create_test_variable("test_binary", MlxVariableSpec::Binary);
+    check_cases(
+        [
+            Case {
+                scenario: "0x-prefixed hex",
+                input: "0x1a2b3c",
+                expect: Yields(MlxValueType::Binary(vec![0x1a, 0x2b, 0x3c])),
+            },
+            Case {
+                scenario: "non-hex is rejected",
+                input: "not_hex",
+                expect: Fails,
+            },
+        ],
+        |raw| parsed(&binary_var, raw),
+    );
     let bytes_var = create_test_variable("test_bytes", MlxVariableSpec::Bytes);
+    Case {
+        scenario: "bare hex",
+        input: "1a2b3c",
+        expect: Yields(MlxValueType::Bytes(vec![0x1a, 0x2b, 0x3c])),
+    }
+    .check(|raw| parsed(&bytes_var, raw));
     let opaque_var = create_test_variable("test_opaque", MlxVariableSpec::Opaque);
+    Case {
+        scenario: "uppercase 0X hex",
+        input: "0X1A2B3C",
+        expect: Yields(MlxValueType::Opaque(vec![0x1a, 0x2b, 0x3c])),
+    }
+    .check(|raw| parsed(&opaque_var, raw));
 
-    assert_eq!(
-        binary_var.with("0x1a2b3c".to_string()).unwrap().value,
-        MlxValueType::Binary(vec![0x1a, 0x2b, 0x3c])
-    );
-    assert_eq!(
-        bytes_var.with("1a2b3c".to_string()).unwrap().value,
-        MlxValueType::Bytes(vec![0x1a, 0x2b, 0x3c])
-    );
-    assert_eq!(
-        opaque_var.with("0X1A2B3C".to_string()).unwrap().value,
-        MlxValueType::Opaque(vec![0x1a, 0x2b, 0x3c])
-    );
-    assert!(binary_var.with("not_hex".to_string()).is_err());
-
-    // Test that single strings reject array specs.
+    // A single string can't satisfy an array spec.
     let bool_array_var =
         create_test_variable("test_bool_array", MlxVariableSpec::BooleanArray { size: 3 });
-    assert!(bool_array_var.with("true".to_string()).is_err());
+    Case {
+        scenario: "single string rejects an array spec",
+        input: "true",
+        expect: Fails,
+    }
+    .check(|raw| parsed(&bool_array_var, raw));
 }
 
-// test_vec_string_parsing_for_array_values is one big test
-// that makes sure all of the string -> spec parsing works
-// as expected. mlxconfig returns all values as strings when
-// working with --json, so we need to make sure this works
-// as part of deserializing the JSON payloads. This one is
-// specifically for testing arrays, including sparse array support.
+// The array-spec counterpart to the single-value parser -- a Vec<String> per row
+// (mlxconfig delivers arrays as string vecs over `--json`). Grouped by spec. The
+// enum-array case pins its exact error, so `parsed` keeps the MlxValueError; the
+// size/element failures just use `Fails`.
 #[test]
 fn test_vec_string_parsing_for_array_values() {
-    // Generic string array.
+    fn parsed(var: &MlxConfigVariable, raw: Vec<&str>) -> Result<MlxValueType, MlxValueError> {
+        var.with(raw.into_iter().map(String::from).collect::<Vec<String>>())
+            .map(|v| v.value)
+    }
+
+    // Generic string array -- trims each element.
     let array_var = create_test_variable("test_array", MlxVariableSpec::Array);
-    let result = array_var
-        .with(vec![
-            "hello".to_string(),
-            " world ".to_string(),
-            "test".to_string(),
-        ])
-        .unwrap();
-    assert_eq!(
-        result.value,
-        MlxValueType::Array(vec![
+    Case {
+        scenario: "trims each element",
+        input: vec!["hello", " world ", "test"],
+        expect: Yields(MlxValueType::Array(vec![
             "hello".to_string(),
             "world".to_string(),
-            "test".to_string()
-        ])
-    ); // trimmed
+            "test".to_string(),
+        ])),
+    }
+    .check(|raw| parsed(&array_var, raw));
 
-    // Boolean array parsing with sparse support.
+    // Boolean array -- dense, sparse ("-" or "" = None), wrong size, bad element.
     let bool_array_var =
         create_test_variable("test_bool_array", MlxVariableSpec::BooleanArray { size: 4 });
-
-    // Dense array
-    let result = bool_array_var
-        .with(vec![
-            "true".to_string(),
-            "0".to_string(),
-            "YES".to_string(),
-            "disabled".to_string(),
-        ])
-        .unwrap();
-    assert_eq!(
-        result.value,
-        MlxValueType::BooleanArray(vec![Some(true), Some(false), Some(true), Some(false)])
+    check_cases(
+        [
+            Case {
+                scenario: "dense",
+                input: vec!["true", "0", "YES", "disabled"],
+                expect: Yields(MlxValueType::BooleanArray(vec![
+                    Some(true),
+                    Some(false),
+                    Some(true),
+                    Some(false),
+                ])),
+            },
+            Case {
+                scenario: "sparse via - and empty string",
+                input: vec!["true", "-", "false", ""],
+                expect: Yields(MlxValueType::BooleanArray(vec![
+                    Some(true),
+                    None,
+                    Some(false),
+                    None,
+                ])),
+            },
+            Case {
+                scenario: "wrong size",
+                input: vec!["true", "false"],
+                expect: Fails,
+            },
+            Case {
+                scenario: "invalid boolean element",
+                input: vec!["true", "maybe", "false", "true"],
+                expect: Fails,
+            },
+        ],
+        |raw| parsed(&bool_array_var, raw),
     );
 
-    // Sparse array with "-" notation
-    let sparse_result = bool_array_var
-        .with(vec![
-            "true".to_string(),
-            "-".to_string(),
-            "false".to_string(),
-            "".to_string(), // empty string also means None
-        ])
-        .unwrap();
-    assert_eq!(
-        sparse_result.value,
-        MlxValueType::BooleanArray(vec![Some(true), None, Some(false), None])
-    );
-
-    // Wrong size.
-    assert!(
-        bool_array_var
-            .with(vec!["true".to_string(), "false".to_string()])
-            .is_err()
-    );
-
-    // Invalid boolean in array.
-    assert!(
-        bool_array_var
-            .with(vec![
-                "true".to_string(),
-                "maybe".to_string(),
-                "false".to_string(),
-                "true".to_string()
-            ])
-            .is_err()
-    );
-
-    // Integer array parsing with sparse support.
+    // Integer array -- same dense/sparse/size/element coverage.
     let int_array_var =
         create_test_variable("test_int_array", MlxVariableSpec::IntegerArray { size: 3 });
-
-    // Dense array
-    let result = int_array_var
-        .with(vec!["42".to_string(), "-123".to_string(), "0".to_string()])
-        .unwrap();
-    assert_eq!(
-        result.value,
-        MlxValueType::IntegerArray(vec![Some(42), Some(-123), Some(0)])
+    check_cases(
+        [
+            Case {
+                scenario: "dense",
+                input: vec!["42", "-123", "0"],
+                expect: Yields(MlxValueType::IntegerArray(vec![
+                    Some(42),
+                    Some(-123),
+                    Some(0),
+                ])),
+            },
+            Case {
+                scenario: "sparse via -",
+                input: vec!["42", "-", "0"],
+                expect: Yields(MlxValueType::IntegerArray(vec![Some(42), None, Some(0)])),
+            },
+            Case {
+                scenario: "wrong size",
+                input: vec!["1", "2"],
+                expect: Fails,
+            },
+            Case {
+                scenario: "invalid integer element",
+                input: vec!["42", "not_a_number", "0"],
+                expect: Fails,
+            },
+        ],
+        |raw| parsed(&int_array_var, raw),
     );
 
-    // Sparse array with "-" notation
-    let sparse_result = int_array_var
-        .with(vec!["42".to_string(), "-".to_string(), "0".to_string()])
-        .unwrap();
-    assert_eq!(
-        sparse_result.value,
-        MlxValueType::IntegerArray(vec![Some(42), None, Some(0)])
-    );
-
-    // Wrong size.
-    assert!(
-        int_array_var
-            .with(vec!["1".to_string(), "2".to_string()])
-            .is_err()
-    );
-
-    // Invalid integer in array.
-    assert!(
-        int_array_var
-            .with(vec![
-                "42".to_string(),
-                "not_a_number".to_string(),
-                "0".to_string()
-            ])
-            .is_err()
-    );
-
-    // Enum array parsing with sparse support.
+    // Enum array -- trims; dense/sparse pass; wrong size fails; a bad option fails
+    // with the exact position / value / allowed set.
     let enum_array_var = create_test_variable(
         "test_enum_array",
         MlxVariableSpec::EnumArray {
@@ -650,146 +711,109 @@ fn test_vec_string_parsing_for_array_values() {
             size: 4,
         },
     );
-
-    // Dense array
-    let result = enum_array_var
-        .with(vec![
-            "input".to_string(),
-            " output ".to_string(),
-            "bidirectional".to_string(),
-            "input".to_string(),
-        ])
-        .unwrap();
-    assert_eq!(
-        result.value,
-        MlxValueType::EnumArray(vec![
-            Some("input".to_string()),
-            Some("output".to_string()),
-            Some("bidirectional".to_string()),
-            Some("input".to_string())
-        ])
+    check_cases(
+        [
+            Case {
+                scenario: "dense, trimmed",
+                input: vec!["input", " output ", "bidirectional", "input"],
+                expect: Yields(MlxValueType::EnumArray(vec![
+                    Some("input".to_string()),
+                    Some("output".to_string()),
+                    Some("bidirectional".to_string()),
+                    Some("input".to_string()),
+                ])),
+            },
+            Case {
+                scenario: "sparse via - and empty string",
+                input: vec!["input", "-", "output", ""],
+                expect: Yields(MlxValueType::EnumArray(vec![
+                    Some("input".to_string()),
+                    None,
+                    Some("output".to_string()),
+                    None,
+                ])),
+            },
+            Case {
+                scenario: "wrong size",
+                input: vec!["input", "output"],
+                expect: Fails,
+            },
+            Case {
+                scenario: "bad option pins position, value, and allowed set",
+                input: vec!["input", "invalid", "output", "input"],
+                expect: FailsWith(MlxValueError::InvalidEnumArrayOption {
+                    position: 1,
+                    value: "invalid".to_string(),
+                    allowed: vec![
+                        "input".to_string(),
+                        "output".to_string(),
+                        "bidirectional".to_string(),
+                    ],
+                }),
+            },
+        ],
+        |raw| parsed(&enum_array_var, raw),
     );
 
-    // Sparse array with "-" notation
-    let sparse_result = enum_array_var
-        .with(vec![
-            "input".to_string(),
-            "-".to_string(),
-            "output".to_string(),
-            "".to_string(), // empty string also means None
-        ])
-        .unwrap();
-    assert_eq!(
-        sparse_result.value,
-        MlxValueType::EnumArray(vec![
-            Some("input".to_string()),
-            None,
-            Some("output".to_string()),
-            None
-        ])
-    );
-
-    // Wrong size.
-    assert!(
-        enum_array_var
-            .with(vec!["input".to_string(), "output".to_string()])
-            .is_err()
-    );
-
-    // Invalid enum option in array.
-    let result = enum_array_var.with(vec![
-        "input".to_string(),
-        "invalid".to_string(),
-        "output".to_string(),
-        "input".to_string(),
-    ]);
-    assert!(result.is_err());
-    match result.unwrap_err() {
-        MlxValueError::InvalidEnumArrayOption {
-            position,
-            value,
-            allowed,
-        } => {
-            assert_eq!(position, 1);
-            assert_eq!(value, "invalid");
-            assert_eq!(allowed, vec!["input", "output", "bidirectional"]);
-        }
-        _ => panic!("Expected InvalidEnumArrayOption error"),
-    }
-
-    // Binary array parsing with sparse support.
+    // Binary array -- hex with or without an 0x/0X prefix, dense and sparse.
     let binary_array_var = create_test_variable(
         "test_binary_array",
         MlxVariableSpec::BinaryArray { size: 3 },
     );
-
-    // Dense array
-    let result = binary_array_var
-        .with(vec![
-            "0x1a2b".to_string(),
-            "3c4d".to_string(),
-            " 0X5E6F ".to_string(),
-        ])
-        .unwrap();
-    assert_eq!(
-        result.value,
-        MlxValueType::BinaryArray(vec![
-            Some(vec![0x1a, 0x2b]),
-            Some(vec![0x3c, 0x4d]),
-            Some(vec![0x5e, 0x6f])
-        ])
+    check_cases(
+        [
+            Case {
+                scenario: "dense, mixed prefixes and whitespace",
+                input: vec!["0x1a2b", "3c4d", " 0X5E6F "],
+                expect: Yields(MlxValueType::BinaryArray(vec![
+                    Some(vec![0x1a, 0x2b]),
+                    Some(vec![0x3c, 0x4d]),
+                    Some(vec![0x5e, 0x6f]),
+                ])),
+            },
+            Case {
+                scenario: "sparse via -",
+                input: vec!["0x1a2b", "-", "3c4d"],
+                expect: Yields(MlxValueType::BinaryArray(vec![
+                    Some(vec![0x1a, 0x2b]),
+                    None,
+                    Some(vec![0x3c, 0x4d]),
+                ])),
+            },
+            Case {
+                scenario: "wrong size",
+                input: vec!["0x1a2b", "3c4d"],
+                expect: Fails,
+            },
+            Case {
+                scenario: "invalid hex element",
+                input: vec!["0x1a2b", "invalid", "3c4d"],
+                expect: Fails,
+            },
+        ],
+        |raw| parsed(&binary_array_var, raw),
     );
 
-    // Sparse array with "-" notation
-    let sparse_result = binary_array_var
-        .with(vec![
-            "0x1a2b".to_string(),
-            "-".to_string(),
-            "3c4d".to_string(),
-        ])
-        .unwrap();
-    assert_eq!(
-        sparse_result.value,
-        MlxValueType::BinaryArray(vec![Some(vec![0x1a, 0x2b]), None, Some(vec![0x3c, 0x4d])])
-    );
-
-    // Wrong size.
-    assert!(
-        binary_array_var
-            .with(vec!["0x1a2b".to_string(), "3c4d".to_string()])
-            .is_err()
-    );
-
-    // Invalid hex in array.
-    assert!(
-        binary_array_var
-            .with(vec![
-                "0x1a2b".to_string(),
-                "invalid".to_string(),
-                "3c4d".to_string()
-            ])
-            .is_err()
-    );
-
-    // Test that array types reject single value specs.
+    // A multi-element vec can't satisfy a single-value spec.
     let string_var = create_test_variable("test_string", MlxVariableSpec::String);
-    assert!(
-        string_var
-            .with(vec!["hello".to_string(), "world".to_string()])
-            .is_err()
-    );
-
+    Case {
+        scenario: "string spec rejects a vec",
+        input: vec!["hello", "world"],
+        expect: Fails,
+    }
+    .check(|raw| parsed(&string_var, raw));
     let enum_var = create_test_variable(
         "test_enum",
         MlxVariableSpec::Enum {
             options: vec!["low".to_string(), "high".to_string()],
         },
     );
-    assert!(
-        enum_var
-            .with(vec!["low".to_string(), "high".to_string()])
-            .is_err()
-    );
+    Case {
+        scenario: "enum spec rejects a vec",
+        input: vec!["low", "high"],
+        expect: Fails,
+    }
+    .check(|raw| parsed(&enum_var, raw));
 }
 
 // test_sparse_array_validation tests that sparse arrays properly validate
@@ -915,198 +939,228 @@ fn test_mixed_dense_and_sparse_operations() {
     assert_eq!(sparse_value.to_display_string(), "[true, -, true]");
 }
 
+// Only the typed array variants report as array types; every scalar -- and the
+// untyped `Array` -- does not. Folds the four per-variant tests and the non-array
+// loop into one table over `is_array_type`.
 #[test]
-fn test_is_array_type_boolean_array() {
-    let array_value = MlxValueType::BooleanArray(vec![Some(true), None, Some(false)]);
-    assert!(array_value.is_array_type());
+fn is_array_type_flags_only_typed_arrays() {
+    check_values(
+        [
+            Check {
+                scenario: "boolean array",
+                input: MlxValueType::BooleanArray(vec![Some(true), None, Some(false)]),
+                expect: true,
+            },
+            Check {
+                scenario: "integer array",
+                input: MlxValueType::IntegerArray(vec![Some(42), None, Some(100)]),
+                expect: true,
+            },
+            Check {
+                scenario: "enum array",
+                input: MlxValueType::EnumArray(vec![
+                    Some("option1".to_string()),
+                    None,
+                    Some("option2".to_string()),
+                ]),
+                expect: true,
+            },
+            Check {
+                scenario: "binary array",
+                input: MlxValueType::BinaryArray(vec![
+                    Some(vec![0x01, 0x02]),
+                    None,
+                    Some(vec![0x03, 0x04]),
+                ]),
+                expect: true,
+            },
+            Check {
+                scenario: "boolean scalar",
+                input: MlxValueType::Boolean(true),
+                expect: false,
+            },
+            Check {
+                scenario: "integer scalar",
+                input: MlxValueType::Integer(42),
+                expect: false,
+            },
+            Check {
+                scenario: "string scalar",
+                input: MlxValueType::String("test".to_string()),
+                expect: false,
+            },
+            Check {
+                scenario: "enum scalar",
+                input: MlxValueType::Enum("option".to_string()),
+                expect: false,
+            },
+            Check {
+                scenario: "preset",
+                input: MlxValueType::Preset(5),
+                expect: false,
+            },
+            Check {
+                scenario: "binary scalar",
+                input: MlxValueType::Binary(vec![0x01, 0x02]),
+                expect: false,
+            },
+            Check {
+                scenario: "bytes",
+                input: MlxValueType::Bytes(vec![0x01, 0x02]),
+                expect: false,
+            },
+            Check {
+                scenario: "untyped string array",
+                input: MlxValueType::Array(vec!["item1".to_string(), "item2".to_string()]),
+                expect: false,
+            },
+            Check {
+                scenario: "opaque",
+                input: MlxValueType::Opaque(vec![0x01, 0x02]),
+                expect: false,
+            },
+        ],
+        |value| value.is_array_type(),
+    );
 }
 
+// `get_set_indices` lists the set (Some) positions of an array value in ascending
+// order, or None for any non-array. Folds the per-variant cases, the edge cases
+// (empty / all-set / all-unset / single), and the non-array loop into one table.
+// Each row's exact index vec already pins the ordering, so the old separate
+// "is it ascending?" assertion is subsumed.
 #[test]
-fn test_is_array_type_integer_array() {
-    let array_value = MlxValueType::IntegerArray(vec![Some(42), None, Some(100)]);
-    assert!(array_value.is_array_type());
-}
-
-#[test]
-fn test_is_array_type_enum_array() {
-    let array_value = MlxValueType::EnumArray(vec![
-        Some("option1".to_string()),
-        None,
-        Some("option2".to_string()),
-    ]);
-    assert!(array_value.is_array_type());
-}
-
-#[test]
-fn test_is_array_type_binary_array() {
-    let array_value =
-        MlxValueType::BinaryArray(vec![Some(vec![0x01, 0x02]), None, Some(vec![0x03, 0x04])]);
-    assert!(array_value.is_array_type());
-}
-
-#[test]
-fn test_is_array_type_non_arrays() {
-    let test_cases = vec![
-        MlxValueType::Boolean(true),
-        MlxValueType::Integer(42),
-        MlxValueType::String("test".to_string()),
-        MlxValueType::Enum("option".to_string()),
-        MlxValueType::Preset(5),
-        MlxValueType::Binary(vec![0x01, 0x02]),
-        MlxValueType::Bytes(vec![0x01, 0x02]),
-        MlxValueType::Array(vec!["item1".to_string(), "item2".to_string()]),
-        MlxValueType::Opaque(vec![0x01, 0x02]),
-    ];
-
-    for value in test_cases {
-        assert!(
-            !value.is_array_type(),
-            "Expected {value:?} to not be an array type",
-        );
-    }
-}
-
-#[test]
-fn test_get_set_indices_boolean_array() {
-    let array_value = MlxValueType::BooleanArray(vec![
-        Some(true),  // index 0
-        None,        // index 1 - not set
-        Some(false), // index 2
-        None,        // index 3 - not set
-        Some(true),  // index 4
-    ]);
-
-    let indices = array_value.get_set_indices().unwrap();
-    assert_eq!(indices, vec![0, 2, 4]);
-}
-
-#[test]
-fn test_get_set_indices_integer_array() {
-    let array_value = MlxValueType::IntegerArray(vec![
-        None,      // index 0 - not set
-        Some(42),  // index 1
-        Some(100), // index 2
-        None,      // index 3 - not set
-    ]);
-
-    let indices = array_value.get_set_indices().unwrap();
-    assert_eq!(indices, vec![1, 2]);
-}
-
-#[test]
-fn test_get_set_indices_enum_array() {
-    let array_value = MlxValueType::EnumArray(vec![
-        Some("option1".to_string()), // index 0
-        Some("option2".to_string()), // index 1
-        None,                        // index 2 - not set
-        Some("option3".to_string()), // index 3
-    ]);
-
-    let indices = array_value.get_set_indices().unwrap();
-    assert_eq!(indices, vec![0, 1, 3]);
-}
-
-#[test]
-fn test_get_set_indices_binary_array() {
-    let array_value = MlxValueType::BinaryArray(vec![
-        Some(vec![0x01, 0x02]), // index 0
-        None,                   // index 1 - not set
-        None,                   // index 2 - not set
-        Some(vec![0x03, 0x04]), // index 3
-    ]);
-
-    let indices = array_value.get_set_indices().unwrap();
-    assert_eq!(indices, vec![0, 3]);
-}
-
-#[test]
-fn test_get_set_indices_all_none() {
-    let array_value = MlxValueType::BooleanArray(vec![None, None, None]);
-    let indices = array_value.get_set_indices().unwrap();
-    assert!(indices.is_empty());
-}
-
-#[test]
-fn test_get_set_indices_all_some() {
-    let array_value = MlxValueType::IntegerArray(vec![Some(1), Some(2), Some(3), Some(4)]);
-    let indices = array_value.get_set_indices().unwrap();
-    assert_eq!(indices, vec![0, 1, 2, 3]);
-}
-
-#[test]
-fn test_get_set_indices_empty_array() {
-    let array_value = MlxValueType::BooleanArray(vec![]);
-    let indices = array_value.get_set_indices().unwrap();
-    assert!(indices.is_empty());
-}
-
-#[test]
-fn test_get_set_indices_single_element() {
-    let array_value = MlxValueType::EnumArray(vec![Some("only_option".to_string())]);
-    let indices = array_value.get_set_indices().unwrap();
-    assert_eq!(indices, vec![0]);
-}
-
-#[test]
-fn test_get_set_indices_non_array_returns_none() {
-    let test_cases = vec![
-        MlxValueType::Boolean(true),
-        MlxValueType::Integer(42),
-        MlxValueType::String("test".to_string()),
-        MlxValueType::Enum("option".to_string()),
-        MlxValueType::Preset(5),
-        MlxValueType::Binary(vec![0x01, 0x02]),
-        MlxValueType::Bytes(vec![0x01, 0x02]),
-        MlxValueType::Array(vec!["item1".to_string(), "item2".to_string()]),
-        MlxValueType::Opaque(vec![0x01, 0x02]),
-    ];
-
-    for value in test_cases {
-        assert!(
-            value.get_set_indices().is_none(),
-            "Expected {value:?} to return None for get_set_indices",
-        );
-    }
-}
-
-#[test]
-fn test_get_set_indices_sparse_pattern() {
-    // Test a realistic sparse array pattern
-    let array_value = MlxValueType::EnumArray(vec![
-        Some("HOST_0".to_string()), // index 0 - set
-        None,                       // index 1 - not set
-        None,                       // index 2 - not set
-        Some("HOST_3".to_string()), // index 3 - set
-        None,                       // index 4 - not set
-        None,                       // index 5 - not set
-        Some("HOST_6".to_string()), // index 6 - set
-        None,                       // index 7 - not set
-    ]);
-
-    let indices = array_value.get_set_indices().unwrap();
-    assert_eq!(indices, vec![0, 3, 6]);
-}
-
-#[test]
-fn test_get_set_indices_maintains_order() {
-    // Ensure indices are returned in ascending order
-    let array_value = MlxValueType::IntegerArray(vec![
-        None,     // index 0
-        Some(10), // index 1
-        None,     // index 2
-        Some(30), // index 3
-        None,     // index 4
-        Some(50), // index 5
-    ]);
-
-    let indices = array_value.get_set_indices().unwrap();
-    assert_eq!(indices, vec![1, 3, 5]);
-
-    // Verify they're in ascending order
-    for window in indices.windows(2) {
-        assert!(
-            window[0] < window[1],
-            "Indices should be in ascending order"
-        );
-    }
+fn get_set_indices_lists_set_positions_for_arrays_only() {
+    check_cases(
+        [
+            Case {
+                scenario: "boolean array, mixed set/unset",
+                input: MlxValueType::BooleanArray(vec![
+                    Some(true),
+                    None,
+                    Some(false),
+                    None,
+                    Some(true),
+                ]),
+                expect: Yields(vec![0, 2, 4]),
+            },
+            Case {
+                scenario: "integer array, leading gap",
+                input: MlxValueType::IntegerArray(vec![None, Some(42), Some(100), None]),
+                expect: Yields(vec![1, 2]),
+            },
+            Case {
+                scenario: "enum array, interior gap",
+                input: MlxValueType::EnumArray(vec![
+                    Some("option1".to_string()),
+                    Some("option2".to_string()),
+                    None,
+                    Some("option3".to_string()),
+                ]),
+                expect: Yields(vec![0, 1, 3]),
+            },
+            Case {
+                scenario: "binary array, interior gaps",
+                input: MlxValueType::BinaryArray(vec![
+                    Some(vec![0x01, 0x02]),
+                    None,
+                    None,
+                    Some(vec![0x03, 0x04]),
+                ]),
+                expect: Yields(vec![0, 3]),
+            },
+            Case {
+                scenario: "all unset",
+                input: MlxValueType::BooleanArray(vec![None, None, None]),
+                expect: Yields(vec![]),
+            },
+            Case {
+                scenario: "all set",
+                input: MlxValueType::IntegerArray(vec![Some(1), Some(2), Some(3), Some(4)]),
+                expect: Yields(vec![0, 1, 2, 3]),
+            },
+            Case {
+                scenario: "empty array",
+                input: MlxValueType::BooleanArray(vec![]),
+                expect: Yields(vec![]),
+            },
+            Case {
+                scenario: "single set element",
+                input: MlxValueType::EnumArray(vec![Some("only_option".to_string())]),
+                expect: Yields(vec![0]),
+            },
+            Case {
+                scenario: "realistic sparse host pattern",
+                input: MlxValueType::EnumArray(vec![
+                    Some("HOST_0".to_string()),
+                    None,
+                    None,
+                    Some("HOST_3".to_string()),
+                    None,
+                    None,
+                    Some("HOST_6".to_string()),
+                    None,
+                ]),
+                expect: Yields(vec![0, 3, 6]),
+            },
+            Case {
+                scenario: "indices stay in ascending order",
+                input: MlxValueType::IntegerArray(vec![
+                    None,
+                    Some(10),
+                    None,
+                    Some(30),
+                    None,
+                    Some(50),
+                ]),
+                expect: Yields(vec![1, 3, 5]),
+            },
+            Case {
+                scenario: "boolean scalar has no indices",
+                input: MlxValueType::Boolean(true),
+                expect: Fails,
+            },
+            Case {
+                scenario: "integer scalar has no indices",
+                input: MlxValueType::Integer(42),
+                expect: Fails,
+            },
+            Case {
+                scenario: "string scalar has no indices",
+                input: MlxValueType::String("test".to_string()),
+                expect: Fails,
+            },
+            Case {
+                scenario: "enum scalar has no indices",
+                input: MlxValueType::Enum("option".to_string()),
+                expect: Fails,
+            },
+            Case {
+                scenario: "preset has no indices",
+                input: MlxValueType::Preset(5),
+                expect: Fails,
+            },
+            Case {
+                scenario: "binary scalar has no indices",
+                input: MlxValueType::Binary(vec![0x01, 0x02]),
+                expect: Fails,
+            },
+            Case {
+                scenario: "bytes have no indices",
+                input: MlxValueType::Bytes(vec![0x01, 0x02]),
+                expect: Fails,
+            },
+            Case {
+                scenario: "untyped string array has no indices",
+                input: MlxValueType::Array(vec!["item1".to_string(), "item2".to_string()]),
+                expect: Fails,
+            },
+            Case {
+                scenario: "opaque has no indices",
+                input: MlxValueType::Opaque(vec![0x01, 0x02]),
+                expect: Fails,
+            },
+        ],
+        |value| value.get_set_indices().ok_or(()),
+    );
 }

--- a/crates/libmlx/tests/variables/test_variable.rs
+++ b/crates/libmlx/tests/variables/test_variable.rs
@@ -30,7 +30,7 @@ fn test_mlx_config_variable_builder_basic() {
     assert_eq!(variable.name, "cpu_frequency");
     assert_eq!(variable.description, "CPU frequency in MHz");
     assert!(!variable.read_only);
-    matches!(variable.spec, MlxVariableSpec::Integer);
+    assert!(matches!(variable.spec, MlxVariableSpec::Integer));
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn test_mlx_config_variable_builder_read_only() {
     assert_eq!(variable.name, "firmware_version");
     assert_eq!(variable.description, "Current firmware version");
     assert!(variable.read_only);
-    matches!(variable.spec, MlxVariableSpec::String);
+    assert!(matches!(variable.spec, MlxVariableSpec::String));
 }
 
 #[test]
@@ -311,15 +311,15 @@ fn test_multiple_variables_with_different_specs() {
     // Verify each variable has the expected properties
     assert_eq!(variables[0].name, "boolean_var");
     assert!(!variables[0].read_only);
-    matches!(variables[0].spec, MlxVariableSpec::Boolean);
+    assert!(matches!(variables[0].spec, MlxVariableSpec::Boolean));
 
     assert_eq!(variables[1].name, "integer_var");
     assert!(!variables[1].read_only);
-    matches!(variables[1].spec, MlxVariableSpec::Integer);
+    assert!(matches!(variables[1].spec, MlxVariableSpec::Integer));
 
     assert_eq!(variables[2].name, "string_var");
     assert!(variables[2].read_only);
-    matches!(variables[2].spec, MlxVariableSpec::String);
+    assert!(matches!(variables[2].spec, MlxVariableSpec::String));
 
     assert_eq!(variables[3].name, "enum_var");
     assert!(!variables[3].read_only);

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -97,6 +97,32 @@
 //! # }
 //! ```
 //!
+//! # A plain value (no `Result`)
+//!
+//! When the operation returns a plain value rather than a `Result` — a `bool`
+//! predicate, a getter — use [`check_values`] with [`Check`]. There's no
+//! [`Outcome`] to dress up; `expect` is just the value:
+//!
+//! ```
+//! use carbide_test_support::{Check, check_values};
+//!
+//! check_values(
+//!     [
+//!         Check {
+//!             scenario: "even",
+//!             input: 4,
+//!             expect: true,
+//!         },
+//!         Check {
+//!             scenario: "odd",
+//!             input: 7,
+//!             expect: false,
+//!         },
+//!     ],
+//!     |n| n % 2 == 0,
+//! );
+//! ```
+//!
 //! # What's shared, and what stays a convention
 //!
 //! [`Outcome`] is the one piece worth sharing — every fallible test otherwise
@@ -212,10 +238,47 @@ where
     }
 }
 
+/// One row of a *total* table test: a labeled `input` and the plain value the
+/// operation is expected to return. The counterpart to [`Case`] for an operation
+/// that can't fail — a predicate, a getter, any `fn(I) -> T`.
+pub struct Check<I, T> {
+    /// What this row exercises; used as the failure label.
+    pub scenario: &'static str,
+    /// The input handed to the operation under test.
+    pub input: I,
+    /// The value the operation should return.
+    pub expect: T,
+}
+
+impl<I, T> Check<I, T> {
+    /// Run this check's `input` through `run` and assert it returns `expect`,
+    /// naming a failure by `scenario`. The single-row counterpart to
+    /// [`check_values`].
+    pub fn check(self, run: impl FnOnce(I) -> T)
+    where
+        T: PartialEq + Debug,
+    {
+        assert_eq!(run(self.input), self.expect, "{}", self.scenario);
+    }
+}
+
+/// Run each check's `input` through `run` and assert the returned value equals its
+/// `expect`. The total-function counterpart to [`check_cases`]: reach for it when
+/// the operation under test returns a plain value — a `bool` predicate, a getter —
+/// rather than a `Result`.
+pub fn check_values<I, T>(checks: impl IntoIterator<Item = Check<I, T>>, run: impl Fn(I) -> T)
+where
+    T: PartialEq + Debug,
+{
+    for check in checks {
+        check.check(&run);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Outcome::*;
-    use super::{Case, assert_outcome, check_cases};
+    use super::{Case, Check, assert_outcome, check_cases, check_values};
 
     #[test]
     fn check_runs_a_single_case() {
@@ -244,6 +307,46 @@ mod tests {
             ],
             |n| n.checked_mul(2).ok_or("overflow"),
         );
+    }
+
+    #[test]
+    fn check_values_runs_every_row() {
+        check_values(
+            [
+                Check {
+                    scenario: "even",
+                    input: 4,
+                    expect: true,
+                },
+                Check {
+                    scenario: "odd",
+                    input: 7,
+                    expect: false,
+                },
+            ],
+            |n| n % 2 == 0,
+        );
+    }
+
+    #[test]
+    fn check_runs_a_single_value() {
+        Check {
+            scenario: "doubles",
+            input: 21,
+            expect: 42,
+        }
+        .check(|n| n * 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "the value is wrong")]
+    fn flags_an_unexpected_value() {
+        Check {
+            scenario: "the value is wrong",
+            input: 1,
+            expect: 2,
+        }
+        .check(|n| n);
     }
 
     #[test]


### PR DESCRIPTION
This supports #3914.

## Description

This refactors `libmlx` tests into the new table-driven test structuring from `carbide-test-support`, allowing us to replace a bunch of copy-pasted test boilerplate with a shared table-driven framework, so the test suite is ideally easier to read, maintain, and provide a pattern to follow.

Test count dropped 20% (from 421 to 336 tests), while maintaining the same test coverage (checked via `cargo-llvm-cov`):

 It's not lost on me that AI is probably going to be the thing writing tests now, and hopefully this will give AI something it can use for writing clean tests for us that are easier for reviewers to verify.

Before/after:
```
  ┌──────────┬──────────────────────┬───────────────┐
  │  Metric  │ Before (origin/main) │ After (this)  │
  ├──────────┼──────────────────────┼───────────────┤
  │ Region   │ 48.61%               │ 48.61%        │
  ├──────────┼──────────────────────┼───────────────┤
  │ Function │ 58.15%               │ 58.15%        │
  ├──────────┼──────────────────────┼───────────────┤
  │ Line     │ 50.18%               │ 50.18%        │
  └──────────┴──────────────────────┴───────────────┘
```

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->