### PR TITLE
test(admin-cli): fold command tests onto carbide-test-support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7173,6 +7173,7 @@ dependencies = [
  "carbide-rpc-utils",
  "carbide-secrets",
  "carbide-ssh",
+ "carbide-test-support",
  "carbide-tls",
  "carbide-utils",
  "carbide-uuid",

--- a/crates/admin-cli/Cargo.toml
+++ b/crates/admin-cli/Cargo.toml
@@ -77,6 +77,9 @@ uuid = { workspace = true }
 x509-parser = { features = ["validate"], workspace = true }
 zip = { workspace = true, default-features = false, features = ["deflate"] }
 
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+
 [build-dependencies]
 clap = { workspace = true }
 carbide-version = { path = "../version" }

--- a/crates/admin-cli/src/bmc_machine/tests.rs
+++ b/crates/admin-cli/src/bmc_machine/tests.rs
@@ -25,6 +25,8 @@
 // Enum Conversions  - Test From implementations for proto <-> non-proto mapping.
 // ValueEnum Parsing - Test string parsing for types deriving claps ValueEnum.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::common::AdminPowerControlAction;
@@ -50,160 +52,175 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_bmc_reset ensures bmc-reset parses with
-// required args.
+// parse_bmc_reset routes to the BmcReset variant; the --machine value is
+// captured verbatim and --use-ipmitool toggles the flag (default off).
 #[test]
 fn parse_bmc_reset() {
-    let cmd = Cmd::try_parse_from(["bmc-machine", "bmc-reset", "--machine", "machine-123"])
-        .expect("should parse bmc-reset");
-
-    match cmd {
-        Cmd::BmcReset(args) => {
-            assert_eq!(args.machine, "machine-123");
-            assert!(!args.use_ipmitool);
-        }
-        _ => panic!("expected BmcReset variant"),
-    }
-}
-
-// parse_bmc_reset_with_ipmitool ensures bmc-reset
-// parses with --use-ipmitool flag.
-#[test]
-fn parse_bmc_reset_with_ipmitool() {
-    let cmd = Cmd::try_parse_from([
-        "bmc-machine",
-        "bmc-reset",
-        "--machine",
-        "machine-123",
-        "--use-ipmitool",
-    ])
-    .expect("should parse bmc-reset with ipmitool");
-
-    match cmd {
-        Cmd::BmcReset(args) => {
-            assert!(args.use_ipmitool);
-        }
-        _ => panic!("expected BmcReset variant"),
-    }
-}
-
-// parse_admin_power_control ensures admin-power-control
-// parses correctly.
-#[test]
-fn parse_admin_power_control() {
-    let cmd = Cmd::try_parse_from([
-        "bmc-machine",
-        "admin-power-control",
-        "--machine",
-        "machine-123",
-        "--action",
-        "on",
-    ])
-    .expect("should parse admin-power-control");
-
-    match cmd {
-        Cmd::AdminPowerControl(args) => {
-            assert_eq!(args.machine, "machine-123");
-            assert!(matches!(args.action, AdminPowerControlAction::On));
-        }
-        _ => panic!("expected AdminPowerControl variant"),
-    }
-}
-
-// parse_lockdown_enable ensures lockdown parses with
-// --enable.
-#[test]
-fn parse_lockdown_enable() {
-    let cmd = Cmd::try_parse_from([
-        "bmc-machine",
-        "lockdown",
-        "--machine",
-        TEST_MACHINE_ID,
-        "--enable",
-    ])
-    .expect("should parse lockdown with enable");
-
-    match cmd {
-        Cmd::Lockdown(args) => {
-            assert!(args.enable);
-            assert!(!args.disable);
-        }
-        _ => panic!("expected Lockdown variant"),
-    }
-}
-
-// parse_lockdown_disable ensures lockdown parses with
-// --disable.
-#[test]
-fn parse_lockdown_disable() {
-    let cmd = Cmd::try_parse_from([
-        "bmc-machine",
-        "lockdown",
-        "--machine",
-        TEST_MACHINE_ID,
-        "--disable",
-    ])
-    .expect("should parse lockdown with disable");
-
-    match cmd {
-        Cmd::Lockdown(args) => {
-            assert!(!args.enable);
-            assert!(args.disable);
-        }
-        _ => panic!("expected Lockdown variant"),
-    }
-}
-
-// parse_lockdown_requires_enable_or_disable ensures
-// lockdown fails without enable/disable.
-#[test]
-fn parse_lockdown_requires_enable_or_disable() {
-    let result = Cmd::try_parse_from(["bmc-machine", "lockdown", "--machine", TEST_MACHINE_ID]);
-    assert!(result.is_err(), "should fail without --enable or --disable");
-}
-
-// parse_lockdown_conflicts_enable_disable ensures
-// lockdown fails with both enable and disable.
-#[test]
-fn parse_lockdown_conflicts_enable_disable() {
-    let result = Cmd::try_parse_from([
-        "bmc-machine",
-        "lockdown",
-        "--machine",
-        TEST_MACHINE_ID,
-        "--enable",
-        "--disable",
-    ]);
-    assert!(
-        result.is_err(),
-        "should fail with both --enable and --disable"
+    check_cases(
+        [
+            Case {
+                scenario: "bmc-reset with required args, ipmitool off",
+                input: &["bmc-machine", "bmc-reset", "--machine", "machine-123"][..],
+                expect: Yields(("machine-123".to_string(), false)),
+            },
+            Case {
+                scenario: "bmc-reset with --use-ipmitool",
+                input: &[
+                    "bmc-machine",
+                    "bmc-reset",
+                    "--machine",
+                    "machine-123",
+                    "--use-ipmitool",
+                ][..],
+                expect: Yields(("machine-123".to_string(), true)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::BmcReset(args) => (args.machine, args.use_ipmitool),
+                    _ => panic!("expected BmcReset variant"),
+                })
+                .map_err(drop)
+        },
     );
 }
 
-// parse_create_bmc_user ensures create-bmc-user parses
-// correctly.
+// parse_admin_power_control routes to the AdminPowerControl variant; the
+// --machine value is captured and --action on maps to the On action.
+#[test]
+fn parse_admin_power_control() {
+    check_cases(
+        [Case {
+            scenario: "admin-power-control --action on",
+            input: &[
+                "bmc-machine",
+                "admin-power-control",
+                "--machine",
+                "machine-123",
+                "--action",
+                "on",
+            ][..],
+            expect: Yields(("machine-123".to_string(), true)),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::AdminPowerControl(args) => (
+                        args.machine,
+                        matches!(args.action, AdminPowerControlAction::On),
+                    ),
+                    _ => panic!("expected AdminPowerControl variant"),
+                })
+                .map_err(drop)
+        },
+    );
+}
+
+// parse_lockdown routes to the Lockdown variant; --enable and --disable are
+// mutually exclusive flags, each setting exactly its own bool.
+#[test]
+fn parse_lockdown() {
+    check_cases(
+        [
+            Case {
+                scenario: "lockdown --enable",
+                input: &[
+                    "bmc-machine",
+                    "lockdown",
+                    "--machine",
+                    TEST_MACHINE_ID,
+                    "--enable",
+                ][..],
+                expect: Yields((true, false)),
+            },
+            Case {
+                scenario: "lockdown --disable",
+                input: &[
+                    "bmc-machine",
+                    "lockdown",
+                    "--machine",
+                    TEST_MACHINE_ID,
+                    "--disable",
+                ][..],
+                expect: Yields((false, true)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Lockdown(args) => (args.enable, args.disable),
+                    _ => panic!("expected Lockdown variant"),
+                })
+                .map_err(drop)
+        },
+    );
+}
+
+// parse_create_bmc_user routes to the CreateBmcUser variant, capturing the
+// username, password, and optional IP address.
 #[test]
 fn parse_create_bmc_user() {
-    let cmd = Cmd::try_parse_from([
-        "bmc-machine",
-        "create-bmc-user",
-        "--username",
-        "admin",
-        "--password",
-        "secret123",
-        "--ip-address",
-        "192.168.1.100",
-    ])
-    .expect("should parse create-bmc-user");
+    check_cases(
+        [Case {
+            scenario: "create-bmc-user with username, password, and ip",
+            input: &[
+                "bmc-machine",
+                "create-bmc-user",
+                "--username",
+                "admin",
+                "--password",
+                "secret123",
+                "--ip-address",
+                "192.168.1.100",
+            ][..],
+            expect: Yields((
+                "admin".to_string(),
+                "secret123".to_string(),
+                Some("192.168.1.100".to_string()),
+            )),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::CreateBmcUser(args) => (args.username, args.password, args.ip_address),
+                    _ => panic!("expected CreateBmcUser variant"),
+                })
+                .map_err(drop)
+        },
+    );
+}
 
-    match cmd {
-        Cmd::CreateBmcUser(args) => {
-            assert_eq!(args.username, "admin");
-            assert_eq!(args.password, "secret123");
-            assert_eq!(args.ip_address, Some("192.168.1.100".to_string()));
-        }
-        _ => panic!("expected CreateBmcUser variant"),
-    }
+// Every malformed lockdown invocation is rejected at parse time -- neither
+// --enable nor --disable, or both at once (a conflict).
+#[test]
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "lockdown without --enable or --disable",
+                input: &["bmc-machine", "lockdown", "--machine", TEST_MACHINE_ID][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "lockdown with both --enable and --disable",
+                input: &[
+                    "bmc-machine",
+                    "lockdown",
+                    "--machine",
+                    TEST_MACHINE_ID,
+                    "--enable",
+                    "--disable",
+                ][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/crates/admin-cli/src/boot_override/tests.rs
+++ b/crates/admin-cli/src/boot_override/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,130 +46,143 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_get ensures get subcommand parses interface_id.
+// parse_get ensures the get subcommand routes to the Get variant and
+// parses its interface_id.
 #[test]
 fn parse_get() {
-    let cmd = Cmd::try_parse_from([
-        "boot-override",
-        "get",
-        "550e8400-e29b-41d4-a716-446655440000",
-    ])
-    .expect("should parse get");
-
-    match cmd {
-        Cmd::Get(args) => {
-            assert_eq!(
-                args.inner.interface_id.to_string(),
-                "550e8400-e29b-41d4-a716-446655440000"
-            );
-        }
-        _ => panic!("expected Get variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "get parses interface_id",
+            input: &[
+                "boot-override",
+                "get",
+                "550e8400-e29b-41d4-a716-446655440000",
+            ][..],
+            expect: Yields("550e8400-e29b-41d4-a716-446655440000".to_string()),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Get(args) => args.inner.interface_id.to_string(),
+                    _ => panic!("expected Get variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_clear ensures clear subcommand parses interface_id.
+// parse_clear ensures the clear subcommand routes to the Clear variant and
+// parses its interface_id.
 #[test]
 fn parse_clear() {
-    let cmd = Cmd::try_parse_from([
-        "boot-override",
-        "clear",
-        "550e8400-e29b-41d4-a716-446655440000",
-    ])
-    .expect("should parse clear");
-
-    match cmd {
-        Cmd::Clear(args) => {
-            assert_eq!(
-                args.inner.interface_id.to_string(),
-                "550e8400-e29b-41d4-a716-446655440000"
-            );
-        }
-        _ => panic!("expected Clear variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "clear parses interface_id",
+            input: &[
+                "boot-override",
+                "clear",
+                "550e8400-e29b-41d4-a716-446655440000",
+            ][..],
+            expect: Yields("550e8400-e29b-41d4-a716-446655440000".to_string()),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Clear(args) => args.inner.interface_id.to_string(),
+                    _ => panic!("expected Clear variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_set_basic ensures set subcommand parses with
-// just interface_id.
+// parse_set covers the set subcommand: it parses with just interface_id
+// (custom flags unset), with the long --custom-pxe/--custom-user-data flags,
+// and with the short -p/-u aliases. Each row yields the parsed
+// (interface_id, custom_pxe, custom_user_data).
 #[test]
-fn parse_set_basic() {
-    let cmd = Cmd::try_parse_from([
-        "boot-override",
-        "set",
-        "550e8400-e29b-41d4-a716-446655440000",
-    ])
-    .expect("should parse set");
+fn parse_set() {
+    type SetFields = (String, Option<String>, Option<String>);
 
-    match cmd {
-        Cmd::Set(args) => {
-            assert_eq!(
-                args.interface_id.to_string(),
-                "550e8400-e29b-41d4-a716-446655440000"
-            );
-            assert!(args.custom_pxe.is_none());
-            assert!(args.custom_user_data.is_none());
-        }
-        _ => panic!("expected Set variant"),
-    }
+    check_cases(
+        [
+            Case {
+                scenario: "set with just interface_id leaves the custom flags unset",
+                input: &[
+                    "boot-override",
+                    "set",
+                    "550e8400-e29b-41d4-a716-446655440000",
+                ][..],
+                expect: Yields((
+                    "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                    None,
+                    None,
+                )),
+            },
+            Case {
+                scenario: "set with the long --custom-pxe/--custom-user-data flags",
+                input: &[
+                    "boot-override",
+                    "set",
+                    "550e8400-e29b-41d4-a716-446655440000",
+                    "--custom-pxe",
+                    "http://pxe.example.com/boot",
+                    "--custom-user-data",
+                    "some-user-data",
+                ][..],
+                expect: Yields((
+                    "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                    Some("http://pxe.example.com/boot".to_string()),
+                    Some("some-user-data".to_string()),
+                )),
+            },
+            Case {
+                scenario: "set with the short -p/-u aliases",
+                input: &[
+                    "boot-override",
+                    "set",
+                    "550e8400-e29b-41d4-a716-446655440000",
+                    "-p",
+                    "http://pxe.example.com/boot",
+                    "-u",
+                    "some-user-data",
+                ][..],
+                expect: Yields((
+                    "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                    Some("http://pxe.example.com/boot".to_string()),
+                    Some("some-user-data".to_string()),
+                )),
+            },
+        ],
+        |argv| -> Result<SetFields, ()> {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Set(args) => (
+                        args.interface_id.to_string(),
+                        args.custom_pxe,
+                        args.custom_user_data,
+                    ),
+                    _ => panic!("expected Set variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_set_with_options ensures set subcommand parses
-// with custom_pxe and custom_user_data.
+// Every malformed invocation is rejected at parse time -- here, a subcommand
+// invoked without its required interface_id.
 #[test]
-fn parse_set_with_options() {
-    let cmd = Cmd::try_parse_from([
-        "boot-override",
-        "set",
-        "550e8400-e29b-41d4-a716-446655440000",
-        "--custom-pxe",
-        "http://pxe.example.com/boot",
-        "--custom-user-data",
-        "some-user-data",
-    ])
-    .expect("should parse set with options");
-
-    match cmd {
-        Cmd::Set(args) => {
-            assert_eq!(
-                args.custom_pxe,
-                Some("http://pxe.example.com/boot".to_string())
-            );
-            assert_eq!(args.custom_user_data, Some("some-user-data".to_string()));
-        }
-        _ => panic!("expected Set variant"),
-    }
-}
-
-// parse_set_short_options ensures set subcommand parses
-// short flags -p and -u.
-#[test]
-fn parse_set_short_options() {
-    let cmd = Cmd::try_parse_from([
-        "boot-override",
-        "set",
-        "550e8400-e29b-41d4-a716-446655440000",
-        "-p",
-        "http://pxe.example.com/boot",
-        "-u",
-        "some-user-data",
-    ])
-    .expect("should parse set with short options");
-
-    match cmd {
-        Cmd::Set(args) => {
-            assert_eq!(
-                args.custom_pxe,
-                Some("http://pxe.example.com/boot".to_string())
-            );
-            assert_eq!(args.custom_user_data, Some("some-user-data".to_string()));
-        }
-        _ => panic!("expected Set variant"),
-    }
-}
-
-// parse_requires_interface_id ensures subcommands
-// require interface_id.
-#[test]
-fn parse_requires_interface_id() {
-    let result = Cmd::try_parse_from(["boot-override", "get"]);
-    assert!(result.is_err(), "should fail without interface_id");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [Case {
+            scenario: "get without interface_id",
+            input: &["boot-override", "get"][..],
+            expect: Fails,
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/component_manager/update_firmware/args.rs
+++ b/crates/admin-cli/src/component_manager/update_firmware/args.rs
@@ -324,6 +324,9 @@ impl TryFrom<Args> for rpc::forge::UpdateComponentFirmwareRequest {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     fn temp_sot_file(contents: &str) -> PathBuf {
@@ -339,90 +342,98 @@ mod tests {
         path
     }
 
+    // A firmware source resolves to its (target_version, access_token) pair:
+    // a legacy --target-version passes through verbatim with no token, while a
+    // SOT JSON file resolves to the file's contents paired with the token --
+    // an empty token collapsing to None.
     #[test]
-    fn target_version_source_uses_legacy_version() {
-        let (target_version, access_token) = resolve_firmware_source(FirmwareSourceArgs {
-            target_version: Some("fw-1.0".to_string()),
-            sot_json_file: None,
-            access_token: None,
-        })
-        .expect("legacy source should resolve");
+    fn firmware_source_resolves_target_version_and_token() {
+        let sot_token = temp_sot_file(r#"{"Id":"fw-object"}"#);
+        let sot_no_token = temp_sot_file(r#"{"Id":"fw-object"}"#);
+        let sot_empty_token = temp_sot_file(r#"{"Id":"fw-object"}"#);
 
-        assert_eq!(target_version, "fw-1.0");
-        assert_eq!(access_token, None);
+        check_cases(
+            [
+                Case {
+                    scenario: "legacy --target-version passes through with no token",
+                    input: FirmwareSourceArgs {
+                        target_version: Some("fw-1.0".to_string()),
+                        sot_json_file: None,
+                        access_token: None,
+                    },
+                    expect: Yields(("fw-1.0".to_string(), None)),
+                },
+                Case {
+                    scenario: "SOT JSON file resolves to its contents and the access token",
+                    input: FirmwareSourceArgs {
+                        target_version: None,
+                        sot_json_file: Some(sot_token.clone()),
+                        access_token: Some("token".to_string()),
+                    },
+                    expect: Yields((
+                        r#"{"Id":"fw-object"}"#.to_string(),
+                        Some("token".to_string()),
+                    )),
+                },
+                Case {
+                    scenario: "SOT JSON file resolves without an access token",
+                    input: FirmwareSourceArgs {
+                        target_version: None,
+                        sot_json_file: Some(sot_no_token.clone()),
+                        access_token: None,
+                    },
+                    expect: Yields((r#"{"Id":"fw-object"}"#.to_string(), None)),
+                },
+                Case {
+                    scenario: "an empty access token collapses to None",
+                    input: FirmwareSourceArgs {
+                        target_version: None,
+                        sot_json_file: Some(sot_empty_token.clone()),
+                        access_token: Some(String::new()),
+                    },
+                    expect: Yields((r#"{"Id":"fw-object"}"#.to_string(), None)),
+                },
+            ],
+            |source| resolve_firmware_source(source).map_err(drop),
+        );
+
+        let _ = std::fs::remove_file(sot_token);
+        let _ = std::fs::remove_file(sot_no_token);
+        let _ = std::fs::remove_file(sot_empty_token);
     }
 
+    // A firmware source is rejected when its parts are incoherent: an access
+    // token without a SOT JSON file has nothing to authenticate, and a SOT JSON
+    // file whose contents aren't valid JSON can't be parsed. (CarbideCliError is
+    // not PartialEq, so these assert only that resolution fails.)
     #[test]
-    fn sot_json_source_reads_file_and_sets_access_token() {
-        let path = temp_sot_file(r#"{"Id":"fw-object"}"#);
+    fn firmware_source_rejects_incoherent_inputs() {
+        let invalid_json = temp_sot_file("not-json");
 
-        let (target_version, access_token) = resolve_firmware_source(FirmwareSourceArgs {
-            target_version: None,
-            sot_json_file: Some(path.clone()),
-            access_token: Some("token".to_string()),
-        })
-        .expect("SOT source should resolve");
+        check_cases(
+            [
+                Case {
+                    scenario: "access token without a SOT JSON file",
+                    input: FirmwareSourceArgs {
+                        target_version: Some("fw-1.0".to_string()),
+                        sot_json_file: None,
+                        access_token: Some("token".to_string()),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "SOT JSON file whose contents are not valid JSON",
+                    input: FirmwareSourceArgs {
+                        target_version: None,
+                        sot_json_file: Some(invalid_json.clone()),
+                        access_token: Some("token".to_string()),
+                    },
+                    expect: Fails,
+                },
+            ],
+            |source| resolve_firmware_source(source).map_err(drop),
+        );
 
-        assert_eq!(target_version, r#"{"Id":"fw-object"}"#);
-        assert_eq!(access_token.as_deref(), Some("token"));
-        let _ = std::fs::remove_file(path);
-    }
-
-    #[test]
-    fn sot_json_source_allows_missing_access_token() {
-        let path = temp_sot_file(r#"{"Id":"fw-object"}"#);
-
-        let (target_version, access_token) = resolve_firmware_source(FirmwareSourceArgs {
-            target_version: None,
-            sot_json_file: Some(path.clone()),
-            access_token: None,
-        })
-        .expect("SOT source should resolve without an access token");
-
-        assert_eq!(target_version, r#"{"Id":"fw-object"}"#);
-        assert_eq!(access_token, None);
-        let _ = std::fs::remove_file(path);
-    }
-
-    #[test]
-    fn sot_json_source_treats_empty_access_token_as_missing() {
-        let path = temp_sot_file(r#"{"Id":"fw-object"}"#);
-
-        let (_, access_token) = resolve_firmware_source(FirmwareSourceArgs {
-            target_version: None,
-            sot_json_file: Some(path.clone()),
-            access_token: Some(String::new()),
-        })
-        .expect("SOT source should resolve with an empty access token");
-
-        assert_eq!(access_token, None);
-        let _ = std::fs::remove_file(path);
-    }
-
-    #[test]
-    fn access_token_without_sot_json_file_is_rejected() {
-        let err = resolve_firmware_source(FirmwareSourceArgs {
-            target_version: Some("fw-1.0".to_string()),
-            sot_json_file: None,
-            access_token: Some("token".to_string()),
-        })
-        .expect_err("access token without SOT JSON should fail");
-
-        assert!(err.to_string().contains("--access-token requires"));
-    }
-
-    #[test]
-    fn invalid_sot_json_file_is_rejected() {
-        let path = temp_sot_file("not-json");
-
-        let err = resolve_firmware_source(FirmwareSourceArgs {
-            target_version: None,
-            sot_json_file: Some(path.clone()),
-            access_token: Some("token".to_string()),
-        })
-        .expect_err("invalid SOT JSON should fail");
-
-        assert!(matches!(err, CarbideCliError::JsonError(_)));
-        let _ = std::fs::remove_file(path);
+        let _ = std::fs::remove_file(invalid_json);
     }
 }

--- a/crates/admin-cli/src/credential/tests.rs
+++ b/crates/admin-cli/src/credential/tests.rs
@@ -26,6 +26,8 @@
 // ValueEnum Parsing - Test string parsing for types deriving claps ValueEnum.
 // Custom Validators - Test external input validation functions.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::common::{BmcCredentialType, UefiCredentialType, password_validator, url_validator};
@@ -48,51 +50,42 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_add_ufm_with_required_args ensures add-ufm
-// parses with only required args.
+// add-ufm routes to the AddUFM variant and carries its url plus token, where the
+// token defaults to the empty string when its optional flag is omitted.
 #[test]
-fn parse_add_ufm_with_required_args() {
-    let cmd = Cmd::try_parse_from(["credential", "add-ufm", "--url", "https://ufm.example.com"])
-        .expect("should parse with required args");
-
-    match cmd {
-        Cmd::AddUFM(args) => {
-            assert_eq!(args.url, "https://ufm.example.com");
-            assert_eq!(args.token, ""); // default value
-        }
-        _ => panic!("expected AddUFM variant"),
-    }
-}
-
-// parse_add_ufm_with_token ensures add-ufm parses with
-// optional token.
-#[test]
-fn parse_add_ufm_with_token() {
-    let cmd = Cmd::try_parse_from([
-        "credential",
-        "add-ufm",
-        "--url",
-        "https://ufm.example.com",
-        "--token",
-        "my-secret-token",
-    ])
-    .expect("should parse with token");
-
-    match cmd {
-        Cmd::AddUFM(args) => {
-            assert_eq!(args.url, "https://ufm.example.com");
-            assert_eq!(args.token, "my-secret-token");
-        }
-        _ => panic!("expected AddUFM variant"),
-    }
-}
-
-// parse_add_ufm_missing_url_fails ensures add-ufm
-// requires --url.
-#[test]
-fn parse_add_ufm_missing_url_fails() {
-    let result = Cmd::try_parse_from(["credential", "add-ufm"]);
-    assert!(result.is_err(), "should fail without required --url");
+fn parse_add_ufm_fields() {
+    check_cases(
+        [
+            Case {
+                scenario: "required args only -- token defaults to empty",
+                input: &["credential", "add-ufm", "--url", "https://ufm.example.com"][..],
+                expect: Yields(("https://ufm.example.com".to_string(), String::new())),
+            },
+            Case {
+                scenario: "with optional --token",
+                input: &[
+                    "credential",
+                    "add-ufm",
+                    "--url",
+                    "https://ufm.example.com",
+                    "--token",
+                    "my-secret-token",
+                ][..],
+                expect: Yields((
+                    "https://ufm.example.com".to_string(),
+                    "my-secret-token".to_string(),
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::AddUFM(args) => (args.url, args.token),
+                    _ => panic!("expected AddUFM variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
 // parse_add_bmc_with_all_args ensures add-bmc parses
@@ -121,21 +114,6 @@ fn parse_add_bmc_with_all_args() {
         }
         _ => panic!("expected AddBMC variant"),
     }
-}
-
-// parse_add_bmc_requires_kind_equals ensures add-bmc
-// --kind requires = sign.
-#[test]
-fn parse_add_bmc_requires_kind_equals() {
-    let result = Cmd::try_parse_from([
-        "credential",
-        "add-bmc",
-        "--kind",
-        "site-wide-root",
-        "--password",
-        "secret",
-    ]);
-    assert!(result.is_err(), "should fail without = in --kind=value");
 }
 
 // parse_add_uefi ensures add-uefi parses correctly.
@@ -178,12 +156,41 @@ fn parse_add_nic_lockdown_ikm() {
     }
 }
 
-// parse_add_nic_lockdown_ikm_missing_password_fails ensures the password is
-// required.
+// Every malformed invocation is rejected at parse time -- a subcommand missing
+// its required flag, or a --kind value passed without the required `=` separator.
 #[test]
-fn parse_add_nic_lockdown_ikm_missing_password_fails() {
-    let result = Cmd::try_parse_from(["credential", "add-nic-lockdown-ikm"]);
-    assert!(result.is_err(), "should fail without required --password");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "add-ufm without required --url",
+                input: &["credential", "add-ufm"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "add-bmc --kind without the = separator",
+                input: &[
+                    "credential",
+                    "add-bmc",
+                    "--kind",
+                    "site-wide-root",
+                    "--password",
+                    "secret",
+                ][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "add-nic-lockdown-ikm without required --password",
+                input: &["credential", "add-nic-lockdown-ikm"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }
 
 // add_nic_lockdown_ikm_maps_to_proto ensures the parsed args convert into a
@@ -301,35 +308,69 @@ fn uefi_credential_type_value_enum() {
 // which are processed by custom/external validation
 // functions. Here, we test that the functions work as expected.
 
-// url_validator_accepts_valid_urls ensures valid URLs
-// pass validation.
+// url_validator accepts well-formed http(s) URLs and rejects anything that does
+// not parse as a URL (including the empty string).
 #[test]
-fn url_validator_accepts_valid_urls() {
-    assert!(url_validator("https://example.com".to_string()).is_ok());
-    assert!(url_validator("http://localhost:8080".to_string()).is_ok());
-    assert!(url_validator("https://ufm.corp.example.com/api".to_string()).is_ok());
+fn url_validator_accepts_only_valid_urls() {
+    check_cases(
+        [
+            Case {
+                scenario: "https host",
+                input: "https://example.com",
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "http host with port",
+                input: "http://localhost:8080",
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "https host with path",
+                input: "https://ufm.corp.example.com/api",
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "not a url",
+                input: "not a url",
+                expect: Fails,
+            },
+            Case {
+                scenario: "empty string",
+                input: "",
+                expect: Fails,
+            },
+        ],
+        |url| url_validator(url.to_string()).map(|_| ()).map_err(drop),
+    );
 }
 
-// url_validator_rejects_invalid_urls ensures invalid
-// URLs fail validation.
+// password_validator accepts any non-empty password and rejects only the empty
+// string.
 #[test]
-fn url_validator_rejects_invalid_urls() {
-    assert!(url_validator("not a url".to_string()).is_err());
-    assert!(url_validator("".to_string()).is_err());
-}
-
-// password_validator_accepts_non_empty ensures non-empty
-// passwords pass validation.
-#[test]
-fn password_validator_accepts_non_empty() {
-    assert!(password_validator("secret123".to_string()).is_ok());
-    assert!(password_validator("a".to_string()).is_ok());
-    assert!(password_validator("spaces are ok".to_string()).is_ok());
-}
-
-// password_validator_rejects_empty ensures empty
-// passwords fail validation.
-#[test]
-fn password_validator_rejects_empty() {
-    assert!(password_validator("".to_string()).is_err());
+fn password_validator_accepts_only_non_empty() {
+    check_cases(
+        [
+            Case {
+                scenario: "ordinary password",
+                input: "secret123",
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "single character",
+                input: "a",
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "spaces are allowed",
+                input: "spaces are ok",
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "empty string is rejected",
+                input: "",
+                expect: Fails,
+            },
+        ],
+        |pw| password_validator(pw.to_string()).map(|_| ()).map_err(drop),
+    );
 }

--- a/crates/admin-cli/src/devenv/tests.rs
+++ b/crates/admin-cli/src/devenv/tests.rs
@@ -24,6 +24,8 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 // ValueEnum Parsing - Test string parsing for types deriving claps ValueEnum.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -45,116 +47,122 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_config_apply_network_segment ensures config
-// apply parses with network-segment mode.
+// config apply routes to Cmd::Config(Apply) for every accepted invocation:
+// the long --mode/-m forms, the kebab-case mode values, and the visible `c`
+// (config) and `a` (apply) aliases. Each row yields the parsed (path, mode).
 #[test]
-fn parse_config_apply_network_segment() {
-    let cmd = Cmd::try_parse_from([
-        "devenv",
-        "config",
-        "apply",
-        "/path/to/config.toml",
-        "--mode",
-        "network-segment",
-    ])
-    .expect("should parse config apply");
-
-    match cmd {
-        Cmd::Config(config::Cmd::Apply(args)) => {
-            assert_eq!(args.path, "/path/to/config.toml");
-            assert_eq!(args.mode, config::NetworkChoice::NetworkSegment);
-        }
-    }
+fn config_apply_parses_path_and_mode() {
+    check_cases(
+        [
+            Case {
+                scenario: "network-segment mode parses path and mode",
+                input: &[
+                    "devenv",
+                    "config",
+                    "apply",
+                    "/path/to/config.toml",
+                    "--mode",
+                    "network-segment",
+                ][..],
+                expect: Yields((
+                    "/path/to/config.toml".to_string(),
+                    config::NetworkChoice::NetworkSegment,
+                )),
+            },
+            Case {
+                scenario: "vpc-prefix mode parses",
+                input: &[
+                    "devenv",
+                    "config",
+                    "apply",
+                    "/path/to/config.toml",
+                    "--mode",
+                    "vpc-prefix",
+                ][..],
+                expect: Yields((
+                    "/path/to/config.toml".to_string(),
+                    config::NetworkChoice::VpcPrefix,
+                )),
+            },
+            Case {
+                scenario: "-m short flag parses",
+                input: &[
+                    "devenv",
+                    "config",
+                    "apply",
+                    "/path/to/config.toml",
+                    "-m",
+                    "network-segment",
+                ][..],
+                expect: Yields((
+                    "/path/to/config.toml".to_string(),
+                    config::NetworkChoice::NetworkSegment,
+                )),
+            },
+            Case {
+                scenario: "config alias 'c' routes to apply",
+                input: &[
+                    "devenv",
+                    "c",
+                    "apply",
+                    "/path/to/config.toml",
+                    "-m",
+                    "network-segment",
+                ][..],
+                expect: Yields((
+                    "/path/to/config.toml".to_string(),
+                    config::NetworkChoice::NetworkSegment,
+                )),
+            },
+            Case {
+                scenario: "apply alias 'a' routes to apply",
+                input: &[
+                    "devenv",
+                    "config",
+                    "a",
+                    "/path/to/config.toml",
+                    "-m",
+                    "network-segment",
+                ][..],
+                expect: Yields((
+                    "/path/to/config.toml".to_string(),
+                    config::NetworkChoice::NetworkSegment,
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Config(config::Cmd::Apply(args)) => (args.path, args.mode),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_config_apply_vpc_prefix ensures config apply
-// parses with vpc-prefix mode.
+// config apply requires both its positional path and its --mode flag; either
+// one missing is rejected at parse time.
 #[test]
-fn parse_config_apply_vpc_prefix() {
-    let cmd = Cmd::try_parse_from([
-        "devenv",
-        "config",
-        "apply",
-        "/path/to/config.toml",
-        "--mode",
-        "vpc-prefix",
-    ])
-    .expect("should parse config apply with vpc-prefix");
-
-    match cmd {
-        Cmd::Config(config::Cmd::Apply(args)) => {
-            assert_eq!(args.mode, config::NetworkChoice::VpcPrefix);
-        }
-    }
-}
-
-// parse_config_apply_short_mode ensures config apply
-// parses with -m short flag.
-#[test]
-fn parse_config_apply_short_mode() {
-    let cmd = Cmd::try_parse_from([
-        "devenv",
-        "config",
-        "apply",
-        "/path/to/config.toml",
-        "-m",
-        "network-segment",
-    ])
-    .expect("should parse with -m");
-
-    match cmd {
-        Cmd::Config(config::Cmd::Apply(args)) => {
-            assert_eq!(args.mode, config::NetworkChoice::NetworkSegment);
-        }
-    }
-}
-
-// parse_config_alias ensures config has visible alias 'c'.
-#[test]
-fn parse_config_alias() {
-    let cmd = Cmd::try_parse_from([
-        "devenv",
-        "c",
-        "apply",
-        "/path/to/config.toml",
-        "-m",
-        "network-segment",
-    ])
-    .expect("should parse via config alias");
-
-    assert!(matches!(cmd, Cmd::Config(_)));
-}
-
-// parse_apply_alias ensures apply has visible alias 'a'.
-#[test]
-fn parse_apply_alias() {
-    let cmd = Cmd::try_parse_from([
-        "devenv",
-        "config",
-        "a",
-        "/path/to/config.toml",
-        "-m",
-        "network-segment",
-    ])
-    .expect("should parse via apply alias");
-
-    assert!(matches!(cmd, Cmd::Config(config::Cmd::Apply(_))));
-}
-
-// parse_missing_path_fails ensures config apply
-// requires path.
-#[test]
-fn parse_missing_path_fails() {
-    let result = Cmd::try_parse_from(["devenv", "config", "apply", "-m", "network-segment"]);
-    assert!(result.is_err(), "should fail without path");
-}
-
-// parse_missing_mode_fails ensures config apply
-// requires --mode.
-#[test]
-fn parse_missing_mode_fails() {
-    let result = Cmd::try_parse_from(["devenv", "config", "apply", "/path/to/config.toml"]);
-    assert!(result.is_err(), "should fail without --mode");
+fn config_apply_rejects_missing_required_args() {
+    check_cases(
+        [
+            Case {
+                scenario: "missing path",
+                input: &["devenv", "config", "apply", "-m", "network-segment"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "missing --mode",
+                input: &["devenv", "config", "apply", "/path/to/config.toml"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -165,19 +173,30 @@ fn parse_missing_mode_fails() {
 // values correctly convert back into their expected variant,
 // or fail otherwise.
 
-// network_choice_value_enum ensures NetworkChoice parses
-// from kebab-case strings.
+// NetworkChoice parses from its kebab-case ValueEnum strings and rejects
+// anything else.
 #[test]
 fn network_choice_value_enum() {
     use clap::ValueEnum;
 
-    assert!(matches!(
-        config::NetworkChoice::from_str("network-segment", false),
-        Ok(config::NetworkChoice::NetworkSegment)
-    ));
-    assert!(matches!(
-        config::NetworkChoice::from_str("vpc-prefix", false),
-        Ok(config::NetworkChoice::VpcPrefix)
-    ));
-    assert!(config::NetworkChoice::from_str("invalid", false).is_err());
+    check_cases(
+        [
+            Case {
+                scenario: "network-segment",
+                input: "network-segment",
+                expect: Yields(config::NetworkChoice::NetworkSegment),
+            },
+            Case {
+                scenario: "vpc-prefix",
+                input: "vpc-prefix",
+                expect: Yields(config::NetworkChoice::VpcPrefix),
+            },
+            Case {
+                scenario: "invalid value",
+                input: "invalid",
+                expect: Fails,
+            },
+        ],
+        |s| config::NetworkChoice::from_str(s, false).map_err(drop),
+    );
 }

--- a/crates/admin-cli/src/domain/tests.rs
+++ b/crates/admin-cli/src/domain/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,29 +46,30 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all domains).
+// show parses with or without the (deprecated) --all flag; bare `show` means
+// all domains with no specific domain selected, and --all flips the flag. Each
+// row yields the `(all, domain.is_some())` pair the originals asserted.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["domain", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(!args.all);
-            assert!(args.domain.is_none());
-        }
-    }
-}
-
-// parse_show_with_all_flag ensures show parses with
-// --all flag (deprecated).
-#[test]
-fn parse_show_with_all_flag() {
-    let cmd = Cmd::try_parse_from(["domain", "show", "--all"]).expect("should parse show --all");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.all);
-        }
-    }
+fn parse_show_variants() {
+    check_cases(
+        [
+            Case {
+                scenario: "no arguments (all domains)",
+                input: &["domain", "show"][..],
+                expect: Yields((false, false)),
+            },
+            Case {
+                scenario: "--all flag (deprecated)",
+                input: &["domain", "show", "--all"][..],
+                expect: Yields((true, false)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => (args.all, args.domain.is_some()),
+                })
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/dpa/tests.rs
+++ b/crates/admin-cli/src/dpa/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 use rpc::forge::DpaInterfaceType;
 
@@ -45,44 +47,64 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all DPAs).
+// show routes to the Show variant; with no positional argument its `id`
+// is left unset (the "all DPAs" case).
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["dpa", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_none());
-        }
-        other => panic!("expected Show, got {other:?}"),
-    }
+fn parse_show() {
+    check_cases(
+        [Case {
+            scenario: "show with no arguments leaves id unset",
+            input: &["dpa", "show"][..],
+            expect: Yields(true),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => args.id.is_none(),
+                    other => panic!("expected Show, got {other:?}"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
+// ensure routes to the Ensure variant, threading every positional through
+// to the parsed fields (machine id, MAC, device type, PCI name, interface).
 #[test]
-fn parse_ensure_args() {
-    let cmd = Cmd::try_parse_from([
-        "dpa",
-        "ensure",
-        "fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30",
-        "00:11:22:33:44:55",
-        "BlueField3",
-        "01:00.0",
-        "svpc",
-    ])
-    .expect("should parse ensure");
-
-    match cmd {
-        Cmd::Ensure(args) => {
-            assert_eq!(
-                args.machine_id.to_string(),
-                "fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30"
-            );
-            assert_eq!(args.mac_addr, "00:11:22:33:44:55");
-            assert_eq!(args.device_type, "BlueField3");
-            assert_eq!(args.pci_name, "01:00.0");
-            assert_eq!(args.interface_type, DpaInterfaceType::Svpc);
-        }
-        other => panic!("expected Ensure, got {other:?}"),
-    }
+fn parse_ensure() {
+    check_cases(
+        [Case {
+            scenario: "ensure with all positional arguments",
+            input: &[
+                "dpa",
+                "ensure",
+                "fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30",
+                "00:11:22:33:44:55",
+                "BlueField3",
+                "01:00.0",
+                "svpc",
+            ][..],
+            expect: Yields((
+                "fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30".to_string(),
+                "00:11:22:33:44:55".to_string(),
+                "BlueField3".to_string(),
+                "01:00.0".to_string(),
+                DpaInterfaceType::Svpc,
+            )),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Ensure(args) => (
+                        args.machine_id.to_string(),
+                        args.mac_addr,
+                        args.device_type,
+                        args.pci_name,
+                        args.interface_type,
+                    ),
+                    other => panic!("expected Ensure, got {other:?}"),
+                })
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/dpu/tests.rs
+++ b/crates/admin-cli/src/dpu/tests.rs
@@ -24,6 +24,8 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 // ValueEnum Parsing - Test string parsing for types deriving claps ValueEnum.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -48,115 +50,116 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_status ensures status parses with no
-// arguments.
+// parse_status ensures status routes to the Status variant
+// with no arguments.
 #[test]
 fn parse_status() {
     let cmd = Cmd::try_parse_from(["dpu", "status"]).expect("should parse status");
     assert!(matches!(cmd, Cmd::Status(_)));
 }
 
-// parse_versions ensures versions parses with no
-// arguments.
+// versions parses with and without --updates-only; the parsed flag mirrors
+// whether the switch was supplied.
 #[test]
 fn parse_versions() {
-    let cmd = Cmd::try_parse_from(["dpu", "versions"]).expect("should parse versions");
-
-    match cmd {
-        Cmd::Versions(args) => {
-            assert!(!args.updates_only);
-        }
-        _ => panic!("expected Versions variant"),
-    }
+    check_cases(
+        [
+            Case {
+                scenario: "versions with no flags leaves updates_only off",
+                input: &["dpu", "versions"][..],
+                expect: Yields(false),
+            },
+            Case {
+                scenario: "versions --updates-only sets the flag",
+                input: &["dpu", "versions", "--updates-only"][..],
+                expect: Yields(true),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Versions(args) => args.updates_only,
+                    _ => panic!("expected Versions variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_versions_updates_only ensures versions parses
-// with --updates-only.
+// reprovision routes to its three subcommands: list (no payload), set (an id
+// plus the --update-firmware flag), and clear (an id). The closure yields the
+// subcommand name, the machine id as a string (empty for list), and the
+// update_firmware flag.
 #[test]
-fn parse_versions_updates_only() {
-    let cmd = Cmd::try_parse_from(["dpu", "versions", "--updates-only"])
-        .expect("should parse versions --updates-only");
-
-    match cmd {
-        Cmd::Versions(args) => {
-            assert!(args.updates_only);
-        }
-        _ => panic!("expected Versions variant"),
-    }
+fn parse_reprovision() {
+    check_cases(
+        [
+            Case {
+                scenario: "reprovision list routes to List",
+                input: &["dpu", "reprovision", "list"][..],
+                expect: Yields(("list", String::new(), false)),
+            },
+            Case {
+                scenario: "reprovision set carries the machine id, firmware off",
+                input: &["dpu", "reprovision", "set", "--id", TEST_MACHINE_ID][..],
+                expect: Yields(("set", TEST_MACHINE_ID.to_string(), false)),
+            },
+            Case {
+                scenario: "reprovision clear carries the machine id",
+                input: &["dpu", "reprovision", "clear", "--id", TEST_MACHINE_ID][..],
+                expect: Yields(("clear", TEST_MACHINE_ID.to_string(), false)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Reprovision(reprovision::Args::List) => ("list", String::new(), false),
+                    Cmd::Reprovision(reprovision::Args::Set(args)) => {
+                        ("set", args.id.to_string(), args.update_firmware)
+                    }
+                    Cmd::Reprovision(reprovision::Args::Clear(args)) => {
+                        ("clear", args.id.to_string(), false)
+                    }
+                    _ => panic!("expected Reprovision variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_reprovision_list ensures reprovision list
-// parses.
+// agent-upgrade-policy parses with no --set (get, leaving set unset) and with
+// --set up-only (selecting the UpOnly choice). The closure yields the policy
+// name the parsed --set resolves to ("<get>" when unset).
 #[test]
-fn parse_reprovision_list() {
-    let cmd =
-        Cmd::try_parse_from(["dpu", "reprovision", "list"]).expect("should parse reprovision list");
-
-    assert!(matches!(cmd, Cmd::Reprovision(reprovision::Args::List)));
-}
-
-// parse_reprovision_set ensures reprovision set parses
-// with machine ID.
-#[test]
-fn parse_reprovision_set() {
-    let cmd = Cmd::try_parse_from(["dpu", "reprovision", "set", "--id", TEST_MACHINE_ID])
-        .expect("should parse reprovision set");
-
-    match cmd {
-        Cmd::Reprovision(reprovision::Args::Set(args)) => {
-            assert_eq!(args.id.to_string(), TEST_MACHINE_ID);
-            assert!(!args.update_firmware);
-        }
-        _ => panic!("expected Reprovision Set variant"),
-    }
-}
-
-// parse_reprovision_clear ensures reprovision clear
-// parses with machine ID.
-#[test]
-fn parse_reprovision_clear() {
-    let cmd = Cmd::try_parse_from(["dpu", "reprovision", "clear", "--id", TEST_MACHINE_ID])
-        .expect("should parse reprovision clear");
-
-    match cmd {
-        Cmd::Reprovision(reprovision::Args::Clear(args)) => {
-            assert_eq!(args.id.to_string(), TEST_MACHINE_ID);
-        }
-        _ => panic!("expected Reprovision Clear variant"),
-    }
-}
-
-// parse_agent_upgrade_policy_get ensures
-// agent-upgrade-policy parses for get.
-#[test]
-fn parse_agent_upgrade_policy_get() {
-    let cmd = Cmd::try_parse_from(["dpu", "agent-upgrade-policy"])
-        .expect("should parse agent-upgrade-policy");
-
-    match cmd {
-        Cmd::AgentUpgradePolicy(args) => {
-            assert!(args.set.is_none());
-        }
-        _ => panic!("expected AgentUpgradePolicy variant"),
-    }
-}
-
-// parse_agent_upgrade_policy_set ensures
-// agent-upgrade-policy parses with --set.
-#[test]
-fn parse_agent_upgrade_policy_set() {
-    let cmd = Cmd::try_parse_from(["dpu", "agent-upgrade-policy", "--set", "up-only"])
-        .expect("should parse agent-upgrade-policy --set");
-
-    match cmd {
-        Cmd::AgentUpgradePolicy(args) => {
-            assert!(matches!(
-                args.set,
-                Some(agent_upgrade_policy::args::AgentUpgradePolicyChoice::UpOnly)
-            ));
-        }
-        _ => panic!("expected AgentUpgradePolicy variant"),
-    }
+fn parse_agent_upgrade_policy() {
+    check_cases(
+        [
+            Case {
+                scenario: "no --set is a get and leaves the policy unset",
+                input: &["dpu", "agent-upgrade-policy"][..],
+                expect: Yields("<get>"),
+            },
+            Case {
+                scenario: "--set up-only selects the UpOnly policy",
+                input: &["dpu", "agent-upgrade-policy", "--set", "up-only"][..],
+                expect: Yields("up-only"),
+            },
+        ],
+        |argv| {
+            use agent_upgrade_policy::args::AgentUpgradePolicyChoice;
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::AgentUpgradePolicy(args) => match args.set {
+                        None => "<get>",
+                        Some(AgentUpgradePolicyChoice::Off) => "off",
+                        Some(AgentUpgradePolicyChoice::UpOnly) => "up-only",
+                        Some(AgentUpgradePolicyChoice::UpDown) => "up-down",
+                    },
+                    _ => panic!("expected AgentUpgradePolicy variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -168,23 +171,45 @@ fn parse_agent_upgrade_policy_set() {
 // or fail otherwise.
 
 // agent_upgrade_policy_choice_value_enum ensures AgentUpgradePolicyChoice
-// parses from strings.
+// parses each valid string to its variant and rejects an unknown value. The
+// enum is not PartialEq, so the closure yields a discriminant name; rows
+// assert that name or a Fails for the unknown value.
 #[test]
 fn agent_upgrade_policy_choice_value_enum() {
     use agent_upgrade_policy::args::AgentUpgradePolicyChoice;
     use clap::ValueEnum;
 
-    assert!(matches!(
-        AgentUpgradePolicyChoice::from_str("off", false),
-        Ok(AgentUpgradePolicyChoice::Off)
-    ));
-    assert!(matches!(
-        AgentUpgradePolicyChoice::from_str("up-only", false),
-        Ok(AgentUpgradePolicyChoice::UpOnly)
-    ));
-    assert!(matches!(
-        AgentUpgradePolicyChoice::from_str("up-down", false),
-        Ok(AgentUpgradePolicyChoice::UpDown)
-    ));
-    assert!(AgentUpgradePolicyChoice::from_str("invalid", false).is_err());
+    check_cases(
+        [
+            Case {
+                scenario: "\"off\" parses to Off",
+                input: "off",
+                expect: Yields("off"),
+            },
+            Case {
+                scenario: "\"up-only\" parses to UpOnly",
+                input: "up-only",
+                expect: Yields("up-only"),
+            },
+            Case {
+                scenario: "\"up-down\" parses to UpDown",
+                input: "up-down",
+                expect: Yields("up-down"),
+            },
+            Case {
+                scenario: "an unknown value is rejected",
+                input: "invalid",
+                expect: Fails,
+            },
+        ],
+        |s| {
+            AgentUpgradePolicyChoice::from_str(s, false)
+                .map(|choice| match choice {
+                    AgentUpgradePolicyChoice::Off => "off",
+                    AgentUpgradePolicyChoice::UpOnly => "up-only",
+                    AgentUpgradePolicyChoice::UpDown => "up-down",
+                })
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/dpu_remediation/tests.rs
+++ b/crates/admin-cli/src/dpu_remediation/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,108 +46,131 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_create ensures create parses with required
-// script_filename.
+// create routes to the Create variant. A bare invocation leaves the optional
+// fields unset; supplying every flag fills them in. Each row yields the parsed
+// (script_filename, retries, meta_name, meta_description, has_labels).
 #[test]
-fn parse_create() {
-    let cmd = Cmd::try_parse_from([
-        "dpu-remediation",
-        "create",
-        "--script-filename",
-        "/path/to/script.sh",
-    ])
-    .expect("should parse create");
-
-    match cmd {
-        Cmd::Create(args) => {
-            assert_eq!(args.script_filename, "/path/to/script.sh");
-            assert!(args.retries.is_none());
-            assert!(args.meta_name.is_none());
-        }
-        _ => panic!("expected Create variant"),
-    }
+fn parse_create_routes_and_fills_fields() {
+    check_cases(
+        [
+            Case {
+                scenario: "required script-filename only",
+                input: &[
+                    "dpu-remediation",
+                    "create",
+                    "--script-filename",
+                    "/path/to/script.sh",
+                ][..],
+                expect: Yields(("/path/to/script.sh".to_string(), None, None, None, false)),
+            },
+            Case {
+                scenario: "all options supplied",
+                input: &[
+                    "dpu-remediation",
+                    "create",
+                    "--script-filename",
+                    "/path/to/script.sh",
+                    "--retries",
+                    "3",
+                    "--meta-name",
+                    "My Remediation",
+                    "--meta-description",
+                    "Fixes a bug",
+                    "--label",
+                    "env:prod",
+                ][..],
+                expect: Yields((
+                    "/path/to/script.sh".to_string(),
+                    Some(3),
+                    Some("My Remediation".to_string()),
+                    Some("Fixes a bug".to_string()),
+                    true,
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Create(args) => (
+                        args.script_filename,
+                        args.retries,
+                        args.meta_name,
+                        args.meta_description,
+                        args.labels.is_some(),
+                    ),
+                    _ => panic!("expected Create variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_create_with_options ensures create parses with
-// all options.
+// show routes to the Show variant. Each row yields (id_present, display_script):
+// a bare invocation leaves the id unset and the flag off, and --display-script
+// turns the flag on.
 #[test]
-fn parse_create_with_options() {
-    let cmd = Cmd::try_parse_from([
-        "dpu-remediation",
-        "create",
-        "--script-filename",
-        "/path/to/script.sh",
-        "--retries",
-        "3",
-        "--meta-name",
-        "My Remediation",
-        "--meta-description",
-        "Fixes a bug",
-        "--label",
-        "env:prod",
-    ])
-    .expect("should parse create with options");
-
-    match cmd {
-        Cmd::Create(args) => {
-            assert_eq!(args.retries, Some(3));
-            assert_eq!(args.meta_name, Some("My Remediation".to_string()));
-            assert_eq!(args.meta_description, Some("Fixes a bug".to_string()));
-            assert!(args.labels.is_some());
-        }
-        _ => panic!("expected Create variant"),
-    }
+fn parse_show_routes_and_fills_fields() {
+    check_cases(
+        [
+            Case {
+                scenario: "no arguments",
+                input: &["dpu-remediation", "show"][..],
+                expect: Yields((false, false)),
+            },
+            Case {
+                scenario: "with --display-script",
+                input: &["dpu-remediation", "show", "--display-script"][..],
+                expect: Yields((false, true)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => (args.id.is_some(), args.display_script),
+                    _ => panic!("expected Show variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_no_args ensures show parses with no arguments.
+// list-applied routes to the ListApplied variant. A bare invocation leaves both
+// optional filters unset; the row yields (remediation_id_present, machine_id_present).
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["dpu-remediation", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_none());
-            assert!(!args.display_script);
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_list_applied_routes_and_fills_fields() {
+    check_cases(
+        [Case {
+            scenario: "no arguments",
+            input: &["dpu-remediation", "list-applied"][..],
+            expect: Yields((false, false)),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::ListApplied(args) => {
+                        (args.remediation_id.is_some(), args.machine_id.is_some())
+                    }
+                    _ => panic!("expected ListApplied variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_with_display_script ensures show parses
-// with --display-script.
+// Every malformed invocation is rejected at parse time -- here, create without
+// its required --script-filename.
 #[test]
-fn parse_show_with_display_script() {
-    let cmd = Cmd::try_parse_from(["dpu-remediation", "show", "--display-script"])
-        .expect("should parse show --display-script");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.display_script);
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_list_applied_no_args ensures list-applied
-// parses with no arguments.
-#[test]
-fn parse_list_applied_no_args() {
-    let cmd = Cmd::try_parse_from(["dpu-remediation", "list-applied"])
-        .expect("should parse list-applied");
-
-    match cmd {
-        Cmd::ListApplied(args) => {
-            assert!(args.remediation_id.is_none());
-            assert!(args.machine_id.is_none());
-        }
-        _ => panic!("expected ListApplied variant"),
-    }
-}
-
-// parse_create_missing_script_fails ensures create
-// fails without --script-filename.
-#[test]
-fn parse_create_missing_script_fails() {
-    let result = Cmd::try_parse_from(["dpu-remediation", "create"]);
-    assert!(result.is_err(), "should fail without --script-filename");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [Case {
+            scenario: "create without --script-filename",
+            input: &["dpu-remediation", "create"][..],
+            expect: Fails,
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/expected_machines/tests.rs
+++ b/crates/admin-cli/src/expected_machines/tests.rs
@@ -24,6 +24,8 @@
 // Argument Parsing    - Ensure required/optional arg combinations parse correctly.
 // Validation Logic    - Test business logic validators on parsed arguments.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -228,70 +230,70 @@ fn parse_erase() {
     assert!(matches!(cmd, Cmd::Erase(_)));
 }
 
-// parse_add_missing_required_fails ensures add fails
-// without required arguments.
+// Every malformed invocation is rejected at parse time -- a missing required
+// argument, one half of a paired credential, or a flag left without its value.
 #[test]
-fn parse_add_missing_required_fails() {
-    let result = Cmd::try_parse_from(["expected-machine", "add"]);
-    assert!(result.is_err(), "should fail without required arguments");
-}
-
-// parse_patch_username_requires_password ensures patch
-// fails with username only (password required).
-#[test]
-fn parse_patch_username_requires_password() {
-    let result = Cmd::try_parse_from([
-        "expected-machine",
-        "patch",
-        "--bmc-mac-address",
-        "00:00:00:00:00:00",
-        "--bmc-username",
-        "admin",
-    ]);
-    assert!(result.is_err(), "should fail with username but no password");
-}
-
-// parse_patch_password_requires_username ensures patch
-// fails with password only (username required).
-#[test]
-fn parse_patch_password_requires_username() {
-    let result = Cmd::try_parse_from([
-        "expected-machine",
-        "patch",
-        "--bmc-mac-address",
-        "00:00:00:00:00:00",
-        "--bmc-password",
-        "secret",
-    ]);
-    assert!(result.is_err(), "should fail with password but no username");
-}
-
-// parse_update_missing_filename_fails ensures update
-// fails without --filename.
-#[test]
-fn parse_update_missing_filename_fails() {
-    let result = Cmd::try_parse_from(["expected-machine", "update"]);
-    assert!(result.is_err(), "should fail without --filename");
-}
-
-// parse_add_dpu_serial_requires_value ensures add fails
-// when --fallback-dpu-serial-number has no value.
-#[test]
-fn parse_add_dpu_serial_requires_value() {
-    let result = Cmd::try_parse_from([
-        "expected-machine",
-        "add",
-        "--bmc-mac-address",
-        "0a:0b:0c:0d:0e:0f",
-        "--bmc-username",
-        "admin",
-        "--bmc-password",
-        "secret",
-        "--chassis-serial-number",
-        "SN12345",
-        "--fallback-dpu-serial-number",
-    ]);
-    assert!(result.is_err(), "should fail without dpu serial value");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "add without its required arguments",
+                input: &["expected-machine", "add"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "patch with a username but no password",
+                input: &[
+                    "expected-machine",
+                    "patch",
+                    "--bmc-mac-address",
+                    "00:00:00:00:00:00",
+                    "--bmc-username",
+                    "admin",
+                ][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "patch with a password but no username",
+                input: &[
+                    "expected-machine",
+                    "patch",
+                    "--bmc-mac-address",
+                    "00:00:00:00:00:00",
+                    "--bmc-password",
+                    "secret",
+                ][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "update without --filename",
+                input: &["expected-machine", "update"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "add with --fallback-dpu-serial-number missing its value",
+                input: &[
+                    "expected-machine",
+                    "add",
+                    "--bmc-mac-address",
+                    "0a:0b:0c:0d:0e:0f",
+                    "--bmc-username",
+                    "admin",
+                    "--bmc-password",
+                    "secret",
+                    "--chassis-serial-number",
+                    "SN12345",
+                    "--fallback-dpu-serial-number",
+                ][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -300,86 +302,77 @@ fn parse_add_dpu_serial_requires_value() {
 // This section tests business logic validators on parsed arguments,
 // including custom validation methods like duplicate detection.
 
-// validate_no_duplicate_dpu_serials ensures
-// has_duplicate_dpu_serials returns false for unique serials.
+// has_duplicate_dpu_serials flags a repeated `-d` serial on an otherwise valid
+// add: unique serials and the no-serials case are clean, a repeat is caught.
 #[test]
-fn validate_no_duplicate_dpu_serials() {
-    let machine = add::Args::try_parse_from([
-        "ExpectedMachine",
-        "--bmc-mac-address",
-        "0a:0b:0c:0d:0e:0f",
-        "--bmc-username",
-        "admin",
-        "--bmc-password",
-        "secret",
-        "--chassis-serial-number",
-        "SN12345",
-        "--fallback-dpu-serial-number",
-        "dpu1",
-        "-d",
-        "dpu2",
-        "-d",
-        "dpu3",
-    ])
-    .expect("should parse");
-
-    assert!(
-        !machine.has_duplicate_dpu_serials(),
-        "unique serials should not be duplicates"
-    );
-}
-
-// validate_duplicate_dpu_serials_detected ensures
-// has_duplicate_dpu_serials returns true for duplicates.
-#[test]
-fn validate_duplicate_dpu_serials_detected() {
-    let machine = add::Args::try_parse_from([
-        "ExpectedMachine",
-        "--bmc-mac-address",
-        "0a:0b:0c:0d:0e:0f",
-        "--bmc-username",
-        "admin",
-        "--bmc-password",
-        "secret",
-        "--chassis-serial-number",
-        "SN12345",
-        "-d",
-        "dpu1",
-        "-d",
-        "dpu2",
-        "-d",
-        "dpu3",
-        "-d",
-        "dpu1",
-    ])
-    .expect("should parse");
-
-    assert!(
-        machine.has_duplicate_dpu_serials(),
-        "duplicate serials should be detected"
-    );
-}
-
-// validate_empty_dpu_serials ensures has_duplicate_dpu_serials
-// returns false when no serials provided.
-#[test]
-fn validate_empty_dpu_serials() {
-    let machine = add::Args::try_parse_from([
-        "ExpectedMachine",
-        "--bmc-mac-address",
-        "0a:0b:0c:0d:0e:0f",
-        "--bmc-username",
-        "admin",
-        "--bmc-password",
-        "secret",
-        "--chassis-serial-number",
-        "SN12345",
-    ])
-    .expect("should parse");
-
-    assert!(
-        !machine.has_duplicate_dpu_serials(),
-        "empty serials should not be duplicates"
+fn has_duplicate_dpu_serials_flags_repeats() {
+    check_cases(
+        [
+            Case {
+                scenario: "three unique serials",
+                input: &[
+                    "ExpectedMachine",
+                    "--bmc-mac-address",
+                    "0a:0b:0c:0d:0e:0f",
+                    "--bmc-username",
+                    "admin",
+                    "--bmc-password",
+                    "secret",
+                    "--chassis-serial-number",
+                    "SN12345",
+                    "--fallback-dpu-serial-number",
+                    "dpu1",
+                    "-d",
+                    "dpu2",
+                    "-d",
+                    "dpu3",
+                ][..],
+                expect: Yields(false),
+            },
+            Case {
+                scenario: "a repeated serial is detected",
+                input: &[
+                    "ExpectedMachine",
+                    "--bmc-mac-address",
+                    "0a:0b:0c:0d:0e:0f",
+                    "--bmc-username",
+                    "admin",
+                    "--bmc-password",
+                    "secret",
+                    "--chassis-serial-number",
+                    "SN12345",
+                    "-d",
+                    "dpu1",
+                    "-d",
+                    "dpu2",
+                    "-d",
+                    "dpu3",
+                    "-d",
+                    "dpu1",
+                ][..],
+                expect: Yields(true),
+            },
+            Case {
+                scenario: "no serials at all",
+                input: &[
+                    "ExpectedMachine",
+                    "--bmc-mac-address",
+                    "0a:0b:0c:0d:0e:0f",
+                    "--bmc-username",
+                    "admin",
+                    "--bmc-password",
+                    "secret",
+                    "--chassis-serial-number",
+                    "SN12345",
+                ][..],
+                expect: Yields(false),
+            },
+        ],
+        |argv| {
+            add::Args::try_parse_from(argv.iter().copied())
+                .map(|m| m.has_duplicate_dpu_serials())
+                .map_err(drop)
+        },
     );
 }
 

--- a/crates/admin-cli/src/expected_power_shelf/tests.rs
+++ b/crates/admin-cli/src/expected_power_shelf/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,153 +46,186 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all power shelves).
-#[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["expected-power-shelf", "show"]).expect("should parse show");
-
+// variant names the subcommand a parsed `Cmd` routed to, so cases that only
+// assert routing (delete, erase) can compare a stable string.
+fn variant(cmd: &Cmd) -> &'static str {
     match cmd {
-        Cmd::Show(args) => {
-            assert!(args.bmc_mac_address.is_none());
-        }
-        _ => panic!("expected Show variant"),
+        Cmd::Show(_) => "show",
+        Cmd::Add(_) => "add",
+        Cmd::Delete(_) => "delete",
+        Cmd::Update(_) => "update",
+        Cmd::ReplaceAll(_) => "replace-all",
+        Cmd::Erase(_) => "erase",
     }
 }
 
-// parse_show_with_mac ensures show parses with MAC address.
+// show parses both with no MAC argument (all power shelves) and with one; the
+// yielded bool is whether `bmc_mac_address` was supplied.
 #[test]
-fn parse_show_with_mac() {
-    let cmd = Cmd::try_parse_from(["expected-power-shelf", "show", "1a:2b:3c:4d:5e:6f"])
-        .expect("should parse show with MAC");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.bmc_mac_address.is_some());
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_show() {
+    check_cases(
+        [
+            Case {
+                scenario: "show with no arguments (all power shelves)",
+                input: &["expected-power-shelf", "show"][..],
+                expect: Yields(false),
+            },
+            Case {
+                scenario: "show with a MAC address",
+                input: &["expected-power-shelf", "show", "1a:2b:3c:4d:5e:6f"][..],
+                expect: Yields(true),
+            },
+        ],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::Show(args)) => Ok(args.bmc_mac_address.is_some()),
+            Ok(other) => panic!("expected Show variant, got {}", variant(&other)),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_add ensures add parses with required arguments.
+// add parses with the required arguments alone and with the full optional set;
+// the yielded tuple is the fields the originals asserted (username, serial,
+// and the optional meta-name).
 #[test]
 fn parse_add() {
-    let cmd = Cmd::try_parse_from([
-        "expected-power-shelf",
-        "add",
-        "--bmc-mac-address",
-        "1a:2b:3c:4d:5e:6f",
-        "--bmc-username",
-        "admin",
-        "--bmc-password",
-        "secret",
-        "--shelf-serial-number",
-        "SHELF12345",
-    ])
-    .expect("should parse add");
-
-    match cmd {
-        Cmd::Add(args) => {
-            assert_eq!(args.bmc_username, "admin");
-            assert_eq!(args.shelf_serial_number, "SHELF12345");
-        }
-        _ => panic!("expected Add variant"),
-    }
+    check_cases(
+        [
+            Case {
+                scenario: "add with required arguments",
+                input: &[
+                    "expected-power-shelf",
+                    "add",
+                    "--bmc-mac-address",
+                    "1a:2b:3c:4d:5e:6f",
+                    "--bmc-username",
+                    "admin",
+                    "--bmc-password",
+                    "secret",
+                    "--shelf-serial-number",
+                    "SHELF12345",
+                ][..],
+                expect: Yields(("admin".to_string(), "SHELF12345".to_string(), None)),
+            },
+            Case {
+                scenario: "add with all options",
+                input: &[
+                    "expected-power-shelf",
+                    "add",
+                    "--bmc-mac-address",
+                    "1a:2b:3c:4d:5e:6f",
+                    "--bmc-username",
+                    "admin",
+                    "--bmc-password",
+                    "secret",
+                    "--shelf-serial-number",
+                    "SHELF12345",
+                    "--meta-name",
+                    "MyPowerShelf",
+                    "--label",
+                    "env:prod",
+                ][..],
+                expect: Yields((
+                    "admin".to_string(),
+                    "SHELF12345".to_string(),
+                    Some("MyPowerShelf".to_string()),
+                )),
+            },
+        ],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::Add(args)) => Ok((args.bmc_username, args.shelf_serial_number, args.meta_name)),
+            Ok(other) => panic!("expected Add variant, got {}", variant(&other)),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_add_with_options ensures add parses with
-// all options.
-#[test]
-fn parse_add_with_options() {
-    let cmd = Cmd::try_parse_from([
-        "expected-power-shelf",
-        "add",
-        "--bmc-mac-address",
-        "1a:2b:3c:4d:5e:6f",
-        "--bmc-username",
-        "admin",
-        "--bmc-password",
-        "secret",
-        "--shelf-serial-number",
-        "SHELF12345",
-        "--meta-name",
-        "MyPowerShelf",
-        "--label",
-        "env:prod",
-    ])
-    .expect("should parse add with options");
-
-    match cmd {
-        Cmd::Add(args) => {
-            assert_eq!(args.meta_name, Some("MyPowerShelf".to_string()));
-        }
-        _ => panic!("expected Add variant"),
-    }
-}
-
-// parse_delete ensures delete parses with MAC address.
-#[test]
-fn parse_delete() {
-    let cmd = Cmd::try_parse_from(["expected-power-shelf", "delete", "1a:2b:3c:4d:5e:6f"])
-        .expect("should parse delete");
-
-    assert!(matches!(cmd, Cmd::Delete(_)));
-}
-
-// parse_update ensures update parses with required
-// arguments.
+// update parses with the required arguments; the yielded value is the new
+// serial number the original asserted.
 #[test]
 fn parse_update() {
-    let cmd = Cmd::try_parse_from([
-        "expected-power-shelf",
-        "update",
-        "--bmc-mac-address",
-        "1a:2b:3c:4d:5e:6f",
-        "--shelf-serial-number",
-        "NEW_SERIAL",
-    ])
-    .expect("should parse update");
-
-    match cmd {
-        Cmd::Update(args) => {
-            assert_eq!(args.shelf_serial_number, Some("NEW_SERIAL".to_string()));
-        }
-        _ => panic!("expected Update variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "update with required arguments",
+            input: &[
+                "expected-power-shelf",
+                "update",
+                "--bmc-mac-address",
+                "1a:2b:3c:4d:5e:6f",
+                "--shelf-serial-number",
+                "NEW_SERIAL",
+            ][..],
+            expect: Yields(Some("NEW_SERIAL".to_string())),
+        }],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::Update(args)) => Ok(args.shelf_serial_number),
+            Ok(other) => panic!("expected Update variant, got {}", variant(&other)),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_replace_all ensures replace-all parses with
-// filename.
+// replace-all parses with a filename; the yielded value is that filename.
 #[test]
 fn parse_replace_all() {
-    let cmd = Cmd::try_parse_from([
-        "expected-power-shelf",
-        "replace-all",
-        "--filename",
-        "shelves.json",
-    ])
-    .expect("should parse replace-all");
-
-    match cmd {
-        Cmd::ReplaceAll(args) => {
-            assert_eq!(args.filename, "shelves.json");
-        }
-        _ => panic!("expected ReplaceAll variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "replace-all with a filename",
+            input: &[
+                "expected-power-shelf",
+                "replace-all",
+                "--filename",
+                "shelves.json",
+            ][..],
+            expect: Yields("shelves.json".to_string()),
+        }],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::ReplaceAll(args)) => Ok(args.filename),
+            Ok(other) => panic!("expected ReplaceAll variant, got {}", variant(&other)),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_erase ensures erase parses with no arguments.
+// delete and erase only need to route to their respective subcommand variant;
+// the yielded value is the variant name.
 #[test]
-fn parse_erase() {
-    let cmd = Cmd::try_parse_from(["expected-power-shelf", "erase"]).expect("should parse erase");
-
-    assert!(matches!(cmd, Cmd::Erase(_)));
+fn parse_routes_to_variant() {
+    check_cases(
+        [
+            Case {
+                scenario: "delete with a MAC address",
+                input: &["expected-power-shelf", "delete", "1a:2b:3c:4d:5e:6f"][..],
+                expect: Yields("delete"),
+            },
+            Case {
+                scenario: "erase with no arguments",
+                input: &["expected-power-shelf", "erase"][..],
+                expect: Yields("erase"),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| variant(&cmd))
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_add_missing_required_fails ensures add fails
-// without required arguments.
+// Every malformed invocation is rejected at parse time -- here, an add missing
+// its required arguments.
 #[test]
-fn parse_add_missing_required_fails() {
-    let result = Cmd::try_parse_from(["expected-power-shelf", "add"]);
-    assert!(result.is_err(), "should fail without required arguments");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [Case {
+            scenario: "add without its required arguments",
+            input: &["expected-power-shelf", "add"][..],
+            expect: Fails,
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/expected_switch/tests.rs
+++ b/crates/admin-cli/src/expected_switch/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,153 +46,197 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all switches).
+// show parses with or without an optional MAC address; the yielded bool is
+// whether a MAC was supplied.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["expected-switch", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.bmc_mac_address.is_none());
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_show() {
+    check_cases(
+        [
+            Case {
+                scenario: "show with no arguments (all switches)",
+                input: &["expected-switch", "show"][..],
+                expect: Yields(false),
+            },
+            Case {
+                scenario: "show with a MAC address",
+                input: &["expected-switch", "show", "1a:2b:3c:4d:5e:6f"][..],
+                expect: Yields(true),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => args.bmc_mac_address.is_some(),
+                    _ => panic!("expected Show variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_with_mac ensures show parses with MAC address.
-#[test]
-fn parse_show_with_mac() {
-    let cmd = Cmd::try_parse_from(["expected-switch", "show", "1a:2b:3c:4d:5e:6f"])
-        .expect("should parse show with MAC");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.bmc_mac_address.is_some());
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_add ensures add parses with required arguments.
+// add parses with the required credential/serial set, and with the optional
+// meta-name supplied; the yielded tuple is (bmc_username, switch_serial_number,
+// meta_name).
 #[test]
 fn parse_add() {
-    let cmd = Cmd::try_parse_from([
-        "expected-switch",
-        "add",
-        "--bmc-mac-address",
-        "1a:2b:3c:4d:5e:6f",
-        "--bmc-username",
-        "admin",
-        "--bmc-password",
-        "secret",
-        "--switch-serial-number",
-        "SW12345",
-    ])
-    .expect("should parse add");
-
-    match cmd {
-        Cmd::Add(args) => {
-            assert_eq!(args.bmc_username, "admin");
-            assert_eq!(args.switch_serial_number, "SW12345");
-        }
-        _ => panic!("expected Add variant"),
-    }
+    check_cases(
+        [
+            Case {
+                scenario: "add with required arguments",
+                input: &[
+                    "expected-switch",
+                    "add",
+                    "--bmc-mac-address",
+                    "1a:2b:3c:4d:5e:6f",
+                    "--bmc-username",
+                    "admin",
+                    "--bmc-password",
+                    "secret",
+                    "--switch-serial-number",
+                    "SW12345",
+                ][..],
+                expect: Yields(("admin".to_string(), "SW12345".to_string(), None)),
+            },
+            Case {
+                scenario: "add with all options",
+                input: &[
+                    "expected-switch",
+                    "add",
+                    "--bmc-mac-address",
+                    "1a:2b:3c:4d:5e:6f",
+                    "--bmc-username",
+                    "admin",
+                    "--bmc-password",
+                    "secret",
+                    "--switch-serial-number",
+                    "SW12345",
+                    "--meta-name",
+                    "MySwitch",
+                    "--label",
+                    "env:prod",
+                ][..],
+                expect: Yields((
+                    "admin".to_string(),
+                    "SW12345".to_string(),
+                    Some("MySwitch".to_string()),
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Add(args) => {
+                        (args.bmc_username, args.switch_serial_number, args.meta_name)
+                    }
+                    _ => panic!("expected Add variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_add_with_options ensures add parses with
-// all options.
-#[test]
-fn parse_add_with_options() {
-    let cmd = Cmd::try_parse_from([
-        "expected-switch",
-        "add",
-        "--bmc-mac-address",
-        "1a:2b:3c:4d:5e:6f",
-        "--bmc-username",
-        "admin",
-        "--bmc-password",
-        "secret",
-        "--switch-serial-number",
-        "SW12345",
-        "--meta-name",
-        "MySwitch",
-        "--label",
-        "env:prod",
-    ])
-    .expect("should parse add with options");
-
-    match cmd {
-        Cmd::Add(args) => {
-            assert_eq!(args.meta_name, Some("MySwitch".to_string()));
-        }
-        _ => panic!("expected Add variant"),
-    }
-}
-
-// parse_delete ensures delete parses with MAC address.
-#[test]
-fn parse_delete() {
-    let cmd = Cmd::try_parse_from(["expected-switch", "delete", "1a:2b:3c:4d:5e:6f"])
-        .expect("should parse delete");
-
-    assert!(matches!(cmd, Cmd::Delete(_)));
-}
-
-// parse_update ensures update parses with required
-// arguments.
+// update parses with the required MAC plus the optional serial-number override;
+// the yielded value is the parsed switch_serial_number.
 #[test]
 fn parse_update() {
-    let cmd = Cmd::try_parse_from([
-        "expected-switch",
-        "update",
-        "--bmc-mac-address",
-        "1a:2b:3c:4d:5e:6f",
-        "--switch-serial-number",
-        "NEW_SERIAL",
-    ])
-    .expect("should parse update");
-
-    match cmd {
-        Cmd::Update(args) => {
-            assert_eq!(args.switch_serial_number, Some("NEW_SERIAL".to_string()));
-        }
-        _ => panic!("expected Update variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "update with required arguments",
+            input: &[
+                "expected-switch",
+                "update",
+                "--bmc-mac-address",
+                "1a:2b:3c:4d:5e:6f",
+                "--switch-serial-number",
+                "NEW_SERIAL",
+            ][..],
+            expect: Yields(Some("NEW_SERIAL".to_string())),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Update(args) => args.switch_serial_number,
+                    _ => panic!("expected Update variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_replace_all ensures replace-all parses with
-// filename.
+// replace-all parses with a filename; the yielded value is the parsed filename.
 #[test]
 fn parse_replace_all() {
-    let cmd = Cmd::try_parse_from([
-        "expected-switch",
-        "replace-all",
-        "--filename",
-        "switches.json",
-    ])
-    .expect("should parse replace-all");
+    check_cases(
+        [Case {
+            scenario: "replace-all with a filename",
+            input: &[
+                "expected-switch",
+                "replace-all",
+                "--filename",
+                "switches.json",
+            ][..],
+            expect: Yields("switches.json".to_string()),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::ReplaceAll(args) => args.filename,
+                    _ => panic!("expected ReplaceAll variant"),
+                })
+                .map_err(drop)
+        },
+    );
+}
 
-    match cmd {
-        Cmd::ReplaceAll(args) => {
-            assert_eq!(args.filename, "switches.json");
+// delete and erase only need to route to their respective subcommand variants;
+// the yielded string names the variant the argv landed on.
+#[test]
+fn parse_routes_to_variant() {
+    fn variant(cmd: &Cmd) -> &'static str {
+        match cmd {
+            Cmd::Show(_) => "show",
+            Cmd::Add(_) => "add",
+            Cmd::Delete(_) => "delete",
+            Cmd::Update(_) => "update",
+            Cmd::ReplaceAll(_) => "replace-all",
+            Cmd::Erase(_) => "erase",
         }
-        _ => panic!("expected ReplaceAll variant"),
     }
+
+    check_cases(
+        [
+            Case {
+                scenario: "delete with a MAC address",
+                input: &["expected-switch", "delete", "1a:2b:3c:4d:5e:6f"][..],
+                expect: Yields("delete"),
+            },
+            Case {
+                scenario: "erase with no arguments",
+                input: &["expected-switch", "erase"][..],
+                expect: Yields("erase"),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| variant(&cmd))
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_erase ensures erase parses with no arguments.
+// Every malformed invocation is rejected at parse time.
 #[test]
-fn parse_erase() {
-    let cmd = Cmd::try_parse_from(["expected-switch", "erase"]).expect("should parse erase");
-
-    assert!(matches!(cmd, Cmd::Erase(_)));
-}
-
-// parse_add_missing_required_fails ensures add fails
-// without required arguments.
-#[test]
-fn parse_add_missing_required_fails() {
-    let result = Cmd::try_parse_from(["expected-switch", "add"]);
-    assert!(result.is_err(), "should fail without required arguments");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [Case {
+            scenario: "add without its required arguments",
+            input: &["expected-switch", "add"][..],
+            expect: Fails,
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/extension_service/tests.rs
+++ b/crates/admin-cli/src/extension_service/tests.rs
@@ -24,6 +24,8 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 // ValueEnum Parsing - Test string parsing for types deriving claps ValueEnum.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::common::ExtensionServiceType;
@@ -46,223 +48,255 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_create ensures create parses with required
-// arguments.
+// Create parses both with just the required arguments and with the full
+// option set; each row asserts the fields the original test inspected:
+// (service_id, service_name, service_type, data, description, registry_url).
 #[test]
-fn parse_create() {
-    let cmd = Cmd::try_parse_from([
-        "extension-service",
-        "create",
-        "--name",
-        "my-service",
-        "--type",
-        "kubernetes-pod",
-        "--data",
-        "{}",
-    ])
-    .expect("should parse create");
+fn parse_create_routes_and_binds_fields() {
+    type CreateFields = (
+        Option<String>,
+        String,
+        ExtensionServiceType,
+        String,
+        Option<String>,
+        Option<String>,
+    );
 
-    match cmd {
-        Cmd::Create(args) => {
-            assert_eq!(args.service_name, "my-service");
-            assert_eq!(args.service_type, ExtensionServiceType::KubernetesPod);
-            assert_eq!(args.data, "{}");
-            assert!(args.service_id.is_none());
-        }
-        _ => panic!("expected Create variant"),
-    }
+    check_cases(
+        [
+            Case {
+                scenario: "create with required arguments",
+                input: &[
+                    "extension-service",
+                    "create",
+                    "--name",
+                    "my-service",
+                    "--type",
+                    "kubernetes-pod",
+                    "--data",
+                    "{}",
+                ][..],
+                expect: Yields((
+                    None,
+                    "my-service".to_string(),
+                    ExtensionServiceType::KubernetesPod,
+                    "{}".to_string(),
+                    None,
+                    None,
+                )),
+            },
+            Case {
+                scenario: "create with all options",
+                input: &[
+                    "extension-service",
+                    "create",
+                    "--id",
+                    "svc-123",
+                    "--name",
+                    "my-service",
+                    "--type",
+                    "k8s",
+                    "--data",
+                    "{}",
+                    "--description",
+                    "My extension service",
+                    "--registry-url",
+                    "https://registry.example.com",
+                    "--username",
+                    "user",
+                    "--password",
+                    "pass",
+                ][..],
+                expect: Yields((
+                    Some("svc-123".to_string()),
+                    "my-service".to_string(),
+                    ExtensionServiceType::KubernetesPod,
+                    "{}".to_string(),
+                    Some("My extension service".to_string()),
+                    Some("https://registry.example.com".to_string()),
+                )),
+            },
+        ],
+        |argv| -> Result<CreateFields, ()> {
+            match Cmd::try_parse_from(argv.iter().copied()).map_err(drop)? {
+                Cmd::Create(args) => Ok((
+                    args.service_id,
+                    args.service_name,
+                    args.service_type,
+                    args.data,
+                    args.description,
+                    args.registry_url,
+                )),
+                _ => panic!("expected Create variant"),
+            }
+        },
+    );
 }
 
-// parse_create_with_options ensures create parses with
-// all options.
+// Update routes to the Update variant and binds (service_id, data).
 #[test]
-fn parse_create_with_options() {
-    let cmd = Cmd::try_parse_from([
-        "extension-service",
-        "create",
-        "--id",
-        "svc-123",
-        "--name",
-        "my-service",
-        "--type",
-        "k8s",
-        "--data",
-        "{}",
-        "--description",
-        "My extension service",
-        "--registry-url",
-        "https://registry.example.com",
-        "--username",
-        "user",
-        "--password",
-        "pass",
-    ])
-    .expect("should parse create with options");
-
-    match cmd {
-        Cmd::Create(args) => {
-            assert_eq!(args.service_id, Some("svc-123".to_string()));
-            assert_eq!(args.description, Some("My extension service".to_string()));
-            assert_eq!(
-                args.registry_url,
-                Some("https://registry.example.com".to_string())
-            );
-        }
-        _ => panic!("expected Create variant"),
-    }
+fn parse_update_routes_and_binds_fields() {
+    check_cases(
+        [Case {
+            scenario: "update with required arguments",
+            input: &[
+                "extension-service",
+                "update",
+                "--id",
+                "svc-123",
+                "--data",
+                "{}",
+            ][..],
+            expect: Yields(("svc-123".to_string(), "{}".to_string())),
+        }],
+        |argv| -> Result<(String, String), ()> {
+            match Cmd::try_parse_from(argv.iter().copied()).map_err(drop)? {
+                Cmd::Update(args) => Ok((args.service_id, args.data)),
+                _ => panic!("expected Update variant"),
+            }
+        },
+    );
 }
 
-// parse_update ensures update parses with required
-// arguments.
+// Delete routes to the Delete variant, with an optional version filter; each
+// row asserts (service_id, versions).
 #[test]
-fn parse_update() {
-    let cmd = Cmd::try_parse_from([
-        "extension-service",
-        "update",
-        "--id",
-        "svc-123",
-        "--data",
-        "{}",
-    ])
-    .expect("should parse update");
-
-    match cmd {
-        Cmd::Update(args) => {
-            assert_eq!(args.service_id, "svc-123");
-            assert_eq!(args.data, "{}");
-        }
-        _ => panic!("expected Update variant"),
-    }
+fn parse_delete_routes_and_binds_fields() {
+    check_cases(
+        [
+            Case {
+                scenario: "delete with service ID only",
+                input: &["extension-service", "delete", "--id", "svc-123"][..],
+                expect: Yields(("svc-123".to_string(), Vec::<String>::new())),
+            },
+            Case {
+                scenario: "delete with version filter",
+                input: &[
+                    "extension-service",
+                    "delete",
+                    "--id",
+                    "svc-123",
+                    "--versions",
+                    "v1,v2,v3",
+                ][..],
+                expect: Yields((
+                    "svc-123".to_string(),
+                    vec!["v1".to_string(), "v2".to_string(), "v3".to_string()],
+                )),
+            },
+        ],
+        |argv| -> Result<(String, Vec<String>), ()> {
+            match Cmd::try_parse_from(argv.iter().copied()).map_err(drop)? {
+                Cmd::Delete(args) => Ok((args.service_id, args.versions)),
+                _ => panic!("expected Delete variant"),
+            }
+        },
+    );
 }
 
-// parse_delete ensures delete parses with
-// service ID.
+// Show routes to the Show variant with all filters optional; each row asserts
+// (id, service_type, service_name).
 #[test]
-fn parse_delete() {
-    let cmd = Cmd::try_parse_from(["extension-service", "delete", "--id", "svc-123"])
-        .expect("should parse delete");
+fn parse_show_routes_and_binds_fields() {
+    type ShowFields = (Option<String>, Option<ExtensionServiceType>, Option<String>);
 
-    match cmd {
-        Cmd::Delete(args) => {
-            assert_eq!(args.service_id, "svc-123");
-            assert!(args.versions.is_empty());
-        }
-        _ => panic!("expected Delete variant"),
-    }
+    check_cases(
+        [
+            Case {
+                scenario: "show with no arguments",
+                input: &["extension-service", "show"][..],
+                expect: Yields((None, None, None)),
+            },
+            Case {
+                scenario: "show with filter options",
+                input: &[
+                    "extension-service",
+                    "show",
+                    "--id",
+                    "svc-123",
+                    "--type",
+                    "kubernetes-pod",
+                    "--name",
+                    "my-service",
+                ][..],
+                expect: Yields((
+                    Some("svc-123".to_string()),
+                    Some(ExtensionServiceType::KubernetesPod),
+                    Some("my-service".to_string()),
+                )),
+            },
+        ],
+        |argv| -> Result<ShowFields, ()> {
+            match Cmd::try_parse_from(argv.iter().copied()).map_err(drop)? {
+                Cmd::Show(args) => Ok((args.id, args.service_type, args.service_name)),
+                _ => panic!("expected Show variant"),
+            }
+        },
+    );
 }
 
-// parse_delete_with_versions ensures delete parses
-// with version filter.
+// GetVersion routes to the GetVersion variant and binds (service_id, versions).
 #[test]
-fn parse_delete_with_versions() {
-    let cmd = Cmd::try_parse_from([
-        "extension-service",
-        "delete",
-        "--id",
-        "svc-123",
-        "--versions",
-        "v1,v2,v3",
-    ])
-    .expect("should parse delete with versions");
-
-    match cmd {
-        Cmd::Delete(args) => {
-            assert_eq!(args.versions, vec!["v1", "v2", "v3"]);
-        }
-        _ => panic!("expected Delete variant"),
-    }
+fn parse_get_version_routes_and_binds_fields() {
+    check_cases(
+        [Case {
+            scenario: "get-version with service ID",
+            input: &[
+                "extension-service",
+                "get-version",
+                "--service-id",
+                "svc-123",
+            ][..],
+            expect: Yields(("svc-123".to_string(), Vec::<String>::new())),
+        }],
+        |argv| -> Result<(String, Vec<String>), ()> {
+            match Cmd::try_parse_from(argv.iter().copied()).map_err(drop)? {
+                Cmd::GetVersion(args) => Ok((args.service_id, args.versions)),
+                _ => panic!("expected GetVersion variant"),
+            }
+        },
+    );
 }
 
-// parse_show_no_args ensures show parses with no
-// arguments (all services).
+// ShowInstances routes to the ShowInstances variant and binds
+// (service_id, version).
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["extension-service", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_none());
-            assert!(args.service_type.is_none());
-            assert!(args.service_name.is_none());
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_show_instances_routes_and_binds_fields() {
+    check_cases(
+        [Case {
+            scenario: "show-instances with service ID",
+            input: &[
+                "extension-service",
+                "show-instances",
+                "--service-id",
+                "svc-123",
+            ][..],
+            expect: Yields(("svc-123".to_string(), None)),
+        }],
+        |argv| -> Result<(String, Option<String>), ()> {
+            match Cmd::try_parse_from(argv.iter().copied()).map_err(drop)? {
+                Cmd::ShowInstances(args) => Ok((args.service_id, args.version)),
+                _ => panic!("expected ShowInstances variant"),
+            }
+        },
+    );
 }
 
-// parse_show_with_filters ensures show parses with
-// filter options.
+// Every malformed invocation is rejected at parse time.
 #[test]
-fn parse_show_with_filters() {
-    let cmd = Cmd::try_parse_from([
-        "extension-service",
-        "show",
-        "--id",
-        "svc-123",
-        "--type",
-        "kubernetes-pod",
-        "--name",
-        "my-service",
-    ])
-    .expect("should parse show with filters");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.id, Some("svc-123".to_string()));
-            assert_eq!(args.service_type, Some(ExtensionServiceType::KubernetesPod));
-            assert_eq!(args.service_name, Some("my-service".to_string()));
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_get_version ensures get-version parses with
-// service ID.
-#[test]
-fn parse_get_version() {
-    let cmd = Cmd::try_parse_from([
-        "extension-service",
-        "get-version",
-        "--service-id",
-        "svc-123",
-    ])
-    .expect("should parse get-version");
-
-    match cmd {
-        Cmd::GetVersion(args) => {
-            assert_eq!(args.service_id, "svc-123");
-            assert!(args.versions.is_empty());
-        }
-        _ => panic!("expected GetVersion variant"),
-    }
-}
-
-// parse_show_instances ensures show-instances parses
-// with service ID.
-#[test]
-fn parse_show_instances() {
-    let cmd = Cmd::try_parse_from([
-        "extension-service",
-        "show-instances",
-        "--service-id",
-        "svc-123",
-    ])
-    .expect("should parse show-instances");
-
-    match cmd {
-        Cmd::ShowInstances(args) => {
-            assert_eq!(args.service_id, "svc-123");
-            assert!(args.version.is_none());
-        }
-        _ => panic!("expected ShowInstances variant"),
-    }
-}
-
-// parse_create_missing_required_fails ensures create
-// fails without required arguments.
-#[test]
-fn parse_create_missing_required_fails() {
-    let result = Cmd::try_parse_from(["extension-service", "create"]);
-    assert!(result.is_err(), "should fail without required arguments");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [Case {
+            scenario: "create without its required arguments",
+            input: &["extension-service", "create"][..],
+            expect: Fails,
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -274,19 +308,30 @@ fn parse_create_missing_required_fails() {
 // or fail otherwise.
 
 // extension_service_type_value_enum ensures ExtensionServiceType
-// parses from strings.
+// parses from strings ("k8s" is an alias for KubernetesPod, and an
+// unknown value is rejected).
 #[test]
 fn extension_service_type_value_enum() {
     use clap::ValueEnum;
 
-    assert!(matches!(
-        ExtensionServiceType::from_str("kubernetes-pod", false),
-        Ok(ExtensionServiceType::KubernetesPod)
-    ));
-    // "k8s" is an alias for KubernetesPod
-    assert!(matches!(
-        ExtensionServiceType::from_str("k8s", false),
-        Ok(ExtensionServiceType::KubernetesPod)
-    ));
-    assert!(ExtensionServiceType::from_str("invalid", false).is_err());
+    check_cases(
+        [
+            Case {
+                scenario: "canonical kubernetes-pod",
+                input: "kubernetes-pod",
+                expect: Yields(ExtensionServiceType::KubernetesPod),
+            },
+            Case {
+                scenario: "k8s alias maps to KubernetesPod",
+                input: "k8s",
+                expect: Yields(ExtensionServiceType::KubernetesPod),
+            },
+            Case {
+                scenario: "unknown value is rejected",
+                input: "invalid",
+                expect: Fails,
+            },
+        ],
+        |s| ExtensionServiceType::from_str(s, false).map_err(drop),
+    );
 }

--- a/crates/admin-cli/src/generate_shell_complete/tests.rs
+++ b/crates/admin-cli/src/generate_shell_complete/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::args::*;
@@ -44,39 +46,63 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_bash ensures bash subcommand parses.
+// Each supported shell name parses to its matching `Shell` variant.
 #[test]
-fn parse_bash() {
-    let cmd = Cmd::try_parse_from(["generate-shell-complete", "bash"]).expect("should parse bash");
-    assert!(matches!(cmd.shell, Shell::Bash));
+fn shell_names_parse_to_their_variant() {
+    fn shell(s: &Shell) -> &'static str {
+        match s {
+            Shell::Bash => "bash",
+            Shell::Fish => "fish",
+            Shell::Zsh => "zsh",
+        }
+    }
+
+    check_cases(
+        [
+            Case {
+                scenario: "bash subcommand",
+                input: &["generate-shell-complete", "bash"][..],
+                expect: Yields("bash"),
+            },
+            Case {
+                scenario: "fish subcommand",
+                input: &["generate-shell-complete", "fish"][..],
+                expect: Yields("fish"),
+            },
+            Case {
+                scenario: "zsh subcommand",
+                input: &["generate-shell-complete", "zsh"][..],
+                expect: Yields("zsh"),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| shell(&cmd.shell))
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_fish ensures fish subcommand parses.
+// A shell subcommand is required, and an unknown shell is rejected.
 #[test]
-fn parse_fish() {
-    let cmd = Cmd::try_parse_from(["generate-shell-complete", "fish"]).expect("should parse fish");
-    assert!(matches!(cmd.shell, Shell::Fish));
-}
-
-// parse_zsh ensures zsh subcommand parses.
-#[test]
-fn parse_zsh() {
-    let cmd = Cmd::try_parse_from(["generate-shell-complete", "zsh"]).expect("should parse zsh");
-    assert!(matches!(cmd.shell, Shell::Zsh));
-}
-
-// parse_missing_shell_fails ensures requires shell
-// subcommand.
-#[test]
-fn parse_missing_shell_fails() {
-    let result = Cmd::try_parse_from(["generate-shell-complete"]);
-    assert!(result.is_err(), "should fail without shell subcommand");
-}
-
-// parse_invalid_shell_fails ensures fails with unknown
-// shell.
-#[test]
-fn parse_invalid_shell_fails() {
-    let result = Cmd::try_parse_from(["generate-shell-complete", "powershell"]);
-    assert!(result.is_err(), "should fail with unknown shell");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "missing shell subcommand",
+                input: &["generate-shell-complete"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "unknown shell",
+                input: &["generate-shell-complete", "powershell"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/host/tests.rs
+++ b/crates/admin-cli/src/host/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -37,6 +39,9 @@ fn verify_cmd_structure() {
     Cmd::command().debug_assert();
 }
 
+// Define a basic/working MachineId for testing.
+const TEST_MACHINE_ID: &str = "fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg";
+
 /////////////////////////////////////////////////////////////////////////////
 // Argument Parsing
 //
@@ -44,146 +49,188 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_set_uefi_password ensures set-uefi-password
-// parses with machine query.
-#[test]
-fn parse_set_uefi_password() {
-    let cmd = Cmd::try_parse_from(["host", "set-uefi-password", "--query", "machine-123"])
-        .expect("should parse set-uefi-password");
-
-    assert!(matches!(cmd, Cmd::SetUefiPassword(_)));
-}
-
-// parse_clear_uefi_password ensures clear-uefi-password
-// parses with machine query.
-#[test]
-fn parse_clear_uefi_password() {
-    let cmd = Cmd::try_parse_from(["host", "clear-uefi-password", "--query", "machine-123"])
-        .expect("should parse clear-uefi-password");
-
-    assert!(matches!(cmd, Cmd::ClearUefiPassword(_)));
-}
-
-// parse_generate_host_uefi_password ensures
-// generate-host-uefi-password parses with no args.
-#[test]
-fn parse_generate_host_uefi_password() {
-    let cmd = Cmd::try_parse_from(["host", "generate-host-uefi-password"])
-        .expect("should parse generate-host-uefi-password");
-
-    assert!(matches!(cmd, Cmd::GenerateHostUefiPassword(_)));
-}
-
-// Define a basic/working MachineId for testing.
-const TEST_MACHINE_ID: &str = "fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg";
-
-// parse_reprovision_set ensures reprovision set parses
-// with required args.
-#[test]
-fn parse_reprovision_set() {
-    let cmd = Cmd::try_parse_from(["host", "reprovision", "set", "--id", TEST_MACHINE_ID])
-        .expect("should parse reprovision set");
-
+// variant names the top-level Cmd subcommand a valid argv routed to, so
+// "routes to the right variant" rows can yield a stable label.
+fn variant(cmd: &Cmd) -> &'static str {
     match cmd {
-        Cmd::Reprovision(reprovision::args::Args::Set(args)) => {
-            assert_eq!(args.id.to_string(), TEST_MACHINE_ID);
-            assert!(!args.update_firmware);
-            assert!(args.update_message.is_none());
-        }
-        _ => panic!("expected Reprovision Set variant"),
+        Cmd::SetUefiPassword(_) => "set-uefi-password",
+        Cmd::ClearUefiPassword(_) => "clear-uefi-password",
+        Cmd::GenerateHostUefiPassword(_) => "generate-host-uefi-password",
+        _ => "other",
     }
 }
 
-// parse_reprovision_set_with_options ensures
-// reprovision set parses with all options.
+// The UEFI-password subcommands each route to their own top-level variant:
+// set/clear take a machine query, generate takes no args.
 #[test]
-fn parse_reprovision_set_with_options() {
-    let cmd = Cmd::try_parse_from([
-        "host",
-        "reprovision",
-        "set",
-        "--id",
-        TEST_MACHINE_ID,
-        "--update-firmware",
-        "--update-message",
-        "Maintenance in progress",
-    ])
-    .expect("should parse reprovision set with options");
-
-    match cmd {
-        Cmd::Reprovision(reprovision::args::Args::Set(args)) => {
-            assert!(args.update_firmware);
-            assert_eq!(
-                args.update_message,
-                Some("Maintenance in progress".to_string())
-            );
-        }
-        _ => panic!("expected Reprovision Set variant"),
-    }
+fn uefi_password_subcommands_route_to_their_variant() {
+    check_cases(
+        [
+            Case {
+                scenario: "set-uefi-password with machine query",
+                input: &["host", "set-uefi-password", "--query", "machine-123"][..],
+                expect: Yields("set-uefi-password"),
+            },
+            Case {
+                scenario: "clear-uefi-password with machine query",
+                input: &["host", "clear-uefi-password", "--query", "machine-123"][..],
+                expect: Yields("clear-uefi-password"),
+            },
+            Case {
+                scenario: "generate-host-uefi-password with no args",
+                input: &["host", "generate-host-uefi-password"][..],
+                expect: Yields("generate-host-uefi-password"),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| variant(&cmd))
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_reprovision_clear ensures reprovision clear
-// parses with required args.
+// reprovision set parses to the Set variant. With only --id the optional
+// flags stay at their defaults; with --update-firmware and --update-message
+// supplied they carry through. The asserted tuple is
+// (id, update_firmware, update_message).
 #[test]
-fn parse_reprovision_clear() {
-    let cmd = Cmd::try_parse_from(["host", "reprovision", "clear", "--id", TEST_MACHINE_ID])
-        .expect("should parse reprovision clear");
-
-    match cmd {
-        Cmd::Reprovision(reprovision::args::Args::Clear(args)) => {
-            assert_eq!(args.id.to_string(), TEST_MACHINE_ID);
-            assert!(!args.update_firmware);
-        }
-        _ => panic!("expected Reprovision Clear variant"),
-    }
+fn reprovision_set_parses_fields() {
+    check_cases(
+        [
+            Case {
+                scenario: "set with only required --id",
+                input: &["host", "reprovision", "set", "--id", TEST_MACHINE_ID][..],
+                expect: Yields((TEST_MACHINE_ID.to_string(), false, None)),
+            },
+            Case {
+                scenario: "set with all options",
+                input: &[
+                    "host",
+                    "reprovision",
+                    "set",
+                    "--id",
+                    TEST_MACHINE_ID,
+                    "--update-firmware",
+                    "--update-message",
+                    "Maintenance in progress",
+                ][..],
+                expect: Yields((
+                    TEST_MACHINE_ID.to_string(),
+                    true,
+                    Some("Maintenance in progress".to_string()),
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Reprovision(reprovision::args::Args::Set(args)) => (
+                        args.id.to_string(),
+                        args.update_firmware,
+                        args.update_message,
+                    ),
+                    _ => panic!("expected Reprovision Set variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_reprovision_list ensures reprovision list
-// parses with no args.
+// reprovision clear parses to the Clear variant with required --id; the
+// update_firmware flag defaults off. The asserted tuple is
+// (id, update_firmware).
 #[test]
-fn parse_reprovision_list() {
-    let cmd = Cmd::try_parse_from(["host", "reprovision", "list"])
-        .expect("should parse reprovision list");
-
-    assert!(matches!(
-        cmd,
-        Cmd::Reprovision(reprovision::args::Args::List)
-    ));
+fn reprovision_clear_parses_fields() {
+    check_cases(
+        [Case {
+            scenario: "clear with required --id",
+            input: &["host", "reprovision", "clear", "--id", TEST_MACHINE_ID][..],
+            expect: Yields((TEST_MACHINE_ID.to_string(), false)),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Reprovision(reprovision::args::Args::Clear(args)) => {
+                        (args.id.to_string(), args.update_firmware)
+                    }
+                    _ => panic!("expected Reprovision Clear variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_reprovision_set_missing_id_fails ensures
-// reprovision set requires --id.
+// reprovision mark-manual-upgrade-complete parses to its variant with the
+// required --id; the asserted value is the id.
 #[test]
-fn parse_reprovision_set_missing_id_fails() {
-    let result = Cmd::try_parse_from(["host", "reprovision", "set"]);
-    assert!(result.is_err(), "should fail without --id");
+fn reprovision_mark_manual_upgrade_complete_parses_fields() {
+    check_cases(
+        [Case {
+            scenario: "mark-manual-upgrade-complete with required --id",
+            input: &[
+                "host",
+                "reprovision",
+                "mark-manual-upgrade-complete",
+                "--id",
+                TEST_MACHINE_ID,
+            ][..],
+            expect: Yields(TEST_MACHINE_ID.to_string()),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Reprovision(reprovision::args::Args::MarkManualUpgradeComplete(args)) => {
+                        args.id.to_string()
+                    }
+                    _ => panic!("expected Reprovision MarkManualUpgradeComplete variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_reprovision_mark_manual_upgrade_complete ensures
-// mark-manual-upgrade-complete parses with required --id.
+// reprovision list parses to the List variant with no args.
 #[test]
-fn parse_reprovision_mark_manual_upgrade_complete() {
-    let cmd = Cmd::try_parse_from([
-        "host",
-        "reprovision",
-        "mark-manual-upgrade-complete",
-        "--id",
-        TEST_MACHINE_ID,
-    ])
-    .expect("should parse mark-manual-upgrade-complete");
-
-    match cmd {
-        Cmd::Reprovision(reprovision::args::Args::MarkManualUpgradeComplete(args)) => {
-            assert_eq!(args.id.to_string(), TEST_MACHINE_ID);
-        }
-        _ => panic!("expected Reprovision MarkManualUpgradeComplete variant"),
-    }
+fn reprovision_list_parses() {
+    check_cases(
+        [Case {
+            scenario: "list with no args",
+            input: &["host", "reprovision", "list"][..],
+            expect: Yields("list"),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Reprovision(reprovision::args::Args::List) => "list",
+                    _ => panic!("expected Reprovision List variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_reprovision_mark_manual_upgrade_complete_missing_id_fails
-// ensures mark-manual-upgrade-complete requires --id.
+// Each malformed reprovision invocation is rejected at parse time: the
+// subcommands that need --id refuse to parse without it.
 #[test]
-fn parse_reprovision_mark_manual_upgrade_complete_missing_id_fails() {
-    let result = Cmd::try_parse_from(["host", "reprovision", "mark-manual-upgrade-complete"]);
-    assert!(result.is_err(), "should fail without --id");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "reprovision set without --id",
+                input: &["host", "reprovision", "set"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "reprovision mark-manual-upgrade-complete without --id",
+                input: &["host", "reprovision", "mark-manual-upgrade-complete"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/ib_partition/tests.rs
+++ b/crates/admin-cli/src/ib_partition/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,44 +46,36 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all partitions).
+// show parses its (all-optional) filters: bare `show` lists everything, while
+// --tenant-org-id and --name each route to the Show variant carrying that filter.
+// Each row yields (id.is_none(), tenant_org_id, name) -- exactly the fields the
+// originals asserted on.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["ib-partition", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_none());
-            assert!(args.tenant_org_id.is_none());
-            assert!(args.name.is_none());
-        }
-    }
-}
-
-// parse_show_with_tenant ensures show parses with
-// --tenant-org-id.
-#[test]
-fn parse_show_with_tenant() {
-    let cmd = Cmd::try_parse_from(["ib-partition", "show", "--tenant-org-id", "tenant-123"])
-        .expect("should parse show with tenant");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.tenant_org_id, Some("tenant-123".to_string()));
-        }
-    }
-}
-
-// parse_show_with_name ensures show parses with --name.
-#[test]
-fn parse_show_with_name() {
-    let cmd = Cmd::try_parse_from(["ib-partition", "show", "--name", "my-partition"])
-        .expect("should parse show with name");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.name, Some("my-partition".to_string()));
-        }
-    }
+fn parse_show_routes_to_show_variant() {
+    check_cases(
+        [
+            Case {
+                scenario: "no args lists all partitions",
+                input: &["ib-partition", "show"][..],
+                expect: Yields((true, None, None)),
+            },
+            Case {
+                scenario: "--tenant-org-id filters by tenant",
+                input: &["ib-partition", "show", "--tenant-org-id", "tenant-123"][..],
+                expect: Yields((true, Some("tenant-123".to_string()), None)),
+            },
+            Case {
+                scenario: "--name filters by partition name",
+                input: &["ib-partition", "show", "--name", "my-partition"][..],
+                expect: Yields((true, None, Some("my-partition".to_string()))),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => (args.id.is_none(), args.tenant_org_id, args.name),
+                })
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/instance/tests.rs
+++ b/crates/admin-cli/src/instance/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -50,187 +52,205 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all instances).
+// Show parses with no arguments (all instances) and with filter options;
+// the tuple is (id.is_empty(), tenant_org_id, vpc_id, extrainfo).
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["instance", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_empty());
-            assert!(!args.extrainfo);
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_with_filters ensures show parses with
-// filter options.
-#[test]
-fn parse_show_with_filters() {
-    let cmd = Cmd::try_parse_from([
-        "instance",
-        "show",
-        "--tenant-org-id",
-        "tenant-123",
-        "--vpc-id",
-        "vpc-456",
-        "--extrainfo",
-    ])
-    .expect("should parse show with filters");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.tenant_org_id, Some("tenant-123".to_string()));
-            assert_eq!(args.vpc_id, Some("vpc-456".to_string()));
-            assert!(args.extrainfo);
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_reboot ensures reboot parses with instance ID.
-#[test]
-fn parse_reboot() {
-    let cmd = Cmd::try_parse_from(["instance", "reboot", "--instance", TEST_INSTANCE_ID])
-        .expect("should parse reboot");
-
-    match cmd {
-        Cmd::Reboot(args) => {
-            assert_eq!(args.instance.to_string(), TEST_INSTANCE_ID);
-            assert!(!args.custom_pxe);
-            assert!(!args.apply_updates_on_reboot);
-        }
-        _ => panic!("expected Reboot variant"),
-    }
-}
-
-// parse_reboot_with_options ensures reboot parses with
-// all options.
-#[test]
-fn parse_reboot_with_options() {
-    let cmd = Cmd::try_parse_from([
-        "instance",
-        "reboot",
-        "--instance",
-        TEST_INSTANCE_ID,
-        "--custom-pxe",
-        "--apply-updates-on-reboot",
-    ])
-    .expect("should parse reboot with options");
-
-    match cmd {
-        Cmd::Reboot(args) => {
-            assert!(args.custom_pxe);
-            assert!(args.apply_updates_on_reboot);
-        }
-        _ => panic!("expected Reboot variant"),
-    }
-}
-
-// parse_release_by_instance ensures release parses with
-// --instance.
-#[test]
-fn parse_release_by_instance() {
-    let cmd = Cmd::try_parse_from(["instance", "release", "--instance", TEST_INSTANCE_ID])
-        .expect("should parse release");
-
-    match cmd {
-        Cmd::Release(args) => {
-            assert_eq!(args.instance, Some(TEST_INSTANCE_ID.to_string()));
-            assert!(args.machine.is_none());
-        }
-        _ => panic!("expected Release variant"),
-    }
-}
-
-// parse_release_by_machine ensures release parses with
-// --machine.
-#[test]
-fn parse_release_by_machine() {
-    let cmd = Cmd::try_parse_from(["instance", "release", "--machine", TEST_MACHINE_ID])
-        .expect("should parse release by machine");
-
-    match cmd {
-        Cmd::Release(args) => {
-            assert!(args.instance.is_none());
-            assert!(args.machine.is_some());
-        }
-        _ => panic!("expected Release variant"),
-    }
-}
-
-// parse_allocate ensures allocate parses with required
-// arguments.
-#[test]
-fn parse_allocate() {
-    let cmd = Cmd::try_parse_from([
-        "instance",
-        "allocate",
-        "--subnet",
-        "10.0.0.0/24",
-        "--prefix-name",
-        "my-prefix",
-    ])
-    .expect("should parse allocate");
-
-    match cmd {
-        Cmd::Allocate(args) => {
-            assert_eq!(args.subnet, vec!["10.0.0.0/24"]);
-            assert_eq!(args.prefix_name, "my-prefix");
-        }
-        _ => panic!("expected Allocate variant"),
-    }
-}
-
-// parse_allocate_with_options ensures allocate parses
-// with all options.
-#[test]
-fn parse_allocate_with_options() {
-    let cmd = Cmd::try_parse_from([
-        "instance",
-        "allocate",
-        "--subnet",
-        "10.0.0.0/24",
-        "--prefix-name",
-        "my-prefix",
-        "--number",
-        "5",
-        "--tenant-org",
-        "tenant-123",
-        "--transactional",
-    ])
-    .expect("should parse allocate with options");
-
-    match cmd {
-        Cmd::Allocate(args) => {
-            assert_eq!(args.number, Some(5));
-            assert_eq!(args.tenant_org, Some("tenant-123".to_string()));
-            assert!(args.transactional);
-        }
-        _ => panic!("expected Allocate variant"),
-    }
-}
-
-// parse_release_missing_required_fails ensures release
-// fails without required arguments.
-#[test]
-fn parse_release_missing_required_fails() {
-    let result = Cmd::try_parse_from(["instance", "release"]);
-    assert!(
-        result.is_err(),
-        "should fail without instance/machine/label"
+fn parse_show_routes_and_carries_filters() {
+    check_cases(
+        [
+            Case {
+                scenario: "show with no arguments",
+                input: &["instance", "show"][..],
+                expect: Yields((true, None, None, false)),
+            },
+            Case {
+                scenario: "show with filter options",
+                input: &[
+                    "instance",
+                    "show",
+                    "--tenant-org-id",
+                    "tenant-123",
+                    "--vpc-id",
+                    "vpc-456",
+                    "--extrainfo",
+                ][..],
+                expect: Yields((
+                    true,
+                    Some("tenant-123".to_string()),
+                    Some("vpc-456".to_string()),
+                    true,
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => (
+                        args.id.is_empty(),
+                        args.tenant_org_id,
+                        args.vpc_id,
+                        args.extrainfo,
+                    ),
+                    _ => panic!("expected Show variant"),
+                })
+                .map_err(drop)
+        },
     );
 }
 
-// parse_allocate_missing_required_fails ensures
-// allocate fails without required arguments.
+// Reboot parses with just the instance ID and with all optional flags;
+// the tuple is (instance, custom_pxe, apply_updates_on_reboot).
 #[test]
-fn parse_allocate_missing_required_fails() {
-    let result = Cmd::try_parse_from(["instance", "allocate"]);
-    assert!(
-        result.is_err(),
-        "should fail without subnet/vpc_prefix and prefix-name"
+fn parse_reboot_routes_and_carries_options() {
+    check_cases(
+        [
+            Case {
+                scenario: "reboot with instance only",
+                input: &["instance", "reboot", "--instance", TEST_INSTANCE_ID][..],
+                expect: Yields((TEST_INSTANCE_ID.to_string(), false, false)),
+            },
+            Case {
+                scenario: "reboot with all options",
+                input: &[
+                    "instance",
+                    "reboot",
+                    "--instance",
+                    TEST_INSTANCE_ID,
+                    "--custom-pxe",
+                    "--apply-updates-on-reboot",
+                ][..],
+                expect: Yields((TEST_INSTANCE_ID.to_string(), true, true)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Reboot(args) => (
+                        args.instance.to_string(),
+                        args.custom_pxe,
+                        args.apply_updates_on_reboot,
+                    ),
+                    _ => panic!("expected Reboot variant"),
+                })
+                .map_err(drop)
+        },
+    );
+}
+
+// Release parses by --instance or by --machine; the tuple is
+// (instance, machine.is_some()).
+#[test]
+fn parse_release_routes_by_target() {
+    check_cases(
+        [
+            Case {
+                scenario: "release by --instance",
+                input: &["instance", "release", "--instance", TEST_INSTANCE_ID][..],
+                expect: Yields((Some(TEST_INSTANCE_ID.to_string()), false)),
+            },
+            Case {
+                scenario: "release by --machine",
+                input: &["instance", "release", "--machine", TEST_MACHINE_ID][..],
+                expect: Yields((None, true)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Release(args) => (args.instance, args.machine.is_some()),
+                    _ => panic!("expected Release variant"),
+                })
+                .map_err(drop)
+        },
+    );
+}
+
+// Allocate parses with just its required arguments and with all options;
+// the tuple is (subnet, prefix_name, number, tenant_org, transactional).
+#[test]
+fn parse_allocate_routes_and_carries_options() {
+    check_cases(
+        [
+            Case {
+                scenario: "allocate with required arguments",
+                input: &[
+                    "instance",
+                    "allocate",
+                    "--subnet",
+                    "10.0.0.0/24",
+                    "--prefix-name",
+                    "my-prefix",
+                ][..],
+                expect: Yields((
+                    vec!["10.0.0.0/24".to_string()],
+                    "my-prefix".to_string(),
+                    None,
+                    None,
+                    false,
+                )),
+            },
+            Case {
+                scenario: "allocate with all options",
+                input: &[
+                    "instance",
+                    "allocate",
+                    "--subnet",
+                    "10.0.0.0/24",
+                    "--prefix-name",
+                    "my-prefix",
+                    "--number",
+                    "5",
+                    "--tenant-org",
+                    "tenant-123",
+                    "--transactional",
+                ][..],
+                expect: Yields((
+                    vec!["10.0.0.0/24".to_string()],
+                    "my-prefix".to_string(),
+                    Some(5),
+                    Some("tenant-123".to_string()),
+                    true,
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Allocate(args) => (
+                        args.subnet,
+                        args.prefix_name,
+                        args.number,
+                        args.tenant_org,
+                        args.transactional,
+                    ),
+                    _ => panic!("expected Allocate variant"),
+                })
+                .map_err(drop)
+        },
+    );
+}
+
+// Every malformed invocation is rejected at parse time -- a subcommand
+// invoked without the required arguments it needs to act on.
+#[test]
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "release without instance/machine/label",
+                input: &["instance", "release"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "allocate without subnet/vpc_prefix and prefix-name",
+                input: &["instance", "allocate"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
     );
 }

--- a/crates/admin-cli/src/instance_type/tests.rs
+++ b/crates/admin-cli/src/instance_type/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -47,174 +49,194 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_create ensures create parses with no required
-// arguments.
+// The `create` subcommand: every field is optional, so a bare `create` leaves
+// id/name/description unset, while supplying them threads each value through.
 #[test]
-fn parse_create() {
-    let cmd = Cmd::try_parse_from(["instance-type", "create"]).expect("should parse create");
-
-    match cmd {
-        Cmd::Create(args) => {
-            assert!(args.id.is_none());
-            assert!(args.name.is_none());
-            assert!(args.description.is_none());
-        }
-        _ => panic!("expected Create variant"),
-    }
+fn parse_create_routes_and_binds_fields() {
+    check_cases(
+        [
+            Case {
+                scenario: "create with no arguments leaves every field unset",
+                input: &["instance-type", "create"][..],
+                expect: Yields((None, None, None)),
+            },
+            Case {
+                scenario: "create with all options binds each field",
+                input: &[
+                    "instance-type",
+                    "create",
+                    "--id",
+                    "type-123",
+                    "--name",
+                    "GPU Instance",
+                    "--description",
+                    "High-performance GPU instance",
+                    "--labels",
+                    r#"{"gpu":"true"}"#,
+                ][..],
+                expect: Yields((
+                    Some("type-123".to_string()),
+                    Some("GPU Instance".to_string()),
+                    Some("High-performance GPU instance".to_string()),
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Create(args) => (args.id, args.name, args.description),
+                    _ => panic!("expected Create variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_create_with_options ensures create parses with
-// all options.
+// The `show` subcommand: `--id` is optional, so a bare `show` lists all types
+// while supplying `--id` narrows to one.
 #[test]
-fn parse_create_with_options() {
-    let cmd = Cmd::try_parse_from([
-        "instance-type",
-        "create",
-        "--id",
-        "type-123",
-        "--name",
-        "GPU Instance",
-        "--description",
-        "High-performance GPU instance",
-        "--labels",
-        r#"{"gpu":"true"}"#,
-    ])
-    .expect("should parse create with options");
-
-    match cmd {
-        Cmd::Create(args) => {
-            assert_eq!(args.id, Some("type-123".to_string()));
-            assert_eq!(args.name, Some("GPU Instance".to_string()));
-            assert_eq!(
-                args.description,
-                Some("High-performance GPU instance".to_string())
-            );
-        }
-        _ => panic!("expected Create variant"),
-    }
+fn parse_show_routes_and_binds_id() {
+    check_cases(
+        [
+            Case {
+                scenario: "show with no arguments leaves id unset",
+                input: &["instance-type", "show"][..],
+                expect: Yields(None),
+            },
+            Case {
+                scenario: "show with --id binds the id",
+                input: &["instance-type", "show", "--id", "type-123"][..],
+                expect: Yields(Some("type-123".to_string())),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => args.id,
+                    _ => panic!("expected Show variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_no_args ensures show parses with no
-// arguments (all types).
+// The `delete` subcommand binds its required `--id`.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["instance-type", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_none());
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_delete_binds_id() {
+    check_cases(
+        [Case {
+            scenario: "delete with required --id",
+            input: &["instance-type", "delete", "--id", "type-123"][..],
+            expect: Yields("type-123".to_string()),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Delete(args) => args.id,
+                    _ => panic!("expected Delete variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_with_id ensures show parses with --id.
+// The `update` subcommand binds its required `--id` and any optional fields.
 #[test]
-fn parse_show_with_id() {
-    let cmd = Cmd::try_parse_from(["instance-type", "show", "--id", "type-123"])
-        .expect("should parse show with id");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.id, Some("type-123".to_string()));
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_update_binds_fields() {
+    check_cases(
+        [Case {
+            scenario: "update with required --id and a new name",
+            input: &[
+                "instance-type",
+                "update",
+                "--id",
+                "type-123",
+                "--name",
+                "Updated Name",
+            ][..],
+            expect: Yields(("type-123".to_string(), Some("Updated Name".to_string()))),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Update(args) => (args.id, args.name),
+                    _ => panic!("expected Update variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_delete ensures delete parses with required ID.
+// The `associate` subcommand binds the type id and its machine list, which
+// accepts a single machine or a comma-separated set.
 #[test]
-fn parse_delete() {
-    let cmd = Cmd::try_parse_from(["instance-type", "delete", "--id", "type-123"])
-        .expect("should parse delete");
-
-    match cmd {
-        Cmd::Delete(args) => {
-            assert_eq!(args.id, "type-123");
-        }
-        _ => panic!("expected Delete variant"),
-    }
+fn parse_associate_binds_type_and_machines() {
+    let two_machines = format!("{TEST_MACHINE_ID},{TEST_MACHINE_ID}");
+    check_cases(
+        [
+            Case {
+                scenario: "associate a single machine",
+                input: &["instance-type", "associate", "type-123", TEST_MACHINE_ID][..],
+                expect: Yields(("type-123".to_string(), 1)),
+            },
+            Case {
+                scenario: "associate comma-separated machines",
+                input: &["instance-type", "associate", "type-123", &two_machines][..],
+                expect: Yields(("type-123".to_string(), 2)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Associate(args) => (args.instance_type_id, args.machine_ids.len()),
+                    _ => panic!("expected Associate variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_update ensures update parses with required ID.
+// The `disassociate` subcommand binds its required machine id.
 #[test]
-fn parse_update() {
-    let cmd = Cmd::try_parse_from([
-        "instance-type",
-        "update",
-        "--id",
-        "type-123",
-        "--name",
-        "Updated Name",
-    ])
-    .expect("should parse update");
-
-    match cmd {
-        Cmd::Update(args) => {
-            assert_eq!(args.id, "type-123");
-            assert_eq!(args.name, Some("Updated Name".to_string()));
-        }
-        _ => panic!("expected Update variant"),
-    }
+fn parse_disassociate_binds_machine_id() {
+    check_cases(
+        [Case {
+            scenario: "disassociate with a machine id",
+            input: &["instance-type", "disassociate", TEST_MACHINE_ID][..],
+            expect: Yields(TEST_MACHINE_ID.to_string()),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Disassociate(args) => args.machine_id.to_string(),
+                    _ => panic!("expected Disassociate variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_associate ensures associate parses with
-// required arguments.
+// Every malformed invocation is rejected at parse time -- here, a subcommand
+// whose required `--id` is missing.
 #[test]
-fn parse_associate() {
-    let cmd = Cmd::try_parse_from(["instance-type", "associate", "type-123", TEST_MACHINE_ID])
-        .expect("should parse associate");
-
-    match cmd {
-        Cmd::Associate(args) => {
-            assert_eq!(args.instance_type_id, "type-123");
-            assert_eq!(args.machine_ids, vec![TEST_MACHINE_ID]);
-        }
-        _ => panic!("expected Associate variant"),
-    }
-}
-
-// parse_associate_multiple_machines ensures associate
-// parses with comma-separated machines.
-#[test]
-fn parse_associate_multiple_machines() {
-    let machine_ids = format!("{},{}", TEST_MACHINE_ID, TEST_MACHINE_ID);
-    let cmd = Cmd::try_parse_from(["instance-type", "associate", "type-123", &machine_ids])
-        .expect("should parse associate with multiple machines");
-
-    match cmd {
-        Cmd::Associate(args) => {
-            assert_eq!(args.machine_ids.len(), 2);
-        }
-        _ => panic!("expected Associate variant"),
-    }
-}
-
-// parse_disassociate ensures disassociate parses with
-// machine ID.
-#[test]
-fn parse_disassociate() {
-    let cmd = Cmd::try_parse_from(["instance-type", "disassociate", TEST_MACHINE_ID])
-        .expect("should parse disassociate");
-
-    match cmd {
-        Cmd::Disassociate(args) => {
-            assert_eq!(args.machine_id.to_string(), TEST_MACHINE_ID);
-        }
-        _ => panic!("expected Disassociate variant"),
-    }
-}
-
-// parse_delete_missing_id_fails ensures delete fails without --id.
-#[test]
-fn parse_delete_missing_id_fails() {
-    let result = Cmd::try_parse_from(["instance-type", "delete"]);
-    assert!(result.is_err(), "should fail without --id");
-}
-
-// parse_update_missing_id_fails ensures update fails without --id.
-#[test]
-fn parse_update_missing_id_fails() {
-    let result = Cmd::try_parse_from(["instance-type", "update"]);
-    assert!(result.is_err(), "should fail without --id");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "delete without --id",
+                input: &["instance-type", "delete"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "update without --id",
+                input: &["instance-type", "update"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/inventory/tests.rs
+++ b/crates/admin-cli/src/inventory/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::args::*;
@@ -44,39 +46,43 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_with_no_args ensures parses with no arguments
-// (optional filename).
+// The optional inventory filename parses from none, the long --filename and the
+// short -f flags, and across absolute and relative path spellings -- each
+// invocation lands in `cmd.filename`.
 #[test]
-fn parse_with_no_args() {
-    let cmd = Cmd::try_parse_from(["inventory"]).expect("should parse with no args");
-    assert!(cmd.filename.is_none());
-}
-
-// parse_with_filename ensures parses with --filename option.
-#[test]
-fn parse_with_filename() {
-    let cmd = Cmd::try_parse_from(["inventory", "--filename", "output.json"])
-        .expect("should parse with filename");
-    assert_eq!(cmd.filename, Some("output.json".to_string()));
-}
-
-// parse_with_short_flag ensures parses with -f short flag.
-#[test]
-fn parse_with_short_flag() {
-    let cmd =
-        Cmd::try_parse_from(["inventory", "-f", "output.json"]).expect("should parse with -f");
-    assert_eq!(cmd.filename, Some("output.json".to_string()));
-}
-
-// parse_with_various_filenames ensures parses various
-// filename formats.
-#[test]
-fn parse_with_various_filenames() {
-    let cmd1 = Cmd::try_parse_from(["inventory", "-f", "/tmp/inventory.json"])
-        .expect("should parse absolute path");
-    assert_eq!(cmd1.filename, Some("/tmp/inventory.json".to_string()));
-
-    let cmd2 = Cmd::try_parse_from(["inventory", "-f", "./relative/path.csv"])
-        .expect("should parse relative path");
-    assert_eq!(cmd2.filename, Some("./relative/path.csv".to_string()));
+fn parses_optional_filename() {
+    check_cases(
+        [
+            Case {
+                scenario: "no arguments leaves filename unset",
+                input: &["inventory"][..],
+                expect: Yields(None),
+            },
+            Case {
+                scenario: "--filename long flag",
+                input: &["inventory", "--filename", "output.json"][..],
+                expect: Yields(Some("output.json".to_string())),
+            },
+            Case {
+                scenario: "-f short flag",
+                input: &["inventory", "-f", "output.json"][..],
+                expect: Yields(Some("output.json".to_string())),
+            },
+            Case {
+                scenario: "absolute path",
+                input: &["inventory", "-f", "/tmp/inventory.json"][..],
+                expect: Yields(Some("/tmp/inventory.json".to_string())),
+            },
+            Case {
+                scenario: "relative path",
+                input: &["inventory", "-f", "./relative/path.csv"][..],
+                expect: Yields(Some("./relative/path.csv".to_string())),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| cmd.filename)
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/ip/tests.rs
+++ b/crates/admin-cli/src/ip/tests.rs
@@ -22,6 +22,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -43,60 +45,71 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_find_with_valid_ip ensures find parses a valid
-// IPv4 address.
+// find parses a valid IP and routes to the Find variant: IPv4 in its various
+// ranges (including 0.0.0.0) and IPv6 all parse, and the parsed address
+// round-trips to the canonical string the original argv supplied.
 #[test]
-fn parse_find_with_valid_ip() {
-    let cmd = Cmd::try_parse_from(["ip", "find", "192.168.1.100"]).expect("should parse find");
-
-    match cmd {
-        Cmd::Find(args) => {
-            assert_eq!(args.ip.to_string(), "192.168.1.100");
-        }
-    }
+fn parse_find_accepts_valid_ips() {
+    check_cases(
+        [
+            Case {
+                scenario: "standard IPv4 address",
+                input: &["ip", "find", "192.168.1.100"][..],
+                expect: Yields("192.168.1.100".to_string()),
+            },
+            Case {
+                scenario: "10.x IPv4 address",
+                input: &["ip", "find", "10.0.0.1"][..],
+                expect: Yields("10.0.0.1".to_string()),
+            },
+            Case {
+                scenario: "172.x IPv4 address",
+                input: &["ip", "find", "172.16.0.1"][..],
+                expect: Yields("172.16.0.1".to_string()),
+            },
+            Case {
+                scenario: "0.0.0.0 IPv4 address",
+                input: &["ip", "find", "0.0.0.0"][..],
+                expect: Yields("0.0.0.0".to_string()),
+            },
+            Case {
+                scenario: "IPv6 loopback address",
+                input: &["ip", "find", "::1"][..],
+                expect: Yields("::1".to_string()),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| {
+                    let Cmd::Find(args) = cmd;
+                    args.ip.to_string()
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_find_with_different_ips ensures find parses
-// various valid IPs.
+// find rejects malformed invocations at parse time: an unparseable IP value
+// and a missing required ip argument.
 #[test]
-fn parse_find_with_different_ips() {
-    let cmd1 = Cmd::try_parse_from(["ip", "find", "10.0.0.1"]).expect("should parse 10.x IP");
-    match cmd1 {
-        Cmd::Find(args) => assert_eq!(args.ip.to_string(), "10.0.0.1"),
-    }
-
-    let cmd2 = Cmd::try_parse_from(["ip", "find", "172.16.0.1"]).expect("should parse 172.x IP");
-    match cmd2 {
-        Cmd::Find(args) => assert_eq!(args.ip.to_string(), "172.16.0.1"),
-    }
-
-    let cmd3 = Cmd::try_parse_from(["ip", "find", "0.0.0.0"]).expect("should parse 0.0.0.0");
-    match cmd3 {
-        Cmd::Find(args) => assert_eq!(args.ip.to_string(), "0.0.0.0"),
-    }
-}
-
-// parse_find_invalid_ip_fails ensures find fails with
-// invalid IP.
-#[test]
-fn parse_find_invalid_ip_fails() {
-    let result = Cmd::try_parse_from(["ip", "find", "not-an-ip"]);
-    assert!(result.is_err(), "should fail with invalid IP");
-}
-
-// parse_find_ipv6 ensures find parses a valid IPv6 address.
-#[test]
-fn parse_find_ipv6() {
-    let cmd = Cmd::try_parse_from(["ip", "find", "::1"]).expect("should parse IPv6 address");
-    match cmd {
-        Cmd::Find(args) => assert_eq!(args.ip.to_string(), "::1"),
-    }
-}
-
-// parse_find_missing_ip_fails ensures find requires
-// ip argument.
-#[test]
-fn parse_find_missing_ip_fails() {
-    let result = Cmd::try_parse_from(["ip", "find"]);
-    assert!(result.is_err(), "should fail without IP argument");
+fn parse_find_rejects_invalid_invocations() {
+    check_cases(
+        [
+            Case {
+                scenario: "value is not a valid IP",
+                input: &["ip", "find", "not-an-ip"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "missing required ip argument",
+                input: &["ip", "find"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/jump/tests.rs
+++ b/crates/admin-cli/src/jump/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::args::Cmd;
@@ -44,39 +46,55 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_with_machine_id ensures parses machine ID format.
+// The positional id accepts any identifier format -- machine ID, IP address,
+// UUID, or MAC address -- and round-trips it verbatim onto `cmd.id`.
 #[test]
-fn parse_with_machine_id() {
-    let cmd = Cmd::try_parse_from(["jump", "machine-123"]).expect("should parse machine ID");
-    assert_eq!(cmd.id, "machine-123");
+fn parse_accepts_any_id_format() {
+    check_cases(
+        [
+            Case {
+                scenario: "machine ID",
+                input: &["jump", "machine-123"][..],
+                expect: Yields("machine-123".to_string()),
+            },
+            Case {
+                scenario: "IP address",
+                input: &["jump", "192.168.1.100"][..],
+                expect: Yields("192.168.1.100".to_string()),
+            },
+            Case {
+                scenario: "UUID",
+                input: &["jump", "550e8400-e29b-41d4-a716-446655440000"][..],
+                expect: Yields("550e8400-e29b-41d4-a716-446655440000".to_string()),
+            },
+            Case {
+                scenario: "MAC address",
+                input: &["jump", "00:11:22:33:44:55"][..],
+                expect: Yields("00:11:22:33:44:55".to_string()),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| cmd.id)
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_with_ip_address ensures parses IP address format.
+// The positional id is required: an invocation without it is rejected at parse
+// time.
 #[test]
-fn parse_with_ip_address() {
-    let cmd = Cmd::try_parse_from(["jump", "192.168.1.100"]).expect("should parse IP");
-    assert_eq!(cmd.id, "192.168.1.100");
-}
-
-// parse_with_uuid ensures parses UUID format.
-#[test]
-fn parse_with_uuid() {
-    let cmd = Cmd::try_parse_from(["jump", "550e8400-e29b-41d4-a716-446655440000"])
-        .expect("should parse UUID");
-    assert_eq!(cmd.id, "550e8400-e29b-41d4-a716-446655440000");
-}
-
-// parse_with_mac_address ensures parses MAC address format.
-#[test]
-fn parse_with_mac_address() {
-    let cmd = Cmd::try_parse_from(["jump", "00:11:22:33:44:55"]).expect("should parse MAC");
-    assert_eq!(cmd.id, "00:11:22:33:44:55");
-}
-
-// parse_requires_id_argument ensures fails without
-// required id.
-#[test]
-fn parse_requires_id_argument() {
-    let result = Cmd::try_parse_from(["jump"]);
-    assert!(result.is_err(), "should fail without required id argument");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [Case {
+            scenario: "no id argument",
+            input: &["jump"][..],
+            expect: Fails,
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/machine/tests.rs
+++ b/crates/admin-cli/src/machine/tests.rs
@@ -24,6 +24,8 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 // ValueEnum Parsing - Test string parsing for types deriving claps ValueEnum.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 use metadata::args::Args as MachineMetadataCommand;
 use network::args::Args as NetworkCommand;
@@ -51,56 +53,41 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all machines).
+// `show` parses with no arguments and with each of its flags, capturing the
+// machine/all/dpus/hosts state in each case.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["machine", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.machine.is_none());
-            assert!(!args.all);
-            assert!(!args.dpus);
-            assert!(!args.hosts);
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_show_variants() {
+    check_cases(
+        [
+            Case {
+                scenario: "no arguments (all machines)",
+                input: &["machine", "show"][..],
+                expect: Yields((false, false, false, false)),
+            },
+            Case {
+                scenario: "--dpus flag",
+                input: &["machine", "show", "--dpus"][..],
+                expect: Yields((false, false, true, false)),
+            },
+            Case {
+                scenario: "--hosts flag",
+                input: &["machine", "show", "--hosts"][..],
+                expect: Yields((false, false, false, true)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => (args.machine.is_some(), args.all, args.dpus, args.hosts),
+                    _ => panic!("expected Show variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_with_dpus ensures show parses with
-// --dpus flag.
-#[test]
-fn parse_show_with_dpus() {
-    let cmd = Cmd::try_parse_from(["machine", "show", "--dpus"]).expect("should parse show --dpus");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.dpus);
-            assert!(!args.hosts);
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_with_hosts ensures show parses with
-// --hosts flag.
-#[test]
-fn parse_show_with_hosts() {
-    let cmd =
-        Cmd::try_parse_from(["machine", "show", "--hosts"]).expect("should parse show --hosts");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.hosts);
-            assert!(!args.dpus);
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_network_status ensures network status
-// parses.
+// network status routes to the Status variant; network config parses with a
+// machine ID and exposes it.
 #[test]
 fn parse_network_status() {
     let cmd =
@@ -130,33 +117,34 @@ fn parse_network_config() {
     }
 }
 
-// parse_health_report_show ensures health-report show parses.
+// health-report show parses, and the legacy health-override alias routes to the
+// same Show variant; both expose the machine ID.
 #[test]
-fn parse_health_report_show() {
-    let cmd = Cmd::try_parse_from(["machine", "health-report", "show", TEST_MACHINE_ID])
-        .expect("should parse health-report show");
-
-    match cmd {
-        Cmd::HealthReport(HealthReportCommand::Show { machine_id }) => {
-            assert_eq!(machine_id.to_string(), TEST_MACHINE_ID);
-        }
-        _ => panic!("expected HealthReport Show variant"),
-    }
-}
-
-// parse_health_override_show ensures the legacy
-// health-override alias still parses.
-#[test]
-fn parse_health_override_show() {
-    let cmd = Cmd::try_parse_from(["machine", "health-override", "show", TEST_MACHINE_ID])
-        .expect("should parse health-override show");
-
-    match cmd {
-        Cmd::HealthReport(HealthReportCommand::Show { machine_id }) => {
-            assert_eq!(machine_id.to_string(), TEST_MACHINE_ID);
-        }
-        _ => panic!("expected HealthReport Show variant"),
-    }
+fn parse_health_report_show_variants() {
+    check_cases(
+        [
+            Case {
+                scenario: "health-report show",
+                input: &["machine", "health-report", "show", TEST_MACHINE_ID][..],
+                expect: Yields(TEST_MACHINE_ID.to_string()),
+            },
+            Case {
+                scenario: "legacy health-override show alias",
+                input: &["machine", "health-override", "show", TEST_MACHINE_ID][..],
+                expect: Yields(TEST_MACHINE_ID.to_string()),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::HealthReport(HealthReportCommand::Show { machine_id }) => {
+                        machine_id.to_string()
+                    }
+                    _ => panic!("expected HealthReport Show variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
 // parse_health_override_add_with_template ensures the
@@ -238,8 +226,8 @@ fn parse_auto_update_enable() {
     }
 }
 
-// parse_metadata_show ensures metadata show parses
-// with machine ID.
+// metadata show exposes the machine ID; metadata set exposes the parsed
+// --name option.
 #[test]
 fn parse_metadata_show() {
     let cmd = Cmd::try_parse_from(["machine", "metadata", "show", TEST_MACHINE_ID])
@@ -297,35 +285,68 @@ fn parse_positions() {
 // values correctly convert back into their expected variant,
 // or fail otherwise.
 
-// health_override_templates_value_enum ensures HealthReportTemplates
-// parses from strings.
+// Each documented HealthReportTemplates string round-trips to its variant, and
+// an unknown string is rejected. The variant itself is not PartialEq, so this
+// folds on a discriminant name rather than the enum value.
 #[test]
 fn health_override_templates_value_enum() {
     use clap::ValueEnum;
 
-    assert!(matches!(
-        HealthReportTemplates::from_str("host-update", false),
-        Ok(HealthReportTemplates::HostUpdate)
-    ));
-    assert!(matches!(
-        HealthReportTemplates::from_str("internal-maintenance", false),
-        Ok(HealthReportTemplates::InternalMaintenance)
-    ));
-    assert!(matches!(
-        HealthReportTemplates::from_str("out-for-repair", false),
-        Ok(HealthReportTemplates::OutForRepair)
-    ));
-    assert!(matches!(
-        HealthReportTemplates::from_str("degraded", false),
-        Ok(HealthReportTemplates::Degraded)
-    ));
-    assert!(matches!(
-        HealthReportTemplates::from_str("validation", false),
-        Ok(HealthReportTemplates::Validation)
-    ));
-    assert!(matches!(
-        HealthReportTemplates::from_str("request-online-repair", false),
-        Ok(HealthReportTemplates::RequestOnlineRepair)
-    ));
-    assert!(HealthReportTemplates::from_str("invalid", false).is_err());
+    fn template_name(t: &HealthReportTemplates) -> &'static str {
+        match t {
+            HealthReportTemplates::HostUpdate => "host-update",
+            HealthReportTemplates::InternalMaintenance => "internal-maintenance",
+            HealthReportTemplates::OutForRepair => "out-for-repair",
+            HealthReportTemplates::Degraded => "degraded",
+            HealthReportTemplates::Validation => "validation",
+            HealthReportTemplates::RequestOnlineRepair => "request-online-repair",
+            // Only the documented templates above are exercised here.
+            _ => unreachable!("untested HealthReportTemplates variant"),
+        }
+    }
+
+    check_cases(
+        [
+            Case {
+                scenario: "host-update",
+                input: "host-update",
+                expect: Yields("host-update"),
+            },
+            Case {
+                scenario: "internal-maintenance",
+                input: "internal-maintenance",
+                expect: Yields("internal-maintenance"),
+            },
+            Case {
+                scenario: "out-for-repair",
+                input: "out-for-repair",
+                expect: Yields("out-for-repair"),
+            },
+            Case {
+                scenario: "degraded",
+                input: "degraded",
+                expect: Yields("degraded"),
+            },
+            Case {
+                scenario: "validation",
+                input: "validation",
+                expect: Yields("validation"),
+            },
+            Case {
+                scenario: "request-online-repair",
+                input: "request-online-repair",
+                expect: Yields("request-online-repair"),
+            },
+            Case {
+                scenario: "invalid string is rejected",
+                input: "invalid",
+                expect: Fails,
+            },
+        ],
+        |s| {
+            HealthReportTemplates::from_str(s, false)
+                .map(|t| template_name(&t))
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/machine_interfaces/tests.rs
+++ b/crates/admin-cli/src/machine_interfaces/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -47,69 +49,75 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all interfaces).
+// show parses with any combination of its optional args; each row yields the
+// observed (interface_id present, --all, --more) so the no-args, --more, and
+// interface-id cases are all checked against one parse.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["machine-interface", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.interface_id.is_none());
-            assert!(!args.all);
-            assert!(!args.more);
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_show_variants() {
+    check_cases(
+        [
+            Case {
+                scenario: "no arguments (all interfaces)",
+                input: &["machine-interface", "show"][..],
+                expect: Yields((false, false, false)),
+            },
+            Case {
+                scenario: "--more flag",
+                input: &["machine-interface", "show", "--more"][..],
+                expect: Yields((false, false, true)),
+            },
+            Case {
+                scenario: "with an interface ID",
+                input: &["machine-interface", "show", TEST_INTERFACE_ID][..],
+                expect: Yields((true, false, false)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => (args.interface_id.is_some(), args.all, args.more),
+                    _ => panic!("expected Show variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_with_more ensures show parses with --more flag.
+// delete parses with an interface ID and routes to the Delete variant,
+// round-tripping the ID through its string form.
 #[test]
-fn parse_show_with_more() {
-    let cmd = Cmd::try_parse_from(["machine-interface", "show", "--more"])
-        .expect("should parse show --more");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.more);
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_delete_variants() {
+    check_cases(
+        [Case {
+            scenario: "with an interface ID",
+            input: &["machine-interface", "delete", TEST_INTERFACE_ID][..],
+            expect: Yields(TEST_INTERFACE_ID.to_string()),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Delete(args) => args.interface_id.to_string(),
+                    _ => panic!("expected Delete variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_with_interface_id ensures show parses
-// with interface ID.
+// Every malformed invocation is rejected at parse time -- e.g. delete left
+// without its required interface ID.
 #[test]
-fn parse_show_with_interface_id() {
-    let cmd = Cmd::try_parse_from(["machine-interface", "show", TEST_INTERFACE_ID])
-        .expect("should parse show with interface ID");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.interface_id.is_some());
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_delete ensures delete parses with interface ID.
-#[test]
-fn parse_delete() {
-    let cmd = Cmd::try_parse_from(["machine-interface", "delete", TEST_INTERFACE_ID])
-        .expect("should parse delete");
-
-    match cmd {
-        Cmd::Delete(args) => {
-            assert_eq!(args.interface_id.to_string(), TEST_INTERFACE_ID);
-        }
-        _ => panic!("expected Delete variant"),
-    }
-}
-
-// parse_delete_missing_id_fails ensures delete fails
-// without interface ID.
-#[test]
-fn parse_delete_missing_id_fails() {
-    let result = Cmd::try_parse_from(["machine-interface", "delete"]);
-    assert!(result.is_err(), "should fail without interface ID");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [Case {
+            scenario: "delete without an interface ID",
+            input: &["machine-interface", "delete"][..],
+            expect: Fails,
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/machine_validation/tests.rs
+++ b/crates/admin-cli/src/machine_validation/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use carbide_uuid::machine_validation::MachineValidationId;
 use clap::{CommandFactory, Parser};
 
@@ -48,229 +50,234 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_external_config_show ensures external-config
-// show parses.
+// external-config parses to the ExternalConfig variant: `show` defaults to an
+// empty name filter, and `add-update` carries its file-name/name through.
 #[test]
-fn parse_external_config_show() {
-    let cmd = Cmd::try_parse_from(["machine-validation", "external-config", "show"])
-        .expect("should parse external-config show");
-
-    match cmd {
-        Cmd::ExternalConfig(external_config::Args::Show(args)) => {
-            assert!(args.name.is_empty());
-        }
-        _ => panic!("expected ExternalConfig Show variant"),
-    }
+fn parse_external_config_routes_and_carries_fields() {
+    check_cases(
+        [
+            Case {
+                scenario: "show defaults to an empty name filter",
+                input: &["machine-validation", "external-config", "show"][..],
+                expect: Yields((String::new(), String::new())),
+            },
+            Case {
+                scenario: "add-update carries file-name and name",
+                input: &[
+                    "machine-validation",
+                    "external-config",
+                    "add-update",
+                    "--file-name",
+                    "config.yaml",
+                    "--name",
+                    "my-config",
+                    "--description",
+                    "Test config",
+                ][..],
+                expect: Yields(("config.yaml".to_string(), "my-config".to_string())),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::ExternalConfig(external_config::Args::Show(args)) => {
+                        // show has no file-name; surface its (empty) name filter
+                        // as a joined string so both arms yield (String, String)
+                        (String::new(), args.name.join(","))
+                    }
+                    Cmd::ExternalConfig(external_config::Args::AddUpdate(args)) => {
+                        (args.file_name, args.name)
+                    }
+                    _ => panic!("expected ExternalConfig variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_external_config_add_update ensures
-// external-config add-update parses.
+// on-demand start parses to the OnDemand::Start variant, carrying the machine ID
+// and defaulting --run-unverified-tests to false.
 #[test]
-fn parse_external_config_add_update() {
-    let cmd = Cmd::try_parse_from([
-        "machine-validation",
-        "external-config",
-        "add-update",
-        "--file-name",
-        "config.yaml",
-        "--name",
-        "my-config",
-        "--description",
-        "Test config",
-    ])
-    .expect("should parse external-config add-update");
-
-    match cmd {
-        Cmd::ExternalConfig(external_config::Args::AddUpdate(args)) => {
-            assert_eq!(args.file_name, "config.yaml");
-            assert_eq!(args.name, "my-config");
-        }
-        _ => panic!("expected ExternalConfig AddUpdate variant"),
-    }
+fn parse_on_demand_start_carries_machine() {
+    check_cases(
+        [Case {
+            scenario: "start with a machine ID",
+            input: &[
+                "machine-validation",
+                "on-demand",
+                "start",
+                "--machine",
+                TEST_MACHINE_ID,
+            ][..],
+            expect: Yields((TEST_MACHINE_ID.to_string(), false)),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::OnDemand(on_demand::Args::Start(args)) => {
+                        (args.machine.to_string(), args.run_unverified_tests)
+                    }
+                    _ => panic!("expected OnDemand Start variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_on_demand_start ensures on-demand start parses
-// with machine ID.
+// runs show parses to the Runs::Show variant: with no --machine the filter is
+// unset (and --history defaults off), with --machine the filter is present.
 #[test]
-fn parse_on_demand_start() {
-    let cmd = Cmd::try_parse_from([
-        "machine-validation",
-        "on-demand",
-        "start",
-        "--machine",
-        TEST_MACHINE_ID,
-    ])
-    .expect("should parse on-demand start");
-
-    match cmd {
-        Cmd::OnDemand(on_demand::Args::Start(args)) => {
-            assert_eq!(args.machine.to_string(), TEST_MACHINE_ID);
-            assert!(!args.run_unverified_tests);
-        }
-        _ => panic!("expected OnDemand Start variant"),
-    }
+fn parse_runs_show_machine_filter() {
+    check_cases(
+        [
+            Case {
+                scenario: "no machine filter (and history defaults off)",
+                input: &["machine-validation", "runs", "show"][..],
+                expect: Yields((false, false)),
+            },
+            Case {
+                scenario: "with a machine filter",
+                input: &[
+                    "machine-validation",
+                    "runs",
+                    "show",
+                    "--machine",
+                    TEST_MACHINE_ID,
+                ][..],
+                expect: Yields((true, false)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Runs(runs::Args::Show(args)) => (args.machine.is_some(), args.history),
+                    _ => panic!("expected Runs Show variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_runs_show ensures runs show parses.
+// results show parses to the Results::Show variant: --machine sets the machine
+// filter, --validation-id sets the validation-id filter.
 #[test]
-fn parse_runs_show() {
-    let cmd = Cmd::try_parse_from(["machine-validation", "runs", "show"])
-        .expect("should parse runs show");
-
-    match cmd {
-        Cmd::Runs(runs::Args::Show(args)) => {
-            assert!(args.machine.is_none());
-            assert!(!args.history);
-        }
-        _ => panic!("expected Runs Show variant"),
-    }
-}
-
-// parse_runs_show_with_machine ensures runs show
-// parses with machine filter.
-#[test]
-fn parse_runs_show_with_machine() {
-    let cmd = Cmd::try_parse_from([
-        "machine-validation",
-        "runs",
-        "show",
-        "--machine",
-        TEST_MACHINE_ID,
-    ])
-    .expect("should parse runs show with machine");
-
-    match cmd {
-        Cmd::Runs(runs::Args::Show(args)) => {
-            assert!(args.machine.is_some());
-        }
-        _ => panic!("expected Runs Show variant"),
-    }
-}
-
-// parse_results_show_with_machine ensures results
-// show parses with machine.
-#[test]
-fn parse_results_show_with_machine() {
-    let cmd = Cmd::try_parse_from([
-        "machine-validation",
-        "results",
-        "show",
-        "--machine",
-        TEST_MACHINE_ID,
-    ])
-    .expect("should parse results show with machine");
-
-    match cmd {
-        Cmd::Results(results::Args::Show(args)) => {
-            assert!(args.machine.is_some());
-        }
-        _ => panic!("expected Results Show variant"),
-    }
-}
-
-// parse_results_show_with_validation_id ensures
-// results show parses with validation ID.
-#[test]
-fn parse_results_show_with_validation_id() {
+fn parse_results_show_filters() {
     let validation_id = MachineValidationId::new();
-    let cmd = Cmd::try_parse_from([
-        "machine-validation",
-        "results",
-        "show",
-        "--validation-id",
-        validation_id.to_string().as_str(),
-    ])
-    .expect("should parse results show with validation-id");
-
-    match cmd {
-        Cmd::Results(results::Args::Show(args)) => {
-            assert_eq!(args.validation_id, Some(validation_id));
-        }
-        _ => panic!("expected Results Show variant"),
-    }
-}
-
-// parse_tests_show ensures tests show parses.
-#[test]
-fn parse_tests_show() {
-    let cmd = Cmd::try_parse_from(["machine-validation", "tests", "show"])
-        .expect("should parse tests show");
-
-    match cmd {
-        Cmd::Tests(tests_cmd) => match tests_cmd {
-            tests_cmd::Args::Show(args) => {
-                assert!(args.test_id.is_none());
-            }
-            _ => panic!("expected Tests Show variant"),
+    check_cases(
+        [
+            Case {
+                scenario: "with a machine filter",
+                input: &[
+                    "machine-validation",
+                    "results",
+                    "show",
+                    "--machine",
+                    TEST_MACHINE_ID,
+                ][..],
+                expect: Yields((true, None)),
+            },
+            Case {
+                scenario: "with a validation-id filter",
+                input: &[
+                    "machine-validation",
+                    "results",
+                    "show",
+                    "--validation-id",
+                    validation_id.to_string().as_str(),
+                ][..],
+                expect: Yields((false, Some(validation_id))),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Results(results::Args::Show(args)) => {
+                        (args.machine.is_some(), args.validation_id)
+                    }
+                    _ => panic!("expected Results Show variant"),
+                })
+                .map_err(drop)
         },
-        _ => panic!("expected Tests variant"),
-    }
+    );
 }
 
-// parse_tests_verify ensures tests verify parses with
-// required args.
+// tests parses to the Tests variant: `show` leaves test-id unset, `verify`
+// carries test-id/version, and `add` carries name/command/args.
 #[test]
-fn parse_tests_verify() {
-    let cmd = Cmd::try_parse_from([
-        "machine-validation",
-        "tests",
-        "verify",
-        "--test-id",
-        "test-123",
-        "--version",
-        "v1",
-    ])
-    .expect("should parse tests verify");
-
-    match cmd {
-        Cmd::Tests(tests_cmd) => match tests_cmd {
-            tests_cmd::Args::Verify(args) => {
-                assert_eq!(args.test_id, "test-123");
-                assert_eq!(args.version, "v1");
-            }
-            _ => panic!("expected Tests Verify variant"),
+fn parse_tests_subcommands() {
+    check_cases(
+        [
+            Case {
+                scenario: "show leaves test-id unset",
+                input: &["machine-validation", "tests", "show"][..],
+                expect: Yields((false, String::new(), String::new())),
+            },
+            Case {
+                scenario: "verify carries test-id and version",
+                input: &[
+                    "machine-validation",
+                    "tests",
+                    "verify",
+                    "--test-id",
+                    "test-123",
+                    "--version",
+                    "v1",
+                ][..],
+                expect: Yields((true, "test-123".to_string(), "v1".to_string())),
+            },
+            Case {
+                scenario: "add carries name, command, and args",
+                input: &[
+                    "machine-validation",
+                    "tests",
+                    "add",
+                    "--name",
+                    "my-test",
+                    "--command",
+                    "/bin/test",
+                    "--args",
+                    "--verbose",
+                ][..],
+                expect: Yields((true, "my-test".to_string(), "/bin/test".to_string())),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Tests(tests_cmd::Args::Show(args)) => {
+                        // show: only test-id is meaningful; pad the tuple
+                        (args.test_id.is_some(), String::new(), String::new())
+                    }
+                    Cmd::Tests(tests_cmd::Args::Verify(args)) => {
+                        // verify: (present, test-id, version)
+                        (true, args.test_id, args.version)
+                    }
+                    Cmd::Tests(tests_cmd::Args::Add(args)) => {
+                        // add: name/command checked here, args asserted below
+                        assert_eq!(args.args, "--verbose", "tests add --args");
+                        (true, args.name, args.command)
+                    }
+                    _ => panic!("expected Tests variant"),
+                })
+                .map_err(drop)
         },
-        _ => panic!("expected Tests variant"),
-    }
+    );
 }
 
-// parse_tests_add ensures tests add parses with
-// required args.
+// Malformed invocations are rejected at parse time -- results show with none of
+// its required filters cannot parse.
 #[test]
-fn parse_tests_add() {
-    let cmd = Cmd::try_parse_from([
-        "machine-validation",
-        "tests",
-        "add",
-        "--name",
-        "my-test",
-        "--command",
-        "/bin/test",
-        "--args",
-        "--verbose",
-    ])
-    .expect("should parse tests add");
-
-    match cmd {
-        Cmd::Tests(tests_cmd) => match tests_cmd {
-            tests_cmd::Args::Add(args) => {
-                assert_eq!(args.name, "my-test");
-                assert_eq!(args.command, "/bin/test");
-                assert_eq!(args.args, "--verbose");
-            }
-            _ => panic!("expected Tests Add variant"),
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [Case {
+            scenario: "results show without machine/validation_id/test_name",
+            input: &["machine-validation", "results", "show"][..],
+            expect: Fails,
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
         },
-        _ => panic!("expected Tests variant"),
-    }
-}
-
-// parse_results_show_missing_required_fails ensures
-// results show fails without required args.
-#[test]
-fn parse_results_show_missing_required_fails() {
-    let result = Cmd::try_parse_from(["machine-validation", "results", "show"]);
-    assert!(
-        result.is_err(),
-        "should fail without machine/validation_id/test_name"
     );
 }

--- a/crates/admin-cli/src/managed_host/tests.rs
+++ b/crates/admin-cli/src/managed_host/tests.rs
@@ -24,6 +24,8 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 // ValueEnum Parsing - Test string parsing for types deriving claps ValueEnum.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::maintenance::args::Args as MaintenanceAction;
@@ -51,141 +53,140 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all hosts).
+// show routes to the Show variant across its argument combinations: bare (all
+// hosts), with a machine id, and with --fix. Each row yields the parsed
+// (machine.is_some(), all, ips, more, fix) so every original assertion holds.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["managed-host", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.machine.is_none());
-            assert!(!args.all);
-            assert!(!args.ips);
-            assert!(!args.more);
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_show_routes_to_show() {
+    check_cases(
+        [
+            Case {
+                scenario: "no args (all hosts)",
+                input: &["managed-host", "show"][..],
+                expect: Yields((false, false, false, false, false)),
+            },
+            Case {
+                scenario: "with machine id",
+                input: &["managed-host", "show", TEST_MACHINE_ID][..],
+                expect: Yields((true, false, false, false, false)),
+            },
+            Case {
+                scenario: "with --fix flag",
+                input: &["managed-host", "show", "--fix"][..],
+                expect: Yields((false, false, false, false, true)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => (
+                        args.machine.is_some(),
+                        args.all,
+                        args.ips,
+                        args.more,
+                        args.fix,
+                    ),
+                    _ => panic!("expected Show variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_with_machine ensures show parses with
-// machine ID.
+// maintenance on/off route to the Maintenance variant with the expected host
+// (and reference, for `on`). Each row yields (host, reference) -- reference is
+// empty for the `off` case which carries none.
 #[test]
-fn parse_show_with_machine() {
-    let cmd = Cmd::try_parse_from(["managed-host", "show", TEST_MACHINE_ID])
-        .expect("should parse show with machine");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.machine.is_some());
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_maintenance_routes_to_maintenance() {
+    check_cases(
+        [
+            Case {
+                scenario: "on with host and reference",
+                input: &[
+                    "managed-host",
+                    "maintenance",
+                    "on",
+                    "--host",
+                    TEST_MACHINE_ID,
+                    "--reference",
+                    "TICKET-123",
+                ][..],
+                expect: Yields((TEST_MACHINE_ID.to_string(), "TICKET-123".to_string())),
+            },
+            Case {
+                scenario: "off with host",
+                input: &[
+                    "managed-host",
+                    "maintenance",
+                    "off",
+                    "--host",
+                    TEST_MACHINE_ID,
+                ][..],
+                expect: Yields((TEST_MACHINE_ID.to_string(), String::new())),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Maintenance(MaintenanceAction::On(args)) => {
+                        (args.host.to_string(), args.reference)
+                    }
+                    Cmd::Maintenance(MaintenanceAction::Off(args)) => {
+                        (args.host.to_string(), String::new())
+                    }
+                    _ => panic!("expected Maintenance variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_with_fix_flag ensures show parses with
-// --fix flag.
+// quarantine on/off route to the Quarantine variant with the expected host
+// (and reason, for `on`). Each row yields (host, reason) -- reason is empty
+// for the `off` case which carries none.
 #[test]
-fn parse_show_with_fix_flag() {
-    let cmd =
-        Cmd::try_parse_from(["managed-host", "show", "--fix"]).expect("should parse show --fix");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.fix);
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_maintenance_on ensures maintenance on parses
-// with required args.
-#[test]
-fn parse_maintenance_on() {
-    let cmd = Cmd::try_parse_from([
-        "managed-host",
-        "maintenance",
-        "on",
-        "--host",
-        TEST_MACHINE_ID,
-        "--reference",
-        "TICKET-123",
-    ])
-    .expect("should parse maintenance on");
-
-    match cmd {
-        Cmd::Maintenance(MaintenanceAction::On(args)) => {
-            assert_eq!(args.host.to_string(), TEST_MACHINE_ID);
-            assert_eq!(args.reference, "TICKET-123");
-        }
-        _ => panic!("expected Maintenance On variant"),
-    }
-}
-
-// parse_maintenance_off ensures maintenance off parses
-// with required args.
-#[test]
-fn parse_maintenance_off() {
-    let cmd = Cmd::try_parse_from([
-        "managed-host",
-        "maintenance",
-        "off",
-        "--host",
-        TEST_MACHINE_ID,
-    ])
-    .expect("should parse maintenance off");
-
-    match cmd {
-        Cmd::Maintenance(MaintenanceAction::Off(args)) => {
-            assert_eq!(args.host.to_string(), TEST_MACHINE_ID);
-        }
-        _ => panic!("expected Maintenance Off variant"),
-    }
-}
-
-// parse_quarantine_on ensures quarantine on parses
-// with required args.
-#[test]
-fn parse_quarantine_on() {
-    let cmd = Cmd::try_parse_from([
-        "managed-host",
-        "quarantine",
-        "on",
-        "--host",
-        TEST_MACHINE_ID,
-        "--reason",
-        "Security issue",
-    ])
-    .expect("should parse quarantine on");
-
-    match cmd {
-        Cmd::Quarantine(QuarantineAction::On(args)) => {
-            assert_eq!(args.host.to_string(), TEST_MACHINE_ID);
-            assert_eq!(args.reason, "Security issue");
-        }
-        _ => panic!("expected Quarantine On variant"),
-    }
-}
-
-// parse_quarantine_off ensures quarantine off parses
-// with required args.
-#[test]
-fn parse_quarantine_off() {
-    let cmd = Cmd::try_parse_from([
-        "managed-host",
-        "quarantine",
-        "off",
-        "--host",
-        TEST_MACHINE_ID,
-    ])
-    .expect("should parse quarantine off");
-
-    match cmd {
-        Cmd::Quarantine(QuarantineAction::Off(args)) => {
-            assert_eq!(args.host.to_string(), TEST_MACHINE_ID);
-        }
-        _ => panic!("expected Quarantine Off variant"),
-    }
+fn parse_quarantine_routes_to_quarantine() {
+    check_cases(
+        [
+            Case {
+                scenario: "on with host and reason",
+                input: &[
+                    "managed-host",
+                    "quarantine",
+                    "on",
+                    "--host",
+                    TEST_MACHINE_ID,
+                    "--reason",
+                    "Security issue",
+                ][..],
+                expect: Yields((TEST_MACHINE_ID.to_string(), "Security issue".to_string())),
+            },
+            Case {
+                scenario: "off with host",
+                input: &[
+                    "managed-host",
+                    "quarantine",
+                    "off",
+                    "--host",
+                    TEST_MACHINE_ID,
+                ][..],
+                expect: Yields((TEST_MACHINE_ID.to_string(), String::new())),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Quarantine(QuarantineAction::On(args)) => {
+                        (args.host.to_string(), args.reason)
+                    }
+                    Cmd::Quarantine(QuarantineAction::Off(args)) => {
+                        (args.host.to_string(), String::new())
+                    }
+                    _ => panic!("expected Quarantine variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
 // parse_reset_host_reprovisioning ensures
@@ -208,42 +209,50 @@ fn parse_reset_host_reprovisioning() {
     }
 }
 
-// parse_power_options_show ensures power-options
-// show parses.
+// power-options show/update route to the PowerOptions variant. show carries no
+// machine; update carries a machine and a desired power state. Each row yields
+// (machine, desired-power-state-string) -- show yields (empty, empty).
 #[test]
-fn parse_power_options_show() {
-    let cmd = Cmd::try_parse_from(["managed-host", "power-options", "show"])
-        .expect("should parse power-options show");
-
-    match cmd {
-        Cmd::PowerOptions(PowerOptions::Show(args)) => {
-            assert!(args.machine.is_none());
-        }
-        _ => panic!("expected PowerOptions Show variant"),
-    }
-}
-
-// parse_power_options_update ensures power-options
-// update parses.
-#[test]
-fn parse_power_options_update() {
-    let cmd = Cmd::try_parse_from([
-        "managed-host",
-        "power-options",
-        "update",
-        TEST_MACHINE_ID,
-        "--desired-power-state",
-        "on",
-    ])
-    .expect("should parse power-options update");
-
-    match cmd {
-        Cmd::PowerOptions(PowerOptions::Update(args)) => {
-            assert_eq!(args.machine.to_string(), TEST_MACHINE_ID);
-            assert_eq!(args.desired_power_state, DesiredPowerState::On);
-        }
-        _ => panic!("expected PowerOptions Update variant"),
-    }
+fn parse_power_options_routes_to_power_options() {
+    check_cases(
+        [
+            Case {
+                scenario: "show with no machine",
+                input: &["managed-host", "power-options", "show"][..],
+                expect: Yields((String::new(), String::new())),
+            },
+            Case {
+                scenario: "update with machine and desired power state",
+                input: &[
+                    "managed-host",
+                    "power-options",
+                    "update",
+                    TEST_MACHINE_ID,
+                    "--desired-power-state",
+                    "on",
+                ][..],
+                expect: Yields((
+                    TEST_MACHINE_ID.to_string(),
+                    format!("{:?}", DesiredPowerState::On),
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::PowerOptions(PowerOptions::Show(args)) => {
+                        assert!(args.machine.is_none());
+                        (String::new(), String::new())
+                    }
+                    Cmd::PowerOptions(PowerOptions::Update(args)) => (
+                        args.machine.to_string(),
+                        format!("{:?}", args.desired_power_state),
+                    ),
+                    _ => panic!("expected PowerOptions variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
 // parse_set_primary_dpu ensures set-primary-dpu parses
@@ -309,14 +318,20 @@ fn parse_debug_bundle() {
     }
 }
 
-// parse_maintenance_on_missing_required_fails ensures
-// maintenance on fails without required args.
+// Every malformed invocation is rejected at parse time.
 #[test]
-fn parse_maintenance_on_missing_required_fails() {
-    let result = Cmd::try_parse_from(["managed-host", "maintenance", "on"]);
-    assert!(
-        result.is_err(),
-        "should fail without --host and --reference"
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [Case {
+            scenario: "maintenance on without --host and --reference",
+            input: &["managed-host", "maintenance", "on"][..],
+            expect: Fails,
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
     );
 }
 
@@ -328,23 +343,36 @@ fn parse_maintenance_on_missing_required_fails() {
 // values correctly convert back into their expected variant,
 // or fail otherwise.
 
-// desired_power_state_value_enum ensures DesiredPowerState
-// parses from strings.
+// desired_power_state_value_enum ensures DesiredPowerState parses from its
+// string representations, and rejects an unknown value. Each row yields the
+// debug form of the parsed variant; the unknown value fails.
 #[test]
 fn desired_power_state_value_enum() {
     use clap::ValueEnum;
 
-    assert!(matches!(
-        DesiredPowerState::from_str("on", false),
-        Ok(DesiredPowerState::On)
-    ));
-    assert!(matches!(
-        DesiredPowerState::from_str("off", false),
-        Ok(DesiredPowerState::Off)
-    ));
-    assert!(matches!(
-        DesiredPowerState::from_str("power-manager-disabled", false),
-        Ok(DesiredPowerState::PowerManagerDisabled)
-    ));
-    assert!(DesiredPowerState::from_str("invalid", false).is_err());
+    check_cases(
+        [
+            Case {
+                scenario: "on",
+                input: "on",
+                expect: Yields(format!("{:?}", DesiredPowerState::On)),
+            },
+            Case {
+                scenario: "off",
+                input: "off",
+                expect: Yields(format!("{:?}", DesiredPowerState::Off)),
+            },
+            Case {
+                scenario: "power-manager-disabled",
+                input: "power-manager-disabled",
+                expect: Yields(format!("{:?}", DesiredPowerState::PowerManagerDisabled)),
+            },
+            Case {
+                scenario: "invalid value",
+                input: "invalid",
+                expect: Fails,
+            },
+        ],
+        |s| DesiredPowerState::from_str(s, false).map(|v| format!("{v:?}")),
+    );
 }

--- a/crates/admin-cli/src/managed_switch/tests.rs
+++ b/crates/admin-cli/src/managed_switch/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,32 +46,32 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all switches).
+// show parses with or without a positional identifier; the optional argument
+// is None when omitted and carries the given value when supplied.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["managed-switch", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.identifier.is_none());
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_with_identifier ensures show parses with identifier.
-#[test]
-fn parse_show_with_identifier() {
-    let cmd = Cmd::try_parse_from(["managed-switch", "show", "switch-123"])
-        .expect("should parse show with identifier");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.identifier, Some("switch-123".to_string()));
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_show_identifier() {
+    check_cases(
+        [
+            Case {
+                scenario: "show with no arguments (all switches)",
+                input: &["managed-switch", "show"][..],
+                expect: Yields(None),
+            },
+            Case {
+                scenario: "show with an identifier",
+                input: &["managed-switch", "show", "switch-123"][..],
+                expect: Yields(Some("switch-123".to_string())),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => args.identifier,
+                    _ => panic!("expected Show variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
 // parse_list ensures list parses with no arguments.

--- a/crates/admin-cli/src/metadata.rs
+++ b/crates/admin-cli/src/metadata.rs
@@ -194,6 +194,9 @@ pub(crate) fn parse_rpc_labels(labels: Vec<String>) -> Vec<rpc::forge::Label> {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     fn label(key: &str, value: Option<&str>) -> rpc::forge::Label {
@@ -211,87 +214,138 @@ mod tests {
         }
     }
 
-    // apply_set tests
-
+    // apply_set: name/description overrides are applied (None leaves the field
+    // untouched), and a missing Metadata is rejected. Each row yields the
+    // resulting (name, description) pair.
     #[test]
-    fn apply_set_updates_name() {
-        let m = metadata_with("old", "desc", vec![]);
-        let result = apply_set(Some(m), Some("new".into()), None).unwrap();
-        assert_eq!(result.name, "new");
-        assert_eq!(result.description, "desc");
+    fn apply_set_applies_overrides() {
+        check_cases(
+            [
+                Case {
+                    scenario: "name override updates name, leaves description",
+                    input: (
+                        Some(metadata_with("old", "desc", vec![])),
+                        Some("new".to_string()),
+                        None,
+                    ),
+                    expect: Yields(("new".to_string(), "desc".to_string())),
+                },
+                Case {
+                    scenario: "description override updates description, leaves name",
+                    input: (
+                        Some(metadata_with("name", "old", vec![])),
+                        None,
+                        Some("new".to_string()),
+                    ),
+                    expect: Yields(("name".to_string(), "new".to_string())),
+                },
+                Case {
+                    scenario: "no overrides leaves both unchanged",
+                    input: (Some(metadata_with("name", "desc", vec![])), None, None),
+                    expect: Yields(("name".to_string(), "desc".to_string())),
+                },
+                Case {
+                    scenario: "missing metadata errors",
+                    input: (None, Some("x".to_string()), None),
+                    expect: Fails,
+                },
+            ],
+            |(metadata, name, description)| {
+                apply_set(metadata, name, description)
+                    .map(|m| (m.name, m.description))
+                    .map_err(drop)
+            },
+        );
     }
 
+    // apply_add_label: a new key is appended, an existing key is replaced in
+    // place (and other labels preserved), and a missing Metadata is rejected.
+    // Each row yields the resulting label list.
     #[test]
-    fn apply_set_updates_description() {
-        let m = metadata_with("name", "old", vec![]);
-        let result = apply_set(Some(m), None, Some("new".into())).unwrap();
-        assert_eq!(result.name, "name");
-        assert_eq!(result.description, "new");
+    fn apply_add_label_adds_or_replaces() {
+        check_cases(
+            [
+                Case {
+                    scenario: "adds a new label",
+                    input: (
+                        Some(metadata_with("n", "", vec![])),
+                        "env".to_string(),
+                        Some("prod".to_string()),
+                    ),
+                    expect: Yields(vec![label("env", Some("prod"))]),
+                },
+                Case {
+                    scenario: "replaces an existing key",
+                    input: (
+                        Some(metadata_with("n", "", vec![label("env", Some("staging"))])),
+                        "env".to_string(),
+                        Some("prod".to_string()),
+                    ),
+                    expect: Yields(vec![label("env", Some("prod"))]),
+                },
+                Case {
+                    scenario: "preserves other labels",
+                    input: (
+                        Some(metadata_with("n", "", vec![label("team", Some("infra"))])),
+                        "env".to_string(),
+                        Some("prod".to_string()),
+                    ),
+                    expect: Yields(vec![
+                        label("team", Some("infra")),
+                        label("env", Some("prod")),
+                    ]),
+                },
+                Case {
+                    scenario: "missing metadata errors",
+                    input: (None, "k".to_string(), None),
+                    expect: Fails,
+                },
+            ],
+            |(metadata, key, value)| {
+                apply_add_label(metadata, key, value)
+                    .map(|m| m.labels)
+                    .map_err(drop)
+            },
+        );
     }
 
+    // apply_remove_labels: matching keys are dropped, missing keys are ignored,
+    // and a missing Metadata is rejected. Each row yields the surviving labels.
     #[test]
-    fn apply_set_none_leaves_unchanged() {
-        let m = metadata_with("name", "desc", vec![]);
-        let result = apply_set(Some(m), None, None).unwrap();
-        assert_eq!(result.name, "name");
-        assert_eq!(result.description, "desc");
-    }
-
-    #[test]
-    fn apply_set_missing_metadata_errors() {
-        assert!(apply_set(None, Some("x".into()), None).is_err());
-    }
-
-    // apply_add_label tests
-
-    #[test]
-    fn apply_add_label_adds_new() {
-        let m = metadata_with("n", "", vec![]);
-        let result = apply_add_label(Some(m), "env".into(), Some("prod".into())).unwrap();
-        assert_eq!(result.labels.len(), 1);
-        assert_eq!(result.labels[0].key, "env");
-        assert_eq!(result.labels[0].value, Some("prod".to_string()));
-    }
-
-    #[test]
-    fn apply_add_label_replaces_existing() {
-        let m = metadata_with("n", "", vec![label("env", Some("staging"))]);
-        let result = apply_add_label(Some(m), "env".into(), Some("prod".into())).unwrap();
-        assert_eq!(result.labels.len(), 1);
-        assert_eq!(result.labels[0].value, Some("prod".to_string()));
-    }
-
-    #[test]
-    fn apply_add_label_preserves_others() {
-        let m = metadata_with("n", "", vec![label("team", Some("infra"))]);
-        let result = apply_add_label(Some(m), "env".into(), Some("prod".into())).unwrap();
-        assert_eq!(result.labels.len(), 2);
-    }
-
-    #[test]
-    fn apply_add_label_missing_metadata_errors() {
-        assert!(apply_add_label(None, "k".into(), None).is_err());
-    }
-
-    // apply_remove_labels tests
-
-    #[test]
-    fn apply_remove_labels_removes_matching() {
-        let m = metadata_with("n", "", vec![label("a", None), label("b", None)]);
-        let result = apply_remove_labels(Some(m), vec!["a".into()]).unwrap();
-        assert_eq!(result.labels.len(), 1);
-        assert_eq!(result.labels[0].key, "b");
-    }
-
-    #[test]
-    fn apply_remove_labels_ignores_missing_keys() {
-        let m = metadata_with("n", "", vec![label("a", None)]);
-        let result = apply_remove_labels(Some(m), vec!["nonexistent".into()]).unwrap();
-        assert_eq!(result.labels.len(), 1);
-    }
-
-    #[test]
-    fn apply_remove_labels_missing_metadata_errors() {
-        assert!(apply_remove_labels(None, vec!["k".into()]).is_err());
+    fn apply_remove_labels_drops_matching() {
+        check_cases(
+            [
+                Case {
+                    scenario: "removes the matching key",
+                    input: (
+                        Some(metadata_with(
+                            "n",
+                            "",
+                            vec![label("a", None), label("b", None)],
+                        )),
+                        vec!["a".to_string()],
+                    ),
+                    expect: Yields(vec![label("b", None)]),
+                },
+                Case {
+                    scenario: "ignores keys that don't exist",
+                    input: (
+                        Some(metadata_with("n", "", vec![label("a", None)])),
+                        vec!["nonexistent".to_string()],
+                    ),
+                    expect: Yields(vec![label("a", None)]),
+                },
+                Case {
+                    scenario: "missing metadata errors",
+                    input: (None, vec!["k".to_string()]),
+                    expect: Fails,
+                },
+            ],
+            |(metadata, keys)| {
+                apply_remove_labels(metadata, keys)
+                    .map(|m| m.labels)
+                    .map_err(drop)
+            },
+        );
     }
 }

--- a/crates/admin-cli/src/network_devices/tests.rs
+++ b/crates/admin-cli/src/network_devices/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,43 +46,34 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all devices).
+// show parses with no arguments (all devices), with a device ID, and with the
+// deprecated --all flag; each row asserts the resulting (id, all) pair.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["network-device", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_empty());
-            assert!(!args.all);
-        }
-    }
-}
-
-// parse_show_with_id ensures show parses with device ID.
-#[test]
-fn parse_show_with_id() {
-    let cmd = Cmd::try_parse_from(["network-device", "show", "mac=00:11:22:33:44:55"])
-        .expect("should parse show with id");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.id, "mac=00:11:22:33:44:55");
-        }
-    }
-}
-
-// parse_show_with_all ensures show parses with
-// --all flag (deprecated).
-#[test]
-fn parse_show_with_all() {
-    let cmd =
-        Cmd::try_parse_from(["network-device", "show", "--all"]).expect("should parse show --all");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.all);
-        }
-    }
+fn parse_show_variants() {
+    check_cases(
+        [
+            Case {
+                scenario: "no arguments parses (all devices)",
+                input: &["network-device", "show"][..],
+                expect: Yields((String::new(), false)),
+            },
+            Case {
+                scenario: "with a device ID",
+                input: &["network-device", "show", "mac=00:11:22:33:44:55"][..],
+                expect: Yields(("mac=00:11:22:33:44:55".to_string(), false)),
+            },
+            Case {
+                scenario: "with the deprecated --all flag",
+                input: &["network-device", "show", "--all"][..],
+                expect: Yields((String::new(), true)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => (args.id, args.all),
+                })
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/network_security_group/tests.rs
+++ b/crates/admin-cli/src/network_security_group/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,191 +46,228 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_create ensures create parses with required
-// arguments.
+// create routes to the Create variant and threads through the tenant org id
+// plus its optional id/name/stateful-egress flags: bare invocation leaves the
+// options unset, the fully-flagged invocation carries them through.
 #[test]
-fn parse_create() {
-    let cmd = Cmd::try_parse_from([
-        "network-security-group",
-        "create",
-        "--tenant-organization-id",
-        "tenant-123",
-    ])
-    .expect("should parse create");
-
-    match cmd {
-        Cmd::Create(args) => {
-            assert_eq!(args.tenant_organization_id, "tenant-123");
-            assert!(args.id.is_none());
-            assert!(args.name.is_none());
-            assert!(!args.stateful_egress);
-        }
-        _ => panic!("expected Create variant"),
-    }
+fn parse_create_routes_to_create_variant() {
+    check_cases(
+        [
+            Case {
+                scenario: "create with only the required tenant org id",
+                input: &[
+                    "network-security-group",
+                    "create",
+                    "--tenant-organization-id",
+                    "tenant-123",
+                ][..],
+                expect: Yields(("tenant-123".to_string(), None, None, false)),
+            },
+            Case {
+                scenario: "create with all options",
+                input: &[
+                    "network-security-group",
+                    "create",
+                    "--tenant-organization-id",
+                    "tenant-123",
+                    "--id",
+                    "nsg-123",
+                    "--name",
+                    "my-nsg",
+                    "--description",
+                    "Test NSG",
+                    "--stateful-egress",
+                ][..],
+                expect: Yields((
+                    "tenant-123".to_string(),
+                    Some("nsg-123".to_string()),
+                    Some("my-nsg".to_string()),
+                    true,
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Create(args) => (
+                        args.tenant_organization_id,
+                        args.id,
+                        args.name,
+                        args.stateful_egress,
+                    ),
+                    _ => panic!("expected Create variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_create_with_options ensures create parses with
-// all options.
+// show routes to the Show variant with an optional positional id: bare leaves
+// it unset, a supplied id is captured.
 #[test]
-fn parse_create_with_options() {
-    let cmd = Cmd::try_parse_from([
-        "network-security-group",
-        "create",
-        "--tenant-organization-id",
-        "tenant-123",
-        "--id",
-        "nsg-123",
-        "--name",
-        "my-nsg",
-        "--description",
-        "Test NSG",
-        "--stateful-egress",
-    ])
-    .expect("should parse create with options");
-
-    match cmd {
-        Cmd::Create(args) => {
-            assert_eq!(args.id, Some("nsg-123".to_string()));
-            assert_eq!(args.name, Some("my-nsg".to_string()));
-            assert!(args.stateful_egress);
-        }
-        _ => panic!("expected Create variant"),
-    }
+fn parse_show_routes_to_show_variant() {
+    check_cases(
+        [
+            Case {
+                scenario: "show with no args (all groups)",
+                input: &["network-security-group", "show"][..],
+                expect: Yields(None),
+            },
+            Case {
+                scenario: "show with a group id",
+                input: &["network-security-group", "show", "nsg-123"][..],
+                expect: Yields(Some("nsg-123".to_string())),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => args.id,
+                    _ => panic!("expected Show variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_no_args ensures show parses with no
-// arguments (all groups).
+// delete routes to the Delete variant, threading through the required id and
+// tenant org id.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["network-security-group", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_none());
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_delete_routes_to_delete_variant() {
+    check_cases(
+        [Case {
+            scenario: "delete with required id and tenant org id",
+            input: &[
+                "network-security-group",
+                "delete",
+                "--id",
+                "nsg-123",
+                "--tenant-organization-id",
+                "tenant-123",
+            ][..],
+            expect: Yields(("nsg-123".to_string(), "tenant-123".to_string())),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Delete(args) => (args.id, args.tenant_organization_id),
+                    _ => panic!("expected Delete variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_with_id ensures show parses with group ID.
+// update routes to the Update variant, threading through the required id and
+// tenant org id.
 #[test]
-fn parse_show_with_id() {
-    let cmd = Cmd::try_parse_from(["network-security-group", "show", "nsg-123"])
-        .expect("should parse show with id");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.id, Some("nsg-123".to_string()));
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_update_routes_to_update_variant() {
+    check_cases(
+        [Case {
+            scenario: "update with required id and tenant org id",
+            input: &[
+                "network-security-group",
+                "update",
+                "--id",
+                "nsg-123",
+                "--tenant-organization-id",
+                "tenant-123",
+            ][..],
+            expect: Yields(("nsg-123".to_string(), "tenant-123".to_string())),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Update(args) => (args.id, args.tenant_organization_id),
+                    _ => panic!("expected Update variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_delete ensures delete parses with required
-// arguments.
+// show-attachments routes to the ShowAttachments variant, threading through the
+// required id; --include-indirect defaults off.
 #[test]
-fn parse_delete() {
-    let cmd = Cmd::try_parse_from([
-        "network-security-group",
-        "delete",
-        "--id",
-        "nsg-123",
-        "--tenant-organization-id",
-        "tenant-123",
-    ])
-    .expect("should parse delete");
-
-    match cmd {
-        Cmd::Delete(args) => {
-            assert_eq!(args.id, "nsg-123");
-            assert_eq!(args.tenant_organization_id, "tenant-123");
-        }
-        _ => panic!("expected Delete variant"),
-    }
+fn parse_show_attachments_routes_to_show_attachments_variant() {
+    check_cases(
+        [Case {
+            scenario: "show-attachments with required id",
+            input: &[
+                "network-security-group",
+                "show-attachments",
+                "--id",
+                "nsg-123",
+            ][..],
+            expect: Yields(("nsg-123".to_string(), false)),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::ShowAttachments(args) => (args.id, args.include_indirect),
+                    _ => panic!("expected ShowAttachments variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_update ensures update parses with required
-// arguments.
+// attach routes to the Attach variant, threading through the required NSG id;
+// the optional vpc/instance targets default unset.
 #[test]
-fn parse_update() {
-    let cmd = Cmd::try_parse_from([
-        "network-security-group",
-        "update",
-        "--id",
-        "nsg-123",
-        "--tenant-organization-id",
-        "tenant-123",
-    ])
-    .expect("should parse update");
-
-    match cmd {
-        Cmd::Update(args) => {
-            assert_eq!(args.id, "nsg-123");
-            assert_eq!(args.tenant_organization_id, "tenant-123");
-        }
-        _ => panic!("expected Update variant"),
-    }
+fn parse_attach_routes_to_attach_variant() {
+    check_cases(
+        [Case {
+            scenario: "attach with NSG id",
+            input: &["network-security-group", "attach", "--id", "nsg-123"][..],
+            expect: Yields(("nsg-123".to_string(), None, None)),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Attach(args) => (args.id, args.vpc_id, args.instance_id),
+                    _ => panic!("expected Attach variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_attachments ensures show-attachments
-// parses with required ID.
+// detach routes to the Detach variant with no required args; the optional
+// vpc/instance targets default unset.
 #[test]
-fn parse_show_attachments() {
-    let cmd = Cmd::try_parse_from([
-        "network-security-group",
-        "show-attachments",
-        "--id",
-        "nsg-123",
-    ])
-    .expect("should parse show-attachments");
-
-    match cmd {
-        Cmd::ShowAttachments(args) => {
-            assert_eq!(args.id, "nsg-123");
-            assert!(!args.include_indirect);
-        }
-        _ => panic!("expected ShowAttachments variant"),
-    }
+fn parse_detach_routes_to_detach_variant() {
+    check_cases(
+        [Case {
+            scenario: "detach with no required args",
+            input: &["network-security-group", "detach"][..],
+            expect: Yields((None, None)),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Detach(args) => (args.vpc_id, args.instance_id),
+                    _ => panic!("expected Detach variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_attach ensures attach parses with NSG ID.
+// Every malformed invocation is rejected at parse time -- here, create without
+// its required --tenant-organization-id.
 #[test]
-fn parse_attach() {
-    let cmd = Cmd::try_parse_from(["network-security-group", "attach", "--id", "nsg-123"])
-        .expect("should parse attach");
-
-    match cmd {
-        Cmd::Attach(args) => {
-            assert_eq!(args.id, "nsg-123");
-            assert!(args.vpc_id.is_none());
-            assert!(args.instance_id.is_none());
-        }
-        _ => panic!("expected Attach variant"),
-    }
-}
-
-// parse_detach ensures detach parses with no required args.
-#[test]
-fn parse_detach() {
-    let cmd =
-        Cmd::try_parse_from(["network-security-group", "detach"]).expect("should parse detach");
-
-    match cmd {
-        Cmd::Detach(args) => {
-            assert!(args.vpc_id.is_none());
-            assert!(args.instance_id.is_none());
-        }
-        _ => panic!("expected Detach variant"),
-    }
-}
-
-// parse_create_missing_required_fails ensures create
-// fails without tenant org ID.
-#[test]
-fn parse_create_missing_required_fails() {
-    let result = Cmd::try_parse_from(["network-security-group", "create"]);
-    assert!(
-        result.is_err(),
-        "should fail without --tenant-organization-id"
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [Case {
+            scenario: "create without --tenant-organization-id",
+            input: &["network-security-group", "create"][..],
+            expect: Fails,
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
     );
 }

--- a/crates/admin-cli/src/network_segment/tests.rs
+++ b/crates/admin-cli/src/network_segment/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,54 +46,53 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all segments).
+// show parses with any mix of its optional filters and routes to the Show
+// variant; each row yields whether `network` is set plus the parsed
+// `tenant_org_id` and `name`.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["network-segment", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.network.is_none());
-            assert!(args.tenant_org_id.is_none());
-            assert!(args.name.is_none());
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_show_routes_to_show() {
+    check_cases(
+        [
+            Case {
+                scenario: "no arguments (all segments)",
+                input: &["network-segment", "show"][..],
+                expect: Yields((false, None, None)),
+            },
+            Case {
+                scenario: "with --tenant-org-id",
+                input: &["network-segment", "show", "--tenant-org-id", "tenant-123"][..],
+                expect: Yields((false, Some("tenant-123".to_string()), None)),
+            },
+            Case {
+                scenario: "with --name",
+                input: &["network-segment", "show", "--name", "my-segment"][..],
+                expect: Yields((false, None, Some("my-segment".to_string()))),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => (args.network.is_some(), args.tenant_org_id, args.name),
+                    _ => panic!("expected Show variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_with_tenant ensures show parses with
-// --tenant-org-id.
+// Every malformed invocation is rejected at parse time.
 #[test]
-fn parse_show_with_tenant() {
-    let cmd = Cmd::try_parse_from(["network-segment", "show", "--tenant-org-id", "tenant-123"])
-        .expect("should parse show with tenant");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.tenant_org_id, Some("tenant-123".to_string()));
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_with_name ensures show parses with --name.
-#[test]
-fn parse_show_with_name() {
-    let cmd = Cmd::try_parse_from(["network-segment", "show", "--name", "my-segment"])
-        .expect("should parse show with name");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.name, Some("my-segment".to_string()));
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_delete_missing_id_fails ensures delete fails without --id.
-#[test]
-fn parse_delete_missing_id_fails() {
-    let result = Cmd::try_parse_from(["network-segment", "delete"]);
-    assert!(result.is_err(), "should fail without --id");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [Case {
+            scenario: "delete without --id",
+            input: &["network-segment", "delete"][..],
+            expect: Fails,
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/nvl_domain/tests.rs
+++ b/crates/admin-cli/src/nvl_domain/tests.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::health_report::args::Args as HealthReportCommand;
@@ -22,49 +24,53 @@ use super::*;
 
 const TEST_DOMAIN_ID: &str = "00000000-0000-0000-0000-000000000001";
 
-fn parse_cmd(args: impl IntoIterator<Item = &'static str>) -> Cmd {
-    match Cmd::try_parse_from(args) {
-        Ok(cmd) => cmd,
-        Err(err) => panic!("failed to parse command: {err}"),
-    }
-}
-
 #[test]
 fn verify_cmd_structure() {
     Cmd::command().debug_assert();
 }
 
+// Every health-report invocation routes to Cmd::HealthReport: `show` yields the
+// domain id with no report source, `remove` yields the domain id plus the report
+// source it targets. Each row pulls out (domain_id, report_source) as the fields
+// the originals asserted.
 #[test]
-fn parse_health_report_show() {
-    let cmd = parse_cmd(["nvl-domain", "health-report", "show", TEST_DOMAIN_ID]);
-
-    let Cmd::HealthReport(command) = cmd;
-    if let HealthReportCommand::Show { domain_id } = command {
-        assert_eq!(domain_id.to_string(), TEST_DOMAIN_ID);
-    } else {
-        panic!("expected HealthReport Show variant");
-    }
-}
-
-#[test]
-fn parse_health_report_remove() {
-    let cmd = parse_cmd([
-        "nvl-domain",
-        "health-report",
-        "remove",
-        TEST_DOMAIN_ID,
-        "haas-log-analyzer",
-    ]);
-
-    let Cmd::HealthReport(command) = cmd;
-    if let HealthReportCommand::Remove {
-        domain_id,
-        report_source,
-    } = command
-    {
-        assert_eq!(domain_id.to_string(), TEST_DOMAIN_ID);
-        assert_eq!(report_source, "haas-log-analyzer");
-    } else {
-        panic!("expected HealthReport Remove variant");
-    }
+fn parse_health_report_subcommands() {
+    check_cases(
+        [
+            Case {
+                scenario: "show routes to HealthReport Show with the domain id",
+                input: &["nvl-domain", "health-report", "show", TEST_DOMAIN_ID][..],
+                expect: Yields((TEST_DOMAIN_ID.to_string(), None)),
+            },
+            Case {
+                scenario: "remove routes to HealthReport Remove with domain id and source",
+                input: &[
+                    "nvl-domain",
+                    "health-report",
+                    "remove",
+                    TEST_DOMAIN_ID,
+                    "haas-log-analyzer",
+                ][..],
+                expect: Yields((
+                    TEST_DOMAIN_ID.to_string(),
+                    Some("haas-log-analyzer".to_string()),
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| {
+                    let Cmd::HealthReport(command) = cmd;
+                    match command {
+                        HealthReportCommand::Show { domain_id } => (domain_id.to_string(), None),
+                        HealthReportCommand::Remove {
+                            domain_id,
+                            report_source,
+                        } => (domain_id.to_string(), Some(report_source)),
+                        other => panic!("unexpected HealthReport variant: {other:?}"),
+                    }
+                })
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/nvl_logical_partition/tests.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,87 +46,105 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all partitions).
+// show parses with or without a --name filter; with no args it
+// targets all partitions (empty id list, no name), and --name
+// threads the filter through.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["nvl-logical-partition", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_empty());
-            assert!(args.name.is_none());
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_with_name ensures show parses with --name filter.
-#[test]
-fn parse_show_with_name() {
-    let cmd = Cmd::try_parse_from(["nvl-logical-partition", "show", "--name", "my-partition"])
-        .expect("should parse show with name");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.name, Some("my-partition".to_string()));
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_create ensures create parses with required
-// arguments.
-#[test]
-fn parse_create() {
-    let cmd = Cmd::try_parse_from([
-        "nvl-logical-partition",
-        "create",
-        "--name",
-        "my-partition",
-        "--tenant-organization-id",
-        "tenant-123",
-    ])
-    .expect("should parse create");
-
-    match cmd {
-        Cmd::Create(args) => {
-            assert_eq!(args.name, "my-partition");
-            assert_eq!(args.tenant_organization_id, "tenant-123");
-        }
-        _ => panic!("expected Create variant"),
-    }
-}
-
-// parse_delete ensures delete parses with required
-// arguments.
-#[test]
-fn parse_delete() {
-    let cmd = Cmd::try_parse_from(["nvl-logical-partition", "delete", "--name", "my-partition"])
-        .expect("should parse delete");
-
-    match cmd {
-        Cmd::Delete(args) => {
-            assert_eq!(args.name, "my-partition");
-        }
-        _ => panic!("expected Delete variant"),
-    }
-}
-
-// parse_create_missing_required_fails ensures create
-// fails without required arguments.
-#[test]
-fn parse_create_missing_required_fails() {
-    let result = Cmd::try_parse_from(["nvl-logical-partition", "create"]);
-    assert!(
-        result.is_err(),
-        "should fail without --name and --tenant-organization-id"
+fn parse_show() {
+    check_cases(
+        [
+            Case {
+                scenario: "no arguments targets all partitions",
+                input: &["nvl-logical-partition", "show"][..],
+                expect: Yields((true, None)),
+            },
+            Case {
+                scenario: "with a --name filter",
+                input: &["nvl-logical-partition", "show", "--name", "my-partition"][..],
+                expect: Yields((true, Some("my-partition".to_string()))),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => (args.id.is_empty(), args.name),
+                    _ => panic!("expected Show variant"),
+                })
+                .map_err(drop)
+        },
     );
 }
 
-// parse_delete_missing_name_fails ensures delete fails without --name.
+// create parses with its required --name and --tenant-organization-id,
+// threading both through to the Create variant.
 #[test]
-fn parse_delete_missing_name_fails() {
-    let result = Cmd::try_parse_from(["nvl-logical-partition", "delete"]);
-    assert!(result.is_err(), "should fail without --name");
+fn parse_create() {
+    check_cases(
+        [Case {
+            scenario: "create with required arguments",
+            input: &[
+                "nvl-logical-partition",
+                "create",
+                "--name",
+                "my-partition",
+                "--tenant-organization-id",
+                "tenant-123",
+            ][..],
+            expect: Yields(("my-partition".to_string(), "tenant-123".to_string())),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Create(args) => (args.name, args.tenant_organization_id),
+                    _ => panic!("expected Create variant"),
+                })
+                .map_err(drop)
+        },
+    );
+}
+
+// delete parses with its required --name, routing to the Delete variant.
+#[test]
+fn parse_delete() {
+    check_cases(
+        [Case {
+            scenario: "delete with required --name",
+            input: &["nvl-logical-partition", "delete", "--name", "my-partition"][..],
+            expect: Yields("my-partition".to_string()),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Delete(args) => args.name,
+                    _ => panic!("expected Delete variant"),
+                })
+                .map_err(drop)
+        },
+    );
+}
+
+// Every malformed invocation is rejected at parse time -- create
+// without its required --name/--tenant-organization-id, and delete
+// without its required --name.
+#[test]
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "create without --name and --tenant-organization-id",
+                input: &["nvl-logical-partition", "create"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "delete without --name",
+                input: &["nvl-logical-partition", "delete"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/nvl_partition/tests.rs
+++ b/crates/admin-cli/src/nvl_partition/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,57 +46,41 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all partitions).
+// show routes to the Show variant and binds its optional filters: a bare
+// invocation leaves id empty and both --tenant-org-id/--name unset, while each
+// of the positional id, --tenant-org-id, and --name lands on its field.
+// Each row yields the (id, tenant_org_id, name) the originals asserted.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["nvl-partition", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_empty());
-            assert!(args.tenant_org_id.is_none());
-            assert!(args.name.is_none());
+fn show_parses_filters() {
+    fn show_filters(argv: &[&str]) -> Result<(String, Option<String>, Option<String>), ()> {
+        match Cmd::try_parse_from(argv.iter().copied()).map_err(drop)? {
+            Cmd::Show(args) => Ok((args.id, args.tenant_org_id, args.name)),
         }
     }
-}
 
-// parse_show_with_tenant ensures show parses with
-// --tenant-org-id.
-#[test]
-fn parse_show_with_tenant() {
-    let cmd = Cmd::try_parse_from(["nvl-partition", "show", "--tenant-org-id", "tenant-123"])
-        .expect("should parse show with tenant");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.tenant_org_id, Some("tenant-123".to_string()));
-        }
-    }
-}
-
-// parse_show_with_name ensures show parses with --name.
-#[test]
-fn parse_show_with_name() {
-    let cmd = Cmd::try_parse_from(["nvl-partition", "show", "--name", "my-partition"])
-        .expect("should parse show with name");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.name, Some("my-partition".to_string()));
-        }
-    }
-}
-
-// parse_show_with_id ensures show parses with positional ID.
-#[test]
-fn parse_show_with_id() {
-    let cmd = Cmd::try_parse_from(["nvl-partition", "show", "partition-123"])
-        .expect("should parse show with id");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.id, "partition-123");
-        }
-    }
+    check_cases(
+        [
+            Case {
+                scenario: "no arguments (all partitions)",
+                input: &["nvl-partition", "show"][..],
+                expect: Yields((String::new(), None, None)),
+            },
+            Case {
+                scenario: "with --tenant-org-id",
+                input: &["nvl-partition", "show", "--tenant-org-id", "tenant-123"][..],
+                expect: Yields((String::new(), Some("tenant-123".to_string()), None)),
+            },
+            Case {
+                scenario: "with --name",
+                input: &["nvl-partition", "show", "--name", "my-partition"][..],
+                expect: Yields((String::new(), None, Some("my-partition".to_string()))),
+            },
+            Case {
+                scenario: "with positional id",
+                input: &["nvl-partition", "show", "partition-123"][..],
+                expect: Yields(("partition-123".to_string(), None, None)),
+            },
+        ],
+        show_filters,
+    );
 }

--- a/crates/admin-cli/src/os_image/tests.rs
+++ b/crates/admin-cli/src/os_image/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,177 +46,244 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_create_with_required_args ensures create parses
-// with required arguments.
+// create parses with its required args (long flags) and with its optional
+// args (short flags + alias `c`); each row routes to the Create variant and
+// the parsed fields match what was supplied.
 #[test]
-fn parse_create_with_required_args() {
-    let cmd = Cmd::try_parse_from([
-        "os-image",
-        "create",
-        "--id",
-        "550e8400-e29b-41d4-a716-446655440000",
-        "--url",
-        "https://images.example.com/ubuntu.qcow2",
-        "--digest",
-        "sha256:abc123",
-        "--tenant-org-id",
-        "tenant-123",
-    ])
-    .expect("should parse create");
-
-    match cmd {
-        Cmd::Create(args) => {
-            assert_eq!(args.id, "550e8400-e29b-41d4-a716-446655440000");
-            assert_eq!(args.url, "https://images.example.com/ubuntu.qcow2");
-            assert_eq!(args.digest, "sha256:abc123");
-            assert_eq!(args.tenant_org_id, "tenant-123");
-        }
-        _ => panic!("expected Create variant"),
-    }
-}
-
-// parse_create_with_optional_args ensures create parses
-// with optional arguments.
-#[test]
-fn parse_create_with_optional_args() {
-    let cmd = Cmd::try_parse_from([
-        "os-image",
-        "create",
-        "-i",
-        "550e8400-e29b-41d4-a716-446655440000",
-        "-u",
-        "https://images.example.com/ubuntu.qcow2",
-        "-m",
-        "sha256:abc123",
-        "-t",
-        "tenant-123",
-        "-n",
-        "Ubuntu 22.04",
-        "-d",
-        "Ubuntu 22.04 LTS Server",
-    ])
-    .expect("should parse create with optional args");
-
-    match cmd {
-        Cmd::Create(args) => {
-            assert_eq!(args.name, Some("Ubuntu 22.04".to_string()));
-            assert_eq!(
-                args.description,
-                Some("Ubuntu 22.04 LTS Server".to_string())
-            );
-        }
-        _ => panic!("expected Create variant"),
-    }
-}
-
-// parse_create_alias ensures create has visible alias 'c'.
-#[test]
-fn parse_create_alias() {
-    let cmd = Cmd::try_parse_from([
-        "os-image",
-        "c",
-        "-i",
-        "550e8400-e29b-41d4-a716-446655440000",
-        "-u",
-        "https://images.example.com/ubuntu.qcow2",
-        "-m",
-        "sha256:abc123",
-        "-t",
-        "tenant-123",
-    ])
-    .expect("should parse create via alias");
-
-    assert!(matches!(cmd, Cmd::Create(_)));
-}
-
-// parse_show_all ensures show parses with no filters.
-#[test]
-fn parse_show_all() {
-    let cmd = Cmd::try_parse_from(["os-image", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_none());
-            assert!(args.tenant_org_id.is_none());
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_with_filters ensures show parses with id
-// and tenant filters.
-#[test]
-fn parse_show_with_filters() {
-    let cmd = Cmd::try_parse_from([
-        "os-image",
-        "show",
-        "-i",
-        "550e8400-e29b-41d4-a716-446655440000",
-        "-t",
-        "tenant-123",
-    ])
-    .expect("should parse show with filters");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(
+fn parse_create_routes_to_create() {
+    fn create_fields(
+        cmd: Cmd,
+    ) -> (
+        String,
+        String,
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+    ) {
+        match cmd {
+            Cmd::Create(args) => (
                 args.id,
-                Some("550e8400-e29b-41d4-a716-446655440000".to_string())
-            );
-            assert_eq!(args.tenant_org_id, Some("tenant-123".to_string()));
+                args.url,
+                args.digest,
+                args.tenant_org_id,
+                args.name,
+                args.description,
+            ),
+            _ => panic!("expected Create variant"),
         }
-        _ => panic!("expected Show variant"),
     }
+
+    check_cases(
+        [
+            Case {
+                scenario: "create with required args (long flags)",
+                input: &[
+                    "os-image",
+                    "create",
+                    "--id",
+                    "550e8400-e29b-41d4-a716-446655440000",
+                    "--url",
+                    "https://images.example.com/ubuntu.qcow2",
+                    "--digest",
+                    "sha256:abc123",
+                    "--tenant-org-id",
+                    "tenant-123",
+                ][..],
+                expect: Yields((
+                    "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                    "https://images.example.com/ubuntu.qcow2".to_string(),
+                    "sha256:abc123".to_string(),
+                    "tenant-123".to_string(),
+                    None,
+                    None,
+                )),
+            },
+            Case {
+                scenario: "create with optional args (short flags)",
+                input: &[
+                    "os-image",
+                    "create",
+                    "-i",
+                    "550e8400-e29b-41d4-a716-446655440000",
+                    "-u",
+                    "https://images.example.com/ubuntu.qcow2",
+                    "-m",
+                    "sha256:abc123",
+                    "-t",
+                    "tenant-123",
+                    "-n",
+                    "Ubuntu 22.04",
+                    "-d",
+                    "Ubuntu 22.04 LTS Server",
+                ][..],
+                expect: Yields((
+                    "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                    "https://images.example.com/ubuntu.qcow2".to_string(),
+                    "sha256:abc123".to_string(),
+                    "tenant-123".to_string(),
+                    Some("Ubuntu 22.04".to_string()),
+                    Some("Ubuntu 22.04 LTS Server".to_string()),
+                )),
+            },
+            Case {
+                scenario: "create via visible alias 'c'",
+                input: &[
+                    "os-image",
+                    "c",
+                    "-i",
+                    "550e8400-e29b-41d4-a716-446655440000",
+                    "-u",
+                    "https://images.example.com/ubuntu.qcow2",
+                    "-m",
+                    "sha256:abc123",
+                    "-t",
+                    "tenant-123",
+                ][..],
+                expect: Yields((
+                    "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                    "https://images.example.com/ubuntu.qcow2".to_string(),
+                    "sha256:abc123".to_string(),
+                    "tenant-123".to_string(),
+                    None,
+                    None,
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(create_fields)
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_delete ensures delete parses with required args.
+// show parses with no filters (all images) and with id + tenant filters; each
+// row routes to the Show variant and yields its optional filter fields.
 #[test]
-fn parse_delete() {
-    let cmd = Cmd::try_parse_from([
-        "os-image",
-        "delete",
-        "-i",
-        "550e8400-e29b-41d4-a716-446655440000",
-        "-t",
-        "tenant-123",
-    ])
-    .expect("should parse delete");
-
-    match cmd {
-        Cmd::Delete(args) => {
-            assert_eq!(args.id, "550e8400-e29b-41d4-a716-446655440000");
-            assert_eq!(args.tenant_org_id, "tenant-123");
+fn parse_show_routes_to_show() {
+    fn show_fields(cmd: Cmd) -> (Option<String>, Option<String>) {
+        match cmd {
+            Cmd::Show(args) => (args.id, args.tenant_org_id),
+            _ => panic!("expected Show variant"),
         }
-        _ => panic!("expected Delete variant"),
     }
+
+    check_cases(
+        [
+            Case {
+                scenario: "show with no filters",
+                input: &["os-image", "show"][..],
+                expect: Yields((None, None)),
+            },
+            Case {
+                scenario: "show with id and tenant filters",
+                input: &[
+                    "os-image",
+                    "show",
+                    "-i",
+                    "550e8400-e29b-41d4-a716-446655440000",
+                    "-t",
+                    "tenant-123",
+                ][..],
+                expect: Yields((
+                    Some("550e8400-e29b-41d4-a716-446655440000".to_string()),
+                    Some("tenant-123".to_string()),
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(show_fields)
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_update ensures update parses with required id.
+// delete parses with its required id + tenant args, routing to the Delete
+// variant and yielding those fields.
 #[test]
-fn parse_update() {
-    let cmd = Cmd::try_parse_from([
-        "os-image",
-        "update",
-        "-i",
-        "550e8400-e29b-41d4-a716-446655440000",
-        "-n",
-        "New Name",
-    ])
-    .expect("should parse update");
-
-    match cmd {
-        Cmd::Update(args) => {
-            assert_eq!(args.id, "550e8400-e29b-41d4-a716-446655440000");
-            assert_eq!(args.name, Some("New Name".to_string()));
+fn parse_delete_routes_to_delete() {
+    fn delete_fields(cmd: Cmd) -> (String, String) {
+        match cmd {
+            Cmd::Delete(args) => (args.id, args.tenant_org_id),
+            _ => panic!("expected Delete variant"),
         }
-        _ => panic!("expected Update variant"),
     }
+
+    check_cases(
+        [Case {
+            scenario: "delete with required args",
+            input: &[
+                "os-image",
+                "delete",
+                "-i",
+                "550e8400-e29b-41d4-a716-446655440000",
+                "-t",
+                "tenant-123",
+            ][..],
+            expect: Yields((
+                "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                "tenant-123".to_string(),
+            )),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(delete_fields)
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_create_missing_required_fails ensures create
-// fails without required args.
+// update parses with its required id (plus an optional name), routing to the
+// Update variant and yielding those fields.
 #[test]
-fn parse_create_missing_required_fails() {
-    let result = Cmd::try_parse_from(["os-image", "create", "-i", "some-id"]);
-    assert!(result.is_err(), "should fail without all required args");
+fn parse_update_routes_to_update() {
+    fn update_fields(cmd: Cmd) -> (String, Option<String>) {
+        match cmd {
+            Cmd::Update(args) => (args.id, args.name),
+            _ => panic!("expected Update variant"),
+        }
+    }
+
+    check_cases(
+        [Case {
+            scenario: "update with required id and a name",
+            input: &[
+                "os-image",
+                "update",
+                "-i",
+                "550e8400-e29b-41d4-a716-446655440000",
+                "-n",
+                "New Name",
+            ][..],
+            expect: Yields((
+                "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                Some("New Name".to_string()),
+            )),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(update_fields)
+                .map_err(drop)
+        },
+    );
+}
+
+// Malformed invocations are rejected at parse time -- e.g. create without all
+// of its required arguments.
+#[test]
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [Case {
+            scenario: "create missing required args",
+            input: &["os-image", "create", "-i", "some-id"][..],
+            expect: Fails,
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/ping/tests.rs
+++ b/crates/admin-cli/src/ping/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::args::*;
@@ -40,27 +42,33 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_default_interval ensures ping parses with default interval.
+// ping parses the --interval value, defaulting to 1.0 when omitted and
+// honoring both the long --interval flag and its -i short form. These decimals
+// are exactly representable in f32, so equality is exact.
 #[test]
-fn parse_default_interval() {
-    let opts = Opts::try_parse_from(["ping"]).expect("should parse ping");
-
-    assert!((opts.interval - 1.0).abs() < f32::EPSILON);
-}
-
-// parse_custom_interval ensures ping parses with a custom interval.
-#[test]
-fn parse_custom_interval() {
-    let opts = Opts::try_parse_from(["ping", "--interval", "2.5"])
-        .expect("should parse ping with interval");
-
-    assert!((opts.interval - 2.5).abs() < f32::EPSILON);
-}
-
-// parse_short_interval_flag ensures ping parses with -i short flag.
-#[test]
-fn parse_short_interval_flag() {
-    let opts = Opts::try_parse_from(["ping", "-i", "0.5"]).expect("should parse ping with -i");
-
-    assert!((opts.interval - 0.5).abs() < f32::EPSILON);
+fn parse_interval() {
+    check_cases(
+        [
+            Case {
+                scenario: "default interval",
+                input: &["ping"][..],
+                expect: Yields(1.0f32),
+            },
+            Case {
+                scenario: "custom --interval",
+                input: &["ping", "--interval", "2.5"][..],
+                expect: Yields(2.5f32),
+            },
+            Case {
+                scenario: "short -i flag",
+                input: &["ping", "-i", "0.5"][..],
+                expect: Yields(0.5f32),
+            },
+        ],
+        |argv| {
+            Opts::try_parse_from(argv.iter().copied())
+                .map(|opts| opts.interval)
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/power_shelf/tests.rs
+++ b/crates/admin-cli/src/power_shelf/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,35 +46,35 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all shelves).
+// `show` parses with and without an identifier; the parsed identifier is the
+// supplied value or `None` when omitted (all shelves).
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["power-shelf", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.identifier.is_none());
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_show_identifier() {
+    check_cases(
+        [
+            Case {
+                scenario: "no identifier (all shelves)",
+                input: &["power-shelf", "show"][..],
+                expect: Yields(None),
+            },
+            Case {
+                scenario: "with identifier",
+                input: &["power-shelf", "show", "shelf-123"][..],
+                expect: Yields(Some("shelf-123".to_string())),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => args.identifier,
+                    _ => panic!("expected Show variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_with_identifier ensures show parses with identifier.
-#[test]
-fn parse_show_with_identifier() {
-    let cmd = Cmd::try_parse_from(["power-shelf", "show", "shelf-123"])
-        .expect("should parse show with identifier");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.identifier, Some("shelf-123".to_string()));
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_list ensures list parses with no arguments.
+// `list` with no arguments routes to the `List` variant.
 #[test]
 fn parse_list() {
     let cmd = Cmd::try_parse_from(["power-shelf", "list"]).expect("should parse list");
@@ -80,43 +82,80 @@ fn parse_list() {
     assert!(matches!(cmd, Cmd::List(_)));
 }
 
-// parse_list_with_filters ensures list parses with filter flags.
+// `list` with all filter flags captures each one: the `--deleted only` filter,
+// the controller-state string, and a parsed `--bmc-mac`.
 #[test]
 fn parse_list_with_filters() {
-    let cmd = Cmd::try_parse_from([
-        "power-shelf",
-        "list",
-        "--deleted",
-        "only",
-        "--controller-state",
-        "ready",
-        "--bmc-mac",
-        "AA:BB:CC:DD:EE:FF",
-    ])
-    .expect("should parse list with filters");
-
-    match cmd {
-        Cmd::List(args) => {
-            assert!(matches!(args.deleted, rpc::forge::DeletedFilter::Only));
-            assert_eq!(args.controller_state, Some("ready".to_string()));
-            assert!(args.bmc_mac.is_some());
-        }
-        _ => panic!("expected List variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "deleted + controller-state + bmc-mac",
+            input: &[
+                "power-shelf",
+                "list",
+                "--deleted",
+                "only",
+                "--controller-state",
+                "ready",
+                "--bmc-mac",
+                "AA:BB:CC:DD:EE:FF",
+            ][..],
+            expect: Yields((true, Some("ready".to_string()), true)),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::List(args) => (
+                        matches!(args.deleted, rpc::forge::DeletedFilter::Only),
+                        args.controller_state,
+                        args.bmc_mac.is_some(),
+                    ),
+                    _ => panic!("expected List variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_list_invalid_deleted ensures invalid deleted value is rejected.
+// Every malformed invocation is rejected at parse time -- an out-of-range
+// `--deleted` value, a malformed MAC, a maintenance action missing its required
+// id, and an unknown maintenance subcommand.
 #[test]
-fn parse_list_invalid_deleted() {
-    let result = Cmd::try_parse_from(["power-shelf", "list", "--deleted", "bogus"]);
-    assert!(result.is_err());
-}
-
-// parse_list_invalid_bmc_mac ensures invalid MAC is rejected.
-#[test]
-fn parse_list_invalid_bmc_mac() {
-    let result = Cmd::try_parse_from(["power-shelf", "list", "--bmc-mac", "not-a-mac"]);
-    assert!(result.is_err());
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "list with an invalid --deleted value",
+                input: &["power-shelf", "list", "--deleted", "bogus"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "list with an invalid --bmc-mac",
+                input: &["power-shelf", "list", "--bmc-mac", "not-a-mac"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "maintenance power-on missing required --power-shelf-id",
+                input: &["power-shelf", "maintenance", "power-on"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "maintenance unknown subcommand power-cycle",
+                input: &[
+                    "power-shelf",
+                    "maintenance",
+                    "power-cycle",
+                    "--power-shelf-id",
+                    SAMPLE_PS_ID_1,
+                ][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -144,127 +183,131 @@ fn parse_ps_id(id: &str) -> PowerShelfId {
     PowerShelfId::from_str(id).unwrap_or_else(|e| panic!("invalid sample power-shelf id {id}: {e}"))
 }
 
-/// `power-shelf maintenance power-on --power-shelf-id <id>` parses to
-/// `Args::PowerOn` carrying the supplied id.
+/// `power-shelf maintenance power-on ...` parses to `Args::PowerOn`. Covers a
+/// single id, multiple ids via repeated flags or a single space-separated flag,
+/// the captured `--reference`, and the `--id` alias for `--power-shelf-id`. Each
+/// row yields the parsed `(power_shelf_ids, reference)`.
 #[test]
-fn parse_maintenance_power_on_single_id() {
-    let cmd = Cmd::try_parse_from([
-        "power-shelf",
-        "maintenance",
-        "power-on",
-        "--power-shelf-id",
-        SAMPLE_PS_ID_1,
-    ])
-    .expect("should parse maintenance power-on");
-
-    match cmd {
-        Cmd::Maintenance(maintenance::Args::PowerOn(args)) => {
-            assert_eq!(args.power_shelf_ids, vec![parse_ps_id(SAMPLE_PS_ID_1)]);
-            assert!(args.reference.is_none());
-        }
-        other => panic!("expected Maintenance(PowerOn(_)), got: {other:?}"),
-    }
-}
-
-/// `power-shelf maintenance power-off --power-shelf-id <id1> --power-shelf-id <id2>`
-/// parses to `Args::PowerOff` carrying both ids.
-#[test]
-fn parse_maintenance_power_off_multiple_ids_repeated_flag() {
-    let cmd = Cmd::try_parse_from([
-        "power-shelf",
-        "maintenance",
-        "power-off",
-        "--power-shelf-id",
-        SAMPLE_PS_ID_1,
-        "--power-shelf-id",
-        SAMPLE_PS_ID_2,
-    ])
-    .expect("should parse maintenance power-off with two ids");
-
-    match cmd {
-        Cmd::Maintenance(maintenance::Args::PowerOff(args)) => {
-            assert_eq!(
-                args.power_shelf_ids,
-                vec![parse_ps_id(SAMPLE_PS_ID_1), parse_ps_id(SAMPLE_PS_ID_2)],
-            );
-        }
-        other => panic!("expected Maintenance(PowerOff(_)), got: {other:?}"),
-    }
-}
-
-/// `--power-shelf-id` accepts space-separated values in a single occurrence
-/// (per its `num_args = 1..` configuration). Both ids must round-trip.
-#[test]
-fn parse_maintenance_power_on_multiple_ids_single_flag() {
-    let cmd = Cmd::try_parse_from([
-        "power-shelf",
-        "maintenance",
-        "power-on",
-        "--power-shelf-id",
-        SAMPLE_PS_ID_1,
-        SAMPLE_PS_ID_2,
-    ])
-    .expect("should parse maintenance power-on with two ids on one flag");
-
-    match cmd {
-        Cmd::Maintenance(maintenance::Args::PowerOn(args)) => {
-            assert_eq!(
-                args.power_shelf_ids,
-                vec![parse_ps_id(SAMPLE_PS_ID_1), parse_ps_id(SAMPLE_PS_ID_2)],
-            );
-        }
-        other => panic!("expected Maintenance(PowerOn(_)), got: {other:?}"),
-    }
-}
-
-/// The `--reference` flag (with `--ref` alias) is captured.
-#[test]
-fn parse_maintenance_with_reference() {
-    let cmd = Cmd::try_parse_from([
-        "power-shelf",
-        "maintenance",
-        "power-on",
-        "--power-shelf-id",
-        SAMPLE_PS_ID_1,
-        "--reference",
-        "https://issues.example.com/TICKET-1",
-    ])
-    .expect("should parse maintenance with reference");
-
-    match cmd {
-        Cmd::Maintenance(maintenance::Args::PowerOn(args)) => {
-            assert_eq!(
-                args.reference.as_deref(),
-                Some("https://issues.example.com/TICKET-1"),
-            );
-        }
-        other => panic!("expected Maintenance(PowerOn(_)), got: {other:?}"),
-    }
-}
-
-/// Maintenance subcommand requires at least one `--power-shelf-id`.
-#[test]
-fn parse_maintenance_rejects_missing_id() {
-    let result = Cmd::try_parse_from(["power-shelf", "maintenance", "power-on"]);
-    assert!(
-        result.is_err(),
-        "missing required --power-shelf-id should fail to parse"
+fn parse_maintenance_power_on() {
+    check_cases(
+        [
+            Case {
+                scenario: "single id",
+                input: &[
+                    "power-shelf",
+                    "maintenance",
+                    "power-on",
+                    "--power-shelf-id",
+                    SAMPLE_PS_ID_1,
+                ][..],
+                expect: Yields((vec![parse_ps_id(SAMPLE_PS_ID_1)], None)),
+            },
+            Case {
+                scenario: "two ids on a single flag occurrence (num_args = 1..)",
+                input: &[
+                    "power-shelf",
+                    "maintenance",
+                    "power-on",
+                    "--power-shelf-id",
+                    SAMPLE_PS_ID_1,
+                    SAMPLE_PS_ID_2,
+                ][..],
+                expect: Yields((
+                    vec![parse_ps_id(SAMPLE_PS_ID_1), parse_ps_id(SAMPLE_PS_ID_2)],
+                    None,
+                )),
+            },
+            Case {
+                scenario: "--reference is captured",
+                input: &[
+                    "power-shelf",
+                    "maintenance",
+                    "power-on",
+                    "--power-shelf-id",
+                    SAMPLE_PS_ID_1,
+                    "--reference",
+                    "https://issues.example.com/TICKET-1",
+                ][..],
+                expect: Yields((
+                    vec![parse_ps_id(SAMPLE_PS_ID_1)],
+                    Some("https://issues.example.com/TICKET-1".to_string()),
+                )),
+            },
+            Case {
+                scenario: "--id alias captures the power-shelf id",
+                input: &[
+                    "power-shelf",
+                    "maintenance",
+                    "power-on",
+                    "--id",
+                    SAMPLE_PS_ID_1,
+                ][..],
+                expect: Yields((vec![parse_ps_id(SAMPLE_PS_ID_1)], None)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Maintenance(maintenance::Args::PowerOn(args)) => {
+                        (args.power_shelf_ids, args.reference)
+                    }
+                    other => panic!("expected Maintenance(PowerOn(_)), got: {other:?}"),
+                })
+                .map_err(drop)
+        },
     );
 }
 
-/// Unknown subcommand under maintenance is rejected.
+/// `power-shelf maintenance power-off ...` parses to `Args::PowerOff`. Covers
+/// two ids via repeated `--power-shelf-id` flags and the `--ref` alias for
+/// `--reference`. Each row yields the parsed `(power_shelf_ids, reference)`.
 #[test]
-fn parse_maintenance_rejects_unknown_action() {
-    let result = Cmd::try_parse_from([
-        "power-shelf",
-        "maintenance",
-        "power-cycle",
-        "--power-shelf-id",
-        SAMPLE_PS_ID_1,
-    ]);
-    assert!(
-        result.is_err(),
-        "unknown subcommand `power-cycle` should fail to parse"
+fn parse_maintenance_power_off() {
+    check_cases(
+        [
+            Case {
+                scenario: "two ids via repeated --power-shelf-id flags",
+                input: &[
+                    "power-shelf",
+                    "maintenance",
+                    "power-off",
+                    "--power-shelf-id",
+                    SAMPLE_PS_ID_1,
+                    "--power-shelf-id",
+                    SAMPLE_PS_ID_2,
+                ][..],
+                expect: Yields((
+                    vec![parse_ps_id(SAMPLE_PS_ID_1), parse_ps_id(SAMPLE_PS_ID_2)],
+                    None,
+                )),
+            },
+            Case {
+                scenario: "--ref alias captures the reference",
+                input: &[
+                    "power-shelf",
+                    "maintenance",
+                    "power-off",
+                    "--power-shelf-id",
+                    SAMPLE_PS_ID_1,
+                    "--ref",
+                    "TICKET-2",
+                ][..],
+                expect: Yields((
+                    vec![parse_ps_id(SAMPLE_PS_ID_1)],
+                    Some("TICKET-2".to_string()),
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Maintenance(maintenance::Args::PowerOff(args)) => {
+                        (args.power_shelf_ids, args.reference)
+                    }
+                    other => panic!("expected Maintenance(PowerOff(_)), got: {other:?}"),
+                })
+                .map_err(drop)
+        },
     );
 }
 
@@ -303,48 +346,4 @@ fn power_off_into_request_uses_power_off_operation() {
         vec![parse_ps_id(SAMPLE_PS_ID_1), parse_ps_id(SAMPLE_PS_ID_2)],
     );
     assert!(req.reference.is_none());
-}
-
-/// `--ref` is a documented visible alias of `--reference`; verify it
-/// captures the same value.
-#[test]
-fn parse_maintenance_ref_alias_captures_reference() {
-    let cmd = Cmd::try_parse_from([
-        "power-shelf",
-        "maintenance",
-        "power-off",
-        "--power-shelf-id",
-        SAMPLE_PS_ID_1,
-        "--ref",
-        "TICKET-2",
-    ])
-    .expect("should parse maintenance with --ref alias");
-
-    match cmd {
-        Cmd::Maintenance(maintenance::Args::PowerOff(args)) => {
-            assert_eq!(args.reference.as_deref(), Some("TICKET-2"));
-        }
-        other => panic!("expected Maintenance(PowerOff(_)), got: {other:?}"),
-    }
-}
-
-/// `id` is a documented visible alias of `--power-shelf-id`; verify it
-/// captures the same value.
-#[test]
-fn parse_maintenance_id_alias_captures_power_shelf_id() {
-    let cmd = Cmd::try_parse_from([
-        "power-shelf",
-        "maintenance",
-        "power-on",
-        "--id",
-        SAMPLE_PS_ID_1,
-    ])
-    .expect("should parse maintenance with --id alias");
-
-    match cmd {
-        Cmd::Maintenance(maintenance::Args::PowerOn(args)) => {
-            assert_eq!(args.power_shelf_ids, vec![parse_ps_id(SAMPLE_PS_ID_1)]);
-        }
-        other => panic!("expected Maintenance(PowerOn(_)), got: {other:?}"),
-    }
 }

--- a/crates/admin-cli/src/rack/maintenance/cmd.rs
+++ b/crates/admin-cli/src/rack/maintenance/cmd.rs
@@ -146,6 +146,8 @@ pub async fn on_demand_rack_maintenance(
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
     use carbide_uuid::rack::RackId;
 
     use super::*;
@@ -165,87 +167,73 @@ mod tests {
         }
     }
 
+    // resolve_firmware_upgrade_source decides the SOT firmware source and access
+    // token for a set of MaintenanceOptions: a firmware-upgrade activity demands a
+    // SOT JSON, inline JSON must actually parse, an empty access token reads as
+    // absent, and --firmware-version/--access-token are rejected without an
+    // activity that uses them. The error type is not PartialEq, so failures use
+    // Fails (+ map_err(drop)); successful rows yield the (firmware_version,
+    // access_token) tuple the originals asserted on.
     #[test]
-    fn firmware_upgrade_requires_sot_json() {
-        let args = MaintenanceOptions {
-            activities: Some(vec!["firmware-upgrade".to_string()]),
-            access_token: Some("token".to_string()),
-            ..options()
-        };
-
-        let err = resolve_firmware_upgrade_source(&args).unwrap_err();
-
-        assert!(err.to_string().contains("requires SOT JSON"));
-    }
-
-    #[test]
-    fn firmware_upgrade_allows_missing_access_token() {
-        let args = MaintenanceOptions {
-            activities: Some(vec!["firmware-upgrade".to_string()]),
-            firmware_version: Some(r#"{"Id":"fw"}"#.to_string()),
-            ..options()
-        };
-
-        let (firmware_version, access_token) = resolve_firmware_upgrade_source(&args).unwrap();
-
-        assert_eq!(firmware_version, r#"{"Id":"fw"}"#);
-        assert_eq!(access_token, None);
-    }
-
-    #[test]
-    fn firmware_upgrade_treats_empty_access_token_as_missing() {
-        let args = MaintenanceOptions {
-            activities: Some(vec!["firmware-upgrade".to_string()]),
-            firmware_version: Some(r#"{"Id":"fw"}"#.to_string()),
-            access_token: Some(String::new()),
-            ..options()
-        };
-
-        let (_, access_token) = resolve_firmware_upgrade_source(&args).unwrap();
-
-        assert_eq!(access_token, None);
-    }
-
-    #[test]
-    fn firmware_upgrade_rejects_invalid_inline_json() {
-        let args = MaintenanceOptions {
-            activities: Some(vec!["firmware-upgrade".to_string()]),
-            firmware_version: Some("not-json".to_string()),
-            access_token: Some("token".to_string()),
-            ..options()
-        };
-
-        assert!(resolve_firmware_upgrade_source(&args).is_err());
-    }
-
-    #[test]
-    fn firmware_source_requires_firmware_upgrade_activity() {
-        let args = MaintenanceOptions {
-            firmware_version: Some(r#"{"Id":"fw"}"#.to_string()),
-            ..options()
-        };
-
-        let err = resolve_firmware_upgrade_source(&args).unwrap_err();
-
-        assert!(
-            err.to_string().contains(
-                "--firmware-version requires --activities firmware-upgrade or nvos-update"
-            )
-        );
-    }
-
-    #[test]
-    fn access_token_requires_firmware_upgrade_activity() {
-        let args = MaintenanceOptions {
-            access_token: Some("token".to_string()),
-            ..options()
-        };
-
-        let err = resolve_firmware_upgrade_source(&args).unwrap_err();
-
-        assert!(
-            err.to_string()
-                .contains("--access-token requires --activities firmware-upgrade or nvos-update")
+    fn resolve_firmware_upgrade_source_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "firmware-upgrade without a SOT JSON source is rejected",
+                    input: MaintenanceOptions {
+                        activities: Some(vec!["firmware-upgrade".to_string()]),
+                        access_token: Some("token".to_string()),
+                        ..options()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "firmware-upgrade with inline JSON allows a missing access token",
+                    input: MaintenanceOptions {
+                        activities: Some(vec!["firmware-upgrade".to_string()]),
+                        firmware_version: Some(r#"{"Id":"fw"}"#.to_string()),
+                        ..options()
+                    },
+                    expect: Yields((r#"{"Id":"fw"}"#.to_string(), None)),
+                },
+                Case {
+                    scenario: "firmware-upgrade treats an empty access token as missing",
+                    input: MaintenanceOptions {
+                        activities: Some(vec!["firmware-upgrade".to_string()]),
+                        firmware_version: Some(r#"{"Id":"fw"}"#.to_string()),
+                        access_token: Some(String::new()),
+                        ..options()
+                    },
+                    expect: Yields((r#"{"Id":"fw"}"#.to_string(), None)),
+                },
+                Case {
+                    scenario: "firmware-upgrade rejects invalid inline JSON",
+                    input: MaintenanceOptions {
+                        activities: Some(vec!["firmware-upgrade".to_string()]),
+                        firmware_version: Some("not-json".to_string()),
+                        access_token: Some("token".to_string()),
+                        ..options()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "--firmware-version without a firmware-upgrade activity is rejected",
+                    input: MaintenanceOptions {
+                        firmware_version: Some(r#"{"Id":"fw"}"#.to_string()),
+                        ..options()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "--access-token without a firmware-upgrade activity is rejected",
+                    input: MaintenanceOptions {
+                        access_token: Some("token".to_string()),
+                        ..options()
+                    },
+                    expect: Fails,
+                },
+            ],
+            |args| resolve_firmware_upgrade_source(&args).map_err(drop),
         );
     }
 }

--- a/crates/admin-cli/src/rack/show/cmd.rs
+++ b/crates/admin-cli/src/rack/show/cmd.rs
@@ -263,6 +263,8 @@ fn show_table_csv(outputs: &[RackOutput]) {
 #[cfg(test)]
 mod tests {
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
     use rpc::admin_cli::OutputFormat;
     use rpc::forge::{Metadata, Rack};
 
@@ -318,28 +320,43 @@ mod tests {
         assert!(output.current_nvlink_switches.is_empty());
     }
 
-    /// A Rack with no ID falls back to an empty string in RackOutput.
+    // A missing Rack component falls back to an empty string in RackOutput:
+    // no ID yields an empty id, no metadata yields an empty name. The run
+    // closure converts the Rack and reads back the field named by the case.
     #[test]
-    fn rack_output_defaults_when_id_missing() {
-        let rack = Rack {
-            id: None,
-            rack_state: "Created".to_string(),
-            ..Default::default()
-        };
-        let output = RackOutput::from(&rack);
-        assert_eq!(output.id, "");
-    }
-
-    /// A Rack with no metadata falls back to an empty name in RackOutput.
-    #[test]
-    fn rack_output_defaults_when_metadata_missing() {
-        let rack = Rack {
-            id: Some("Rack1".parse().unwrap()),
-            metadata: None,
-            ..Default::default()
-        };
-        let output = RackOutput::from(&rack);
-        assert_eq!(output.name, "");
+    fn rack_output_defaults_when_fields_missing() {
+        check_cases(
+            [
+                Case {
+                    scenario: "missing id falls back to empty string",
+                    input: Rack {
+                        id: None,
+                        rack_state: "Created".to_string(),
+                        ..Default::default()
+                    },
+                    expect: Yields(String::new()),
+                },
+                Case {
+                    scenario: "missing metadata falls back to empty name",
+                    input: Rack {
+                        id: Some("Rack1".parse().unwrap()),
+                        metadata: None,
+                        ..Default::default()
+                    },
+                    expect: Yields(String::new()),
+                },
+            ],
+            // Read the field that the missing component would have populated:
+            // id for the no-id case, name for the no-metadata case.
+            |rack: Rack| -> Result<String, ()> {
+                let output = RackOutput::from(&rack);
+                Ok(if rack.id.is_none() {
+                    output.id
+                } else {
+                    output.name
+                })
+            },
+        );
     }
 
     /////////////////////////////////////////////////////////////////////////////
@@ -426,51 +443,68 @@ mod tests {
     /////////////////////////////////////////////////////////////////////////////
     // Rendering functions
 
-    /// show_single renders JSON without errors.
+    // The structured renderers return Ok for both formats: show_single and
+    // show_list each serialize cleanly as JSON and as YAML. Each row's input
+    // is a thunk that builds the fixture and runs one renderer at one format.
     #[test]
-    fn show_single_json_returns_ok() {
-        let output = make_output("Rack1", "NVL72", "Created", "V1", vec![], vec![], vec![]);
-        assert!(show_single(&output, OutputFormat::Json).is_ok());
-    }
-
-    /// show_single renders YAML without errors.
-    #[test]
-    fn show_single_yaml_returns_ok() {
-        let output = make_output("Rack1", "NVL72", "Created", "V1", vec![], vec![], vec![]);
-        assert!(show_single(&output, OutputFormat::Yaml).is_ok());
-    }
-
-    /// show_list renders JSON without errors.
-    #[test]
-    fn show_list_json_returns_ok() {
-        let outputs = vec![
-            make_output("Rack1", "NVL72", "Created", "V1", vec![], vec![], vec![]),
-            make_output(
-                "Rack2",
-                "NVL36",
-                "Provisioned",
-                "V2",
-                vec!["t-1"],
-                vec![],
-                vec![],
-            ),
+    fn structured_renderers_return_ok() {
+        type RenderCase = Case<fn() -> Result<()>, (), ()>;
+        let cases: [RenderCase; 4] = [
+            Case {
+                scenario: "show_single renders JSON",
+                input: || {
+                    let output =
+                        make_output("Rack1", "NVL72", "Created", "V1", vec![], vec![], vec![]);
+                    show_single(&output, OutputFormat::Json)
+                },
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "show_single renders YAML",
+                input: || {
+                    let output =
+                        make_output("Rack1", "NVL72", "Created", "V1", vec![], vec![], vec![]);
+                    show_single(&output, OutputFormat::Yaml)
+                },
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "show_list renders JSON",
+                input: || {
+                    let outputs = vec![
+                        make_output("Rack1", "NVL72", "Created", "V1", vec![], vec![], vec![]),
+                        make_output(
+                            "Rack2",
+                            "NVL36",
+                            "Provisioned",
+                            "V2",
+                            vec!["t-1"],
+                            vec![],
+                            vec![],
+                        ),
+                    ];
+                    show_list(&outputs, OutputFormat::Json)
+                },
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "show_list renders YAML",
+                input: || {
+                    let outputs = vec![make_output(
+                        "Rack1",
+                        "NVL72",
+                        "Created",
+                        "V1",
+                        vec![],
+                        vec![],
+                        vec![],
+                    )];
+                    show_list(&outputs, OutputFormat::Yaml)
+                },
+                expect: Yields(()),
+            },
         ];
-        assert!(show_list(&outputs, OutputFormat::Json).is_ok());
-    }
-
-    /// show_list renders YAML without errors.
-    #[test]
-    fn show_list_yaml_returns_ok() {
-        let outputs = vec![make_output(
-            "Rack1",
-            "NVL72",
-            "Created",
-            "V1",
-            vec![],
-            vec![],
-            vec![],
-        )];
-        assert!(show_list(&outputs, OutputFormat::Yaml).is_ok());
+        check_cases(cases, |run| run().map_err(drop));
     }
 
     /// show_detail with all-empty component lists renders "N/A" paths without panicking.

--- a/crates/admin-cli/src/rack/tests.rs
+++ b/crates/admin-cli/src/rack/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,32 +46,32 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all racks).
+// show parses with or without a rack identifier: bare `show` targets all
+// racks (no rack), while a trailing identifier scopes it to that one rack.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["rack", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.rack.is_none());
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_with_identifier ensures show parses with identifier.
-#[test]
-fn parse_show_with_identifier() {
-    let cmd = Cmd::try_parse_from(["rack", "show", "rack-123"])
-        .expect("should parse show with identifier");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.rack, Some("rack-123".parse().unwrap()));
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_show_routes_to_show_variant() {
+    check_cases(
+        [
+            Case {
+                scenario: "no args targets all racks",
+                input: &["rack", "show"][..],
+                expect: Yields(None),
+            },
+            Case {
+                scenario: "trailing identifier scopes to one rack",
+                input: &["rack", "show", "rack-123"][..],
+                expect: Yields(Some("rack-123".to_string())),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => args.rack.map(|r| r.to_string()),
+                    _ => panic!("expected Show variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
 // parse_list ensures list parses with no arguments.
@@ -93,14 +95,6 @@ fn parse_delete() {
     }
 }
 
-// parse_delete_missing_identifier_fails ensures delete
-// fails without identifier.
-#[test]
-fn parse_delete_missing_identifier_fails() {
-    let result = Cmd::try_parse_from(["rack", "delete"]);
-    assert!(result.is_err(), "should fail without identifier");
-}
-
 // parse_profile_show ensures profile show parses with rack ID.
 #[test]
 fn parse_profile_show() {
@@ -115,10 +109,27 @@ fn parse_profile_show() {
     }
 }
 
-// parse_profile_show_missing_rack_id_fails ensures profile
-// show fails without rack ID.
+// Every malformed invocation is rejected at parse time -- a delete or a
+// profile-show left without its required rack identifier.
 #[test]
-fn parse_profile_show_missing_rack_id_fails() {
-    let result = Cmd::try_parse_from(["rack", "profile", "show"]);
-    assert!(result.is_err(), "should fail without rack_id");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "delete without an identifier",
+                input: &["rack", "delete"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "profile show without a rack_id",
+                input: &["rack", "profile", "show"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/redfish/tests.rs
+++ b/crates/admin-cli/src/redfish/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::args::*;
@@ -44,70 +46,69 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_bios_attrs ensures bios-attrs parses.
-#[test]
-fn parse_bios_attrs() {
-    let action =
-        RedfishAction::try_parse_from(["redfish", "--address", "192.0.2.10", "bios-attrs"])
-            .expect("should parse bios-attrs");
-
-    assert!(matches!(action.command, Cmd::BiosAttrs));
+// variant names the parsed subcommand so routing tests can assert which
+// `Cmd` an argv lands on without matching every payload-free variant by hand.
+fn variant(cmd: &Cmd) -> &'static str {
+    match cmd {
+        Cmd::BiosAttrs => "bios-attrs",
+        Cmd::BootHdd => "boot-hdd",
+        Cmd::BootPxe => "boot-pxe",
+        Cmd::GetPowerState => "get-power-state",
+        Cmd::ForceOff => "force-off",
+        Cmd::ForceRestart => "force-restart",
+        Cmd::On => "on",
+        other => panic!("unexpected variant: {other:?}"),
+    }
 }
 
-// parse_boot_hdd ensures boot-hdd parses.
+// Each payload-free subcommand routes to its matching `Cmd` variant when given
+// a valid global --address.
 #[test]
-fn parse_boot_hdd() {
-    let action = RedfishAction::try_parse_from(["redfish", "--address", "192.0.2.10", "boot-hdd"])
-        .expect("should parse boot-hdd");
-
-    assert!(matches!(action.command, Cmd::BootHdd));
-}
-
-// parse_boot_pxe ensures boot-pxe parses.
-#[test]
-fn parse_boot_pxe() {
-    let action = RedfishAction::try_parse_from(["redfish", "--address", "192.0.2.10", "boot-pxe"])
-        .expect("should parse boot-pxe");
-
-    assert!(matches!(action.command, Cmd::BootPxe));
-}
-
-// parse_get_power_state ensures get-power-state parses.
-#[test]
-fn parse_get_power_state() {
-    let action =
-        RedfishAction::try_parse_from(["redfish", "--address", "192.0.2.10", "get-power-state"])
-            .expect("should parse get-power-state");
-
-    assert!(matches!(action.command, Cmd::GetPowerState));
-}
-
-// parse_force_off ensures force-off parses.
-#[test]
-fn parse_force_off() {
-    let action = RedfishAction::try_parse_from(["redfish", "--address", "192.0.2.10", "force-off"])
-        .expect("should parse force-off");
-
-    assert!(matches!(action.command, Cmd::ForceOff));
-}
-
-// parse_force_restart ensures force-restart parses.
-#[test]
-fn parse_force_restart() {
-    let action =
-        RedfishAction::try_parse_from(["redfish", "--address", "192.0.2.10", "force-restart"])
-            .expect("should parse force-restart");
-
-    assert!(matches!(action.command, Cmd::ForceRestart));
-}
-
-// parse_on ensures on parses.
-#[test]
-fn parse_on() {
-    let action = RedfishAction::try_parse_from(["redfish", "--address", "192.0.2.10", "on"])
-        .expect("should parse on");
-
-    assert!(matches!(action.command, Cmd::On));
+fn payload_free_subcommands_route_to_their_variant() {
+    check_cases(
+        [
+            Case {
+                scenario: "bios-attrs",
+                input: &["redfish", "--address", "192.0.2.10", "bios-attrs"][..],
+                expect: Yields("bios-attrs"),
+            },
+            Case {
+                scenario: "boot-hdd",
+                input: &["redfish", "--address", "192.0.2.10", "boot-hdd"][..],
+                expect: Yields("boot-hdd"),
+            },
+            Case {
+                scenario: "boot-pxe",
+                input: &["redfish", "--address", "192.0.2.10", "boot-pxe"][..],
+                expect: Yields("boot-pxe"),
+            },
+            Case {
+                scenario: "get-power-state",
+                input: &["redfish", "--address", "192.0.2.10", "get-power-state"][..],
+                expect: Yields("get-power-state"),
+            },
+            Case {
+                scenario: "force-off",
+                input: &["redfish", "--address", "192.0.2.10", "force-off"][..],
+                expect: Yields("force-off"),
+            },
+            Case {
+                scenario: "force-restart",
+                input: &["redfish", "--address", "192.0.2.10", "force-restart"][..],
+                expect: Yields("force-restart"),
+            },
+            Case {
+                scenario: "on",
+                input: &["redfish", "--address", "192.0.2.10", "on"][..],
+                expect: Yields("on"),
+            },
+        ],
+        |argv| {
+            RedfishAction::try_parse_from(argv.iter().copied())
+                .map(|a| variant(&a.command))
+                .map_err(drop)
+        },
+    );
 }
 
 // parse_with_address ensures command parses with
@@ -154,46 +155,60 @@ fn parse_with_credentials() {
     assert_eq!(action.password, Some("secret".to_string()));
 }
 
-// parse_create_bmc_user ensures create-bmc-user parses
-// with required args.
+// create-bmc-user parses with its required args, carrying user and
+// new-password through to the CreateBmcUser variant.
 #[test]
 fn parse_create_bmc_user() {
-    let action = RedfishAction::try_parse_from([
-        "redfish",
-        "--address",
-        "192.0.2.10",
-        "create-bmc-user",
-        "--new-password",
-        "secret",
-        "--user",
-        "admin",
-    ])
-    .expect("should parse create-bmc-user");
-
-    match action.command {
-        Cmd::CreateBmcUser(args) => {
-            assert_eq!(args.user, "admin");
-            assert_eq!(args.new_password, "secret");
-        }
-        _ => panic!("expected CreateBmcUser variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "create-bmc-user with user and new-password",
+            input: &[
+                "redfish",
+                "--address",
+                "192.0.2.10",
+                "create-bmc-user",
+                "--new-password",
+                "secret",
+                "--user",
+                "admin",
+            ][..],
+            expect: Yields(("admin".to_string(), "secret".to_string())),
+        }],
+        |argv| {
+            RedfishAction::try_parse_from(argv.iter().copied())
+                .map(|a| match a.command {
+                    Cmd::CreateBmcUser(args) => (args.user, args.new_password),
+                    _ => panic!("expected CreateBmcUser variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_dpu_firmware_status ensures dpu firmware status parses.
+// `dpu firmware status` parses through the nested DpuOperations / FwCommand
+// subcommands to the Dpu Firmware Status variant.
 #[test]
 fn parse_dpu_firmware_status() {
-    let action = RedfishAction::try_parse_from([
-        "redfish",
-        "--address",
-        "192.0.2.10",
-        "dpu",
-        "firmware",
-        "status",
-    ])
-    .expect("should parse dpu firmware status");
-
-    match action.command {
-        Cmd::Dpu(DpuOperations::Firmware(FwCommand::Status)) => {}
-        _ => panic!("expected Dpu Firmware Status variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "dpu firmware status",
+            input: &[
+                "redfish",
+                "--address",
+                "192.0.2.10",
+                "dpu",
+                "firmware",
+                "status",
+            ][..],
+            expect: Yields("dpu firmware status"),
+        }],
+        |argv| {
+            RedfishAction::try_parse_from(argv.iter().copied())
+                .map(|a| match a.command {
+                    Cmd::Dpu(DpuOperations::Firmware(FwCommand::Status)) => "dpu firmware status",
+                    _ => panic!("expected Dpu Firmware Status variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/resource_pool/tests.rs
+++ b/crates/admin-cli/src/resource_pool/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,32 +46,66 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_list ensures list parses with no arguments.
-#[test]
-fn parse_list() {
-    let cmd = Cmd::try_parse_from(["resource-pool", "list"]).expect("should parse list");
-
-    assert!(matches!(cmd, Cmd::List(_)));
-}
-
-// parse_grow ensures grow parses with filename.
-#[test]
-fn parse_grow() {
-    let cmd = Cmd::try_parse_from(["resource-pool", "grow", "--filename", "config.toml"])
-        .expect("should parse grow");
-
+// variant names the subcommand a parsed Cmd routes to, for cases that only
+// assert "routes to variant X" with no field checks.
+fn variant(cmd: &Cmd) -> &'static str {
     match cmd {
-        Cmd::Grow(args) => {
-            assert_eq!(args.filename, "config.toml");
-        }
-        _ => panic!("expected Grow variant"),
+        Cmd::List(_) => "list",
+        Cmd::Grow(_) => "grow",
     }
 }
 
-// parse_grow_missing_filename_fails ensures grow fails
-// without --filename.
+// list parses with no arguments and routes to the List variant.
 #[test]
-fn parse_grow_missing_filename_fails() {
-    let result = Cmd::try_parse_from(["resource-pool", "grow"]);
-    assert!(result.is_err(), "should fail without --filename");
+fn parse_list() {
+    check_cases(
+        [Case {
+            scenario: "list with no arguments",
+            input: &["resource-pool", "list"][..],
+            expect: Yields("list"),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| variant(&cmd))
+                .map_err(drop)
+        },
+    );
+}
+
+// grow parses with --filename and surfaces that filename on the Grow variant.
+#[test]
+fn parse_grow() {
+    check_cases(
+        [Case {
+            scenario: "grow with --filename",
+            input: &["resource-pool", "grow", "--filename", "config.toml"][..],
+            expect: Yields("config.toml".to_string()),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Grow(args) => args.filename,
+                    _ => panic!("expected Grow variant"),
+                })
+                .map_err(drop)
+        },
+    );
+}
+
+// Every malformed invocation is rejected at parse time -- here, grow without
+// its required --filename.
+#[test]
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [Case {
+            scenario: "grow without --filename",
+            input: &["resource-pool", "grow"][..],
+            expect: Fails,
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/rms/tests.rs
+++ b/crates/admin-cli/src/rms/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::args::*;
@@ -44,56 +46,62 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_inventory ensures inventory subcommand parses with no args.
-#[test]
-fn parse_inventory() {
-    let cmd = Cmd::try_parse_from(["rms", "inventory"]).expect("should parse inventory");
-    assert!(matches!(cmd, Cmd::Inventory));
-}
-
-// parse_poweron_sequence ensures poweron-sequence subcommand
-// parses with no args.
-#[test]
-fn parse_poweron_sequence() {
-    let cmd = Cmd::try_parse_from(["rms", "power-on-sequence", "rack-123"])
-        .expect("should parse power-on-sequence");
+// route names the parsed subcommand and surfaces its positional fields, so a
+// single table can assert that each valid invocation lands on the right
+// variant carrying the right (rack_id, node_id). Variants without a given
+// field report an empty string for it.
+fn route(cmd: &Cmd) -> (&'static str, String, String) {
     match cmd {
-        Cmd::PowerOnSequence(args) => {
-            assert_eq!(args.rack_id, "rack-123");
-        }
-        _ => panic!("expected power-on-sequence variant"),
+        Cmd::Inventory => ("inventory", String::new(), String::new()),
+        Cmd::PowerOnSequence(args) => ("power-on-sequence", args.rack_id.clone(), String::new()),
+        Cmd::PowerState(args) => ("power-state", args.rack_id.clone(), args.node_id.clone()),
+        Cmd::FirmwareInventory(args) => (
+            "firmware-inventory",
+            args.rack_id.clone(),
+            args.node_id.clone(),
+        ),
     }
 }
 
-// parse_power_state ensures power-state parses with rack_id and node_id.
+// Every valid invocation parses, routes to its subcommand variant, and carries
+// the expected positional arguments.
 #[test]
-fn parse_power_state() {
-    let cmd = Cmd::try_parse_from(["rms", "power-state", "rack-123", "node-123"])
-        .expect("should parse power-state");
-
-    match cmd {
-        Cmd::PowerState(args) => {
-            assert_eq!(args.rack_id, "rack-123");
-            assert_eq!(args.node_id, "node-123");
-            assert_eq!(args.rack_id, "rack-123");
-        }
-        _ => panic!("expected PowerState variant"),
-    }
-}
-
-// parse_firmware_inventory ensures firmware-inventory
-// parses with rack_id and node_id.
-#[test]
-fn parse_firmware_inventory() {
-    let cmd = Cmd::try_parse_from(["rms", "firmware-inventory", "rack-123", "node-123"])
-        .expect("should parse firmware-inventory");
-
-    match cmd {
-        Cmd::FirmwareInventory(args) => {
-            assert_eq!(args.rack_id, "rack-123");
-            assert_eq!(args.node_id, "node-123");
-            assert_eq!(args.rack_id, "rack-123");
-        }
-        _ => panic!("expected FirmwareInventory variant"),
-    }
+fn valid_invocations_route_to_their_subcommand() {
+    check_cases(
+        [
+            Case {
+                scenario: "inventory takes no args",
+                input: &["rms", "inventory"][..],
+                expect: Yields(("inventory", String::new(), String::new())),
+            },
+            Case {
+                scenario: "power-on-sequence carries rack_id",
+                input: &["rms", "power-on-sequence", "rack-123"][..],
+                expect: Yields(("power-on-sequence", "rack-123".to_string(), String::new())),
+            },
+            Case {
+                scenario: "power-state carries rack_id and node_id",
+                input: &["rms", "power-state", "rack-123", "node-123"][..],
+                expect: Yields((
+                    "power-state",
+                    "rack-123".to_string(),
+                    "node-123".to_string(),
+                )),
+            },
+            Case {
+                scenario: "firmware-inventory carries rack_id and node_id",
+                input: &["rms", "firmware-inventory", "rack-123", "node-123"][..],
+                expect: Yields((
+                    "firmware-inventory",
+                    "rack-123".to_string(),
+                    "node-123".to_string(),
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| route(&cmd))
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/route_server/tests.rs
+++ b/crates/admin-cli/src/route_server/tests.rs
@@ -24,9 +24,22 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 // ValueEnum Parsing - Test clap ValueEnum translations (if applicable).
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
+
+// variant names the parsed subcommand so a routing-only case can assert
+// "parsed into the right variant" without inspecting any fields.
+fn variant(cmd: &Cmd) -> &'static str {
+    match cmd {
+        Cmd::Get(_) => "get",
+        Cmd::Add(_) => "add",
+        Cmd::Remove(_) => "remove",
+        Cmd::Replace(_) => "replace",
+    }
+}
 
 // verify_cmd_structure runs a baseline clap debug_assert()
 // to do basic command configuration checking and validation,
@@ -45,107 +58,105 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_get_no_args ensures get parses with no arguments.
+// Each subcommand parses to its own variant, with no arguments required:
+// `get` always, and `add`/`remove`/`replace` accept an empty IP list too.
 #[test]
-fn parse_get_no_args() {
-    let cmd = Cmd::try_parse_from(["route-server", "get"]).expect("should parse get");
-
-    assert!(matches!(cmd, Cmd::Get(_)));
+fn subcommands_route_to_their_variant() {
+    check_cases(
+        [
+            Case {
+                scenario: "get with no args",
+                input: &["route-server", "get"][..],
+                expect: Yields("get"),
+            },
+            Case {
+                scenario: "remove with an IP",
+                input: &["route-server", "remove", "192.168.1.1"][..],
+                expect: Yields("remove"),
+            },
+            Case {
+                scenario: "replace with an IP",
+                input: &["route-server", "replace", "192.168.1.1"][..],
+                expect: Yields("replace"),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| variant(&cmd))
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_add_single_ip ensures add parses with a single
-// IP address.
+// The positional IP list parses for add/remove/replace: a single address, a
+// comma-separated list, and the empty (no-args) case all land as the right
+// count. Yields the parsed IP count for whichever subcommand carries them.
 #[test]
-fn parse_add_single_ip() {
-    let cmd = Cmd::try_parse_from(["route-server", "add", "192.168.1.1"])
-        .expect("should parse add with single IP");
-
-    match cmd {
-        Cmd::Add(args) => {
-            assert_eq!(args.inner.ip.len(), 1);
-            assert_eq!(args.inner.ip[0].to_string(), "192.168.1.1");
+fn ip_list_parses_for_each_subcommand() {
+    fn ip_count(cmd: &Cmd) -> usize {
+        match cmd {
+            Cmd::Add(args) => args.inner.ip.len(),
+            Cmd::Remove(args) => args.inner.ip.len(),
+            Cmd::Replace(args) => args.inner.ip.len(),
+            Cmd::Get(_) => panic!("expected an IP-bearing variant"),
         }
-        _ => panic!("expected Add variant"),
     }
+
+    check_cases(
+        [
+            Case {
+                scenario: "add with a single IP",
+                input: &["route-server", "add", "192.168.1.1"][..],
+                expect: Yields(1),
+            },
+            Case {
+                scenario: "add with comma-separated IPs",
+                input: &["route-server", "add", "192.168.1.1,192.168.1.2,10.0.0.1"][..],
+                expect: Yields(3),
+            },
+            Case {
+                scenario: "add with no IPs",
+                input: &["route-server", "add"][..],
+                expect: Yields(0),
+            },
+            Case {
+                scenario: "remove with no IPs",
+                input: &["route-server", "remove"][..],
+                expect: Yields(0),
+            },
+            Case {
+                scenario: "replace with no IPs",
+                input: &["route-server", "replace"][..],
+                expect: Yields(0),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| ip_count(&cmd))
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_add_multiple_ips ensures add parses with
-// comma-separated IP addresses.
+// A single IP renders back to its canonical string, confirming the positional
+// argument is parsed into a real address type rather than a raw string.
 #[test]
-fn parse_add_multiple_ips() {
-    let cmd = Cmd::try_parse_from(["route-server", "add", "192.168.1.1,192.168.1.2,10.0.0.1"])
-        .expect("should parse add with multiple IPs");
-
-    match cmd {
-        Cmd::Add(args) => {
-            assert_eq!(args.inner.ip.len(), 3);
-        }
-        _ => panic!("expected Add variant"),
-    }
-}
-
-// parse_remove_with_ip ensures remove parses with
-// IP address.
-#[test]
-fn parse_remove_with_ip() {
-    let cmd = Cmd::try_parse_from(["route-server", "remove", "192.168.1.1"])
-        .expect("should parse remove");
-
-    assert!(matches!(cmd, Cmd::Remove(_)));
-}
-
-// parse_replace_with_ip ensures replace parses with
-// IP address.
-#[test]
-fn parse_replace_with_ip() {
-    let cmd = Cmd::try_parse_from(["route-server", "replace", "192.168.1.1"])
-        .expect("should parse replace");
-
-    assert!(matches!(cmd, Cmd::Replace(_)));
-}
-
-// parse_add_no_ips ensures add parses with no
-// IP addresses (empty list).
-#[test]
-fn parse_add_no_ips() {
-    let cmd = Cmd::try_parse_from(["route-server", "add"]).expect("should parse add with no IPs");
-
-    match cmd {
-        Cmd::Add(args) => {
-            assert!(args.inner.ip.is_empty());
-        }
-        _ => panic!("expected Add variant"),
-    }
-}
-
-// parse_remove_no_ips ensures remove parses with no
-// IP addresses (empty list).
-#[test]
-fn parse_remove_no_ips() {
-    let cmd =
-        Cmd::try_parse_from(["route-server", "remove"]).expect("should parse remove with no IPs");
-
-    match cmd {
-        Cmd::Remove(args) => {
-            assert!(args.inner.ip.is_empty());
-        }
-        _ => panic!("expected Remove variant"),
-    }
-}
-
-// parse_replace_no_ips ensures replace parses with no
-// IP addresses (empty list).
-#[test]
-fn parse_replace_no_ips() {
-    let cmd =
-        Cmd::try_parse_from(["route-server", "replace"]).expect("should parse replace with no IPs");
-
-    match cmd {
-        Cmd::Replace(args) => {
-            assert!(args.inner.ip.is_empty());
-        }
-        _ => panic!("expected Replace variant"),
-    }
+fn parse_add_single_ip_renders_back() {
+    check_cases(
+        [Case {
+            scenario: "single IP round-trips its string form",
+            input: &["route-server", "add", "192.168.1.1"][..],
+            expect: Yields("192.168.1.1".to_string()),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Add(args) => args.inner.ip[0].to_string(),
+                    _ => panic!("expected Add variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -154,68 +165,73 @@ fn parse_replace_no_ips() {
 // This section tests clap ValueEnum translations for the
 // source_type argument.
 
-// parse_add_with_source_type_admin_api ensures add parses
-// with --source-type admin_api.
+// --source-type maps each accepted ValueEnum string onto its proto integer:
+// config_file = 0, admin_api = 1. Yields the parsed source_type as i32.
 #[test]
-fn parse_add_with_source_type_admin_api() {
-    let cmd = Cmd::try_parse_from([
-        "route-server",
-        "add",
-        "192.168.1.1",
-        "--source-type",
-        "admin_api",
-    ])
-    .expect("should parse add with source-type admin_api");
-
-    match cmd {
-        Cmd::Add(args) => {
-            // AdminApi = 1 in the proto enum
-            assert_eq!(args.inner.source_type as i32, 1);
-        }
-        _ => panic!("expected Add variant"),
-    }
+fn add_source_type_maps_to_proto_int() {
+    check_cases(
+        [
+            Case {
+                scenario: "admin_api is 1",
+                input: &[
+                    "route-server",
+                    "add",
+                    "192.168.1.1",
+                    "--source-type",
+                    "admin_api",
+                ][..],
+                expect: Yields(1),
+            },
+            Case {
+                scenario: "config_file is 0",
+                input: &[
+                    "route-server",
+                    "add",
+                    "192.168.1.1",
+                    "--source-type",
+                    "config_file",
+                ][..],
+                expect: Yields(0),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Add(args) => args.inner.source_type as i32,
+                    _ => panic!("expected Add variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_add_with_source_type_config_file ensures add
-// parses with --source-type config_file.
+// Malformed add invocations are rejected at parse time: an unknown
+// --source-type value, and a positional that isn't a valid IP address.
 #[test]
-fn parse_add_with_source_type_config_file() {
-    let cmd = Cmd::try_parse_from([
-        "route-server",
-        "add",
-        "192.168.1.1",
-        "--source-type",
-        "config_file",
-    ])
-    .expect("should parse add with source-type config_file");
-
-    match cmd {
-        Cmd::Add(args) => {
-            // ConfigFile = 0 in the proto enum
-            assert_eq!(args.inner.source_type as i32, 0);
-        }
-        _ => panic!("expected Add variant"),
-    }
-}
-
-// parse_add_invalid_source_type_fails ensures add fails
-// with invalid source-type value.
-#[test]
-fn parse_add_invalid_source_type_fails() {
-    let result = Cmd::try_parse_from([
-        "route-server",
-        "add",
-        "192.168.1.1",
-        "--source-type",
-        "invalid",
-    ]);
-    assert!(result.is_err(), "should fail with invalid source-type");
-}
-
-// parse_add_invalid_ip_fails ensures add fails with
-// invalid IP address format.
-#[test]
-fn parse_add_invalid_ip_fails() {
-    let result = Cmd::try_parse_from(["route-server", "add", "not-an-ip"]);
-    assert!(result.is_err(), "should fail with invalid IP");
+fn invalid_add_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "unknown --source-type value",
+                input: &[
+                    "route-server",
+                    "add",
+                    "192.168.1.1",
+                    "--source-type",
+                    "invalid",
+                ][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "positional is not an IP",
+                input: &["route-server", "add", "not-an-ip"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/scout_stream/tests.rs
+++ b/crates/admin-cli/src/scout_stream/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -46,55 +48,85 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show ensures show parses with no arguments.
+// parse_show ensures show parses with no arguments and routes to the Show
+// variant.
 #[test]
 fn parse_show() {
-    let action =
-        ScoutStreamAction::try_parse_from(["scout-stream", "show"]).expect("should parse show");
-
-    assert!(matches!(action, ScoutStreamAction::Show(_)));
+    check_cases(
+        [Case {
+            scenario: "show with no arguments",
+            input: &["scout-stream", "show"][..],
+            expect: Yields("show"),
+        }],
+        |argv| {
+            ScoutStreamAction::try_parse_from(argv.iter().copied())
+                .map(|a| variant(&a))
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_disconnect ensures disconnect parses with machine_id.
+// The machine-id subcommands (disconnect, ping) parse the supplied id and route
+// to their respective variant; this table confirms each one round-trips the id.
 #[test]
-fn parse_disconnect() {
-    let action = ScoutStreamAction::try_parse_from(["scout-stream", "disconnect", TEST_MACHINE_ID])
-        .expect("should parse disconnect");
+fn parse_machine_id_subcommands() {
+    check_cases(
+        [
+            Case {
+                scenario: "disconnect parses machine_id",
+                input: &["scout-stream", "disconnect", TEST_MACHINE_ID][..],
+                expect: Yields(("disconnect", TEST_MACHINE_ID.to_string())),
+            },
+            Case {
+                scenario: "ping parses machine_id",
+                input: &["scout-stream", "ping", TEST_MACHINE_ID][..],
+                expect: Yields(("ping", TEST_MACHINE_ID.to_string())),
+            },
+        ],
+        |argv| {
+            ScoutStreamAction::try_parse_from(argv.iter().copied())
+                .map(|a| match a {
+                    ScoutStreamAction::Disconnect(cmd) => {
+                        ("disconnect", cmd.machine_id.to_string())
+                    }
+                    ScoutStreamAction::Ping(cmd) => ("ping", cmd.machine_id.to_string()),
+                    _ => panic!("expected Disconnect or Ping variant"),
+                })
+                .map_err(drop)
+        },
+    );
+}
 
+// The machine-id subcommands reject an invocation that omits the required
+// machine_id positional argument.
+#[test]
+fn missing_machine_id_is_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "disconnect without machine_id",
+                input: &["scout-stream", "disconnect"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "ping without machine_id",
+                input: &["scout-stream", "ping"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            ScoutStreamAction::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
+}
+
+// variant names the parsed subcommand, for cases that only assert routing.
+fn variant(action: &ScoutStreamAction) -> &'static str {
     match action {
-        ScoutStreamAction::Disconnect(cmd) => {
-            assert_eq!(cmd.machine_id.to_string(), TEST_MACHINE_ID);
-        }
-        _ => panic!("expected Disconnect variant"),
+        ScoutStreamAction::Show(_) => "show",
+        ScoutStreamAction::Disconnect(_) => "disconnect",
+        ScoutStreamAction::Ping(_) => "ping",
     }
-}
-
-// parse_ping ensures ping parses with machine_id.
-#[test]
-fn parse_ping() {
-    let action = ScoutStreamAction::try_parse_from(["scout-stream", "ping", TEST_MACHINE_ID])
-        .expect("should parse ping");
-
-    match action {
-        ScoutStreamAction::Ping(cmd) => {
-            assert_eq!(cmd.machine_id.to_string(), TEST_MACHINE_ID);
-        }
-        _ => panic!("expected Ping variant"),
-    }
-}
-
-// parse_disconnect_missing_machine_id_fails ensures
-// disconnect fails without machine_id.
-#[test]
-fn parse_disconnect_missing_machine_id_fails() {
-    let result = ScoutStreamAction::try_parse_from(["scout-stream", "disconnect"]);
-    assert!(result.is_err(), "should fail without machine_id");
-}
-
-// parse_ping_missing_machine_id_fails ensures ping fails
-// without machine_id.
-#[test]
-fn parse_ping_missing_machine_id_fails() {
-    let result = ScoutStreamAction::try_parse_from(["scout-stream", "ping"]);
-    assert!(result.is_err(), "should fail without machine_id");
 }

--- a/crates/admin-cli/src/set/tests.rs
+++ b/crates/admin-cli/src/set/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,168 +46,180 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_log_filter ensures log-filter parses with required filter arg.
+// Every malformed invocation is rejected at parse time -- log-filter without
+// its required --filter, and the toggle subcommands left without an
+// --enable/--disable choice.
 #[test]
-fn parse_log_filter() {
-    let cmd = Cmd::try_parse_from(["set", "log-filter", "--filter", "debug"])
-        .expect("should parse log-filter");
-
-    match cmd {
-        Cmd::LogFilter(args) => {
-            assert_eq!(args.filter, "debug");
-            assert_eq!(args.expiry, "1h"); // default
-        }
-        _ => panic!("expected LogFilter variant"),
-    }
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "log-filter without --filter",
+                input: &["set", "log-filter"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "create-machines without --enable/--disable",
+                input: &["set", "create-machines"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "site-explorer without --enable/--disable",
+                input: &["set", "site-explorer"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_log_filter_with_expiry ensures log-filter parses
-// with custom expiry.
+// log-filter parses its required --filter and an optional --expiry that
+// defaults to "1h"; the yielded tuple is (filter, expiry).
 #[test]
-fn parse_log_filter_with_expiry() {
-    let cmd = Cmd::try_parse_from([
-        "set",
-        "log-filter",
-        "--filter",
-        "trace",
-        "--expiry",
-        "30min",
-    ])
-    .expect("should parse log-filter with expiry");
-
-    match cmd {
-        Cmd::LogFilter(args) => {
-            assert_eq!(args.filter, "trace");
-            assert_eq!(args.expiry, "30min");
-        }
-        _ => panic!("expected LogFilter variant"),
-    }
+fn parse_log_filter_routes_to_variant() {
+    check_cases(
+        [
+            Case {
+                scenario: "filter only, expiry defaults",
+                input: &["set", "log-filter", "--filter", "debug"][..],
+                expect: Yields(("debug".to_string(), "1h".to_string())),
+            },
+            Case {
+                scenario: "filter with custom expiry",
+                input: &[
+                    "set",
+                    "log-filter",
+                    "--filter",
+                    "trace",
+                    "--expiry",
+                    "30min",
+                ][..],
+                expect: Yields(("trace".to_string(), "30min".to_string())),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::LogFilter(args) => (args.filter, args.expiry),
+                    _ => panic!("expected LogFilter variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_log_filter_missing_filter_fails ensures
-// log-filter requires --filter.
+// create-machines routes to the CreateMachines variant; --enable yields
+// is_enabled() == true, --disable yields false.
 #[test]
-fn parse_log_filter_missing_filter_fails() {
-    let result = Cmd::try_parse_from(["set", "log-filter"]);
-    assert!(result.is_err(), "should fail without --filter");
+fn parse_create_machines_toggle() {
+    check_cases(
+        [
+            Case {
+                scenario: "--enable",
+                input: &["set", "create-machines", "--enable"][..],
+                expect: Yields(true),
+            },
+            Case {
+                scenario: "--disable",
+                input: &["set", "create-machines", "--disable"][..],
+                expect: Yields(false),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::CreateMachines(args) => args.is_enabled(),
+                    _ => panic!("expected CreateMachines variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_create_machines_enable ensures create-machines --enable works.
+// site-explorer routes to the SiteExplorer variant; --enable yields
+// is_enabled() == true, --disable yields false.
 #[test]
-fn parse_create_machines_enable() {
-    let cmd = Cmd::try_parse_from(["set", "create-machines", "--enable"])
-        .expect("should parse create-machines --enable");
-
-    match cmd {
-        Cmd::CreateMachines(args) => {
-            assert!(args.is_enabled());
-        }
-        _ => panic!("expected CreateMachines variant"),
-    }
+fn parse_site_explorer_toggle() {
+    check_cases(
+        [
+            Case {
+                scenario: "--enable",
+                input: &["set", "site-explorer", "--enable"][..],
+                expect: Yields(true),
+            },
+            Case {
+                scenario: "--disable",
+                input: &["set", "site-explorer", "--disable"][..],
+                expect: Yields(false),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::SiteExplorer(args) => args.is_enabled(),
+                    _ => panic!("expected SiteExplorer variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_create_machines_disable ensures create-machines --disable works.
+// bmc-proxy parses --enabled and --proxy; the yielded tuple is
+// (enabled, proxy).
 #[test]
-fn parse_create_machines_disable() {
-    let cmd = Cmd::try_parse_from(["set", "create-machines", "--disable"])
-        .expect("should parse create-machines --disable");
-
-    match cmd {
-        Cmd::CreateMachines(args) => {
-            assert!(!args.is_enabled());
-        }
-        _ => panic!("expected CreateMachines variant"),
-    }
+fn parse_bmc_proxy_routes_to_variant() {
+    check_cases(
+        [Case {
+            scenario: "enabled with a proxy address",
+            input: &[
+                "set",
+                "bmc-proxy",
+                "--enabled",
+                "true",
+                "--proxy",
+                "proxy.example.com:8080",
+            ][..],
+            expect: Yields((true, Some("proxy.example.com:8080".to_string()))),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::BmcProxy(args) => (args.enabled, args.proxy),
+                    _ => panic!("expected BmcProxy variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_create_machines_requires_toggle ensures create-machines fails without --enable/--disable.
+// tracing-enabled routes to the TracingEnabled variant; "true" yields
+// value == true, "false" yields false.
 #[test]
-fn parse_create_machines_requires_toggle() {
-    let result = Cmd::try_parse_from(["set", "create-machines"]);
-    assert!(result.is_err(), "should fail without --enable or --disable");
-}
-
-// parse_site_explorer_enable ensures site-explorer --enable works.
-#[test]
-fn parse_site_explorer_enable() {
-    let cmd = Cmd::try_parse_from(["set", "site-explorer", "--enable"])
-        .expect("should parse site-explorer --enable");
-
-    match cmd {
-        Cmd::SiteExplorer(args) => {
-            assert!(args.is_enabled());
-        }
-        _ => panic!("expected SiteExplorer variant"),
-    }
-}
-
-// parse_site_explorer_disable ensures site-explorer --disable works.
-#[test]
-fn parse_site_explorer_disable() {
-    let cmd = Cmd::try_parse_from(["set", "site-explorer", "--disable"])
-        .expect("should parse site-explorer --disable");
-
-    match cmd {
-        Cmd::SiteExplorer(args) => {
-            assert!(!args.is_enabled());
-        }
-        _ => panic!("expected SiteExplorer variant"),
-    }
-}
-
-// parse_site_explorer_requires_toggle ensures site-explorer fails without --enable/--disable.
-#[test]
-fn parse_site_explorer_requires_toggle() {
-    let result = Cmd::try_parse_from(["set", "site-explorer"]);
-    assert!(result.is_err(), "should fail without --enable or --disable");
-}
-
-// parse_bmc_proxy ensures bmc-proxy parses with --enabled and --proxy.
-#[test]
-fn parse_bmc_proxy() {
-    let cmd = Cmd::try_parse_from([
-        "set",
-        "bmc-proxy",
-        "--enabled",
-        "true",
-        "--proxy",
-        "proxy.example.com:8080",
-    ])
-    .expect("should parse bmc-proxy");
-
-    match cmd {
-        Cmd::BmcProxy(args) => {
-            assert!(args.enabled);
-            assert_eq!(args.proxy, Some("proxy.example.com:8080".to_string()));
-        }
-        _ => panic!("expected BmcProxy variant"),
-    }
-}
-
-// parse_tracing_enabled_true ensures tracing-enabled parses true.
-#[test]
-fn parse_tracing_enabled_true() {
-    let cmd =
-        Cmd::try_parse_from(["set", "tracing-enabled", "true"]).expect("should parse tracing true");
-
-    match cmd {
-        Cmd::TracingEnabled(args) => {
-            assert!(args.value);
-        }
-        _ => panic!("expected TracingEnabled variant"),
-    }
-}
-
-// parse_tracing_enabled_false ensures tracing-enabled parses false.
-#[test]
-fn parse_tracing_enabled_false() {
-    let cmd = Cmd::try_parse_from(["set", "tracing-enabled", "false"])
-        .expect("should parse tracing false");
-
-    match cmd {
-        Cmd::TracingEnabled(args) => {
-            assert!(!args.value);
-        }
-        _ => panic!("expected TracingEnabled variant"),
-    }
+fn parse_tracing_enabled_value() {
+    check_cases(
+        [
+            Case {
+                scenario: "true",
+                input: &["set", "tracing-enabled", "true"][..],
+                expect: Yields(true),
+            },
+            Case {
+                scenario: "false",
+                input: &["set", "tracing-enabled", "false"][..],
+                expect: Yields(false),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::TracingEnabled(args) => args.value,
+                    _ => panic!("expected TracingEnabled variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/site_explorer/tests.rs
+++ b/crates/admin-cli/src/site_explorer/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 use get_report::args::Args as GetReportMode;
 
@@ -88,40 +90,38 @@ fn parse_get_report_endpoint() {
     }
 }
 
-// parse_explore ensures explore parses with address.
+// explore routes to the Explore variant; --mac is optional. Each row yields
+// (parsed address, whether a MAC was supplied).
 #[test]
 fn parse_explore() {
-    let cmd = Cmd::try_parse_from(["site-explorer", "explore", "192.168.1.100"])
-        .expect("should parse explore");
-
-    match cmd {
-        Cmd::Explore(args) => {
-            assert_eq!(args.inner.address, "192.168.1.100");
-            assert!(args.inner.mac.is_none());
-        }
-        _ => panic!("expected Explore variant"),
-    }
-}
-
-// parse_explore_with_mac ensures explore parses with
-// address and mac.
-#[test]
-fn parse_explore_with_mac() {
-    let cmd = Cmd::try_parse_from([
-        "site-explorer",
-        "explore",
-        "192.168.1.100",
-        "--mac",
-        "00:11:22:33:44:55",
-    ])
-    .expect("should parse explore with mac");
-
-    match cmd {
-        Cmd::Explore(args) => {
-            assert!(args.inner.mac.is_some());
-        }
-        _ => panic!("expected Explore variant"),
-    }
+    check_cases(
+        [
+            Case {
+                scenario: "address only, no mac",
+                input: &["site-explorer", "explore", "192.168.1.100"][..],
+                expect: Yields(("192.168.1.100".to_string(), false)),
+            },
+            Case {
+                scenario: "address with mac",
+                input: &[
+                    "site-explorer",
+                    "explore",
+                    "192.168.1.100",
+                    "--mac",
+                    "00:11:22:33:44:55",
+                ][..],
+                expect: Yields(("192.168.1.100".to_string(), true)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Explore(args) => (args.inner.address, args.inner.mac.is_some()),
+                    _ => panic!("expected Explore variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
 // parse_re_explore ensures re-explore parses with address.
@@ -183,10 +183,20 @@ fn parse_remediation() {
     }
 }
 
-// parse_explore_missing_address_fails ensures explore
-// fails without address.
+// Malformed invocations are rejected at parse time -- e.g. a subcommand left
+// without its required positional address.
 #[test]
-fn parse_explore_missing_address_fails() {
-    let result = Cmd::try_parse_from(["site-explorer", "explore"]);
-    assert!(result.is_err(), "should fail without address");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [Case {
+            scenario: "explore without an address",
+            input: &["site-explorer", "explore"][..],
+            expect: Fails,
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/sku/tests.rs
+++ b/crates/admin-cli/src/sku/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -46,228 +48,251 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no arguments.
+// show parses with no arguments (sku_id absent) and with a
+// positional sku_id (present).
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["sku", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.sku_id.is_none());
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_show() {
+    check_cases(
+        [
+            Case {
+                scenario: "no args leaves sku_id unset",
+                input: &["sku", "show"][..],
+                expect: Yields(None),
+            },
+            Case {
+                scenario: "positional sku_id is captured",
+                input: &["sku", "show", "sku-123"][..],
+                expect: Yields(Some("sku-123".to_string())),
+            },
+        ],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::Show(args)) => Ok(args.sku_id),
+            Ok(_) => panic!("expected Show variant"),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_show_with_sku_id ensures show parses with sku_id.
-#[test]
-fn parse_show_with_sku_id() {
-    let cmd =
-        Cmd::try_parse_from(["sku", "show", "sku-123"]).expect("should parse show with sku_id");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.sku_id, Some("sku-123".to_string()));
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_machines ensures show-machines parses.
+// show-machines parses with a positional sku_id, captured on the
+// inner args.
 #[test]
 fn parse_show_machines() {
-    let cmd = Cmd::try_parse_from(["sku", "show-machines", "sku-123"])
-        .expect("should parse show-machines");
-
-    match cmd {
-        Cmd::ShowMachines(args) => {
-            assert_eq!(args.inner.sku_id, Some("sku-123".to_string()));
-        }
-        _ => panic!("expected ShowMachines variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "positional sku_id is captured on inner",
+            input: &["sku", "show-machines", "sku-123"][..],
+            expect: Yields(Some("sku-123".to_string())),
+        }],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::ShowMachines(args)) => Ok(args.inner.sku_id),
+            Ok(_) => panic!("expected ShowMachines variant"),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_generate ensures generate parses with machine_id.
+// generate parses with a required machine_id and an optional --id
+// override; the tuple is (machine_id, id).
 #[test]
 fn parse_generate() {
-    let cmd =
-        Cmd::try_parse_from(["sku", "generate", TEST_MACHINE_ID]).expect("should parse generate");
-
-    match cmd {
-        Cmd::Generate(args) => {
-            assert_eq!(args.machine_id.to_string(), TEST_MACHINE_ID);
-            assert!(args.id.is_none());
-        }
-        _ => panic!("expected Generate variant"),
-    }
+    check_cases(
+        [
+            Case {
+                scenario: "machine_id only leaves id unset",
+                input: &["sku", "generate", TEST_MACHINE_ID][..],
+                expect: Yields((TEST_MACHINE_ID.to_string(), None)),
+            },
+            Case {
+                scenario: "--id override is captured",
+                input: &["sku", "generate", TEST_MACHINE_ID, "--id", "custom-sku"][..],
+                expect: Yields((TEST_MACHINE_ID.to_string(), Some("custom-sku".to_string()))),
+            },
+        ],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::Generate(args)) => Ok((args.machine_id.to_string(), args.id)),
+            Ok(_) => panic!("expected Generate variant"),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_generate_with_id_override ensures generate parses
-// with --id override.
-#[test]
-fn parse_generate_with_id_override() {
-    let cmd = Cmd::try_parse_from(["sku", "generate", TEST_MACHINE_ID, "--id", "custom-sku"])
-        .expect("should parse generate with id");
-
-    match cmd {
-        Cmd::Generate(args) => {
-            assert_eq!(args.id, Some("custom-sku".to_string()));
-        }
-        _ => panic!("expected Generate variant"),
-    }
-}
-
-// parse_create ensures create parses with filename.
+// create parses with a positional filename; --id defaults to unset.
+// The tuple is (filename, id).
 #[test]
 fn parse_create() {
-    let cmd = Cmd::try_parse_from(["sku", "create", "sku.json"]).expect("should parse create");
-
-    match cmd {
-        Cmd::Create(args) => {
-            assert_eq!(args.filename, "sku.json");
-            assert!(args.id.is_none());
-        }
-        _ => panic!("expected Create variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "filename captured, id unset",
+            input: &["sku", "create", "sku.json"][..],
+            expect: Yields(("sku.json".to_string(), None)),
+        }],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::Create(args)) => Ok((args.filename, args.id)),
+            Ok(_) => panic!("expected Create variant"),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_delete ensures delete parses with sku_id.
+// delete parses with a positional sku_id.
 #[test]
 fn parse_delete() {
-    let cmd = Cmd::try_parse_from(["sku", "delete", "sku-123"]).expect("should parse delete");
-
-    match cmd {
-        Cmd::Delete(args) => {
-            assert_eq!(args.sku_id, "sku-123");
-        }
-        _ => panic!("expected Delete variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "positional sku_id is captured",
+            input: &["sku", "delete", "sku-123"][..],
+            expect: Yields("sku-123".to_string()),
+        }],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::Delete(args)) => Ok(args.sku_id),
+            Ok(_) => panic!("expected Delete variant"),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_assign ensures assign parses with sku_id and machine_id.
+// assign parses with sku_id and machine_id, with an optional --force
+// flag. The tuple is (sku_id, machine_id, force).
 #[test]
 fn parse_assign() {
-    let cmd = Cmd::try_parse_from(["sku", "assign", "sku-123", TEST_MACHINE_ID])
-        .expect("should parse assign");
-
-    match cmd {
-        Cmd::Assign(args) => {
-            assert_eq!(args.sku_id, "sku-123");
-            assert_eq!(args.machine_id.to_string(), TEST_MACHINE_ID);
-            assert!(!args.force);
-        }
-        _ => panic!("expected Assign variant"),
-    }
+    check_cases(
+        [
+            Case {
+                scenario: "force defaults off",
+                input: &["sku", "assign", "sku-123", TEST_MACHINE_ID][..],
+                expect: Yields(("sku-123".to_string(), TEST_MACHINE_ID.to_string(), false)),
+            },
+            Case {
+                scenario: "--force flag sets force",
+                input: &["sku", "assign", "sku-123", TEST_MACHINE_ID, "--force"][..],
+                expect: Yields(("sku-123".to_string(), TEST_MACHINE_ID.to_string(), true)),
+            },
+        ],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::Assign(args)) => Ok((args.sku_id, args.machine_id.to_string(), args.force)),
+            Ok(_) => panic!("expected Assign variant"),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_assign_with_force ensures assign parses with --force flag.
-#[test]
-fn parse_assign_with_force() {
-    let cmd = Cmd::try_parse_from(["sku", "assign", "sku-123", TEST_MACHINE_ID, "--force"])
-        .expect("should parse assign with force");
-
-    match cmd {
-        Cmd::Assign(args) => {
-            assert!(args.force);
-        }
-        _ => panic!("expected Assign variant"),
-    }
-}
-
-// parse_unassign ensures unassign parses with machine_id.
+// unassign parses with a machine_id; --force defaults off. The tuple
+// is (machine_id, force).
 #[test]
 fn parse_unassign() {
-    let cmd =
-        Cmd::try_parse_from(["sku", "unassign", TEST_MACHINE_ID]).expect("should parse unassign");
-
-    match cmd {
-        Cmd::Unassign(args) => {
-            assert_eq!(args.machine_id.to_string(), TEST_MACHINE_ID);
-            assert!(!args.force);
-        }
-        _ => panic!("expected Unassign variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "machine_id captured, force defaults off",
+            input: &["sku", "unassign", TEST_MACHINE_ID][..],
+            expect: Yields((TEST_MACHINE_ID.to_string(), false)),
+        }],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::Unassign(args)) => Ok((args.machine_id.to_string(), args.force)),
+            Ok(_) => panic!("expected Unassign variant"),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_verify ensures verify parses with machine_id.
+// verify parses with a machine_id.
 #[test]
 fn parse_verify() {
-    let cmd = Cmd::try_parse_from(["sku", "verify", TEST_MACHINE_ID]).expect("should parse verify");
-
-    match cmd {
-        Cmd::Verify(args) => {
-            assert_eq!(args.machine_id.to_string(), TEST_MACHINE_ID);
-        }
-        _ => panic!("expected Verify variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "machine_id is captured",
+            input: &["sku", "verify", TEST_MACHINE_ID][..],
+            expect: Yields(TEST_MACHINE_ID.to_string()),
+        }],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::Verify(args)) => Ok(args.machine_id.to_string()),
+            Ok(_) => panic!("expected Verify variant"),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_update_metadata ensures update-metadata parses
-// with required args.
+// update-metadata parses with a sku_id and a --description; --device-type
+// defaults to unset. The tuple is (sku_id, description, device_type).
 #[test]
 fn parse_update_metadata() {
-    let cmd = Cmd::try_parse_from([
-        "sku",
-        "update-metadata",
-        "sku-123",
-        "--description",
-        "New desc",
-    ])
-    .expect("should parse update-metadata");
-
-    match cmd {
-        Cmd::UpdateMetadata(args) => {
-            assert_eq!(args.sku_id, "sku-123");
-            assert_eq!(args.description, Some("New desc".to_string()));
-            assert!(args.device_type.is_none());
-        }
-        _ => panic!("expected UpdateMetadata variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "sku_id and description captured, device_type unset",
+            input: &[
+                "sku",
+                "update-metadata",
+                "sku-123",
+                "--description",
+                "New desc",
+            ][..],
+            expect: Yields(("sku-123".to_string(), Some("New desc".to_string()), true)),
+        }],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::UpdateMetadata(args)) => {
+                Ok((args.sku_id, args.description, args.device_type.is_none()))
+            }
+            Ok(_) => panic!("expected UpdateMetadata variant"),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_bulk_update_metadata ensures bulk-update-metadata
-// parses with filename.
+// bulk-update-metadata parses with a positional filename.
 #[test]
 fn parse_bulk_update_metadata() {
-    let cmd = Cmd::try_parse_from(["sku", "bulk-update-metadata", "updates.csv"])
-        .expect("should parse bulk-update-metadata");
-
-    match cmd {
-        Cmd::BulkUpdateMetadata(args) => {
-            assert_eq!(args.filename, "updates.csv");
-        }
-        _ => panic!("expected BulkUpdateMetadata variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "filename is captured",
+            input: &["sku", "bulk-update-metadata", "updates.csv"][..],
+            expect: Yields("updates.csv".to_string()),
+        }],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::BulkUpdateMetadata(args)) => Ok(args.filename),
+            Ok(_) => panic!("expected BulkUpdateMetadata variant"),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_replace ensures replace parses with filename.
+// replace parses with a positional filename, captured on the inner args.
 #[test]
 fn parse_replace() {
-    let cmd = Cmd::try_parse_from(["sku", "replace", "sku.json"]).expect("should parse replace");
-
-    match cmd {
-        Cmd::Replace(args) => {
-            assert_eq!(args.inner.filename, "sku.json");
-        }
-        _ => panic!("expected Replace variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "filename is captured on inner",
+            input: &["sku", "replace", "sku.json"][..],
+            expect: Yields("sku.json".to_string()),
+        }],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::Replace(args)) => Ok(args.inner.filename),
+            Ok(_) => panic!("expected Replace variant"),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_generate_missing_machine_id_fails ensures generate
-// fails without machine_id.
+// Every malformed invocation is rejected at parse time -- generate
+// without its required machine_id, and update-metadata with neither a
+// description nor a device_type to change.
 #[test]
-fn parse_generate_missing_machine_id_fails() {
-    let result = Cmd::try_parse_from(["sku", "generate"]);
-    assert!(result.is_err(), "should fail without machine_id");
-}
-
-// parse_update_metadata_missing_field_fails ensures
-// update-metadata fails without description or device_type.
-#[test]
-fn parse_update_metadata_missing_field_fails() {
-    let result = Cmd::try_parse_from(["sku", "update-metadata", "sku-123"]);
-    assert!(
-        result.is_err(),
-        "should fail without description or device_type"
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "generate without machine_id",
+                input: &["sku", "generate"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "update-metadata without description or device_type",
+                input: &["sku", "update-metadata", "sku-123"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
     );
 }

--- a/crates/admin-cli/src/spx_partition/tests.rs
+++ b/crates/admin-cli/src/spx_partition/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,44 +46,35 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all partitions).
+// `show` routes to the Show variant across its optional filters: no args leaves
+// every selector unset, while --tenant-org-id and --name each thread their value
+// through. Each row yields the (id, tenant_org_id, name) the originals asserted.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["ib-partition", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_none());
-            assert!(args.tenant_org_id.is_none());
-            assert!(args.name.is_none());
-        }
-    }
-}
-
-// parse_show_with_tenant ensures show parses with
-// --tenant-org-id.
-#[test]
-fn parse_show_with_tenant() {
-    let cmd = Cmd::try_parse_from(["ib-partition", "show", "--tenant-org-id", "tenant-123"])
-        .expect("should parse show with tenant");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.tenant_org_id, Some("tenant-123".to_string()));
-        }
-    }
-}
-
-// parse_show_with_name ensures show parses with --name.
-#[test]
-fn parse_show_with_name() {
-    let cmd = Cmd::try_parse_from(["ib-partition", "show", "--name", "my-partition"])
-        .expect("should parse show with name");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.name, Some("my-partition".to_string()));
-        }
-    }
+fn show_parses_optional_filters() {
+    check_cases(
+        [
+            Case {
+                scenario: "no args (all partitions)",
+                input: &["ib-partition", "show"][..],
+                expect: Yields((None, None, None)),
+            },
+            Case {
+                scenario: "with --tenant-org-id",
+                input: &["ib-partition", "show", "--tenant-org-id", "tenant-123"][..],
+                expect: Yields((None, Some("tenant-123".to_string()), None)),
+            },
+            Case {
+                scenario: "with --name",
+                input: &["ib-partition", "show", "--name", "my-partition"][..],
+                expect: Yields((None, None, Some("my-partition".to_string()))),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => (args.id, args.tenant_org_id, args.name),
+                })
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/ssh/tests.rs
+++ b/crates/admin-cli/src/ssh/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -45,101 +47,136 @@ fn verify_cmd_structure() {
 // flag-specific checking.
 
 // parse_get_rshim_status ensures get-rshim-status parses
-// with credentials.
+// with credentials and routes them onto the credential fields.
 #[test]
 fn parse_get_rshim_status() {
-    let cmd = Cmd::try_parse_from([
-        "ssh",
-        "get-rshim-status",
-        "192.168.1.100:443",
-        "admin",
-        "password123",
-    ])
-    .expect("should parse get-rshim-status");
-
-    match cmd {
-        Cmd::GetRshimStatus(args) => {
-            assert_eq!(
-                args.inner.credentials.bmc_ip_address.to_string(),
-                "192.168.1.100:443"
-            );
-            assert_eq!(args.inner.credentials.bmc_username, "admin");
-            assert_eq!(args.inner.credentials.bmc_password, "password123");
-        }
-        _ => panic!("expected GetRshimStatus variant"),
-    }
-}
-
-// parse_disable_rshim ensures disable-rshim parses correctly.
-#[test]
-fn parse_disable_rshim() {
-    let cmd = Cmd::try_parse_from([
-        "ssh",
-        "disable-rshim",
-        "192.168.1.100:443",
-        "admin",
-        "password123",
-    ])
-    .expect("should parse disable-rshim");
-
-    assert!(matches!(cmd, Cmd::DisableRshim(_)));
-}
-
-// parse_enable_rshim ensures enable-rshim parses correctly.
-#[test]
-fn parse_enable_rshim() {
-    let cmd = Cmd::try_parse_from([
-        "ssh",
-        "enable-rshim",
-        "192.168.1.100:443",
-        "admin",
-        "password123",
-    ])
-    .expect("should parse enable-rshim");
-
-    assert!(matches!(cmd, Cmd::EnableRshim(_)));
+    check_cases(
+        [Case {
+            scenario: "get-rshim-status with credentials",
+            input: &[
+                "ssh",
+                "get-rshim-status",
+                "192.168.1.100:443",
+                "admin",
+                "password123",
+            ][..],
+            expect: Yields((
+                "192.168.1.100:443".to_string(),
+                "admin".to_string(),
+                "password123".to_string(),
+            )),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::GetRshimStatus(args) => (
+                        args.inner.credentials.bmc_ip_address.to_string(),
+                        args.inner.credentials.bmc_username,
+                        args.inner.credentials.bmc_password,
+                    ),
+                    _ => panic!("expected GetRshimStatus variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
 // parse_copy_bfb ensures copy-bfb parses with bfb_path.
 #[test]
 fn parse_copy_bfb() {
-    let cmd = Cmd::try_parse_from([
-        "ssh",
-        "copy-bfb",
-        "192.168.1.100:443",
-        "admin",
-        "password123",
-        "/path/to/image.bfb",
-    ])
-    .expect("should parse copy-bfb");
+    check_cases(
+        [Case {
+            scenario: "copy-bfb with bfb path",
+            input: &[
+                "ssh",
+                "copy-bfb",
+                "192.168.1.100:443",
+                "admin",
+                "password123",
+                "/path/to/image.bfb",
+            ][..],
+            expect: Yields("/path/to/image.bfb".to_string()),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::CopyBfb(args) => args.bfb_path,
+                    _ => panic!("expected CopyBfb variant"),
+                })
+                .map_err(drop)
+        },
+    );
+}
 
-    match cmd {
-        Cmd::CopyBfb(args) => {
-            assert_eq!(args.bfb_path, "/path/to/image.bfb");
+// Credential-only subcommands route a valid argv onto their own Cmd variant.
+#[test]
+fn credential_subcommands_route_to_variant() {
+    fn variant(cmd: &Cmd) -> &'static str {
+        match cmd {
+            Cmd::DisableRshim(_) => "disable-rshim",
+            Cmd::EnableRshim(_) => "enable-rshim",
+            Cmd::ShowObmcLog(_) => "show-obmc-log",
+            _ => panic!("expected a credential-only subcommand variant"),
         }
-        _ => panic!("expected CopyBfb variant"),
     }
+
+    check_cases(
+        [
+            Case {
+                scenario: "disable-rshim routes to DisableRshim",
+                input: &[
+                    "ssh",
+                    "disable-rshim",
+                    "192.168.1.100:443",
+                    "admin",
+                    "password123",
+                ][..],
+                expect: Yields("disable-rshim"),
+            },
+            Case {
+                scenario: "enable-rshim routes to EnableRshim",
+                input: &[
+                    "ssh",
+                    "enable-rshim",
+                    "192.168.1.100:443",
+                    "admin",
+                    "password123",
+                ][..],
+                expect: Yields("enable-rshim"),
+            },
+            Case {
+                scenario: "show-obmc-log routes to ShowObmcLog",
+                input: &[
+                    "ssh",
+                    "show-obmc-log",
+                    "192.168.1.100:443",
+                    "admin",
+                    "password123",
+                ][..],
+                expect: Yields("show-obmc-log"),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| variant(&cmd))
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_obmc_log ensures show-obmc-log parses correctly.
+// Every malformed invocation is rejected at parse time.
 #[test]
-fn parse_show_obmc_log() {
-    let cmd = Cmd::try_parse_from([
-        "ssh",
-        "show-obmc-log",
-        "192.168.1.100:443",
-        "admin",
-        "password123",
-    ])
-    .expect("should parse show-obmc-log");
-
-    assert!(matches!(cmd, Cmd::ShowObmcLog(_)));
-}
-
-// parse_missing_credentials_fails ensures subcommands
-// require all credentials.
-#[test]
-fn parse_missing_credentials_fails() {
-    let result = Cmd::try_parse_from(["ssh", "get-rshim-status", "192.168.1.100:443"]);
-    assert!(result.is_err(), "should fail without username and password");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [Case {
+            scenario: "get-rshim-status without username and password",
+            input: &["ssh", "get-rshim-status", "192.168.1.100:443"][..],
+            expect: Fails,
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/switch/tests.rs
+++ b/crates/admin-cli/src/switch/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use carbide_uuid::switch::SwitchId;
 use clap::{CommandFactory, Parser};
 
@@ -45,80 +47,102 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all switches).
+// show parses with or without an identifier: with no positional it leaves
+// switch_id unset (all switches); given a SwitchId it parses that exact id.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["switch", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.switch_id.is_none());
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_with_identifier ensures show parses with identifier.
-#[test]
-fn parse_show_with_identifier() {
+fn parse_show_routes_to_show() {
     use std::str::FromStr;
+
     let switch_id = "sw100nsmnq69j4ntqlj162fnnbvg747gfqbicaa6tqgq6spocirfle7rom0";
-    let cmd = Cmd::try_parse_from(["switch", "show", switch_id])
-        .expect("should parse show with identifier");
 
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.switch_id.is_some());
-            assert_eq!(args.switch_id, Some(SwitchId::from_str(switch_id).unwrap()));
-        }
-        _ => panic!("expected Show variant"),
-    }
+    check_cases(
+        [
+            Case {
+                scenario: "no args parses with no switch id",
+                input: &["switch", "show"][..],
+                expect: Yields(None),
+            },
+            Case {
+                scenario: "an identifier parses to that switch id",
+                input: &["switch", "show", switch_id][..],
+                expect: Yields(Some(SwitchId::from_str(switch_id).unwrap())),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => args.switch_id,
+                    _ => panic!("expected Show variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_list ensures list parses with no arguments.
+// list parses with no arguments, and with its optional filter flags: bare
+// `list` leaves the filters at their defaults, while the flags set deleted,
+// controller-state, and bmc-mac. The tuple is
+// (deleted == Only, controller_state, bmc_mac.is_some()).
 #[test]
-fn parse_list() {
-    let cmd = Cmd::try_parse_from(["switch", "list"]).expect("should parse list");
-
-    assert!(matches!(cmd, Cmd::List(_)));
+fn parse_list_routes_to_list() {
+    check_cases(
+        [
+            Case {
+                scenario: "no args parses with default filters",
+                input: &["switch", "list"][..],
+                expect: Yields((false, None, false)),
+            },
+            Case {
+                scenario: "filter flags parse onto the args",
+                input: &[
+                    "switch",
+                    "list",
+                    "--deleted",
+                    "only",
+                    "--controller-state",
+                    "ready",
+                    "--bmc-mac",
+                    "AA:BB:CC:DD:EE:FF",
+                ][..],
+                expect: Yields((true, Some("ready".to_string()), true)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::List(args) => (
+                        matches!(args.deleted, rpc::forge::DeletedFilter::Only),
+                        args.controller_state,
+                        args.bmc_mac.is_some(),
+                    ),
+                    _ => panic!("expected List variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_list_with_filters ensures list parses with filter flags.
+// Every malformed list invocation is rejected at parse time -- an out-of-range
+// `--deleted` value, or a `--bmc-mac` that isn't a MAC address.
 #[test]
-fn parse_list_with_filters() {
-    let cmd = Cmd::try_parse_from([
-        "switch",
-        "list",
-        "--deleted",
-        "only",
-        "--controller-state",
-        "ready",
-        "--bmc-mac",
-        "AA:BB:CC:DD:EE:FF",
-    ])
-    .expect("should parse list with filters");
-
-    match cmd {
-        Cmd::List(args) => {
-            assert!(matches!(args.deleted, rpc::forge::DeletedFilter::Only));
-            assert_eq!(args.controller_state, Some("ready".to_string()));
-            assert!(args.bmc_mac.is_some());
-        }
-        _ => panic!("expected List variant"),
-    }
-}
-
-// parse_list_invalid_deleted ensures invalid deleted value is rejected.
-#[test]
-fn parse_list_invalid_deleted() {
-    let result = Cmd::try_parse_from(["switch", "list", "--deleted", "bogus"]);
-    assert!(result.is_err());
-}
-
-// parse_list_invalid_bmc_mac ensures invalid MAC is rejected.
-#[test]
-fn parse_list_invalid_bmc_mac() {
-    let result = Cmd::try_parse_from(["switch", "list", "--bmc-mac", "not-a-mac"]);
-    assert!(result.is_err());
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "list with an invalid --deleted value",
+                input: &["switch", "list", "--deleted", "bogus"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "list with an invalid --bmc-mac",
+                input: &["switch", "list", "--bmc-mac", "not-a-mac"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/tenant/tests.rs
+++ b/crates/admin-cli/src/tenant/tests.rs
@@ -24,6 +24,8 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 // Routing Profile Parsing - Ensure profile strings are accepted unchanged.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -45,96 +47,95 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no arguments.
+// show parses with or without the optional positional tenant_org; the parsed
+// value flows straight through, so each row yields the resulting Option.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["tenant", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.tenant_org.is_none());
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_show_tenant_org() {
+    check_cases(
+        [
+            Case {
+                scenario: "no arguments",
+                input: &["tenant", "show"][..],
+                expect: Yields(None),
+            },
+            Case {
+                scenario: "with tenant_org",
+                input: &["tenant", "show", "org-123"][..],
+                expect: Yields(Some("org-123".to_string())),
+            },
+        ],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::Show(args)) => Ok(args.tenant_org),
+            Ok(_) => panic!("expected Show variant"),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_show_with_tenant_org ensures show parses with tenant_org.
+// update parses with a required tenant_org plus optional -p/-v/-n flags; each
+// row yields the full (tenant_org, routing_profile_type, version, name) tuple.
 #[test]
-fn parse_show_with_tenant_org() {
-    let cmd =
-        Cmd::try_parse_from(["tenant", "show", "org-123"]).expect("should parse show with tenant");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.tenant_org, Some("org-123".to_string()));
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_update_fields() {
+    check_cases(
+        [
+            Case {
+                scenario: "tenant_org only",
+                input: &["tenant", "update", "org-123"][..],
+                expect: Yields(("org-123".to_string(), None, None, None)),
+            },
+            Case {
+                scenario: "with -p routing profile",
+                input: &["tenant", "update", "org-123", "-p", "profile-a"][..],
+                expect: Yields((
+                    "org-123".to_string(),
+                    Some("profile-a".to_string()),
+                    None,
+                    None,
+                )),
+            },
+            Case {
+                scenario: "with -v version",
+                input: &["tenant", "update", "org-123", "-v", "1.0"][..],
+                expect: Yields(("org-123".to_string(), None, Some("1.0".to_string()), None)),
+            },
+            Case {
+                scenario: "with -n name",
+                input: &["tenant", "update", "org-123", "-n", "New Name"][..],
+                expect: Yields((
+                    "org-123".to_string(),
+                    None,
+                    None,
+                    Some("New Name".to_string()),
+                )),
+            },
+        ],
+        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::Update(args)) => Ok((
+                args.tenant_org,
+                args.routing_profile_type,
+                args.version,
+                args.name,
+            )),
+            Ok(_) => panic!("expected Update variant"),
+            Err(_) => Err(()),
+        },
+    );
 }
 
-// parse_update ensures update parses with tenant_org.
+// Every malformed invocation is rejected at parse time -- here, update with its
+// required tenant_org positional omitted.
 #[test]
-fn parse_update() {
-    let cmd = Cmd::try_parse_from(["tenant", "update", "org-123"]).expect("should parse update");
-
-    match cmd {
-        Cmd::Update(args) => {
-            assert_eq!(args.tenant_org, "org-123");
-            assert!(args.routing_profile_type.is_none());
-            assert!(args.version.is_none());
-            assert!(args.name.is_none());
-        }
-        _ => panic!("expected Update variant"),
-    }
-}
-
-// parse_update_with_routing_profile ensures update parses
-// with -p routing profile.
-#[test]
-fn parse_update_with_routing_profile() {
-    let cmd = Cmd::try_parse_from(["tenant", "update", "org-123", "-p", "profile-a"])
-        .expect("should parse update with routing profile");
-
-    match cmd {
-        Cmd::Update(args) => {
-            assert_eq!(args.routing_profile_type, Some("profile-a".to_string()));
-        }
-        _ => panic!("expected Update variant"),
-    }
-}
-
-// parse_update_with_version ensures update parses with -v version.
-#[test]
-fn parse_update_with_version() {
-    let cmd = Cmd::try_parse_from(["tenant", "update", "org-123", "-v", "1.0"])
-        .expect("should parse update with version");
-
-    match cmd {
-        Cmd::Update(args) => {
-            assert_eq!(args.version, Some("1.0".to_string()));
-        }
-        _ => panic!("expected Update variant"),
-    }
-}
-
-// parse_update_with_name ensures update parses with -n name.
-#[test]
-fn parse_update_with_name() {
-    let cmd = Cmd::try_parse_from(["tenant", "update", "org-123", "-n", "New Name"])
-        .expect("should parse update with name");
-
-    match cmd {
-        Cmd::Update(args) => {
-            assert_eq!(args.name, Some("New Name".to_string()));
-        }
-        _ => panic!("expected Update variant"),
-    }
-}
-
-// parse_update_missing_tenant_org_fails ensures update
-// fails without tenant_org.
-#[test]
-fn parse_update_missing_tenant_org_fails() {
-    let result = Cmd::try_parse_from(["tenant", "update"]);
-    assert!(result.is_err(), "should fail without tenant_org");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [Case {
+            scenario: "update without tenant_org",
+            input: &["tenant", "update"][..],
+            expect: Fails,
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/tenant_keyset/tests.rs
+++ b/crates/admin-cli/src/tenant_keyset/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,52 +46,50 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no
-// arguments (all keysets).
+// show parses every combination of its optional positional keyset id and
+// optional --tenant-org-id: neither (all keysets), id only, org only, and both.
+// Each row yields the parsed (id, tenant_org_id) pair.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["tenant-keyset", "show"]).expect("should parse show");
-    let Cmd::Show(args) = cmd;
-
-    assert_eq!(args.id, "");
-    assert!(args.tenant_org_id.is_none());
-}
-
-// parse_show_with_id ensures show parses with keyset id.
-#[test]
-fn parse_show_with_id() {
-    let cmd = Cmd::try_parse_from(["tenant-keyset", "show", "org-123/keyset-456"])
-        .expect("should parse show with id");
-    let Cmd::Show(args) = cmd;
-
-    assert_eq!(args.id, "org-123/keyset-456");
-}
-
-// parse_show_with_tenant_org_id ensures show parses with
-// --tenant-org-id.
-#[test]
-fn parse_show_with_tenant_org_id() {
-    let cmd = Cmd::try_parse_from(["tenant-keyset", "show", "--tenant-org-id", "org-123"])
-        .expect("should parse show with tenant-org-id");
-    let Cmd::Show(args) = cmd;
-
-    assert_eq!(args.tenant_org_id, Some("org-123".to_string()));
-}
-
-// parse_show_with_both_args ensures show parses with both
-// id and tenant-org-id.
-#[test]
-fn parse_show_with_both_args() {
-    let cmd = Cmd::try_parse_from([
-        "tenant-keyset",
-        "show",
-        "org-123/keyset-456",
-        "--tenant-org-id",
-        "org-123",
-    ])
-    .expect("should parse show with both args");
-    let Cmd::Show(args) = cmd;
-
-    assert_eq!(args.id, "org-123/keyset-456");
-    assert_eq!(args.tenant_org_id, Some("org-123".to_string()));
+fn parse_show_arg_combinations() {
+    check_cases(
+        [
+            Case {
+                scenario: "no arguments (all keysets)",
+                input: &["tenant-keyset", "show"][..],
+                expect: Yields((String::new(), None)),
+            },
+            Case {
+                scenario: "with keyset id",
+                input: &["tenant-keyset", "show", "org-123/keyset-456"][..],
+                expect: Yields(("org-123/keyset-456".to_string(), None)),
+            },
+            Case {
+                scenario: "with --tenant-org-id",
+                input: &["tenant-keyset", "show", "--tenant-org-id", "org-123"][..],
+                expect: Yields((String::new(), Some("org-123".to_string()))),
+            },
+            Case {
+                scenario: "with both id and --tenant-org-id",
+                input: &[
+                    "tenant-keyset",
+                    "show",
+                    "org-123/keyset-456",
+                    "--tenant-org-id",
+                    "org-123",
+                ][..],
+                expect: Yields((
+                    "org-123/keyset-456".to_string(),
+                    Some("org-123".to_string()),
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| {
+                    let Cmd::Show(args) = cmd;
+                    (args.id, args.tenant_org_id)
+                })
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/tpm_ca/tests.rs
+++ b/crates/admin-cli/src/tpm_ca/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,85 +46,120 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show ensures show parses with no arguments.
+// The argument-free subcommands route to their own variant: `show` lists every
+// CA, `show-unmatched-ek` lists endorsement keys with no matching CA.
 #[test]
-fn parse_show() {
-    let cmd = Cmd::try_parse_from(["tpm-ca", "show"]).expect("should parse show");
+fn parse_routes_argument_free_subcommands() {
+    fn variant(cmd: &Cmd) -> &'static str {
+        match cmd {
+            Cmd::Show(_) => "show",
+            Cmd::ShowUnmatchedEk(_) => "show-unmatched-ek",
+            _ => "other",
+        }
+    }
 
-    assert!(matches!(cmd, Cmd::Show(_)));
+    check_cases(
+        [
+            Case {
+                scenario: "show parses with no arguments",
+                input: &["tpm-ca", "show"][..],
+                expect: Yields("show"),
+            },
+            Case {
+                scenario: "show-unmatched-ek parses with no arguments",
+                input: &["tpm-ca", "show-unmatched-ek"][..],
+                expect: Yields("show-unmatched-ek"),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| variant(&cmd))
+                .map_err(drop)
+        },
+    );
 }
 
 // parse_delete ensures delete parses with ca_id.
 #[test]
 fn parse_delete() {
-    let cmd =
-        Cmd::try_parse_from(["tpm-ca", "delete", "--ca-id", "123"]).expect("should parse delete");
-
-    match cmd {
-        Cmd::Delete(args) => {
-            assert_eq!(args.ca_id, 123);
-        }
-        _ => panic!("expected Delete variant"),
+    Case {
+        scenario: "delete parses with --ca-id",
+        input: &["tpm-ca", "delete", "--ca-id", "123"][..],
+        expect: Yields(123),
     }
+    .check(|argv| {
+        Cmd::try_parse_from(argv.iter().copied())
+            .map(|cmd| match cmd {
+                Cmd::Delete(args) => args.ca_id,
+                _ => panic!("expected Delete variant"),
+            })
+            .map_err(drop)
+    });
 }
 
 // parse_add ensures add parses with filename.
 #[test]
 fn parse_add() {
-    let cmd =
-        Cmd::try_parse_from(["tpm-ca", "add", "--filename", "ca.pem"]).expect("should parse add");
-
-    match cmd {
-        Cmd::Add(args) => {
-            assert_eq!(args.filename, "ca.pem");
-        }
-        _ => panic!("expected Add variant"),
+    Case {
+        scenario: "add parses with --filename",
+        input: &["tpm-ca", "add", "--filename", "ca.pem"][..],
+        expect: Yields("ca.pem".to_string()),
     }
-}
-
-// parse_show_unmatched_ek ensures show-unmatched-ek parses.
-#[test]
-fn parse_show_unmatched_ek() {
-    let cmd = Cmd::try_parse_from(["tpm-ca", "show-unmatched-ek"])
-        .expect("should parse show-unmatched-ek");
-
-    assert!(matches!(cmd, Cmd::ShowUnmatchedEk(_)));
+    .check(|argv| {
+        Cmd::try_parse_from(argv.iter().copied())
+            .map(|cmd| match cmd {
+                Cmd::Add(args) => args.filename,
+                _ => panic!("expected Add variant"),
+            })
+            .map_err(drop)
+    });
 }
 
 // parse_add_bulk ensures add-bulk parses with dirname.
 #[test]
 fn parse_add_bulk() {
-    let cmd = Cmd::try_parse_from(["tpm-ca", "add-bulk", "--dirname", "/path/to/certs"])
-        .expect("should parse add-bulk");
-
-    match cmd {
-        Cmd::AddBulk(args) => {
-            assert_eq!(args.dirname, "/path/to/certs");
-        }
-        _ => panic!("expected AddBulk variant"),
+    Case {
+        scenario: "add-bulk parses with --dirname",
+        input: &["tpm-ca", "add-bulk", "--dirname", "/path/to/certs"][..],
+        expect: Yields("/path/to/certs".to_string()),
     }
+    .check(|argv| {
+        Cmd::try_parse_from(argv.iter().copied())
+            .map(|cmd| match cmd {
+                Cmd::AddBulk(args) => args.dirname,
+                _ => panic!("expected AddBulk variant"),
+            })
+            .map_err(drop)
+    });
 }
 
-// parse_delete_missing_ca_id_fails ensures delete fails
-// without --ca-id.
+// Every subcommand that takes a required argument is rejected at parse time when
+// that argument is omitted: delete without --ca-id, add without --filename, and
+// add-bulk without --dirname.
 #[test]
-fn parse_delete_missing_ca_id_fails() {
-    let result = Cmd::try_parse_from(["tpm-ca", "delete"]);
-    assert!(result.is_err(), "should fail without --ca-id");
-}
-
-// parse_add_missing_filename_fails ensures add fails
-// without --filename.
-#[test]
-fn parse_add_missing_filename_fails() {
-    let result = Cmd::try_parse_from(["tpm-ca", "add"]);
-    assert!(result.is_err(), "should fail without --filename");
-}
-
-// parse_add_bulk_missing_dirname_fails ensures add-bulk
-// fails without --dirname.
-#[test]
-fn parse_add_bulk_missing_dirname_fails() {
-    let result = Cmd::try_parse_from(["tpm-ca", "add-bulk"]);
-    assert!(result.is_err(), "should fail without --dirname");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "delete without --ca-id",
+                input: &["tpm-ca", "delete"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "add without --filename",
+                input: &["tpm-ca", "add"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "add-bulk without --dirname",
+                input: &["tpm-ca", "add-bulk"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/trim_table/tests.rs
+++ b/crates/admin-cli/src/trim_table/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -44,66 +46,64 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_measured_boot ensures measured-boot parses with keep_entries.
+// measured-boot routes to the MeasuredBoot variant and threads --keep-entries
+// through verbatim: a typical count, zero, and a large value all parse.
 #[test]
-fn parse_measured_boot() {
-    let cmd = Cmd::try_parse_from(["trim-table", "measured-boot", "--keep-entries", "100"])
-        .expect("should parse measured-boot");
-
-    match cmd {
-        Cmd::MeasuredBoot(args) => {
-            assert_eq!(args.keep_entries, 100);
-        }
-    }
+fn parse_measured_boot_keep_entries() {
+    check_cases(
+        [
+            Case {
+                scenario: "typical count",
+                input: &["trim-table", "measured-boot", "--keep-entries", "100"][..],
+                expect: Yields(100),
+            },
+            Case {
+                scenario: "zero entries",
+                input: &["trim-table", "measured-boot", "--keep-entries", "0"][..],
+                expect: Yields(0),
+            },
+            Case {
+                scenario: "large value",
+                input: &["trim-table", "measured-boot", "--keep-entries", "1000000"][..],
+                expect: Yields(1000000),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::MeasuredBoot(args) => args.keep_entries,
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_measured_boot_zero ensures measured-boot accepts zero entries.
+// Malformed measured-boot invocations are rejected at parse time: the missing
+// required --keep-entries, a non-numeric value, and a negative value.
 #[test]
-fn parse_measured_boot_zero() {
-    let cmd = Cmd::try_parse_from(["trim-table", "measured-boot", "--keep-entries", "0"])
-        .expect("should parse with zero");
-
-    match cmd {
-        Cmd::MeasuredBoot(args) => {
-            assert_eq!(args.keep_entries, 0);
-        }
-    }
-}
-
-// parse_measured_boot_large_value ensures measured-boot
-// accepts large values.
-#[test]
-fn parse_measured_boot_large_value() {
-    let cmd = Cmd::try_parse_from(["trim-table", "measured-boot", "--keep-entries", "1000000"])
-        .expect("should parse large value");
-
-    match cmd {
-        Cmd::MeasuredBoot(args) => {
-            assert_eq!(args.keep_entries, 1000000);
-        }
-    }
-}
-
-// parse_measured_boot_missing_arg_fails ensures
-// measured-boot requires --keep-entries.
-#[test]
-fn parse_measured_boot_missing_arg_fails() {
-    let result = Cmd::try_parse_from(["trim-table", "measured-boot"]);
-    assert!(result.is_err(), "should fail without --keep-entries");
-}
-
-// parse_measured_boot_invalid_value_fails ensures
-// measured-boot fails with non-numeric value.
-#[test]
-fn parse_measured_boot_invalid_value_fails() {
-    let result = Cmd::try_parse_from(["trim-table", "measured-boot", "--keep-entries", "abc"]);
-    assert!(result.is_err(), "should fail with non-numeric value");
-}
-
-// parse_measured_boot_negative_fails ensures measured-boot
-// fails with negative value.
-#[test]
-fn parse_measured_boot_negative_fails() {
-    let result = Cmd::try_parse_from(["trim-table", "measured-boot", "--keep-entries", "-1"]);
-    assert!(result.is_err(), "should fail with negative value");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "missing --keep-entries",
+                input: &["trim-table", "measured-boot"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "non-numeric value",
+                input: &["trim-table", "measured-boot", "--keep-entries", "abc"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "negative value",
+                input: &["trim-table", "measured-boot", "--keep-entries", "-1"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/version/tests.rs
+++ b/crates/admin-cli/src/version/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::args::*;
@@ -44,28 +46,32 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_no_args ensures parses with no arguments.
+// The `--show-runtime-config` flag is off by default and flipped on by either
+// its short `-s` or long form -- each invocation parses and yields the flag.
 #[test]
-fn parse_no_args() {
-    let opts = Opts::try_parse_from(["version"]).expect("should parse with no args");
-
-    assert!(!opts.show_runtime_config);
-}
-
-// parse_show_runtime_config_short ensures parses with -s flag.
-#[test]
-fn parse_show_runtime_config_short() {
-    let opts = Opts::try_parse_from(["version", "-s"]).expect("should parse with -s");
-
-    assert!(opts.show_runtime_config);
-}
-
-// parse_show_runtime_config_long ensures parses with
-// --show-runtime-config flag.
-#[test]
-fn parse_show_runtime_config_long() {
-    let opts = Opts::try_parse_from(["version", "--show-runtime-config"])
-        .expect("should parse with --show-runtime-config");
-
-    assert!(opts.show_runtime_config);
+fn parse_show_runtime_config_flag() {
+    check_cases(
+        [
+            Case {
+                scenario: "no args defaults the flag off",
+                input: &["version"][..],
+                expect: Yields(false),
+            },
+            Case {
+                scenario: "-s turns the flag on",
+                input: &["version", "-s"][..],
+                expect: Yields(true),
+            },
+            Case {
+                scenario: "--show-runtime-config turns the flag on",
+                input: &["version", "--show-runtime-config"][..],
+                expect: Yields(true),
+            },
+        ],
+        |argv| {
+            Opts::try_parse_from(argv.iter().copied())
+                .map(|opts| opts.show_runtime_config)
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/vpc/tests.rs
+++ b/crates/admin-cli/src/vpc/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -46,126 +48,122 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no arguments.
+// `show` accepts every selector slot as optional: bare, by id, and by each
+// of --tenant-org-id, --name, and the --label-key/--label-value pair. Each
+// row checks whether `id` is present plus the four optional string filters.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["vpc", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_none());
-            assert!(args.tenant_org_id.is_none());
-            assert!(args.name.is_none());
-            assert!(args.label_key.is_none());
-            assert!(args.label_value.is_none());
+fn parse_show_routes_and_captures_filters() {
+    fn show_fields(
+        argv: &[&str],
+    ) -> (
+        bool,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    ) {
+        match Cmd::try_parse_from(argv.iter().copied()).expect("should parse show") {
+            Cmd::Show(args) => (
+                args.id.is_some(),
+                args.tenant_org_id,
+                args.name,
+                args.label_key,
+                args.label_value,
+            ),
+            _ => panic!("expected Show variant"),
         }
-        _ => panic!("expected Show variant"),
     }
+
+    check_cases(
+        [
+            Case {
+                scenario: "no arguments",
+                input: &["vpc", "show"][..],
+                expect: Yields((false, None, None, None, None)),
+            },
+            Case {
+                scenario: "with VPC id",
+                input: &["vpc", "show", TEST_VPC_ID][..],
+                expect: Yields((true, None, None, None, None)),
+            },
+            Case {
+                scenario: "with --tenant-org-id",
+                input: &["vpc", "show", "--tenant-org-id", "org-123"][..],
+                expect: Yields((false, Some("org-123".to_string()), None, None, None)),
+            },
+            Case {
+                scenario: "with --name",
+                input: &["vpc", "show", "--name", "my-vpc"][..],
+                expect: Yields((false, None, Some("my-vpc".to_string()), None, None)),
+            },
+            Case {
+                scenario: "with label key and value",
+                input: &["vpc", "show", "--label-key", "env", "--label-value", "prod"][..],
+                expect: Yields((
+                    false,
+                    None,
+                    None,
+                    Some("env".to_string()),
+                    Some("prod".to_string()),
+                )),
+            },
+        ],
+        |argv| Ok::<_, ()>(show_fields(argv)),
+    );
 }
 
-// parse_show_with_id ensures show parses with VPC ID.
+// `set-virtualizer` takes a VPC id and a virtualizer name; fnn, etv, and
+// etv_nvue all parse to the SetVirtualizer variant carrying the id.
 #[test]
-fn parse_show_with_id() {
-    let cmd = Cmd::try_parse_from(["vpc", "show", TEST_VPC_ID]).expect("should parse show with id");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_some());
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_set_virtualizer_routes_with_id() {
+    check_cases(
+        [
+            Case {
+                scenario: "fnn virtualizer",
+                input: &["vpc", "set-virtualizer", TEST_VPC_ID, "fnn"][..],
+                expect: Yields(TEST_VPC_ID.to_string()),
+            },
+            Case {
+                scenario: "etv virtualizer",
+                input: &["vpc", "set-virtualizer", TEST_VPC_ID, "etv"][..],
+                expect: Yields(TEST_VPC_ID.to_string()),
+            },
+            Case {
+                scenario: "etv_nvue virtualizer",
+                input: &["vpc", "set-virtualizer", TEST_VPC_ID, "etv_nvue"][..],
+                expect: Yields(TEST_VPC_ID.to_string()),
+            },
+        ],
+        |argv| match Cmd::try_parse_from(argv.iter().copied())
+            .expect("should parse set-virtualizer")
+        {
+            Cmd::SetVirtualizer(args) => Ok::<_, ()>(args.id.to_string()),
+            _ => panic!("expected SetVirtualizer variant"),
+        },
+    );
 }
 
-// parse_show_with_tenant_org_id ensures show parses with
-// --tenant-org-id.
+// Malformed `set-virtualizer` invocations are rejected at parse time:
+// missing both positional arguments, or an unknown virtualizer name.
 #[test]
-fn parse_show_with_tenant_org_id() {
-    let cmd = Cmd::try_parse_from(["vpc", "show", "--tenant-org-id", "org-123"])
-        .expect("should parse show with tenant-org-id");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.tenant_org_id, Some("org-123".to_string()));
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_with_name ensures show parses with --name.
-#[test]
-fn parse_show_with_name() {
-    let cmd = Cmd::try_parse_from(["vpc", "show", "--name", "my-vpc"])
-        .expect("should parse show with name");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.name, Some("my-vpc".to_string()));
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_with_label ensures show parses with label
-// key and value.
-#[test]
-fn parse_show_with_label() {
-    let cmd = Cmd::try_parse_from(["vpc", "show", "--label-key", "env", "--label-value", "prod"])
-        .expect("should parse show with labels");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert_eq!(args.label_key, Some("env".to_string()));
-            assert_eq!(args.label_value, Some("prod".to_string()));
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_set_virtualizer ensures set-virtualizer parses
-// with id and virtualizer.
-#[test]
-fn parse_set_virtualizer() {
-    let cmd = Cmd::try_parse_from(["vpc", "set-virtualizer", TEST_VPC_ID, "fnn"])
-        .expect("should parse set-virtualizer");
-
-    match cmd {
-        Cmd::SetVirtualizer(args) => {
-            assert_eq!(args.id.to_string(), TEST_VPC_ID);
-        }
-        _ => panic!("expected SetVirtualizer variant"),
-    }
-}
-
-// parse_set_virtualizer_etv ensures set-virtualizer parses with etv.
-#[test]
-fn parse_set_virtualizer_etv() {
-    let cmd = Cmd::try_parse_from(["vpc", "set-virtualizer", TEST_VPC_ID, "etv"])
-        .expect("should parse set-virtualizer etv");
-
-    assert!(matches!(cmd, Cmd::SetVirtualizer(_)));
-}
-
-// parse_set_virtualizer_etv_nvue ensures set-virtualizer parses with etv_nvue.
-#[test]
-fn parse_set_virtualizer_etv_nvue() {
-    let cmd = Cmd::try_parse_from(["vpc", "set-virtualizer", TEST_VPC_ID, "etv_nvue"])
-        .expect("should parse set-virtualizer etv_nvue");
-
-    assert!(matches!(cmd, Cmd::SetVirtualizer(_)));
-}
-
-// parse_set_virtualizer_missing_args_fails ensures
-// set-virtualizer fails without args.
-#[test]
-fn parse_set_virtualizer_missing_args_fails() {
-    let result = Cmd::try_parse_from(["vpc", "set-virtualizer"]);
-    assert!(result.is_err(), "should fail without id and virtualizer");
-}
-
-// parse_set_virtualizer_invalid_virtualizer_fails ensures
-// set-virtualizer fails with invalid virtualizer.
-#[test]
-fn parse_set_virtualizer_invalid_virtualizer_fails() {
-    let result = Cmd::try_parse_from(["vpc", "set-virtualizer", TEST_VPC_ID, "invalid"]);
-    assert!(result.is_err(), "should fail with invalid virtualizer");
+fn invalid_set_virtualizer_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "missing id and virtualizer",
+                input: &["vpc", "set-virtualizer"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "invalid virtualizer name",
+                input: &["vpc", "set-virtualizer", TEST_VPC_ID, "invalid"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/vpc_peering/tests.rs
+++ b/crates/admin-cli/src/vpc_peering/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -48,113 +50,119 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_create ensures create parses with two VPC IDs.
+// parse_create ensures create parses two positional VPC IDs into the Create
+// variant, preserving each id in order.
 #[test]
 fn parse_create() {
-    let cmd = Cmd::try_parse_from(["vpc-peering", "create", TEST_VPC_ID_1, TEST_VPC_ID_2])
-        .expect("should parse create");
-
-    match cmd {
-        Cmd::Create(args) => {
-            assert_eq!(args.vpc1_id.to_string(), TEST_VPC_ID_1);
-            assert_eq!(args.vpc2_id.to_string(), TEST_VPC_ID_2);
-        }
-        _ => panic!("expected Create variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "create with two VPC IDs",
+            input: &["vpc-peering", "create", TEST_VPC_ID_1, TEST_VPC_ID_2][..],
+            expect: Yields((TEST_VPC_ID_1.to_string(), TEST_VPC_ID_2.to_string())),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Create(args) => (args.vpc1_id.to_string(), args.vpc2_id.to_string()),
+                    _ => panic!("expected Create variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_no_args ensures show parses with no arguments.
+// parse_show covers the Show variant's optional selectors: no args, --id alone,
+// and --vpc-id alone each parse, yielding which of (id, vpc_id) is set.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["vpc-peering", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_none());
-            assert!(args.vpc_id.is_none());
-        }
-        _ => panic!("expected Show variant"),
-    }
+fn parse_show() {
+    check_cases(
+        [
+            Case {
+                scenario: "no arguments",
+                input: &["vpc-peering", "show"][..],
+                expect: Yields((false, false)),
+            },
+            Case {
+                scenario: "with --id",
+                input: &["vpc-peering", "show", "--id", TEST_PEERING_ID][..],
+                expect: Yields((true, false)),
+            },
+            Case {
+                scenario: "with --vpc-id",
+                input: &["vpc-peering", "show", "--vpc-id", TEST_VPC_ID_1][..],
+                expect: Yields((false, true)),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => (args.id.is_some(), args.vpc_id.is_some()),
+                    _ => panic!("expected Show variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_show_with_id ensures show parses with --id.
-#[test]
-fn parse_show_with_id() {
-    let cmd = Cmd::try_parse_from(["vpc-peering", "show", "--id", TEST_PEERING_ID])
-        .expect("should parse show with id");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_some());
-            assert!(args.vpc_id.is_none());
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_with_vpc_id ensures show parses with --vpc-id.
-#[test]
-fn parse_show_with_vpc_id() {
-    let cmd = Cmd::try_parse_from(["vpc-peering", "show", "--vpc-id", TEST_VPC_ID_1])
-        .expect("should parse show with vpc-id");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.id.is_none());
-            assert!(args.vpc_id.is_some());
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_id_and_vpc_id_conflict ensures show fails
-// with both --id and --vpc-id.
-#[test]
-fn parse_show_id_and_vpc_id_conflict() {
-    let result = Cmd::try_parse_from([
-        "vpc-peering",
-        "show",
-        "--id",
-        TEST_PEERING_ID,
-        "--vpc-id",
-        TEST_VPC_ID_1,
-    ]);
-    assert!(result.is_err(), "should fail with both --id and --vpc-id");
-}
-
-// parse_delete ensures delete parses with --id.
+// parse_delete ensures delete parses with --id into the Delete variant,
+// preserving the peering id.
 #[test]
 fn parse_delete() {
-    let cmd = Cmd::try_parse_from(["vpc-peering", "delete", "--id", TEST_PEERING_ID])
-        .expect("should parse delete");
-
-    match cmd {
-        Cmd::Delete(args) => {
-            assert_eq!(args.id.to_string(), TEST_PEERING_ID);
-        }
-        _ => panic!("expected Delete variant"),
-    }
+    check_cases(
+        [Case {
+            scenario: "delete with --id",
+            input: &["vpc-peering", "delete", "--id", TEST_PEERING_ID][..],
+            expect: Yields(TEST_PEERING_ID.to_string()),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Delete(args) => args.id.to_string(),
+                    _ => panic!("expected Delete variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_delete_missing_id_fails ensures delete fails without --id.
+// Every malformed invocation is rejected at parse time -- conflicting selectors
+// on show, or a required argument left off create/delete.
 #[test]
-fn parse_delete_missing_id_fails() {
-    let result = Cmd::try_parse_from(["vpc-peering", "delete"]);
-    assert!(result.is_err(), "should fail without --id");
-}
-
-// parse_create_missing_vpc_ids_fails ensures create fails
-// without VPC IDs.
-#[test]
-fn parse_create_missing_vpc_ids_fails() {
-    let result = Cmd::try_parse_from(["vpc-peering", "create"]);
-    assert!(result.is_err(), "should fail without VPC IDs");
-}
-
-// parse_create_missing_second_vpc_id_fails ensures create
-// fails with only one VPC ID.
-#[test]
-fn parse_create_missing_second_vpc_id_fails() {
-    let result = Cmd::try_parse_from(["vpc-peering", "create", TEST_VPC_ID_1]);
-    assert!(result.is_err(), "should fail with only one VPC ID");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "show with both --id and --vpc-id",
+                input: &[
+                    "vpc-peering",
+                    "show",
+                    "--id",
+                    TEST_PEERING_ID,
+                    "--vpc-id",
+                    TEST_VPC_ID_1,
+                ][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "delete without --id",
+                input: &["vpc-peering", "delete"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "create without VPC IDs",
+                input: &["vpc-peering", "create"][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "create with only one VPC ID",
+                input: &["vpc-peering", "create", TEST_VPC_ID_1][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }

--- a/crates/admin-cli/src/vpc_prefix/tests.rs
+++ b/crates/admin-cli/src/vpc_prefix/tests.rs
@@ -23,6 +23,8 @@
 // Command Structure - Baseline debug_assert() of the entire command.
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -47,212 +49,201 @@ fn verify_cmd_structure() {
 // including testing required arguments, as well as optional
 // flag-specific checking.
 
-// parse_show_no_args ensures show parses with no arguments.
+// parse_show routes every valid `show` invocation to the Show variant and
+// reports which selectors/filters landed: a tuple of (prefix_selector?,
+// vpc_id?, contains?, contained_by?, deleted-discriminant) so each original
+// presence/enum assertion survives as a row.
 #[test]
-fn parse_show_no_args() {
-    let cmd = Cmd::try_parse_from(["vpc-prefix", "show"]).expect("should parse show");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.prefix_selector.is_none());
-            assert!(args.vpc_id.is_none());
-            assert!(args.contains.is_none());
-            assert!(args.contained_by.is_none());
-            assert!(matches!(args.deleted, rpc::forge::DeletedFilter::Exclude));
+fn parse_show_routes_to_show_variant() {
+    fn deleted_str(d: &rpc::forge::DeletedFilter) -> &'static str {
+        match d {
+            rpc::forge::DeletedFilter::Exclude => "exclude",
+            rpc::forge::DeletedFilter::Only => "only",
+            _ => "other",
         }
-        _ => panic!("expected Show variant"),
     }
-}
 
-// parse_show_with_deleted ensures show parses deleted filtering.
-#[test]
-fn parse_show_with_deleted() {
-    let cmd = Cmd::try_parse_from(["vpc-prefix", "show", "--deleted", "only"])
-        .expect("should parse show with deleted filter");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(matches!(args.deleted, rpc::forge::DeletedFilter::Only));
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_with_prefix_selector_id ensures show parses
-// with VPC prefix ID.
-#[test]
-fn parse_show_with_prefix_selector_id() {
-    let cmd = Cmd::try_parse_from(["vpc-prefix", "show", TEST_VPC_PREFIX_ID])
-        .expect("should parse show with id");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.prefix_selector.is_some());
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_with_prefix_selector_cidr ensures show parses
-// with IP prefix.
-#[test]
-fn parse_show_with_prefix_selector_cidr() {
-    let cmd = Cmd::try_parse_from(["vpc-prefix", "show", "10.0.0.0/8"])
-        .expect("should parse show with cidr");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.prefix_selector.is_some());
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_with_vpc_id ensures show parses with --vpc-id.
-#[test]
-fn parse_show_with_vpc_id() {
-    let cmd = Cmd::try_parse_from(["vpc-prefix", "show", "--vpc-id", TEST_VPC_ID])
-        .expect("should parse show with vpc-id");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.vpc_id.is_some());
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_with_contains ensures show parses with --contains.
-#[test]
-fn parse_show_with_contains() {
-    let cmd = Cmd::try_parse_from(["vpc-prefix", "show", "--contains", "10.0.0.0/24"])
-        .expect("should parse show with contains");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.contains.is_some());
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_with_contained_by ensures show parses with
-// --contained-by.
-#[test]
-fn parse_show_with_contained_by() {
-    let cmd = Cmd::try_parse_from(["vpc-prefix", "show", "--contained-by", "10.0.0.0/8"])
-        .expect("should parse show with contained-by");
-
-    match cmd {
-        Cmd::Show(args) => {
-            assert!(args.contained_by.is_some());
-        }
-        _ => panic!("expected Show variant"),
-    }
-}
-
-// parse_show_contains_and_contained_by_conflict ensures
-// show fails with both contains and contained-by.
-#[test]
-fn parse_show_contains_and_contained_by_conflict() {
-    let result = Cmd::try_parse_from([
-        "vpc-prefix",
-        "show",
-        "--contains",
-        "10.0.0.0/24",
-        "--contained-by",
-        "10.0.0.0/8",
-    ]);
-    assert!(
-        result.is_err(),
-        "should fail with both --contains and --contained-by"
+    check_cases(
+        [
+            Case {
+                scenario: "show with no arguments",
+                input: &["vpc-prefix", "show"][..],
+                expect: Yields((false, false, false, false, "exclude")),
+            },
+            Case {
+                scenario: "show with --deleted only",
+                input: &["vpc-prefix", "show", "--deleted", "only"][..],
+                expect: Yields((false, false, false, false, "only")),
+            },
+            Case {
+                scenario: "show with a prefix-selector id",
+                input: &["vpc-prefix", "show", TEST_VPC_PREFIX_ID][..],
+                expect: Yields((true, false, false, false, "exclude")),
+            },
+            Case {
+                scenario: "show with a prefix-selector cidr",
+                input: &["vpc-prefix", "show", "10.0.0.0/8"][..],
+                expect: Yields((true, false, false, false, "exclude")),
+            },
+            Case {
+                scenario: "show with --vpc-id",
+                input: &["vpc-prefix", "show", "--vpc-id", TEST_VPC_ID][..],
+                expect: Yields((false, true, false, false, "exclude")),
+            },
+            Case {
+                scenario: "show with --contains",
+                input: &["vpc-prefix", "show", "--contains", "10.0.0.0/24"][..],
+                expect: Yields((false, false, true, false, "exclude")),
+            },
+            Case {
+                scenario: "show with --contained-by",
+                input: &["vpc-prefix", "show", "--contained-by", "10.0.0.0/8"][..],
+                expect: Yields((false, false, false, true, "exclude")),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Show(args) => (
+                        args.prefix_selector.is_some(),
+                        args.vpc_id.is_some(),
+                        args.contains.is_some(),
+                        args.contained_by.is_some(),
+                        deleted_str(&args.deleted),
+                    ),
+                    _ => panic!("expected Show variant"),
+                })
+                .map_err(drop)
+        },
     );
 }
 
-// parse_create ensures create parses with required args.
+// parse_create routes every valid `create` invocation to the Create variant,
+// reporting (vpc_id, prefix, name, vpc_prefix_id?) so the required-field and
+// optional-id assertions each become a row.
 #[test]
-fn parse_create() {
-    let cmd = Cmd::try_parse_from([
-        "vpc-prefix",
-        "create",
-        "--vpc-id",
-        TEST_VPC_ID,
-        "--prefix",
-        "10.0.0.0/8",
-        "--name",
-        "test-prefix",
-    ])
-    .expect("should parse create");
-
-    match cmd {
-        Cmd::Create(args) => {
-            assert_eq!(args.vpc_id.to_string(), TEST_VPC_ID);
-            assert_eq!(args.prefix.to_string(), "10.0.0.0/8");
-            assert_eq!(args.name, "test-prefix");
-            assert!(args.vpc_prefix_id.is_none());
-        }
-        _ => panic!("expected Create variant"),
-    }
+fn parse_create_routes_to_create_variant() {
+    check_cases(
+        [
+            Case {
+                scenario: "create with required args",
+                input: &[
+                    "vpc-prefix",
+                    "create",
+                    "--vpc-id",
+                    TEST_VPC_ID,
+                    "--prefix",
+                    "10.0.0.0/8",
+                    "--name",
+                    "test-prefix",
+                ][..],
+                expect: Yields((
+                    TEST_VPC_ID.to_string(),
+                    "10.0.0.0/8".to_string(),
+                    "test-prefix".to_string(),
+                    false,
+                )),
+            },
+            Case {
+                scenario: "create with optional --vpc-prefix-id",
+                input: &[
+                    "vpc-prefix",
+                    "create",
+                    "--vpc-id",
+                    TEST_VPC_ID,
+                    "--prefix",
+                    "10.0.0.0/8",
+                    "--name",
+                    "test-prefix",
+                    "--vpc-prefix-id",
+                    TEST_VPC_PREFIX_ID,
+                ][..],
+                expect: Yields((
+                    TEST_VPC_ID.to_string(),
+                    "10.0.0.0/8".to_string(),
+                    "test-prefix".to_string(),
+                    true,
+                )),
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Create(args) => (
+                        args.vpc_id.to_string(),
+                        args.prefix.to_string(),
+                        args.name,
+                        args.vpc_prefix_id.is_some(),
+                    ),
+                    _ => panic!("expected Create variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_create_with_vpc_prefix_id ensures create parses
-// with optional --vpc-prefix-id.
+// parse_delete routes a valid `delete` invocation to the Delete variant,
+// reporting the parsed vpc_prefix_id.
 #[test]
-fn parse_create_with_vpc_prefix_id() {
-    let cmd = Cmd::try_parse_from([
-        "vpc-prefix",
-        "create",
-        "--vpc-id",
-        TEST_VPC_ID,
-        "--prefix",
-        "10.0.0.0/8",
-        "--name",
-        "test-prefix",
-        "--vpc-prefix-id",
-        TEST_VPC_PREFIX_ID,
-    ])
-    .expect("should parse create with vpc-prefix-id");
-
-    match cmd {
-        Cmd::Create(args) => {
-            assert!(args.vpc_prefix_id.is_some());
-        }
-        _ => panic!("expected Create variant"),
-    }
+fn parse_delete_routes_to_delete_variant() {
+    check_cases(
+        [Case {
+            scenario: "delete with a vpc-prefix-id",
+            input: &["vpc-prefix", "delete", TEST_VPC_PREFIX_ID][..],
+            expect: Yields(TEST_VPC_PREFIX_ID.to_string()),
+        }],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Delete(args) => args.vpc_prefix_id.to_string(),
+                    _ => panic!("expected Delete variant"),
+                })
+                .map_err(drop)
+        },
+    );
 }
 
-// parse_delete ensures delete parses with VPC prefix ID.
+// Every malformed invocation is rejected at parse time -- mutually exclusive
+// filters, a missing required argument, or a subcommand left without its
+// positional id.
 #[test]
-fn parse_delete() {
-    let cmd = Cmd::try_parse_from(["vpc-prefix", "delete", TEST_VPC_PREFIX_ID])
-        .expect("should parse delete");
-
-    match cmd {
-        Cmd::Delete(args) => {
-            assert_eq!(args.vpc_prefix_id.to_string(), TEST_VPC_PREFIX_ID);
-        }
-        _ => panic!("expected Delete variant"),
-    }
-}
-
-// parse_create_missing_vpc_id_fails ensures create fails
-// without --vpc-id.
-#[test]
-fn parse_create_missing_vpc_id_fails() {
-    let result = Cmd::try_parse_from([
-        "vpc-prefix",
-        "create",
-        "--prefix",
-        "10.0.0.0/8",
-        "--name",
-        "test",
-    ]);
-    assert!(result.is_err(), "should fail without --vpc-id");
-}
-
-// parse_delete_missing_id_fails ensures delete fails without ID.
-#[test]
-fn parse_delete_missing_id_fails() {
-    let result = Cmd::try_parse_from(["vpc-prefix", "delete"]);
-    assert!(result.is_err(), "should fail without vpc-prefix-id");
+fn invalid_invocations_are_rejected() {
+    check_cases(
+        [
+            Case {
+                scenario: "show with both --contains and --contained-by",
+                input: &[
+                    "vpc-prefix",
+                    "show",
+                    "--contains",
+                    "10.0.0.0/24",
+                    "--contained-by",
+                    "10.0.0.0/8",
+                ][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "create without --vpc-id",
+                input: &[
+                    "vpc-prefix",
+                    "create",
+                    "--prefix",
+                    "10.0.0.0/8",
+                    "--name",
+                    "test",
+                ][..],
+                expect: Fails,
+            },
+            Case {
+                scenario: "delete without a vpc-prefix-id",
+                input: &["vpc-prefix", "delete"][..],
+                expect: Fails,
+            },
+        ],
+        |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|_| ())
+                .map_err(drop)
+        },
+    );
 }


### PR DESCRIPTION
This supports #3914.

## Description

This refactors the super boilerplate `admin-cli` CLI parsing tests (not workflow/RPC related) into the new table-driven test structuring from `carbide-test-support`, allowing us to replace a bunch of copy-pasted test boilerplate with a shared table-driven framework, so the test suite is ideally easier to read, maintain, and provide a pattern to follow. This is very similar to. https://github.com/NVIDIA/infra-controller/pull/2498.

`admin-cli` tests drop 36%, from 548 to 350 test functions, collapsing the repeated try_parse_from / "match variant or panic' pattern while preserving every original case as a row.

Test coverage unchanged, but its like 3% because the CLI parsing tests are a super small use case compared to everything else, which currently is untested, and should probably be.

All tests pass and clippy is clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->