### PR TITLE
feat: more consistently resolve the machine boot interface

### DIFF
--- a/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
@@ -28,7 +28,8 @@ use mac_address::MacAddress;
 use model::expected_entity::ExpectedEntity;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{LoadSnapshotOptions, MachineInterfaceSnapshot};
-use model::site_explorer::{ExploredEndpoint, NicMode, PreingestionState};
+use model::machine_boot_interface::MachineBootInterface;
+use model::site_explorer::{NicMode, PreingestionState};
 use sqlx::PgConnection;
 use tokio::net::lookup_host;
 use tonic::{Request, Response, Status};
@@ -36,24 +37,97 @@ use tonic::{Request, Response, Status};
 use crate::CarbideError;
 use crate::api::{Api, log_machine_id, log_request_data};
 
-/// Resolve how to target a host's boot interface for an admin Redfish action.
+/// Resolve the boot interface an admin Redfish action should target, the same
+/// way the machine-controller resolves it.
 ///
-/// If the operator entered the host's stored boot MAC (or entered nothing), use
-/// the stored, fully-captured boot interface so the MAC-first / interface-id
-/// fallback applies. If the operator entered some other MAC, target exactly that
-/// MAC.
+/// When a machine exists for the endpoint, its interfaces alone decide:
+/// `pick_boot_interface` selects the machine's primary interface -- the same
+/// row the machine-controller configures boot from -- and the row's own
+/// captured id completes the [`MachineBootInterface`], or the action targets
+/// the MAC alone ([`BootInterfaceTarget::MacOnly`], no id fallback), exactly
+/// like the controller's `boot_interface_target`.
+///
+/// Site-explorer's stored default (`ExploredEndpoint::boot_interface()`)
+/// answers only for endpoints no machine owns. Owned endpoints with no
+/// candidate rows (DPU machines, hosts that have only discovered their BMC)
+/// fall through to it as well, but the explorer never records a default for
+/// those, so in practice they run with no target -- also matching the
+/// controller.
+///
+/// An explicitly entered MAC is always honored as given, never redirected to
+/// another NIC; either store may complete it with the id recorded for that
+/// exact MAC.
 fn resolve_admin_boot_interface_target(
-    stored: Option<&ExploredEndpoint>,
+    stored: Option<MachineBootInterface>,
+    machine_interfaces: Option<&[MachineInterfaceSnapshot]>,
     entered_mac: Option<MacAddress>,
 ) -> Option<BootInterfaceTarget> {
-    let stored = stored.and_then(|ep| ep.boot_interface());
-    match (entered_mac, stored) {
-        (None, stored) => stored.map(BootInterfaceTarget::Pair),
-        (Some(mac), Some(boot_interface)) if boot_interface.mac_address == mac => {
-            Some(BootInterfaceTarget::Pair(boot_interface))
+    // The full `MachineBootInterface` for `mac` from the machine's own
+    // interface rows, if known.
+    let row_pair_for = |mac: MacAddress| -> Option<MachineBootInterface> {
+        machine_interfaces?
+            .iter()
+            .find(|row| row.mac_address == mac)
+            .and_then(|row| {
+                MachineBootInterface::from_parts(
+                    Some(row.mac_address),
+                    row.boot_interface_id.clone(),
+                )
+            })
+    };
+
+    match entered_mac {
+        Some(mac) => row_pair_for(mac)
+            .or_else(|| stored.filter(|pair| pair.mac_address == mac))
+            .map(BootInterfaceTarget::Pair)
+            .or(Some(BootInterfaceTarget::MacOnly(mac))),
+        None => {
+            if let Some(interfaces) = machine_interfaces
+                && let Some(picked) = model::machine::pick_boot_interface(interfaces)
+            {
+                // The machine's own row decides, exactly like the
+                // machine-controller's boot_interface_target: the row's
+                // captured id completes the pair, or the MAC is targeted
+                // alone. The explored default is not consulted for an owned
+                // machine.
+                return Some(
+                    match MachineBootInterface::from_parts(
+                        Some(picked.mac_address),
+                        picked.boot_interface_id.clone(),
+                    ) {
+                        Some(pair) => BootInterfaceTarget::Pair(pair),
+                        None => BootInterfaceTarget::MacOnly(picked.mac_address),
+                    },
+                );
+            }
+            // No machine, or no candidate rows yet (e.g. only the BMC has been
+            // discovered) -- fall through to the explored default.
+            stored.map(BootInterfaceTarget::Pair)
         }
-        (Some(mac), _) => Some(BootInterfaceTarget::MacOnly(mac)),
     }
+}
+
+/// The `machine_interfaces` rows boot-interface resolution selects from, when
+/// the BMC endpoint belongs to a (predicted or confirmed) host machine.
+///
+/// Returns `None` -- meaning resolution falls through to the explored
+/// default -- for endpoints with no machine; for DPU machines, whose own
+/// setup runs without a boot-interface target, exactly like the
+/// machine-controller path; and for a host with no candidate rows yet
+/// (`find_by_machine_ids` filters BMC rows, so a host whose only discovered
+/// interface is its BMC yields none).
+pub(crate) async fn boot_interface_candidates(
+    txn: &mut PgConnection,
+    machine_id: Option<MachineId>,
+) -> Result<Option<Vec<MachineInterfaceSnapshot>>, CarbideError> {
+    let Some(machine_id) = machine_id.filter(|id| !id.machine_type().is_dpu()) else {
+        return Ok(None);
+    };
+    Ok(
+        db::machine_interface::find_by_machine_ids(txn, &[machine_id])
+            .await?
+            .remove(&machine_id),
+    )
 }
 
 pub(crate) async fn admin_bmc_reset(
@@ -300,9 +374,10 @@ pub(crate) async fn machine_setup(
 
     let mut txn = api.txn_begin().await?;
 
-    let (bmc_endpoint_request, _) =
+    let (bmc_endpoint_request, owning_machine_id) =
         validate_and_complete_bmc_endpoint_request(&mut txn, req.bmc_endpoint_request, machine_id)
             .await?;
+    let machine_interfaces = boot_interface_candidates(&mut txn, owning_machine_id).await?;
 
     txn.commit().await?;
 
@@ -324,8 +399,10 @@ pub(crate) async fn machine_setup(
     let stored = db::explored_endpoints::find_by_ips(&api.database_connection, vec![bmc_addr.ip()])
         .await?
         .into_iter()
-        .next();
-    let boot_interface = resolve_admin_boot_interface_target(stored.as_ref(), entered_mac);
+        .next()
+        .and_then(|ep| ep.boot_interface());
+    let boot_interface =
+        resolve_admin_boot_interface_target(stored, machine_interfaces.as_deref(), entered_mac);
 
     api.endpoint_explorer
         .machine_setup(bmc_addr, &machine_interface, boot_interface.as_ref())
@@ -353,9 +430,10 @@ pub(crate) async fn set_dpu_first_boot_order(
 
     let mut txn = api.txn_begin().await?;
 
-    let (bmc_endpoint_request, _) =
+    let (bmc_endpoint_request, owning_machine_id) =
         validate_and_complete_bmc_endpoint_request(&mut txn, req.bmc_endpoint_request, machine_id)
             .await?;
+    let machine_interfaces = boot_interface_candidates(&mut txn, owning_machine_id).await?;
 
     txn.commit().await?;
 
@@ -381,13 +459,16 @@ pub(crate) async fn set_dpu_first_boot_order(
     let stored = db::explored_endpoints::find_by_ips(&api.database_connection, vec![bmc_addr.ip()])
         .await?
         .into_iter()
-        .next();
-    let boot_interface = resolve_admin_boot_interface_target(stored.as_ref(), entered_mac)
-        .ok_or_else(|| {
-            CarbideError::InvalidArgument(
-                "no boot interface available: enter a MAC or explore the host first".to_string(),
-            )
-        })?;
+        .next()
+        .and_then(|ep| ep.boot_interface());
+    let boot_interface =
+        resolve_admin_boot_interface_target(stored, machine_interfaces.as_deref(), entered_mac)
+            .ok_or_else(|| {
+                CarbideError::InvalidArgument(
+                    "no boot interface available: enter a MAC or explore the host first"
+                        .to_string(),
+                )
+            })?;
 
     api.endpoint_explorer
         .set_boot_order_dpu_first(bmc_addr, &machine_interface, &boot_interface)
@@ -985,5 +1066,129 @@ pub(crate) async fn validate_and_complete_bmc_endpoint_request(
         _ => Err(CarbideError::InvalidArgument(
             "Provide either machine_id or BmcEndpointRequest with at least ip_address".to_string(),
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(mac: &str, primary: bool, boot_interface_id: Option<&str>) -> MachineInterfaceSnapshot {
+        let mut row = MachineInterfaceSnapshot::mock_with_mac(mac.parse().unwrap());
+        row.primary_interface = primary;
+        row.boot_interface_id = boot_interface_id.map(String::from);
+        row
+    }
+
+    fn pair(mac: &str, interface_id: &str) -> MachineBootInterface {
+        MachineBootInterface {
+            mac_address: mac.parse().unwrap(),
+            interface_id: interface_id.to_string(),
+        }
+    }
+
+    #[test]
+    fn entered_mac_upgrades_to_a_pair_from_the_machines_own_row() {
+        // The operator picked a NIC; its machine_interface row holds the Redfish
+        // id, so the target is the full pair -- even though the explored default
+        // names a different NIC.
+        let rows = [
+            row("00:00:5e:00:53:01", true, Some("NIC.Integrated.1-1-1")),
+            row("00:00:5e:00:53:02", false, Some("NIC.Slot.7-1-1")),
+        ];
+        let stored = Some(pair("00:00:5e:00:53:01", "NIC.Integrated.1-1-1"));
+        let target = resolve_admin_boot_interface_target(
+            stored,
+            Some(&rows),
+            Some("00:00:5e:00:53:02".parse().unwrap()),
+        );
+        assert_eq!(
+            target,
+            Some(BootInterfaceTarget::Pair(pair(
+                "00:00:5e:00:53:02",
+                "NIC.Slot.7-1-1"
+            ))),
+        );
+    }
+
+    #[test]
+    fn entered_mac_falls_back_to_the_explored_default_then_mac_only() {
+        // No machine rows: the explored default completes the pair only when it
+        // names the entered MAC; any other entered MAC is targeted alone.
+        let stored = pair("00:00:5e:00:53:01", "NIC.Integrated.1-1-1");
+        assert_eq!(
+            resolve_admin_boot_interface_target(
+                Some(stored.clone()),
+                None,
+                Some("00:00:5e:00:53:01".parse().unwrap()),
+            ),
+            Some(BootInterfaceTarget::Pair(stored.clone())),
+        );
+        assert_eq!(
+            resolve_admin_boot_interface_target(
+                Some(stored),
+                None,
+                Some("00:00:5e:00:53:99".parse().unwrap()),
+            ),
+            Some(BootInterfaceTarget::MacOnly(
+                "00:00:5e:00:53:99".parse().unwrap()
+            )),
+        );
+    }
+
+    #[test]
+    fn no_mac_prefers_the_machines_designation_over_the_explored_default() {
+        // The machine's primary row is the authority; the explored default
+        // (site-explorer's automatic pick) names a different NIC and loses.
+        let rows = [
+            row("00:00:5e:00:53:01", false, Some("NIC.Integrated.1-1-1")),
+            row("00:00:5e:00:53:02", true, Some("NIC.Slot.7-1-1")),
+        ];
+        let stored = Some(pair("00:00:5e:00:53:01", "NIC.Integrated.1-1-1"));
+        assert_eq!(
+            resolve_admin_boot_interface_target(stored, Some(&rows), None),
+            Some(BootInterfaceTarget::Pair(pair(
+                "00:00:5e:00:53:02",
+                "NIC.Slot.7-1-1"
+            ))),
+        );
+    }
+
+    #[test]
+    fn no_mac_machine_row_without_an_id_targets_the_mac_alone() {
+        // The designated row hasn't captured an id yet: the action targets the
+        // MAC alone, exactly like the machine-controller's
+        // boot_interface_target. The explored default is not consulted for an
+        // owned machine -- even when it holds an id for the very same NIC.
+        let rows = [row("00:00:5e:00:53:02", true, None)];
+        for stored in [
+            Some(pair("00:00:5e:00:53:02", "NIC.Slot.7-1-1")),
+            Some(pair("00:00:5e:00:53:01", "NIC.Integrated.1-1-1")),
+            None,
+        ] {
+            assert_eq!(
+                resolve_admin_boot_interface_target(stored, Some(&rows), None),
+                Some(BootInterfaceTarget::MacOnly(
+                    "00:00:5e:00:53:02".parse().unwrap()
+                )),
+            );
+        }
+    }
+
+    #[test]
+    fn no_mac_without_candidate_rows_falls_through_to_the_explored_default() {
+        // A machine that owns no candidate interface rows yet (or no machine at
+        // all) resolves from the explored default; with neither, there is no
+        // target.
+        let stored = pair("00:00:5e:00:53:01", "NIC.Integrated.1-1-1");
+        assert_eq!(
+            resolve_admin_boot_interface_target(Some(stored.clone()), Some(&[]), None),
+            Some(BootInterfaceTarget::Pair(stored.clone())),
+        );
+        assert_eq!(
+            resolve_admin_boot_interface_target(Some(stored.clone()), None, None),
+            Some(BootInterfaceTarget::Pair(stored)),
+        );
+        assert_eq!(resolve_admin_boot_interface_target(None, None, None), None);
     }
 }

--- a/crates/api-core/src/tests/boot_interface_resolution.rs
+++ b/crates/api-core/src/tests/boot_interface_resolution.rs
@@ -1,0 +1,293 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Admin boot-interface resolution: the by-BMC-endpoint admin RPCs
+//! (`machine_setup`, `set_dpu_first_boot_order`) resolve a host's boot
+//! interface from the machine's own `machine_interfaces` rows -- the same
+//! designation every other flow acts on -- and use site-explorer's explored
+//! default only for endpoints no machine owns. (Owned endpoints with no
+//! candidate rows -- DPU machines, BMC-only hosts -- fall through to that
+//! default too, but the explorer never records one for them, so in practice
+//! they run with no target, matching the machine-controller.)
+//!
+//! The Redfish sim records the MAC each boot-order call targeted, so these
+//! tests assert the *selection* end to end; the pair-vs-MAC-only upgrade
+//! details are unit-tested next to the resolver itself.
+
+use carbide_redfish::libredfish::test_support::RedfishSimAction;
+use carbide_uuid::machine::MachineId;
+use ipnetwork::IpNetwork;
+use mac_address::MacAddress;
+use model::network_segment::NetworkSegmentType;
+use model::test_support::{DpuConfig, ManagedHostConfig};
+use rpc::forge;
+use rpc::forge::forge_server::Forge;
+
+use crate::handlers::bmc_endpoint_explorer::boot_interface_candidates;
+use crate::test_support::fixture_config::{FixtureDefault as _, ManagedHostConfigExt as _};
+use crate::tests::common::api_fixtures;
+use crate::tests::common::api_fixtures::network_segment::{
+    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY,
+    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY, create_admin_network_segment,
+    create_host_inband_network_segment, create_underlay_network_segment,
+};
+
+/// Creates a two-DPU host and moves its primary to a different host interface
+/// via `set_primary_interface`, returning the host id and the promoted
+/// interface's MAC -- the boot interface the admin actions under test must now
+/// target.
+async fn host_with_moved_primary(
+    env: &api_fixtures::TestEnv,
+) -> Result<(MachineId, MacAddress), Box<dyn std::error::Error>> {
+    let host = api_fixtures::site_explorer::new_host(
+        env,
+        ManagedHostConfig::with_dpus(vec![DpuConfig::default(), DpuConfig::default()]),
+    )
+    .await?;
+    let host_id = host.host_snapshot.id;
+
+    let (promote_id, promote_mac) = {
+        let mut txn = env.pool.begin().await?;
+        let interfaces = db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
+            .await?
+            .remove(&host_id)
+            .expect("host should have interface rows");
+        let promote = interfaces
+            .iter()
+            .find(|i| !i.primary_interface && i.attached_dpu_machine_id.is_some())
+            .expect("host should have a non-primary host interface to promote");
+        (promote.id, promote.mac_address)
+    };
+
+    env.api
+        .set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
+            host_machine_id: Some(host_id),
+            interface_id: Some(promote_id),
+            reboot: false,
+        }))
+        .await?;
+
+    Ok((host_id, promote_mac))
+}
+
+// An operator-moved primary is the boot interface the admin path must target:
+// after set-primary-interface, a no-MAC set_dpu_first_boot_order resolves the
+// promoted interface from the machine's own rows. (It used to resolve
+// site-explorer's explored default, which still names the original NIC --
+// re-applying the very boot order the operator just moved away from.)
+#[crate::sqlx_test]
+async fn test_set_dpu_first_targets_an_operator_moved_primary(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = api_fixtures::create_test_env(pool).await;
+    let (host_id, promote_mac) = host_with_moved_primary(&env).await?;
+
+    // Only observe the admin RPC below, not the promotion's own boot-order call.
+    let timepoint = env.redfish_sim.timepoint();
+
+    env.api
+        .set_dpu_first_boot_order(tonic::Request::new(forge::SetDpuFirstBootOrderRequest {
+            machine_id: Some(host_id.to_string()),
+            bmc_endpoint_request: None,
+            boot_interface_mac: None,
+        }))
+        .await?;
+
+    let actions = env.redfish_sim.actions_since(&timepoint).all_hosts();
+    assert_eq!(
+        actions,
+        vec![RedfishSimAction::SetBootOrderDpuFirst {
+            boot_interface_mac: promote_mac.to_string(),
+        }],
+        "the admin path should target the operator-moved primary, not the explored default",
+    );
+
+    Ok(())
+}
+
+// machine_setup shares the resolver with set_dpu_first_boot_order but has its
+// own downstream semantics (BIOS boot-device pinning rather than boot-order
+// promotion) -- assert its resolved target end to end as well: after
+// set-primary-interface, an admin machine_setup configures BIOS for the
+// promoted NIC, not the explored default.
+#[crate::sqlx_test]
+async fn test_machine_setup_targets_an_operator_moved_primary(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = api_fixtures::create_test_env(pool).await;
+    let (host_id, promote_mac) = host_with_moved_primary(&env).await?;
+
+    let timepoint = env.redfish_sim.timepoint();
+
+    env.api
+        .machine_setup(tonic::Request::new(forge::MachineSetupRequest {
+            machine_id: Some(host_id.to_string()),
+            bmc_endpoint_request: None,
+            boot_interface_mac: None,
+        }))
+        .await?;
+
+    let actions = env.redfish_sim.actions_since(&timepoint).all_hosts();
+    let targeted = actions
+        .iter()
+        .find_map(|action| match action {
+            RedfishSimAction::MachineSetup {
+                boot_interface_mac, ..
+            } => Some(boot_interface_mac.clone()),
+            _ => None,
+        })
+        .expect("machine_setup should have been called");
+    assert_eq!(
+        targeted,
+        Some(promote_mac.to_string()),
+        "machine_setup should configure BIOS for the operator-moved primary",
+    );
+
+    Ok(())
+}
+
+// A zero-DPU host has no explored default (site-explorer's automatic pick only
+// resolves for DPU-mode hosts), so a no-MAC set_dpu_first_boot_order used to
+// fail with "explore the host first". The machine's own interface rows resolve
+// it now: the HostInband NIC -- the same row the machine-controller boots the
+// host from -- is the target.
+#[crate::sqlx_test]
+async fn test_set_dpu_first_resolves_a_zero_dpu_host_without_an_explored_default(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Zero-DPU ingestion needs a HostInband segment with a routable relay
+    // address; the default test env doesn't define one.
+    let env = api_fixtures::create_test_env_with_overrides(
+        pool,
+        api_fixtures::TestEnvOverrides {
+            site_prefixes: Some(vec![
+                IpNetwork::new(
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+                IpNetwork::new(
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+                IpNetwork::new(
+                    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.network(),
+                    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.prefix(),
+                )
+                .unwrap(),
+            ]),
+            create_network_segments: Some(false),
+            ..Default::default()
+        },
+    )
+    .await;
+    // HostInband segments must live in a Flat VPC.
+    let flat_vpc_id = api_fixtures::network_segment::create_default_flat_vpc(
+        &env.api,
+        "boot-interface-resolution zero-dpu flat vpc",
+    )
+    .await;
+    create_underlay_network_segment(&env.api).await;
+    create_admin_network_segment(&env.api).await;
+    create_host_inband_network_segment(&env.api, Some(flat_vpc_id)).await;
+    env.run_network_segment_controller_iteration().await;
+    env.run_network_segment_controller_iteration().await;
+
+    let host =
+        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::with_dpus(vec![])).await?;
+    let host_id = host.host_snapshot.id;
+
+    let inband_mac = {
+        let mut txn = env.pool.begin().await?;
+        db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
+            .await?
+            .remove(&host_id)
+            .expect("zero-DPU host should have interface rows")
+            .into_iter()
+            .find(|i| i.network_segment_type == Some(NetworkSegmentType::HostInband))
+            .expect("zero-DPU host should have a HostInband interface")
+            .mac_address
+    };
+
+    let timepoint = env.redfish_sim.timepoint();
+
+    env.api
+        .set_dpu_first_boot_order(tonic::Request::new(forge::SetDpuFirstBootOrderRequest {
+            machine_id: Some(host_id.to_string()),
+            bmc_endpoint_request: None,
+            boot_interface_mac: None,
+        }))
+        .await?;
+
+    let actions = env.redfish_sim.actions_since(&timepoint).all_hosts();
+    assert_eq!(
+        actions,
+        vec![RedfishSimAction::SetBootOrderDpuFirst {
+            boot_interface_mac: inband_mac.to_string(),
+        }],
+        "the zero-DPU host's NIC should resolve from its machine_interfaces row",
+    );
+
+    Ok(())
+}
+
+// Machine-row resolution applies to hosts (confirmed or predicted) only: a
+// DPU machine's endpoint must not resolve a boot-interface target from
+// interface rows -- a DPU's own setup runs without one, exactly like the
+// machine-controller path.
+#[crate::sqlx_test]
+async fn test_boot_interface_candidates_skips_dpu_machines(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = api_fixtures::create_test_env(pool).await;
+
+    let host = api_fixtures::site_explorer::new_host(
+        &env,
+        ManagedHostConfig::with_dpus(vec![DpuConfig::default()]),
+    )
+    .await?;
+    let host_id = host.host_snapshot.id;
+    let dpu_id = host
+        .dpu_snapshots
+        .first()
+        .expect("host should have a DPU snapshot")
+        .id;
+
+    let mut txn = env.pool.begin().await?;
+    assert!(
+        boot_interface_candidates(txn.as_mut(), Some(dpu_id))
+            .await?
+            .is_none(),
+        "a DPU machine should not resolve boot-interface rows",
+    );
+    assert!(
+        boot_interface_candidates(txn.as_mut(), None)
+            .await?
+            .is_none(),
+        "an unowned endpoint should not resolve boot-interface rows",
+    );
+    let rows = boot_interface_candidates(txn.as_mut(), Some(host_id))
+        .await?
+        .expect("a host machine should resolve its interface rows");
+    assert!(
+        rows.iter().any(|i| i.primary_interface),
+        "the host's rows should include its primary interface",
+    );
+
+    Ok(())
+}

--- a/crates/api-core/src/tests/machine_setup.rs
+++ b/crates/api-core/src/tests/machine_setup.rs
@@ -77,6 +77,7 @@ async fn test_oem_manager_profiles_passed_to_machine_setup() {
         actions[0],
         RedfishSimAction::MachineSetup {
             oem_manager_profiles: config.oem_manager_profiles,
+            boot_interface_mac: None,
         }
     );
 }

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -16,6 +16,8 @@
  */
 
 #[cfg(test)]
+mod boot_interface_resolution;
+#[cfg(test)]
 mod client_resolution;
 pub mod common;
 #[cfg(test)]

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -273,7 +273,12 @@ impl From<ManagedHostStateSnapshotError> for sqlx::Error {
 ///    so it's on the caller to figure out. What this usually means is the
 ///    caller passes `boot_interface_mac: None` to machine_setup, and then
 ///    subsequent logic flows from there (e.g. ::NoDpu handling).
-fn pick_boot_interface(
+///
+/// Public because admin boot-interface resolution (api-core) applies the same
+/// selection to a machine's interface rows when targeting a host by BMC
+/// endpoint -- the designation must resolve identically no matter which door
+/// the Redfish action comes through.
+pub fn pick_boot_interface(
     interfaces: &[MachineInterfaceSnapshot],
 ) -> Option<&MachineInterfaceSnapshot> {
     // The primary wins!

--- a/crates/api-web/src/explored_endpoint.rs
+++ b/crates/api-web/src/explored_endpoint.rs
@@ -1200,14 +1200,16 @@ pub async fn set_dpu_first_boot_order(
     Redirect::to(&redirect_url).into_response()
 }
 
-/// Re-applies the host's stored boot interface on demand.
+/// Re-applies the host's resolved boot interface on demand.
 ///
-/// Unlike `set_dpu_first_boot_order`, this takes no MAC from the operator: it
-/// reuses the same RPC with `boot_interface_mac: None`, which makes the backend
-/// resolve the stored `MachineBootInterface` (MAC + Redfish interface id) and
-/// set it boot-first via the same MAC-first / interface-id fallback as automated
-/// setup. It gives an operator a one-click way to restore boot setup to the last
-/// known/healthy boot interface.
+/// This takes no MAC from the operator: it reuses `set_dpu_first_boot_order`
+/// with `boot_interface_mac: None`, which makes the backend resolve the boot
+/// interface the same way every other flow does -- the owning machine's
+/// designated interface (`primary_interface` + its captured Redfish interface
+/// id) once a machine owns this endpoint, or site-explorer's automatic default
+/// for a not-yet-managed endpoint -- and set it boot-first via the usual
+/// MAC-first / interface-id fallback. One click to put the BMC's boot order
+/// back in line with what Carbide would target.
 pub async fn restore_boot_interface(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
@@ -1231,7 +1233,7 @@ pub async fn restore_boot_interface(
         Ok(_) => ActionStatus {
             action: action_status::Type::RestoreBootInterface,
             class: action_status::Class::Success,
-            message: "Boot interface restored from the last-known-good record".into(),
+            message: "Boot order re-applied from the resolved boot interface".into(),
         }
         .update_redirect_url(&view_url),
         Err(err) => {

--- a/crates/api-web/templates/explored_endpoint_detail.html
+++ b/crates/api-web/templates/explored_endpoint_detail.html
@@ -173,7 +173,7 @@
 							<input type="submit" value="Restore Boot Interface">
 						</div>
 					</form>
-					<div class="config-card-reminder">Re-applies this host's stored boot interface (MAC + Redfish interface id). Use it to restore boot setup when the boot MAC is no longer reported by Redfish, e.g. after a DPU was switched to NIC mode.</div>
+					<div class="config-card-reminder">Re-applies this host's resolved boot interface (MAC + Redfish interface id): the machine's designated primary interface once managed, or site-explorer's automatic default before that. Use it to restore boot setup when the boot MAC is no longer reported by Redfish, e.g. after a DPU was switched to NIC mode.</div>
 				</div>
 				{% include "restart_reminder.html" %}
 				{% if let Some(status) = action_status %}

--- a/crates/redfish/src/boot_interface.rs
+++ b/crates/redfish/src/boot_interface.rs
@@ -24,6 +24,7 @@ use mac_address::MacAddress;
 use model::machine_boot_interface::MachineBootInterface;
 
 /// How to target a host's boot interface for a Redfish setup operation.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BootInterfaceTarget {
     /// A fully-captured boot interface (MAC + Redfish interface id). The MAC is
     /// tried first; on failure the [stable] interface id is used as a fallback

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -201,6 +201,10 @@ pub enum RedfishSimAction {
     SetUtcTimezone,
     MachineSetup {
         oem_manager_profiles: libredfish::BiosProfileVendor,
+        /// The boot interface the setup call targeted (`None` when the caller
+        /// ran setup without one, e.g. DPU setup), letting tests assert which
+        /// NIC boot-device configuration was applied for.
+        boot_interface_mac: Option<String>,
     },
     /// Records a call to `Redfish::is_boot_order_setup`, letting
     /// tests assert that the managed-host state controller actually
@@ -300,7 +304,7 @@ impl Redfish for RedfishSimClient {
 
     fn machine_setup<'a>(
         &'a self,
-        _boot_interface: Option<libredfish::BootInterfaceRef<'a>>,
+        boot_interface: Option<libredfish::BootInterfaceRef<'a>>,
         _bios_profiles: &'a HashMap<
             libredfish::model::service_root::RedfishVendor,
             HashMap<
@@ -322,6 +326,7 @@ impl Redfish for RedfishSimClient {
             let host_state = state.hosts.get_mut(&self._host).unwrap();
             host_state.actions.push(RedfishSimAction::MachineSetup {
                 oem_manager_profiles: oem_manager_profiles.clone(),
+                boot_interface_mac: boot_interface.map(boot_interface_ref_to_string),
             });
             Ok(state.machine_setup_bios_job_id.clone())
         })


### PR DESCRIPTION
## Description

The admin boot-interface actions (`machine_setup`, `set_dpu_first_boot_order`, and the web UI buttons behind them) now answer "which NIC does this host boot from?" the same way the rest of the system does: from the machine `MachineBootInterface` data, specifically the primary interface marked in `machine_interfaces`, coming in as `ManagedHostStateSnapshot::boot_interface()`. This is the same one used by the `machine-controller`, when operators call `set-primary-dpu-interface`, etc.

Generally speaking:
  - The primary interface is set automatically at ingestion -- and operators can `set-primary-interface` to override as needed.
  - The `machine-controller` is the consumer of this for everything boot-related: `machine_setup`, BIOS verification, boot-order set/check all target the `MachineBootInterface` data via the same `pick_boot_interface` selection (that this PR now shares).

The `site-explorer` stored default (in `ExploredEndpoints::boot_interface()`) is used only when no machine owns the endpoint yet, and an explicitly entered MAC is always honored as given.

And until now, these RPCs read only `explored_endpoints` -- meaning they could potentially revert the boot device back to the "default" fallback device, not the one that the `machine-controller` was looking at (and uses to configure).

Tests added to cover the resolution logic + integration tests for both RPCs, with the Redfish sim now recording the boot interface that `machine_setup` targets.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->



Closes #2169
