### PR TITLE
feat(librms): `v0.9.0-rc1` for hardware type-specific support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,6 +2568,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "state-controller",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tonic",
@@ -2824,6 +2825,7 @@ dependencies = [
  "carbide-health-report",
  "carbide-ipmi",
  "carbide-network",
+ "carbide-rack",
  "carbide-redfish",
  "carbide-rpc",
  "carbide-secrets",
@@ -3480,6 +3482,7 @@ dependencies = [
  "carbide-api-model",
  "carbide-api-test-helper",
  "carbide-macros",
+ "carbide-rack",
  "carbide-redfish",
  "carbide-secrets",
  "carbide-sqlx-testing",
@@ -6555,8 +6558,8 @@ dependencies = [
 
 [[package]]
 name = "librms"
-version = "0.0.13"
-source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.0.13#a87f91da04009c62d9133e0ab4820361f3c541d1"
+version = "0.0.14"
+source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.9.0-rc1#dd35e101e21f5d35240d57e62f24e33767c3c770"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11518,7 +11521,7 @@ dependencies = [
 [[package]]
 name = "tonic-client-wrapper"
 version = "1.0.0"
-source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.0.13#a87f91da04009c62d9133e0ab4820361f3c541d1"
+source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.9.0-rc1#dd35e101e21f5d35240d57e62f24e33767c3c770"
 dependencies = [
  "async-trait",
  "heck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.10" }
-librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.0.13" }
+librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.9.0-rc1" }
 ansi-to-html = "0.2.2"
 
 tokio = { version = "1", features = ["full", "tracing"] }

--- a/book/src/configuration/configurability.md
+++ b/book/src/configuration/configurability.md
@@ -190,11 +190,132 @@ explicitly enabled in the TOML.
 | `[machine_identity]` | SPIFFE JWT-SVID issuance for machine (host) identity | Per-org JWT signing. See [Day 0 Machine Identity](../../../docs/getting-started/installation-options/day0-machine-identity.md) and [Machine Identity (Day 1)](../../../docs/configuration/machine_identity.md). |
 | `[measured_boot_collector]` | TPM-based attestation metrics | |
 | `[machine_validation_config]` | Pre-ingestion validation tests | |
-| `[component_manager]` | NvLink switch and power shelf management | |
+| `[component_manager]` | NvLink switch and power shelf management | RMS backends require rack profile data for node type resolution. |
 | `[vmaas_config]` | VM system integration / VM-aware traffic intercept | Requires `public_prefixes`. |
 | `[rms]` | Rack Manager Service (mTLS connectivity to external RMS) | |
 | `[dpf]` | DPU Platform Framework — Kubernetes DPU workload deployment | Requires the DPF operator deployed in-cluster. |
 | `rack_management_enabled` | Standalone infrastructure manager mode (GB200/GB300/VR144) | Top-level boolean, not a sub-section. |
+
+For RMS component-manager backends, NICo resolves the RMS node type from the
+rack profile. The rack profile provides two facts:
+
+- Product family from `product_family`, which is required for RMS-backed
+  operations and currently accepts `gb200` or `gb300`.
+- Vendor from `rack_capabilities.<role>.vendor` for each role using an RMS
+  backend.
+
+NICo validates configured rack profiles at startup when any component-manager
+backend is set to `rms`. The component-manager backend fields default to `rms`,
+so deployments that only want one RMS role must explicitly set the other backend
+fields to non-RMS values. Startup validation checks the product family and only
+the vendor fields for enabled RMS roles. For example, if only
+`power_shelf_backend = "rms"` after the other backend fields are set to non-RMS
+values, then only `rack_capabilities.power_shelf.vendor` is required as a vendor
+field.
+
+Use these canonical vendor names in config:
+
+| Role | Canonical values |
+| --- | --- |
+| Compute, when `compute_tray_backend = "rms"` | `NVIDIA`, `Lenovo` |
+| Switch, when `nv_switch_backend = "rms"` | `NVIDIA` |
+| Power shelf, when `power_shelf_backend = "rms"` | `LiteOn`, `Delta` |
+
+The `product_family` value is not normalized. It must exactly match one of the
+accepted lowercase values, such as `gb200` or `gb300`; values like `GB200` are
+rejected. Vendor matching is more forgiving. Vendor values are trimmed,
+case-insensitive, and ignore spaces, hyphens, and underscores, so `NVIDIA`,
+`nvidia`, `LiteOn`, `liteon`, `Lite-On`, and `lite_on` all work. Common company
+suffix text also works when the normalized value starts with the canonical
+vendor, but the canonical values above are preferred for operator-supplied
+config.
+
+The examples below only show the component-manager and rack-profile fields.
+Configure `[rms]` separately when NICo needs to call RMS.
+
+Example: GB200 rack where all component-manager roles use RMS:
+
+```toml
+[component_manager]
+compute_tray_backend = "rms"
+nv_switch_backend = "rms"
+power_shelf_backend = "rms"
+
+[rack_profiles.NVL72]
+product_family = "gb200"
+rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
+
+[rack_profiles.NVL72.rack_capabilities.compute]
+vendor = "NVIDIA"
+
+[rack_profiles.NVL72.rack_capabilities.switch]
+vendor = "NVIDIA"
+
+[rack_profiles.NVL72.rack_capabilities.power_shelf]
+vendor = "LiteOn"
+```
+
+Example: GB300 rack with Lenovo compute trays and Delta power shelves:
+
+```toml
+[component_manager]
+compute_tray_backend = "rms"
+nv_switch_backend = "rms"
+power_shelf_backend = "rms"
+
+[rack_profiles.NVL72_GB300]
+product_family = "gb300"
+rack_hardware_topology = "gb300_nvl72r1_c2g4_topology"
+
+[rack_profiles.NVL72_GB300.rack_capabilities.compute]
+vendor = "Lenovo"
+
+[rack_profiles.NVL72_GB300.rack_capabilities.switch]
+vendor = "nvidia"
+
+[rack_profiles.NVL72_GB300.rack_capabilities.power_shelf]
+vendor = "delta"
+```
+
+Example: only the component-manager power shelf backend uses RMS. The compute
+and switch component-manager backends are explicitly set to real non-RMS values
+so component-manager startup validation only requires the power shelf vendor
+field:
+
+```toml
+[component_manager]
+compute_tray_backend = "core"
+nv_switch_backend = "nsm"
+power_shelf_backend = "rms"
+
+[component_manager.nsm]
+url = "http://nsm.example.internal:50052"
+
+[rack_profiles.NVL72_POWER]
+product_family = "gb200"
+rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
+
+[rack_profiles.NVL72_POWER.rack_capabilities.power_shelf]
+vendor = "Lite-On"
+```
+
+Each rack that uses an RMS-backed operation must have a `rack_profile_id`
+matching a key under `[rack_profiles]`. Startup validation does not scan
+existing rack database rows, so missing or unknown per-rack profile IDs are
+still checked when an RMS operation runs.
+
+| Field | Accepted values |
+| --- | --- |
+| `product_family`, when an RMS-backed operation uses the profile | Exact match: `gb200`, `gb300` |
+| `rack_hardware_topology` | `gb200_nvl36r1_c2g4_topology`, `gb200_nvl72r1_c2g4_topology`, `gb300_nvl36r1_c2g4_topology`, `gb300_nvl72r1_c2g4_topology` |
+| Compute profile vendor, when `compute_tray_backend = "rms"` | `nvidia`, `lenovo` after normalization |
+| Switch profile vendor, when `nv_switch_backend = "rms"` | `nvidia` after normalization |
+| Power shelf profile vendor, when `power_shelf_backend = "rms"` | `liteon`, `delta` after normalization |
+
+The separate site-explorer machine-ingestion RMS slot/tray lookup also uses the
+rack profile for RMS node type resolution. If that path is enabled for machines
+with rack IDs, the profile also needs compute product-family and vendor data even
+when `compute_tray_backend` is not `rms`.
 
 ### State-controller timing
 
@@ -1060,7 +1181,7 @@ on or off.
 | Rack Management | siteConfig | `rack_management_enabled = true` | off | Standalone infrastructure manager mode (GB200/GB300/VR144). |
 | Site Explorer machine auto-creation | siteConfig | `[site_explorer].create_machines` | on | Disable for manual-onboarding environments. |
 | Firmware autoupdate | siteConfig | `[firmware_global].autoupdate` | off | Enable once the fleet's firmware baseline is stable. |
-| Component Manager (NvLink switches / power shelves) | siteConfig | `[component_manager]` present | off | GB200/GB300 sites with managed power and switch fabric. |
+| Component Manager (NvLink switches / power shelves) | siteConfig | `[component_manager]` present | off | GB200/GB300 sites with managed power and switch fabric. RMS backends require rack profile data for node type resolution. |
 | Auto-repair plugin | siteConfig | `[auto_machine_repair_plugin]` | off | Enable per fault class as fleet maturity grows. |
 | BOM / SKU validation | siteConfig | `[bom_validation]` present | off | Validate ingested hardware against expected BOM before `Ready`. |
 | Network Security Groups | siteConfig | `[network_security_group]` | default | Touch only for non-default direction policy or scale-out limits. |

--- a/book/src/configuration/configurability.md
+++ b/book/src/configuration/configurability.md
@@ -190,7 +190,7 @@ explicitly enabled in the TOML.
 | `[machine_identity]` | SPIFFE JWT-SVID issuance for machine (host) identity | Per-org JWT signing. See [Day 0 Machine Identity](../../../docs/getting-started/installation-options/day0-machine-identity.md) and [Machine Identity (Day 1)](../../../docs/configuration/machine_identity.md). |
 | `[measured_boot_collector]` | TPM-based attestation metrics | |
 | `[machine_validation_config]` | Pre-ingestion validation tests | |
-| `[component_manager]` | NvLink switch and power shelf management | RMS backends require rack profile data for node type resolution. |
+| `[component_manager]` | Compute tray, NvLink switch, and power shelf management | RMS backends require rack profile data for node type resolution. |
 | `[vmaas_config]` | VM system integration / VM-aware traffic intercept | Requires `public_prefixes`. |
 | `[rms]` | Rack Manager Service (mTLS connectivity to external RMS) | |
 | `[dpf]` | DPU Platform Framework — Kubernetes DPU workload deployment | Requires the DPF operator deployed in-cluster. |
@@ -1181,7 +1181,7 @@ on or off.
 | Rack Management | siteConfig | `rack_management_enabled = true` | off | Standalone infrastructure manager mode (GB200/GB300/VR144). |
 | Site Explorer machine auto-creation | siteConfig | `[site_explorer].create_machines` | on | Disable for manual-onboarding environments. |
 | Firmware autoupdate | siteConfig | `[firmware_global].autoupdate` | off | Enable once the fleet's firmware baseline is stable. |
-| Component Manager (NvLink switches / power shelves) | siteConfig | `[component_manager]` present | off | GB200/GB300 sites with managed power and switch fabric. RMS backends require rack profile data for node type resolution. |
+| Component Manager (compute trays / NvLink switches / power shelves) | siteConfig | `[component_manager]` present | off | GB200/GB300 sites with managed compute, power, and switch fabric. RMS backends require rack profile data for node type resolution. |
 | Auto-repair plugin | siteConfig | `[auto_machine_repair_plugin]` | off | Enable per fault class as fleet maturity grows. |
 | BOM / SKU validation | siteConfig | `[bom_validation]` present | off | Validate ingested hardware against expected BOM before `Ready`. |
 | Network Security Groups | siteConfig | `[network_security_group]` | default | Touch only for non-default direction policy or scale-out limits. |

--- a/crates/admin-cli/src/rack/profile/show/cmd.rs
+++ b/crates/admin-cli/src/rack/profile/show/cmd.rs
@@ -29,6 +29,7 @@ use crate::rpc::ApiClient;
 struct ProfileOutput {
     rack_id: String,
     rack_profile_id: String,
+    product_family: String,
     rack_hardware_type: String,
     rack_hardware_topology: String,
     rack_hardware_class: String,
@@ -65,6 +66,9 @@ impl From<&GetRackProfileResponse> for ProfileOutput {
                 .as_ref()
                 .map(|id| id.to_string())
                 .unwrap_or_default(),
+            product_family: profile
+                .map(|p| product_family_display(p.product_family))
+                .unwrap_or_else(|| "N/A".to_string()),
             rack_hardware_type: profile
                 .and_then(|p| p.rack_hardware_type.as_ref())
                 .map(|t| t.value.clone())
@@ -141,6 +145,15 @@ fn slot_ids_display(ids: &[u32]) -> String {
     }
 }
 
+fn product_family_display(value: i32) -> String {
+    match rpc::forge::RackProductFamily::try_from(value) {
+        Ok(
+            family @ (rpc::forge::RackProductFamily::Gb200 | rpc::forge::RackProductFamily::Gb300),
+        ) => family.as_str_name().to_string(),
+        Ok(rpc::forge::RackProductFamily::Unspecified) | Err(_) => "N/A".to_string(),
+    }
+}
+
 fn show_detail(r: &GetRackProfileResponse) {
     let profile = r.profile.as_ref();
     let capabilities = profile.and_then(|p| p.capabilities.as_ref());
@@ -169,6 +182,12 @@ fn show_detail(r: &GetRackProfileResponse) {
             .and_then(|p| p.rack_hardware_type.as_ref())
             .map(|t| t.value.as_str())
             .unwrap_or("N/A")
+    ]);
+    table.add_row(row![
+        "Product Family",
+        profile
+            .map(|p| product_family_display(p.product_family))
+            .unwrap_or_else(|| "N/A".to_string())
     ]);
     table.add_row(row![
         "Hardware Topology",

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -101,6 +101,127 @@ applicable.
 
 ---
 
+### Component Manager RMS Node Type Resolution
+
+When `[component_manager]` uses RMS backends, NICo resolves RMS node types from
+rack profiles. The rack profile provides two facts:
+
+- Product family from `product_family`, which is required for RMS-backed
+  operations and currently accepts `gb200` or `gb300`.
+- Vendor from `rack_capabilities.<role>.vendor` for each role using an RMS
+  backend.
+
+NICo validates configured rack profiles at startup when any component-manager
+backend is set to `rms`. The component-manager backend fields default to `rms`,
+so deployments that only want one RMS role must explicitly set the other backend
+fields to non-RMS values. Startup validation checks the product family and only
+the vendor fields for enabled RMS roles. For example, if only
+`power_shelf_backend = "rms"` after the other backend fields are set to non-RMS
+values, then only `rack_capabilities.power_shelf.vendor` is required as a vendor
+field.
+
+Use these canonical vendor names in config:
+
+| Role | Canonical values |
+|------|------------------|
+| Compute, when `compute_tray_backend = "rms"` | `NVIDIA`, `Lenovo` |
+| Switch, when `nv_switch_backend = "rms"` | `NVIDIA` |
+| Power shelf, when `power_shelf_backend = "rms"` | `LiteOn`, `Delta` |
+
+The `product_family` value is not normalized. It must exactly match one of the
+accepted lowercase values, such as `gb200` or `gb300`; values like `GB200` are
+rejected. Vendor matching is more forgiving. Vendor values are trimmed,
+case-insensitive, and ignore spaces, hyphens, and underscores, so `NVIDIA`,
+`nvidia`, `LiteOn`, `liteon`, `Lite-On`, and `lite_on` all work. Common company
+suffix text also works when the normalized value starts with the canonical
+vendor, but the canonical values above are preferred for operator-supplied
+config.
+
+The examples below only show the component-manager and rack-profile fields.
+Configure `[rms]` separately when NICo needs to call RMS.
+
+Example: GB200 rack where all component-manager roles use RMS:
+
+```toml
+[component_manager]
+compute_tray_backend = "rms"
+nv_switch_backend = "rms"
+power_shelf_backend = "rms"
+
+[rack_profiles.NVL72]
+product_family = "gb200"
+rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
+
+[rack_profiles.NVL72.rack_capabilities.compute]
+vendor = "NVIDIA"
+
+[rack_profiles.NVL72.rack_capabilities.switch]
+vendor = "NVIDIA"
+
+[rack_profiles.NVL72.rack_capabilities.power_shelf]
+vendor = "LiteOn"
+```
+
+Example: GB300 rack with Lenovo compute trays and Delta power shelves:
+
+```toml
+[component_manager]
+compute_tray_backend = "rms"
+nv_switch_backend = "rms"
+power_shelf_backend = "rms"
+
+[rack_profiles.NVL72_GB300]
+product_family = "gb300"
+rack_hardware_topology = "gb300_nvl72r1_c2g4_topology"
+
+[rack_profiles.NVL72_GB300.rack_capabilities.compute]
+vendor = "Lenovo"
+
+[rack_profiles.NVL72_GB300.rack_capabilities.switch]
+vendor = "nvidia"
+
+[rack_profiles.NVL72_GB300.rack_capabilities.power_shelf]
+vendor = "delta"
+```
+
+Example: only the component-manager power shelf backend uses RMS. The compute
+and switch component-manager backends are explicitly set to real non-RMS values
+so component-manager startup validation only requires the power shelf vendor
+field:
+
+```toml
+[component_manager]
+compute_tray_backend = "core"
+nv_switch_backend = "nsm"
+power_shelf_backend = "rms"
+
+[component_manager.nsm]
+url = "http://nsm.example.internal:50052"
+
+[rack_profiles.NVL72_POWER]
+product_family = "gb200"
+rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
+
+[rack_profiles.NVL72_POWER.rack_capabilities.power_shelf]
+vendor = "Lite-On"
+```
+
+Each rack that uses an RMS-backed operation must have a `rack_profile_id`
+matching a key under `[rack_profiles]`. Startup validation does not scan
+existing rack database rows, so missing or unknown per-rack profile IDs are
+still checked when an RMS operation runs.
+
+The separate site-explorer machine-ingestion RMS slot/tray lookup also uses the
+rack profile for RMS node type resolution. If that path is enabled for machines
+with rack IDs, the profile also needs compute product-family and vendor data even
+when `compute_tray_backend` is not `rms`.
+
+Supported RMS product-family values are exact-match `gb200` and `gb300`. The
+optional `rack_hardware_topology` field remains available for topology-specific
+flows.
+
+---
+
 ## Sub-Structs
 
 ### `TlsConfig`

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -3170,6 +3170,10 @@ mod tests {
 
         assert_eq!(config.rack_profiles.rack_profiles.len(), 2);
         let nvl72 = config.rack_profiles.get("NVL72").unwrap();
+        assert_eq!(
+            nvl72.product_family,
+            Some(model::rack_type::RackProductFamily::Gb200)
+        );
         assert_eq!(nvl72.rack_capabilities.compute.count, 18);
         assert_eq!(
             nvl72.rack_capabilities.compute.name.as_deref(),
@@ -3182,6 +3186,10 @@ mod tests {
         assert_eq!(nvl72.rack_capabilities.switch.count, 9);
         assert_eq!(nvl72.rack_capabilities.power_shelf.count, 8);
         let nvl36 = config.rack_profiles.get("NVL36").unwrap();
+        assert_eq!(
+            nvl36.product_family,
+            Some(model::rack_type::RackProductFamily::Gb200)
+        );
         assert_eq!(nvl36.rack_capabilities.compute.count, 9);
         assert_eq!(nvl36.rack_capabilities.switch.count, 9);
         assert_eq!(nvl36.rack_capabilities.power_shelf.count, 2);

--- a/crates/api-core/src/cfg/test_data/full_config.toml
+++ b/crates/api-core/src/cfg/test_data/full_config.toml
@@ -206,6 +206,8 @@ DevicesandIOPorts_IOMMU = "Disabled"
 OperatingModes_ChooseOperatingMode = "MinimalPower"
 
 [rack_profiles.NVL72]
+product_family = "gb200"
+
 [rack_profiles.NVL72.rack_capabilities.compute]
 name = "GB200"
 count = 18
@@ -218,6 +220,8 @@ count = 9
 count = 8
 
 [rack_profiles.NVL36]
+product_family = "gb200"
+
 [rack_profiles.NVL36.rack_capabilities.compute]
 count = 9
 

--- a/crates/api-core/src/cfg/test_data/full_config_post_migration.toml
+++ b/crates/api-core/src/cfg/test_data/full_config_post_migration.toml
@@ -169,6 +169,8 @@ DevicesandIOPorts_IOMMU = "Disabled"
 OperatingModes_ChooseOperatingMode = "MinimalPower"
 
 [rack_profiles.NVL72]
+product_family = "gb200"
+
 [rack_profiles.NVL72.rack_capabilities.compute]
 name = "GB200"
 count = 18
@@ -181,6 +183,8 @@ count = 9
 count = 8
 
 [rack_profiles.NVL36]
+product_family = "gb200"
+
 [rack_profiles.NVL36.rack_capabilities.compute]
 count = 9
 

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -205,6 +205,14 @@ pub fn parse_carbide_config(
     // part_number and psid values. Mismatches are logged as warnings.
     config.validate_supernic_firmware_profiles();
 
+    if let Some(manager_config) = &config.component_manager {
+        component_manager::rms::validate_rms_backend_rack_profiles(
+            manager_config,
+            &config.rack_profiles,
+        )
+        .map_err(|error| eyre::eyre!(error).wrap_err("Invalid configuration"))?;
+    }
+
     model::tenant::validate_trust_domain_allowlist_patterns(
         &config.machine_identity.trust_domain_allowlist,
     )
@@ -531,6 +539,7 @@ pub async fn start_api(
     let component_manager = if let Some(cd_config) = &carbide_config.component_manager {
         match component_manager::component_manager::build_component_manager(
             cd_config,
+            carbide_config.rack_profiles.clone(),
             rms_client.clone(),
             switch_system_image_rms_api.clone().map(|client| {
                 client as Arc<dyn component_manager::rms::RmsSwitchSystemImageStatusApi>
@@ -1430,6 +1439,7 @@ async fn initialize_and_start_controllers<'a>(
         Arc::new(carbide_config.get_firmware_config()),
         common_pools.clone(),
         work_lock_manager_handle.clone(),
+        carbide_config.rack_profiles.clone(),
         rms_client.clone(),
         credential_manager.clone(),
     )
@@ -1653,6 +1663,53 @@ mod tests {
             networks: None,
             vpcs: None,
         }
+    }
+
+    #[test]
+    fn parse_rejects_rms_component_manager_missing_vendor() -> eyre::Result<()> {
+        let mut config = tempfile::NamedTempFile::new()?;
+        std::io::Write::write_all(
+            &mut config,
+            br#"
+                database_url = "postgres://test"
+                listen = "[::]:1081"
+                asn = 1
+
+                [component_manager]
+                nv_switch_backend = "rms"
+                power_shelf_backend = "mock"
+                compute_tray_backend = "mock"
+
+                [rack_profiles.NVL72]
+                product_family = "gb200"
+                rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
+
+                [rack_profiles.NVL72.rack_capabilities.compute]
+                name = "GB200"
+                count = 18
+                vendor = "NVIDIA"
+
+                [rack_profiles.NVL72.rack_capabilities.switch]
+                count = 9
+
+                [rack_profiles.NVL72.rack_capabilities.power_shelf]
+                count = 8
+            "#,
+        )?;
+
+        let result = parse_carbide_config(config.path(), None);
+        let Err(error) = result else {
+            panic!("missing RMS vendor should be rejected");
+        };
+
+        let error = format!("{error:?}");
+
+        assert!(
+            error.contains("rack_capabilities.switch.vendor"),
+            "error message should name the missing vendor field: {error}"
+        );
+
+        Ok(())
     }
 
     // neither source declares pools — operator misconfiguration.

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -95,6 +95,10 @@ use model::machine::{
 };
 use model::metadata::Metadata;
 use model::network_security_group;
+use model::rack_type::{
+    RackCapabilitiesSet, RackCapabilityCompute, RackCapabilityPowerShelf, RackCapabilitySwitch,
+    RackHardwareTopology, RackProductFamily, RackProfile, RackProfileConfig,
+};
 use model::resource_pool::common::CommonPools;
 use model::resource_pool::{self};
 use model::tenant::TenantOrganizationId;
@@ -1013,6 +1017,78 @@ pub fn get_config() -> CarbideConfig {
     default_config::get()
 }
 
+/// Rack profile ID used by RMS-ready test fixtures.
+pub const TEST_RMS_RACK_PROFILE_ID: &str = "NVL72";
+
+/// Returns the default test config plus an RMS-ready NVL72 rack profile.
+pub fn get_config_with_rack_profiles() -> CarbideConfig {
+    let mut config = get_config();
+    config.rack_profiles = RackProfileConfig {
+        rack_profiles: [(
+            TEST_RMS_RACK_PROFILE_ID.to_string(),
+            RackProfile {
+                product_family: Some(RackProductFamily::Gb200),
+                rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
+                rack_capabilities: RackCapabilitiesSet {
+                    compute: RackCapabilityCompute {
+                        count: 18,
+                        vendor: Some("NVIDIA".to_string()),
+                        ..Default::default()
+                    },
+                    switch: RackCapabilitySwitch {
+                        count: 9,
+                        vendor: Some("NVIDIA".to_string()),
+                        ..Default::default()
+                    },
+                    power_shelf: RackCapabilityPowerShelf {
+                        count: 8,
+                        vendor: Some("LiteOn".to_string()),
+                        ..Default::default()
+                    },
+                },
+                ..Default::default()
+            },
+        )]
+        .into_iter()
+        .collect(),
+    };
+
+    config
+}
+
+fn extend_component_manager_rms_profiles(
+    target: &mut RackProfileConfig,
+    source: &RackProfileConfig,
+) {
+    // This fixture builds component-manager with RMS switch and power shelf
+    // backends. Include custom RMS-ready profiles so tests exercise the profile
+    // IDs used by API paths, but keep intentionally incomplete profiles for
+    // call-time negative tests out of startup validation.
+    target.rack_profiles.extend(
+        source
+            .rack_profiles
+            .iter()
+            .filter(|(_, profile)| is_component_manager_rms_ready_profile(profile))
+            .map(|(profile_id, profile)| (profile_id.clone(), profile.clone())),
+    );
+}
+
+fn is_component_manager_rms_ready_profile(profile: &RackProfile) -> bool {
+    profile.product_family.is_some()
+        && profile
+            .rack_capabilities
+            .switch
+            .vendor
+            .as_deref()
+            .is_some_and(|vendor| !vendor.trim().is_empty())
+        && profile
+            .rack_capabilities
+            .power_shelf
+            .vendor
+            .as_deref()
+            .is_some_and(|vendor| !vendor.trim().is_empty())
+}
+
 /// crate::sqlx_test shares the pool with all testcases in a file. If there are many testcases in a file,
 /// test cases will start getting PoolTimedOut error. To avoid it, each test case will be assigned
 /// its own pool.
@@ -1246,6 +1322,17 @@ pub async fn create_test_env_with_overrides(
     let ib_fabric_manager = ib_fabric_test_manager(&config, composite_manager.clone());
 
     let rms_sim = Arc::new(RmsSim::default());
+    let mut component_manager_rack_profiles = get_config_with_rack_profiles().rack_profiles;
+    extend_component_manager_rms_profiles(
+        &mut component_manager_rack_profiles,
+        &config.rack_profiles,
+    );
+
+    let mut site_explorer_rack_profiles = component_manager_rack_profiles.clone();
+    site_explorer_rack_profiles
+        .rack_profiles
+        .extend(config.rack_profiles.rack_profiles.clone());
+
     let test_component_manager = component_manager::component_manager::build_component_manager(
         &component_manager::config::ComponentManagerConfig {
             nv_switch_backend: component_manager::nv_switch_manager::Backend::Rms,
@@ -1254,14 +1341,15 @@ pub async fn create_test_env_with_overrides(
             nv_switch_use_state_controller: true,
             ..Default::default()
         },
+        component_manager_rack_profiles,
         rms_sim.as_rms_client(),
         None,
         Some(db_pool.clone()),
         None,
     )
     .await
-    .ok()
-    .map(Arc::new);
+    .expect("test component manager should build");
+    let test_component_manager = Some(Arc::new(test_component_manager));
 
     let mut api_builder = TestApiBuilder::new(
         db_pool.clone(),
@@ -1581,6 +1669,7 @@ pub async fn create_test_env_with_overrides(
         Arc::new(config.get_firmware_config()),
         common_pools.clone(),
         api.work_lock_manager_handle.clone(),
+        site_explorer_rack_profiles,
         rms_sim.as_rms_client(),
         credential_manager.clone(),
     );

--- a/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
@@ -1887,7 +1887,7 @@ impl Default for TestRackDbBuilder {
     fn default() -> Self {
         TestRackDbBuilder {
             rack_id: RackId::new(uuid::Uuid::new_v4().to_string()),
-            rack_profile_id: Some(RackProfileId::new("rack")),
+            rack_profile_id: Some(RackProfileId::new(super::TEST_RMS_RACK_PROFILE_ID)),
         }
     }
 }

--- a/crates/api-core/src/tests/expected_rack.rs
+++ b/crates/api-core/src/tests/expected_rack.rs
@@ -19,7 +19,7 @@ use carbide_uuid::rack::{RackId, RackProfileId};
 use common::api_fixtures::{create_test_env, create_test_env_with_overrides, get_config};
 use model::rack_type::{
     RackCapabilitiesSet, RackCapabilityCompute, RackCapabilityPowerShelf, RackCapabilitySwitch,
-    RackProfile, RackProfileConfig,
+    RackProductFamily, RackProfile, RackProfileConfig,
 };
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{ExpectedRackList, ExpectedRackRequest};
@@ -34,6 +34,7 @@ fn config_with_rack_profiles() -> crate::cfg::file::CarbideConfig {
             (
                 "NVL72".to_string(),
                 RackProfile {
+                    product_family: Some(RackProductFamily::Gb200),
                     rack_capabilities: RackCapabilitiesSet {
                         compute: RackCapabilityCompute {
                             name: Some("GB200".to_string()),
@@ -60,6 +61,7 @@ fn config_with_rack_profiles() -> crate::cfg::file::CarbideConfig {
             (
                 "NVL36".to_string(),
                 RackProfile {
+                    product_family: Some(RackProductFamily::Gb200),
                     rack_capabilities: RackCapabilitiesSet {
                         compute: RackCapabilityCompute {
                             name: None,

--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -437,6 +437,7 @@ async fn test_machine_creator_created_host_advances_through_dpu_discovery(
         env.pool.clone(),
         explorer_config,
         env.common_pools.clone(),
+        Arc::new(env.config.rack_profiles.clone()),
         None,
         env.test_credential_manager.clone(),
     );

--- a/crates/api-core/src/tests/power_shelf_state_controller/error_state.rs
+++ b/crates/api-core/src/tests/power_shelf_state_controller/error_state.rs
@@ -32,8 +32,8 @@ use sqlx::PgConnection;
 use state_controller::db_write_batch::DbWriteBatch;
 use state_controller::state_handler::{StateHandler, StateHandlerContext, StateHandlerOutcome};
 
-use crate::tests::common::api_fixtures::create_test_env;
 use crate::tests::common::api_fixtures::site_explorer::new_power_shelf;
+use crate::tests::common::api_fixtures::{create_test_env, get_config_with_rack_profiles};
 use crate::tests::power_shelf_state_controller::fixtures::power_shelf::{
     mark_power_shelf_as_deleted, set_power_shelf_controller_state,
 };
@@ -51,14 +51,15 @@ async fn services(
     };
     let component_manager = component_manager::component_manager::build_component_manager(
         &config,
+        get_config_with_rack_profiles().rack_profiles,
         env.rms_sim.as_rms_client(),
         None,
         Some(env.pool.clone()),
         None,
     )
     .await
-    .ok()
-    .map(Arc::new);
+    .expect("test component manager should build");
+    let component_manager = Some(Arc::new(component_manager));
 
     PowerShelfStateHandlerServices {
         db_pool: env.pool.clone(),

--- a/crates/api-core/src/tests/power_shelf_state_controller/maintenance.rs
+++ b/crates/api-core/src/tests/power_shelf_state_controller/maintenance.rs
@@ -44,27 +44,58 @@ use carbide_power_shelf_controller::metrics::PowerShelfMetrics;
 use carbide_secrets::credentials::Credentials;
 use carbide_secrets::test_support::credentials::TestCredentialManager;
 use carbide_uuid::power_shelf::PowerShelfId;
-use carbide_uuid::rack::RackId;
+use carbide_uuid::rack::{RackId, RackProfileId};
 use component_manager::compute_tray_manager::Backend as ComputeBackend;
 use component_manager::config::ComponentManagerConfig;
 use component_manager::nv_switch_manager::Backend as NvSwitchBackend;
 use component_manager::power_shelf_manager::Backend as PowerShelfBackend;
-use db::{expected_power_shelf as db_expected_power_shelf, power_shelf as db_power_shelf};
+use db::{
+    expected_power_shelf as db_expected_power_shelf, power_shelf as db_power_shelf, rack as db_rack,
+};
 use librms::protos::rack_manager as rms;
 use mac_address::MacAddress;
 use model::expected_power_shelf::ExpectedPowerShelf;
 use model::metadata::Metadata;
 use model::power_shelf::{PowerShelf, PowerShelfControllerState, PowerShelfMaintenanceOperation};
+use model::rack::RackConfig;
 use sqlx::PgConnection;
 use state_controller::db_write_batch::DbWriteBatch;
 use state_controller::state_handler::{StateHandler, StateHandlerContext, StateHandlerOutcome};
 
 use crate::tests::common::api_fixtures::site_explorer::new_power_shelf;
-use crate::tests::common::api_fixtures::{TestEnv, create_test_env};
+use crate::tests::common::api_fixtures::{
+    TEST_RMS_RACK_PROFILE_ID, TestEnv, TestEnvOverrides, create_test_env_with_overrides,
+    get_config_with_rack_profiles,
+};
 use crate::tests::power_shelf_state_controller::fixtures::power_shelf::set_power_shelf_controller_state;
 
 const TEST_BMC_USER: &str = "root";
 const TEST_BMC_PASSWORD: &str = "password";
+
+async fn create_power_shelf_test_env(pool: sqlx::PgPool) -> TestEnv {
+    create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::with_config(get_config_with_rack_profiles()),
+    )
+    .await
+}
+
+async fn create_rms_power_shelf_rack(
+    pool: &sqlx::PgPool,
+) -> Result<RackId, Box<dyn std::error::Error>> {
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
+    let rack_profile_id = RackProfileId::new(TEST_RMS_RACK_PROFILE_ID);
+    let mut txn = pool.acquire().await?;
+    db_rack::create(
+        &mut txn,
+        &rack_id,
+        Some(&rack_profile_id),
+        &RackConfig::default(),
+        None,
+    )
+    .await?;
+    Ok(rack_id)
+}
 
 /// Build a `PowerShelfStateHandlerServices` whose `component_manager` may be
 /// cleared (to exercise the "component manager not configured" path) while
@@ -101,16 +132,18 @@ async fn build_test_component_manager(
         compute_tray_backend: ComputeBackend::Mock,
         ..Default::default()
     };
-    component_manager::component_manager::build_component_manager(
+    let component_manager = component_manager::component_manager::build_component_manager(
         &config,
+        get_config_with_rack_profiles().rack_profiles,
         rms_client,
         None,
         Some(env.pool.clone()),
         None,
     )
     .await
-    .ok()
-    .map(Arc::new)
+    .expect("test component manager should build");
+
+    Some(Arc::new(component_manager))
 }
 
 /// Drive a power shelf into `Maintenance { operation }` with a maintenance
@@ -248,11 +281,11 @@ fn assert_error_with_substring(state: &PowerShelfControllerState, expected_subst
 async fn power_on_transitions_to_error_when_bmc_ip_unresolvable(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
+    let env = create_power_shelf_test_env(pool.clone()).await;
     let power_shelf_id =
         new_power_shelf(&env, Some("PowerOn no-ip".into()), None, None, None).await?;
 
-    let rack_id = RackId::default();
+    let rack_id = create_rms_power_shelf_rack(&pool).await?;
     let bmc_mac: MacAddress = "AA:BB:CC:DD:EE:01".parse().unwrap();
 
     // Queue a success response so we can assert it was *not* consumed.
@@ -311,7 +344,7 @@ async fn power_on_transitions_to_error_when_bmc_ip_unresolvable(
 async fn power_on_transitions_to_error_when_component_manager_missing(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
+    let env = create_power_shelf_test_env(pool.clone()).await;
     let power_shelf_id =
         new_power_shelf(&env, Some("PowerOn no-rms".into()), None, None, None).await?;
     {
@@ -340,7 +373,7 @@ async fn power_on_transitions_to_error_when_component_manager_missing(
 async fn power_on_transitions_to_error_when_rack_id_missing(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
+    let env = create_power_shelf_test_env(pool.clone()).await;
     let power_shelf_id =
         new_power_shelf(&env, Some("PowerOn no-rack".into()), None, None, None).await?;
     let bmc_mac: MacAddress = "AA:BB:CC:DD:EE:02".parse().unwrap();
@@ -376,10 +409,10 @@ async fn power_on_transitions_to_error_when_rack_id_missing(
 async fn power_on_transitions_to_error_when_bmc_mac_missing(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
+    let env = create_power_shelf_test_env(pool.clone()).await;
     let power_shelf_id =
         new_power_shelf(&env, Some("PowerOn no-mac".into()), None, None, None).await?;
-    let rack_id = RackId::default();
+    let rack_id = create_rms_power_shelf_rack(&pool).await?;
 
     {
         let mut txn = pool.acquire().await?;
@@ -417,7 +450,7 @@ async fn power_on_transitions_to_error_when_bmc_mac_missing(
 async fn power_off_transitions_to_error_when_component_manager_missing(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
+    let env = create_power_shelf_test_env(pool.clone()).await;
     let power_shelf_id =
         new_power_shelf(&env, Some("PowerOff no-rms".into()), None, None, None).await?;
     {
@@ -455,7 +488,7 @@ async fn power_off_transitions_to_error_when_component_manager_missing(
 async fn power_off_transitions_to_error_when_rack_id_missing(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
+    let env = create_power_shelf_test_env(pool.clone()).await;
     let power_shelf_id =
         new_power_shelf(&env, Some("PowerOff no-rack".into()), None, None, None).await?;
     let bmc_mac: MacAddress = "AA:BB:CC:DD:EE:03".parse().unwrap();
@@ -493,10 +526,10 @@ async fn power_off_transitions_to_error_when_rack_id_missing(
 async fn power_off_transitions_to_error_when_bmc_mac_missing(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
+    let env = create_power_shelf_test_env(pool.clone()).await;
     let power_shelf_id =
         new_power_shelf(&env, Some("PowerOff no-mac".into()), None, None, None).await?;
-    let rack_id = RackId::default();
+    let rack_id = create_rms_power_shelf_rack(&pool).await?;
 
     {
         let mut txn = pool.acquire().await?;
@@ -532,7 +565,7 @@ async fn power_off_transitions_to_error_when_bmc_mac_missing(
 async fn ready_state_does_not_invoke_rms_set_power_state(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
+    let env = create_power_shelf_test_env(pool.clone()).await;
     let power_shelf_id =
         new_power_shelf(&env, Some("Ready no-rms-call".into()), None, None, None).await?;
     {

--- a/crates/api-core/src/tests/rack_state_controller/handler.rs
+++ b/crates/api-core/src/tests/rack_state_controller/handler.rs
@@ -40,7 +40,8 @@ use model::rack::{
 };
 use model::rack_type::{
     RackCapabilitiesSet, RackCapabilityCompute, RackCapabilityPowerShelf, RackCapabilitySwitch,
-    RackHardwareClass, RackHardwareTopology, RackHardwareType, RackProfile, RackProfileConfig,
+    RackHardwareClass, RackHardwareTopology, RackHardwareType, RackProductFamily, RackProfile,
+    RackProfileConfig,
 };
 use model::switch::{NewSwitch, SwitchConfig};
 use model::test_support::ManagedHostConfig;
@@ -59,19 +60,19 @@ fn test_capabilities() -> RackCapabilitiesSet {
         compute: RackCapabilityCompute {
             name: None,
             count: 2,
-            vendor: None,
+            vendor: Some("NVIDIA".to_string()),
             slot_ids: None,
         },
         switch: RackCapabilitySwitch {
             name: None,
             count: 1,
-            vendor: None,
+            vendor: Some("NVIDIA".to_string()),
             slot_ids: None,
         },
         power_shelf: RackCapabilityPowerShelf {
             name: None,
             count: 1,
-            vendor: None,
+            vendor: Some("LiteOn".to_string()),
             slot_ids: None,
         },
     }
@@ -82,19 +83,19 @@ fn simple_capabilities() -> RackCapabilitiesSet {
         compute: RackCapabilityCompute {
             name: None,
             count: 2,
-            vendor: None,
+            vendor: Some("NVIDIA".to_string()),
             slot_ids: None,
         },
         switch: RackCapabilitySwitch {
             name: None,
             count: 0,
-            vendor: None,
+            vendor: Some("NVIDIA".to_string()),
             slot_ids: None,
         },
         power_shelf: RackCapabilityPowerShelf {
             name: None,
             count: 0,
-            vendor: None,
+            vendor: Some("LiteOn".to_string()),
             slot_ids: None,
         },
     }
@@ -105,19 +106,19 @@ fn single_capabilities() -> RackCapabilitiesSet {
         compute: RackCapabilityCompute {
             name: None,
             count: 1,
-            vendor: None,
+            vendor: Some("NVIDIA".to_string()),
             slot_ids: None,
         },
         switch: RackCapabilitySwitch {
             name: None,
             count: 0,
-            vendor: None,
+            vendor: Some("NVIDIA".to_string()),
             slot_ids: None,
         },
         power_shelf: RackCapabilityPowerShelf {
             name: None,
             count: 0,
-            vendor: None,
+            vendor: Some("LiteOn".to_string()),
             slot_ids: None,
         },
     }
@@ -130,6 +131,8 @@ pub(crate) fn config_with_rack_profiles() -> crate::cfg::file::CarbideConfig {
             (
                 "NVL72".to_string(),
                 RackProfile {
+                    product_family: Some(RackProductFamily::Gb200),
+                    rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
                     rack_capabilities: test_capabilities(),
                     ..Default::default()
                 },
@@ -137,19 +140,21 @@ pub(crate) fn config_with_rack_profiles() -> crate::cfg::file::CarbideConfig {
             (
                 "Simple".to_string(),
                 RackProfile {
+                    product_family: Some(RackProductFamily::Gb200),
+                    rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
                     rack_hardware_type: Some(RackHardwareType::any()),
                     rack_hardware_class: Some(RackHardwareClass::Prod),
                     rack_capabilities: simple_capabilities(),
-                    ..Default::default()
                 },
             ),
             (
                 "Single".to_string(),
                 RackProfile {
+                    product_family: Some(RackProductFamily::Gb200),
+                    rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
                     rack_hardware_type: Some(RackHardwareType::any()),
                     rack_hardware_class: Some(RackHardwareClass::Prod),
                     rack_capabilities: single_capabilities(),
-                    ..Default::default()
                 },
             ),
             ("Empty".to_string(), RackProfile::default()),
@@ -165,7 +170,9 @@ fn config_with_nmx_cluster_profile() -> crate::cfg::file::CarbideConfig {
     config.rack_profiles.rack_profiles.insert(
         "NmxCluster".to_string(),
         RackProfile {
+            product_family: Some(RackProductFamily::Gb200),
             rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
+            rack_capabilities: test_capabilities(),
             ..Default::default()
         },
     );
@@ -343,7 +350,7 @@ async fn create_ready_rack_with_switch(
     db_rack::create(
         &mut txn,
         &rack_id,
-        Some(&RackProfileId::new("Empty")),
+        Some(&RackProfileId::new("NVL72")),
         &RackConfig::default(),
         None,
     )
@@ -604,7 +611,7 @@ async fn test_on_demand_rack_maintenance_defaults_missing_access_token_to_noauth
         token_credentials,
         Credentials::UsernamePassword {
             username: "access_token".to_string(),
-            password: "NOAUTH".to_string(),
+            password: carbide_rack::firmware_object::RMS_NOAUTH_ACCESS_TOKEN.to_string(),
         }
     );
 
@@ -1461,7 +1468,7 @@ async fn test_firmware_upgrade_start_submits_json_and_deletes_access_token(
     let requests = env.rms_sim.submitted_apply_firmware_object_requests().await;
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0].config_json, r#"{"Id":"fw-json"}"#);
-    assert_eq!(requests[0].access_token, "token");
+    assert_eq!(requests[0].access_token.as_deref(), Some("token"));
     assert_eq!(requests[0].firmware_type, "prod");
     assert!(requests[0].force_update);
     assert_eq!(requests[0].nodes.as_ref().unwrap().nodes.len(), 1);
@@ -1473,6 +1480,101 @@ async fn test_firmware_upgrade_start_submits_json_and_deletes_access_token(
         })
         .await
         .expect("credential lookup should succeed");
+    assert!(token_after.is_none());
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_firmware_upgrade_start_missing_profile_deletes_access_token(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides {
+            config: Some(config_with_rack_profiles()),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let rack_id = new_rack_id();
+    let mut txn = pool.acquire().await?;
+    db_rack::create(&mut txn, &rack_id, None, &RackConfig::default(), None).await?;
+    drop(txn);
+
+    let switch_id = attach_switch_with_nvos_credentials(&env, &rack_id).await?;
+    let config = RackConfig {
+        maintenance_requested: Some(MaintenanceScope {
+            switch_ids: vec![switch_id],
+            activities: vec![MaintenanceActivity::FirmwareUpgrade {
+                firmware_version: Some(r#"{"Id":"fw-json"}"#.to_string()),
+                components: vec!["BMC".to_string()],
+                force_update: false,
+            }],
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let mut txn = pool.acquire().await?;
+    db_rack::update(&mut txn, &rack_id, &config).await?;
+    drop(txn);
+
+    env.api
+        .credential_manager
+        .set_credentials(
+            &CredentialKey::RackMaintenanceAccessToken {
+                rack_id: rack_id.clone(),
+            },
+            &Credentials::UsernamePassword {
+                username: "access_token".to_string(),
+                password: "token".to_string(),
+            },
+        )
+        .await
+        .map_err(|error| eyre::eyre!("failed to set maintenance access token: {}", error))?;
+
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+    let handler_instance = RackStateHandler::default();
+    let mut services = env.rack_state_handler_services();
+    let mut metrics = RackMetrics::default();
+    let mut db_writes = DbWriteBatch::default();
+    let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut db_writes,
+    };
+
+    let fw_state = RackState::Maintenance {
+        maintenance_state: RackMaintenanceState::FirmwareUpgrade {
+            rack_firmware_upgrade: FirmwareUpgradeState::Start,
+        },
+    };
+    let mut outcome = handler_instance
+        .handle_object_state(&rack_id, &mut rack, &fw_state, &mut ctx)
+        .await?;
+    if let Some(txn) = outcome.take_transaction() {
+        txn.commit().await?;
+    }
+
+    assert!(
+        matches!(
+            outcome,
+            StateHandlerOutcome::Transition {
+                next_state: RackState::Error { .. },
+                ..
+            }
+        ),
+        "expected missing rack profile to transition to Error"
+    );
+    let token_after = env
+        .test_credential_manager
+        .get_credentials(&CredentialKey::RackMaintenanceAccessToken {
+            rack_id: rack_id.clone(),
+        })
+        .await
+        .map_err(|error| eyre::eyre!("failed to get maintenance access token: {}", error))?;
+
     assert!(token_after.is_none());
 
     Ok(())
@@ -2019,14 +2121,21 @@ async fn test_firmware_upgrade_wait_for_complete_retries_on_transient_poll_error
 async fn test_nvos_update_start_transitions_to_wait_for_complete(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env_with_overrides(pool.clone(), TestEnvOverrides::default()).await;
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides {
+            config: Some(config_with_nmx_cluster_profile()),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let rack_id = new_rack_id();
     let mut txn = pool.acquire().await?;
     db_rack::create(
         &mut txn,
         &rack_id,
-        Some(&RackProfileId::new("Empty")),
+        Some(&RackProfileId::new("NmxCluster")),
         &RackConfig::default(),
         None,
     )
@@ -2108,7 +2217,7 @@ async fn test_nvos_update_start_transitions_to_wait_for_complete(
         "NVOSUpdate(Start) should submit ApplySwitchSystemImage"
     );
     assert_eq!(requests[0].config_json, r#"{"Id":"fw-nvos-default"}"#);
-    assert_eq!(requests[0].access_token, "token");
+    assert_eq!(requests[0].access_token.as_deref(), Some("token"));
     let mut txn = pool.acquire().await?;
     let switch = db_switch::find_by_id(&mut txn, &switch_id)
         .await?
@@ -2225,14 +2334,21 @@ async fn test_configure_nmx_cluster_start_advances_to_disable_scale_up_fabric_st
 async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_runs_on_all_switches(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env_with_overrides(pool.clone(), TestEnvOverrides::default()).await;
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides {
+            config: Some(config_with_nmx_cluster_profile()),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let rack_id = new_rack_id();
     let mut txn = pool.acquire().await?;
     db_rack::create(
         &mut txn,
         &rack_id,
-        Some(&RackProfileId::new("Empty")),
+        Some(&RackProfileId::new("NmxCluster")),
         &RackConfig::default(),
         None,
     )
@@ -2787,14 +2903,21 @@ async fn test_configure_nmx_cluster_runs_start_disable_configure_to_wait_for_fab
 async fn test_configure_nmx_cluster_disable_scale_up_fabric_state_failure_stops_flow(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env_with_overrides(pool.clone(), TestEnvOverrides::default()).await;
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides {
+            config: Some(config_with_nmx_cluster_profile()),
+            ..Default::default()
+        },
+    )
+    .await;
 
     let rack_id = new_rack_id();
     let mut txn = pool.acquire().await?;
     db_rack::create(
         &mut txn,
         &rack_id,
-        Some(&RackProfileId::new("Empty")),
+        Some(&RackProfileId::new("NmxCluster")),
         &RackConfig::default(),
         None,
     )

--- a/crates/api-core/src/tests/switch_state_controller/maintenance.rs
+++ b/crates/api-core/src/tests/switch_state_controller/maintenance.rs
@@ -34,7 +34,10 @@ use state_controller::state_handler::{StateHandler, StateHandlerContext, StateHa
 use tonic::Request;
 
 use crate::tests::common::api_fixtures::site_explorer::new_switch;
-use crate::tests::common::api_fixtures::{TestEnv, create_test_env};
+use crate::tests::common::api_fixtures::{
+    TestEnv, TestEnvOverrides, create_test_env, create_test_env_with_overrides,
+    get_config_with_rack_profiles,
+};
 use crate::tests::switch_state_controller::fixtures::switch::set_switch_controller_state;
 
 fn cm_power_action(operation: SwitchMaintenanceOperation) -> SystemPowerControl {
@@ -138,7 +141,11 @@ async fn services_with_component_manager(env: &TestEnv) -> SwitchStateHandlerSer
 async fn ready_transitions_to_maintenance_when_request_is_set(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool.clone()).await;
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(get_config_with_rack_profiles()),
+    )
+    .await;
     let switch_id = new_switch(&env, None, None).await?;
 
     request_switch_maintenance_via_cm(&env, &switch_id, SwitchMaintenanceOperation::PowerOff).await;

--- a/crates/api-core/src/tests/switch_state_controller/mod.rs
+++ b/crates/api-core/src/tests/switch_state_controller/mod.rs
@@ -34,7 +34,7 @@ use state_controller::controller::StateController;
 use tokio_util::sync::CancellationToken;
 
 use crate::tests::common;
-use crate::tests::common::api_fixtures::create_test_env;
+use crate::tests::common::api_fixtures::{create_test_env, get_config_with_rack_profiles};
 
 mod fixtures;
 mod maintenance;
@@ -55,16 +55,18 @@ async fn build_test_component_manager(
         nv_switch_use_state_controller: true,
         ..Default::default()
     };
-    component_manager::component_manager::build_component_manager(
+    let component_manager = component_manager::component_manager::build_component_manager(
         &config,
+        get_config_with_rack_profiles().rack_profiles,
         rms_client,
         None,
         Some(env.pool.clone()),
         None,
     )
     .await
-    .ok()
-    .map(Arc::new)
+    .expect("test component manager should build");
+
+    Some(Arc::new(component_manager))
 }
 
 #[crate::sqlx_test]

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -26,7 +26,7 @@ use carbide_uuid::dpa_interface::DpaInterfaceId;
 use carbide_uuid::instance_type::InstanceTypeId;
 use carbide_uuid::machine::{MachineId, MachineType};
 use carbide_uuid::machine_validation::MachineValidationId;
-use carbide_uuid::rack::RackId;
+use carbide_uuid::rack::{RackId, RackProfileId};
 use chrono::{DateTime, Utc};
 use config_version::{ConfigVersion, Versioned};
 use health_report::{HealthReport, HealthReportApplyMode};
@@ -2579,26 +2579,33 @@ impl<'r> FromRow<'r, PgRow> for _HealthReportWrapper {
     }
 }
 
-/// RMS identity for a compute tray machine: the machine ID (used as the RMS
-/// node_id), the BMC IP address, the BMC MAC address, and the rack_id.
+/// RMS identity for a compute tray machine, including rack profile context for
+/// node type resolution.
 #[derive(Debug, sqlx::FromRow)]
 pub struct MachineRmsIdentity {
     pub id: String,
     pub bmc_ip: IpAddr,
     pub bmc_mac_address: MacAddress,
     pub rack_id: Option<RackId>,
+    pub rack_profile_id: Option<RackProfileId>,
 }
 
-/// Look up RMS identities (node_id, rack_id) for compute tray machines by their
-/// BMC IP addresses.
+/// Look up RMS identities and rack profile context for compute tray machines by
+/// their BMC IP addresses.
 pub async fn find_rms_identities_by_bmc_ips(
     db: impl crate::db_read::DbReader<'_>,
     bmc_ips: &[IpAddr],
 ) -> DatabaseResult<Vec<MachineRmsIdentity>> {
     let ip_strings: Vec<String> = bmc_ips.iter().map(ToString::to_string).collect();
     let sql = r#"
-        SELECT m.id::text, mia.address AS bmc_ip, mi.mac_address AS bmc_mac_address, m.rack_id
+        SELECT
+            m.id::text,
+            mia.address AS bmc_ip,
+            mi.mac_address AS bmc_mac_address,
+            m.rack_id,
+            r.rack_profile_id
         FROM machines m
+        LEFT JOIN racks r ON r.id = m.rack_id
         JOIN machine_interfaces mi
             ON mi.machine_id = m.id
             AND mi.interface_type = 'Bmc'

--- a/crates/api-db/src/power_shelf.rs
+++ b/crates/api-db/src/power_shelf.rs
@@ -16,6 +16,7 @@
  */
 
 use carbide_uuid::power_shelf::PowerShelfId;
+use carbide_uuid::rack::RackProfileId;
 use chrono::prelude::*;
 use config_version::{ConfigVersion, Versioned};
 use health_report::{HealthReport, HealthReportApplyMode};
@@ -513,24 +514,30 @@ pub async fn find_ids_by_bmc_macs(
         .map_err(|err| DatabaseError::new("power_shelf::find_ids_by_bmc_macs", err))
 }
 
-/// RMS identity for a power shelf: the power shelf ID (used as the RMS
-/// node_id), the BMC MAC address, and the rack_id.
+/// RMS identity for a power shelf, including rack profile context for node type
+/// resolution.
 #[derive(Debug, sqlx::FromRow)]
 pub struct PowerShelfRmsIdentity {
     pub id: String,
     pub bmc_mac_address: MacAddress,
     pub rack_id: Option<RackId>,
+    pub rack_profile_id: Option<RackProfileId>,
 }
 
-/// Look up RMS identities (node_id, rack_id) for power shelves by their
+/// Look up RMS identities and rack profile context for power shelves by their
 /// BMC MAC addresses.
 pub async fn find_rms_identities_by_macs(
     db: impl crate::db_read::DbReader<'_>,
     macs: &[MacAddress],
 ) -> DatabaseResult<Vec<PowerShelfRmsIdentity>> {
     let sql = r#"
-        SELECT ps.id::text, ps.bmc_mac_address, ps.rack_id
+        SELECT
+            ps.id::text,
+            ps.bmc_mac_address,
+            ps.rack_id,
+            r.rack_profile_id
         FROM power_shelves ps
+        LEFT JOIN racks r ON r.id = ps.rack_id
         WHERE ps.bmc_mac_address = ANY($1)
     "#;
 

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -17,7 +17,7 @@
 
 use std::net::IpAddr;
 
-use carbide_uuid::rack::RackId;
+use carbide_uuid::rack::{RackId, RackProfileId};
 use carbide_uuid::switch::SwitchId;
 use chrono::prelude::*;
 use config_version::{ConfigVersion, Versioned};
@@ -685,24 +685,30 @@ pub async fn find_ids_by_bmc_macs(
         .map_err(|err| DatabaseError::new("switch::find_ids_by_bmc_macs", err))
 }
 
-/// RMS identity for a switch: the switch ID (used as the RMS node_id),
-/// the BMC MAC address, and the rack_id.
+/// RMS identity for a switch, including rack profile context for node type
+/// resolution.
 #[derive(Debug, sqlx::FromRow)]
 pub struct SwitchRmsIdentity {
     pub id: String,
     pub bmc_mac_address: MacAddress,
     pub rack_id: Option<RackId>,
+    pub rack_profile_id: Option<RackProfileId>,
 }
 
-/// Look up RMS identities (node_id, rack_id) for switches by their
-/// BMC MAC addresses.
+/// Look up RMS identities and rack profile context for switches by their BMC
+/// MAC addresses.
 pub async fn find_rms_identities_by_macs(
     db: impl crate::db_read::DbReader<'_>,
     macs: &[MacAddress],
 ) -> DatabaseResult<Vec<SwitchRmsIdentity>> {
     let sql = r#"
-        SELECT s.id::text, s.bmc_mac_address, s.rack_id
+        SELECT
+            s.id::text,
+            s.bmc_mac_address,
+            s.rack_id,
+            r.rack_profile_id
         FROM switches s
+        LEFT JOIN racks r ON r.id = s.rack_id
         WHERE s.bmc_mac_address = ANY($1)
     "#;
 

--- a/crates/api-model/src/rack_type.rs
+++ b/crates/api-model/src/rack_type.rs
@@ -65,6 +65,26 @@ impl From<&str> for RackHardwareType {
     }
 }
 
+/// RackProductFamily identifies the product family shared by rack components.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "text", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum RackProductFamily {
+    /// GB200 rack hardware.
+    Gb200,
+    /// GB300 rack hardware.
+    Gb300,
+}
+
+impl fmt::Display for RackProductFamily {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RackProductFamily::Gb200 => write!(f, "gb200"),
+            RackProductFamily::Gb300 => write!(f, "gb300"),
+        }
+    }
+}
+
 /// RackHardwareTopology describes the hardware topology of a rack.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "text", rename_all = "snake_case")]
@@ -239,6 +259,10 @@ pub struct RackCapabilitiesSet {
 /// (the map key in the config file) from expected racks and rack configs.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RackProfile {
+    /// Product family used for product-level component behavior.
+    #[serde(default)]
+    pub product_family: Option<RackProductFamily>,
+
     #[serde(default)]
     pub rack_hardware_type: Option<RackHardwareType>,
 
@@ -290,6 +314,7 @@ mod tests {
         config.rack_profiles.insert(
             "NVL72".to_string(),
             RackProfile {
+                product_family: Some(RackProductFamily::Gb200),
                 rack_capabilities: RackCapabilitiesSet {
                     compute: RackCapabilityCompute {
                         name: Some("GB200".to_string()),
@@ -325,6 +350,9 @@ mod tests {
     #[test]
     fn test_rack_profile_config_toml_deserialization() {
         let toml_str = r#"
+[NVL72]
+product_family = "gb200"
+
 [NVL72.rack_capabilities.compute]
 name = "GB200"
 count = 18
@@ -335,6 +363,9 @@ count = 9
 
 [NVL72.rack_capabilities.power_shelf]
 count = 8
+
+[NVL36]
+product_family = "gb200"
 
 [NVL36.rack_capabilities.compute]
 count = 9
@@ -349,6 +380,7 @@ count = 2
         assert_eq!(config.rack_profiles.len(), 2);
 
         let nvl72 = config.get("NVL72").unwrap();
+        assert_eq!(nvl72.product_family, Some(RackProductFamily::Gb200));
         assert_eq!(nvl72.rack_capabilities.compute.count, 18);
         assert_eq!(
             nvl72.rack_capabilities.compute.name.as_deref(),
@@ -356,6 +388,7 @@ count = 2
         );
 
         let nvl36 = config.get("NVL36").unwrap();
+        assert_eq!(nvl36.product_family, Some(RackProductFamily::Gb200));
         assert_eq!(nvl36.rack_capabilities.compute.count, 9);
         assert_eq!(nvl36.rack_capabilities.switch.count, 9);
         assert_eq!(nvl36.rack_capabilities.power_shelf.count, 2);
@@ -365,6 +398,7 @@ count = 2
     fn test_rack_profile_config_toml_with_hardware_fields() {
         let toml_str = r#"
 [NVL72]
+product_family = "gb200"
 rack_hardware_type = "dsx_gb200nvl_72x1"
 rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
 rack_hardware_class = "prod"
@@ -383,6 +417,7 @@ count = 8
         let config: RackProfileConfig = toml::from_str(toml_str).unwrap();
         let nvl72 = config.get("NVL72").unwrap();
 
+        assert_eq!(nvl72.product_family, Some(RackProductFamily::Gb200));
         assert_eq!(
             nvl72.rack_hardware_type,
             Some(RackHardwareType::from("dsx_gb200nvl_72x1"))
@@ -398,6 +433,9 @@ count = 8
     #[test]
     fn test_rack_profile_config_toml_without_hardware_fields_defaults_to_none() {
         let toml_str = r#"
+[NVL36]
+product_family = "gb300"
+
 [NVL36.rack_capabilities.compute]
 count = 9
 [NVL36.rack_capabilities.switch]
@@ -408,9 +446,27 @@ count = 2
         let config: RackProfileConfig = toml::from_str(toml_str).unwrap();
         let nvl36 = config.get("NVL36").unwrap();
 
+        assert_eq!(nvl36.product_family, Some(RackProductFamily::Gb300));
         assert_eq!(nvl36.rack_hardware_type, None);
         assert_eq!(nvl36.rack_hardware_topology, None);
         assert_eq!(nvl36.rack_hardware_class, None);
+    }
+
+    #[test]
+    fn test_rack_profile_config_without_product_family_defaults_to_none() {
+        let toml_str = r#"
+[NVL36.rack_capabilities.compute]
+count = 9
+[NVL36.rack_capabilities.switch]
+count = 9
+[NVL36.rack_capabilities.power_shelf]
+count = 2
+"#;
+
+        let config: RackProfileConfig = toml::from_str(toml_str).unwrap();
+        let nvl36 = config.get("NVL36").unwrap();
+
+        assert_eq!(nvl36.product_family, None);
     }
 
     // RackHardwareType tests.
@@ -530,6 +586,62 @@ count = 2
 
             "owned and borrowed agree" {
                 RackHardwareType::from("any".to_string()) => RackHardwareType::from("any"),
+            }
+        );
+    }
+
+    // RackProductFamily serde.
+
+    #[test]
+    fn test_rack_product_family_serde_round_trip() {
+        scenarios!(
+            run = |variant| {
+                let json = serde_json::to_string(&variant).map_err(drop)?;
+                let back: RackProductFamily = serde_json::from_str(&json).map_err(drop)?;
+                Ok::<_, ()>((json, back))
+            };
+            "gb200 round-trips" {
+                RackProductFamily::Gb200 => Yields(("\"gb200\"".to_string(), RackProductFamily::Gb200)),
+            }
+
+            "gb300 round-trips" {
+                RackProductFamily::Gb300 => Yields(("\"gb300\"".to_string(), RackProductFamily::Gb300)),
+            }
+        );
+    }
+
+    #[test]
+    fn test_rack_product_family_display() {
+        value_scenarios!(
+            run = |variant| variant.to_string();
+            "gb200" {
+                RackProductFamily::Gb200 => "gb200".to_string(),
+            }
+
+            "gb300" {
+                RackProductFamily::Gb300 => "gb300".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_rack_product_family_deserialize() {
+        scenarios!(
+            run = |json| serde_json::from_str::<RackProductFamily>(json).map_err(drop);
+            "valid gb200" {
+                "\"gb200\"" => Yields(RackProductFamily::Gb200),
+            }
+
+            "valid gb300" {
+                "\"gb300\"" => Yields(RackProductFamily::Gb300),
+            }
+
+            "unknown product family" {
+                "\"gb400\"" => Fails,
+            }
+
+            "wrong case" {
+                "\"GB200\"" => Fails,
             }
         );
     }

--- a/crates/api-test-helper/src/mock_rms.rs
+++ b/crates/api-test-helper/src/mock_rms.rs
@@ -201,14 +201,6 @@ pub struct MockRmsApi {
     upgrade_switch_firmware_calls: Mutex<Vec<rms::UpgradeSwitchFirmwareRequest>>,
 
     // Switch system images calls.
-    fetch_switch_system_image_responses:
-        Mutex<VecDeque<Result<rms::FetchSwitchSystemImageResponse, RackManagerError>>>,
-    fetch_switch_system_image_calls: Mutex<Vec<rms::FetchSwitchSystemImageRequest>>,
-
-    install_switch_system_image_responses:
-        Mutex<VecDeque<Result<rms::InstallSwitchSystemImageResponse, RackManagerError>>>,
-    install_switch_system_image_calls: Mutex<Vec<rms::InstallSwitchSystemImageRequest>>,
-
     list_switch_system_images_responses:
         Mutex<VecDeque<Result<rms::ListSwitchSystemImagesResponse, RackManagerError>>>,
     list_switch_system_images_calls: Mutex<Vec<rms::ListSwitchSystemImagesRequest>>,
@@ -338,10 +330,6 @@ impl MockRmsApi {
             push_switch_firmware_calls: Default::default(),
             upgrade_switch_firmware_responses: Default::default(),
             upgrade_switch_firmware_calls: Default::default(),
-            fetch_switch_system_image_responses: Default::default(),
-            fetch_switch_system_image_calls: Default::default(),
-            install_switch_system_image_responses: Default::default(),
-            install_switch_system_image_calls: Default::default(),
             list_switch_system_images_responses: Default::default(),
             list_switch_system_images_calls: Default::default(),
             poll_switch_firmware_job_status_responses: Default::default(),
@@ -669,22 +657,6 @@ impl MockRmsApi {
     );
 
     // Switch system images
-    impl_enqueue_inspect!(
-        enqueue_fetch_switch_system_image,
-        fetch_switch_system_image_calls,
-        fetch_switch_system_image_responses,
-        fetch_switch_system_image_calls,
-        rms::FetchSwitchSystemImageRequest,
-        rms::FetchSwitchSystemImageResponse
-    );
-    impl_enqueue_inspect!(
-        enqueue_install_switch_system_image,
-        install_switch_system_image_calls,
-        install_switch_system_image_responses,
-        install_switch_system_image_calls,
-        rms::InstallSwitchSystemImageRequest,
-        rms::InstallSwitchSystemImageResponse
-    );
     impl_enqueue_inspect!(
         enqueue_list_switch_system_images,
         list_switch_system_images_calls,
@@ -1343,23 +1315,6 @@ impl RmsApi for MockRmsApi {
     ) -> Result<rms::UpgradeSwitchFirmwareResponse, RackManagerError> {
         self.upgrade_switch_firmware_calls.lock().await.push(cmd);
         pop_or_err(&mut self.upgrade_switch_firmware_responses.lock().await)
-    }
-    async fn fetch_switch_system_image(
-        &self,
-        cmd: rms::FetchSwitchSystemImageRequest,
-    ) -> Result<rms::FetchSwitchSystemImageResponse, RackManagerError> {
-        self.fetch_switch_system_image_calls.lock().await.push(cmd);
-        pop_or_err(&mut self.fetch_switch_system_image_responses.lock().await)
-    }
-    async fn install_switch_system_image(
-        &self,
-        cmd: rms::InstallSwitchSystemImageRequest,
-    ) -> Result<rms::InstallSwitchSystemImageResponse, RackManagerError> {
-        self.install_switch_system_image_calls
-            .lock()
-            .await
-            .push(cmd);
-        pop_or_err(&mut self.install_switch_system_image_responses.lock().await)
     }
     async fn list_switch_system_images(
         &self,

--- a/crates/component-manager/Cargo.toml
+++ b/crates/component-manager/Cargo.toml
@@ -25,6 +25,7 @@ authors.workspace = true
 async-trait = { workspace = true }
 carbide-api-db = { path = "../api-db", default-features = false }
 carbide-api-model = { path = "../api-model" }
+carbide-rack = { path = "../rack", default-features = false }
 carbide-redfish = { path = "../redfish" }
 carbide-secrets = { path = "../secrets" }
 carbide-uuid = { path = "../uuid" }

--- a/crates/component-manager/src/component_manager.rs
+++ b/crates/component-manager/src/component_manager.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use carbide_redfish::libredfish::RedfishClientPool;
 use librms::RmsApi;
+use model::rack_type::RackProfileConfig;
 use sqlx::PgPool;
 
 use crate::compute_tray_manager::{Backend as ComputeBackend, ComputeTrayManager};
@@ -12,7 +13,7 @@ use crate::config::ComponentManagerConfig;
 use crate::error::ComponentManagerError;
 use crate::nv_switch_manager::{Backend as NvSwitchBackend, NvSwitchManager};
 use crate::power_shelf_manager::{Backend as PowerShelfBackend, PowerShelfManager};
-use crate::rms::RmsSwitchSystemImageStatusApi;
+use crate::rms::{RmsSwitchSystemImageStatusApi, validate_rms_backend_rack_profiles};
 
 /// Holds the configured backend implementations for each component type.
 #[derive(Debug, Clone)]
@@ -59,16 +60,24 @@ impl ComponentManager {
 
 /// Build `ComponentManager` from configuration.
 ///
-/// The factory inspects `config.nv_switch_backend` and `config.power_shelf_backend`
-/// to decide which concrete implementation to instantiate. Unknown backend names
-/// are rejected at config-deserialization time by the backend enums.
+/// The factory inspects the configured nv-switch, power-shelf, and compute-tray
+/// backend selectors to decide which concrete implementations to instantiate.
+/// Unknown backend names are rejected at config-deserialization time by the
+/// backend enums. When any backend uses RMS, `rack_profiles` must contain enough
+/// product-family and vendor data to resolve RMS node types before startup
+/// continues.
 pub async fn build_component_manager(
     config: &ComponentManagerConfig,
+    rack_profiles: RackProfileConfig,
     rms_client: Option<Arc<dyn RmsApi>>,
     rms_switch_system_image_client: Option<Arc<dyn RmsSwitchSystemImageStatusApi>>,
     db: Option<PgPool>,
     redfish_pool: Option<Arc<dyn RedfishClientPool>>,
 ) -> Result<ComponentManager, ComponentManagerError> {
+    validate_rms_backend_rack_profiles(config, &rack_profiles)?;
+
+    let rack_profiles = Arc::new(rack_profiles);
+
     let nv_switch: Arc<dyn NvSwitchManager> = match config.nv_switch_backend {
         NvSwitchBackend::Nsm => {
             let endpoint = config.nsm.as_ref().ok_or_else(|| {
@@ -96,6 +105,7 @@ pub async fn build_component_manager(
                 client,
                 rms_switch_system_image_client.clone(),
                 db,
+                rack_profiles.clone(),
             ))
         }
         NvSwitchBackend::Mock => Arc::new(crate::mock::MockNvSwitchManager),
@@ -129,6 +139,7 @@ pub async fn build_component_manager(
                 client,
                 rms_switch_system_image_client.clone(),
                 db,
+                rack_profiles.clone(),
             ))
         }
         PowerShelfBackend::Mock => Arc::new(crate::mock::MockPowerShelfManager),
@@ -150,6 +161,7 @@ pub async fn build_component_manager(
                 client,
                 rms_switch_system_image_client.clone(),
                 db,
+                rack_profiles.clone(),
             ))
         }
         ComputeBackend::Core => {
@@ -178,8 +190,41 @@ pub async fn build_component_manager(
 
 #[cfg(test)]
 mod tests {
+    use model::rack_type::{
+        RackCapabilitiesSet, RackCapabilityCompute, RackCapabilityPowerShelf, RackCapabilitySwitch,
+        RackHardwareTopology, RackProductFamily, RackProfile,
+    };
+
     use super::*;
     use crate::config::ComponentManagerConfig;
+
+    fn rms_rack_profiles(profile: RackProfile) -> RackProfileConfig {
+        RackProfileConfig {
+            rack_profiles: [("NVL72".to_string(), profile)].into_iter().collect(),
+        }
+    }
+
+    fn rms_rack_profile() -> RackProfile {
+        RackProfile {
+            product_family: Some(RackProductFamily::Gb200),
+            rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
+            rack_capabilities: RackCapabilitiesSet {
+                compute: RackCapabilityCompute {
+                    vendor: Some("NVIDIA".to_string()),
+                    ..Default::default()
+                },
+                switch: RackCapabilitySwitch {
+                    vendor: Some("NVIDIA".to_string()),
+                    ..Default::default()
+                },
+                power_shelf: RackCapabilityPowerShelf {
+                    vendor: Some("LiteOn".to_string()),
+                    ..Default::default()
+                },
+            },
+            ..Default::default()
+        }
+    }
 
     #[tokio::test]
     async fn build_with_mock_backends() {
@@ -189,9 +234,11 @@ mod tests {
             compute_tray_backend: ComputeBackend::Mock,
             ..Default::default()
         };
-        let cm = build_component_manager(&config, None, None, None, None)
+
+        let cm = build_component_manager(&config, Default::default(), None, None, None, None)
             .await
             .unwrap();
+
         assert_eq!(cm.nv_switch.name(), "mock-nsm");
         assert_eq!(cm.power_shelf.name(), "mock-psm");
         assert_eq!(cm.compute_tray.name(), "mock-ctm");
@@ -219,9 +266,11 @@ mod tests {
             compute_tray_backend: ComputeBackend::Mock,
             ..Default::default()
         };
-        let err = build_component_manager(&config, None, None, None, None)
+
+        let err = build_component_manager(&config, Default::default(), None, None, None, None)
             .await
             .unwrap_err();
+
         assert!(matches!(err, ComponentManagerError::InvalidArgument(_)));
     }
 
@@ -233,33 +282,107 @@ mod tests {
             compute_tray_backend: ComputeBackend::Mock,
             ..Default::default()
         };
-        let err = build_component_manager(&config, None, None, None, None)
+
+        let err = build_component_manager(&config, Default::default(), None, None, None, None)
             .await
             .unwrap_err();
+
         assert!(matches!(err, ComponentManagerError::InvalidArgument(_)));
     }
 
     // A config that explicitly selects working switch/power-shelf backends but
     // leaves `compute_tray_backend` at its default (now `Rms`) must not be able
-    // to silently come up half-configured: the RMS compute-tray arm fails when
-    // no RMS client is wired, and that error aborts the whole build via `?`,
-    // discarding the already-built switch/power-shelf backends. `setup.rs` then
-    // disables the component manager entirely. This pins that behavior so the
-    // default flip to RMS is a deliberate, visible choice.
+    // to silently come up half-configured: RMS validation rejects missing rack
+    // profile config before any partial component manager can be built. This
+    // keeps the default flip to RMS a deliberate, visible choice.
     #[tokio::test]
-    async fn rms_compute_tray_default_without_rms_client_fails_whole_build() {
+    async fn rms_compute_tray_default_requires_rack_profiles() {
         let config = ComponentManagerConfig {
             nv_switch_backend: NvSwitchBackend::Mock,
             power_shelf_backend: PowerShelfBackend::Mock,
             // compute_tray_backend intentionally left at its default.
             ..Default::default()
         };
+
         assert_eq!(config.compute_tray_backend, ComputeBackend::Rms);
 
-        let err = build_component_manager(&config, None, None, None, None)
+        let err = build_component_manager(&config, Default::default(), None, None, None, None)
             .await
             .unwrap_err();
-        assert!(matches!(err, ComponentManagerError::InvalidArgument(msg)
-                if msg.contains("compute_tray_backend is 'rms'")));
+
+        assert!(matches!(
+            err,
+            ComponentManagerError::InvalidArgument(msg)
+                if msg.contains("rack_profiles must contain at least one profile")
+        ));
+    }
+
+    #[tokio::test]
+    async fn build_requires_rack_profiles_for_rms_backend() {
+        let config = ComponentManagerConfig {
+            nv_switch_backend: NvSwitchBackend::Rms,
+            power_shelf_backend: PowerShelfBackend::Mock,
+            compute_tray_backend: ComputeBackend::Mock,
+            ..Default::default()
+        };
+
+        let result =
+            build_component_manager(&config, Default::default(), None, None, None, None).await;
+        let Err(error) = result else {
+            panic!("missing RMS rack profiles should be rejected");
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "invalid argument: rack_profiles must contain at least one profile when component_manager uses an RMS backend"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_requires_vendor_for_rms_backend_role() {
+        let mut profile = rms_rack_profile();
+        profile.rack_capabilities.power_shelf.vendor = None;
+
+        let rack_profiles = rms_rack_profiles(profile);
+        let config = ComponentManagerConfig {
+            nv_switch_backend: NvSwitchBackend::Mock,
+            power_shelf_backend: PowerShelfBackend::Rms,
+            compute_tray_backend: ComputeBackend::Mock,
+            ..Default::default()
+        };
+
+        let result = build_component_manager(&config, rack_profiles, None, None, None, None).await;
+        let Err(error) = result else {
+            panic!("missing RMS vendor should be rejected");
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "invalid argument: rack profile NVL72 rack_capabilities.power_shelf.vendor is required when power_shelf_backend is 'rms'"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_validates_rms_backend_vendor_value() {
+        let mut profile = rms_rack_profile();
+        profile.rack_capabilities.switch.vendor = Some("Other".to_string());
+
+        let rack_profiles = rms_rack_profiles(profile);
+        let config = ComponentManagerConfig {
+            nv_switch_backend: NvSwitchBackend::Rms,
+            power_shelf_backend: PowerShelfBackend::Mock,
+            compute_tray_backend: ComputeBackend::Mock,
+            ..Default::default()
+        };
+
+        let result = build_component_manager(&config, rack_profiles, None, None, None, None).await;
+        let Err(error) = result else {
+            panic!("unsupported RMS vendor should be rejected");
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "invalid argument: rack profile NVL72 cannot resolve RMS switch node type: RMS does not support switch vendor Other"
+        );
     }
 }

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -19,13 +19,19 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
 
+use carbide_rack::firmware_object::rms_access_token_or_noauth;
+use carbide_rack::rms_node_type::{
+    compute_node_type_for_profile, power_shelf_node_type_for_profile, switch_node_type_for_profile,
+};
 use carbide_secrets::credentials::Credentials;
+use carbide_uuid::rack::RackProfileId;
 use librms::protos::rack_manager as rms;
 use librms::{RackManagerError, RmsApi};
 use mac_address::MacAddress;
 use model::component_manager::{
     ComputeTrayComponent, FirmwareState, NvSwitchComponent, PowerAction, PowerShelfComponent,
 };
+use model::rack_type::{RackProfile, RackProfileConfig};
 use sqlx::PgPool;
 use tracing::instrument;
 
@@ -33,33 +39,47 @@ use crate::compute_tray_manager::{
     Backend as ComputeTrayBackend, ComputeTrayEndpoint, ComputeTrayFirmwareUpdateStatus,
     ComputeTrayManager, ComputeTrayResult,
 };
+use crate::config::ComponentManagerConfig;
 use crate::error::ComponentManagerError;
 use crate::nv_switch_manager::{
-    NvSwitchManager, SwitchComponentResult, SwitchEndpoint, SwitchFirmwareUpdateStatus,
-    SwitchPowerStateResult, SwitchSlotAndTrayResult,
+    Backend as NvSwitchBackend, NvSwitchManager, SwitchComponentResult, SwitchEndpoint,
+    SwitchFirmwareUpdateStatus, SwitchPowerStateResult, SwitchSlotAndTrayResult,
 };
 use crate::power_shelf_manager::{
-    PowerShelfComponentResult, PowerShelfEndpoint, PowerShelfFirmwareUpdateStatus,
-    PowerShelfFirmwareVersions, PowerShelfManager, PowerShelfPowerStateResult,
+    Backend as PowerShelfBackend, PowerShelfComponentResult, PowerShelfEndpoint,
+    PowerShelfFirmwareUpdateStatus, PowerShelfFirmwareVersions, PowerShelfManager,
+    PowerShelfPowerStateResult,
 };
 use crate::types::FirmwareUpdateOptions;
 
-/// RMS identity for a device: the node_id and rack_id that RMS needs
-/// to address it. Used for both power shelves and switches.
+/// Common RMS identity needed to address a device in RMS.
 #[derive(Clone)]
 struct RmsIdentity {
     node_id: String,
     rack_id: String,
+    rack_profile_id: Option<RackProfileId>,
+}
+
+struct ResolvedRmsNode<'a> {
+    identity: &'a RmsIdentity,
+    node_type: rms::NodeType,
+}
+
+/// Role for MAC-keyed switch and power shelf lookups.
+///
+/// Compute trays use `ComputeTrayRmsIdentity` and `resolve_compute_node`
+/// because component-manager addresses compute endpoints by BMC IP and also
+/// needs the BMC MAC address when building RMS requests.
+#[derive(Clone, Copy)]
+enum SwitchOrPowerShelfRole {
+    PowerShelf,
+    Switch,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum RmsTrackedFirmwareJob {
     FirmwareObject(String),
-    SwitchSystemImage {
-        job_id: String,
-        rack_id: String,
-        node_id: String,
-    },
+    SwitchSystemImage(String),
 }
 
 // The direct RMS path matches the rack-maintenance flow and applies production
@@ -67,14 +87,109 @@ enum RmsTrackedFirmwareJob {
 const RMS_FIRMWARE_OBJECT_FIRMWARE_TYPE: &str = "prod";
 const RMS_SWITCH_SYSTEM_IMAGE_SOFTWARE_TYPE: &str = "prod";
 const RMS_FIRMWARE_OBJECT_HARDWARE_TYPE: &str = "any";
-const RMS_NOAUTH_ACCESS_TOKEN: &str = "NOAUTH";
-const RMS_SWITCH_NODE_TYPE: rms::NodeType = rms::NodeType::Switch;
-const RMS_COMPUTE_NODE_TYPE: rms::NodeType = rms::NodeType::Compute;
+const RMS_IDENTITY_LOOKUP_ERROR: &str = "could not resolve RMS identity from database";
+
+/// Validates rack profile fields required by RMS component-manager backends.
+///
+/// RMS requests use concrete node type variants, such as the product family
+/// and vendor-specific compute, switch, or power shelf type. NICo resolves
+/// those variants from rack profile product-family and vendor data. When an RMS
+/// backend is enabled, invalid or incomplete rack profile data would otherwise
+/// surface later as per-device power or firmware operation failures, so
+/// validate all configured profiles during startup.
+pub fn validate_rms_backend_rack_profiles(
+    config: &ComponentManagerConfig,
+    rack_profiles: &RackProfileConfig,
+) -> Result<(), ComponentManagerError> {
+    let compute_uses_rms = matches!(config.compute_tray_backend, ComputeTrayBackend::Rms);
+    let switch_uses_rms = matches!(config.nv_switch_backend, NvSwitchBackend::Rms);
+    let power_shelf_uses_rms = matches!(config.power_shelf_backend, PowerShelfBackend::Rms);
+
+    if !(compute_uses_rms || switch_uses_rms || power_shelf_uses_rms) {
+        return Ok(());
+    }
+
+    if rack_profiles.rack_profiles.is_empty() {
+        return Err(ComponentManagerError::InvalidArgument(
+            "rack_profiles must contain at least one profile when component_manager uses an RMS backend"
+                .into(),
+        ));
+    }
+
+    for (profile_id, profile) in &rack_profiles.rack_profiles {
+        if compute_uses_rms {
+            require_rms_vendor(
+                profile_id,
+                "rack_capabilities.compute.vendor",
+                profile.rack_capabilities.compute.vendor.as_deref(),
+                "compute_tray_backend",
+            )?;
+            compute_node_type_for_profile(profile).map_err(|error| {
+                rms_node_type_config_error(profile_id, "compute", error.to_string())
+            })?;
+        }
+
+        if switch_uses_rms {
+            require_rms_vendor(
+                profile_id,
+                "rack_capabilities.switch.vendor",
+                profile.rack_capabilities.switch.vendor.as_deref(),
+                "nv_switch_backend",
+            )?;
+            switch_node_type_for_profile(profile).map_err(|error| {
+                rms_node_type_config_error(profile_id, "switch", error.to_string())
+            })?;
+        }
+
+        if power_shelf_uses_rms {
+            require_rms_vendor(
+                profile_id,
+                "rack_capabilities.power_shelf.vendor",
+                profile.rack_capabilities.power_shelf.vendor.as_deref(),
+                "power_shelf_backend",
+            )?;
+            power_shelf_node_type_for_profile(profile).map_err(|error| {
+                rms_node_type_config_error(profile_id, "power shelf", error.to_string())
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+fn require_rms_vendor(
+    profile_id: &str,
+    field: &str,
+    vendor: Option<&str>,
+    backend_field: &str,
+) -> Result<(), ComponentManagerError> {
+    if vendor
+        .map(str::trim)
+        .is_some_and(|vendor| !vendor.is_empty())
+    {
+        return Ok(());
+    }
+
+    Err(ComponentManagerError::InvalidArgument(format!(
+        "rack profile {profile_id} {field} is required when {backend_field} is 'rms'"
+    )))
+}
+
+fn rms_node_type_config_error(
+    profile_id: &str,
+    role: &str,
+    error: String,
+) -> ComponentManagerError {
+    ComponentManagerError::InvalidArgument(format!(
+        "rack profile {profile_id} cannot resolve RMS {role} node type: {error}"
+    ))
+}
 
 pub struct RmsBackend {
     client: Arc<dyn RmsApi>,
     switch_system_image_client: Option<Arc<dyn RmsSwitchSystemImageStatusApi>>,
     db: PgPool,
+    rack_profiles: Arc<RackProfileConfig>,
     /// Tracks firmware update job IDs keyed by device MAC address.
     firmware_jobs: Mutex<HashMap<MacAddress, Vec<RmsTrackedFirmwareJob>>>,
 }
@@ -110,13 +225,77 @@ impl RmsBackend {
         client: Arc<dyn RmsApi>,
         switch_system_image_client: Option<Arc<dyn RmsSwitchSystemImageStatusApi>>,
         db: PgPool,
+        rack_profiles: Arc<RackProfileConfig>,
     ) -> Self {
         Self {
             client,
             switch_system_image_client,
             db,
+            rack_profiles,
             firmware_jobs: Mutex::new(HashMap::new()),
         }
+    }
+
+    fn rack_profile<'a>(
+        &'a self,
+        identity: &RmsIdentity,
+    ) -> Result<&'a RackProfile, ComponentManagerError> {
+        let Some(rack_profile_id) = &identity.rack_profile_id else {
+            return Err(ComponentManagerError::InvalidArgument(format!(
+                "rack {} has no rack_profile_id for RMS node type resolution",
+                identity.rack_id
+            )));
+        };
+
+        self.rack_profiles
+            .get(rack_profile_id.as_str())
+            .ok_or_else(|| {
+                ComponentManagerError::InvalidArgument(format!(
+                    "rack profile {} is not configured for RMS node type resolution",
+                    rack_profile_id
+                ))
+            })
+    }
+
+    fn resolve_switch_or_power_shelf_node<'a>(
+        &self,
+        identities: &'a HashMap<MacAddress, RmsIdentity>,
+        device_mac: MacAddress,
+        role: SwitchOrPowerShelfRole,
+    ) -> Result<ResolvedRmsNode<'a>, String> {
+        let Some(identity) = identities.get(&device_mac) else {
+            return Err(RMS_IDENTITY_LOOKUP_ERROR.to_owned());
+        };
+
+        let profile = self
+            .rack_profile(identity)
+            .map_err(|error| error.to_string())?;
+        let node_type = match role {
+            SwitchOrPowerShelfRole::PowerShelf => power_shelf_node_type_for_profile(profile),
+            SwitchOrPowerShelfRole::Switch => switch_node_type_for_profile(profile),
+        }
+        .map_err(|error| error.to_string())?;
+
+        Ok(ResolvedRmsNode {
+            identity,
+            node_type,
+        })
+    }
+
+    fn resolve_compute_node<'a>(
+        &self,
+        identity: &'a ComputeTrayRmsIdentity,
+    ) -> Result<ResolvedRmsNode<'a>, String> {
+        let profile = self
+            .rack_profile(&identity.identity)
+            .map_err(|error| error.to_string())?;
+        let node_type =
+            compute_node_type_for_profile(profile).map_err(|error| error.to_string())?;
+
+        Ok(ResolvedRmsNode {
+            identity: &identity.identity,
+            node_type,
+        })
     }
 }
 
@@ -144,6 +323,7 @@ async fn resolve_power_shelf_identities(
             RmsIdentity {
                 node_id: row.id,
                 rack_id: rack_id.to_string(),
+                rack_profile_id: row.rack_profile_id,
             },
         );
     }
@@ -181,6 +361,7 @@ async fn resolve_compute_tray_identities(
                 identity: RmsIdentity {
                     node_id: row.id,
                     rack_id: rack_id.to_string(),
+                    rack_profile_id: row.rack_profile_id,
                 },
                 bmc_mac: row.bmc_mac_address,
             },
@@ -211,6 +392,7 @@ async fn resolve_switch_identities(
             RmsIdentity {
                 node_id: row.id,
                 rack_id: rack_id.to_string(),
+                rack_profile_id: row.rack_profile_id,
             },
         );
     }
@@ -289,11 +471,15 @@ const POWER_SHELF_BMC_PORT: u32 = 443;
 /// `BatchSetPowerState` request. The caller-supplied variant of the
 /// RPC requires the BMC connection details inline rather than relying on
 /// RMS's inventory; power shelves do not expose a host endpoint.
-fn build_power_shelf_node_info(ep: &PowerShelfEndpoint, identity: &RmsIdentity) -> rms::NodeInfo {
+fn build_power_shelf_node_info(
+    ep: &PowerShelfEndpoint,
+    identity: &RmsIdentity,
+    node_type: rms::NodeType,
+) -> rms::NodeInfo {
     rms::NodeInfo {
         node_id: identity.node_id.clone(),
         rack_id: identity.rack_id.clone(),
-        r#type: Some(rms::NodeType::Powershelf as i32),
+        r#type: Some(node_type as i32),
         bmc_endpoint: Some(rms::Endpoint {
             interface: Some(rms::NetworkInterface {
                 ip_address: ep.pmc_ip.to_string(),
@@ -329,16 +515,23 @@ impl PowerShelfManager for RmsBackend {
         let mut results = Vec::with_capacity(endpoints.len());
 
         for ep in endpoints {
-            let Some(identity) = ids.get(&ep.pmc_mac) else {
-                results.push(PowerShelfComponentResult {
-                    pmc_mac: ep.pmc_mac,
-                    success: false,
-                    error: Some("could not resolve RMS identity from database".into()),
-                });
-                continue;
+            let resolved = match self.resolve_switch_or_power_shelf_node(
+                &ids,
+                ep.pmc_mac,
+                SwitchOrPowerShelfRole::PowerShelf,
+            ) {
+                Ok(resolved) => resolved,
+                Err(error) => {
+                    results.push(PowerShelfComponentResult {
+                        pmc_mac: ep.pmc_mac,
+                        success: false,
+                        error: Some(error),
+                    });
+                    continue;
+                }
             };
 
-            let device = build_power_shelf_node_info(ep, identity);
+            let device = build_power_shelf_node_info(ep, resolved.identity, resolved.node_type);
             let request = rms::BatchSetPowerStateRequest {
                 nodes: Some(rms::NodeSet {
                     nodes: vec![device],
@@ -389,22 +582,29 @@ impl PowerShelfManager for RmsBackend {
         let mut results = Vec::with_capacity(endpoints.len());
 
         for ep in endpoints {
-            let Some(identity) = ids.get(&ep.pmc_mac) else {
-                results.push(PowerShelfComponentResult {
-                    pmc_mac: ep.pmc_mac,
-                    success: false,
-                    error: Some("could not resolve RMS identity from database".into()),
-                });
-                continue;
+            let resolved = match self.resolve_switch_or_power_shelf_node(
+                &ids,
+                ep.pmc_mac,
+                SwitchOrPowerShelfRole::PowerShelf,
+            ) {
+                Ok(resolved) => resolved,
+                Err(error) => {
+                    results.push(PowerShelfComponentResult {
+                        pmc_mac: ep.pmc_mac,
+                        success: false,
+                        error: Some(error),
+                    });
+                    continue;
+                }
             };
 
-            let device = build_power_shelf_node_info(ep, identity);
+            let device = build_power_shelf_node_info(ep, resolved.identity, resolved.node_type);
             let request = match apply_firmware_object_request(
                 device,
-                identity,
+                resolved.identity,
                 target_version,
                 options,
-                rms::NodeType::Powershelf,
+                resolved.node_type,
                 component_filters.clone(),
             ) {
                 Ok(request) => request,
@@ -420,8 +620,10 @@ impl PowerShelfManager for RmsBackend {
 
             match self.client.apply_firmware_object(request).await {
                 Ok(response) => {
-                    let (success, error, job_id) =
-                        summarize_firmware_object_apply_response(response, &identity.node_id);
+                    let (success, error, job_id) = summarize_firmware_object_apply_response(
+                        response,
+                        &resolved.identity.node_id,
+                    );
 
                     if success {
                         if let Some(job_id) = job_id {
@@ -475,7 +677,7 @@ impl PowerShelfManager for RmsBackend {
                     let job_id = jobs.get(&ep.pmc_mac).and_then(|jobs| {
                         jobs.iter().find_map(|job| match job {
                             RmsTrackedFirmwareJob::FirmwareObject(job_id) => Some(job_id.clone()),
-                            RmsTrackedFirmwareJob::SwitchSystemImage { .. } => None,
+                            RmsTrackedFirmwareJob::SwitchSystemImage(_) => None,
                         })
                     });
                     (ep.pmc_mac, job_id)
@@ -556,7 +758,7 @@ impl PowerShelfManager for RmsBackend {
                 results.push(PowerShelfFirmwareVersions {
                     pmc_mac: ep.pmc_mac,
                     versions: vec![],
-                    error: Some("could not resolve RMS identity from database".into()),
+                    error: Some(RMS_IDENTITY_LOOKUP_ERROR.into()),
                 });
                 continue;
             };
@@ -617,20 +819,27 @@ impl PowerShelfManager for RmsBackend {
         let mut results = Vec::with_capacity(endpoints.len());
 
         for ep in endpoints {
-            let Some(identity) = ids.get(&ep.pmc_mac) else {
-                results.push(PowerShelfPowerStateResult {
-                    pmc_mac: ep.pmc_mac,
-                    power_state: None,
-                    error: Some("could not resolve RMS identity from database".into()),
-                });
-                continue;
+            let resolved = match self.resolve_switch_or_power_shelf_node(
+                &ids,
+                ep.pmc_mac,
+                SwitchOrPowerShelfRole::PowerShelf,
+            ) {
+                Ok(resolved) => resolved,
+                Err(error) => {
+                    results.push(PowerShelfPowerStateResult {
+                        pmc_mac: ep.pmc_mac,
+                        power_state: None,
+                        error: Some(error),
+                    });
+                    continue;
+                }
             };
 
-            let device = build_power_shelf_node_info(ep, identity);
+            let device = build_power_shelf_node_info(ep, resolved.identity, resolved.node_type);
             let observed = query_rms_power_state(
                 self.client.as_ref(),
                 device,
-                &identity.node_id,
+                &resolved.identity.node_id,
                 ep.pmc_mac,
                 "power shelf",
             )
@@ -687,11 +896,15 @@ fn credentials_to_rms(creds: &Credentials) -> rms::Credentials {
 /// `BatchSetPowerState` request. The caller-supplied variant of the
 /// RPC requires the BMC connection details inline rather than relying on
 /// RMS's inventory; the NVOS host endpoint is included for completeness.
-fn build_switch_node_info(ep: &SwitchEndpoint, identity: &RmsIdentity) -> rms::NodeInfo {
+fn build_switch_node_info(
+    ep: &SwitchEndpoint,
+    identity: &RmsIdentity,
+    node_type: rms::NodeType,
+) -> rms::NodeInfo {
     rms::NodeInfo {
         node_id: identity.node_id.clone(),
         rack_id: identity.rack_id.clone(),
-        r#type: Some(RMS_SWITCH_NODE_TYPE as i32),
+        r#type: Some(node_type as i32),
         bmc_endpoint: Some(rms::Endpoint {
             interface: Some(rms::NetworkInterface {
                 ip_address: ep.bmc_ip.to_string(),
@@ -814,13 +1027,6 @@ async fn query_rms_power_state(
     }
 }
 
-fn rms_access_token_or_noauth(access_token: Option<&str>) -> String {
-    access_token
-        .filter(|token| !token.trim().is_empty())
-        .unwrap_or(RMS_NOAUTH_ACCESS_TOKEN)
-        .to_string()
-}
-
 fn apply_firmware_object_request(
     device: rms::NodeInfo,
     identity: &RmsIdentity,
@@ -829,7 +1035,7 @@ fn apply_firmware_object_request(
     node_type: rms::NodeType,
     components: Vec<String>,
 ) -> Result<rms::ApplyFirmwareObjectRequest, ComponentManagerError> {
-    let access_token = rms_access_token_or_noauth(options.access_token.as_deref());
+    let access_token = Some(rms_access_token_or_noauth(options.access_token.as_deref()));
 
     if config_json.trim().is_empty() {
         return Err(ComponentManagerError::InvalidArgument(
@@ -863,7 +1069,7 @@ fn apply_switch_system_image_request(
     config_json: &str,
     options: &FirmwareUpdateOptions,
 ) -> Result<rms::ApplySwitchSystemImageRequest, ComponentManagerError> {
-    let access_token = rms_access_token_or_noauth(options.access_token.as_deref());
+    let access_token = Some(rms_access_token_or_noauth(options.access_token.as_deref()));
 
     if config_json.trim().is_empty() {
         return Err(ComponentManagerError::InvalidArgument(
@@ -939,11 +1145,12 @@ fn build_compute_tray_node_info(
     ep: &ComputeTrayEndpoint,
     identity: &RmsIdentity,
     bmc_mac: MacAddress,
+    node_type: rms::NodeType,
 ) -> rms::NodeInfo {
     rms::NodeInfo {
         node_id: identity.node_id.clone(),
         rack_id: identity.rack_id.clone(),
-        r#type: Some(RMS_COMPUTE_NODE_TYPE as i32),
+        r#type: Some(node_type as i32),
         bmc_endpoint: Some(rms::Endpoint {
             interface: Some(rms::NetworkInterface {
                 ip_address: ep.bmc_ip.to_string(),
@@ -1073,11 +1280,7 @@ async fn query_tracked_firmware_job_status(
                 Err(e) => (FirmwareState::Unknown, Some(e.to_string())),
             }
         }
-        RmsTrackedFirmwareJob::SwitchSystemImage {
-            job_id,
-            rack_id: _,
-            node_id: _,
-        } => {
+        RmsTrackedFirmwareJob::SwitchSystemImage(job_id) => {
             let Some(client) = switch_system_image_client else {
                 return (
                     FirmwareState::Unknown,
@@ -1142,16 +1345,23 @@ impl NvSwitchManager for RmsBackend {
         let mut results = Vec::with_capacity(endpoints.len());
 
         for ep in endpoints {
-            let Some(identity) = ids.get(&ep.bmc_mac) else {
-                results.push(SwitchComponentResult {
-                    bmc_mac: ep.bmc_mac,
-                    success: false,
-                    error: Some("could not resolve RMS identity from database".into()),
-                });
-                continue;
+            let resolved = match self.resolve_switch_or_power_shelf_node(
+                &ids,
+                ep.bmc_mac,
+                SwitchOrPowerShelfRole::Switch,
+            ) {
+                Ok(resolved) => resolved,
+                Err(error) => {
+                    results.push(SwitchComponentResult {
+                        bmc_mac: ep.bmc_mac,
+                        success: false,
+                        error: Some(error),
+                    });
+                    continue;
+                }
             };
 
-            let device = build_switch_node_info(ep, identity);
+            let device = build_switch_node_info(ep, resolved.identity, resolved.node_type);
             let request = rms::BatchSetPowerStateRequest {
                 nodes: Some(rms::NodeSet {
                     nodes: vec![device],
@@ -1204,13 +1414,20 @@ impl NvSwitchManager for RmsBackend {
         let mut results = Vec::with_capacity(endpoints.len());
 
         for ep in endpoints {
-            let Some(identity) = ids.get(&ep.bmc_mac) else {
-                results.push(SwitchComponentResult {
-                    bmc_mac: ep.bmc_mac,
-                    success: false,
-                    error: Some("could not resolve RMS identity from database".into()),
-                });
-                continue;
+            let resolved = match self.resolve_switch_or_power_shelf_node(
+                &ids,
+                ep.bmc_mac,
+                SwitchOrPowerShelfRole::Switch,
+            ) {
+                Ok(resolved) => resolved,
+                Err(error) => {
+                    results.push(SwitchComponentResult {
+                        bmc_mac: ep.bmc_mac,
+                        success: false,
+                        error: Some(error),
+                    });
+                    continue;
+                }
             };
 
             let mut success = true;
@@ -1218,13 +1435,13 @@ impl NvSwitchManager for RmsBackend {
             let mut tracked_jobs = Vec::new();
 
             if include_firmware_object {
-                let device = build_switch_node_info(ep, identity);
+                let device = build_switch_node_info(ep, resolved.identity, resolved.node_type);
                 match apply_firmware_object_request(
                     device,
-                    identity,
+                    resolved.identity,
                     bundle_version,
                     options,
-                    rms::NodeType::Switch,
+                    resolved.node_type,
                     component_filters.clone(),
                 ) {
                     Ok(request) => match self.client.apply_firmware_object(request).await {
@@ -1232,7 +1449,7 @@ impl NvSwitchManager for RmsBackend {
                             let (operation_success, error, job_id) =
                                 summarize_firmware_object_apply_response(
                                     response,
-                                    &identity.node_id,
+                                    &resolved.identity.node_id,
                                 );
 
                             if !operation_success {
@@ -1271,14 +1488,19 @@ impl NvSwitchManager for RmsBackend {
             }
 
             if include_system_image {
-                let device = build_switch_node_info(ep, identity);
-                match apply_switch_system_image_request(device, identity, bundle_version, options) {
+                let device = build_switch_node_info(ep, resolved.identity, resolved.node_type);
+                match apply_switch_system_image_request(
+                    device,
+                    resolved.identity,
+                    bundle_version,
+                    options,
+                ) {
                     Ok(request) => match self.client.apply_switch_system_image(request).await {
                         Ok(response) => {
                             let (operation_success, error, job_id) =
                                 summarize_switch_system_image_apply_response(
                                     response,
-                                    &identity.node_id,
+                                    &resolved.identity.node_id,
                                 );
 
                             if !operation_success {
@@ -1289,11 +1511,8 @@ impl NvSwitchManager for RmsBackend {
                             }
                             if operation_success {
                                 if let Some(job_id) = job_id {
-                                    tracked_jobs.push(RmsTrackedFirmwareJob::SwitchSystemImage {
-                                        job_id,
-                                        rack_id: identity.rack_id.clone(),
-                                        node_id: identity.node_id.clone(),
-                                    });
+                                    tracked_jobs
+                                        .push(RmsTrackedFirmwareJob::SwitchSystemImage(job_id));
                                 }
                             } else if job_id.is_some() {
                                 tracing::debug!(
@@ -1410,20 +1629,27 @@ impl NvSwitchManager for RmsBackend {
         let mut results = Vec::with_capacity(endpoints.len());
 
         for ep in endpoints {
-            let Some(identity) = ids.get(&ep.bmc_mac) else {
-                results.push(SwitchPowerStateResult {
-                    bmc_mac: ep.bmc_mac,
-                    power_state: None,
-                    error: Some("could not resolve RMS identity from database".into()),
-                });
-                continue;
+            let resolved = match self.resolve_switch_or_power_shelf_node(
+                &ids,
+                ep.bmc_mac,
+                SwitchOrPowerShelfRole::Switch,
+            ) {
+                Ok(resolved) => resolved,
+                Err(error) => {
+                    results.push(SwitchPowerStateResult {
+                        bmc_mac: ep.bmc_mac,
+                        power_state: None,
+                        error: Some(error),
+                    });
+                    continue;
+                }
             };
 
-            let device = build_switch_node_info(ep, identity);
+            let device = build_switch_node_info(ep, resolved.identity, resolved.node_type);
             let observed = query_rms_power_state(
                 self.client.as_ref(),
                 device,
-                &identity.node_id,
+                &resolved.identity.node_id,
                 ep.bmc_mac,
                 "switch",
             )
@@ -1448,17 +1674,24 @@ impl NvSwitchManager for RmsBackend {
         let mut results = Vec::with_capacity(endpoints.len());
 
         for ep in endpoints {
-            let Some(identity) = ids.get(&ep.bmc_mac) else {
-                results.push(SwitchSlotAndTrayResult {
-                    bmc_mac: ep.bmc_mac,
-                    slot_number: None,
-                    tray_index: None,
-                    error: Some("could not resolve RMS identity from database".into()),
-                });
-                continue;
+            let resolved = match self.resolve_switch_or_power_shelf_node(
+                &ids,
+                ep.bmc_mac,
+                SwitchOrPowerShelfRole::Switch,
+            ) {
+                Ok(resolved) => resolved,
+                Err(error) => {
+                    results.push(SwitchSlotAndTrayResult {
+                        bmc_mac: ep.bmc_mac,
+                        slot_number: None,
+                        tray_index: None,
+                        error: Some(error),
+                    });
+                    continue;
+                }
             };
 
-            let device = build_switch_node_info(ep, identity);
+            let device = build_switch_node_info(ep, resolved.identity, resolved.node_type);
             let request = rms::BatchGetNodeDeviceInfoRequest {
                 nodes: Some(rms::NodeSet {
                     nodes: vec![device],
@@ -1554,7 +1787,24 @@ impl ComputeTrayManager for RmsBackend {
                 continue;
             };
 
-            let device = build_compute_tray_node_info(ep, &identity.identity, identity.bmc_mac);
+            let resolved = match self.resolve_compute_node(identity) {
+                Ok(resolved) => resolved,
+                Err(error) => {
+                    results.push(ComputeTrayResult {
+                        bmc_ip: ep.bmc_ip,
+                        success: false,
+                        error: Some(error),
+                    });
+                    continue;
+                }
+            };
+
+            let device = build_compute_tray_node_info(
+                ep,
+                resolved.identity,
+                identity.bmc_mac,
+                resolved.node_type,
+            );
             let request = rms::BatchSetPowerStateRequest {
                 nodes: Some(rms::NodeSet {
                     nodes: vec![device],
@@ -1613,13 +1863,30 @@ impl ComputeTrayManager for RmsBackend {
                 continue;
             };
 
-            let device = build_compute_tray_node_info(ep, &identity.identity, identity.bmc_mac);
+            let resolved = match self.resolve_compute_node(identity) {
+                Ok(resolved) => resolved,
+                Err(error) => {
+                    results.push(ComputeTrayResult {
+                        bmc_ip: ep.bmc_ip,
+                        success: false,
+                        error: Some(error),
+                    });
+                    continue;
+                }
+            };
+
+            let device = build_compute_tray_node_info(
+                ep,
+                resolved.identity,
+                identity.bmc_mac,
+                resolved.node_type,
+            );
             let request = match apply_firmware_object_request(
                 device,
-                &identity.identity,
+                resolved.identity,
                 target_version,
                 options,
-                RMS_COMPUTE_NODE_TYPE,
+                resolved.node_type,
                 component_filters.clone(),
             ) {
                 Ok(request) => request,
@@ -1637,7 +1904,7 @@ impl ComputeTrayManager for RmsBackend {
                 Ok(response) => {
                     let (success, error, job_id) = summarize_firmware_object_apply_response(
                         response,
-                        &identity.identity.node_id,
+                        &resolved.identity.node_id,
                     );
 
                     if success {
@@ -1696,7 +1963,7 @@ impl ComputeTrayManager for RmsBackend {
                                 RmsTrackedFirmwareJob::FirmwareObject(job_id) => {
                                     Some(job_id.clone())
                                 }
-                                RmsTrackedFirmwareJob::SwitchSystemImage { .. } => None,
+                                RmsTrackedFirmwareJob::SwitchSystemImage(_) => None,
                             })
                         })
                     });
@@ -1777,6 +2044,10 @@ mod tests {
     use carbide_uuid::power_shelf::PowerShelfId;
     use carbide_uuid::rack::RackId;
     use carbide_uuid::switch::SwitchId;
+    use model::rack_type::{
+        RackCapabilitiesSet, RackCapabilityCompute, RackCapabilityPowerShelf, RackCapabilitySwitch,
+        RackHardwareTopology, RackProductFamily, RackProfile, RackProfileConfig,
+    };
 
     use super::*;
     use crate::compute_tray_manager::{ComputeTrayManager, ComputeTrayVendor};
@@ -1792,8 +2063,8 @@ mod tests {
         }
     }
     use crate::test_support::{
-        CT_IP_1, CT_IP_2, CT_MAC_1, CT_MAC_2, PS_MAC_1, PS_MAC_2, SW_MAC_1, SW_MAC_2, UNKNOWN_MAC,
-        seed_machine, seed_test_data,
+        CT_IP_1, CT_IP_2, CT_MAC_1, CT_MAC_2, PS_MAC_1, PS_MAC_2, SW_MAC_1, SW_MAC_2,
+        TEST_RACK_PROFILE_ID, UNKNOWN_MAC, seed_machine, seed_test_data,
     };
 
     // ---- Mapping unit tests ----
@@ -2035,6 +2306,35 @@ mod tests {
         }
     }
 
+    fn rack_profile_config() -> RackProfileConfig {
+        RackProfileConfig {
+            rack_profiles: [(
+                TEST_RACK_PROFILE_ID.to_string(),
+                RackProfile {
+                    product_family: Some(RackProductFamily::Gb200),
+                    rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
+                    rack_capabilities: RackCapabilitiesSet {
+                        compute: RackCapabilityCompute {
+                            vendor: Some("NVIDIA".to_string()),
+                            ..Default::default()
+                        },
+                        switch: RackCapabilitySwitch {
+                            vendor: Some("NVIDIA".to_string()),
+                            ..Default::default()
+                        },
+                        power_shelf: RackCapabilityPowerShelf {
+                            vendor: Some("LiteOn".to_string()),
+                            ..Default::default()
+                        },
+                    },
+                    ..Default::default()
+                },
+            )]
+            .into_iter()
+            .collect(),
+        }
+    }
+
     /// Create a backend with a real DB pool seeded with test data.
     async fn make_backend(
         pool: &sqlx::PgPool,
@@ -2049,7 +2349,12 @@ mod tests {
     ) {
         let (rack_id, ps1, ps2, sw1, sw2) = seed_test_data(pool).await;
         let mock = Arc::new(MockRmsApi::new());
-        let backend = RmsBackend::new(mock.clone(), Some(mock.clone()), pool.clone());
+        let backend = RmsBackend::new(
+            mock.clone(),
+            Some(mock.clone()),
+            pool.clone(),
+            Arc::new(rack_profile_config()),
+        );
         (mock, backend, rack_id, ps1, ps2, sw1, sw2)
     }
 
@@ -2058,10 +2363,11 @@ mod tests {
     ) -> (Arc<MockRmsApi>, RmsBackend, RackId, MachineId, MachineId) {
         let mut txn = pool.begin().await.unwrap();
         let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
+        let rack_profile_id = RackProfileId::new(TEST_RACK_PROFILE_ID);
         db::rack::create(
             &mut txn,
             &rack_id,
-            None,
+            Some(&rack_profile_id),
             &model::rack::RackConfig::default(),
             None,
         )
@@ -2072,7 +2378,12 @@ mod tests {
         txn.commit().await.unwrap();
 
         let mock = Arc::new(MockRmsApi::new());
-        let backend = RmsBackend::new(mock.clone(), Some(mock.clone()), pool.clone());
+        let backend = RmsBackend::new(
+            mock.clone(),
+            Some(mock.clone()),
+            pool.clone(),
+            Arc::new(rack_profile_config()),
+        );
         (mock, backend, rack_id, ct1, ct2)
     }
 
@@ -2106,6 +2417,52 @@ mod tests {
             .components
     }
 
+    fn single_batch_set_power_state_node_type(
+        calls: &[rms::BatchSetPowerStateRequest],
+    ) -> Option<i32> {
+        let [call] = calls else {
+            return None;
+        };
+        let nodes = call.nodes.as_ref()?;
+        let [node] = nodes.nodes.as_slice() else {
+            return None;
+        };
+
+        node.r#type
+    }
+
+    #[test]
+    fn direct_rms_power_shelf_node_info_uses_concrete_node_type() {
+        let endpoint = make_ps_endpoint(PS_MAC_1);
+        let identity = RmsIdentity {
+            node_id: "node-1".to_string(),
+            rack_id: "rack-1".to_string(),
+            rack_profile_id: None,
+        };
+
+        let node =
+            build_power_shelf_node_info(&endpoint, &identity, rms::NodeType::PowershelfGb300Delta);
+
+        assert_eq!(
+            node.r#type,
+            Some(rms::NodeType::PowershelfGb300Delta as i32)
+        );
+    }
+
+    #[test]
+    fn direct_rms_switch_node_info_uses_concrete_node_type() {
+        let endpoint = make_sw_endpoint(SW_MAC_1);
+        let identity = RmsIdentity {
+            node_id: "node-1".to_string(),
+            rack_id: "rack-1".to_string(),
+            rack_profile_id: None,
+        };
+
+        let node = build_switch_node_info(&endpoint, &identity, rms::NodeType::SwitchGb300Nvidia);
+
+        assert_eq!(node.r#type, Some(rms::NodeType::SwitchGb300Nvidia as i32));
+    }
+
     #[test]
     fn direct_rms_firmware_object_json_request_defaults_missing_access_token_to_noauth() {
         let request = apply_firmware_object_request(
@@ -2113,18 +2470,50 @@ mod tests {
             &RmsIdentity {
                 node_id: "node-1".to_string(),
                 rack_id: "rack-1".to_string(),
+                rack_profile_id: None,
             },
             r#"{"Id":"fw-json"}"#,
             &FirmwareUpdateOptions {
                 access_token: None,
                 force_update: false,
             },
-            rms::NodeType::Switch,
+            rms::NodeType::SwitchGb200Nvidia,
             Vec::new(),
         )
         .unwrap();
 
-        assert_eq!(request.access_token, RMS_NOAUTH_ACCESS_TOKEN);
+        assert_eq!(
+            request.access_token.as_deref(),
+            Some(carbide_rack::firmware_object::RMS_NOAUTH_ACCESS_TOKEN)
+        );
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn power_shelf_power_control_request_uses_profile_vendor_node_type(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (mock, backend, _, ps1, _, _, _) = make_backend(&pool).await;
+
+        mock.enqueue_batch_set_power_state(Ok(MockRmsApi::batch_set_power_state_ok(
+            &ps1.to_string(),
+        )))
+        .await;
+        let results = PowerShelfManager::power_control(
+            &backend,
+            &[make_ps_endpoint(PS_MAC_1)],
+            PowerAction::On,
+        )
+        .await?;
+
+        assert!(results[0].success);
+
+        let calls = mock.batch_set_power_state_calls().await;
+        assert_eq!(
+            single_batch_set_power_state_node_type(&calls),
+            Some(rms::NodeType::PowershelfGb200Liteon as i32)
+        );
+
+        Ok(())
     }
 
     #[test]
@@ -2134,6 +2523,7 @@ mod tests {
             &RmsIdentity {
                 node_id: "node-1".to_string(),
                 rack_id: "rack-1".to_string(),
+                rack_profile_id: None,
             },
             r#"{"Id":"fw-json"}"#,
             &FirmwareUpdateOptions {
@@ -2143,7 +2533,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(request.access_token, RMS_NOAUTH_ACCESS_TOKEN);
+        assert_eq!(
+            request.access_token.as_deref(),
+            Some(carbide_rack::firmware_object::RMS_NOAUTH_ACCESS_TOKEN)
+        );
     }
 
     // ---- PowerShelfManager tests ----
@@ -2175,7 +2568,10 @@ mod tests {
         let dev0 = &calls[0].nodes.as_ref().unwrap().nodes[0];
         assert_eq!(dev0.node_id, ps1.to_string());
         assert_eq!(dev0.rack_id, rack_id.to_string());
-        assert_eq!(dev0.r#type, Some(rms::NodeType::Powershelf as i32));
+        assert_eq!(
+            dev0.r#type,
+            Some(rms::NodeType::PowershelfGb200Liteon as i32)
+        );
         assert!(dev0.bmc_endpoint.is_some());
         assert!(dev0.host_endpoint.is_none());
         let dev1 = &calls[1].nodes.as_ref().unwrap().nodes[0];
@@ -2286,16 +2682,19 @@ mod tests {
         let calls = mock.apply_firmware_object_calls().await;
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].config_json, r#"{"Id":"fw-json"}"#);
-        assert_eq!(calls[0].access_token, "token");
+        assert_eq!(calls[0].access_token.as_deref(), Some("token"));
         assert_eq!(calls[0].firmware_type, "prod");
         assert_eq!(calls[0].hardware_type, "any");
         assert!(calls[0].force_update);
-        let filters = component_filters_for(&calls[0], rms::NodeType::Powershelf);
+        let filters = component_filters_for(&calls[0], rms::NodeType::PowershelfGb200Liteon);
         assert_eq!(filters, ["PowerShelfFW"]);
         let dev0 = &calls[0].nodes.as_ref().unwrap().nodes[0];
         assert_eq!(dev0.node_id, ps1.to_string());
         assert_eq!(dev0.rack_id, rack_id.to_string());
-        assert_eq!(dev0.r#type, Some(rms::NodeType::Powershelf as i32));
+        assert_eq!(
+            dev0.r#type,
+            Some(rms::NodeType::PowershelfGb200Liteon as i32)
+        );
         assert!(dev0.bmc_endpoint.is_some());
 
         let jobs = backend.firmware_jobs.lock().unwrap();
@@ -2336,7 +2735,7 @@ mod tests {
         assert!(results[0].success);
 
         let calls = mock.apply_firmware_object_calls().await;
-        let filters = component_filters_for(&calls[0], rms::NodeType::Powershelf);
+        let filters = component_filters_for(&calls[0], rms::NodeType::PowershelfGb200Liteon);
         assert_eq!(filters, ["PowerShelfFW"]);
     }
 
@@ -2654,7 +3053,7 @@ mod tests {
         let dev0 = &calls[0].nodes.as_ref().unwrap().nodes[0];
         assert_eq!(dev0.node_id, sw1.to_string());
         assert_eq!(dev0.rack_id, rack_id.to_string());
-        assert_eq!(dev0.r#type, Some(rms::NodeType::Switch as i32));
+        assert_eq!(dev0.r#type, Some(rms::NodeType::SwitchGb200Nvidia as i32));
         assert!(dev0.bmc_endpoint.is_some());
         let dev1 = &calls[1].nodes.as_ref().unwrap().nodes[0];
         assert_eq!(dev1.node_id, sw2.to_string());
@@ -2705,13 +3104,13 @@ mod tests {
 
         let calls = mock.apply_firmware_object_calls().await;
         assert_eq!(calls[0].config_json, r#"{"Id":"fw-json"}"#);
-        assert_eq!(calls[0].access_token, "token");
+        assert_eq!(calls[0].access_token.as_deref(), Some("token"));
         assert!(calls[0].force_update);
-        let filters = component_filters_for(&calls[0], rms::NodeType::Switch);
+        let filters = component_filters_for(&calls[0], rms::NodeType::SwitchGb200Nvidia);
         assert_eq!(filters, ["BMC", "BIOS"]);
         let dev0 = &calls[0].nodes.as_ref().unwrap().nodes[0];
         assert_eq!(dev0.node_id, sw1.to_string());
-        assert_eq!(dev0.r#type, Some(rms::NodeType::Switch as i32));
+        assert_eq!(dev0.r#type, Some(rms::NodeType::SwitchGb200Nvidia as i32));
         assert!(dev0.bmc_endpoint.is_some());
         assert!(dev0.host_endpoint.is_some());
 
@@ -2790,30 +3189,28 @@ mod tests {
         let calls = mock.apply_switch_system_image_calls().await;
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].config_json, r#"{"Id":"fw-json"}"#);
-        assert_eq!(calls[0].access_token, "token");
+        assert_eq!(calls[0].access_token.as_deref(), Some("token"));
         assert_eq!(calls[0].software_type, "prod");
         assert_eq!(calls[0].hardware_type, "any");
         assert_eq!(calls[0].rack_id, rack_id.to_string());
         let dev0 = &calls[0].nodes.as_ref().unwrap().nodes[0];
         assert_eq!(dev0.node_id, sw1.to_string());
-        assert_eq!(dev0.r#type, Some(rms::NodeType::Switch as i32));
+        assert_eq!(dev0.r#type, Some(rms::NodeType::SwitchGb200Nvidia as i32));
         assert!(dev0.bmc_endpoint.is_some());
         assert!(dev0.host_endpoint.is_some());
 
         let jobs = backend.firmware_jobs.lock().unwrap();
         assert_eq!(
             jobs.get(&SW_MAC_1.parse::<MacAddress>().unwrap()),
-            Some(&vec![RmsTrackedFirmwareJob::SwitchSystemImage {
-                job_id: "nvos-job-1".to_string(),
-                rack_id: rack_id.to_string(),
-                node_id: sw1.to_string(),
-            }])
+            Some(&vec![RmsTrackedFirmwareJob::SwitchSystemImage(
+                "nvos-job-1".to_string()
+            )])
         );
     }
 
     #[carbide_macros::sqlx_test]
     async fn sw_queue_firmware_updates_mixed_tracks_both_jobs(pool: sqlx::PgPool) {
-        let (mock, backend, rack_id, _, _, sw1, _) = make_backend(&pool).await;
+        let (mock, backend, _, _, _, sw1, _) = make_backend(&pool).await;
         mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_ok(
             &sw1.to_string(),
             "sw-fw-job",
@@ -2846,11 +3243,7 @@ mod tests {
                 jobs.get(&SW_MAC_1.parse::<MacAddress>().unwrap()),
                 Some(&vec![
                     RmsTrackedFirmwareJob::FirmwareObject("sw-fw-job".to_string()),
-                    RmsTrackedFirmwareJob::SwitchSystemImage {
-                        job_id: "sw-nvos-job".to_string(),
-                        rack_id: rack_id.to_string(),
-                        node_id: sw1.to_string(),
-                    },
+                    RmsTrackedFirmwareJob::SwitchSystemImage("sw-nvos-job".to_string()),
                 ])
             );
         }
@@ -3053,7 +3446,7 @@ mod tests {
         let dev0 = &calls[0].nodes.as_ref().unwrap().nodes[0];
         assert_eq!(dev0.node_id, ct1.to_string());
         assert_eq!(dev0.rack_id, rack_id.to_string());
-        assert_eq!(dev0.r#type, Some(rms::NodeType::Compute as i32));
+        assert_eq!(dev0.r#type, Some(rms::NodeType::ComputeGb200Nvidia as i32));
         assert!(dev0.bmc_endpoint.is_some());
         assert!(dev0.host_endpoint.is_none());
     }
@@ -3083,10 +3476,10 @@ mod tests {
         let calls = mock.apply_firmware_object_calls().await;
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].rack_id, rack_id.to_string());
-        let filters = component_filters_for(&calls[0], rms::NodeType::Compute);
+        let filters = component_filters_for(&calls[0], rms::NodeType::ComputeGb200Nvidia);
         assert_eq!(filters, &["BMC".to_owned()]);
         let dev0 = &calls[0].nodes.as_ref().unwrap().nodes[0];
-        assert_eq!(dev0.r#type, Some(rms::NodeType::Compute as i32));
+        assert_eq!(dev0.r#type, Some(rms::NodeType::ComputeGb200Nvidia as i32));
 
         let jobs = backend.firmware_jobs.lock().unwrap();
         assert_eq!(

--- a/crates/component-manager/src/test_support.rs
+++ b/crates/component-manager/src/test_support.rs
@@ -6,7 +6,7 @@ use std::net::IpAddr;
 use carbide_uuid::machine::{MachineId, MachineIdSource, MachineInterfaceId, MachineType};
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::power_shelf::{PowerShelfId, PowerShelfIdSource, PowerShelfType};
-use carbide_uuid::rack::RackId;
+use carbide_uuid::rack::{RackId, RackProfileId};
 use carbide_uuid::switch::{SwitchId, SwitchIdSource, SwitchType};
 use mac_address::MacAddress;
 use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
@@ -28,6 +28,7 @@ pub(crate) const CT_MAC_2: &str = "AA:BB:CC:DD:CC:02";
 pub(crate) const CT_IP_1: &str = "10.0.1.1";
 pub(crate) const CT_IP_2: &str = "10.0.1.2";
 pub(crate) const UNKNOWN_MAC: &str = "FF:FF:FF:FF:FF:FF";
+pub(crate) const TEST_RACK_PROFILE_ID: &str = "NVL72";
 
 pub(crate) fn test_power_shelf_id(label: &str) -> PowerShelfId {
     let mut hash = [0u8; 32];
@@ -67,9 +68,16 @@ pub(crate) async fn seed_test_data(
     let mut txn = pool.begin().await.unwrap();
 
     let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
-    let rack = db::rack::create(&mut txn, &rack_id, None, &RackConfig::default(), None)
-        .await
-        .expect("failed to create rack");
+    let rack_profile_id = RackProfileId::new(TEST_RACK_PROFILE_ID);
+    let rack = db::rack::create(
+        &mut txn,
+        &rack_id,
+        Some(&rack_profile_id),
+        &RackConfig::default(),
+        None,
+    )
+    .await
+    .expect("failed to create rack");
 
     let ps1 = seed_power_shelf(&mut txn, PS_MAC_1, "PS-001", &rack_id).await;
     let ps2 = seed_power_shelf(&mut txn, PS_MAC_2, "PS-002", &rack_id).await;

--- a/crates/rack-controller/src/fabric_manager.rs
+++ b/crates/rack-controller/src/fabric_manager.rs
@@ -56,12 +56,13 @@ pub(super) fn validate_switch_inventory_for_nmx_cluster(
 fn build_scale_up_fabric_services_status_request(
     rack_id: &RackId,
     switches: &[FirmwareUpgradeDeviceInfo],
+    node_type: rms::NodeType,
 ) -> rms::BatchGetScaleUpFabricServiceStatusRequest {
     rms::BatchGetScaleUpFabricServiceStatusRequest {
         nodes: Some(rms::NodeSet {
             nodes: switches
                 .iter()
-                .map(|switch| build_new_node_info(rack_id, switch, rms::NodeType::Switch))
+                .map(|switch| build_new_node_info(rack_id, switch, node_type))
                 .collect(),
         }),
     }
@@ -71,6 +72,7 @@ pub(super) async fn batch_get_scale_up_fabric_service_status(
     rms_config: &RmsConfig,
     rack_id: &RackId,
     switches: &[FirmwareUpgradeDeviceInfo],
+    node_type: rms::NodeType,
 ) -> Result<rms::BatchGetScaleUpFabricServiceStatusResponse, String> {
     let Some(url) = rms_config.api_url.as_deref().filter(|url| !url.is_empty()) else {
         return Err("RMS client not configured".to_string());
@@ -88,7 +90,7 @@ pub(super) async fn batch_get_scale_up_fabric_service_status(
     rms_client
         .client
         .batch_get_scale_up_fabric_service_status(build_scale_up_fabric_services_status_request(
-            rack_id, switches,
+            rack_id, switches, node_type,
         ))
         .await
         .map_err(|error| format!("RMS BatchGetScaleUpFabricServiceStatus failed: {}", error))

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -19,6 +19,7 @@
 
 use carbide_rack::firmware_object::{
     ANY_RACK_HARDWARE_TYPE, profile_hardware_type_wire_value, rack_maintenance_access_token_key,
+    rms_access_token_or_noauth,
 };
 use carbide_rack::firmware_update::{
     RackFirmwareInventory, RackSwitchFirmwareInventory, build_new_node_info,
@@ -26,6 +27,7 @@ use carbide_rack::firmware_update::{
 };
 use carbide_rack::rack_manager_error;
 use carbide_rack::rms_client::SwitchSystemImageRmsClient;
+use carbide_rack::rms_node_type::{compute_node_type_for_profile, switch_node_type_for_profile};
 use carbide_rack_controller::config::RmsConfig;
 use carbide_rack_controller::context::RackStateHandlerContextObjects;
 use carbide_rack_controller::fabric_manager::{
@@ -438,12 +440,13 @@ fn skip_configure_nmx_cluster_outcome(
 fn build_switch_device_info_request(
     rack_id: &RackId,
     switches: &[FirmwareUpgradeDeviceInfo],
+    node_type: rms::NodeType,
 ) -> rms::BatchGetNodeDeviceInfoRequest {
     rms::BatchGetNodeDeviceInfoRequest {
         nodes: Some(rms::NodeSet {
             nodes: switches
                 .iter()
-                .map(|switch| build_new_node_info(rack_id, switch, rms::NodeType::Switch))
+                .map(|switch| build_new_node_info(rack_id, switch, node_type))
                 .collect(),
         }),
     }
@@ -469,25 +472,25 @@ fn build_nmx_configure_rms_client(rms_config: &RmsConfig) -> Option<librms::Rack
 
 fn rms_component_filters_from_components(
     components: &[String],
-    include_machines: bool,
-    include_switches: bool,
+    compute_node_type: Option<rms::NodeType>,
+    switch_node_type: Option<rms::NodeType>,
 ) -> std::collections::HashMap<i32, rms::FirmwareObjectComponentFilter> {
     if components.is_empty() {
         return std::collections::HashMap::new();
     }
 
     let mut filters = std::collections::HashMap::new();
-    if include_machines {
+    if let Some(compute_node_type) = compute_node_type {
         filters.insert(
-            rms::NodeType::Compute as i32,
+            compute_node_type as i32,
             rms::FirmwareObjectComponentFilter {
                 components: components.to_vec(),
             },
         );
     }
-    if include_switches {
+    if let Some(switch_node_type) = switch_node_type {
         filters.insert(
-            rms::NodeType::Switch as i32,
+            switch_node_type as i32,
             rms::FirmwareObjectComponentFilter {
                 components: components.to_vec(),
             },
@@ -532,6 +535,7 @@ fn firmware_device_status(
 
 struct RmsFirmwareObjectJsonApply<'a> {
     rack_id: &'a RackId,
+    profile: &'a RackProfile,
     config_json: &'a str,
     access_token: &'a str,
     firmware_type: &'a str,
@@ -550,32 +554,65 @@ async fn rms_start_firmware_upgrade_from_json(
     let machine_count = request.machines.len();
     let switch_count = request.switches.len();
     let mut nodes = Vec::with_capacity(machine_count + switch_count);
-    nodes.extend(
-        request
-            .machines
-            .iter()
-            .map(|device| build_new_node_info(request.rack_id, device, rms::NodeType::Compute)),
-    );
-    nodes.extend(
-        request
-            .switches
-            .iter()
-            .map(|device| build_new_node_info(request.rack_id, device, rms::NodeType::Switch)),
-    );
+
+    // Resolve all required node types before constructing the RMS request so a
+    // mixed-device update fails before any partial firmware submission.
+    let compute_node_type = if machine_count > 0 {
+        Some(
+            compute_node_type_for_profile(request.profile).map_err(|error| {
+                StateHandlerError::GenericError(eyre::eyre!(
+                    "failed to resolve RMS compute node type: {}",
+                    error
+                ))
+            })?,
+        )
+    } else {
+        None
+    };
+    let switch_node_type = if switch_count > 0 {
+        Some(
+            switch_node_type_for_profile(request.profile).map_err(|error| {
+                StateHandlerError::GenericError(eyre::eyre!(
+                    "failed to resolve RMS switch node type: {}",
+                    error
+                ))
+            })?,
+        )
+    } else {
+        None
+    };
+
+    if let Some(node_type) = compute_node_type {
+        nodes.extend(
+            request
+                .machines
+                .iter()
+                .map(|device| build_new_node_info(request.rack_id, device, node_type)),
+        );
+    }
+
+    if let Some(node_type) = switch_node_type {
+        nodes.extend(
+            request
+                .switches
+                .iter()
+                .map(|device| build_new_node_info(request.rack_id, device, node_type)),
+        );
+    }
 
     let response = rms_client
         .apply_firmware_object(rms::ApplyFirmwareObjectRequest {
             rack_id: request.rack_id.to_string(),
             config_json: request.config_json.to_string(),
-            access_token: request.access_token.to_string(),
+            access_token: Some(rms_access_token_or_noauth(Some(request.access_token))),
             firmware_type: request.firmware_type.to_string(),
             hardware_type: request.hardware_type.to_string(),
             nodes: Some(rms::NodeSet { nodes }),
             force_update: request.force_update,
             component_filters: rms_component_filters_from_components(
                 request.components,
-                machine_count > 0,
-                switch_count > 0,
+                compute_node_type,
+                switch_node_type,
             ),
         })
         .await
@@ -848,12 +885,13 @@ async fn rms_start_nvos_update(
     source: NvosUpdateSource<'_>,
     software_type: &str,
     hardware_type: &str,
+    switch_node_type: rms::NodeType,
     switches: Vec<FirmwareUpgradeDeviceInfo>,
 ) -> Result<NvosUpdateJob, StateHandlerError> {
     let started_at = chrono::Utc::now();
     let nodes: Vec<_> = switches
         .iter()
-        .map(|switch| build_new_node_info(rack_id, switch, rms::NodeType::Switch))
+        .map(|switch| build_new_node_info(rack_id, switch, switch_node_type))
         .collect();
     let nodes = Some(rms::NodeSet { nodes });
     let NvosUpdateSource {
@@ -864,7 +902,7 @@ async fn rms_start_nvos_update(
         .apply_switch_system_image(rms::ApplySwitchSystemImageRequest {
             rack_id: rack_id.to_string(),
             config_json: config_json.to_string(),
-            access_token: access_token.to_string(),
+            access_token: Some(rms_access_token_or_noauth(Some(access_token))),
             software_type: software_type.to_string(),
             hardware_type: hardware_type.to_string(),
             nodes,
@@ -1136,7 +1174,8 @@ pub async fn handle_maintenance(
                         scope,
                     ));
                 };
-                // Defensive: older persisted maintenance state may predate API-side JSON validation.
+                // Defensive: older persisted maintenance state may predate API-side JSON
+                // validation.
                 let Some(config_json) = config_json.filter(|json| !json.trim().is_empty()) else {
                     return transition_to_rack_error(
                         id,
@@ -1203,6 +1242,24 @@ pub async fn handle_maintenance(
                     ));
                 }
 
+                let Some(profile) = profile else {
+                    // Keep this aligned with the NVOS missing-profile path.
+                    // Startup validation deliberately does not scan rack rows,
+                    // so this call-time error still owns token cleanup.
+                    delete_rack_maintenance_access_token(
+                        ctx.services.credential_manager.as_ref(),
+                        id,
+                    )
+                    .await;
+                    return transition_to_rack_error(
+                        id,
+                        state,
+                        "rack profile is missing or unknown; cannot resolve RMS node types",
+                        ctx,
+                    )
+                    .await;
+                };
+
                 tracing::info!(
                     rack_id = %id,
                     firmware_type = %firmware_type,
@@ -1217,6 +1274,7 @@ pub async fn handle_maintenance(
                     rms_client.as_ref(),
                     RmsFirmwareObjectJsonApply {
                         rack_id: id,
+                        profile,
                         config_json: &config_json,
                         access_token: &access_token,
                         firmware_type: &firmware_type,
@@ -1531,6 +1589,31 @@ pub async fn handle_maintenance(
                         maintenance_state: next,
                     }));
                 }
+                let Some(profile) = profile else {
+                    delete_rack_maintenance_access_token(
+                        ctx.services.credential_manager.as_ref(),
+                        id,
+                    )
+                    .await;
+                    return transition_to_rack_error(
+                        id,
+                        state,
+                        "rack profile is missing or unknown; cannot resolve RMS switch node type",
+                        ctx,
+                    )
+                    .await;
+                };
+                let switch_node_type = match switch_node_type_for_profile(profile) {
+                    Ok(node_type) => node_type,
+                    Err(error) => {
+                        delete_rack_maintenance_access_token(
+                            ctx.services.credential_manager.as_ref(),
+                            id,
+                        )
+                        .await;
+                        return transition_to_rack_error(id, state, error.to_string(), ctx).await;
+                    }
+                };
 
                 tracing::info!(
                     rack_id = %id,
@@ -1571,6 +1654,7 @@ pub async fn handle_maintenance(
                     source,
                     software_type,
                     &rack_hardware_type,
+                    switch_node_type,
                     switch_inventory.switches,
                 )
                 .await;
@@ -1789,6 +1873,21 @@ pub async fn handle_maintenance(
                 {
                     return transition_to_rack_error(id, state, cause, ctx).await;
                 }
+                let Some(profile) = super::resolve_profile(id, rack_profile_id, ctx) else {
+                    return transition_to_rack_error(
+                        id,
+                        state,
+                        "rack profile is missing or unknown; cannot resolve RMS switch node type",
+                        ctx,
+                    )
+                    .await;
+                };
+                let switch_node_type = match switch_node_type_for_profile(profile) {
+                    Ok(node_type) => node_type,
+                    Err(error) => {
+                        return transition_to_rack_error(id, state, error.to_string(), ctx).await;
+                    }
+                };
 
                 tracing::info!(
                     rack_id = %id,
@@ -1801,9 +1900,7 @@ pub async fn handle_maintenance(
                             nodes: switch_inventory
                                 .switches
                                 .iter()
-                                .map(|switch| {
-                                    build_new_node_info(id, switch, rms::NodeType::Switch)
-                                })
+                                .map(|switch| build_new_node_info(id, switch, switch_node_type))
                                 .collect(),
                         }),
                         enabled: false,
@@ -1948,11 +2045,18 @@ pub async fn handle_maintenance(
                     )
                     .await;
                 };
+                let switch_node_type = match switch_node_type_for_profile(profile) {
+                    Ok(node_type) => node_type,
+                    Err(error) => {
+                        return transition_to_rack_error(id, state, error.to_string(), ctx).await;
+                    }
+                };
 
                 let response = match rms_client
                     .batch_get_node_device_info(build_switch_device_info_request(
                         id,
                         &switch_inventory.switches,
+                        switch_node_type,
                     ))
                     .await
                 {
@@ -1994,7 +2098,7 @@ pub async fn handle_maintenance(
                         node: Some(build_new_node_info(
                             id,
                             &primary_switch.device,
-                            rms::NodeType::Switch,
+                            switch_node_type,
                         )),
                         topology_type: topology_type.clone(),
                     })
@@ -2080,11 +2184,27 @@ pub async fn handle_maintenance(
                         scope,
                     ));
                 }
+                let Some(profile) = super::resolve_profile(id, rack_profile_id, ctx) else {
+                    return transition_to_rack_error(
+                        id,
+                        state,
+                        "rack profile is missing or unknown; cannot resolve RMS switch node type",
+                        ctx,
+                    )
+                    .await;
+                };
+                let switch_node_type = match switch_node_type_for_profile(profile) {
+                    Ok(node_type) => node_type,
+                    Err(error) => {
+                        return transition_to_rack_error(id, state, error.to_string(), ctx).await;
+                    }
+                };
 
                 let fabric_status_response = match batch_get_scale_up_fabric_service_status(
                     &ctx.services.site_config.rms,
                     id,
                     &switch_inventory.switches,
+                    switch_node_type,
                 )
                 .await
                 {

--- a/crates/rack/Cargo.toml
+++ b/crates/rack/Cargo.toml
@@ -45,6 +45,7 @@ opentelemetry = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/crates/rack/src/firmware_update.rs
+++ b/crates/rack/src/firmware_update.rs
@@ -28,6 +28,8 @@ use model::rack::FirmwareUpgradeDeviceInfo;
 use model::rack_type::{RackHardwareClass, RackProfile};
 use sqlx::PgPool;
 
+use crate::rms_node_type::is_switch_node_type;
+
 #[derive(Debug, Clone)]
 pub struct RackFirmwareInventory {
     pub machine_ids: Vec<carbide_uuid::machine::MachineId>,
@@ -226,7 +228,7 @@ pub fn build_new_node_info(
         })
     };
 
-    let host_endpoint = if matches!(node_type, rms::NodeType::Switch) {
+    let host_endpoint = if is_switch_node_type(node_type) {
         Some(rms::Endpoint {
             interface: build_host_interface(device),
             port: 0,

--- a/crates/rack/src/lib.rs
+++ b/crates/rack/src/lib.rs
@@ -22,6 +22,7 @@ pub mod bms_client;
 pub mod firmware_object;
 pub mod firmware_update;
 pub mod rms_client;
+pub mod rms_node_type;
 
 pub fn rack_manager_error(operation: &'static str, error: RackManagerError) -> StateHandlerError {
     ExternalServiceError::with_source(

--- a/crates/rack/src/rms_client.rs
+++ b/crates/rack/src/rms_client.rs
@@ -960,18 +960,6 @@ pub mod test_support {
         ) -> Result<rms::GetScaleUpFabricStateResponse, RackManagerError> {
             Ok(rms::GetScaleUpFabricStateResponse::default())
         }
-        async fn fetch_switch_system_image(
-            &self,
-            _cmd: rms::FetchSwitchSystemImageRequest,
-        ) -> Result<rms::FetchSwitchSystemImageResponse, RackManagerError> {
-            Ok(rms::FetchSwitchSystemImageResponse::default())
-        }
-        async fn install_switch_system_image(
-            &self,
-            _cmd: rms::InstallSwitchSystemImageRequest,
-        ) -> Result<rms::InstallSwitchSystemImageResponse, RackManagerError> {
-            Ok(rms::InstallSwitchSystemImageResponse::default())
-        }
         async fn list_switch_system_images(
             &self,
             _cmd: rms::ListSwitchSystemImagesRequest,

--- a/crates/rack/src/rms_node_type.rs
+++ b/crates/rack/src/rms_node_type.rs
@@ -1,0 +1,442 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use librms::protos::rack_manager as rms;
+use model::rack_type::{RackProductFamily, RackProfile};
+
+/// Power shelf vendors represented by RMS node type variants.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PowerShelfVendor {
+    /// LiteOn power shelf hardware.
+    Liteon,
+    /// Delta power shelf hardware.
+    Delta,
+}
+
+/// Error returned when local data cannot resolve an RMS node type.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum NodeTypeError {
+    /// The rack profile does not identify a product family needed by RMS.
+    #[error("rack profile does not identify an RMS product family")]
+    MissingProductFamily,
+    /// The configured vendor is not supported for the node role.
+    #[error("RMS does not support {role} vendor {vendor}")]
+    UnsupportedVendor { role: &'static str, vendor: String },
+}
+
+/// Resolves the RMS compute node type for a rack profile.
+pub fn compute_node_type_for_profile(
+    profile: &RackProfile,
+) -> Result<rms::NodeType, NodeTypeError> {
+    let product_family = profile
+        .product_family
+        .ok_or(NodeTypeError::MissingProductFamily)?;
+    let vendor = profile
+        .rack_capabilities
+        .compute
+        .vendor
+        .as_deref()
+        .map(str::trim)
+        .filter(|vendor| !vendor.is_empty());
+
+    compute_node_type(product_family, vendor)
+}
+
+/// Resolves the RMS switch node type for a rack profile.
+pub fn switch_node_type_for_profile(profile: &RackProfile) -> Result<rms::NodeType, NodeTypeError> {
+    let product_family = profile
+        .product_family
+        .ok_or(NodeTypeError::MissingProductFamily)?;
+    let vendor = profile
+        .rack_capabilities
+        .switch
+        .vendor
+        .as_deref()
+        .map(str::trim)
+        .filter(|vendor| !vendor.is_empty());
+
+    let Some(vendor) = vendor else {
+        return Err(NodeTypeError::UnsupportedVendor {
+            role: "switch",
+            vendor: String::new(),
+        });
+    };
+
+    if !is_vendor(vendor, "nvidia") {
+        return Err(NodeTypeError::UnsupportedVendor {
+            role: "switch",
+            vendor: vendor.to_string(),
+        });
+    }
+
+    Ok(switch_node_type(product_family))
+}
+
+/// Resolves the RMS power shelf node type for a rack profile.
+pub fn power_shelf_node_type_for_profile(
+    profile: &RackProfile,
+) -> Result<rms::NodeType, NodeTypeError> {
+    let product_family = profile
+        .product_family
+        .ok_or(NodeTypeError::MissingProductFamily)?;
+    let vendor = profile
+        .rack_capabilities
+        .power_shelf
+        .vendor
+        .as_deref()
+        .map(str::trim)
+        .filter(|vendor| !vendor.is_empty());
+
+    let Some(vendor) = vendor else {
+        return Err(NodeTypeError::UnsupportedVendor {
+            role: "power shelf",
+            vendor: String::new(),
+        });
+    };
+
+    let Some(power_shelf_vendor) = supported_power_shelf_vendor(vendor) else {
+        return Err(NodeTypeError::UnsupportedVendor {
+            role: "power shelf",
+            vendor: vendor.to_string(),
+        });
+    };
+
+    Ok(power_shelf_node_type(product_family, power_shelf_vendor))
+}
+
+/// Returns true when an RMS node type represents a switch.
+pub(crate) fn is_switch_node_type(node_type: rms::NodeType) -> bool {
+    // Keep this exhaustive so new RMS node types must be classified when
+    // librms adds variants.
+    match node_type {
+        rms::NodeType::SwitchGb200Nvidia | rms::NodeType::SwitchGb300Nvidia => true,
+        rms::NodeType::Unspecified
+        | rms::NodeType::ComputeGb200Nvidia
+        | rms::NodeType::PowershelfGb200Liteon
+        | rms::NodeType::PowershelfGb200Delta
+        | rms::NodeType::ComputeGb300Nvidia
+        | rms::NodeType::PowershelfGb300Liteon
+        | rms::NodeType::PowershelfGb300Delta
+        | rms::NodeType::ComputeGb300Lenovo => false,
+    }
+}
+
+fn compute_node_type(
+    product_family: RackProductFamily,
+    vendor: Option<&str>,
+) -> Result<rms::NodeType, NodeTypeError> {
+    let nvidia_node_type = match product_family {
+        RackProductFamily::Gb200 => rms::NodeType::ComputeGb200Nvidia,
+        RackProductFamily::Gb300 => rms::NodeType::ComputeGb300Nvidia,
+    };
+
+    let Some(vendor) = vendor else {
+        return Err(NodeTypeError::UnsupportedVendor {
+            role: "compute",
+            vendor: String::new(),
+        });
+    };
+
+    if is_vendor(vendor, "nvidia") {
+        return Ok(nvidia_node_type);
+    }
+
+    if matches!(product_family, RackProductFamily::Gb300) && is_vendor(vendor, "lenovo") {
+        return Ok(rms::NodeType::ComputeGb300Lenovo);
+    }
+
+    Err(NodeTypeError::UnsupportedVendor {
+        role: "compute",
+        vendor: vendor.to_string(),
+    })
+}
+
+fn switch_node_type(product_family: RackProductFamily) -> rms::NodeType {
+    match product_family {
+        RackProductFamily::Gb200 => rms::NodeType::SwitchGb200Nvidia,
+        RackProductFamily::Gb300 => rms::NodeType::SwitchGb300Nvidia,
+    }
+}
+
+fn power_shelf_node_type(
+    product_family: RackProductFamily,
+    vendor: PowerShelfVendor,
+) -> rms::NodeType {
+    match (product_family, vendor) {
+        (RackProductFamily::Gb200, PowerShelfVendor::Liteon) => {
+            rms::NodeType::PowershelfGb200Liteon
+        }
+        (RackProductFamily::Gb200, PowerShelfVendor::Delta) => rms::NodeType::PowershelfGb200Delta,
+        (RackProductFamily::Gb300, PowerShelfVendor::Liteon) => {
+            rms::NodeType::PowershelfGb300Liteon
+        }
+        (RackProductFamily::Gb300, PowerShelfVendor::Delta) => rms::NodeType::PowershelfGb300Delta,
+    }
+}
+
+fn supported_power_shelf_vendor(vendor: &str) -> Option<PowerShelfVendor> {
+    if is_vendor(vendor, "liteon") {
+        Some(PowerShelfVendor::Liteon)
+    } else if is_vendor(vendor, "delta") {
+        Some(PowerShelfVendor::Delta)
+    } else {
+        None
+    }
+}
+
+fn is_vendor(vendor: &str, expected: &str) -> bool {
+    // Vendors often include spaces, punctuation, or company suffixes. Match at
+    // the front after compacting those differences so embedded names do not
+    // classify unrelated vendors as supported.
+    normalize(vendor).starts_with(&normalize(expected))
+}
+
+fn normalize(value: &str) -> String {
+    value
+        .trim()
+        .to_ascii_lowercase()
+        .replace([' ', '-', '_'], "")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use model::rack_type::RackHardwareTopology;
+
+    fn profile_with_product_family(product_family: RackProductFamily) -> RackProfile {
+        RackProfile {
+            product_family: Some(product_family),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn compute_node_type_maps_gb200_nvidia() {
+        let mut profile = profile_with_product_family(RackProductFamily::Gb200);
+        profile.rack_capabilities.compute.vendor = Some("NVIDIA".to_string());
+
+        let node_type = compute_node_type_for_profile(&profile);
+
+        assert_eq!(node_type, Ok(rms::NodeType::ComputeGb200Nvidia));
+    }
+
+    #[test]
+    fn compute_node_type_maps_gb300_nvidia() {
+        let mut profile = profile_with_product_family(RackProductFamily::Gb300);
+        profile.rack_capabilities.compute.vendor = Some("NVIDIA".to_string());
+
+        let node_type = compute_node_type_for_profile(&profile);
+
+        assert_eq!(node_type, Ok(rms::NodeType::ComputeGb300Nvidia));
+    }
+
+    #[test]
+    fn compute_node_type_maps_gb300_lenovo() {
+        let mut profile = profile_with_product_family(RackProductFamily::Gb300);
+        profile.rack_capabilities.compute.vendor = Some("Lenovo".to_string());
+
+        let node_type = compute_node_type_for_profile(&profile);
+
+        assert_eq!(node_type, Ok(rms::NodeType::ComputeGb300Lenovo));
+    }
+
+    #[test]
+    fn switch_node_type_maps_gb200_and_gb300() {
+        let mut gb200 = profile_with_product_family(RackProductFamily::Gb200);
+        gb200.rack_capabilities.switch.vendor = Some("NVIDIA".to_string());
+
+        let mut gb300 = profile_with_product_family(RackProductFamily::Gb300);
+        gb300.rack_capabilities.switch.vendor = Some("NVIDIA".to_string());
+
+        assert_eq!(
+            switch_node_type_for_profile(&gb200),
+            Ok(rms::NodeType::SwitchGb200Nvidia)
+        );
+        assert_eq!(
+            switch_node_type_for_profile(&gb300),
+            Ok(rms::NodeType::SwitchGb300Nvidia)
+        );
+    }
+
+    #[test]
+    fn switch_node_type_requires_vendor() {
+        let profile = profile_with_product_family(RackProductFamily::Gb200);
+
+        let node_type = switch_node_type_for_profile(&profile);
+
+        assert_eq!(
+            node_type,
+            Err(NodeTypeError::UnsupportedVendor {
+                role: "switch",
+                vendor: String::new()
+            })
+        );
+    }
+
+    #[test]
+    fn switch_node_type_uses_profile_vendor_for_validation() {
+        let mut profile = profile_with_product_family(RackProductFamily::Gb200);
+        profile.rack_capabilities.switch.vendor = Some("Other".to_string());
+
+        let node_type = switch_node_type_for_profile(&profile);
+
+        assert_eq!(
+            node_type,
+            Err(NodeTypeError::UnsupportedVendor {
+                role: "switch",
+                vendor: "Other".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn is_switch_node_type_matches_switch_variants_only() {
+        let switch_types = [
+            rms::NodeType::SwitchGb200Nvidia,
+            rms::NodeType::SwitchGb300Nvidia,
+        ];
+
+        for node_type in switch_types {
+            assert!(is_switch_node_type(node_type));
+        }
+
+        let non_switch_types = [
+            rms::NodeType::Unspecified,
+            rms::NodeType::ComputeGb200Nvidia,
+            rms::NodeType::PowershelfGb200Liteon,
+            rms::NodeType::PowershelfGb200Delta,
+            rms::NodeType::ComputeGb300Nvidia,
+            rms::NodeType::PowershelfGb300Liteon,
+            rms::NodeType::PowershelfGb300Delta,
+            rms::NodeType::ComputeGb300Lenovo,
+        ];
+
+        for node_type in non_switch_types {
+            assert!(!is_switch_node_type(node_type));
+        }
+    }
+
+    #[test]
+    fn power_shelf_node_type_uses_profile_vendor() {
+        let mut gb200_liteon = profile_with_product_family(RackProductFamily::Gb200);
+        gb200_liteon.rack_capabilities.power_shelf.vendor = Some("LiteOn".to_string());
+
+        let mut gb300_delta = profile_with_product_family(RackProductFamily::Gb300);
+        gb300_delta.rack_capabilities.power_shelf.vendor = Some("Delta".to_string());
+
+        assert_eq!(
+            power_shelf_node_type_for_profile(&gb200_liteon),
+            Ok(rms::NodeType::PowershelfGb200Liteon)
+        );
+
+        assert_eq!(
+            power_shelf_node_type_for_profile(&gb300_delta),
+            Ok(rms::NodeType::PowershelfGb300Delta)
+        );
+    }
+
+    #[test]
+    fn power_shelf_node_type_requires_supported_vendor() {
+        let profile = profile_with_product_family(RackProductFamily::Gb200);
+
+        assert_eq!(
+            power_shelf_node_type_for_profile(&profile),
+            Err(NodeTypeError::UnsupportedVendor {
+                role: "power shelf",
+                vendor: String::new()
+            })
+        );
+    }
+
+    #[test]
+    fn product_family_not_topology_selects_node_type() {
+        let mut profile = profile_with_product_family(RackProductFamily::Gb300);
+        profile.rack_hardware_topology = Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology);
+        profile.rack_capabilities.switch.vendor = Some("NVIDIA".to_string());
+
+        let node_type = switch_node_type_for_profile(&profile);
+
+        assert_eq!(node_type, Ok(rms::NodeType::SwitchGb300Nvidia));
+    }
+
+    #[test]
+    fn compute_node_type_requires_vendor() {
+        let profile = profile_with_product_family(RackProductFamily::Gb200);
+
+        let err = compute_node_type_for_profile(&profile);
+
+        assert_eq!(
+            err,
+            Err(NodeTypeError::UnsupportedVendor {
+                role: "compute",
+                vendor: String::new()
+            })
+        );
+    }
+
+    #[test]
+    fn compute_node_type_requires_product_family() {
+        let mut profile = RackProfile::default();
+        profile.rack_capabilities.compute.vendor = Some("NVIDIA".to_string());
+
+        let err = compute_node_type_for_profile(&profile);
+
+        assert_eq!(err, Err(NodeTypeError::MissingProductFamily));
+    }
+
+    #[test]
+    fn unsupported_vendor_returns_error() {
+        let mut profile = profile_with_product_family(RackProductFamily::Gb200);
+        profile.rack_capabilities.compute.vendor = Some("Other".to_string());
+
+        let err = compute_node_type_for_profile(&profile);
+
+        assert_eq!(
+            err,
+            Err(NodeTypeError::UnsupportedVendor {
+                role: "compute",
+                vendor: "Other".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn vendor_matching_trims_outer_whitespace() {
+        let mut profile = profile_with_product_family(RackProductFamily::Gb200);
+        profile.rack_capabilities.compute.vendor = Some("\tNVIDIA\n".to_string());
+
+        let node_type = compute_node_type_for_profile(&profile);
+
+        assert_eq!(node_type, Ok(rms::NodeType::ComputeGb200Nvidia));
+    }
+
+    #[test]
+    fn embedded_vendor_name_does_not_match() {
+        let mut profile = profile_with_product_family(RackProductFamily::Gb200);
+        profile.rack_capabilities.compute.vendor = Some("Not NVIDIA".to_string());
+
+        let err = compute_node_type_for_profile(&profile);
+
+        assert_eq!(
+            err,
+            Err(NodeTypeError::UnsupportedVendor {
+                role: "compute",
+                vendor: "Not NVIDIA".to_string()
+            })
+        );
+    }
+}

--- a/crates/rack/src/rms_node_type.rs
+++ b/crates/rack/src/rms_node_type.rs
@@ -214,8 +214,9 @@ fn normalize(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use model::rack_type::RackHardwareTopology;
+
+    use super::*;
 
     fn profile_with_product_family(product_family: RackProductFamily) -> RackProfile {
         RackProfile {

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -7230,6 +7230,12 @@ enum RackHardwareTopology {
   RACK_HARDWARE_TOPOLOGY_VR_NVL72R1_C2G4 = 6;
 }
 
+enum RackProductFamily {
+  RACK_PRODUCT_FAMILY_UNSPECIFIED = 0;
+  RACK_PRODUCT_FAMILY_GB200 = 1;
+  RACK_PRODUCT_FAMILY_GB300 = 2;
+}
+
 enum RackHardwareClass {
   RACK_HARDWARE_CLASS_UNSPECIFIED = 0;
   RACK_HARDWARE_CLASS_DEV = 1;
@@ -7268,6 +7274,7 @@ message RackProfile {
   RackHardwareTopology rack_hardware_topology = 2;
   RackHardwareClass rack_hardware_class = 3;
   RackCapabilitiesSet capabilities = 4;
+  RackProductFamily product_family = 5;
 }
 
 message GetRackProfileRequest {

--- a/crates/rpc/src/model/rack_type.rs
+++ b/crates/rpc/src/model/rack_type.rs
@@ -17,7 +17,7 @@
 
 use model::rack_type::{
     RackCapabilitiesSet, RackCapabilityCompute, RackCapabilityPowerShelf, RackCapabilitySwitch,
-    RackHardwareClass, RackHardwareTopology, RackHardwareType, RackProfile,
+    RackHardwareClass, RackHardwareTopology, RackHardwareType, RackProductFamily, RackProfile,
 };
 
 use crate as rpc;
@@ -32,6 +32,31 @@ impl From<RackHardwareType> for rpc::common::RackHardwareType {
 impl From<rpc::common::RackHardwareType> for RackHardwareType {
     fn from(value: rpc::common::RackHardwareType) -> Self {
         RackHardwareType(value.value)
+    }
+}
+
+impl From<RackProductFamily> for rpc::forge::RackProductFamily {
+    fn from(value: RackProductFamily) -> Self {
+        match value {
+            RackProductFamily::Gb200 => rpc::forge::RackProductFamily::Gb200,
+            RackProductFamily::Gb300 => rpc::forge::RackProductFamily::Gb300,
+        }
+    }
+}
+
+impl TryFrom<rpc::forge::RackProductFamily> for RackProductFamily {
+    type Error = RpcDataConversionError;
+
+    fn try_from(value: rpc::forge::RackProductFamily) -> Result<Self, Self::Error> {
+        match value {
+            rpc::forge::RackProductFamily::Gb200 => Ok(RackProductFamily::Gb200),
+            rpc::forge::RackProductFamily::Gb300 => Ok(RackProductFamily::Gb300),
+            rpc::forge::RackProductFamily::Unspecified => {
+                Err(RpcDataConversionError::InvalidArgument(
+                    "unspecified rack product family".to_string(),
+                ))
+            }
+        }
     }
 }
 
@@ -176,6 +201,10 @@ impl From<&RackProfile> for rpc::forge::RackProfile {
                 .map(|c| rpc::forge::RackHardwareClass::from(c) as i32)
                 .unwrap_or(rpc::forge::RackHardwareClass::Unspecified as i32),
             capabilities: Some((&value.rack_capabilities).into()),
+            product_family: value
+                .product_family
+                .map(|p| rpc::forge::RackProductFamily::from(p) as i32)
+                .unwrap_or(rpc::forge::RackProductFamily::Unspecified as i32),
         }
     }
 }
@@ -187,6 +216,51 @@ mod tests {
 
     use super::*;
     // Proto conversion tests.
+
+    #[test]
+    fn test_rack_product_family_proto_round_trip() {
+        struct Row {
+            scenario: &'static str,
+            model: RackProductFamily,
+            proto: rpc::forge::RackProductFamily,
+        }
+
+        check_cases(
+            [
+                Row {
+                    scenario: "gb200",
+                    model: RackProductFamily::Gb200,
+                    proto: rpc::forge::RackProductFamily::Gb200,
+                },
+                Row {
+                    scenario: "gb300",
+                    model: RackProductFamily::Gb300,
+                    proto: rpc::forge::RackProductFamily::Gb300,
+                },
+            ]
+            .map(|row| Case {
+                scenario: row.scenario,
+                input: (row.model, row.proto),
+                expect: Yields(row.model),
+            }),
+            |(model, proto)| {
+                let converted: rpc::forge::RackProductFamily = model.into();
+                assert_eq!(converted, proto);
+
+                RackProductFamily::try_from(proto).map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn test_rack_product_family_proto_unspecified_errors() {
+        Case {
+            scenario: "unspecified product family rejected",
+            input: rpc::forge::RackProductFamily::Unspecified,
+            expect: Fails,
+        }
+        .check(|proto| RackProductFamily::try_from(proto).map_err(drop));
+    }
 
     // Each topology round-trips: model -> proto matches the expected proto, and the
     // proto -> model TryFrom yields the original model. The op asserts the forward
@@ -306,6 +380,7 @@ mod tests {
     #[test]
     fn test_rack_profile_proto_conversion() {
         let profile = RackProfile {
+            product_family: Some(RackProductFamily::Gb200),
             rack_hardware_type: Some(RackHardwareType::from("dsx_gb200nvl_72x1")),
             rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
             rack_hardware_class: Some(RackHardwareClass::Prod),
@@ -333,6 +408,10 @@ mod tests {
 
         let proto: rpc::forge::RackProfile = (&profile).into();
 
+        assert_eq!(
+            proto.product_family,
+            rpc::forge::RackProductFamily::Gb200 as i32
+        );
         assert_eq!(proto.rack_hardware_type.unwrap().value, "dsx_gb200nvl_72x1");
         assert_eq!(
             proto.rack_hardware_topology,
@@ -366,6 +445,10 @@ mod tests {
         let profile = RackProfile::default();
         let proto: rpc::forge::RackProfile = (&profile).into();
 
+        assert_eq!(
+            proto.product_family,
+            rpc::forge::RackProductFamily::Unspecified as i32
+        );
         assert_eq!(proto.rack_hardware_type, None);
         assert_eq!(
             proto.rack_hardware_topology,

--- a/crates/site-explorer/Cargo.toml
+++ b/crates/site-explorer/Cargo.toml
@@ -21,6 +21,7 @@ carbide-firmware = { path = "../firmware" }
 carbide-health-report = { path = "../health-report" }
 carbide-ipmi = { path = "../ipmi" }
 carbide-network = { path = "../network" }
+carbide-rack = { path = "../rack", default-features = false }
 carbide-redfish = { path = "../redfish" }
 carbide-secrets = { path = "../secrets" }
 carbide-utils = { path = "../utils" }

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -47,6 +47,7 @@ use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine_boot_interface::MachineBootInterface;
 use model::machine_interface::InterfaceType;
 use model::power_shelf::{NewPowerShelf, PowerShelfConfig};
+use model::rack_type::RackProfileConfig;
 use model::resource_pool::common::CommonPools;
 use model::site_explorer::{
     EndpointExplorationError, EndpointExplorationReport, EndpointType, ExploredDpu,
@@ -293,6 +294,7 @@ impl SiteExplorer {
         firmware_config: Arc<FirmwareConfig>,
         common_pools: Arc<CommonPools>,
         work_lock_manager_handle: WorkLockManagerHandle,
+        rack_profiles: RackProfileConfig,
         rms_client: Option<Arc<dyn RmsApi>>,
         credential_manager: Arc<dyn CredentialManager>,
     ) -> Self {
@@ -308,12 +310,14 @@ impl SiteExplorer {
             hold_period,
             &explorer_config,
         ));
+        let rack_profiles = Arc::new(rack_profiles);
 
         SiteExplorer {
             machine_creator: MachineCreator::new(
                 database_connection.clone(),
                 explorer_config.clone(),
                 common_pools,
+                rack_profiles,
                 rms_client.clone(),
                 credential_manager,
             ),

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -17,6 +17,7 @@
 
 use std::sync::Arc;
 
+use carbide_rack::rms_node_type::compute_node_type_for_profile;
 use carbide_secrets::credentials::{
     BmcCredentialType, CredentialKey, CredentialManager, Credentials,
 };
@@ -24,6 +25,7 @@ use carbide_uuid::machine::MachineId;
 use db::{ObjectColumnFilter, Transaction};
 use itertools::Itertools;
 use librms::RmsApi;
+use librms::protos::rack_manager as rms;
 use mac_address::MacAddress;
 use model::bmc_info::BmcInfo;
 use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
@@ -37,6 +39,7 @@ use model::machine::{
 use model::machine_interface_address::MachineInterfaceAssociation;
 use model::network_segment::NetworkSegmentType;
 use model::predicted_machine_interface::NewPredictedMachineInterface;
+use model::rack_type::RackProfileConfig;
 use model::resource_pool::common::CommonPools;
 use model::site_explorer::{EndpointExplorationReport, ExploredDpu, ExploredManagedHost};
 use sqlx::{PgConnection, PgPool};
@@ -47,19 +50,23 @@ use crate::explored_endpoint_index::ExploredEndpointIndex;
 use crate::managed_host::ManagedHost;
 use crate::metrics::SiteExplorationMetrics;
 
+/// Creates machines from site-explorer managed-host reports.
 pub struct MachineCreator {
     database_connection: PgPool,
     config: SiteExplorerConfig,
     common_pools: Arc<CommonPools>,
+    rack_profiles: Arc<RackProfileConfig>,
     rms_client: Option<Arc<dyn RmsApi>>,
     credential_manager: Arc<dyn CredentialManager>,
 }
 
 impl MachineCreator {
+    /// Creates a machine creator with site configuration and optional RMS integration.
     pub fn new(
         database_connection: PgPool,
         config: SiteExplorerConfig,
         common_pools: Arc<CommonPools>,
+        rack_profiles: Arc<RackProfileConfig>,
         rms_client: Option<Arc<dyn RmsApi>>,
         credential_manager: Arc<dyn CredentialManager>,
     ) -> Self {
@@ -67,6 +74,7 @@ impl MachineCreator {
             database_connection,
             config,
             common_pools,
+            rack_profiles,
             rms_client,
             credential_manager,
         }
@@ -229,10 +237,12 @@ impl MachineCreator {
         )
         .await?;
 
+        let mut rack_profile_id = None;
         if let Some(rack_id) = machine_data.and_then(|d| d.rack_id.as_ref()) {
             tracing::info!(%rack_id, %host_machine_id, "Ensuring rack exists for host machine");
             if let Some(rack) = crate::ensure_rack_exists(&mut txn, rack_id).await? {
                 tracing::info!(%rack_id, "Rack exists for host machine {host_machine_id}: {rack:#?}");
+                rack_profile_id = rack.rack_profile_id;
             }
         }
 
@@ -241,33 +251,53 @@ impl MachineCreator {
         self.reconcile_host_admin_addresses(&mut txn, &host_machine_id)
             .await?;
 
-        txn.commit().await?;
-
-        if let (Some(rack_id), Some(rms_client)) =
+        let rms_node_type = if let (Some(rack_id), Some(_)) =
             (&expected_machine.data.rack_id, &self.rms_client)
         {
-            let request = librms::protos::rack_manager::BatchGetNodeDeviceInfoRequest {
-                nodes: Some(librms::protos::rack_manager::NodeSet {
-                    nodes: vec![librms::protos::rack_manager::NodeInfo {
+            let Some(rack_profile_id) = rack_profile_id.as_ref() else {
+                return Err(SiteExplorerError::InvalidArgument(format!(
+                    "rack {rack_id} has no rack_profile_id for RMS slot and tray lookup for host machine {host_machine_id}"
+                )));
+            };
+
+            let Some(rack_profile) = self.rack_profiles.get(rack_profile_id.as_str()) else {
+                return Err(SiteExplorerError::InvalidArgument(format!(
+                    "rack profile {rack_profile_id} is not configured for RMS slot and tray lookup for host machine {host_machine_id}"
+                )));
+            };
+
+            Some(
+                compute_node_type_for_profile(rack_profile)
+                    .map_err(|error| SiteExplorerError::InvalidArgument(error.to_string()))?,
+            )
+        } else {
+            None
+        };
+
+        txn.commit().await?;
+
+        if let (Some(rack_id), Some(rms_client), Some(node_type)) = (
+            &expected_machine.data.rack_id,
+            &self.rms_client,
+            rms_node_type,
+        ) {
+            let request = rms::BatchGetNodeDeviceInfoRequest {
+                nodes: Some(rms::NodeSet {
+                    nodes: vec![rms::NodeInfo {
                         node_id: host_machine_id.to_string(),
                         rack_id: rack_id.to_string(),
-                        r#type: Some(librms::protos::rack_manager::NodeType::Compute as i32),
-                        bmc_endpoint: Some(librms::protos::rack_manager::Endpoint {
-                            interface: Some(librms::protos::rack_manager::NetworkInterface {
+                        r#type: Some(node_type as i32),
+                        bmc_endpoint: Some(rms::Endpoint {
+                            interface: Some(rms::NetworkInterface {
                                 ip_address: explored_host.host_bmc_ip.to_string(),
                                 mac_address: expected_machine.bmc_mac_address.to_string(),
                             }),
                             port: 443,
                             credentials: bmc_credentials.map(|(username, password)| {
-                                librms::protos::rack_manager::Credentials {
-                                    auth: Some(
-                                        librms::protos::rack_manager::credentials::Auth::UserPass(
-                                            librms::protos::rack_manager::UsernamePassword {
-                                                username,
-                                                password,
-                                            },
-                                        ),
-                                    ),
+                                rms::Credentials {
+                                    auth: Some(rms::credentials::Auth::UserPass(
+                                        rms::UsernamePassword { username, password },
+                                    )),
                                 }
                             }),
                             dangerously_accept_invalid_certs: true,

--- a/crates/site-explorer/tests/env.rs
+++ b/crates/site-explorer/tests/env.rs
@@ -68,6 +68,7 @@ pub fn test_site_explorer(
         Arc::new(api.runtime_config.get_firmware_config()),
         api.common_pools().clone(),
         api.work_lock_manager_handle(),
+        api.runtime_config.rack_profiles.clone(),
         None,
         api.credential_manager().clone(),
     );

--- a/crates/site-explorer/tests/health_report.rs
+++ b/crates/site-explorer/tests/health_report.rs
@@ -67,6 +67,7 @@ fn test_site_explorer(
         Arc::new(api.runtime_config.get_firmware_config()),
         api.common_pools().clone(),
         api.work_lock_manager_handle(),
+        api.runtime_config.rack_profiles.clone(),
         None,
         api.credential_manager().clone(),
     );

--- a/crates/site-explorer/tests/machine_creator.rs
+++ b/crates/site-explorer/tests/machine_creator.rs
@@ -198,10 +198,11 @@ async fn test_machine_creator_compute_rms_request_uses_rack_profile(
     db::expected_rack::create(txn.as_mut(), &expected_rack).await?;
     txn.commit().await?;
 
-    let managed_host = ManagedHostConfig::with_expected_machine_data(ExpectedMachineData {
-        rack_id: Some(rack_id.clone()),
-        ..Default::default()
-    });
+    let managed_host =
+        ManagedHostConfig::default().with_expected_machine_data(ExpectedMachineData {
+            rack_id: Some(rack_id.clone()),
+            ..Default::default()
+        });
     let mut fixture = explored_host_fixture(&env, &managed_host).await;
 
     assert!(
@@ -255,10 +256,11 @@ async fn test_machine_creator_compute_rms_request_errors_for_rack_without_profil
     db::rack::create(txn.as_mut(), &rack_id, None, &RackConfig::default(), None).await?;
     txn.commit().await?;
 
-    let managed_host = ManagedHostConfig::with_expected_machine_data(ExpectedMachineData {
-        rack_id: Some(rack_id.clone()),
-        ..Default::default()
-    });
+    let managed_host =
+        ManagedHostConfig::default().with_expected_machine_data(ExpectedMachineData {
+            rack_id: Some(rack_id.clone()),
+            ..Default::default()
+        });
     let mut fixture = explored_host_fixture(&env, &managed_host).await;
 
     let result = creator
@@ -306,10 +308,11 @@ async fn test_machine_creator_compute_rms_request_errors_for_unknown_profile(
     .await?;
     txn.commit().await?;
 
-    let managed_host = ManagedHostConfig::with_expected_machine_data(ExpectedMachineData {
-        rack_id: Some(rack_id.clone()),
-        ..Default::default()
-    });
+    let managed_host =
+        ManagedHostConfig::default().with_expected_machine_data(ExpectedMachineData {
+            rack_id: Some(rack_id.clone()),
+            ..Default::default()
+        });
     let mut fixture = explored_host_fixture(&env, &managed_host).await;
 
     let result = creator

--- a/crates/site-explorer/tests/machine_creator.rs
+++ b/crates/site-explorer/tests/machine_creator.rs
@@ -20,6 +20,7 @@ use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use carbide_rack::rms_client::test_support::RmsSim;
 use carbide_site_explorer::MachineCreator;
 use carbide_site_explorer::config::SiteExplorerConfig;
 use carbide_test_harness::network::segment::TestNetworkSegment;
@@ -29,12 +30,20 @@ use carbide_test_harness::test_support::fixture_config::{
 };
 use carbide_utils::arch::CpuArchitecture;
 use carbide_uuid::machine::MachineId;
+use carbide_uuid::rack::{RackId, RackProfileId};
 use db::ObjectFilter;
 use itertools::Itertools;
+use librms::protos::rack_manager as rms;
 use mac_address::MacAddress;
 use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
+use model::expected_rack::ExpectedRack;
 use model::machine::ManagedHostState;
 use model::machine::machine_search_config::MachineSearchConfig;
+use model::rack::RackConfig;
+use model::rack_type::{
+    RackCapabilitiesSet, RackCapabilityCompute, RackCapabilityPowerShelf, RackCapabilitySwitch,
+    RackHardwareTopology, RackProductFamily, RackProfile, RackProfileConfig,
+};
 use model::resource_pool::ResourcePoolStats;
 use model::site_explorer::{EndpointExplorationReport, ExploredDpu, ExploredManagedHost};
 use model::test_support::{DpuConfig, ManagedHostConfig};
@@ -53,6 +62,8 @@ struct Env {
     underlay_segment: TestNetworkSegment,
     test_harness: TestHarness,
 }
+
+const TEST_RMS_RACK_PROFILE_ID: &str = "NVL72";
 
 impl Env {
     async fn new(pool: PgPool) -> Self {
@@ -95,7 +106,46 @@ fn machine_creator(env: &Env, config: SiteExplorerConfig) -> MachineCreator {
         env.pool.clone(),
         config,
         env.api().common_pools().clone(),
+        Arc::new(env.api().runtime_config.rack_profiles.clone()),
         None,
+        env.api().credential_manager().clone(),
+    )
+}
+
+fn machine_creator_with_rms(env: &Env, rms_sim: &RmsSim) -> MachineCreator {
+    let rack_profiles = RackProfileConfig {
+        rack_profiles: [(
+            TEST_RMS_RACK_PROFILE_ID.to_string(),
+            RackProfile {
+                product_family: Some(RackProductFamily::Gb200),
+                rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
+                rack_capabilities: RackCapabilitiesSet {
+                    compute: RackCapabilityCompute {
+                        vendor: Some("NVIDIA".to_string()),
+                        ..Default::default()
+                    },
+                    switch: RackCapabilitySwitch {
+                        vendor: Some("NVIDIA".to_string()),
+                        ..Default::default()
+                    },
+                    power_shelf: RackCapabilityPowerShelf {
+                        vendor: Some("LiteOn".to_string()),
+                        ..Default::default()
+                    },
+                },
+                ..Default::default()
+            },
+        )]
+        .into_iter()
+        .collect(),
+    };
+
+    MachineCreator::new(
+        env.pool.clone(),
+        machine_creator_config(false),
+        env.api().common_pools().clone(),
+        Arc::new(rack_profiles),
+        rms_sim.as_rms_client(),
         env.api().credential_manager().clone(),
     )
 }
@@ -109,6 +159,182 @@ fn expected_machine(managed_host: &ManagedHostConfig) -> ExpectedMachine {
             .clone()
             .unwrap_or_default(),
     }
+}
+
+async fn assert_no_machines_created(pool: &PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let machines = db::machine::find(
+        pool,
+        ObjectFilter::All,
+        MachineSearchConfig {
+            include_predicted_host: true,
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    assert_eq!(
+        machines.len(),
+        0,
+        "expected no machine rows after RMS rack-profile preflight failure, got {machines:#?}"
+    );
+    Ok(())
+}
+
+#[sqlx_test]
+async fn test_machine_creator_compute_rms_request_uses_rack_profile(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = Env::new(pool).await;
+    let rms_sim = RmsSim::default();
+    let creator = machine_creator_with_rms(&env, &rms_sim);
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
+    let expected_rack = ExpectedRack {
+        rack_id: rack_id.clone(),
+        rack_profile_id: RackProfileId::new(TEST_RMS_RACK_PROFILE_ID),
+        metadata: Default::default(),
+    };
+
+    let mut txn = env.pool.begin().await?;
+    db::expected_rack::create(txn.as_mut(), &expected_rack).await?;
+    txn.commit().await?;
+
+    let managed_host = ManagedHostConfig::with_expected_machine_data(ExpectedMachineData {
+        rack_id: Some(rack_id.clone()),
+        ..Default::default()
+    });
+    let mut fixture = explored_host_fixture(&env, &managed_host).await;
+
+    assert!(
+        creator
+            .create_managed_host(
+                &fixture.host,
+                &mut fixture.host_report,
+                Some(&expected_machine(&managed_host)),
+                &env.pool,
+            )
+            .await?
+    );
+
+    let requests = rms_sim
+        .submitted_batch_get_node_device_info_requests()
+        .await;
+    let [request] = requests.as_slice() else {
+        return Err(std::io::Error::other(format!(
+            "expected one RMS BatchGetNodeDeviceInfo request, got {}",
+            requests.len()
+        ))
+        .into());
+    };
+    let Some(nodes) = request.nodes.as_ref() else {
+        return Err(std::io::Error::other("RMS request missing nodes").into());
+    };
+    let [node] = nodes.nodes.as_slice() else {
+        return Err(std::io::Error::other(format!(
+            "expected one RMS node in request, got {}",
+            nodes.nodes.len()
+        ))
+        .into());
+    };
+
+    assert_eq!(node.rack_id, rack_id.to_string());
+    assert_eq!(node.r#type, Some(rms::NodeType::ComputeGb200Nvidia as i32));
+
+    Ok(())
+}
+
+#[sqlx_test]
+async fn test_machine_creator_compute_rms_request_errors_for_rack_without_profile(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = Env::new(pool).await;
+    let rms_sim = RmsSim::default();
+    let creator = machine_creator_with_rms(&env, &rms_sim);
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
+
+    let mut txn = env.pool.begin().await?;
+    db::rack::create(txn.as_mut(), &rack_id, None, &RackConfig::default(), None).await?;
+    txn.commit().await?;
+
+    let managed_host = ManagedHostConfig::with_expected_machine_data(ExpectedMachineData {
+        rack_id: Some(rack_id.clone()),
+        ..Default::default()
+    });
+    let mut fixture = explored_host_fixture(&env, &managed_host).await;
+
+    let result = creator
+        .create_managed_host(
+            &fixture.host,
+            &mut fixture.host_report,
+            Some(&expected_machine(&managed_host)),
+            &env.pool,
+        )
+        .await;
+
+    let Err(error) = result else {
+        return Err(std::io::Error::other("expected missing rack profile error").into());
+    };
+
+    assert!(error.to_string().contains("has no rack_profile_id"));
+    assert_eq!(
+        rms_sim
+            .submitted_batch_get_node_device_info_requests()
+            .await,
+        Vec::new()
+    );
+    assert_no_machines_created(&env.pool).await?;
+
+    Ok(())
+}
+
+#[sqlx_test]
+async fn test_machine_creator_compute_rms_request_errors_for_unknown_profile(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = Env::new(pool).await;
+    let rms_sim = RmsSim::default();
+    let creator = machine_creator_with_rms(&env, &rms_sim);
+    let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());
+
+    let mut txn = env.pool.begin().await?;
+    db::rack::create(
+        txn.as_mut(),
+        &rack_id,
+        Some(&RackProfileId::new("Unknown")),
+        &RackConfig::default(),
+        None,
+    )
+    .await?;
+    txn.commit().await?;
+
+    let managed_host = ManagedHostConfig::with_expected_machine_data(ExpectedMachineData {
+        rack_id: Some(rack_id.clone()),
+        ..Default::default()
+    });
+    let mut fixture = explored_host_fixture(&env, &managed_host).await;
+
+    let result = creator
+        .create_managed_host(
+            &fixture.host,
+            &mut fixture.host_report,
+            Some(&expected_machine(&managed_host)),
+            &env.pool,
+        )
+        .await;
+
+    let Err(error) = result else {
+        return Err(std::io::Error::other("expected unknown rack profile error").into());
+    };
+
+    assert!(error.to_string().contains("is not configured"));
+    assert_eq!(
+        rms_sim
+            .submitted_batch_get_node_device_info_requests()
+            .await,
+        Vec::new()
+    );
+    assert_no_machines_created(&env.pool).await?;
+
+    Ok(())
 }
 
 async fn discover_bmc(

--- a/crates/site-explorer/tests/zero_dpu.rs
+++ b/crates/site-explorer/tests/zero_dpu.rs
@@ -68,6 +68,7 @@ async fn init(pool: PgPool) -> ZeroDpuEnv {
             Arc::new(api.runtime_config.get_firmware_config()),
             api.common_pools().clone(),
             api.work_lock_manager_handle(),
+            api.runtime_config.rack_profiles.clone(),
             None,
             api.credential_manager().clone(),
         ),

--- a/crates/test-harness/src/lib.rs
+++ b/crates/test-harness/src/lib.rs
@@ -128,6 +128,7 @@ impl TestHarness {
             Arc::new(api.runtime_config.get_firmware_config()),
             api.common_pools().clone(),
             api.work_lock_manager_handle(),
+            api.runtime_config.rack_profiles.clone(),
             None,
             api.credential_manager().clone(),
         );

--- a/dev/mac-local-dev/README.md
+++ b/dev/mac-local-dev/README.md
@@ -55,6 +55,72 @@ grpcurl -insecure localhost:1079 list
 open https://localhost:1079/admin
 ```
 
+### RMS node type resolution
+
+When testing RMS component-manager backends, configure the local rack profile so
+`product_family` is set to `gb200` or `gb300`. This field is required for
+RMS-backed operations and must exactly match the lowercase value; it is not
+normalized. The component-manager backend fields default to `rms`, so set any
+role you are not testing to a non-RMS backend. When a backend is set to `rms`,
+the matching vendor field in each configured profile is required for startup
+validation.
+
+Recommended vendor values are `NVIDIA` or `Lenovo` for compute, `NVIDIA` for
+switches, and `LiteOn` or `Delta` for power shelves. Vendor matching is
+case-insensitive and ignores spaces, hyphens, and underscores, so values like
+`nvidia`, `Lite-On`, and `lite_on` are accepted. The rack's `rack_profile_id`
+must match a key in `[rack_profiles]`.
+
+The examples below only show the component-manager and rack-profile fields.
+Configure local `[rms]` settings separately when NICo needs to call RMS.
+
+Example: GB200 rack with all component-manager roles using RMS:
+
+```toml
+[component_manager]
+compute_tray_backend = "rms"
+nv_switch_backend = "rms"
+power_shelf_backend = "rms"
+
+[rack_profiles.NVL72]
+product_family = "gb200"
+rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
+
+[rack_profiles.NVL72.rack_capabilities.compute]
+vendor = "NVIDIA"
+
+[rack_profiles.NVL72.rack_capabilities.switch]
+vendor = "NVIDIA"
+
+[rack_profiles.NVL72.rack_capabilities.power_shelf]
+vendor = "LiteOn"
+```
+
+Example: only the component-manager power shelf backend uses RMS in local dev.
+The compute backend uses `mock` here because this file is for local testing; the
+switch backend uses the local NSM endpoint:
+
+```toml
+[component_manager]
+compute_tray_backend = "mock"
+nv_switch_backend = "nsm"
+power_shelf_backend = "rms"
+
+[component_manager.nsm]
+url = "http://localhost:50052"
+
+[rack_profiles.NVL72_POWER]
+product_family = "gb200"
+rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
+
+[rack_profiles.NVL72_POWER.rack_capabilities.power_shelf]
+vendor = "Lite-On"
+```
+
+If site-explorer machine ingestion is also using the configured RMS client for
+slot/tray lookup, include the compute vendor fields too even when
+`compute_tray_backend` is not `rms`.
+
 ### Resetting state
 
 ```bash

--- a/dev/mac-local-dev/carbide-api-config.toml
+++ b/dev/mac-local-dev/carbide-api-config.toml
@@ -163,6 +163,9 @@ run_interval = "10s"
 [component_manager]
 nv_switch_backend = "nsm"
 power_shelf_backend = "psm"
+# Local dev does not configure RMS by default. Keep compute tray management on a
+# non-RMS backend so startup validation does not require rack profiles.
+compute_tray_backend = "mock"
 
 [component_manager.nsm]
 url = "http://localhost:50052"


### PR DESCRIPTION
Resolve RMS node type selection from rack profile data.

RMS requests now need concrete `NodeType` enum values. NICo should not infer those values from raw BMC model codes or part numbers because those values can be unreliable, slow to discover, and hard to maintain in open-source mapping tables. This PR makes the rack profile the source of truth for RMS node type resolution.

The design is:

Rack identity is resolved from inventory. For a compute tray, switch, or power shelf, NICo resolves the node ID, rack ID, and rack profile ID from the database. The rack profile ID links the physical rack to the operator-supplied rack profile.

Product family comes from the rack profile. NICo reads `product_family` from the matching rack profile. This value is intentionally exact-match and currently accepts `gb200` or `gb300`.

Vendor comes from the rack profile. The relevant capability vendor field supplies the vendor dimension:

- compute uses `rack_capabilities.compute.vendor`
- switch uses `rack_capabilities.switch.vendor`
- power shelf uses `rack_capabilities.power_shelf.vendor`

Product family plus role plus vendor selects the RMS enum. The resolver combines:

- device role: compute, switch, or power shelf
- product family: GB200 or GB300
- vendor: NVIDIA, Lenovo, LiteOn, or Delta depending on role

That produces the concrete RMS `NodeType` used in outbound requests.

Configuration is validated early for component-manager RMS backends. When a component-manager backend is set to `rms`, NICo validates the needed rack profile fields during startup. This catches missing product family, missing vendor, or unsupported vendor before a power or firmware operation reaches RMS.

Startup validation only validates configured rack profiles. It does not scan existing rack database rows to prove every rack has a valid `rack_profile_id`. Missing or unknown per-rack profile IDs are still checked at call time. This keeps startup validation simple while still preserving correctness at the RMS request boundary.

The runtime data flow is:

1. Component-manager receives a compute, switch, or power shelf operation.
2. NICo resolves the inventory record to a node ID, rack ID, and rack profile ID.
3. NICo loads the matching rack profile from config.
4. NICo resolves RMS `NodeType` from rack profile product family and capability vendor.
5. NICo builds the RMS node request with node ID, rack ID, endpoint information, credentials, and the resolved concrete node type.
6. RMS receives a fully classified node without NICo doing raw model-code discovery.

The site-explorer RMS slot/tray lookup follows the same principle. Once a machine is associated with a rack, NICo uses the rack profile to classify the compute node for RMS instead of parsing observed BMC model or manufacturer strings.

This keeps vendor/product classification deterministic, operator-controlled, and scoped to the rack profile rather than spreading hardware-specific model-code mapping logic through NICo.

**NOTE**: `product_family` is added to `forge.proto`, but rest-api side proto is not updated as this configuration's source of truth is the config file. The rest-api side is not making use of RackProfile and it's nico proto is not in sync with `forge.proto` prior to this change. This change should not affect proto compatibility between rest-api and the core.

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issue

Closes #2428

## Breaking Changes
- [x] This PR contains breaking changes

Deployments using RMS component-manager backends must configure rack profiles with:
- `product_family`
- `rack_capabilities.compute.vendor` when `compute_tray_backend = "rms"`
- `rack_capabilities.switch.vendor` when `nv_switch_backend = "rms"`
- `rack_capabilities.power_shelf.vendor` when `power_shelf_backend = "rms"`

Racks used with RMS **must** reference a configured profile by `rack_profile_id`.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)