### PR TITLE
test(api-model): fold tests onto carbide-test-support

### DIFF
--- a/crates/api-model/src/allocation_type.rs
+++ b/crates/api-model/src/allocation_type.rs
@@ -90,8 +90,15 @@ pub enum AssignStaticResult {
 mod tests {
     use std::net::Ipv4Addr;
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
     use crate::address_selection_strategy::AddressSelectionStrategy;
+
+    // Total `From<AddressSelectionStrategy>` conversions: every strategy maps to an
+    // allocation type. These are infallible, so they stay standalone rather than
+    // being wrapped in a fake Result.
 
     #[test]
     fn next_available_ip_is_dhcp() {
@@ -127,21 +134,30 @@ mod tests {
         );
     }
 
+    // JSON round-trip: serialize each variant and deserialize it back, asserting
+    // both the wire form and that it survives the trip. The closure returns the
+    // wire string plus the recovered value so each row pins down both directions.
     #[test]
     fn serde_roundtrip() {
-        let dhcp: AllocationType = serde_json::from_str(r#""dhcp""#).unwrap();
-        assert_eq!(dhcp, AllocationType::Dhcp);
-
-        let static_: AllocationType = serde_json::from_str(r#""static""#).unwrap();
-        assert_eq!(static_, AllocationType::Static);
-
-        assert_eq!(
-            serde_json::to_string(&AllocationType::Dhcp).unwrap(),
-            r#""dhcp""#
-        );
-        assert_eq!(
-            serde_json::to_string(&AllocationType::Static).unwrap(),
-            r#""static""#
+        check_cases(
+            [
+                Case {
+                    scenario: "dhcp",
+                    input: AllocationType::Dhcp,
+                    expect: Yields((r#""dhcp""#.to_string(), AllocationType::Dhcp)),
+                },
+                Case {
+                    scenario: "static",
+                    input: AllocationType::Static,
+                    expect: Yields((r#""static""#.to_string(), AllocationType::Static)),
+                },
+            ],
+            // serialize, then deserialize the wire form back into a value
+            |value| {
+                let wire = serde_json::to_string(&value).map_err(drop)?;
+                let recovered: AllocationType = serde_json::from_str(&wire).map_err(drop)?;
+                Ok::<_, ()>((wire, recovered))
+            },
         );
     }
 }

--- a/crates/api-model/src/controller_outcome.rs
+++ b/crates/api-model/src/controller_outcome.rs
@@ -78,57 +78,81 @@ impl From<&&'static Location<'static>> for PersistentSourceReference {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
+
+    // Serialize each outcome variant to JSON. The serialized String is the
+    // contract, so we yield it directly. serde_json::Error is not PartialEq, so
+    // the (unreachable here) failing path would use Fails; every row succeeds.
     #[test]
     fn test_state_outcome_serialize() {
-        let wait_state = PersistentStateHandlerOutcome::Wait {
-            reason: "Reason goes here".to_string(),
-            source_ref: None,
-        };
-        let serialized = serde_json::to_string(&wait_state).unwrap();
-        assert_eq!(
-            serialized,
-            r#"{"outcome":"wait","reason":"Reason goes here"}"#
+        check_cases(
+            [
+                Case {
+                    scenario: "wait with reason",
+                    input: PersistentStateHandlerOutcome::Wait {
+                        reason: "Reason goes here".to_string(),
+                        source_ref: None,
+                    },
+                    expect: Yields(r#"{"outcome":"wait","reason":"Reason goes here"}"#.to_string()),
+                },
+                Case {
+                    scenario: "transition, no source ref",
+                    input: PersistentStateHandlerOutcome::Transition { source_ref: None },
+                    expect: Yields(r#"{"outcome":"transition"}"#.to_string()),
+                },
+                Case {
+                    scenario: "donothing with source ref details",
+                    input: PersistentStateHandlerOutcome::DoNothing {
+                        source_ref: Some(PersistentSourceReference {
+                            file: "a.rs".to_string(),
+                            line: 100,
+                        }),
+                    },
+                    expect: Yields(
+                        r#"{"outcome":"donothing","source_ref":{"file":"a.rs","line":100}}"#
+                            .to_string(),
+                    ),
+                },
+            ],
+            |outcome| serde_json::to_string(&outcome).map_err(drop),
         );
     }
 
+    // Deserialize JSON back into the outcome variant (the round-trip targets and
+    // the standalone deserialize case). The deserialized type is PartialEq+Debug,
+    // so we yield it directly. serde_json::Error is not PartialEq, hence map_err.
     #[test]
     fn test_state_outcome_deserialize() {
-        let serialized = r#"{"outcome":"error","err":"Error message here"}"#;
-        let expected_error_state = PersistentStateHandlerOutcome::Error {
-            err: "Error message here".to_string(),
-            source_ref: None,
-        };
-        let deserialized: PersistentStateHandlerOutcome = serde_json::from_str(serialized).unwrap();
-        assert_eq!(deserialized, expected_error_state);
-    }
-
-    #[test]
-    fn test_state_outcome_serialize_deserialize_basic() {
-        let transition_state = PersistentStateHandlerOutcome::Transition { source_ref: None };
-        let serialized = serde_json::to_string(&transition_state).unwrap();
-        assert_eq!(serialized, r#"{"outcome":"transition"}"#);
-
-        let deserialized: PersistentStateHandlerOutcome =
-            serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized, transition_state);
-    }
-
-    #[test]
-    fn test_state_outcome_serialize_details() {
-        let state = PersistentStateHandlerOutcome::DoNothing {
-            source_ref: Some(PersistentSourceReference {
-                file: "a.rs".to_string(),
-                line: 100,
-            }),
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(
-            serialized,
-            r#"{"outcome":"donothing","source_ref":{"file":"a.rs","line":100}}"#
+        check_cases(
+            [
+                Case {
+                    scenario: "error variant",
+                    input: r#"{"outcome":"error","err":"Error message here"}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::Error {
+                        err: "Error message here".to_string(),
+                        source_ref: None,
+                    }),
+                },
+                Case {
+                    scenario: "transition round-trip",
+                    input: r#"{"outcome":"transition"}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::Transition { source_ref: None }),
+                },
+                Case {
+                    scenario: "donothing with source ref round-trip",
+                    input: r#"{"outcome":"donothing","source_ref":{"file":"a.rs","line":100}}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::DoNothing {
+                        source_ref: Some(PersistentSourceReference {
+                            file: "a.rs".to_string(),
+                            line: 100,
+                        }),
+                    }),
+                },
+            ],
+            |json| serde_json::from_str::<PersistentStateHandlerOutcome>(json).map_err(drop),
         );
-        let deserialized: PersistentStateHandlerOutcome =
-            serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized, state);
     }
 }

--- a/crates/api-model/src/dpa_interface/mod.rs
+++ b/crates/api-model/src/dpa_interface/mod.rs
@@ -438,89 +438,107 @@ impl TryFrom<DpaInterfaceSnapshotPgJson> for DpaInterface {
 mod tests {
     use std::str::FromStr;
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
-    #[test]
-    fn from_device_info_extracts_fields() {
-        let machine_id =
-            MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30")
-                .unwrap();
+    fn test_machine_id() -> MachineId {
+        MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30").unwrap()
+    }
 
-        let base_mac = MacAddress::from_str("00:11:22:33:44:55").unwrap();
-        let device_type = "BlueField3".to_string();
-        let pci_name = "01:00.0".to_string();
-        let device_description = Some("SuperNIC".to_string());
-        let interface_type = DpaInterfaceType::Svpc;
-
-        let new_intf = NewDpaInterface::from_device_info(
-            machine_id,
-            Some(base_mac),
-            device_type,
-            pci_name,
-            device_description,
-            interface_type,
-        )
-        .unwrap();
-        assert_eq!(new_intf.machine_id, machine_id);
-        assert_eq!(
-            new_intf.mac_address,
-            MacAddress::from_str("00:11:22:33:44:55").unwrap()
-        );
-        assert_eq!(new_intf.device_type, "BlueField3");
-        assert_eq!(new_intf.pci_name, "01:00.0");
+    /// Inputs to `NewDpaInterface::from_device_info`, one per row.
+    struct DeviceInfoInput {
+        base_mac: Option<MacAddress>,
+        device_type: String,
+        pci_name: String,
+        device_description: Option<String>,
+        interface_type: DpaInterfaceType,
     }
 
     #[test]
-    fn from_device_info_returns_none_without_base_mac() {
-        let machine_id =
-            MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30")
-                .unwrap();
-        let base_mac = None;
-        let device_type = "BlueField3".to_string();
-        let pci_name = "01:00.0".to_string();
-        let device_description = None;
-        let interface_type = DpaInterfaceType::Svpc;
-
-        assert!(
-            NewDpaInterface::from_device_info(
-                machine_id,
-                base_mac,
-                device_type,
-                pci_name,
-                device_description,
-                interface_type
-            )
-            .is_none()
+    fn from_device_info() {
+        // `from_device_info` only fails (returns None) when the base MAC is unset;
+        // with a MAC present it projects the input fields straight through. We map
+        // the Option to a Result and, for the success row, yield the asserted
+        // (machine_id, mac_address, device_type, pci_name) fields.
+        let machine_id = test_machine_id();
+        check_cases(
+            [
+                Case {
+                    scenario: "extracts fields when base mac present",
+                    input: DeviceInfoInput {
+                        base_mac: Some(MacAddress::from_str("00:11:22:33:44:55").unwrap()),
+                        device_type: "BlueField3".to_string(),
+                        pci_name: "01:00.0".to_string(),
+                        device_description: Some("SuperNIC".to_string()),
+                        interface_type: DpaInterfaceType::Svpc,
+                    },
+                    expect: Yields((
+                        machine_id,
+                        MacAddress::from_str("00:11:22:33:44:55").unwrap(),
+                        "BlueField3".to_string(),
+                        "01:00.0".to_string(),
+                    )),
+                },
+                Case {
+                    scenario: "returns none without base mac",
+                    input: DeviceInfoInput {
+                        base_mac: None,
+                        device_type: "BlueField3".to_string(),
+                        pci_name: "01:00.0".to_string(),
+                        device_description: None,
+                        interface_type: DpaInterfaceType::Svpc,
+                    },
+                    expect: Fails,
+                },
+            ],
+            |i| {
+                NewDpaInterface::from_device_info(
+                    machine_id,
+                    i.base_mac,
+                    i.device_type,
+                    i.pci_name,
+                    i.device_description,
+                    i.interface_type,
+                )
+                .map(|n| (n.machine_id, n.mac_address, n.device_type, n.pci_name))
+                .ok_or(())
+            },
         );
     }
 
     #[test]
     fn serialize_controller_state() {
-        // Make sure the Provisioning state serializes to/from "provisioning".
-        let state = DpaInterfaceControllerState::Provisioning {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"provisioning\"}");
-        assert_eq!(
-            serde_json::from_str::<DpaInterfaceControllerState>(&serialized).unwrap(),
-            state
-        );
-
-        // Make sure the Ready state serializes to/from "ready".
-        let state = DpaInterfaceControllerState::Ready {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"ready\"}");
-        assert_eq!(
-            serde_json::from_str::<DpaInterfaceControllerState>(&serialized).unwrap(),
-            state
-        );
-
-        // Make sure the ApplyFirmware state serializes to/from "applyfirmware".
-        let state = DpaInterfaceControllerState::ApplyFirmware;
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"applyfirmware\"}");
-        assert_eq!(
-            serde_json::from_str::<DpaInterfaceControllerState>(&serialized).unwrap(),
-            state
+        // Each state must serialize to its exact tagged JSON and deserialize back to
+        // the original value. The closure serializes, asserts the round-trip equals
+        // the input state, and yields the serialized string (which is the contract).
+        check_cases(
+            [
+                Case {
+                    scenario: "provisioning",
+                    input: DpaInterfaceControllerState::Provisioning {},
+                    expect: Yields("{\"state\":\"provisioning\"}".to_string()),
+                },
+                Case {
+                    scenario: "ready",
+                    input: DpaInterfaceControllerState::Ready {},
+                    expect: Yields("{\"state\":\"ready\"}".to_string()),
+                },
+                Case {
+                    scenario: "applyfirmware",
+                    input: DpaInterfaceControllerState::ApplyFirmware,
+                    expect: Yields("{\"state\":\"applyfirmware\"}".to_string()),
+                },
+            ],
+            |state| -> Result<String, ()> {
+                let serialized = serde_json::to_string(&state).map_err(|_| ())?;
+                let round_tripped =
+                    serde_json::from_str::<DpaInterfaceControllerState>(&serialized)
+                        .map_err(|_| ())?;
+                assert_eq!(round_tripped, state);
+                Ok(serialized)
+            },
         );
     }
 }

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -244,6 +244,9 @@ pub struct UnexpectedMachine {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     /// Nothing set anywhere -- the host falls back to the absolute
@@ -344,33 +347,43 @@ mod tests {
         assert!(!DpuMode::NoDpu.is_dpu_managed());
     }
 
+    /// JSON deserialization of `ExpectedMachine`, projecting to the
+    /// `host_lifecycle_profile.disable_lockdown` field under test. A missing
+    /// `host_lifecycle_profile` defaults to `None` (equivalent to
+    /// `HostLifecycleProfile::default()`, whose only field is `disable_lockdown`).
     #[test]
-    fn host_lifecycle_profile_defaults_when_missing_from_json() {
-        let json = r#"{
-            "bmc_mac_address": "AA:BB:CC:DD:EE:FF",
-            "bmc_username": "root",
-            "bmc_password": "pass",
-            "serial_number": "SN-1"
-        }"#;
-        let em: ExpectedMachine = serde_json::from_str(json).unwrap();
-        assert_eq!(
-            em.data.host_lifecycle_profile,
-            HostLifecycleProfile::default()
+    fn host_lifecycle_profile_deserializes_from_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "missing host_lifecycle_profile defaults to None",
+                    input: r#"{
+                        "bmc_mac_address": "AA:BB:CC:DD:EE:FF",
+                        "bmc_username": "root",
+                        "bmc_password": "pass",
+                        "serial_number": "SN-1"
+                    }"#,
+                    expect: Yields(None),
+                },
+                Case {
+                    scenario: "present host_lifecycle_profile parses disable_lockdown",
+                    input: r#"{
+                        "bmc_mac_address": "AA:BB:CC:DD:EE:FF",
+                        "bmc_username": "root",
+                        "bmc_password": "pass",
+                        "serial_number": "SN-1",
+                        "host_lifecycle_profile": {"disable_lockdown": true}
+                    }"#,
+                    expect: Yields(Some(true)),
+                },
+            ],
+            // serde_json::Error is not PartialEq, so discard it on the error path.
+            |json| {
+                serde_json::from_str::<ExpectedMachine>(json)
+                    .map(|em| em.data.host_lifecycle_profile.disable_lockdown)
+                    .map_err(drop)
+            },
         );
-        assert_eq!(em.data.host_lifecycle_profile.disable_lockdown, None);
-    }
-
-    #[test]
-    fn host_lifecycle_profile_parses_from_json_when_present() {
-        let json = r#"{
-            "bmc_mac_address": "AA:BB:CC:DD:EE:FF",
-            "bmc_username": "root",
-            "bmc_password": "pass",
-            "serial_number": "SN-1",
-            "host_lifecycle_profile": {"disable_lockdown": true}
-        }"#;
-        let em: ExpectedMachine = serde_json::from_str(json).unwrap();
-        assert_eq!(em.data.host_lifecycle_profile.disable_lockdown, Some(true));
     }
 
     #[test]

--- a/crates/api-model/src/extension_service/mod.rs
+++ b/crates/api-model/src/extension_service/mod.rs
@@ -236,3 +236,97 @@ pub struct ExtensionServiceObservabilityConfig {
 pub struct ExtensionServiceObservability {
     pub configs: Vec<ExtensionServiceObservabilityConfig>,
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
+    use super::*;
+
+    // ExtensionServiceType parses case-insensitively from its wire form, and an
+    // unknown string is rejected.
+    #[test]
+    fn extension_service_type_from_str() {
+        check_cases(
+            [
+                Case {
+                    scenario: "canonical kubernetes_pod",
+                    input: "kubernetes_pod",
+                    expect: Yields(ExtensionServiceType::KubernetesPod),
+                },
+                Case {
+                    scenario: "mixed case is normalized",
+                    input: "Kubernetes_Pod",
+                    expect: Yields(ExtensionServiceType::KubernetesPod),
+                },
+                Case {
+                    scenario: "unknown type is rejected",
+                    input: "virtual_machine",
+                    expect: Fails,
+                },
+            ],
+            |s| ExtensionServiceType::from_str(s).map_err(drop),
+        );
+    }
+
+    // Display is the inverse of from_str: each variant's wire form parses back to it.
+    #[test]
+    fn extension_service_type_display_round_trips() {
+        check_cases(
+            [Case {
+                scenario: "kubernetes_pod",
+                input: ExtensionServiceType::KubernetesPod,
+                expect: Yields(ExtensionServiceType::KubernetesPod),
+            }],
+            |t| ExtensionServiceType::from_str(&t.to_string()).map_err(drop),
+        );
+    }
+
+    // The observability config tree round-trips through JSON for each variant,
+    // exercising the nested enum and its Prometheus / Logging payloads.
+    #[test]
+    fn observability_config_json_round_trip() {
+        let prometheus = ExtensionServiceObservability {
+            configs: vec![ExtensionServiceObservabilityConfig {
+                name: Some("metrics".to_string()),
+                config: ExtensionServiceObservabilityConfigType::Prometheus(
+                    ExtensionServiceObservabilityConfigTypePrometheus {
+                        scrape_interval_seconds: 30,
+                        endpoint: "/metrics".to_string(),
+                    },
+                ),
+            }],
+        };
+        let logging = ExtensionServiceObservability {
+            configs: vec![ExtensionServiceObservabilityConfig {
+                name: None,
+                config: ExtensionServiceObservabilityConfigType::Logging(
+                    ExtensionServiceObservabilityConfigTypeLogging {
+                        path: "/var/log/svc.log".to_string(),
+                    },
+                ),
+            }],
+        };
+        check_cases(
+            [
+                Case {
+                    scenario: "prometheus config",
+                    input: prometheus.clone(),
+                    expect: Yields(prometheus),
+                },
+                Case {
+                    scenario: "logging config",
+                    input: logging.clone(),
+                    expect: Yields(logging),
+                },
+            ],
+            |obs| {
+                let json = serde_json::to_string(&obs).map_err(drop)?;
+                serde_json::from_str::<ExtensionServiceObservability>(&json).map_err(drop)
+            },
+        );
+    }
+}

--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -396,6 +396,9 @@ impl From<libnmxm::nmxm_model::Gpu> for NvLinkGpu {
 #[cfg(test)]
 mod tests {
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     const DPU_INFO_JSON: &[u8] = include_bytes!("hardware_info/test_data/dpu_info.json");
@@ -425,31 +428,40 @@ mod tests {
         );
     }
 
+    // Deserialize an LLDP switch entry and project to the management `ip_address`
+    // list: invalid entries are dropped lossily and a null list defaults to empty.
     #[test]
-    fn lldp_switch_data_filters_invalid_management_addresses() {
-        let json = r#"{
-            "ip_address": [
-                "192.0.2.10",
-                "not-an-ip",
-                "2001:db8::1"
-            ]
-        }"#;
-        let switch: LldpSwitchData = serde_json::from_str(json).unwrap();
-
-        assert_eq!(
-            switch.ip_address,
-            vec![
-                "192.0.2.10".parse::<IpAddr>().unwrap(),
-                "2001:db8::1".parse::<IpAddr>().unwrap(),
-            ]
+    fn lldp_switch_data_management_addresses() {
+        check_cases(
+            [
+                Case {
+                    scenario: "filters invalid management addresses",
+                    input: r#"{
+                        "ip_address": [
+                            "192.0.2.10",
+                            "not-an-ip",
+                            "2001:db8::1"
+                        ]
+                    }"#,
+                    expect: Yields(vec![
+                        "192.0.2.10".parse::<IpAddr>().unwrap(),
+                        "2001:db8::1".parse::<IpAddr>().unwrap(),
+                    ]),
+                },
+                Case {
+                    scenario: "defaults null management addresses to empty",
+                    input: r#"{"ip_address":null}"#,
+                    expect: Yields(vec![]),
+                },
+            ],
+            // serde_json::Error is not PartialEq, so deserialization failure would
+            // be Fails; here every row parses, so the error type is irrelevant.
+            |json| {
+                serde_json::from_str::<LldpSwitchData>(json)
+                    .map(|switch| switch.ip_address)
+                    .map_err(drop)
+            },
         );
-    }
-
-    #[test]
-    fn lldp_switch_data_defaults_null_management_addresses() {
-        let switch: LldpSwitchData = serde_json::from_str(r#"{"ip_address":null}"#).unwrap();
-
-        assert!(switch.ip_address.is_empty());
     }
 
     #[test]
@@ -551,16 +563,41 @@ mod tests {
         );
     }
 
+    // Deserialize a HardwareInfo fixture and project to whether it is classified as
+    // a DPU: x86 hardware is not, both BlueField fixtures are.
     #[test]
-    fn deserialize_x86_info() {
-        let info = serde_json::from_slice::<HardwareInfo>(X86_INFO_JSON).unwrap();
-        assert!(!info.is_dpu());
+    fn deserialize_info_is_dpu() {
+        check_cases(
+            [
+                Case {
+                    scenario: "x86 host is not a DPU",
+                    input: X86_INFO_JSON,
+                    expect: Yields(false),
+                },
+                Case {
+                    scenario: "dpu info is a DPU",
+                    input: DPU_INFO_JSON,
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "bf3 dpu info is a DPU",
+                    input: DPU_BF3_INFO_JSON,
+                    expect: Yields(true),
+                },
+            ],
+            // serde_json::Error is not PartialEq; every fixture parses, so the error
+            // type is irrelevant here.
+            |bytes| {
+                serde_json::from_slice::<HardwareInfo>(bytes)
+                    .map(|info| info.is_dpu())
+                    .map_err(drop)
+            },
+        );
     }
 
     #[test]
-    fn deserialize_dpu_info() {
+    fn deserialize_dpu_info_decodes_ch_64_mac() {
         let info = serde_json::from_slice::<HardwareInfo>(DPU_INFO_JSON).unwrap();
-        assert!(info.is_dpu());
 
         // Make sure deserialize_ch_64 works as expected, where
         // the source dpu_info.json file for this has ch:64 as
@@ -569,12 +606,6 @@ mod tests {
             info.network_interfaces[1].mac_address.to_string(),
             "00:00:00:00:00:64"
         );
-    }
-
-    #[test]
-    fn deserialize_dpu_bf3_info() {
-        let info = serde_json::from_slice::<HardwareInfo>(DPU_BF3_INFO_JSON).unwrap();
-        assert!(info.is_dpu());
     }
 
     #[test]

--- a/crates/api-model/src/health.rs
+++ b/crates/api-model/src/health.rs
@@ -79,7 +79,22 @@ impl HealthReportSources {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
+
+    /// Build a `HealthReportSources` from a replace source name and a list of merge
+    /// source names, using empty reports keyed by their own source identifier.
+    fn sources(replace: Option<&str>, merges: &[&str]) -> HealthReportSources {
+        HealthReportSources {
+            replace: replace.map(|s| HealthReport::empty(s.to_string())),
+            merges: merges
+                .iter()
+                .map(|s| (s.to_string(), HealthReport::empty(s.to_string())))
+                .collect(),
+        }
+    }
 
     #[test]
     fn health_reports_default_is_empty() {
@@ -90,93 +105,73 @@ mod tests {
     }
 
     #[test]
-    fn health_reports_into_iter_merges_only() {
-        let mut sources = HealthReportSources::default();
-        sources.merges.insert(
-            "source-a".to_string(),
-            HealthReport::empty("source-a".to_string()),
-        );
-        sources.merges.insert(
-            "source-b".to_string(),
-            HealthReport::empty("source-b".to_string()),
-        );
-
-        let items: Vec<_> = sources.into_iter().collect();
-        assert_eq!(items.len(), 2);
-        assert!(
-            items
-                .iter()
-                .all(|(_, mode)| *mode == HealthReportApplyMode::Merge)
+    fn health_reports_into_iter() {
+        // `into_iter` yields every merge source as `Merge` followed by the replace
+        // source (if any) as `Replace`. Each row projects the iterator to a list of
+        // (source name, apply mode) pairs so the ordering and modes are asserted
+        // directly. This is infallible, so every row `Yields`.
+        check_cases(
+            [
+                Case {
+                    scenario: "merges only",
+                    input: sources(None, &["source-a", "source-b"]),
+                    expect: Yields(vec![
+                        ("source-a".to_string(), HealthReportApplyMode::Merge),
+                        ("source-b".to_string(), HealthReportApplyMode::Merge),
+                    ]),
+                },
+                Case {
+                    scenario: "replace only",
+                    input: sources(Some("admin-replace"), &[]),
+                    expect: Yields(vec![(
+                        "admin-replace".to_string(),
+                        HealthReportApplyMode::Replace,
+                    )]),
+                },
+                Case {
+                    scenario: "mixed merge and replace",
+                    input: sources(Some("sre-override"), &["external-monitor"]),
+                    expect: Yields(vec![
+                        ("external-monitor".to_string(), HealthReportApplyMode::Merge),
+                        ("sre-override".to_string(), HealthReportApplyMode::Replace),
+                    ]),
+                },
+            ],
+            |sources: HealthReportSources| {
+                Ok::<_, ()>(
+                    sources
+                        .into_iter()
+                        .map(|(report, mode)| (report.source, mode))
+                        .collect::<Vec<_>>(),
+                )
+            },
         );
     }
 
     #[test]
-    fn health_reports_into_iter_replace_only() {
-        let sources = HealthReportSources {
-            replace: Some(HealthReport::empty("admin-replace".to_string())),
-            merges: BTreeMap::new(),
-        };
+    fn health_reports_deserialize() {
+        // `HealthReportSources` deserializes from JSON. A full round-trip (serialize
+        // then deserialize) must reproduce the original, and a partial document
+        // (the DB column can be NULL / absent `replace`) deserializes to default.
+        // Deserialization is fallible; `serde_json::Error` is not PartialEq, so
+        // failing rows would use `Fails`, but every case here is valid input.
+        let round_trip = sources(Some("admin-replace"), &["external-monitor"]);
+        let round_trip_json = serde_json::to_string(&round_trip).unwrap();
 
-        let items: Vec<_> = sources.into_iter().collect();
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].0.source, "admin-replace");
-        assert_eq!(items[0].1, HealthReportApplyMode::Replace);
-    }
-
-    #[test]
-    fn health_reports_into_iter_mixed() {
-        let mut merges = BTreeMap::new();
-        merges.insert(
-            "external-monitor".to_string(),
-            HealthReport::empty("external-monitor".to_string()),
+        check_cases(
+            [
+                Case {
+                    scenario: "round trips serialized form",
+                    input: round_trip_json.as_str(),
+                    expect: Yields(round_trip),
+                },
+                Case {
+                    scenario: "null replace deserializes to default",
+                    input: r#"{"merges":{}}"#,
+                    expect: Yields(HealthReportSources::default()),
+                },
+            ],
+            |json: &str| serde_json::from_str::<HealthReportSources>(json).map_err(|_| ()),
         );
-
-        let sources = HealthReportSources {
-            replace: Some(HealthReport::empty("sre-override".to_string())),
-            merges,
-        };
-
-        let items: Vec<_> = sources.into_iter().collect();
-        assert_eq!(items.len(), 2);
-
-        let merge_items: Vec<_> = items
-            .iter()
-            .filter(|(_, mode)| *mode == HealthReportApplyMode::Merge)
-            .collect();
-        let replace_items: Vec<_> = items
-            .iter()
-            .filter(|(_, mode)| *mode == HealthReportApplyMode::Replace)
-            .collect();
-        assert_eq!(merge_items.len(), 1);
-        assert_eq!(replace_items.len(), 1);
-        assert_eq!(merge_items[0].0.source, "external-monitor");
-        assert_eq!(replace_items[0].0.source, "sre-override");
-    }
-
-    #[test]
-    fn health_reports_json_round_trip() {
-        let mut merges = BTreeMap::new();
-        merges.insert(
-            "external-monitor".to_string(),
-            HealthReport::empty("external-monitor".to_string()),
-        );
-
-        let sources = HealthReportSources {
-            replace: Some(HealthReport::empty("admin-replace".to_string())),
-            merges,
-        };
-
-        let json = serde_json::to_string(&sources).unwrap();
-        let deserialized: HealthReportSources = serde_json::from_str(&json).unwrap();
-        assert_eq!(sources, deserialized);
-    }
-
-    #[test]
-    fn health_reports_deserialize_null_as_default() {
-        // The DB column can be NULL, which gets deserialized as default
-        let json = r#"{"merges":{}}"#;
-        let sources: HealthReportSources = serde_json::from_str(json).unwrap();
-        assert!(sources.replace.is_none());
-        assert!(sources.merges.is_empty());
     }
 }

--- a/crates/api-model/src/instance/config/network.rs
+++ b/crates/api-model/src/instance/config/network.rs
@@ -735,6 +735,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     #[test]
@@ -756,22 +759,33 @@ mod tests {
         }
     }
 
+    // Serde JSON round-trip for each InterfaceFunctionId variant: each row
+    // asserts the exact serialized form, and the closure confirms the value
+    // round-trips back equal before yielding that string.
     #[test]
     fn serialize_function_id() {
-        let function_id = InterfaceFunctionId::Physical {};
-        let serialized = serde_json::to_string(&function_id).unwrap();
-        assert_eq!(serialized, "{\"type\":\"physical\"}");
-        assert_eq!(
-            serde_json::from_str::<InterfaceFunctionId>(&serialized).unwrap(),
-            function_id
-        );
-
-        let function_id = InterfaceFunctionId::Virtual { id: 24 };
-        let serialized = serde_json::to_string(&function_id).unwrap();
-        assert_eq!(serialized, "{\"type\":\"virtual\",\"id\":24}");
-        assert_eq!(
-            serde_json::from_str::<InterfaceFunctionId>(&serialized).unwrap(),
-            function_id
+        check_cases(
+            [
+                Case {
+                    scenario: "physical",
+                    input: InterfaceFunctionId::Physical {},
+                    expect: Yields(r#"{"type":"physical"}"#.to_string()),
+                },
+                Case {
+                    scenario: "virtual",
+                    input: InterfaceFunctionId::Virtual { id: 24 },
+                    expect: Yields(r#"{"type":"virtual","id":24}"#.to_string()),
+                },
+            ],
+            // Serialize, confirm it round-trips back equal, then yield the JSON.
+            // serde_json::Error is not PartialEq, so collapse failures to ().
+            |function_id| {
+                let serialized = serde_json::to_string(&function_id).map_err(|_| ())?;
+                let round_tripped =
+                    serde_json::from_str::<InterfaceFunctionId>(&serialized).map_err(|_| ())?;
+                assert_eq!(round_tripped, function_id);
+                Ok::<_, ()>(serialized)
+            },
         );
     }
 
@@ -850,43 +864,80 @@ mod tests {
         }
     }
 
+    // InstanceNetworkConfig::validate over a base valid config mutated per row.
+    // Input is (config, allow_instance_vf). ConfigValidationError is not
+    // PartialEq, so rejections assert only that validation errs (Fails); the
+    // exact error value is not part of the contract here.
     #[test]
     fn validate_network_config() {
-        let config = create_valid_network_config();
-        config.validate(true).unwrap();
-
-        // Same config with virtual function, but virtual functions are disabled
-        assert!(config.validate(false).is_err());
-
-        // Duplicate virtual function
-        let mut config = create_valid_network_config();
-        config.interfaces[2].function_id = InterfaceFunctionId::Virtual { id: 0 };
-        assert!(config.validate(true).is_err());
-
-        // Out of bounds virtual function
-        let mut config = create_valid_network_config();
-        config.interfaces[2].function_id = InterfaceFunctionId::Virtual { id: 16 };
-        assert!(config.validate(true).is_err());
-
-        // No physical function
-        let mut config = create_valid_network_config();
-        config.interfaces.swap_remove(0);
-        assert!(config.validate(true).is_err());
-
-        // Missing virtual function id in between is now a valid scenario.
-        // The last virtual function is ok to be missing
-        let mut config = create_valid_network_config();
-        config
-            .interfaces
-            .swap_remove(INTERFACE_VFID_MAX as usize + 1);
-        config.validate(true).unwrap();
-
-        // Duplicate network segment
         const DUPLICATE_SEGMENT_ID: uuid::Uuid =
             uuid::uuid!("91609f10-c91d-470d-a260-1234560c0000");
-        let mut config = create_valid_network_config();
-        config.interfaces[0].network_segment_id = Some(DUPLICATE_SEGMENT_ID.into());
-        config.interfaces[1].network_segment_id = Some(DUPLICATE_SEGMENT_ID.into());
-        assert!(config.validate(true).is_err());
+
+        let valid = create_valid_network_config();
+
+        let virtual_functions_disabled = create_valid_network_config();
+
+        let mut duplicate_virtual_function = create_valid_network_config();
+        duplicate_virtual_function.interfaces[2].function_id =
+            InterfaceFunctionId::Virtual { id: 0 };
+
+        let mut out_of_bounds_virtual_function = create_valid_network_config();
+        out_of_bounds_virtual_function.interfaces[2].function_id =
+            InterfaceFunctionId::Virtual { id: 16 };
+
+        let mut no_physical_function = create_valid_network_config();
+        no_physical_function.interfaces.swap_remove(0);
+
+        let mut missing_middle_virtual_function = create_valid_network_config();
+        missing_middle_virtual_function
+            .interfaces
+            .swap_remove(INTERFACE_VFID_MAX as usize + 1);
+
+        let mut duplicate_network_segment = create_valid_network_config();
+        duplicate_network_segment.interfaces[0].network_segment_id =
+            Some(DUPLICATE_SEGMENT_ID.into());
+        duplicate_network_segment.interfaces[1].network_segment_id =
+            Some(DUPLICATE_SEGMENT_ID.into());
+
+        check_cases(
+            [
+                Case {
+                    scenario: "valid config with virtual functions allowed",
+                    input: (valid, true),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "virtual functions disabled by site configuration",
+                    input: (virtual_functions_disabled, false),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "duplicate virtual function id",
+                    input: (duplicate_virtual_function, true),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "out of bounds virtual function id",
+                    input: (out_of_bounds_virtual_function, true),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "no physical function",
+                    input: (no_physical_function, true),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing middle virtual function id is allowed",
+                    input: (missing_middle_virtual_function, true),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "duplicate network segment",
+                    input: (duplicate_network_segment, true),
+                    expect: Fails,
+                },
+            ],
+            |(config, allow_instance_vf)| config.validate(allow_instance_vf).map_err(drop),
+        );
     }
 }

--- a/crates/api-model/src/instance/config/tenant_config.rs
+++ b/crates/api-model/src/instance/config/tenant_config.rs
@@ -83,6 +83,11 @@ impl TenantConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::mem::discriminant;
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     #[test]
@@ -105,32 +110,46 @@ mod tests {
     }
 
     #[test]
-    fn validate_tenant_config_duplicate_keysets() {
-        let config = TenantConfig {
-            tenant_organization_id: TenantOrganizationId::try_from("TenantA".to_string()).unwrap(),
-            tenant_keyset_ids: vec![
-                "a".to_string(),
-                "b".to_string(),
-                "c".to_string(),
-                "a".to_string(),
+    fn validate_tenant_config() {
+        // `TenantConfig::validate`: duplicate keyset IDs are rejected, unique ones
+        // pass. The error type (ConfigValidationError) is not PartialEq, so failing
+        // rows assert the rejected *variant* via its discriminant rather than the
+        // exact error value.
+        check_cases(
+            [
+                Case {
+                    scenario: "duplicate keyset ids are rejected",
+                    input: TenantConfig {
+                        tenant_organization_id: TenantOrganizationId::try_from(
+                            "TenantA".to_string(),
+                        )
+                        .unwrap(),
+                        tenant_keyset_ids: vec![
+                            "a".to_string(),
+                            "b".to_string(),
+                            "c".to_string(),
+                            "a".to_string(),
+                        ],
+                        hostname: Some("test-instance".to_string()),
+                    },
+                    expect: FailsWith(discriminant(
+                        &ConfigValidationError::DuplicateTenantKeysetId(String::new()),
+                    )),
+                },
+                Case {
+                    scenario: "unique keyset ids validate",
+                    input: TenantConfig {
+                        tenant_organization_id: TenantOrganizationId::try_from(
+                            "TenantA".to_string(),
+                        )
+                        .unwrap(),
+                        tenant_keyset_ids: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+                        hostname: Some("test-instance".to_string()),
+                    },
+                    expect: Yields(()),
+                },
             ],
-            hostname: Some("test-instance".to_string()),
-        };
-
-        assert!(matches!(
-            config.validate(),
-            Err(ConfigValidationError::DuplicateTenantKeysetId(_))
-        ))
-    }
-
-    #[test]
-    fn validate_tenant_config_unique_keysets() {
-        let config = TenantConfig {
-            tenant_organization_id: TenantOrganizationId::try_from("TenantA".to_string()).unwrap(),
-            tenant_keyset_ids: vec!["a".to_string(), "b".to_string(), "c".to_string()],
-            hostname: Some("test-instance".to_string()),
-        };
-
-        config.validate().unwrap()
+            |config: TenantConfig| config.validate().map_err(|e| discriminant(&e)),
+        );
     }
 }

--- a/crates/api-model/src/instance/snapshot.rs
+++ b/crates/api-model/src/instance/snapshot.rs
@@ -380,6 +380,8 @@ impl TryFrom<InstanceSnapshotPgJson> for InstanceSnapshot {
 mod tests {
     use std::str::FromStr;
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
     use chrono::Utc;
     use uuid::Uuid;
 
@@ -454,41 +456,74 @@ mod tests {
         }
     }
 
+    /// `InstanceSnapshot::try_from` derives the OS variant from the legacy
+    /// instance columns (priority: operating_system_id > os_image_id > inline
+    /// iPXE). Each row mutates a minimal pg-json row, then projects the converted
+    /// snapshot to the fields under test: (os variant, user_data, phone_home).
     #[test]
-    fn test_try_from_legacy_ipxe_derives_os_from_instance_columns() {
-        let mut pg_json = minimal_pg_json();
-        pg_json.operating_system_id = None;
-        pg_json.os_ipxe_script = "legacy-inline-script".to_string();
-        pg_json.os_image_id = None;
-        pg_json.os_user_data = Some("legacy-user-data".to_string());
-        pg_json.os_phone_home_enabled = true;
-        let snapshot = InstanceSnapshot::try_from(pg_json).unwrap();
-        assert!(matches!(
-            &snapshot.config.os.variant,
-            OperatingSystemVariant::Ipxe(_)
-        ));
-        if let OperatingSystemVariant::Ipxe(ipxe) = &snapshot.config.os.variant {
-            assert_eq!(ipxe.ipxe_script, "legacy-inline-script");
-        }
-        assert_eq!(
-            snapshot.config.os.user_data.as_deref(),
-            Some("legacy-user-data")
-        );
-        assert!(snapshot.config.os.phone_home_enabled);
-    }
-
-    #[test]
-    fn test_try_from_legacy_os_image_derives_os_from_instance_columns() {
+    fn test_try_from_derives_os_from_instance_columns() {
         let image_uuid = uuid::uuid!("a1b2c3d4-e5f6-4780-a123-456789abcdef");
-        let mut pg_json = minimal_pg_json();
-        pg_json.operating_system_id = None;
-        pg_json.os_image_id = Some(image_uuid);
-        pg_json.os_ipxe_script = "ignored".to_string();
-        let snapshot = InstanceSnapshot::try_from(pg_json).unwrap();
-        assert!(matches!(
-            &snapshot.config.os.variant,
-            OperatingSystemVariant::OsImage(id) if *id == image_uuid
-        ));
+        let os_uuid = uuid::uuid!("b2c3d4e5-f6a7-4890-b234-567890abcdef");
+
+        check_cases(
+            [
+                Case {
+                    scenario: "legacy inline iPXE derives Ipxe variant with user_data and phone_home",
+                    input: Box::new(|pg: &mut InstanceSnapshotPgJson| {
+                        pg.operating_system_id = None;
+                        pg.os_image_id = None;
+                        pg.os_ipxe_script = "legacy-inline-script".to_string();
+                        pg.os_user_data = Some("legacy-user-data".to_string());
+                        pg.os_phone_home_enabled = true;
+                    }) as Box<dyn Fn(&mut InstanceSnapshotPgJson)>,
+                    expect: Yields((
+                        OperatingSystemVariant::Ipxe(InlineIpxe {
+                            ipxe_script: "legacy-inline-script".to_string(),
+                        }),
+                        Some("legacy-user-data".to_string()),
+                        true,
+                    )),
+                },
+                Case {
+                    scenario: "legacy os_image_id derives OsImage variant (iPXE script ignored)",
+                    input: Box::new(move |pg: &mut InstanceSnapshotPgJson| {
+                        pg.operating_system_id = None;
+                        pg.os_image_id = Some(image_uuid);
+                        pg.os_ipxe_script = "ignored".to_string();
+                    }),
+                    expect: Yields((OperatingSystemVariant::OsImage(image_uuid), None, false)),
+                },
+                Case {
+                    scenario: "operating_system_id takes priority over image and iPXE",
+                    input: Box::new(move |pg: &mut InstanceSnapshotPgJson| {
+                        pg.operating_system_id = Some(os_uuid);
+                        pg.os_image_id = None;
+                        pg.os_ipxe_script = String::new();
+                    }),
+                    expect: Yields((
+                        OperatingSystemVariant::OperatingSystemId(os_uuid),
+                        None,
+                        false,
+                    )),
+                },
+            ],
+            // Apply the row's mutation to a minimal pg-json, convert, and project
+            // to the asserted OS fields. The error type (sqlx::Error) is not
+            // PartialEq, so on failure we discard it.
+            |mutate| {
+                let mut pg_json = minimal_pg_json();
+                mutate(&mut pg_json);
+                InstanceSnapshot::try_from(pg_json)
+                    .map(|snapshot| {
+                        (
+                            snapshot.config.os.variant,
+                            snapshot.config.os.user_data,
+                            snapshot.config.os.phone_home_enabled,
+                        )
+                    })
+                    .map_err(drop)
+            },
+        );
     }
 
     #[test]
@@ -501,19 +536,5 @@ mod tests {
         assert!(matches!(err, sqlx::Error::ColumnDecode { .. }));
         assert!(format!("{err}").contains("no operating_system_id"));
         assert!(format!("{err}").contains("no iPXE script"));
-    }
-
-    #[test]
-    fn test_try_from_with_operating_system_id() {
-        let os_uuid = uuid::uuid!("b2c3d4e5-f6a7-4890-b234-567890abcdef");
-        let mut pg_json = minimal_pg_json();
-        pg_json.operating_system_id = Some(os_uuid);
-        pg_json.os_ipxe_script = String::new();
-        pg_json.os_image_id = None;
-        let snapshot = InstanceSnapshot::try_from(pg_json).unwrap();
-        assert!(matches!(
-            &snapshot.config.os.variant,
-            OperatingSystemVariant::OperatingSystemId(id) if *id == os_uuid
-        ));
     }
 }

--- a/crates/api-model/src/machine/infiniband.rs
+++ b/crates/api-model/src/machine/infiniband.rs
@@ -208,17 +208,45 @@ pub fn ib_config_synced(
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     #[test]
     fn deserialize_legacy_ib_status_observation() {
-        let obs1 = r#"{"observed_at": "2024-12-18T23:17:57.919166804Z", "ib_interfaces": []}"#;
-        let _deserialized: MachineInfinibandStatusObservation = serde_json::from_str(obs1).unwrap();
+        // Legacy IB status observations should deserialize, defaulting the fields
+        // that older payloads omit. We project to the first interface's
+        // (fabric_id_is_empty, associated_pkeys_is_none) so the asserted defaults
+        // are comparable.
+        check_cases(
+            [Case {
+                scenario: "interfaces without fabric_id or pkeys default them",
+                input: r#"{"observed_at": "2025-06-06T19:47:16.597282585Z", "ib_interfaces": [{"lid": 65535, "guid": "1070fd0300bd7574"}, {"lid": 65535, "guid": "1070fd0300bd7575"}]}"#,
+                expect: Yields((true, true)),
+            }],
+            // Deserialize, then project the first interface's defaulted fields.
+            // serde_json::Error is not PartialEq, so a failing row would discard it.
+            |s| {
+                serde_json::from_str::<MachineInfinibandStatusObservation>(s)
+                    .map(|obs| {
+                        let iface = obs.ib_interfaces.first().expect("row supplies interfaces");
+                        (iface.fabric_id.is_empty(), iface.associated_pkeys.is_none())
+                    })
+                    .map_err(drop)
+            },
+        );
+    }
 
-        let obs2 = r#"{"observed_at": "2025-06-06T19:47:16.597282585Z", "ib_interfaces": [{"lid": 65535, "guid": "1070fd0300bd7574"}, {"lid": 65535, "guid": "1070fd0300bd7575"}]}"#;
-        let deserialized: MachineInfinibandStatusObservation = serde_json::from_str(obs2).unwrap();
-        assert!(deserialized.ib_interfaces[0].fabric_id.is_empty());
-        assert!(deserialized.ib_interfaces[0].associated_pkeys.is_none());
+    // An empty interface list deserializes cleanly -- older payloads may omit
+    // interfaces entirely.
+    #[test]
+    fn deserialize_legacy_ib_status_empty_interfaces() {
+        let obs: MachineInfinibandStatusObservation = serde_json::from_str(
+            r#"{"observed_at": "2024-12-18T23:17:57.919166804Z", "ib_interfaces": []}"#,
+        )
+        .expect("empty interface list should deserialize");
+        assert!(obs.ib_interfaces.is_empty());
     }
 
     #[test]
@@ -247,81 +275,17 @@ mod tests {
     }
 
     #[test]
-    fn test_ib_config_synced_missing_observation() {
-        use crate::instance::config::network::InterfaceFunctionId;
-
-        let config = InstanceInfinibandConfig {
-            ib_interfaces: vec![
-                crate::instance::config::infiniband::InstanceIbInterfaceConfig {
-                    function_id: InterfaceFunctionId::Physical {},
-                    ib_partition_id: uuid::uuid!("91609f10-c91d-470d-a260-6293ea0c1200").into(),
-                    pf_guid: None,
-                    guid: Some("946dae03006104f8".to_string()),
-                    device: "MT2910 Family [ConnectX-7]".to_string(),
-                    vendor: None,
-                    device_instance: 1,
-                },
-            ],
-        };
-        let result = ib_config_synced(None, Some(&config), true);
-        assert!(matches!(
-            result,
-            Err(IbConfigNotSyncedReason::MissingObservation { .. })
-        ));
-    }
-
-    #[test]
-    fn test_ib_config_synced_port_state_unobservable() {
-        use crate::instance::config::network::InterfaceFunctionId;
-
-        let config = InstanceInfinibandConfig {
-            ib_interfaces: vec![
-                crate::instance::config::infiniband::InstanceIbInterfaceConfig {
-                    function_id: InterfaceFunctionId::Physical {},
-                    ib_partition_id: uuid::uuid!("91609f10-c91d-470d-a260-6293ea0c1200").into(),
-                    pf_guid: None,
-                    guid: Some("946dae03006104f8".to_string()),
-                    device: "MT2910 Family [ConnectX-7]".to_string(),
-                    vendor: None,
-                    device_instance: 1,
-                },
-            ],
-        };
-
-        let observation = MachineInfinibandStatusObservation {
-            ib_interfaces: vec![MachineIbInterfaceStatusObservation {
-                guid: "946dae03006104f8".to_string(),
-                lid: 0xffff,
-                fabric_id: "".to_string(),
-                associated_pkeys: None, // Port is down/unobservable
-                associated_partition_ids: None,
-            }],
-            observed_at: chrono::Utc::now(),
-        };
-
-        let result = ib_config_synced(Some(&observation), Some(&config), true);
-
-        match result {
-            Err(IbConfigNotSyncedReason::PortStateUnobservable { guids, details }) => {
-                assert_eq!(guids.len(), 1);
-                assert_eq!(guids[0], "946dae03006104f8");
-                assert!(details.contains("946dae03006104f8"));
-                assert!(details.contains("missing or incomplete"));
-            }
-            _ => panic!("Expected PortStateUnobservable error, got: {:?}", result),
-        }
-    }
-
-    #[test]
-    fn test_ib_config_synced_ok_when_synced() {
+    fn test_ib_config_synced() {
         use carbide_uuid::infiniband::IBPartitionId;
 
         use crate::instance::config::network::InterfaceFunctionId;
+
         let partition_id: IBPartitionId =
             uuid::uuid!("91609f10-c91d-470d-a260-6293ea0c1200").into();
         let pkey: PartitionKey = 0x13.try_into().unwrap();
 
-        let config = InstanceInfinibandConfig {
+        // A single-interface config requesting the partition above.
+        let config = || InstanceInfinibandConfig {
             ib_interfaces: vec![
                 crate::instance::config::infiniband::InstanceIbInterfaceConfig {
                     function_id: InterfaceFunctionId::Physical {},
@@ -335,7 +299,20 @@ mod tests {
             ],
         };
 
-        let observation = MachineInfinibandStatusObservation {
+        // Observation where the port is down/unobservable (no pkeys/partition ids).
+        let unobservable = MachineInfinibandStatusObservation {
+            ib_interfaces: vec![MachineIbInterfaceStatusObservation {
+                guid: "946dae03006104f8".to_string(),
+                lid: 0xffff,
+                fabric_id: "".to_string(),
+                associated_pkeys: None,
+                associated_partition_ids: None,
+            }],
+            observed_at: chrono::Utc::now(),
+        };
+
+        // Observation where the interface is on exactly the requested partition.
+        let synced = MachineInfinibandStatusObservation {
             ib_interfaces: vec![MachineIbInterfaceStatusObservation {
                 guid: "946dae03006104f8".to_string(),
                 lid: 0x10,
@@ -346,7 +323,57 @@ mod tests {
             observed_at: chrono::Utc::now(),
         };
 
-        let result = ib_config_synced(Some(&observation), Some(&config), true);
-        assert!(result.is_ok());
+        // ib_config_synced over (observation, config, use_tenant_network). The
+        // error variant's `details` are built dynamically, so rather than assert
+        // the exact reason we project the result to a comparable summary:
+        // - Ok            -> a static "ok" tag, no guids, no substrings
+        // - the error variant tag, the affected guids, and whether `details`
+        //   carries the expected substrings (only the PortStateUnobservable row
+        //   asserts those).
+        type Summary = (&'static str, Vec<String>, bool, bool);
+        let cfg = config();
+        check_cases(
+            [
+                Case {
+                    scenario: "missing observation",
+                    input: (None, Some(&cfg), true),
+                    expect: Yields(("MissingObservation", Vec::new(), false, false)),
+                },
+                Case {
+                    scenario: "port state unobservable",
+                    input: (Some(&unobservable), Some(&cfg), true),
+                    expect: Yields((
+                        "PortStateUnobservable",
+                        vec!["946dae03006104f8".to_string()],
+                        true,
+                        true,
+                    )),
+                },
+                Case {
+                    scenario: "ok when synced",
+                    input: (Some(&synced), Some(&cfg), true),
+                    expect: Yields(("ok", Vec::new(), false, false)),
+                },
+            ],
+            |(observation, config, use_tenant_network)| -> Result<Summary, ()> {
+                Ok(
+                    match ib_config_synced(observation, config, use_tenant_network) {
+                        Ok(()) => ("ok", Vec::new(), false, false),
+                        Err(IbConfigNotSyncedReason::MissingObservation { .. }) => {
+                            ("MissingObservation", Vec::new(), false, false)
+                        }
+                        Err(IbConfigNotSyncedReason::ConfigurationMismatch { .. }) => {
+                            ("ConfigurationMismatch", Vec::new(), false, false)
+                        }
+                        Err(IbConfigNotSyncedReason::PortStateUnobservable { guids, details }) => (
+                            "PortStateUnobservable",
+                            guids,
+                            details.contains("946dae03006104f8"),
+                            details.contains("missing or incomplete"),
+                        ),
+                    },
+                )
+            },
+        );
     }
 }

--- a/crates/api-model/src/machine/machine_id.rs
+++ b/crates/api-model/src/machine/machine_id.rs
@@ -105,6 +105,8 @@ pub enum MissingHardwareInfo {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
     use carbide_uuid::machine::MACHINE_ID_LENGTH;
 
     use super::*;
@@ -188,34 +190,52 @@ mod tests {
         assert!(constructor(fingerprint).is_err());
     }
 
+    // Each row loads a hardware-info fixture and derives a Machine ID through one
+    // constructor, expecting a given MachineType. `test_derive_machine_id` does all
+    // the assertions internally (and panics on mismatch), so each row just expects
+    // the run to complete, i.e. `Yields(())`.
     #[test]
-    fn derive_host_machine_id() {
-        let path = format!("{TEST_DATA_DIR}/x86_info.json");
-        let data = std::fs::read(path).unwrap();
-        let mut fingerprint = serde_json::from_slice::<HardwareInfo>(&data).unwrap();
+    fn derive_machine_id() {
+        type Constructor = fn(&HardwareInfo) -> Result<MachineId, MissingHardwareInfo>;
 
-        test_derive_machine_id(&mut fingerprint, MachineType::Host, from_hardware_info);
-    }
+        check_cases(
+            [
+                Case {
+                    scenario: "host machine id from x86 fingerprint",
+                    input: (
+                        "x86_info.json",
+                        MachineType::Host,
+                        from_hardware_info as Constructor,
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "dpu machine id from dpu fingerprint",
+                    input: (
+                        "dpu_info.json",
+                        MachineType::Dpu,
+                        from_hardware_info as Constructor,
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "predicted-host machine id from dpu fingerprint",
+                    input: (
+                        "dpu_info.json",
+                        MachineType::PredictedHost,
+                        host_id_from_dpu_hardware_info as Constructor,
+                    ),
+                    expect: Yields(()),
+                },
+            ],
+            |(fixture, expected_type, constructor)| -> Result<(), ()> {
+                let path = format!("{TEST_DATA_DIR}/{fixture}");
+                let data = std::fs::read(path).unwrap();
+                let mut fingerprint = serde_json::from_slice::<HardwareInfo>(&data).unwrap();
 
-    #[test]
-    fn derive_dpu_machine_id() {
-        let path = format!("{TEST_DATA_DIR}/dpu_info.json");
-        let data = std::fs::read(path).unwrap();
-        let mut fingerprint = serde_json::from_slice::<HardwareInfo>(&data).unwrap();
-
-        test_derive_machine_id(&mut fingerprint, MachineType::Dpu, from_hardware_info);
-    }
-
-    #[test]
-    fn derive_host_machine_id_from_dpu_fingerprint() {
-        let path = format!("{TEST_DATA_DIR}/dpu_info.json");
-        let data = std::fs::read(path).unwrap();
-        let mut fingerprint = serde_json::from_slice::<HardwareInfo>(&data).unwrap();
-
-        test_derive_machine_id(
-            &mut fingerprint,
-            MachineType::PredictedHost,
-            host_id_from_dpu_hardware_info,
+                test_derive_machine_id(&mut fingerprint, expected_type, constructor);
+                Ok(())
+            },
         );
     }
 }

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -2852,114 +2852,159 @@ pub fn dpf_based_dpu_provisioning_possible(
 mod tests {
     use std::str::FromStr;
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
+    // Deserializing a `FailureDetails` JSON blob: the parsed value must match the
+    // expected struct (cause + failed_at + source). The type is PartialEq, so we
+    // yield the whole struct.
     #[test]
-    fn test_json_deserialize_no_error() {
-        let serialized = r#"{"cause": "noerror", "source": "noerror", "failed_at": "2023-07-31T11:26:18.261228950Z"}"#;
-        let deserialized: FailureDetails = serde_json::from_str(serialized).unwrap();
-
-        let expected_time =
-            chrono::DateTime::parse_from_rfc3339("2023-07-31T11:26:18.261228950+00:00").unwrap();
-        assert_eq!(FailureCause::NoError, deserialized.cause);
-        assert_eq!(expected_time, deserialized.failed_at);
+    fn test_json_deserialize_failure_details() {
+        let failed_at = chrono::DateTime::parse_from_rfc3339("2023-07-31T11:26:18.261228950+00:00")
+            .unwrap()
+            .with_timezone(&Utc);
+        check_cases(
+            [
+                Case {
+                    scenario: "no error",
+                    input: r#"{"cause": "noerror", "source": "noerror", "failed_at": "2023-07-31T11:26:18.261228950Z"}"#,
+                    expect: Yields(FailureDetails {
+                        cause: FailureCause::NoError,
+                        failed_at,
+                        source: FailureSource::NoError,
+                    }),
+                },
+                Case {
+                    scenario: "nvme clean failed",
+                    input: r#"{"cause": {"nvmecleanfailed":{"err": "error1"}},  "source": "noerror","failed_at": "2023-07-31T11:26:18.261228950Z"}"#,
+                    expect: Yields(FailureDetails {
+                        cause: FailureCause::NVMECleanFailed {
+                            err: "error1".to_string(),
+                        },
+                        failed_at,
+                        source: FailureSource::NoError,
+                    }),
+                },
+            ],
+            |s| serde_json::from_str::<FailureDetails>(s).map_err(drop),
+        );
     }
 
+    // Reprovisioning states deserialize to the expected `ManagedHostState` AND
+    // render the expected `Display` string; we yield the (state, display) pair so
+    // both assertions ride along.
     #[test]
-    fn test_json_deserialize_nvme_error() {
-        let serialized = r#"{"cause": {"nvmecleanfailed":{"err": "error1"}},  "source": "noerror","failed_at": "2023-07-31T11:26:18.261228950Z"}"#;
-        let deserialized: FailureDetails = serde_json::from_str(serialized).unwrap();
-
-        let expected_time =
-            chrono::DateTime::parse_from_rfc3339("2023-07-31T11:26:18.261228950+00:00").unwrap();
-        assert_eq!(
-            FailureCause::NVMECleanFailed {
-                err: "error1".to_string()
+    fn test_json_deserialize_reprovisioning_states() {
+        let machine_id =
+            MachineId::from_str("fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng")
+                .unwrap();
+        check_cases(
+            [
+                Case {
+                    scenario: "dpu reprovision firmware upgrade",
+                    input: r#"{"state":"dpureprovision","dpu_states":{"states":{"fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng":"firmwareupgrade"}}}"#,
+                    expect: Yields((
+                        ManagedHostState::DPUReprovision {
+                            dpu_states: DpuReprovisionStates {
+                                states: HashMap::from([(
+                                    machine_id,
+                                    ReprovisionState::FirmwareUpgrade,
+                                )]),
+                            },
+                        },
+                        "Reprovisioning/FirmwareUpgrade".to_string(),
+                    )),
+                },
+                Case {
+                    scenario: "assigned dpu reprovision firmware upgrade",
+                    input: r#"{"state":"assigned","instance_state":{"state":"dpureprovision","dpu_states":{"states":{"fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng":"firmwareupgrade"}}}}"#,
+                    expect: Yields((
+                        ManagedHostState::Assigned {
+                            instance_state: InstanceState::DPUReprovision {
+                                dpu_states: DpuReprovisionStates {
+                                    states: HashMap::from([(
+                                        machine_id,
+                                        ReprovisionState::FirmwareUpgrade,
+                                    )]),
+                                },
+                            },
+                        },
+                        "Assigned/Reprovision/FirmwareUpgrade".to_string(),
+                    )),
+                },
+            ],
+            |s| {
+                serde_json::from_str::<ManagedHostState>(s)
+                    .map(|state| (state.clone(), state.to_string()))
+                    .map_err(drop)
             },
-            deserialized.cause
         );
-        assert_eq!(expected_time, deserialized.failed_at);
     }
 
+    // The remaining `ManagedHostState` JSON blobs each deserialize to a specific
+    // variant; the parsed value (PartialEq) is the whole assertion.
     #[test]
-    fn test_json_deserialize_reprovisioning_state() {
-        let serialized = r#"{"state":"dpureprovision","dpu_states":{"states":{"fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng":"firmwareupgrade"}}}"#;
-        let deserialized: ManagedHostState = serde_json::from_str(serialized).unwrap();
-        assert_eq!(
-            deserialized,
-            ManagedHostState::DPUReprovision {
-                dpu_states: DpuReprovisionStates {
-                    states: HashMap::from([(
-                        MachineId::from_str(
-                            "fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng"
-                        )
-                        .unwrap(),
-                        ReprovisionState::FirmwareUpgrade
-                    )])
-                }
-            }
-        );
-
-        assert_eq!(deserialized.to_string(), "Reprovisioning/FirmwareUpgrade");
-    }
-
-    #[test]
-    fn test_json_deserialize_reprovisioning_state_for_instance() {
-        let serialized = r#"{"state":"assigned","instance_state":{"state":"dpureprovision","dpu_states":{"states":{"fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng":"firmwareupgrade"}}}}"#;
-
-        let deserialized: ManagedHostState = serde_json::from_str(serialized).unwrap();
-
-        assert_eq!(
-            deserialized,
-            ManagedHostState::Assigned {
-                instance_state: InstanceState::DPUReprovision {
-                    dpu_states: DpuReprovisionStates {
-                        states: HashMap::from([(
-                            MachineId::from_str(
-                                "fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng"
-                            )
-                            .unwrap(),
-                            ReprovisionState::FirmwareUpgrade
-                        )])
-                    }
+    fn test_json_deserialize_managed_host_states() {
+        check_cases(
+            [
+                Case {
+                    scenario: "assigned booting with discovery image, default retry",
+                    input: r#"{"state":"assigned","instance_state":{"state":"bootingwithdiscoveryimage"}}"#,
+                    expect: Yields(ManagedHostState::Assigned {
+                        instance_state: InstanceState::BootingWithDiscoveryImage {
+                            retry: RetryInfo { count: 0 },
+                        },
+                    }),
                 },
-            }
-        );
-
-        assert_eq!(
-            deserialized.to_string(),
-            "Assigned/Reprovision/FirmwareUpgrade"
-        );
-    }
-
-    #[test]
-    fn test_json_deserialize_bootingwithdiscoveryimage_state_for_instance() {
-        let serialized =
-            r#"{"state":"assigned","instance_state":{"state":"bootingwithdiscoveryimage"}}"#;
-        let deserialized: ManagedHostState = serde_json::from_str(serialized).unwrap();
-
-        assert_eq!(
-            deserialized,
-            ManagedHostState::Assigned {
-                instance_state: InstanceState::BootingWithDiscoveryImage {
-                    retry: RetryInfo { count: 0 }
+                Case {
+                    scenario: "assigned booting with discovery image, explicit retry",
+                    input: r#"{"state":"assigned","instance_state":{"state":"bootingwithdiscoveryimage", "retry":{"count": 10}}}"#,
+                    expect: Yields(ManagedHostState::Assigned {
+                        instance_state: InstanceState::BootingWithDiscoveryImage {
+                            retry: RetryInfo { count: 10 },
+                        },
+                    }),
                 },
-            }
-        );
-    }
-
-    #[test]
-    fn test_json_deserialize_bootingwithdiscoveryimage_state_with_retry_for_instance() {
-        let serialized = r#"{"state":"assigned","instance_state":{"state":"bootingwithdiscoveryimage", "retry":{"count": 10}}}"#;
-        let deserialized: ManagedHostState = serde_json::from_str(serialized).unwrap();
-
-        assert_eq!(
-            deserialized,
-            ManagedHostState::Assigned {
-                instance_state: InstanceState::BootingWithDiscoveryImage {
-                    retry: RetryInfo { count: 10 }
-                }
-            }
+                Case {
+                    scenario: "host init polling bios setup, default retry",
+                    input: r#"{"state":"hostinit","machine_state":{"state":"pollingbiossetup"}}"#,
+                    expect: Yields(ManagedHostState::HostInit {
+                        machine_state: MachineState::PollingBiosSetup { retry_count: 0 },
+                    }),
+                },
+                Case {
+                    scenario: "host init polling bios setup, explicit retry count",
+                    input: r#"{"state":"hostinit","machine_state":{"state":"pollingbiossetup","retry_count":2}}"#,
+                    expect: Yields(ManagedHostState::HostInit {
+                        machine_state: MachineState::PollingBiosSetup { retry_count: 2 },
+                    }),
+                },
+                Case {
+                    scenario: "assigned host platform configuration polling bios setup (legacy)",
+                    input: r#"{"state":"assigned","instance_state":{"state":"hostplatformconfiguration","platform_config_state":{"state":"pollingbiossetup"}}}"#,
+                    expect: Yields(ManagedHostState::Assigned {
+                        instance_state: InstanceState::HostPlatformConfiguration {
+                            platform_config_state:
+                                HostPlatformConfigurationState::PollingBiosSetup { retry_count: 0 },
+                        },
+                    }),
+                },
+                Case {
+                    scenario: "host init waiting for lockdown",
+                    input: r#"{"state":"hostinit","machine_state":{"state":"waitingforlockdown","lockdown_info":{"state":"setlockdown","mode":"enable"}}}"#,
+                    expect: Yields(ManagedHostState::HostInit {
+                        machine_state: MachineState::WaitingForLockdown {
+                            lockdown_info: LockdownInfo {
+                                state: LockdownState::SetLockdown,
+                                mode: LockdownMode::Enable,
+                            },
+                        },
+                    }),
+                },
+            ],
+            |s| serde_json::from_str::<ManagedHostState>(s).map_err(drop),
         );
     }
 
@@ -2978,113 +3023,67 @@ mod tests {
         ));
     }
 
+    // Current `DpfState` tags deserialize to the expected variant and survive a
+    // serialize/deserialize round-trip; the unknown-tag rows verify the lenient
+    // fall-back to `DpfState::Unknown`. We yield the (parsed, round-tripped) pair
+    // so both the direct parse and the round-trip are asserted.
     #[test]
-    fn test_json_deserialize_platformconfig_machine_handler() {
-        // Test polling BIOS setup state
-        let serialized = r#"{"state":"hostinit","machine_state":{"state":"pollingbiossetup"}}"#;
-        let deserialized: ManagedHostState = serde_json::from_str(serialized).unwrap();
-
-        assert_eq!(
-            deserialized,
-            ManagedHostState::HostInit {
-                machine_state: MachineState::PollingBiosSetup { retry_count: 0 },
-            }
-        );
-    }
-
-    #[test]
-    fn test_json_deserialize_polling_bios_setup_with_retry_count() {
-        let serialized =
-            r#"{"state":"hostinit","machine_state":{"state":"pollingbiossetup","retry_count":2}}"#;
-        let deserialized: ManagedHostState = serde_json::from_str(serialized).unwrap();
-
-        assert_eq!(
-            deserialized,
-            ManagedHostState::HostInit {
-                machine_state: MachineState::PollingBiosSetup { retry_count: 2 },
-            }
-        );
-    }
-
-    #[test]
-    fn test_json_deserialize_host_platform_configuration_polling_bios_setup_legacy() {
-        let serialized = r#"{"state":"assigned","instance_state":{"state":"hostplatformconfiguration","platform_config_state":{"state":"pollingbiossetup"}}}"#;
-        let deserialized: ManagedHostState = serde_json::from_str(serialized).unwrap();
-
-        assert_eq!(
-            deserialized,
-            ManagedHostState::Assigned {
-                instance_state: InstanceState::HostPlatformConfiguration {
-                    platform_config_state: HostPlatformConfigurationState::PollingBiosSetup {
-                        retry_count: 0,
-                    },
+    fn test_dpf_state_deserialize_and_roundtrip() {
+        check_cases(
+            [
+                Case {
+                    scenario: "provisioning",
+                    input: r#"{"dpfstate":"provisioning"}"#,
+                    expect: Yields((DpfState::Provisioning, DpfState::Provisioning)),
                 },
-            }
-        );
-    }
-
-    #[test]
-    fn test_json_deserialize_lockdown_states() {
-        // Test Lockdown state
-        let serialized = r#"{"state":"hostinit","machine_state":{"state":"waitingforlockdown","lockdown_info":{"state":"setlockdown","mode":"enable"}}}"#;
-        let deserialized: ManagedHostState = serde_json::from_str(serialized).unwrap();
-
-        assert_eq!(
-            deserialized,
-            ManagedHostState::HostInit {
-                machine_state: MachineState::WaitingForLockdown {
-                    lockdown_info: LockdownInfo {
-                        state: LockdownState::SetLockdown,
-                        mode: LockdownMode::Enable,
-                    },
+                Case {
+                    scenario: "waiting for ready, no phase detail",
+                    input: r#"{"dpfstate":"waitingforready"}"#,
+                    expect: Yields((
+                        DpfState::WaitingForReady { phase_detail: None },
+                        DpfState::WaitingForReady { phase_detail: None },
+                    )),
                 },
-            }
-        );
-    }
-
-    /// Current tags deserialize to the correct variant and round-trip.
-    #[test]
-    fn test_dpf_state_deserialize_current_tags_and_roundtrip() {
-        for (json_tag, expected) in [
-            (r#"{"dpfstate":"provisioning"}"#, DpfState::Provisioning),
-            (
-                r#"{"dpfstate":"waitingforready"}"#,
-                DpfState::WaitingForReady { phase_detail: None },
-            ),
-            (
-                r#"{"dpfstate":"waitingforready","phase_detail":"some-detail"}"#,
-                DpfState::WaitingForReady {
-                    phase_detail: Some("some-detail".to_string()),
+                Case {
+                    scenario: "waiting for ready, with phase detail",
+                    input: r#"{"dpfstate":"waitingforready","phase_detail":"some-detail"}"#,
+                    expect: Yields((
+                        DpfState::WaitingForReady {
+                            phase_detail: Some("some-detail".to_string()),
+                        },
+                        DpfState::WaitingForReady {
+                            phase_detail: Some("some-detail".to_string()),
+                        },
+                    )),
                 },
-            ),
-            (r#"{"dpfstate":"deviceready"}"#, DpfState::DeviceReady),
-            (r#"{"dpfstate":"reprovisioning"}"#, DpfState::Reprovisioning),
-        ] {
-            let parsed: DpfState = serde_json::from_str(json_tag).unwrap();
-            assert_eq!(
-                parsed, expected,
-                "tag {} should deserialize to {:?}",
-                json_tag, expected
-            );
-            let serialized = serde_json::to_string(&parsed).unwrap();
-            let roundtrip: DpfState = serde_json::from_str(&serialized).unwrap();
-            assert_eq!(
-                roundtrip, expected,
-                "round-trip for {:?} must preserve value",
-                expected
-            );
-        }
-    }
-
-    #[test]
-    fn test_dpf_state_unknown_variant_falls_back() {
-        for json in [
-            r#"{"dpfstate":"somethingold"}"#,
-            r#"{"dpfstate":"bogus","extra":"field"}"#,
-        ] {
-            let parsed: DpfState = serde_json::from_str(json).unwrap();
-            assert_eq!(parsed, DpfState::Unknown);
-        }
+                Case {
+                    scenario: "device ready",
+                    input: r#"{"dpfstate":"deviceready"}"#,
+                    expect: Yields((DpfState::DeviceReady, DpfState::DeviceReady)),
+                },
+                Case {
+                    scenario: "reprovisioning",
+                    input: r#"{"dpfstate":"reprovisioning"}"#,
+                    expect: Yields((DpfState::Reprovisioning, DpfState::Reprovisioning)),
+                },
+                Case {
+                    scenario: "unknown tag falls back to Unknown",
+                    input: r#"{"dpfstate":"somethingold"}"#,
+                    expect: Yields((DpfState::Unknown, DpfState::Unknown)),
+                },
+                Case {
+                    scenario: "bogus tag with extra field falls back to Unknown",
+                    input: r#"{"dpfstate":"bogus","extra":"field"}"#,
+                    expect: Yields((DpfState::Unknown, DpfState::Unknown)),
+                },
+            ],
+            |s| {
+                let parsed: DpfState = serde_json::from_str(s).map_err(drop)?;
+                let serialized = serde_json::to_string(&parsed).map_err(drop)?;
+                let roundtrip: DpfState = serde_json::from_str(&serialized).map_err(drop)?;
+                Ok::<_, ()>((parsed, roundtrip))
+            },
+        );
     }
 
     fn alert_with_classifications(
@@ -3410,26 +3409,44 @@ mod tests {
         assert!(!profile.disable_lockdown);
     }
 
+    // A `HostProfile` serializes to the expected JSON and deserializes back to an
+    // equal value. We yield the (serialized json, round-tripped profile) pair so
+    // the exact serialized form and the round-trip equality are both asserted.
     #[test]
-    fn host_profile_serde_round_trip_lockdown_true() {
-        let profile = HostProfile {
-            disable_lockdown: true,
-        };
-        let json = serde_json::to_string(&profile).unwrap();
-        assert_eq!(json, r#"{"disable_lockdown":true}"#);
-        let back: HostProfile = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, profile);
-    }
-
-    #[test]
-    fn host_profile_serde_round_trip_lockdown_false() {
-        let profile = HostProfile {
-            disable_lockdown: false,
-        };
-        let json = serde_json::to_string(&profile).unwrap();
-        assert_eq!(json, r#"{"disable_lockdown":false}"#);
-        let back: HostProfile = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, profile);
+    fn host_profile_serde_round_trip() {
+        check_cases(
+            [
+                Case {
+                    scenario: "lockdown disabled (true)",
+                    input: HostProfile {
+                        disable_lockdown: true,
+                    },
+                    expect: Yields((
+                        r#"{"disable_lockdown":true}"#.to_string(),
+                        HostProfile {
+                            disable_lockdown: true,
+                        },
+                    )),
+                },
+                Case {
+                    scenario: "lockdown enabled (false)",
+                    input: HostProfile {
+                        disable_lockdown: false,
+                    },
+                    expect: Yields((
+                        r#"{"disable_lockdown":false}"#.to_string(),
+                        HostProfile {
+                            disable_lockdown: false,
+                        },
+                    )),
+                },
+            ],
+            |profile| {
+                let json = serde_json::to_string(&profile).map_err(drop)?;
+                let back: HostProfile = serde_json::from_str(&json).map_err(drop)?;
+                Ok::<_, ()>((json, back))
+            },
+        );
     }
 
     #[test]

--- a/crates/api-model/src/machine/network.rs
+++ b/crates/api-model/src/machine/network.rs
@@ -200,21 +200,106 @@ impl Default for ManagedHostNetworkConfig {
 mod tests {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
-    // Verify that existing JSON with IPv4 addresses (as stored in Postgres) still
-    // deserializes correctly after going from Ipv4Addr to IpAddr (to support v6).
+    // JSON round-trips: serialize a config to JSON and deserialize it back; the
+    // config must survive intact. Covers the IPv4 case (existing Postgres JSON
+    // still deserializes after Ipv4Addr -> IpAddr) and the IPv6 case (new v6
+    // pools). The error type (serde_json::Error) is not PartialEq, so failing
+    // rows would use `Fails`; all rows here round-trip cleanly.
     #[test]
-    fn test_managed_host_network_config_ipv4_json_roundtrip() {
-        let config = ManagedHostNetworkConfig {
-            loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
-            secondary_overlay_vtep_ip: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
-            use_admin_network: Some(true),
-            quarantine_state: None,
-        };
-        let json = serde_json::to_string(&config).unwrap();
-        let deserialized: ManagedHostNetworkConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(config, deserialized);
+    fn test_managed_host_network_config_json_roundtrip() {
+        check_cases(
+            [
+                Case {
+                    scenario: "ipv4 round-trip",
+                    input: ManagedHostNetworkConfig {
+                        loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                        secondary_overlay_vtep_ip: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
+                        use_admin_network: Some(true),
+                        quarantine_state: None,
+                    },
+                    expect: Yields(ManagedHostNetworkConfig {
+                        loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                        secondary_overlay_vtep_ip: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
+                        use_admin_network: Some(true),
+                        quarantine_state: None,
+                    }),
+                },
+                Case {
+                    scenario: "ipv6 round-trip",
+                    input: ManagedHostNetworkConfig {
+                        loopback_ip: Some(IpAddr::V6(Ipv6Addr::new(
+                            0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
+                        ))),
+                        secondary_overlay_vtep_ip: Some(IpAddr::V6(Ipv6Addr::new(
+                            0xfd00, 0, 0, 0, 0, 0, 0, 0x42,
+                        ))),
+                        use_admin_network: Some(false),
+                        quarantine_state: None,
+                    },
+                    expect: Yields(ManagedHostNetworkConfig {
+                        loopback_ip: Some(IpAddr::V6(Ipv6Addr::new(
+                            0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
+                        ))),
+                        secondary_overlay_vtep_ip: Some(IpAddr::V6(Ipv6Addr::new(
+                            0xfd00, 0, 0, 0, 0, 0, 0, 0x42,
+                        ))),
+                        use_admin_network: Some(false),
+                        quarantine_state: None,
+                    }),
+                },
+            ],
+            |config| {
+                let json = serde_json::to_string(&config).map_err(drop)?;
+                serde_json::from_str::<ManagedHostNetworkConfig>(&json).map_err(drop)
+            },
+        );
+    }
+
+    // Deserialize raw JSON (as it would already exist in the database) into the
+    // IpAddr-typed config, projecting to the (loopback_ip, secondary_overlay_vtep_ip)
+    // pair the original tests asserted. Covers legacy IPv4 JSON and IPv6 JSON.
+    #[test]
+    fn test_managed_host_network_config_deserialize_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "legacy ipv4 json",
+                    input: r#"{
+                        "loopback_ip": "10.0.0.1",
+                        "secondary_overlay_vtep_ip": "172.16.0.5",
+                        "use_admin_network": true,
+                        "quarantine_state": null
+                    }"#,
+                    expect: Yields((
+                        Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                        Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
+                    )),
+                },
+                Case {
+                    scenario: "ipv6 json",
+                    input: r#"{
+                        "loopback_ip": "2001:db8::1",
+                        "secondary_overlay_vtep_ip": null,
+                        "use_admin_network": true,
+                        "quarantine_state": null
+                    }"#,
+                    expect: Yields((
+                        Some(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))),
+                        None,
+                    )),
+                },
+            ],
+            |json| {
+                serde_json::from_str::<ManagedHostNetworkConfig>(json)
+                    .map(|c| (c.loopback_ip, c.secondary_overlay_vtep_ip))
+                    .map_err(drop)
+            },
+        );
     }
 
     // Ensure that the JSON representation of an IPv4 address under IpAddr is
@@ -232,63 +317,6 @@ mod tests {
         let json = serde_json::to_string(&config).unwrap();
         // Ensure IpAddr serializes IPv4 same as Ipv4Addr.
         assert!(json.contains(r#""loopback_ip":"10.0.0.1""#), "json: {json}");
-    }
-
-    // Confirm that a raw JSON string with an IPv4 address (as would already
-    // exist in the database from before switching to IpAddr for v6 support),
-    // deserializes correctly into the new IpAddr type.
-    #[test]
-    fn test_managed_host_network_config_deserialize_legacy_ipv4_json() {
-        let json = r#"{
-            "loopback_ip": "10.0.0.1",
-            "secondary_overlay_vtep_ip": "172.16.0.5",
-            "use_admin_network": true,
-            "quarantine_state": null
-        }"#;
-        let config: ManagedHostNetworkConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(
-            config.loopback_ip,
-            Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))
-        );
-        assert_eq!(
-            config.secondary_overlay_vtep_ip,
-            Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5)))
-        );
-    }
-
-    // Verify that IPv6 addresses serialize/deserialize correctly through our
-    // ManagedHostNetworkConfig JSON representation, for the case when IPv6
-    // pools are enabled.
-    #[test]
-    fn test_managed_host_network_config_ipv6_json_roundtrip() {
-        let config = ManagedHostNetworkConfig {
-            loopback_ip: Some(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))),
-            secondary_overlay_vtep_ip: Some(IpAddr::V6(Ipv6Addr::new(
-                0xfd00, 0, 0, 0, 0, 0, 0, 0x42,
-            ))),
-            use_admin_network: Some(false),
-            quarantine_state: None,
-        };
-        let json = serde_json::to_string(&config).unwrap();
-        let deserialized: ManagedHostNetworkConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(config, deserialized);
-    }
-
-    // ...aand confirm deserialization of IPv6 addresses from JSON.
-    #[test]
-    fn test_managed_host_network_config_deserialize_ipv6_json() {
-        let json = r#"{
-            "loopback_ip": "2001:db8::1",
-            "secondary_overlay_vtep_ip": null,
-            "use_admin_network": true,
-            "quarantine_state": null
-        }"#;
-        let config: ManagedHostNetworkConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(
-            config.loopback_ip,
-            Some(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)))
-        );
-        assert_eq!(config.secondary_overlay_vtep_ip, None);
     }
 
     // Ensure default ManagedHostNetworkConfig is still all-None/Some(true),
@@ -314,19 +342,26 @@ mod tests {
         assert_eq!(v6.to_string(), "2001:db8::1");
     }
 
-    // Verify that IPv4 strings parse correctly as IpAddr, since resource pools
-    // store values as strings and parse them via IpAddr::from_str.
+    // Parse pool strings as IpAddr (resource pools store values as strings and
+    // parse them via IpAddr::from_str). Yielding the exact IpAddr value also
+    // covers the original is_ipv4()/is_ipv6() family assertions. AddrParseError
+    // is not PartialEq, so failing rows would use `Fails`; both rows parse.
     #[test]
     fn test_ip_addr_parse_from_pool_strings() {
-        let v4: IpAddr = "10.0.0.1".parse().unwrap();
-        assert!(v4.is_ipv4());
-        assert_eq!(v4, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
-
-        let v6: IpAddr = "2001:db8::1".parse().unwrap();
-        assert!(v6.is_ipv6());
-        assert_eq!(
-            v6,
-            IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))
+        check_cases(
+            [
+                Case {
+                    scenario: "ipv4 string",
+                    input: "10.0.0.1",
+                    expect: Yields(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                },
+                Case {
+                    scenario: "ipv6 string",
+                    input: "2001:db8::1",
+                    expect: Yields(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))),
+                },
+            ],
+            |s| s.parse::<IpAddr>(),
         );
     }
 }

--- a/crates/api-model/src/power_shelf/mod.rs
+++ b/crates/api-model/src/power_shelf/mod.rs
@@ -230,122 +230,170 @@ pub struct PowerShelfSearchFilter {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     #[test]
     fn serialize_controller_state() {
-        let state = PowerShelfControllerState::Initializing {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"initializing\"}");
-        assert_eq!(
-            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = PowerShelfControllerState::FetchingData {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"fetchingdata\"}");
-        assert_eq!(
-            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = PowerShelfControllerState::Configuring {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"configuring\"}");
-        assert_eq!(
-            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = PowerShelfControllerState::Ready {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"ready\"}");
-        assert_eq!(
-            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = PowerShelfControllerState::Error {
-            cause: "cause goes here".to_string(),
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, r#"{"state":"error","cause":"cause goes here"}"#);
-        assert_eq!(
-            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = PowerShelfControllerState::Deleting {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"deleting\"}");
-        assert_eq!(
-            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = PowerShelfControllerState::Maintenance {
-            operation: PowerShelfMaintenanceOperation::PowerOn,
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(
-            serialized,
-            r#"{"state":"maintenance","operation":{"operation":"poweron"}}"#
-        );
-        assert_eq!(
-            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = PowerShelfControllerState::Maintenance {
-            operation: PowerShelfMaintenanceOperation::PowerOff,
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(
-            serialized,
-            r#"{"state":"maintenance","operation":{"operation":"poweroff"}}"#
-        );
-        assert_eq!(
-            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
-            state
+        // Each controller-state variant serializes to its tagged JSON and round-trips
+        // back to the same value. The op yields (serialized, deserialized) so both the
+        // exact JSON string and the round-trip equality are asserted per row.
+        check_cases(
+            [
+                Case {
+                    scenario: "initializing",
+                    input: PowerShelfControllerState::Initializing {},
+                    expect: Yields((
+                        "{\"state\":\"initializing\"}".to_string(),
+                        PowerShelfControllerState::Initializing {},
+                    )),
+                },
+                Case {
+                    scenario: "fetching data",
+                    input: PowerShelfControllerState::FetchingData {},
+                    expect: Yields((
+                        "{\"state\":\"fetchingdata\"}".to_string(),
+                        PowerShelfControllerState::FetchingData {},
+                    )),
+                },
+                Case {
+                    scenario: "configuring",
+                    input: PowerShelfControllerState::Configuring {},
+                    expect: Yields((
+                        "{\"state\":\"configuring\"}".to_string(),
+                        PowerShelfControllerState::Configuring {},
+                    )),
+                },
+                Case {
+                    scenario: "ready",
+                    input: PowerShelfControllerState::Ready {},
+                    expect: Yields((
+                        "{\"state\":\"ready\"}".to_string(),
+                        PowerShelfControllerState::Ready {},
+                    )),
+                },
+                Case {
+                    scenario: "error with cause",
+                    input: PowerShelfControllerState::Error {
+                        cause: "cause goes here".to_string(),
+                    },
+                    expect: Yields((
+                        r#"{"state":"error","cause":"cause goes here"}"#.to_string(),
+                        PowerShelfControllerState::Error {
+                            cause: "cause goes here".to_string(),
+                        },
+                    )),
+                },
+                Case {
+                    scenario: "deleting",
+                    input: PowerShelfControllerState::Deleting {},
+                    expect: Yields((
+                        "{\"state\":\"deleting\"}".to_string(),
+                        PowerShelfControllerState::Deleting {},
+                    )),
+                },
+                Case {
+                    scenario: "maintenance power-on",
+                    input: PowerShelfControllerState::Maintenance {
+                        operation: PowerShelfMaintenanceOperation::PowerOn,
+                    },
+                    expect: Yields((
+                        r#"{"state":"maintenance","operation":{"operation":"poweron"}}"#
+                            .to_string(),
+                        PowerShelfControllerState::Maintenance {
+                            operation: PowerShelfMaintenanceOperation::PowerOn,
+                        },
+                    )),
+                },
+                Case {
+                    scenario: "maintenance power-off",
+                    input: PowerShelfControllerState::Maintenance {
+                        operation: PowerShelfMaintenanceOperation::PowerOff,
+                    },
+                    expect: Yields((
+                        r#"{"state":"maintenance","operation":{"operation":"poweroff"}}"#
+                            .to_string(),
+                        PowerShelfControllerState::Maintenance {
+                            operation: PowerShelfMaintenanceOperation::PowerOff,
+                        },
+                    )),
+                },
+            ],
+            // Serialize the state, then deserialize the produced JSON back.
+            |state: PowerShelfControllerState| {
+                let serialized = serde_json::to_string(&state).map_err(drop)?;
+                let parsed =
+                    serde_json::from_str::<PowerShelfControllerState>(&serialized).map_err(drop)?;
+                Ok::<_, ()>((serialized, parsed))
+            },
         );
     }
 
     #[test]
-    fn serialize_maintenance_operation_round_trip() {
-        for operation in [
-            PowerShelfMaintenanceOperation::PowerOn,
-            PowerShelfMaintenanceOperation::PowerOff,
-        ] {
-            let serialized = serde_json::to_string(&operation).unwrap();
-            let parsed: PowerShelfMaintenanceOperation = serde_json::from_str(&serialized).unwrap();
-            assert_eq!(parsed, operation);
-        }
-    }
-
-    #[test]
-    fn serialize_maintenance_operation_lowercase_tags() {
-        assert_eq!(
-            serde_json::to_string(&PowerShelfMaintenanceOperation::PowerOn).unwrap(),
-            r#"{"operation":"poweron"}"#
-        );
-        assert_eq!(
-            serde_json::to_string(&PowerShelfMaintenanceOperation::PowerOff).unwrap(),
-            r#"{"operation":"poweroff"}"#
+    fn serialize_maintenance_operation() {
+        // Each maintenance operation serializes to its lowercase-tagged JSON and
+        // round-trips back. The op yields (serialized, deserialized), folding the
+        // exact-tag and round-trip assertions into one table.
+        check_cases(
+            [
+                Case {
+                    scenario: "power on",
+                    input: PowerShelfMaintenanceOperation::PowerOn,
+                    expect: Yields((
+                        r#"{"operation":"poweron"}"#.to_string(),
+                        PowerShelfMaintenanceOperation::PowerOn,
+                    )),
+                },
+                Case {
+                    scenario: "power off",
+                    input: PowerShelfMaintenanceOperation::PowerOff,
+                    expect: Yields((
+                        r#"{"operation":"poweroff"}"#.to_string(),
+                        PowerShelfMaintenanceOperation::PowerOff,
+                    )),
+                },
+            ],
+            |operation: PowerShelfMaintenanceOperation| {
+                let serialized = serde_json::to_string(&operation).map_err(drop)?;
+                let parsed = serde_json::from_str::<PowerShelfMaintenanceOperation>(&serialized)
+                    .map_err(drop)?;
+                Ok::<_, ()>((serialized, parsed))
+            },
         );
     }
 
     #[test]
     fn serialize_maintenance_request_round_trip() {
+        // A maintenance request round-trips through JSON for each operation. Only the
+        // operation varies; the timestamp and initiator are fixed across rows.
         let now = chrono::DateTime::parse_from_rfc3339("2026-05-13T12:00:00Z")
             .unwrap()
             .with_timezone(&chrono::Utc);
-        for operation in [
-            PowerShelfMaintenanceOperation::PowerOn,
-            PowerShelfMaintenanceOperation::PowerOff,
-        ] {
-            let request = PowerShelfMaintenanceRequest {
-                requested_at: now,
-                initiator: "operator (TICKET-1)".to_string(),
-                operation,
-            };
-            let serialized = serde_json::to_string(&request).unwrap();
-            let parsed: PowerShelfMaintenanceRequest = serde_json::from_str(&serialized).unwrap();
-            assert_eq!(parsed, request);
-        }
+        let request = |operation| PowerShelfMaintenanceRequest {
+            requested_at: now,
+            initiator: "operator (TICKET-1)".to_string(),
+            operation,
+        };
+        check_cases(
+            [
+                Case {
+                    scenario: "power on",
+                    input: PowerShelfMaintenanceOperation::PowerOn,
+                    expect: Yields(request(PowerShelfMaintenanceOperation::PowerOn)),
+                },
+                Case {
+                    scenario: "power off",
+                    input: PowerShelfMaintenanceOperation::PowerOff,
+                    expect: Yields(request(PowerShelfMaintenanceOperation::PowerOff)),
+                },
+            ],
+            |operation| {
+                let serialized = serde_json::to_string(&request(operation)).map_err(drop)?;
+                serde_json::from_str::<PowerShelfMaintenanceRequest>(&serialized).map_err(drop)
+            },
+        );
     }
 
     #[test]

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -821,6 +821,8 @@ pub fn state_sla(state: &RackState, state_version: &ConfigVersion) -> StateSla {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
     use carbide_uuid::machine::{MachineIdSource, MachineType};
     use carbide_uuid::power_shelf::{PowerShelfIdSource, PowerShelfType};
     use carbide_uuid::switch::{SwitchIdSource, SwitchType};
@@ -1026,54 +1028,69 @@ mod tests {
         }
     }
 
+    // check_accepts_maintenance: Ready/Error (with no pending request) accept;
+    // every other state is rejected as NotReadyOrError, and a state that already
+    // has a pending request is rejected as AlreadyPending. The originals only
+    // asserted the rejection variant (via matches!), so we compare the error's
+    // discriminant rather than its full value. The input is the (state, pending)
+    // pair handed to `test_rack`.
     #[test]
-    fn accepts_maintenance_in_ready_state() {
-        let rack = test_rack(RackState::Ready, None);
-        assert!(rack.check_accepts_maintenance().is_ok());
-    }
-
-    #[test]
-    fn accepts_maintenance_in_error_state() {
-        let rack = test_rack(
-            RackState::Error {
-                cause: "something broke".into(),
-            },
-            None,
+    fn check_accepts_maintenance_cases() {
+        // Discriminant sentinels for the two rejection variants.
+        let not_ready_or_error = std::mem::discriminant(
+            &RackMaintenanceRejection::NotReadyOrError(RackState::Created),
         );
-        assert!(rack.check_accepts_maintenance().is_ok());
-    }
+        let already_pending = std::mem::discriminant(&RackMaintenanceRejection::AlreadyPending);
 
-    #[test]
-    fn rejects_maintenance_in_created_state() {
-        let rack = test_rack(RackState::Created, None);
-        let err = rack.check_accepts_maintenance().unwrap_err();
-        assert!(matches!(err, RackMaintenanceRejection::NotReadyOrError(_)));
-    }
-
-    #[test]
-    fn rejects_maintenance_in_discovering_state() {
-        let rack = test_rack(RackState::Discovering, None);
-        let err = rack.check_accepts_maintenance().unwrap_err();
-        assert!(matches!(err, RackMaintenanceRejection::NotReadyOrError(_)));
-    }
-
-    #[test]
-    fn rejects_maintenance_in_maintenance_state() {
-        let rack = test_rack(
-            RackState::Maintenance {
-                maintenance_state: RackMaintenanceState::Completed,
+        check_cases(
+            [
+                Case {
+                    scenario: "accepts in ready state",
+                    input: (RackState::Ready, None),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "accepts in error state",
+                    input: (
+                        RackState::Error {
+                            cause: "something broke".into(),
+                        },
+                        None,
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "rejects in created state",
+                    input: (RackState::Created, None),
+                    expect: FailsWith(not_ready_or_error),
+                },
+                Case {
+                    scenario: "rejects in discovering state",
+                    input: (RackState::Discovering, None),
+                    expect: FailsWith(not_ready_or_error),
+                },
+                Case {
+                    scenario: "rejects in maintenance state",
+                    input: (
+                        RackState::Maintenance {
+                            maintenance_state: RackMaintenanceState::Completed,
+                        },
+                        None,
+                    ),
+                    expect: FailsWith(not_ready_or_error),
+                },
+                Case {
+                    scenario: "rejects when already pending",
+                    input: (RackState::Ready, Some(MaintenanceScope::default())),
+                    expect: FailsWith(already_pending),
+                },
+            ],
+            |(state, maintenance_requested)| {
+                test_rack(state, maintenance_requested)
+                    .check_accepts_maintenance()
+                    .map_err(|e| std::mem::discriminant(&e))
             },
-            None,
         );
-        let err = rack.check_accepts_maintenance().unwrap_err();
-        assert!(matches!(err, RackMaintenanceRejection::NotReadyOrError(_)));
-    }
-
-    #[test]
-    fn rejects_maintenance_when_already_pending() {
-        let rack = test_rack(RackState::Ready, Some(MaintenanceScope::default()));
-        let err = rack.check_accepts_maintenance().unwrap_err();
-        assert!(matches!(err, RackMaintenanceRejection::AlreadyPending));
     }
 
     // ── RackMaintenanceRejection display ────────────────────────────────

--- a/crates/api-model/src/rack_type.rs
+++ b/crates/api-model/src/rack_type.rs
@@ -279,6 +279,9 @@ impl RackProfileConfig {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     #[test]
@@ -412,13 +415,26 @@ count = 2
 
     // RackHardwareType tests.
 
+    // JSON round-trip: each variant serializes to its expected string and
+    // deserializes back to itself. Projected to (json, value_back); the closure
+    // discards the (non-PartialEq) serde_json error since every row succeeds.
     #[test]
     fn test_rack_hardware_type_serde_round_trip() {
-        let hw_type = RackHardwareType::from("dsx_gb200nvl_72x1");
-        let json = serde_json::to_string(&hw_type).unwrap();
-        assert_eq!(json, "\"dsx_gb200nvl_72x1\"");
-        let deserialized: RackHardwareType = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized, hw_type);
+        check_cases(
+            [Case {
+                scenario: "dsx hardware type round-trips through json",
+                input: RackHardwareType::from("dsx_gb200nvl_72x1"),
+                expect: Yields((
+                    "\"dsx_gb200nvl_72x1\"".to_string(),
+                    RackHardwareType::from("dsx_gb200nvl_72x1"),
+                )),
+            }],
+            |hw_type| {
+                let json = serde_json::to_string(&hw_type).map_err(drop)?;
+                let back: RackHardwareType = serde_json::from_str(&json).map_err(drop)?;
+                Ok::<_, ()>((json, back))
+            },
+        );
     }
 
     #[test]
@@ -443,40 +459,68 @@ count = 2
 
     // RackHardwareTopology serde.
 
+    // JSON round-trip: each topology variant serializes to its expected
+    // snake_case string and deserializes back to itself. Projected to
+    // (json, value_back); the (non-PartialEq) serde_json error is discarded.
     #[test]
     fn test_rack_hardware_topology_serde_round_trip() {
-        let cases = [
-            (
-                RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
-                "\"gb200_nvl36r1_c2g4_topology\"",
-            ),
-            (
-                RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
-                "\"gb300_nvl36r1_c2g4_topology\"",
-            ),
-            (
-                RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
-                "\"gb200_nvl72r1_c2g4_topology\"",
-            ),
-            (
-                RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
-                "\"gb300_nvl72r1_c2g4_topology\"",
-            ),
-            (
-                RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
-                "\"vr_nvl8r1_c2g4_rtf_topology\"",
-            ),
-            (
-                RackHardwareTopology::VrNvl72r1C2g4Topology,
-                "\"vr_nvl72r1_c2g4_topology\"",
-            ),
-        ];
-        for (variant, expected_json) in cases {
-            let json = serde_json::to_string(&variant).unwrap();
-            assert_eq!(json, expected_json, "serialize {:?}", variant);
-            let deserialized: RackHardwareTopology = serde_json::from_str(&json).unwrap();
-            assert_eq!(deserialized, variant, "deserialize {:?}", variant);
-        }
+        check_cases(
+            [
+                Case {
+                    scenario: "gb200 nvl36 round-trips",
+                    input: RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
+                    expect: Yields((
+                        "\"gb200_nvl36r1_c2g4_topology\"".to_string(),
+                        RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
+                    )),
+                },
+                Case {
+                    scenario: "gb300 nvl36 round-trips",
+                    input: RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
+                    expect: Yields((
+                        "\"gb300_nvl36r1_c2g4_topology\"".to_string(),
+                        RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
+                    )),
+                },
+                Case {
+                    scenario: "gb200 nvl72 round-trips",
+                    input: RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
+                    expect: Yields((
+                        "\"gb200_nvl72r1_c2g4_topology\"".to_string(),
+                        RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
+                    )),
+                },
+                Case {
+                    scenario: "gb300 nvl72 round-trips",
+                    input: RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
+                    expect: Yields((
+                        "\"gb300_nvl72r1_c2g4_topology\"".to_string(),
+                        RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
+                    )),
+                },
+                Case {
+                    scenario: "vr nvl8 rtf round-trips",
+                    input: RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
+                    expect: Yields((
+                        "\"vr_nvl8r1_c2g4_rtf_topology\"".to_string(),
+                        RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
+                    )),
+                },
+                Case {
+                    scenario: "vr nvl72 round-trips",
+                    input: RackHardwareTopology::VrNvl72r1C2g4Topology,
+                    expect: Yields((
+                        "\"vr_nvl72r1_c2g4_topology\"".to_string(),
+                        RackHardwareTopology::VrNvl72r1C2g4Topology,
+                    )),
+                },
+            ],
+            |variant| {
+                let json = serde_json::to_string(&variant).map_err(drop)?;
+                let back: RackHardwareTopology = serde_json::from_str(&json).map_err(drop)?;
+                Ok::<_, ()>((json, back))
+            },
+        );
     }
 
     #[test]
@@ -497,18 +541,30 @@ count = 2
 
     // RackHardwareClass serde.
 
+    // JSON round-trip: each class variant serializes to its expected snake_case
+    // string and deserializes back to itself. Projected to (json, value_back);
+    // the (non-PartialEq) serde_json error is discarded.
     #[test]
     fn test_rack_hardware_class_serde_round_trip() {
-        let cases = [
-            (RackHardwareClass::Dev, "\"dev\""),
-            (RackHardwareClass::Prod, "\"prod\""),
-        ];
-        for (variant, expected_json) in cases {
-            let json = serde_json::to_string(&variant).unwrap();
-            assert_eq!(json, expected_json, "serialize {:?}", variant);
-            let deserialized: RackHardwareClass = serde_json::from_str(&json).unwrap();
-            assert_eq!(deserialized, variant, "deserialize {:?}", variant);
-        }
+        check_cases(
+            [
+                Case {
+                    scenario: "dev round-trips",
+                    input: RackHardwareClass::Dev,
+                    expect: Yields(("\"dev\"".to_string(), RackHardwareClass::Dev)),
+                },
+                Case {
+                    scenario: "prod round-trips",
+                    input: RackHardwareClass::Prod,
+                    expect: Yields(("\"prod\"".to_string(), RackHardwareClass::Prod)),
+                },
+            ],
+            |variant| {
+                let json = serde_json::to_string(&variant).map_err(drop)?;
+                let back: RackHardwareClass = serde_json::from_str(&json).map_err(drop)?;
+                Ok::<_, ()>((json, back))
+            },
+        );
     }
 
     #[test]

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -1553,6 +1553,9 @@ pub fn is_bluefield_model(model: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
     use crate::firmware::FirmwareComponent;
     use crate::machine::machine_id::from_hardware_info;
@@ -1613,28 +1616,36 @@ mod tests {
         }
     }
 
+    /// `find_version` locates the firmware version matching a component regex,
+    /// yielding the version string when an inventory matches and absent otherwise.
     #[test]
-    fn test_find_version_single_match() {
+    fn test_find_version() {
         let fw_info = create_test_firmware(FirmwareComponentType::Bmc, r"^BMC_Firmware$");
-        let endpoint = create_test_endpoint(vec![
-            ("BMC_Firmware", Some("1.2.3")),
-            ("DPU_UEFI", Some("4.5.6")),
-        ]);
-
-        let result = endpoint.find_version(&fw_info, FirmwareComponentType::Bmc);
-        assert_eq!(result, Some(&"1.2.3".to_string()));
-    }
-
-    #[test]
-    fn test_find_version_no_match() {
-        let fw_info = create_test_firmware(FirmwareComponentType::Bmc, r"^BMC_Firmware$");
-        let endpoint = create_test_endpoint(vec![
-            ("DPU_UEFI", Some("4.5.6")),
-            ("Other_Component", Some("7.8.9")),
-        ]);
-
-        let result = endpoint.find_version(&fw_info, FirmwareComponentType::Bmc);
-        assert_eq!(result, None);
+        check_cases(
+            [
+                Case {
+                    scenario: "single match",
+                    input: vec![("BMC_Firmware", Some("1.2.3")), ("DPU_UEFI", Some("4.5.6"))],
+                    expect: Yields("1.2.3".to_string()),
+                },
+                Case {
+                    scenario: "no match",
+                    input: vec![
+                        ("DPU_UEFI", Some("4.5.6")),
+                        ("Other_Component", Some("7.8.9")),
+                    ],
+                    expect: Fails,
+                },
+            ],
+            // Build an endpoint from the inventories, then look up the BMC
+            // version; absent -> error so the no-match row reads as a failure.
+            |inventories| {
+                create_test_endpoint(inventories)
+                    .find_version(&fw_info, FirmwareComponentType::Bmc)
+                    .cloned()
+                    .ok_or(())
+            },
+        );
     }
 
     #[test]
@@ -1969,28 +1980,45 @@ mod tests {
         assert_eq!(deserialized.machine_id.unwrap(), machine_id);
     }
 
+    /// `UefiDevicePath::from_str` parses a UEFI PciRoot/Pci device path into a
+    /// dotted decimal address, requiring at least one Pci node after PciRoot.
     #[test]
     fn test_uefi_device_path() {
-        let path = "PciRoot(0x2)/Pci(0x1,0x0)/Pci(0x0,0x1)";
-        let converted: UefiDevicePath = UefiDevicePath::from_str(path).unwrap();
-        assert_eq!(converted.0, "2.1.0.0.1");
-
-        let path = "PciRoot(0x11)/Pci(0x1,0x0)/Pci(0x0,0xa)/MAC(A088C20C87C6,0x1)";
-        let converted: UefiDevicePath = UefiDevicePath::from_str(path).unwrap();
-        assert_eq!(converted.0, "17.1.0.0.10");
-
-        // NIC attached directly to a root port (no PCI-PCI bridge upstream).
-        let path = "PciRoot(0x7)/Pci(0x0,0x0)/MAC(525400A8282F,0x1)";
-        let converted: UefiDevicePath = UefiDevicePath::from_str(path).unwrap();
-        assert_eq!(converted.0, "7.0.0");
-
-        // Three Pci nodes (NIC behind two upstream bridges/switches).
-        let path = "PciRoot(0x0)/Pci(0x1,0x0)/Pci(0x0,0x0)/Pci(0x0,0x0)";
-        let converted: UefiDevicePath = UefiDevicePath::from_str(path).unwrap();
-        assert_eq!(converted.0, "0.1.0.0.0.0.0");
-
-        // PciRoot without any Pci node should fail.
-        assert!(UefiDevicePath::from_str("PciRoot(0x7)/MAC(525400A8282F,0x1)").is_err());
+        check_cases(
+            [
+                Case {
+                    scenario: "two Pci nodes",
+                    input: "PciRoot(0x2)/Pci(0x1,0x0)/Pci(0x0,0x1)",
+                    expect: Yields("2.1.0.0.1".to_string()),
+                },
+                Case {
+                    scenario: "trailing MAC discarded",
+                    input: "PciRoot(0x11)/Pci(0x1,0x0)/Pci(0x0,0xa)/MAC(A088C20C87C6,0x1)",
+                    expect: Yields("17.1.0.0.10".to_string()),
+                },
+                Case {
+                    // NIC attached directly to a root port (no PCI-PCI bridge upstream).
+                    scenario: "single Pci node on a root port",
+                    input: "PciRoot(0x7)/Pci(0x0,0x0)/MAC(525400A8282F,0x1)",
+                    expect: Yields("7.0.0".to_string()),
+                },
+                Case {
+                    // Three Pci nodes (NIC behind two upstream bridges/switches).
+                    scenario: "three Pci nodes",
+                    input: "PciRoot(0x0)/Pci(0x1,0x0)/Pci(0x0,0x0)/Pci(0x0,0x0)",
+                    expect: Yields("0.1.0.0.0.0.0".to_string()),
+                },
+                Case {
+                    // PciRoot without any Pci node should fail.
+                    scenario: "PciRoot without any Pci node",
+                    input: "PciRoot(0x7)/MAC(525400A8282F,0x1)",
+                    expect: Fails,
+                },
+            ],
+            // The error type is String, but the failing row only asserts that it
+            // errors, so discard it; yield the dotted address on success.
+            |path| UefiDevicePath::from_str(path).map(|u| u.0).map_err(drop),
+        );
     }
 
     #[test]
@@ -2078,11 +2106,16 @@ mod tests {
         assert!(report.is_power_shelf());
     }
 
+    /// `find_interface_id_for_mac` returns the Redfish interface id of the host
+    /// ethernet interface whose MAC matches, treating a missing or empty id (and
+    /// an unknown MAC) as absent so a last-known-good capture is never clobbered.
     #[test]
-    fn find_interface_id_for_mac_matches_host_ethernet_interface() {
+    fn find_interface_id_for_mac() {
         let mac = MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01]);
         let other = MacAddress::new([0x11, 0x22, 0x33, 0x44, 0x55, 0x66]);
-        let report = EndpointExplorationReport {
+
+        // Report with two interfaces: `other` then `mac`, both with ids.
+        let two_iface_report = EndpointExplorationReport {
             systems: vec![ComputerSystem {
                 ethernet_interfaces: vec![
                     EthernetInterface {
@@ -2100,25 +2133,11 @@ mod tests {
             }],
             ..Default::default()
         };
-
-        assert_eq!(
-            report.find_interface_id_for_mac(mac),
-            Some("NIC.Slot.7-1-1")
-        );
-        // Unknown MAC -> None (so the capture keeps the last-known-good record).
-        assert_eq!(
-            report.find_interface_id_for_mac(MacAddress::new([0, 0, 0, 0, 0, 0])),
-            None
-        );
-    }
-
-    #[test]
-    fn find_interface_id_for_mac_none_when_id_missing() {
-        let mac = MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01]);
-        let report = EndpointExplorationReport {
+        // Single interface carrying `mac` but no usable id.
+        let single_iface_report = |id: Option<String>| EndpointExplorationReport {
             systems: vec![ComputerSystem {
                 ethernet_interfaces: vec![EthernetInterface {
-                    id: None,
+                    id,
                     mac_address: Some(mac),
                     ..Default::default()
                 }],
@@ -2126,28 +2145,37 @@ mod tests {
             }],
             ..Default::default()
         };
-        // MAC present but no interface id -> can't form a fully-populated pair.
-        assert_eq!(report.find_interface_id_for_mac(mac), None);
-    }
 
-    #[test]
-    fn find_interface_id_for_mac_none_when_id_empty() {
-        let mac = MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01]);
-        let report = EndpointExplorationReport {
-            systems: vec![ComputerSystem {
-                ethernet_interfaces: vec![EthernetInterface {
-                    id: Some(String::new()),
-                    mac_address: Some(mac),
-                    ..Default::default()
-                }],
-                ..Default::default()
-            }],
-            ..Default::default()
-        };
-        // An empty id is not a usable interface id, so it's treated as absent --
-        // the capture then keeps the last-known-good stored boot interface
-        // rather than clobbering it with an empty string.
-        assert_eq!(report.find_interface_id_for_mac(mac), None);
+        check_cases(
+            [
+                Case {
+                    scenario: "matching MAC yields its interface id",
+                    input: (two_iface_report.clone(), mac),
+                    expect: Yields("NIC.Slot.7-1-1".to_string()),
+                },
+                Case {
+                    scenario: "unknown MAC -> None (keeps last-known-good record)",
+                    input: (two_iface_report, MacAddress::new([0, 0, 0, 0, 0, 0])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "MAC present but no interface id -> no complete pair",
+                    input: (single_iface_report(None), mac),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty id treated as absent (don't clobber stored boot interface)",
+                    input: (single_iface_report(Some(String::new())), mac),
+                    expect: Fails,
+                },
+            ],
+            |(report, mac)| {
+                report
+                    .find_interface_id_for_mac(mac)
+                    .map(str::to_string)
+                    .ok_or(())
+            },
+        );
     }
 
     #[test]
@@ -2265,78 +2293,80 @@ mod tests {
         assert!(!report.is_power_shelf());
     }
 
+    /// A `ComputerSystem` deserializes regardless of the `BaseMac` field: a valid
+    /// value parses through, while an invalid, null, or missing one becomes `None`.
+    /// Each row projects to the resulting `base_mac`.
     #[test]
-    fn test_computer_system_with_invalid_base_mac_deserializes_as_none() {
-        let json = serde_json::json!({
-            "EthernetInterfaces": [],
-            "Id": "Bluefield",
-            "Manufacturer": "Nvidia",
-            "Model": "Bluefield-3 DPU",
-            "SerialNumber": "ABC1234",
-            "Attributes": {},
-            "PcieDevices": [],
-            "BaseMac": "pe:",
-            "PowerState": "On"
-        });
-
-        let system: ComputerSystem =
-            serde_json::from_value(json).expect("should deserialize despite invalid BaseMac");
-        assert_eq!(system.base_mac, None);
-    }
-
-    #[test]
-    fn test_computer_system_with_valid_base_mac_deserializes_correctly() {
-        let json = serde_json::json!({
-            "EthernetInterfaces": [],
-            "Id": "Bluefield",
-            "Manufacturer": "Nvidia",
-            "Model": "Bluefield-3 DPU",
-            "SerialNumber": "ABC1234",
-            "Attributes": {},
-            "PcieDevices": [],
-            "BaseMac": "A088C208804C",
-            "PowerState": "On"
-        });
-
-        let system: ComputerSystem =
-            serde_json::from_value(json).expect("should deserialize valid BaseMac");
-        assert_eq!(system.base_mac, Some("A088C208804C".parse().unwrap()));
-    }
-
-    #[test]
-    fn test_computer_system_with_null_base_mac_deserializes_as_none() {
-        let json = serde_json::json!({
-            "EthernetInterfaces": [],
-            "Id": "Bluefield",
-            "Manufacturer": "Nvidia",
-            "Model": "Bluefield-3 DPU",
-            "SerialNumber": "ABC1234",
-            "Attributes": {},
-            "PcieDevices": [],
-            "BaseMac": null,
-            "PowerState": "On"
-        });
-
-        let system: ComputerSystem =
-            serde_json::from_value(json).expect("should deserialize null BaseMac");
-        assert_eq!(system.base_mac, None);
-    }
-
-    #[test]
-    fn test_computer_system_with_missing_base_mac_deserializes_as_none() {
-        let json = serde_json::json!({
-            "EthernetInterfaces": [],
-            "Id": "Bluefield",
-            "Manufacturer": "Nvidia",
-            "Model": "Bluefield-3 DPU",
-            "SerialNumber": "ABC1234",
-            "Attributes": {},
-            "PcieDevices": [],
-            "PowerState": "On"
-        });
-
-        let system: ComputerSystem =
-            serde_json::from_value(json).expect("should deserialize missing BaseMac");
-        assert_eq!(system.base_mac, None);
+    fn test_computer_system_base_mac_deserialization() {
+        check_cases(
+            [
+                Case {
+                    scenario: "invalid BaseMac -> None",
+                    input: serde_json::json!({
+                        "EthernetInterfaces": [],
+                        "Id": "Bluefield",
+                        "Manufacturer": "Nvidia",
+                        "Model": "Bluefield-3 DPU",
+                        "SerialNumber": "ABC1234",
+                        "Attributes": {},
+                        "PcieDevices": [],
+                        "BaseMac": "pe:",
+                        "PowerState": "On"
+                    }),
+                    expect: Yields(None),
+                },
+                Case {
+                    scenario: "valid BaseMac parses through",
+                    input: serde_json::json!({
+                        "EthernetInterfaces": [],
+                        "Id": "Bluefield",
+                        "Manufacturer": "Nvidia",
+                        "Model": "Bluefield-3 DPU",
+                        "SerialNumber": "ABC1234",
+                        "Attributes": {},
+                        "PcieDevices": [],
+                        "BaseMac": "A088C208804C",
+                        "PowerState": "On"
+                    }),
+                    expect: Yields(Some("A088C208804C".parse().unwrap())),
+                },
+                Case {
+                    scenario: "null BaseMac -> None",
+                    input: serde_json::json!({
+                        "EthernetInterfaces": [],
+                        "Id": "Bluefield",
+                        "Manufacturer": "Nvidia",
+                        "Model": "Bluefield-3 DPU",
+                        "SerialNumber": "ABC1234",
+                        "Attributes": {},
+                        "PcieDevices": [],
+                        "BaseMac": null,
+                        "PowerState": "On"
+                    }),
+                    expect: Yields(None),
+                },
+                Case {
+                    scenario: "missing BaseMac -> None",
+                    input: serde_json::json!({
+                        "EthernetInterfaces": [],
+                        "Id": "Bluefield",
+                        "Manufacturer": "Nvidia",
+                        "Model": "Bluefield-3 DPU",
+                        "SerialNumber": "ABC1234",
+                        "Attributes": {},
+                        "PcieDevices": [],
+                        "PowerState": "On"
+                    }),
+                    expect: Yields(None),
+                },
+            ],
+            // Deserialize and project to base_mac; every row is expected to
+            // deserialize, so the (non-PartialEq) serde error is discarded.
+            |json| {
+                serde_json::from_value::<ComputerSystem>(json)
+                    .map(|system| system.base_mac)
+                    .map_err(drop)
+            },
+        );
     }
 }

--- a/crates/api-model/src/tenant/identity_config_policy.rs
+++ b/crates/api-model/src/tenant/identity_config_policy.rs
@@ -438,6 +438,9 @@ pub fn resolve_subject_prefix(
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     fn resolve_identity(issuer: &str, proto: Option<&str>) -> Result<String, String> {
@@ -445,177 +448,211 @@ mod tests {
         resolve_subject_prefix(&td, proto)
     }
 
+    // Issuer trust-domain extraction (the `.1` of `normalize_issuer_and_trust_domain`).
+    // Each row is `(issuer, error_substring)`: success rows `Yields` the lowercased trust
+    // domain (the substring is unused, left ""); rejection rows assert the error contains the
+    // given token via `FailsWith(true)`. The `String` error is not the asserted contract here
+    // (the originals only checked substrings), so we project the error to "does it contain token".
     #[test]
-    fn trust_domain_https_issuer() {
-        assert_eq!(
-            normalize_issuer_and_trust_domain("https://Issuer.EXAMPLE/path")
-                .unwrap()
-                .1,
-            "issuer.example"
+    fn issuer_trust_domain_extraction() {
+        check_cases(
+            [
+                Case {
+                    scenario: "https issuer lowercases host, drops path",
+                    input: ("https://Issuer.EXAMPLE/path", ""),
+                    expect: Yields("issuer.example".to_string()),
+                },
+                Case {
+                    scenario: "https issuer with explicit port",
+                    input: ("https://Issuer.EXAMPLE:8443/", ""),
+                    expect: Yields("issuer.example".to_string()),
+                },
+                Case {
+                    scenario: "spiffe issuer lowercases host",
+                    input: ("spiffe://Issuer.EXAMPLE/bundle", ""),
+                    expect: Yields("issuer.example".to_string()),
+                },
+                Case {
+                    scenario: "spiffe scheme uppercase",
+                    input: ("SPIFFE://Issuer.EXAMPLE/bundle", ""),
+                    expect: Yields("issuer.example".to_string()),
+                },
+                Case {
+                    scenario: "spiffe scheme mixed case, no path",
+                    input: ("SpIfFe://issuer.example", ""),
+                    expect: Yields("issuer.example".to_string()),
+                },
+                Case {
+                    scenario: "query string rejected",
+                    input: ("https://issuer.example/?q=1", "query"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "ipv4 host rejected",
+                    input: ("https://127.0.0.1/", "IP"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "ipv6 host rejected",
+                    input: ("spiffe://[::1]/x", "IP"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "userinfo (user only) rejected",
+                    input: ("https://user@issuer.example/", "userinfo"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "userinfo with password rejected",
+                    input: ("https://user:pass@issuer.example/", "userinfo"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "non-http(s)/spiffe scheme rejected",
+                    input: ("ftp://issuer.example/", "http"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "bare hostname (no scheme) rejected",
+                    input: ("issuer.example", "http://"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "bare hostname with path rejected",
+                    input: ("issuer.example/extra", "http://"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "backslash rejected",
+                    input: ("https://issuer.example\\evil", "disallowed"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "control char rejected",
+                    input: ("https://issuer.ex\0ample.com/", "disallowed"),
+                    expect: FailsWith(true),
+                },
+            ],
+            |(issuer, token)| {
+                normalize_issuer_and_trust_domain(issuer)
+                    .map(|(_, td)| td)
+                    .map_err(|e| e.contains(token))
+            },
         );
     }
 
+    // Normalized `iss` string (the `.0` of `normalize_issuer_and_trust_domain`): scheme/path/port
+    // preservation, host lowercasing, default lone-`/` path omitted. All success rows.
     #[test]
-    fn trust_domain_https_issuer_optional_port() {
-        assert_eq!(
-            normalize_issuer_and_trust_domain("https://Issuer.EXAMPLE:8443/")
-                .unwrap()
-                .1,
-            "issuer.example"
+    fn normalize_issuer_preserves_scheme_path_and_port() {
+        check_cases(
+            [
+                Case {
+                    scenario: "http scheme and path lowercased host",
+                    input: "HTTP://Issuer.EXAMPLE/path",
+                    expect: Yields("http://issuer.example/path".to_string()),
+                },
+                Case {
+                    scenario: "explicit port and path preserved",
+                    input: "https://issuer.example:8443/ns",
+                    expect: Yields("https://issuer.example:8443/ns".to_string()),
+                },
+                Case {
+                    scenario: "spiffe scheme normalized",
+                    input: "SpIfFe://Issuer.EXAMPLE/bundle",
+                    expect: Yields("spiffe://issuer.example/bundle".to_string()),
+                },
+            ],
+            |s| {
+                normalize_issuer_and_trust_domain(s)
+                    .map(|(iss, _)| iss)
+                    .map_err(drop)
+            },
         );
     }
 
+    // Subject-prefix resolution end-to-end (`resolve_identity`). Rows are `(issuer, proto, token)`:
+    // success rows `Yields` the canonical prefix (token unused, ""); rejection rows assert the
+    // error contains `token` via `FailsWith(true)`.
     #[test]
-    fn trust_domain_https_issuer_rejects_query() {
-        let err = normalize_issuer_and_trust_domain("https://issuer.example/?q=1").unwrap_err();
-        assert!(err.contains("query"), "{err}");
-    }
-
-    #[test]
-    fn trust_domain_spiffe_issuer() {
-        assert_eq!(
-            normalize_issuer_and_trust_domain("spiffe://Issuer.EXAMPLE/bundle")
-                .unwrap()
-                .1,
-            "issuer.example"
+    fn resolve_subject_prefix_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "no proto prefix -> default from https issuer",
+                    input: ("https://my.idp.example", None, ""),
+                    expect: Yields("spiffe://my.idp.example".to_string()),
+                },
+                Case {
+                    scenario: "no proto prefix -> default from spiffe issuer",
+                    input: ("spiffe://my.idp.example/ns/x", None, ""),
+                    expect: Yields("spiffe://my.idp.example".to_string()),
+                },
+                Case {
+                    scenario: "explicit prefix canonicalizes trust-domain case",
+                    input: (
+                        "https://issuer.example",
+                        Some("spiffe://ISSUER.EXAMPLE/wl"),
+                        "",
+                    ),
+                    expect: Yields("spiffe://issuer.example/wl".to_string()),
+                },
+                Case {
+                    scenario: "trust domain mismatch rejected",
+                    input: (
+                        "https://issuer.example",
+                        Some("spiffe://other.example"),
+                        "does not match",
+                    ),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "percent-encoding rejected",
+                    input: (
+                        "https://issuer.example",
+                        Some("spiffe://issuer.example/a%2Fb"),
+                        "disallowed",
+                    ),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "https scheme prefix rejected (must be spiffe)",
+                    input: (
+                        "https://issuer.example",
+                        Some("https://issuer.example/p"),
+                        "spiffe://",
+                    ),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "backslash in prefix rejected",
+                    input: (
+                        "https://issuer.example",
+                        Some("spiffe://issuer.example/a\\b"),
+                        "disallowed",
+                    ),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "whitespace in prefix rejected",
+                    input: (
+                        "https://issuer.example",
+                        Some("spiffe://issuer.example/a b"),
+                        "disallowed",
+                    ),
+                    expect: FailsWith(true),
+                },
+            ],
+            |(issuer, proto, token)| resolve_identity(issuer, proto).map_err(|e| e.contains(token)),
         );
     }
 
-    #[test]
-    fn trust_domain_spiffe_issuer_scheme_any_case() {
-        assert_eq!(
-            normalize_issuer_and_trust_domain("SPIFFE://Issuer.EXAMPLE/bundle")
-                .unwrap()
-                .1,
-            "issuer.example"
-        );
-        assert_eq!(
-            normalize_issuer_and_trust_domain("SpIfFe://issuer.example")
-                .unwrap()
-                .1,
-            "issuer.example"
-        );
-    }
-
-    #[test]
-    fn trust_domain_rejects_ip_host() {
-        let err = normalize_issuer_and_trust_domain("https://127.0.0.1/").unwrap_err();
-        assert!(err.contains("IP") || err.contains("not an IP"), "{err}");
-        let err = normalize_issuer_and_trust_domain("spiffe://[::1]/x").unwrap_err();
-        assert!(err.contains("IP"), "{err}");
-    }
-
-    #[test]
-    fn resolve_identity_defaults_prefix() {
-        assert_eq!(
-            resolve_identity("https://my.idp.example", None).unwrap(),
-            "spiffe://my.idp.example"
-        );
-    }
-
-    #[test]
-    fn resolve_identity_spiffe_form_issuer() {
-        assert_eq!(
-            resolve_identity("spiffe://my.idp.example/ns/x", None).unwrap(),
-            "spiffe://my.idp.example"
-        );
-    }
-
-    #[test]
-    fn explicit_prefix_canonicalizes_td_case() {
-        let p =
-            resolve_identity("https://issuer.example", Some("spiffe://ISSUER.EXAMPLE/wl")).unwrap();
-        assert_eq!(p, "spiffe://issuer.example/wl");
-    }
-
-    #[test]
-    fn wrong_td_rejected() {
-        let err =
-            resolve_identity("https://issuer.example", Some("spiffe://other.example")).unwrap_err();
-        assert!(err.contains("does not match"));
-    }
-
-    #[test]
-    fn percent_encoding_rejected() {
-        let err = resolve_identity(
-            "https://issuer.example",
-            Some("spiffe://issuer.example/a%2Fb"),
-        )
-        .unwrap_err();
-        assert!(err.contains("disallowed"), "{err}");
-    }
-
-    #[test]
-    fn https_scheme_subject_prefix_rejected() {
-        let err = resolve_identity("https://issuer.example", Some("https://issuer.example/p"))
-            .unwrap_err();
-        assert!(err.contains("spiffe://"));
-    }
-
-    #[test]
-    fn https_userinfo_rejected() {
-        let err = normalize_issuer_and_trust_domain("https://user@issuer.example/").unwrap_err();
-        assert!(err.contains("userinfo"), "{err}");
-    }
-
-    #[test]
-    fn https_password_in_userinfo_rejected() {
-        let err =
-            normalize_issuer_and_trust_domain("https://user:pass@issuer.example/").unwrap_err();
-        assert!(err.contains("userinfo"), "{err}");
-    }
-
-    #[test]
-    fn non_http_scheme_rejected() {
-        let err = normalize_issuer_and_trust_domain("ftp://issuer.example/").unwrap_err();
-        assert!(err.contains("http"), "{err}");
-    }
-
-    #[test]
-    fn issuer_without_scheme_rejected() {
-        let err = normalize_issuer_and_trust_domain("issuer.example").unwrap_err();
-        assert!(err.contains("http://") || err.contains("https://"), "{err}");
-        let err = normalize_issuer_and_trust_domain("issuer.example/extra").unwrap_err();
-        assert!(err.contains("http://") || err.contains("bare"), "{err}");
-    }
-
-    #[test]
-    fn issuer_backslash_rejected() {
-        let err = normalize_issuer_and_trust_domain("https://issuer.example\\evil").unwrap_err();
-        assert!(err.contains("disallowed"), "{err}");
-    }
-
+    // Length-limit rejections build runtime strings, so they stay out of the literal-input tables.
     #[test]
     fn issuer_too_long_rejected() {
         let long = format!("https://{}.example/", "a".repeat(MAX_ISSUER_BYTES));
         let err = normalize_issuer_and_trust_domain(&long).unwrap_err();
         assert!(err.contains("maximum length"), "{err}");
-    }
-
-    #[test]
-    fn issuer_control_char_rejected() {
-        let err = normalize_issuer_and_trust_domain("https://issuer.ex\0ample.com/").unwrap_err();
-        assert!(err.contains("disallowed") || err.contains("ASCII"), "{err}");
-    }
-
-    #[test]
-    fn subject_prefix_backslash_rejected() {
-        let err = resolve_identity(
-            "https://issuer.example",
-            Some("spiffe://issuer.example/a\\b"),
-        )
-        .unwrap_err();
-        assert!(err.contains("disallowed"), "{err}");
-    }
-
-    #[test]
-    fn subject_prefix_whitespace_rejected() {
-        let err = resolve_identity(
-            "https://issuer.example",
-            Some("spiffe://issuer.example/a b"),
-        )
-        .unwrap_err();
-        assert!(err.contains("disallowed"), "{err}");
     }
 
     #[test]
@@ -649,200 +686,388 @@ mod tests {
         assert!(p.matches('/').count() >= 200);
     }
 
+    // Hostname/trust-domain allowlist matching (`trust_domain_matches_allowlist`). Rows are
+    // `(hostname, patterns)`: the originals only checked `is_ok()`/`is_err()`, so we map to
+    // `Yields(())` / `Fails` (error discarded). Each row carries its own pattern list.
     #[test]
-    fn normalize_issuer_preserves_scheme_path_and_port() {
-        assert_eq!(
-            normalize_issuer_and_trust_domain("HTTP://Issuer.EXAMPLE/path")
-                .unwrap()
-                .0,
-            "http://issuer.example/path"
+    fn trust_domain_allowlist_matching() {
+        fn list(entries: &[&str]) -> Vec<String> {
+            entries.iter().map(|s| s.to_string()).collect()
+        }
+        check_cases(
+            [
+                Case {
+                    scenario: "empty allowlist allows any host",
+                    input: ("anything.example", list(&[])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "exact match",
+                    input: (
+                        "login.example.com",
+                        list(&["login.example.com", "other.net"]),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "exact match ignores case and trailing dot",
+                    input: (
+                        "LOGIN.EXAMPLE.COM.",
+                        list(&["login.example.com", "other.net"]),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "exact mismatch",
+                    input: ("bad.example.com", list(&["login.example.com", "other.net"])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "single-star: one label under suffix matches",
+                    input: ("auth.something.net", list(&["*.something.net"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "single-star: bare suffix does not match",
+                    input: ("something.net", list(&["*.something.net"])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "single-star: two labels under suffix do not match",
+                    input: ("a.b.something.net", list(&["*.something.net"])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "single-star: dot boundary before suffix",
+                    input: ("notsomething.net", list(&["*.something.net"])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "double-star: bare suffix matches",
+                    input: ("internal.example", list(&["**.internal.example"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "double-star: one label deep matches",
+                    input: ("x.internal.example", list(&["**.internal.example"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "double-star: many labels deep match",
+                    input: ("a.b.internal.example", list(&["**.internal.example"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "double-star: suffix not at end does not match",
+                    input: (
+                        "evil.internal.example.evil.com",
+                        list(&["**.internal.example"]),
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "single-star: multi-label under suffix rejected",
+                    input: ("auth.prod.something.net", list(&["*.something.net"])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "single-star: one label matches mixed-case pattern",
+                    input: ("auth.something.net", list(&["*.SOMETHING.NET"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "double-star: suffix as substring of longer zone rejected",
+                    input: ("api.internal.example.com", list(&["**.internal.example"])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "double-star: suffix mid-host rejected",
+                    input: (
+                        "not-relevant.internal.example.evil.com",
+                        list(&["**.internal.example"]),
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "double-star: zone apex matches",
+                    input: ("co.uk", list(&["**.co.uk"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "double-star: child of apex matches",
+                    input: ("tenant.co.uk", list(&["**.co.uk"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "double-star: deep child of apex matches",
+                    input: ("a.b.co.uk", list(&["**.co.uk"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "double-star: different apex rejected",
+                    input: ("other.uk", list(&["**.co.uk"])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "OR across entries: literal matches",
+                    input: ("exact.only", list(&["exact.only", "**.allowed.zone"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "OR across entries: double-star matches",
+                    input: ("x.allowed.zone", list(&["exact.only", "**.allowed.zone"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "OR across entries: neither matches",
+                    input: ("wrong.zone", list(&["exact.only", "**.allowed.zone"])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "mixed list: literal host matches",
+                    input: (
+                        "idp.example.com",
+                        list(&[
+                            "idp.example.com",
+                            "localhost",
+                            "*.tenant.example.net",
+                            "**.corp.internal",
+                        ]),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "mixed list: literal host case-insensitive",
+                    input: (
+                        "LOCALHOST",
+                        list(&[
+                            "idp.example.com",
+                            "localhost",
+                            "*.tenant.example.net",
+                            "**.corp.internal",
+                        ]),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "mixed list: single-star matches",
+                    input: (
+                        "auth.tenant.example.net",
+                        list(&[
+                            "idp.example.com",
+                            "localhost",
+                            "*.tenant.example.net",
+                            "**.corp.internal",
+                        ]),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "mixed list: double-star apex matches",
+                    input: (
+                        "corp.internal",
+                        list(&[
+                            "idp.example.com",
+                            "localhost",
+                            "*.tenant.example.net",
+                            "**.corp.internal",
+                        ]),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "mixed list: double-star deep matches",
+                    input: (
+                        "a.b.corp.internal",
+                        list(&[
+                            "idp.example.com",
+                            "localhost",
+                            "*.tenant.example.net",
+                            "**.corp.internal",
+                        ]),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "mixed list: unrelated literal rejected",
+                    input: (
+                        "other.example.com",
+                        list(&[
+                            "idp.example.com",
+                            "localhost",
+                            "*.tenant.example.net",
+                            "**.corp.internal",
+                        ]),
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "mixed list: single-star too deep rejected",
+                    input: (
+                        "auth.app.tenant.example.net",
+                        list(&[
+                            "idp.example.com",
+                            "localhost",
+                            "*.tenant.example.net",
+                            "**.corp.internal",
+                        ]),
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "mixed list: double-star suffix mid-host rejected",
+                    input: (
+                        "not.corp.internal.evil.com",
+                        list(&[
+                            "idp.example.com",
+                            "localhost",
+                            "*.tenant.example.net",
+                            "**.corp.internal",
+                        ]),
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "pattern trimmed and trailing-dot stripped",
+                    input: ("bar.foo.com", list(&["  *.Foo.COM.  "])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "single-star: dot boundary, one label matches",
+                    input: ("svc.internal.example", list(&["*.internal.example"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "single-star: no dot before suffix rejected",
+                    input: ("notinternal.example", list(&["*.internal.example"])),
+                    expect: Fails,
+                },
+            ],
+            |(hostname, patterns)| {
+                trust_domain_matches_allowlist(hostname, &patterns).map_err(drop)
+            },
         );
-        assert_eq!(
-            normalize_issuer_and_trust_domain("https://issuer.example:8443/ns")
-                .unwrap()
-                .0,
-            "https://issuer.example:8443/ns"
-        );
-        assert_eq!(
-            normalize_issuer_and_trust_domain("SpIfFe://Issuer.EXAMPLE/bundle")
-                .unwrap()
-                .0,
-            "spiffe://issuer.example/bundle"
-        );
     }
 
+    // Allowlist pattern validation (`validate_trust_domain_allowlist_patterns`). Each row is one
+    // entry list; the originals only checked `is_ok()`/`is_err()`, so `Yields(())` / `Fails`.
     #[test]
-    fn allowlist_empty_allows_any_trust_domain() {
-        assert!(trust_domain_matches_allowlist("anything.example", &[]).is_ok());
-    }
-
-    #[test]
-    fn allowlist_exact_match() {
-        let list = vec!["login.example.com".to_string(), "other.net".to_string()];
-        assert!(trust_domain_matches_allowlist("login.example.com", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("LOGIN.EXAMPLE.COM.", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("bad.example.com", &list).is_err());
-    }
-
-    #[test]
-    fn allowlist_single_star_one_label_under_suffix() {
-        let list = vec!["*.something.net".to_string()];
-        assert!(trust_domain_matches_allowlist("auth.something.net", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("something.net", &list).is_err());
-        assert!(trust_domain_matches_allowlist("a.b.something.net", &list).is_err());
-        assert!(
-            trust_domain_matches_allowlist("notsomething.net", &list).is_err(),
-            "dot boundary"
-        );
-    }
-
-    #[test]
-    fn allowlist_double_star_any_depth() {
-        let list = vec!["**.internal.example".to_string()];
-        assert!(trust_domain_matches_allowlist("internal.example", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("x.internal.example", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("a.b.internal.example", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("evil.internal.example.evil.com", &list).is_err());
-    }
-
-    #[test]
-    fn allowlist_pattern_validation_rejects_bare_star() {
-        assert!(validate_trust_domain_allowlist_patterns(&["*".to_string()]).is_err());
-        assert!(validate_trust_domain_allowlist_patterns(&["**".to_string()]).is_err());
-        assert!(validate_trust_domain_allowlist_patterns(&["*.".to_string()]).is_err());
-        assert!(validate_trust_domain_allowlist_patterns(&["foo*bar".to_string()]).is_err());
-        assert!(validate_trust_domain_allowlist_patterns(&["login.example".to_string()]).is_ok());
-    }
-
-    /// `*.suffix` must not match when there are two or more labels between leaf and suffix.
-    #[test]
-    fn allowlist_single_star_rejects_multi_label_under_suffix() {
-        let list = vec!["*.something.net".to_string()];
-        assert!(
-            trust_domain_matches_allowlist("auth.prod.something.net", &list).is_err(),
-            "only one label allowed above the suffix"
-        );
-    }
-
-    /// `*.suffix` accepts a single DNS label (no dots) above the suffix.
-    #[test]
-    fn allowlist_single_star_accepts_one_label_mixed_case_pattern() {
-        let list = vec!["*.SOMETHING.NET".to_string()];
-        assert!(trust_domain_matches_allowlist("auth.something.net", &list).is_ok());
-    }
-
-    /// `**.suffix` must not match hosts that merely share a substring with suffix (dot-separated).
-    #[test]
-    fn allowlist_double_star_suffix_requires_dot_separated_zone() {
-        let list = vec!["**.internal.example".to_string()];
-        assert!(
-            trust_domain_matches_allowlist("api.internal.example.com", &list).is_err(),
-            "must end with .internal.example, not .internal.example.com"
-        );
-        assert!(
-            trust_domain_matches_allowlist("not-relevant.internal.example.evil.com", &list)
-                .is_err(),
+    fn trust_domain_allowlist_pattern_validation() {
+        fn list(entries: &[&str]) -> Vec<String> {
+            entries.iter().map(|s| s.to_string()).collect()
+        }
+        check_cases(
+            [
+                Case {
+                    scenario: "bare `*` rejected",
+                    input: list(&["*"]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "bare `**` rejected",
+                    input: list(&["**"]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "`*.` (empty suffix) rejected",
+                    input: list(&["*."]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wildcard inside label rejected",
+                    input: list(&["foo*bar"]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "plain hostname accepted",
+                    input: list(&["login.example"]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "`**.` (empty suffix) rejected",
+                    input: list(&["**."]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "`*.` (empty suffix) rejected again",
+                    input: list(&["*."]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "star inside double-star suffix rejected",
+                    input: list(&["**.foo.*.com"]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "star inside single-star suffix rejected",
+                    input: list(&["*.foo*bar.com"]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "whitespace-only entry rejected",
+                    input: list(&["   "]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "tab/space-only entry rejected",
+                    input: list(&["  \t "]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "double-star multi-label suffix accepted",
+                    input: list(&["**.svc.cluster.local"]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "mixed valid list passes startup validation",
+                    input: list(&[
+                        "idp.example.com",
+                        "localhost",
+                        "*.tenant.example.net",
+                        "**.corp.internal",
+                    ]),
+                    expect: Yields(()),
+                },
+            ],
+            |patterns| validate_trust_domain_allowlist_patterns(&patterns).map_err(drop),
         );
     }
 
-    /// `**.suffix`: bare suffix and immediate child; `suffix` alone is the zone apex in pattern.
-    #[test]
-    fn allowlist_double_star_suffix_apex_and_subdomain() {
-        let list = vec!["**.co.uk".to_string()];
-        assert!(trust_domain_matches_allowlist("co.uk", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("tenant.co.uk", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("a.b.co.uk", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("other.uk", &list).is_err());
-    }
-
-    #[test]
-    fn allowlist_matches_if_any_pattern_matches() {
-        let list = vec!["exact.only".to_string(), "**.allowed.zone".to_string()];
-        assert!(trust_domain_matches_allowlist("exact.only", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("x.allowed.zone", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("wrong.zone", &list).is_err());
-    }
-
-    /// Several allowlist entries at once: literal, `*.suffix`, and `**.suffix`; match is OR across entries.
-    #[test]
-    fn allowlist_multiple_entries_mixed_literal_and_wildcards() {
-        let list = vec![
-            "idp.example.com".to_string(),
-            "localhost".to_string(),
-            "*.tenant.example.net".to_string(),
-            "**.corp.internal".to_string(),
-        ];
-        assert!(
-            validate_trust_domain_allowlist_patterns(&list).is_ok(),
-            "whole list must pass startup validation"
-        );
-
-        assert!(trust_domain_matches_allowlist("idp.example.com", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("LOCALHOST", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("auth.tenant.example.net", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("corp.internal", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("a.b.corp.internal", &list).is_ok());
-
-        assert!(trust_domain_matches_allowlist("other.example.com", &list).is_err());
-        assert!(trust_domain_matches_allowlist("auth.app.tenant.example.net", &list).is_err());
-        assert!(trust_domain_matches_allowlist("not.corp.internal.evil.com", &list).is_err());
-    }
-
-    #[test]
-    fn allowlist_patterns_trim_and_strip_trailing_dot() {
-        let list = vec!["  *.Foo.COM.  ".to_string()];
-        assert!(trust_domain_matches_allowlist("bar.foo.com", &list).is_ok());
-    }
-
-    #[test]
-    fn validate_allowlist_rejects_empty_suffix_after_wildcard_prefix() {
-        assert!(validate_trust_domain_allowlist_patterns(&["**.".to_string()]).is_err());
-        assert!(validate_trust_domain_allowlist_patterns(&["*.".to_string()]).is_err());
-    }
-
-    #[test]
-    fn validate_allowlist_rejects_star_inside_suffix() {
-        assert!(validate_trust_domain_allowlist_patterns(&["**.foo.*.com".to_string()]).is_err());
-        assert!(validate_trust_domain_allowlist_patterns(&["*.foo*bar.com".to_string()]).is_err());
-    }
-
-    #[test]
-    fn validate_allowlist_rejects_empty_entry_after_trim() {
-        assert!(validate_trust_domain_allowlist_patterns(&["   ".to_string()]).is_err());
-        assert!(validate_trust_domain_allowlist_patterns(&["  \t ".to_string()]).is_err(),);
-    }
-
-    #[test]
-    fn validate_allowlist_accepts_double_star_multi_label_suffix() {
-        assert!(
-            validate_trust_domain_allowlist_patterns(&["**.svc.cluster.local".to_string()]).is_ok()
-        );
-    }
-
-    /// `notinternal.example` must not satisfy `*.internal.example` (no dot before `internal`).
-    #[test]
-    fn allowlist_single_star_dot_boundary_before_suffix() {
-        let list = vec!["*.internal.example".to_string()];
-        assert!(trust_domain_matches_allowlist("svc.internal.example", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("notinternal.example", &list).is_err());
-    }
-
+    // Token-endpoint registered-host extraction (`registered_host_for_token_endpoint`): http/https
+    // only. Rows are `(endpoint, token)`: success rows `Yields` the host (token ""); rejection rows
+    // assert the error contains `token` via `FailsWith(true)`.
     #[test]
     fn token_endpoint_url_accepts_http_and_https_only() {
-        assert_eq!(
-            registered_host_for_token_endpoint("https://auth.example.com/oauth/token").unwrap(),
-            "auth.example.com"
+        check_cases(
+            [
+                Case {
+                    scenario: "https endpoint -> host",
+                    input: ("https://auth.example.com/oauth/token", &[][..]),
+                    expect: Yields("auth.example.com".to_string()),
+                },
+                Case {
+                    scenario: "http endpoint with port -> host",
+                    input: ("http://auth.example:8080/token", &[][..]),
+                    expect: Yields("auth.example".to_string()),
+                },
+                Case {
+                    scenario: "spiffe scheme rejected",
+                    input: ("spiffe://trust.example/path", &["http", "https"][..]),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "ftp scheme rejected",
+                    input: ("ftp://auth.example/token", &["http"][..]),
+                    expect: FailsWith(true),
+                },
+            ],
+            // Rejection rows require every listed token in the error, preserving the
+            // original's independent contains("http") && contains("https") check
+            // rather than coupling to one exact phrase.
+            |(endpoint, tokens)| {
+                registered_host_for_token_endpoint(endpoint)
+                    .map_err(|e| tokens.iter().all(|t| e.contains(t)))
+            },
         );
-        assert_eq!(
-            registered_host_for_token_endpoint("http://auth.example:8080/token").unwrap(),
-            "auth.example"
-        );
-        let err = registered_host_for_token_endpoint("spiffe://trust.example/path").unwrap_err();
-        assert!(
-            err.contains("http") && err.contains("https"),
-            "unexpected err: {err}"
-        );
-        let err = registered_host_for_token_endpoint("ftp://auth.example/token").unwrap_err();
-        assert!(err.contains("http") || err.contains("https"), "{err}");
     }
 }

--- a/crates/api-model/src/tenant/mod.rs
+++ b/crates/api-model/src/tenant/mod.rs
@@ -537,6 +537,9 @@ impl<'r> sqlx::FromRow<'r, PgRow> for TenantKeyset {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     #[test]
@@ -549,21 +552,66 @@ mod tests {
         assert_eq!(truncate_hash_for_display("no-colon"), "no-colon");
     }
 
+    // Parsing a tenant-org id, via both `TryFrom<String>` and `FromStr` (which
+    // delegates to the same validation). Valid input yields the round-tripped
+    // string; invalid input is rejected. `InvalidTenantOrg` is not PartialEq and
+    // the original only checked `is_err()`, so failing rows assert only that it
+    // errors. The closure exercises both entry points and confirms they agree.
     #[test]
     fn parse_tenant_org() {
-        // Valid cases
-        for &valid in &["TenantA", "Tenant_B", "Tenant-C-_And_D_"] {
-            let org = TenantOrganizationId::try_from(valid.to_string()).unwrap();
-            assert_eq!(org.as_str(), valid);
-            let org: TenantOrganizationId = valid.parse().unwrap();
-            assert_eq!(org.as_str(), valid);
-        }
-
-        // Invalid cases
-        for &invalid in &["", " Tenant_B", "Tenant_C ", "Tenant D", "Tenant!A"] {
-            assert!(TenantOrganizationId::try_from(invalid.to_string()).is_err());
-            assert!(invalid.parse::<TenantOrganizationId>().is_err());
-        }
+        check_cases(
+            [
+                Case {
+                    scenario: "alphabetic",
+                    input: "TenantA",
+                    expect: Yields("TenantA".to_string()),
+                },
+                Case {
+                    scenario: "with underscore",
+                    input: "Tenant_B",
+                    expect: Yields("Tenant_B".to_string()),
+                },
+                Case {
+                    scenario: "with dashes and underscores",
+                    input: "Tenant-C-_And_D_",
+                    expect: Yields("Tenant-C-_And_D_".to_string()),
+                },
+                Case {
+                    scenario: "empty",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "leading space",
+                    input: " Tenant_B",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "trailing space",
+                    input: "Tenant_C ",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "internal space",
+                    input: "Tenant D",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "disallowed punctuation",
+                    input: "Tenant!A",
+                    expect: Fails,
+                },
+            ],
+            |s| {
+                let via_try_from = TenantOrganizationId::try_from(s.to_string());
+                let via_parse = s.parse::<TenantOrganizationId>();
+                // Both entry points must agree on success/failure.
+                assert_eq!(via_try_from.is_ok(), via_parse.is_ok(), "{s}");
+                via_try_from
+                    .map(|org| org.as_str().to_string())
+                    .map_err(drop)
+            },
+        );
     }
 
     #[test]
@@ -619,18 +667,25 @@ mod tests {
         assert_eq!(config_json, "{}");
     }
 
+    // Parsing a JWT signing algorithm: only "ES256" is supported. The error
+    // (`UnsupportedTenantSigningAlgorithm`) was only checked with `is_err()`, so
+    // the failing row asserts only that it errors.
     #[test]
     fn tenant_identity_signing_algorithm_from_str_rejects_unknown() {
-        assert_eq!(
-            "ES256"
-                .parse::<identity_config::SigningAlgorithm>()
-                .unwrap(),
-            identity_config::SigningAlgorithm::Es256
-        );
-        assert!(
-            "RS256"
-                .parse::<identity_config::SigningAlgorithm>()
-                .is_err()
+        check_cases(
+            [
+                Case {
+                    scenario: "supported ES256",
+                    input: "ES256",
+                    expect: Yields(identity_config::SigningAlgorithm::Es256),
+                },
+                Case {
+                    scenario: "unsupported RS256",
+                    input: "RS256",
+                    expect: Fails,
+                },
+            ],
+            |s| s.parse::<identity_config::SigningAlgorithm>().map_err(drop),
         );
     }
 }

--- a/crates/api-model/src/vpc/capability.rs
+++ b/crates/api-model/src/vpc/capability.rs
@@ -493,6 +493,11 @@ impl VpcVirtualizationTypeCapabilities for VpcVirtualizationType {
 
 #[cfg(test)]
 mod tests {
+    use std::mem::discriminant;
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     #[test]
@@ -884,49 +889,73 @@ mod tests {
         }
     }
 
+    // `ensure_supports_segment` gating: segment-type whitelist plus
+    // per-address-family prefix support. `VpcCapabilityError` is not
+    // `PartialEq`, so rejection rows assert the error *variant* via its
+    // discriminant; the success row yields `()`.
     #[test]
-    fn ensure_supports_segment_passes_for_compatible_segment_v4_only() {
-        let segment = segment_with(NetworkSegmentType::Tenant, vec!["192.0.2.0/24"], None);
-        VpcVirtualizationType::Fnn
-            .ensure_supports_segment(&segment)
-            .expect("FNN + Tenant + IPv4 is the standard happy path");
-    }
+    fn ensure_supports_segment_gates_by_type_and_address_family() {
+        // A representative error value per variant we expect, used only to
+        // pull its discriminant for comparison.
+        let unsupported_segment_type = discriminant(&VpcCapabilityError::UnsupportedSegmentType {
+            vpc_type: VpcVirtualizationType::Flat,
+            segment_type: NetworkSegmentType::Tenant,
+        });
+        let ipv6_unsupported = discriminant(&VpcCapabilityError::Ipv6Unsupported {
+            vpc_type: VpcVirtualizationType::EthernetVirtualizer,
+        });
 
-    #[test]
-    fn ensure_supports_segment_rejects_unsupported_segment_type() {
-        let segment = segment_with(NetworkSegmentType::Tenant, vec!["192.0.2.0/24"], None);
-        let err = VpcVirtualizationType::Flat
-            .ensure_supports_segment(&segment)
-            .expect_err("Flat doesn't accept Tenant segments");
-        assert!(matches!(
-            err,
-            VpcCapabilityError::UnsupportedSegmentType { .. }
-        ));
-    }
-
-    #[test]
-    fn ensure_supports_segment_rejects_ipv6_on_etv() {
-        let segment = segment_with(
-            NetworkSegmentType::Tenant,
-            vec!["192.0.2.0/24", "2001:db8::/64"],
-            None,
+        check_cases(
+            [
+                Case {
+                    scenario: "FNN + Tenant + IPv4 is the standard happy path",
+                    input: (
+                        VpcVirtualizationType::Fnn,
+                        segment_with(NetworkSegmentType::Tenant, vec!["192.0.2.0/24"], None),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "Flat doesn't accept Tenant segments",
+                    input: (
+                        VpcVirtualizationType::Flat,
+                        segment_with(NetworkSegmentType::Tenant, vec!["192.0.2.0/24"], None),
+                    ),
+                    expect: FailsWith(unsupported_segment_type),
+                },
+                Case {
+                    scenario: "ETV doesn't accept IPv6 prefixes even if segment-type matches",
+                    input: (
+                        VpcVirtualizationType::EthernetVirtualizer,
+                        segment_with(
+                            NetworkSegmentType::Tenant,
+                            vec!["192.0.2.0/24", "2001:db8::/64"],
+                            None,
+                        ),
+                    ),
+                    expect: FailsWith(ipv6_unsupported),
+                },
+                Case {
+                    scenario: "Flat + HostInband + IPv6 is a supported combination",
+                    input: (
+                        VpcVirtualizationType::Flat,
+                        segment_with(
+                            NetworkSegmentType::HostInband,
+                            vec!["192.0.2.0/24", "2001:db8::/64"],
+                            None,
+                        ),
+                    ),
+                    expect: Yields(()),
+                },
+            ],
+            // The operation under test: gate a segment against a VPC type. The
+            // error type isn't `PartialEq`, so we project it to its discriminant
+            // so the asserted variant is comparable.
+            |(vt, segment)| {
+                vt.ensure_supports_segment(&segment)
+                    .map_err(|e| discriminant(&e))
+            },
         );
-        let err = VpcVirtualizationType::EthernetVirtualizer
-            .ensure_supports_segment(&segment)
-            .expect_err("ETV doesn't accept IPv6 prefixes even if segment-type matches");
-        assert!(matches!(err, VpcCapabilityError::Ipv6Unsupported { .. }));
-    }
-
-    #[test]
-    fn ensure_supports_segment_allows_ipv6_on_flat_with_host_inband() {
-        let segment = segment_with(
-            NetworkSegmentType::HostInband,
-            vec!["192.0.2.0/24", "2001:db8::/64"],
-            None,
-        );
-        VpcVirtualizationType::Flat
-            .ensure_supports_segment(&segment)
-            .expect("Flat + HostInband + IPv6 is a supported combination");
     }
 
     #[test]


### PR DESCRIPTION
This supports #3914.

## Description

This refactors `api-model` tests into the new table-driven test structuring from `carbide-test-support`, allowing us to replace a bunch of copy-pasted test boilerplate with a shared table-driven framework, so the test suite is ideally easier to read, maintain, and provide a pattern to follow. This is similar to https://github.com/NVIDIA/infra-controller/pull/2498 and https://github.com/NVIDIA/infra-controller/pull/2499.

The model tests are mostly fallible (serde `from_str`, `TryFrom`, `.validate()`), so `check_cases` is the fit -- `serde` round-trips and conversions become `Yields` rows, validation failures become `Fails` / `FailsWith` (substring-matched where an error message is being compared), and each input is a labeled case.

Test count goes down 26% (from 277 to 205), collapsing repeated serialize / deserialize / match-or-panic tests while preserving every original case as a row. The pass also adds a small table covering `extension_service` observability config, which previously had no tests at all.

Coverage (via `cargo-llvm-cov`), before (origin/main) vs after.

```
  ┌──────────┬──────────────────────┬───────────────┐
  │  Metric  │ Before (origin/main) │ After (this)  │
  ├──────────┼──────────────────────┼───────────────┤
  │ Region   │ 51.73%               │ 51.49%        │
  ├──────────┼──────────────────────┼───────────────┤
  │ Function │ 45.67%               │ 45.87%        │
  ├──────────┼──────────────────────┼───────────────┤
  │ Line     │ 53.07%               │ 56.39%        │
  └──────────┴──────────────────────┴───────────────┘
```

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->