### PR TITLE
test(rpc): fold conversion tests onto carbide-test-support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,6 +2628,7 @@ dependencies = [
  "carbide-network",
  "carbide-prost-builder",
  "carbide-secrets",
+ "carbide-test-support",
  "carbide-tls",
  "carbide-utils",
  "carbide-uuid",

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -120,6 +120,7 @@ base64 = { workspace = true, optional = true }
 
 [dev-dependencies]
 carbide-libmlx-model = { path = "../libmlx-model", features = ["test-support"] }
+carbide-test-support = { path = "../test-support" }
 
 [build-dependencies]
 tonic-prost-build = "0.14"

--- a/crates/rpc/src/forge_tls_client.rs
+++ b/crates/rpc/src/forge_tls_client.rs
@@ -749,6 +749,7 @@ pub type ForgeHttpsClientResult<T> = Result<T, ForgeTlsClientError>;
 mod tests {
     use std::net::SocketAddr;
 
+    use carbide_test_support::{Check, check_values};
     use forge_http_connector::connector::ConnectorMetrics;
     use hyper_rustls::HttpsConnector;
 
@@ -855,7 +856,7 @@ mod tests {
     }
 
     #[test]
-    fn format_error_chain_walks_source_chain() {
+    fn format_error_chain_formats_each_error() {
         #[derive(thiserror::Error, Debug)]
         #[error("invalid peer certificate: UnknownIssuer")]
         struct Inner;
@@ -864,19 +865,27 @@ mod tests {
         #[error("client error (Connect)")]
         struct Outer(#[from] Inner);
 
-        let err: Outer = Inner.into();
-        assert_eq!(
-            format_error_chain(&err),
-            "client error (Connect): invalid peer certificate: UnknownIssuer"
-        );
-    }
-
-    #[test]
-    fn format_error_chain_with_no_source_returns_top_message() {
         #[derive(thiserror::Error, Debug)]
         #[error("only message")]
         struct Plain;
 
-        assert_eq!(format_error_chain(&Plain), "only message");
+        // `format_error_chain` appends the deepest `source()` when it differs
+        // from the top-level message, otherwise returns the top message alone.
+        check_values(
+            [
+                Check {
+                    scenario: "walks source chain to the root cause",
+                    input: Box::new(Outer::from(Inner)) as Box<dyn std::error::Error>,
+                    expect: "client error (Connect): invalid peer certificate: UnknownIssuer"
+                        .to_string(),
+                },
+                Check {
+                    scenario: "no source returns top message",
+                    input: Box::new(Plain) as Box<dyn std::error::Error>,
+                    expect: "only message".to_string(),
+                },
+            ],
+            |err| format_error_chain(err.as_ref()),
+        );
     }
 }

--- a/crates/rpc/src/libmlx.rs
+++ b/crates/rpc/src/libmlx.rs
@@ -118,117 +118,136 @@ impl From<FirmwareFlashReportPb> for FirmwareFlashReport {
 
 #[cfg(test)]
 mod test {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
+    // Proto -> model `TryFrom`: every input proto should convert back to the
+    // expected `MlxDeviceInfo`, with empty proto strings (and an empty MAC)
+    // becoming `None`. The roundtrip rows feed a model through its own
+    // `Into<MlxDeviceInfoPb>` first.
     #[test]
-    fn test_device_info_roundtrip_conversion() {
-        let original = MlxDeviceInfo::create_test_device();
-        let proto: MlxDeviceInfoPb = original.clone().into();
-        let converted: MlxDeviceInfo = proto.try_into().unwrap();
-        assert_eq!(original, converted);
+    fn device_info_proto_to_model() {
+        check_cases(
+            [
+                Case {
+                    scenario: "full device roundtrips",
+                    input: MlxDeviceInfo::create_test_device().into(),
+                    expect: Yields(MlxDeviceInfo::create_test_device()),
+                },
+                Case {
+                    scenario: "missing-data device roundtrips",
+                    input: MlxDeviceInfo::create_test_device_with_missing_data().into(),
+                    expect: Yields(MlxDeviceInfo::create_test_device_with_missing_data()),
+                },
+                Case {
+                    scenario: "empty string fields become none",
+                    input: MlxDeviceInfoPb {
+                        pci_name: "01:00.0".to_string(),
+                        device_type: "BlueField3".to_string(),
+                        psid: "".to_string(), // Empty string should become None
+                        device_description: "".to_string(),
+                        part_number: "".to_string(),
+                        fw_version_current: "".to_string(),
+                        pxe_version_current: "".to_string(),
+                        uefi_version_current: "".to_string(),
+                        uefi_version_virtio_blk_current: "".to_string(),
+                        uefi_version_virtio_net_current: "".to_string(),
+                        base_mac: "".to_string(), // Empty MAC becomes None
+                        status: "".to_string(),
+                    },
+                    expect: Yields(MlxDeviceInfo {
+                        pci_name: "01:00.0".to_string(),
+                        device_type: "BlueField3".to_string(),
+                        psid: None,
+                        device_description: None,
+                        part_number: None,
+                        fw_version_current: None,
+                        pxe_version_current: None,
+                        uefi_version_current: None,
+                        uefi_version_virtio_blk_current: None,
+                        uefi_version_virtio_net_current: None,
+                        base_mac: None,
+                        status: None,
+                    }),
+                },
+            ],
+            |proto: MlxDeviceInfoPb| MlxDeviceInfo::try_from(proto).map_err(drop),
+        );
     }
 
+    // `FirmwareFlashReport` -> proto -> `FirmwareFlashReport` roundtrip. The
+    // report isn't `PartialEq`, so project to the tuple of fields the originals
+    // asserted; the conversions are total (`From`), hence `check_values`.
     #[test]
-    fn test_device_info_with_missing_data_conversion() {
-        let original = MlxDeviceInfo::create_test_device_with_missing_data();
-        let proto: MlxDeviceInfoPb = original.clone().into();
-        let converted: MlxDeviceInfo = proto.try_into().unwrap();
-
-        // Required fields should be preserved
-        assert_eq!(original.pci_name, converted.pci_name);
-        assert_eq!(original.device_type, converted.device_type);
-
-        // Optional fields should become None
-        assert_eq!(converted.psid, None);
-        assert_eq!(converted.part_number, None);
-        assert_eq!(converted.base_mac, None);
-        assert_eq!(converted.status, Some("Failed to open device".to_string()));
-    }
-
-    #[test]
-    fn test_empty_string_fields_become_none() {
-        let proto = MlxDeviceInfoPb {
-            pci_name: "01:00.0".to_string(),
-            device_type: "BlueField3".to_string(),
-            psid: "".to_string(), // Empty string should become None
-            device_description: "".to_string(),
-            part_number: "".to_string(),
-            fw_version_current: "".to_string(),
-            pxe_version_current: "".to_string(),
-            uefi_version_current: "".to_string(),
-            uefi_version_virtio_blk_current: "".to_string(),
-            uefi_version_virtio_net_current: "".to_string(),
-            base_mac: "".to_string(), // Empty MAC becomes None
-            status: "".to_string(),
-        };
-
-        let converted: MlxDeviceInfo = proto.try_into().unwrap();
-
-        assert_eq!(converted.psid, None);
-        assert_eq!(converted.part_number, None);
-        assert_eq!(converted.base_mac, None);
-        assert_eq!(converted.fw_version_current, None);
-        assert_eq!(converted.status, None);
-    }
-
-    #[test]
-    fn test_flasher_result_all_steps_success() {
-        let original = FirmwareFlashReport {
-            flashed: true,
-            reset: Some(true),
-            verified_image: Some(true),
-            verified_version: Some(true),
-            observed_version: Some("32.43.1014".to_string()),
-            expected_version: Some("32.43.1014".to_string()),
-        };
-        let proto: FirmwareFlashReportPb = original.clone().into();
-        let converted: FirmwareFlashReport = proto.into();
-
-        assert_eq!(original.flashed, converted.flashed);
-        assert_eq!(original.reset, converted.reset);
-        assert_eq!(original.verified_image, converted.verified_image);
-        assert_eq!(original.verified_version, converted.verified_version);
-        assert_eq!(original.observed_version, converted.observed_version);
-        assert_eq!(original.expected_version, converted.expected_version);
-    }
-
-    #[test]
-    fn test_flasher_result_flash_only() {
-        let original = FirmwareFlashReport {
-            flashed: true,
-            reset: None,
-            verified_image: None,
-            verified_version: None,
-            observed_version: None,
-            expected_version: None,
-        };
-        let proto: FirmwareFlashReportPb = original.into();
-        let converted: FirmwareFlashReport = proto.into();
-
-        assert!(converted.flashed);
-        assert!(converted.reset.is_none());
-        assert!(converted.verified_image.is_none());
-        assert!(converted.verified_version.is_none());
-        assert!(converted.observed_version.is_none());
-    }
-
-    #[test]
-    fn test_flasher_result_partial_failure() {
-        let original = FirmwareFlashReport {
-            flashed: true,
-            reset: Some(false),
-            verified_image: Some(false),
-            verified_version: Some(false),
-            observed_version: Some("32.42.900".to_string()),
-            expected_version: Some("32.43.1014".to_string()),
-        };
-        let proto: FirmwareFlashReportPb = original.into();
-        let converted: FirmwareFlashReport = proto.into();
-
-        assert!(converted.flashed);
-        assert_eq!(converted.reset, Some(false));
-        assert_eq!(converted.verified_image, Some(false));
-        assert_eq!(converted.verified_version, Some(false));
+    fn firmware_flash_report_roundtrip() {
+        check_values(
+            [
+                Check {
+                    scenario: "all steps success",
+                    input: FirmwareFlashReport {
+                        flashed: true,
+                        reset: Some(true),
+                        verified_image: Some(true),
+                        verified_version: Some(true),
+                        observed_version: Some("32.43.1014".to_string()),
+                        expected_version: Some("32.43.1014".to_string()),
+                    },
+                    expect: (
+                        true,
+                        Some(true),
+                        Some(true),
+                        Some(true),
+                        Some("32.43.1014".to_string()),
+                        Some("32.43.1014".to_string()),
+                    ),
+                },
+                Check {
+                    scenario: "flash only",
+                    input: FirmwareFlashReport {
+                        flashed: true,
+                        reset: None,
+                        verified_image: None,
+                        verified_version: None,
+                        observed_version: None,
+                        expected_version: None,
+                    },
+                    expect: (true, None, None, None, None, None),
+                },
+                Check {
+                    scenario: "partial failure",
+                    input: FirmwareFlashReport {
+                        flashed: true,
+                        reset: Some(false),
+                        verified_image: Some(false),
+                        verified_version: Some(false),
+                        observed_version: Some("32.42.900".to_string()),
+                        expected_version: Some("32.43.1014".to_string()),
+                    },
+                    expect: (
+                        true,
+                        Some(false),
+                        Some(false),
+                        Some(false),
+                        Some("32.42.900".to_string()),
+                        Some("32.43.1014".to_string()),
+                    ),
+                },
+            ],
+            |original: FirmwareFlashReport| {
+                let proto: FirmwareFlashReportPb = original.into();
+                let converted: FirmwareFlashReport = proto.into();
+                (
+                    converted.flashed,
+                    converted.reset,
+                    converted.verified_image,
+                    converted.verified_version,
+                    converted.observed_version,
+                    converted.expected_version,
+                )
+            },
+        );
     }
 
     #[test]

--- a/crates/rpc/src/model/expected_machine.rs
+++ b/crates/rpc/src/model/expected_machine.rs
@@ -268,25 +268,50 @@ fn metadata_from_request(
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
-    /// Unspecified (0) on the wire means "use the default." Old clients
-    /// sending no value land here, and we want to preserve the DpuMode
-    /// default so existing deployments keep their behavior.
+    /// `DpuMode::from(rpc::forge::DpuMode)` maps each named variant onto its
+    /// model twin, and Unspecified (what old clients send) onto the default —
+    /// which keeps existing deployments behaving as before. The named rows also
+    /// stand in for the model -> rpc -> model round trip, since the rpc input is
+    /// exactly what `rpc::forge::DpuMode::from(model)` produces.
     #[test]
-    fn from_rpc_unspecified_maps_to_default() {
-        assert_eq!(
-            DpuMode::from(rpc::forge::DpuMode::Unspecified),
-            DpuMode::default()
+    fn rpc_dpu_mode_maps_to_model() {
+        check_values(
+            [
+                Check {
+                    scenario: "unspecified maps to default",
+                    input: rpc::forge::DpuMode::Unspecified,
+                    expect: DpuMode::default(),
+                },
+                Check {
+                    scenario: "dpu mode round trips",
+                    input: rpc::forge::DpuMode::DpuMode,
+                    expect: DpuMode::DpuMode,
+                },
+                Check {
+                    scenario: "nic mode round trips",
+                    input: rpc::forge::DpuMode::NicMode,
+                    expect: DpuMode::NicMode,
+                },
+                Check {
+                    scenario: "no dpu round trips",
+                    input: rpc::forge::DpuMode::NoDpu,
+                    expect: DpuMode::NoDpu,
+                },
+            ],
+            DpuMode::from,
         );
-        assert_eq!(DpuMode::default(), DpuMode::DpuMode);
     }
 
+    /// The DpuMode default is DpuMode, which is what the Unspecified mapping above
+    /// relies on.
     #[test]
-    fn rpc_enum_round_trips_all_named_variants() {
-        for mode in [DpuMode::DpuMode, DpuMode::NicMode, DpuMode::NoDpu] {
-            assert_eq!(DpuMode::from(rpc::forge::DpuMode::from(mode)), mode);
-        }
+    fn dpu_mode_default_is_dpu_mode() {
+        assert_eq!(DpuMode::default(), DpuMode::DpuMode);
     }
 
     #[test]
@@ -332,54 +357,46 @@ mod tests {
         }
     }
 
+    /// `disable_lockdown` survives the rpc -> data -> rpc round trip: each input
+    /// is projected to (data-side disable_lockdown, back-side host_lifecycle_profile
+    /// mapped to its disable_lockdown). A `None` input yields no profile on the way
+    /// back, so the back-side projection is `None` rather than `Some(None)`.
     #[test]
-    fn disable_lockdown_true_round_trips_through_proto() {
-        let rpc_em = make_rpc_expected_machine(Some(true));
-        let data = ExpectedMachineData::try_from(rpc_em).unwrap();
-        assert_eq!(data.host_lifecycle_profile.disable_lockdown, Some(true));
+    fn disable_lockdown_round_trips_through_proto() {
+        check_cases(
+            [
+                Case {
+                    scenario: "true",
+                    input: Some(true),
+                    expect: Yields((Some(true), Some(Some(true)))),
+                },
+                Case {
+                    scenario: "false",
+                    input: Some(false),
+                    expect: Yields((Some(false), Some(Some(false)))),
+                },
+                Case {
+                    scenario: "none",
+                    input: None,
+                    expect: Yields((None, None)),
+                },
+            ],
+            |disable_lockdown| {
+                let data =
+                    ExpectedMachineData::try_from(make_rpc_expected_machine(disable_lockdown))
+                        .map_err(drop)?;
+                let data_side = data.host_lifecycle_profile.disable_lockdown;
 
-        let em = ExpectedMachine {
-            id: None,
-            bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
-            data,
-        };
-        let back: rpc::forge::ExpectedMachine = em.into();
-        assert_eq!(
-            back.host_lifecycle_profile.unwrap().disable_lockdown,
-            Some(true)
+                let em = ExpectedMachine {
+                    id: None,
+                    bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().map_err(drop)?,
+                    data,
+                };
+                let back: rpc::forge::ExpectedMachine = em.into();
+                let back_side = back.host_lifecycle_profile.map(|p| p.disable_lockdown);
+
+                Ok::<_, ()>((data_side, back_side))
+            },
         );
-    }
-
-    #[test]
-    fn disable_lockdown_false_round_trips_through_proto() {
-        let rpc_em = make_rpc_expected_machine(Some(false));
-        let data = ExpectedMachineData::try_from(rpc_em).unwrap();
-        assert_eq!(data.host_lifecycle_profile.disable_lockdown, Some(false));
-
-        let em = ExpectedMachine {
-            id: None,
-            bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
-            data,
-        };
-        let back: rpc::forge::ExpectedMachine = em.into();
-        assert_eq!(
-            back.host_lifecycle_profile.unwrap().disable_lockdown,
-            Some(false)
-        );
-    }
-
-    #[test]
-    fn disable_lockdown_none_round_trips_through_proto() {
-        let rpc_em = make_rpc_expected_machine(None);
-        let data = ExpectedMachineData::try_from(rpc_em).unwrap();
-        assert_eq!(data.host_lifecycle_profile.disable_lockdown, None);
-
-        let em = ExpectedMachine {
-            id: None,
-            bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
-            data,
-        };
-        let back: rpc::forge::ExpectedMachine = em.into();
-        assert!(back.host_lifecycle_profile.is_none());
     }
 }

--- a/crates/rpc/src/model/instance/config/network.rs
+++ b/crates/rpc/src/model/instance/config/network.rs
@@ -419,6 +419,8 @@ impl TryFrom<rpc::forge::instance_interface_config::NetworkDetails> for NetworkD
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
     use carbide_uuid::network::NetworkSegmentId;
     use carbide_uuid::vpc::VpcPrefixId;
     use model::instance::config::network::{INTERFACE_VFID_MAX, INTERFACE_VFID_MIN};
@@ -603,111 +605,73 @@ mod tests {
         ]
     }
 
+    // Converting an rpc config validates virtual-function ids and assigns them.
+    // Each row starts from `get_rpc_instance_network_config()`, optionally mutated,
+    // and the op converts then projects the sorted VF ids out of the model (or
+    // fails when the VF ids are invalid). The error type isn't pinned here -- a
+    // duplicate or a mix of None/valid just `Fails`.
     #[test]
     fn test_validate_virtual_function_ids() {
-        let interfaces = get_rpc_instance_network_config();
+        let all = get_rpc_instance_network_config();
 
-        let network_config = rpc::InstanceNetworkConfig {
-            interfaces,
-            auto: false,
-        };
-        let network_config: InstanceNetworkConfig = network_config.try_into().unwrap();
+        let only_physical = vec![all[0].clone()];
 
-        let vf_ids = network_config.interfaces.iter().filter_map(|x| {
-            if let InterfaceFunctionId::Virtual { id } = x.function_id {
-                Some(id)
-            } else {
-                None
-            }
-        });
+        let mut missing_1 = get_rpc_instance_network_config();
+        missing_1.remove(2);
 
-        let vf_ids = vf_ids.sorted().collect_vec();
+        let mut duplicate = get_rpc_instance_network_config();
+        duplicate[2].virtual_function_id = Some(0);
 
-        // All VF ids should be present after converting.
-        let expected = vec![0, 1, 2];
-        assert_eq!(expected, vf_ids);
-    }
+        let mut mix = get_rpc_instance_network_config();
+        mix[2].virtual_function_id = None;
 
-    #[test]
-    fn test_validate_virtual_function_ids_missing_1() {
-        let mut interfaces = get_rpc_instance_network_config();
-        interfaces.remove(2);
-
-        let network_config = rpc::InstanceNetworkConfig {
-            interfaces,
-            auto: false,
-        };
-        let network_config: InstanceNetworkConfig = network_config.try_into().unwrap();
-
-        let vf_ids = network_config.interfaces.iter().filter_map(|x| {
-            if let InterfaceFunctionId::Virtual { id } = x.function_id {
-                Some(id)
-            } else {
-                None
-            }
-        });
-
-        let vf_ids = vf_ids.sorted().collect_vec();
-
-        // Since vf_id: 1 is removed, it should not be present in the parsed config.
-        let expected = vec![0, 2];
-        assert_eq!(expected, vf_ids);
-    }
-
-    #[test]
-    fn test_validate_virtual_function_ids_only_physical() {
-        let mut interfaces = get_rpc_instance_network_config();
-        interfaces = vec![interfaces[0].clone()];
-
-        let network_config = rpc::InstanceNetworkConfig {
-            interfaces,
-            auto: false,
-        };
-        let network_config: InstanceNetworkConfig = network_config.try_into().unwrap();
-
-        let vf_ids = network_config
-            .interfaces
-            .iter()
-            .filter_map(|x| {
-                if let InterfaceFunctionId::Virtual { id } = x.function_id {
-                    Some(id)
-                } else {
-                    None
-                }
-            })
-            .collect_vec();
-
-        assert!(vf_ids.is_empty());
-    }
-
-    #[test]
-    fn test_validate_virtual_function_ids_duplicate() {
-        let mut interfaces = get_rpc_instance_network_config();
-        interfaces[2].virtual_function_id = Some(0);
-
-        let network_config = rpc::InstanceNetworkConfig {
-            interfaces,
-            auto: false,
-        };
-        let network_config: Result<InstanceNetworkConfig, RpcDataConversionError> =
-            network_config.try_into();
-
-        assert!(network_config.is_err());
-    }
-
-    #[test]
-    fn test_validate_virtual_function_ids_mix() {
-        let mut interfaces = get_rpc_instance_network_config();
-        interfaces[2].virtual_function_id = None;
-
-        let network_config = rpc::InstanceNetworkConfig {
-            interfaces,
-            auto: false,
-        };
-        let network_config: Result<InstanceNetworkConfig, RpcDataConversionError> =
-            network_config.try_into();
-
-        assert!(network_config.is_err());
+        check_cases(
+            [
+                Case {
+                    scenario: "all VF ids present after converting",
+                    input: all,
+                    expect: Yields(vec![0, 1, 2]),
+                },
+                Case {
+                    scenario: "removed vf_id 1 is absent from the parsed config",
+                    input: missing_1,
+                    expect: Yields(vec![0, 2]),
+                },
+                Case {
+                    scenario: "only a physical interface yields no VF ids",
+                    input: only_physical,
+                    expect: Yields(vec![]),
+                },
+                Case {
+                    scenario: "duplicate VF id is rejected",
+                    input: duplicate,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "mix of None and valid VF ids is rejected",
+                    input: mix,
+                    expect: Fails,
+                },
+            ],
+            |interfaces| {
+                let network_config = rpc::InstanceNetworkConfig {
+                    interfaces,
+                    auto: false,
+                };
+                let network_config =
+                    InstanceNetworkConfig::try_from(network_config).map_err(drop)?;
+                let vf_ids = network_config
+                    .interfaces
+                    .iter()
+                    .filter_map(|x| match x.function_id {
+                        InterfaceFunctionId::Virtual { id } => Some(id),
+                        InterfaceFunctionId::Physical {} => None,
+                    })
+                    .sorted()
+                    .collect_vec();
+                Ok::<_, ()>(vf_ids)
+            },
+        );
     }
 
     #[test]
@@ -883,33 +847,96 @@ mod tests {
         ));
     }
 
+    // ipv6_interface_config alongside ip_address / network_details is gated at the
+    // RPC boundary: each row builds one interface config and the op asserts only
+    // whether the conversion succeeds (`true`) or is rejected (`false`).
     #[test]
-    fn test_ipv6_requires_vpc_prefix_id() {
-        // ipv6 without vpc_prefix_id should be rejected.
+    fn test_ipv6_interface_config_acceptance() {
         let v6_id = VpcPrefixId::new();
-        let rpc_config = rpc::InstanceNetworkConfig {
-            interfaces: vec![rpc::InstanceInterfaceConfig {
-                function_type: rpc::InterfaceFunctionType::Physical as i32,
-                network_segment_id: Some(NetworkSegmentId::new()),
-                network_details: Some(
-                    rpc::forge::instance_interface_config::NetworkDetails::SegmentId(
-                        NetworkSegmentId::new(),
-                    ),
+        let v4_id = VpcPrefixId::new();
+
+        // ipv6 without vpc_prefix_id (network_details is a segment) should be rejected.
+        let ipv6_without_vpc_prefix = rpc::InstanceInterfaceConfig {
+            function_type: rpc::InterfaceFunctionType::Physical as i32,
+            network_segment_id: Some(NetworkSegmentId::new()),
+            network_details: Some(
+                rpc::forge::instance_interface_config::NetworkDetails::SegmentId(
+                    NetworkSegmentId::new(),
                 ),
-                device: None,
-                device_instance: 0,
-                virtual_function_id: None,
+            ),
+            device: None,
+            device_instance: 0,
+            virtual_function_id: None,
+            ip_address: None,
+            ipv6_interface_config: Some(rpc::forge::InstanceInterfaceIpv6Config {
+                vpc_prefix_id: Some(v6_id),
                 ip_address: None,
-                ipv6_interface_config: Some(rpc::forge::InstanceInterfaceIpv6Config {
-                    vpc_prefix_id: Some(v6_id),
-                    ip_address: None,
-                }),
-                routing_profile: None,
-            }],
-            auto: false,
+            }),
+            routing_profile: None,
         };
-        let result: Result<InstanceNetworkConfig, _> = rpc_config.try_into();
-        assert!(result.is_err());
+
+        // An IPv6 ip_address AND ipv6_interface_config together should be rejected.
+        let v6_ip_with_ipv6_config = rpc::InstanceInterfaceConfig {
+            function_type: rpc::InterfaceFunctionType::Physical as i32,
+            network_segment_id: None,
+            network_details: Some(
+                rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(v4_id),
+            ),
+            device: None,
+            device_instance: 0,
+            virtual_function_id: None,
+            ip_address: Some("2001:db8::1".to_string()),
+            ipv6_interface_config: Some(rpc::forge::InstanceInterfaceIpv6Config {
+                vpc_prefix_id: Some(v6_id),
+                ip_address: None,
+            }),
+            routing_profile: None,
+        };
+
+        // An IPv4 ip_address AND ipv6_interface_config is fine (dual-stack).
+        let v4_ip_with_ipv6_config = rpc::InstanceInterfaceConfig {
+            function_type: rpc::InterfaceFunctionType::Physical as i32,
+            network_segment_id: None,
+            network_details: Some(
+                rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(v4_id),
+            ),
+            device: None,
+            device_instance: 0,
+            virtual_function_id: None,
+            ip_address: Some("10.0.0.1".to_string()),
+            ipv6_interface_config: Some(rpc::forge::InstanceInterfaceIpv6Config {
+                vpc_prefix_id: Some(v6_id),
+                ip_address: None,
+            }),
+            routing_profile: None,
+        };
+
+        check_values(
+            [
+                Check {
+                    scenario: "ipv6 without vpc_prefix_id is rejected",
+                    input: ipv6_without_vpc_prefix,
+                    expect: false,
+                },
+                Check {
+                    scenario: "ipv6 ip_address with ipv6_interface_config is rejected",
+                    input: v6_ip_with_ipv6_config,
+                    expect: false,
+                },
+                Check {
+                    scenario: "ipv4 ip_address with ipv6_interface_config is allowed",
+                    input: v4_ip_with_ipv6_config,
+                    expect: true,
+                },
+            ],
+            |iface| {
+                let rpc_config = rpc::InstanceNetworkConfig {
+                    interfaces: vec![iface],
+                    auto: false,
+                };
+                InstanceNetworkConfig::try_from(rpc_config).is_ok()
+            },
+        );
     }
 
     #[test]
@@ -938,62 +965,6 @@ mod tests {
             Some(NetworkDetails::VpcPrefixId(v6_id))
         );
         assert_eq!(model.interfaces[0].ipv6_interface_config, None);
-    }
-
-    #[test]
-    fn test_reject_v6_ip_address_with_ipv6_interface_config() {
-        // Setting an IPv6 ip_address AND ipv6_interface_config should be rejected.
-        let v4_id = VpcPrefixId::new();
-        let v6_id = VpcPrefixId::new();
-        let rpc_config = rpc::InstanceNetworkConfig {
-            interfaces: vec![rpc::InstanceInterfaceConfig {
-                function_type: rpc::InterfaceFunctionType::Physical as i32,
-                network_segment_id: None,
-                network_details: Some(
-                    rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(v4_id),
-                ),
-                device: None,
-                device_instance: 0,
-                virtual_function_id: None,
-                ip_address: Some("2001:db8::1".to_string()),
-                ipv6_interface_config: Some(rpc::forge::InstanceInterfaceIpv6Config {
-                    vpc_prefix_id: Some(v6_id),
-                    ip_address: None,
-                }),
-                routing_profile: None,
-            }],
-            auto: false,
-        };
-        let result: Result<InstanceNetworkConfig, _> = rpc_config.try_into();
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_allow_v4_ip_address_with_ipv6_interface_config() {
-        // Setting an IPv4 ip_address AND ipv6_interface_config is fine (dual-stack).
-        let v4_id = VpcPrefixId::new();
-        let v6_id = VpcPrefixId::new();
-        let rpc_config = rpc::InstanceNetworkConfig {
-            interfaces: vec![rpc::InstanceInterfaceConfig {
-                function_type: rpc::InterfaceFunctionType::Physical as i32,
-                network_segment_id: None,
-                network_details: Some(
-                    rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(v4_id),
-                ),
-                device: None,
-                device_instance: 0,
-                virtual_function_id: None,
-                ip_address: Some("10.0.0.1".to_string()),
-                ipv6_interface_config: Some(rpc::forge::InstanceInterfaceIpv6Config {
-                    vpc_prefix_id: Some(v6_id),
-                    ip_address: None,
-                }),
-                routing_profile: None,
-            }],
-            auto: false,
-        };
-        let result: Result<InstanceNetworkConfig, _> = rpc_config.try_into();
-        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/rpc/src/model/instance/status/tenant.rs
+++ b/crates/rpc/src/model/instance/status/tenant.rs
@@ -174,6 +174,8 @@ mod tests {
     use std::collections::HashMap;
     use std::str::FromStr;
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
     use carbide_uuid::machine::MachineId;
     use chrono::Utc;
     use health_report::{HealthReport, REPAIR_REQUEST_MERGE_SOURCE};
@@ -214,135 +216,128 @@ mod tests {
             machine_id,
         };
 
-        struct Case {
-            name: &'static str,
-            machine_state: ManagedHostState,
-            configs_synced: SyncState,
-            repair_active: bool,
-            expected: TenantState,
-        }
-
-        let cases = [
-            Case {
-                name: "tenant-ready with repair merge",
-                machine_state: ManagedHostState::Assigned {
-                    instance_state: InstanceState::Ready,
-                },
-                configs_synced: SyncState::Synced,
-                repair_active: true,
-                expected: TenantState::Repairing,
-            },
-            Case {
-                name: "terminating with repair merge",
-                machine_state: ManagedHostState::Assigned {
-                    instance_state: InstanceState::SwitchToAdminNetwork,
-                },
-                configs_synced: SyncState::Synced,
-                repair_active: true,
-                expected: TenantState::Terminating,
-            },
-            Case {
-                name: "reprovision with repair merge",
-                machine_state: ManagedHostState::Assigned {
-                    instance_state: InstanceState::DPUReprovision {
-                        dpu_states: DpuReprovisionStates {
-                            states: HashMap::new(),
+        // Each row: a (machine_state, configs_synced) pair under repair_active=true,
+        // exercising which states repair-merge does or does not override.
+        check_cases(
+            [
+                Case {
+                    scenario: "tenant-ready with repair merge",
+                    input: (
+                        ManagedHostState::Assigned {
+                            instance_state: InstanceState::Ready,
                         },
-                    },
+                        SyncState::Synced,
+                    ),
+                    expect: Yields(TenantState::Repairing),
                 },
-                configs_synced: SyncState::Synced,
-                repair_active: true,
-                expected: TenantState::Updating,
-            },
-            Case {
-                name: "configuring with repair merge",
-                machine_state: ManagedHostState::Assigned {
-                    instance_state: InstanceState::Ready,
+                Case {
+                    scenario: "terminating with repair merge",
+                    input: (
+                        ManagedHostState::Assigned {
+                            instance_state: InstanceState::SwitchToAdminNetwork,
+                        },
+                        SyncState::Synced,
+                    ),
+                    expect: Yields(TenantState::Terminating),
                 },
-                configs_synced: SyncState::Pending,
-                repair_active: true,
-                expected: TenantState::Configuring,
-            },
-            Case {
-                name: "failed with repair merge",
-                machine_state: ManagedHostState::Assigned {
-                    instance_state: failed,
+                Case {
+                    scenario: "reprovision with repair merge",
+                    input: (
+                        ManagedHostState::Assigned {
+                            instance_state: InstanceState::DPUReprovision {
+                                dpu_states: DpuReprovisionStates {
+                                    states: HashMap::new(),
+                                },
+                            },
+                        },
+                        SyncState::Synced,
+                    ),
+                    expect: Yields(TenantState::Updating),
                 },
-                configs_synced: SyncState::Synced,
-                repair_active: true,
-                expected: TenantState::Failed,
+                Case {
+                    scenario: "configuring with repair merge",
+                    input: (
+                        ManagedHostState::Assigned {
+                            instance_state: InstanceState::Ready,
+                        },
+                        SyncState::Pending,
+                    ),
+                    expect: Yields(TenantState::Configuring),
+                },
+                Case {
+                    scenario: "failed with repair merge",
+                    input: (
+                        ManagedHostState::Assigned {
+                            instance_state: failed,
+                        },
+                        SyncState::Synced,
+                    ),
+                    expect: Yields(TenantState::Failed),
+                },
+            ],
+            |(machine_state, configs_synced)| {
+                instance_status_tenant_state(
+                    machine_state,
+                    configs_synced,
+                    false,
+                    None,
+                    true,
+                    false,
+                    true,
+                )
+                .map_err(drop)
             },
-        ];
-
-        for case in cases {
-            let state = instance_status_tenant_state(
-                case.machine_state,
-                case.configs_synced,
-                false,
-                None,
-                true,
-                false,
-                case.repair_active,
-            )
-            .unwrap_or_else(|_| panic!("case {:?} failed conversion", case.name));
-            assert_eq!(state, case.expected, "case: {}", case.name);
-        }
+        );
     }
 
     #[test]
     fn operator_managed_allocations_project_as_tenant_ready() {
-        struct Case {
-            name: &'static str,
-            machine_state: ManagedHostState,
-            expected: TenantState,
-        }
-
-        // Cover allocated/network-wait states where Flat has no NICo readiness signal.
-        let cases = [
-            Case {
-                name: "allocated before state controller pickup",
-                machine_state: ManagedHostState::Ready,
-                expected: TenantState::Ready,
-            },
-            Case {
-                name: "assigned init",
-                machine_state: ManagedHostState::Assigned {
-                    instance_state: InstanceState::Init,
+        // Allocated/network-wait states where Flat has no NICo readiness signal:
+        // operator-managed networking should not wait on network observations.
+        check_cases(
+            [
+                Case {
+                    scenario: "allocated before state controller pickup",
+                    input: ManagedHostState::Ready,
+                    expect: Yields(TenantState::Ready),
                 },
-                expected: TenantState::Ready,
-            },
-            Case {
-                name: "waiting for network config",
-                machine_state: ManagedHostState::Assigned {
-                    instance_state: InstanceState::WaitingForNetworkConfig,
-                },
-                expected: TenantState::Ready,
-            },
-            Case {
-                name: "network config update",
-                machine_state: ManagedHostState::Assigned {
-                    instance_state: InstanceState::NetworkConfigUpdate {
-                        network_config_update_state:
-                            model::machine::NetworkConfigUpdateState::WaitingForNetworkSegmentToBeReady,
+                Case {
+                    scenario: "assigned init",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::Init,
                     },
+                    expect: Yields(TenantState::Ready),
                 },
-                expected: TenantState::Ready,
+                Case {
+                    scenario: "waiting for network config",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::WaitingForNetworkConfig,
+                    },
+                    expect: Yields(TenantState::Ready),
+                },
+                Case {
+                    scenario: "network config update",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::NetworkConfigUpdate {
+                            network_config_update_state:
+                                model::machine::NetworkConfigUpdateState::WaitingForNetworkSegmentToBeReady,
+                        },
+                    },
+                    expect: Yields(TenantState::Ready),
+                },
+            ],
+            |machine_state| {
+                instance_status_tenant_state(
+                    machine_state,
+                    SyncState::Pending,
+                    true,
+                    None,
+                    false,
+                    true,
+                    false,
+                )
+                .map_err(drop)
             },
-        ];
-
-        // Flat/operator-managed states should not wait on network observations.
-        for case in cases {
-            let state = instance_status_tenant_state(
-                case.machine_state,
-                SyncState::Pending,
-                true,
-                None,
-                false,
-                true,
-                false,
-            )
-            .unwrap_or_else(|_| panic!("case {:?} failed conversion", case.name));
-            assert_eq!(state, case.expected, "case: {}", case.name);
-        }
+        );
     }
 }

--- a/crates/rpc/src/model/instance_type.rs
+++ b/crates/rpc/src/model/instance_type.rs
@@ -132,6 +132,8 @@ impl TryFrom<InstanceType> for rpc::InstanceType {
 mod tests {
     use std::collections::HashMap;
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_values};
     use config_version::ConfigVersion;
     use model::machine::capabilities;
     use model::metadata::Metadata;
@@ -139,90 +141,9 @@ mod tests {
     use super::*;
     use crate::forge as rpc;
 
-    #[test]
-    fn test_model_instance_type_to_rpc_conversion() {
-        let version = ConfigVersion::initial();
-
-        let req_type = rpc::InstanceType {
-            id: "test_id".to_string(),
-            version: version.to_string(),
-            metadata: Some(rpc::Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: vec![],
-            }),
-            allocation_stats: None,
-            attributes: Some(rpc::InstanceTypeAttributes {
-                desired_capabilities: vec![rpc::InstanceTypeMachineCapabilityFilterAttributes {
-                    capability_type: rpc::MachineCapabilityType::CapTypeCpu.into(),
-                    name: Some("pentium 4 HT".to_string()),
-                    frequency: Some("1.3 GHz".to_string()),
-                    capacity: Some("9001 GB".to_string()),
-                    vendor: Some("intel".to_string()),
-                    count: Some(1),
-                    hardware_revision: Some("rev 9001".to_string()),
-                    cores: Some(1),
-                    threads: Some(2),
-                    inactive_devices: Some(rpc_common::Uint32List { items: vec![2, 4] }),
-                    device_type: Some(rpc::MachineCapabilityDeviceType::Unknown as i32),
-                }],
-            }),
-            created_at: Some("2023-01-01 00:00:00 UTC".to_string()),
-        };
-
-        let inst_type = InstanceType {
-            id: "test_id".parse().unwrap(),
-            deleted: None,
-            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
-            version,
-            metadata: Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: HashMap::new(),
-            },
-            desired_capabilities: vec![InstanceTypeMachineCapabilityFilter {
-                capability_type: rpc::MachineCapabilityType::CapTypeCpu.try_into().unwrap(),
-                name: Some("pentium 4 HT".to_string()),
-                frequency: Some("1.3 GHz".to_string()),
-                capacity: Some("9001 GB".to_string()),
-                vendor: Some("intel".to_string()),
-                count: Some(1),
-                hardware_revision: Some("rev 9001".to_string()),
-                cores: Some(1),
-                threads: Some(2),
-                inactive_devices: Some(vec![2, 4]),
-                device_type: Some(capabilities::MachineCapabilityDeviceType::Unknown),
-            }],
-        };
-
-        // Verify that we can go from an internal instance type to the
-        // protobuf InstanceType message
-        assert_eq!(req_type, rpc::InstanceType::try_from(inst_type).unwrap());
-    }
-
-    #[test]
-    fn test_model_instance_type_match_fails_on_empty_machine() {
-        //
-        // Verify that an empty capability set fails to match.
-        //
-
-        let inst_type = InstanceType {
-            id: "test_id".parse().unwrap(),
-            deleted: None,
-            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
-            version: ConfigVersion::initial(),
-            metadata: Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: HashMap::new(),
-            },
-            desired_capabilities: vec![InstanceTypeMachineCapabilityFilter {
-                capability_type: rpc::MachineCapabilityType::CapTypeCpu.try_into().unwrap(),
-                ..Default::default()
-            }],
-        };
-
-        let machine_cap_set = capabilities::MachineCapabilitiesSet {
+    // A capability set with every category empty -- nothing for a filter to match.
+    fn empty_cap_set() -> capabilities::MachineCapabilitiesSet {
+        capabilities::MachineCapabilitiesSet {
             cpu: vec![],
             gpu: vec![],
             memory: vec![],
@@ -230,34 +151,12 @@ mod tests {
             network: vec![],
             infiniband: vec![],
             dpu: vec![],
-        };
-
-        assert!(!inst_type.matches_capability_set(&machine_cap_set));
+        }
     }
 
-    #[test]
-    fn test_model_instance_type_loose_type_match() {
-        //
-        // Verify that a general match works on just type
-        //
-
-        let inst_type = InstanceType {
-            id: "test_id".parse().unwrap(),
-            deleted: None,
-            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
-            version: ConfigVersion::initial(),
-            metadata: Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: HashMap::new(),
-            },
-            desired_capabilities: vec![InstanceTypeMachineCapabilityFilter {
-                capability_type: rpc::MachineCapabilityType::CapTypeCpu.try_into().unwrap(),
-                ..Default::default()
-            }],
-        };
-
-        let machine_cap_set = capabilities::MachineCapabilitiesSet {
+    // A capability set holding a single CPU.
+    fn cpu_only_cap_set() -> capabilities::MachineCapabilitiesSet {
+        capabilities::MachineCapabilitiesSet {
             cpu: vec![capabilities::MachineCapabilityCpu {
                 name: "pentium 4 HT".to_string(),
                 vendor: Some("intel".to_string()),
@@ -265,73 +164,13 @@ mod tests {
                 cores: Some(1),
                 threads: Some(2),
             }],
-            gpu: vec![],
-            memory: vec![],
-            storage: vec![],
-            network: vec![],
-            infiniband: vec![],
-            dpu: vec![],
-        };
-
-        assert!(inst_type.matches_capability_set(&machine_cap_set));
+            ..empty_cap_set()
+        }
     }
 
-    #[test]
-    fn test_model_instance_type_zero_count_match() {
-        //
-        // Verify that a general match works on just type
-        // with a zero-count InstanceType filter
-        //
-
-        let inst_type = InstanceType {
-            id: "test_id".parse().unwrap(),
-            deleted: None,
-            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
-            version: ConfigVersion::initial(),
-            metadata: Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: HashMap::new(),
-            },
-            desired_capabilities: vec![
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeCpu.try_into().unwrap(),
-                    ..Default::default()
-                },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeDpu.try_into().unwrap(),
-                    count: Some(0),
-                    ..Default::default()
-                },
-            ],
-        };
-
-        let machine_cap_set = capabilities::MachineCapabilitiesSet {
-            cpu: vec![capabilities::MachineCapabilityCpu {
-                name: "pentium 4 HT".to_string(),
-                vendor: Some("intel".to_string()),
-                count: 1,
-                cores: Some(1),
-                threads: Some(2),
-            }],
-            gpu: vec![],
-            memory: vec![],
-            storage: vec![],
-            network: vec![],
-            infiniband: vec![],
-            dpu: vec![],
-        };
-
-        assert!(inst_type.matches_capability_set(&machine_cap_set));
-    }
-
-    #[test]
-    fn test_model_instance_type_specific_match() {
-        //
-        // Verify that a more specific capability set matches
-        //
-
-        let machine_cap_set = capabilities::MachineCapabilitiesSet {
+    // A fully-populated capability set spanning every category.
+    fn full_cap_set() -> capabilities::MachineCapabilitiesSet {
+        capabilities::MachineCapabilitiesSet {
             cpu: vec![capabilities::MachineCapabilityCpu {
                 name: "pentium 4 HT".to_string(),
                 vendor: Some("intel".to_string()),
@@ -386,15 +225,66 @@ mod tests {
                 hardware_revision: Some("abc123".to_string()),
                 count: 1,
             }],
-        };
+        }
+    }
 
-        // First test with a simple InstanceType
+    // Wraps a list of desired-capability filters in an otherwise-fixed InstanceType.
+    fn inst_type_with(
+        desired_capabilities: Vec<InstanceTypeMachineCapabilityFilter>,
+    ) -> InstanceType {
+        InstanceType {
+            id: "test_id".parse().unwrap(),
+            deleted: None,
+            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
+            version: ConfigVersion::initial(),
+            metadata: Metadata {
+                name: "fancy name".to_string(),
+                description: "".to_string(),
+                labels: HashMap::new(),
+            },
+            desired_capabilities,
+        }
+    }
+
+    // Verify that an internal InstanceType converts into the protobuf
+    // InstanceType message. The error (RpcDataConversionError) is not the
+    // contract here, so the row only asserts the converted value.
+    #[test]
+    fn model_instance_type_converts_to_rpc() {
+        let version = ConfigVersion::initial();
+
+        let req_type = rpc::InstanceType {
+            id: "test_id".to_string(),
+            version: version.to_string(),
+            metadata: Some(rpc::Metadata {
+                name: "fancy name".to_string(),
+                description: "".to_string(),
+                labels: vec![],
+            }),
+            allocation_stats: None,
+            attributes: Some(rpc::InstanceTypeAttributes {
+                desired_capabilities: vec![rpc::InstanceTypeMachineCapabilityFilterAttributes {
+                    capability_type: rpc::MachineCapabilityType::CapTypeCpu.into(),
+                    name: Some("pentium 4 HT".to_string()),
+                    frequency: Some("1.3 GHz".to_string()),
+                    capacity: Some("9001 GB".to_string()),
+                    vendor: Some("intel".to_string()),
+                    count: Some(1),
+                    hardware_revision: Some("rev 9001".to_string()),
+                    cores: Some(1),
+                    threads: Some(2),
+                    inactive_devices: Some(rpc_common::Uint32List { items: vec![2, 4] }),
+                    device_type: Some(rpc::MachineCapabilityDeviceType::Unknown as i32),
+                }],
+            }),
+            created_at: Some("2023-01-01 00:00:00 UTC".to_string()),
+        };
 
         let inst_type = InstanceType {
             id: "test_id".parse().unwrap(),
             deleted: None,
             created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
-            version: ConfigVersion::initial(),
+            version,
             metadata: Metadata {
                 name: "fancy name".to_string(),
                 description: "".to_string(),
@@ -404,186 +294,267 @@ mod tests {
                 capability_type: rpc::MachineCapabilityType::CapTypeCpu.try_into().unwrap(),
                 name: Some("pentium 4 HT".to_string()),
                 frequency: Some("1.3 GHz".to_string()),
-                capacity: None,
+                capacity: Some("9001 GB".to_string()),
                 vendor: Some("intel".to_string()),
                 count: Some(1),
-                hardware_revision: None,
+                hardware_revision: Some("rev 9001".to_string()),
                 cores: Some(1),
                 threads: Some(2),
-                inactive_devices: None,
+                inactive_devices: Some(vec![2, 4]),
                 device_type: Some(capabilities::MachineCapabilityDeviceType::Unknown),
             }],
         };
 
-        assert!(inst_type.matches_capability_set(&machine_cap_set));
+        Case {
+            scenario: "internal instance type to protobuf message",
+            input: inst_type,
+            expect: Yields(req_type),
+        }
+        .check(|it| rpc::InstanceType::try_from(it).map_err(drop));
+    }
 
-        // Then a fuller instance type
-
-        let inst_type = InstanceType {
-            id: "test_id".parse().unwrap(),
-            deleted: None,
-            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
-            version: ConfigVersion::initial(),
-            metadata: Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: HashMap::new(),
-            },
-            desired_capabilities: vec![
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeCpu.try_into().unwrap(),
-                    name: Some("pentium 4 HT".to_string()),
-                    frequency: Some("1.3 GHz".to_string()),
-                    capacity: None,
-                    vendor: Some("intel".to_string()),
-                    count: Some(1),
-                    hardware_revision: None,
-                    cores: Some(1),
-                    threads: Some(2),
-                    ..Default::default()
+    // `matches_capability_set` is a total bool predicate: does an InstanceType's
+    // desired-capability filter set match a machine's capabilities? Folds the
+    // empty/loose/zero-count/specific cases (the specific test ran three filter
+    // sets against the full set) into one table over (InstanceType, set).
+    #[test]
+    fn instance_type_matches_capability_set() {
+        check_values(
+            [
+                Check {
+                    scenario: "empty machine fails to match a typed filter",
+                    input: (
+                        inst_type_with(vec![InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                                .try_into()
+                                .unwrap(),
+                            ..Default::default()
+                        }]),
+                        empty_cap_set(),
+                    ),
+                    expect: false,
                 },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeGpu.try_into().unwrap(),
-                    name: Some("rtx6000".to_string()),
-                    frequency: None,
-                    vendor: Some("nvidia".to_string()),
-                    count: Some(1),
-                    cores: Some(1),
-                    threads: Some(2),
-                    capacity: Some("12 GB".to_string()),
-                    ..Default::default()
+                Check {
+                    scenario: "loose match on just the type",
+                    input: (
+                        inst_type_with(vec![InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                                .try_into()
+                                .unwrap(),
+                            ..Default::default()
+                        }]),
+                        cpu_only_cap_set(),
+                    ),
+                    expect: true,
                 },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeMemory
-                        .try_into()
-                        .unwrap(),
-                    name: Some("ddr4".to_string()),
-                    vendor: Some("micron".to_string()),
-                    count: Some(1),
-                    capacity: Some("16 GB".to_string()),
-                    ..Default::default()
+                Check {
+                    scenario: "zero-count filter for an absent type still matches",
+                    input: (
+                        inst_type_with(vec![
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                                    .try_into()
+                                    .unwrap(),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeDpu
+                                    .try_into()
+                                    .unwrap(),
+                                count: Some(0),
+                                ..Default::default()
+                            },
+                        ]),
+                        cpu_only_cap_set(),
+                    ),
+                    expect: true,
                 },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeStorage
-                        .try_into()
-                        .unwrap(),
-                    name: Some("HDD".to_string()),
-                    vendor: Some("western digital".to_string()),
-                    count: Some(1),
-                    capacity: Some("2 TB".to_string()),
-                    ..Default::default()
+                Check {
+                    scenario: "specific single CPU filter matches the full set",
+                    input: (
+                        inst_type_with(vec![InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                                .try_into()
+                                .unwrap(),
+                            name: Some("pentium 4 HT".to_string()),
+                            frequency: Some("1.3 GHz".to_string()),
+                            capacity: None,
+                            vendor: Some("intel".to_string()),
+                            count: Some(1),
+                            hardware_revision: None,
+                            cores: Some(1),
+                            threads: Some(2),
+                            inactive_devices: None,
+                            device_type: Some(capabilities::MachineCapabilityDeviceType::Unknown),
+                        }]),
+                        full_cap_set(),
+                    ),
+                    expect: true,
                 },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeNetwork
-                        .try_into()
-                        .unwrap(),
-                    name: Some("e10000".to_string()),
-                    vendor: Some("intel".to_string()),
-                    count: Some(1),
-                    ..Default::default()
+                Check {
+                    scenario: "full multi-category filter set with names matches",
+                    input: (
+                        inst_type_with(vec![
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                                    .try_into()
+                                    .unwrap(),
+                                name: Some("pentium 4 HT".to_string()),
+                                frequency: Some("1.3 GHz".to_string()),
+                                capacity: None,
+                                vendor: Some("intel".to_string()),
+                                count: Some(1),
+                                hardware_revision: None,
+                                cores: Some(1),
+                                threads: Some(2),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeGpu
+                                    .try_into()
+                                    .unwrap(),
+                                name: Some("rtx6000".to_string()),
+                                frequency: None,
+                                vendor: Some("nvidia".to_string()),
+                                count: Some(1),
+                                cores: Some(1),
+                                threads: Some(2),
+                                capacity: Some("12 GB".to_string()),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeMemory
+                                    .try_into()
+                                    .unwrap(),
+                                name: Some("ddr4".to_string()),
+                                vendor: Some("micron".to_string()),
+                                count: Some(1),
+                                capacity: Some("16 GB".to_string()),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeStorage
+                                    .try_into()
+                                    .unwrap(),
+                                name: Some("HDD".to_string()),
+                                vendor: Some("western digital".to_string()),
+                                count: Some(1),
+                                capacity: Some("2 TB".to_string()),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeNetwork
+                                    .try_into()
+                                    .unwrap(),
+                                name: Some("e10000".to_string()),
+                                vendor: Some("intel".to_string()),
+                                count: Some(1),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeInfiniband
+                                    .try_into()
+                                    .unwrap(),
+                                name: Some("connectx7".to_string()),
+                                vendor: Some("nvidia".to_string()),
+                                count: Some(1),
+                                inactive_devices: Some(vec![2, 4]),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeDpu
+                                    .try_into()
+                                    .unwrap(),
+                                name: Some("bluefield3".to_string()),
+                                hardware_revision: Some("abc123".to_string()),
+                                count: Some(1),
+                                ..Default::default()
+                            },
+                        ]),
+                        full_cap_set(),
+                    ),
+                    expect: true,
                 },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeInfiniband
-                        .try_into()
-                        .unwrap(),
-                    name: Some("connectx7".to_string()),
-                    vendor: Some("nvidia".to_string()),
-                    count: Some(1),
-                    inactive_devices: Some(vec![2, 4]),
-                    ..Default::default()
-                },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeDpu.try_into().unwrap(),
-                    name: Some("bluefield3".to_string()),
-                    hardware_revision: Some("abc123".to_string()),
-                    count: Some(1),
-                    ..Default::default()
+                Check {
+                    scenario: "full filter set without names/models matches by type/vendor",
+                    input: (
+                        inst_type_with(vec![
+                            InstanceTypeMachineCapabilityFilter {
+                                name: None,
+                                capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                                    .try_into()
+                                    .unwrap(),
+                                frequency: Some("1.3 GHz".to_string()),
+                                capacity: None,
+                                vendor: Some("intel".to_string()),
+                                count: Some(1),
+                                hardware_revision: None,
+                                cores: Some(1),
+                                threads: Some(2),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeGpu
+                                    .try_into()
+                                    .unwrap(),
+                                frequency: None,
+                                vendor: Some("nvidia".to_string()),
+                                count: Some(1),
+                                cores: Some(1),
+                                threads: Some(2),
+                                capacity: Some("12 GB".to_string()),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeMemory
+                                    .try_into()
+                                    .unwrap(),
+                                vendor: Some("micron".to_string()),
+                                count: Some(1),
+                                capacity: Some("16 GB".to_string()),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeStorage
+                                    .try_into()
+                                    .unwrap(),
+                                vendor: Some("western digital".to_string()),
+                                count: Some(1),
+                                capacity: Some("2 TB".to_string()),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeNetwork
+                                    .try_into()
+                                    .unwrap(),
+                                vendor: Some("intel".to_string()),
+                                count: Some(3), // Two intel nics of different speeds: 2x one and 1x the other.
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeInfiniband
+                                    .try_into()
+                                    .unwrap(),
+                                vendor: Some("nvidia".to_string()),
+                                count: Some(1),
+                                inactive_devices: Some(vec![2, 4]),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeDpu
+                                    .try_into()
+                                    .unwrap(),
+                                hardware_revision: Some("abc123".to_string()),
+                                count: Some(1),
+                                ..Default::default()
+                            },
+                        ]),
+                        full_cap_set(),
+                    ),
+                    expect: true,
                 },
             ],
-        };
-
-        assert!(inst_type.matches_capability_set(&machine_cap_set));
-
-        // Then a fuller instance type but without caring about name/model
-
-        let inst_type = InstanceType {
-            id: "test_id".parse().unwrap(),
-            deleted: None,
-            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
-            version: ConfigVersion::initial(),
-            metadata: Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: HashMap::new(),
-            },
-            desired_capabilities: vec![
-                InstanceTypeMachineCapabilityFilter {
-                    name: None,
-                    capability_type: rpc::MachineCapabilityType::CapTypeCpu.try_into().unwrap(),
-                    frequency: Some("1.3 GHz".to_string()),
-                    capacity: None,
-                    vendor: Some("intel".to_string()),
-                    count: Some(1),
-                    hardware_revision: None,
-                    cores: Some(1),
-                    threads: Some(2),
-                    ..Default::default()
-                },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeGpu.try_into().unwrap(),
-                    frequency: None,
-                    vendor: Some("nvidia".to_string()),
-                    count: Some(1),
-                    cores: Some(1),
-                    threads: Some(2),
-                    capacity: Some("12 GB".to_string()),
-                    ..Default::default()
-                },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeMemory
-                        .try_into()
-                        .unwrap(),
-                    vendor: Some("micron".to_string()),
-                    count: Some(1),
-                    capacity: Some("16 GB".to_string()),
-                    ..Default::default()
-                },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeStorage
-                        .try_into()
-                        .unwrap(),
-                    vendor: Some("western digital".to_string()),
-                    count: Some(1),
-                    capacity: Some("2 TB".to_string()),
-                    ..Default::default()
-                },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeNetwork
-                        .try_into()
-                        .unwrap(),
-                    vendor: Some("intel".to_string()),
-                    count: Some(3), // There are two intel nics of different speeds.  2x of one and 1x of the other.
-
-                    ..Default::default()
-                },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeInfiniband
-                        .try_into()
-                        .unwrap(),
-                    vendor: Some("nvidia".to_string()),
-                    count: Some(1),
-                    inactive_devices: Some(vec![2, 4]),
-                    ..Default::default()
-                },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeDpu.try_into().unwrap(),
-                    hardware_revision: Some("abc123".to_string()),
-                    count: Some(1),
-                    ..Default::default()
-                },
-            ],
-        };
-
-        assert!(inst_type.matches_capability_set(&machine_cap_set));
+            |(inst_type, machine_cap_set)| inst_type.matches_capability_set(&machine_cap_set),
+        );
     }
 }

--- a/crates/rpc/src/model/machine/capabilities.rs
+++ b/crates/rpc/src/model/machine/capabilities.rs
@@ -190,174 +190,167 @@ impl TryFrom<rpc::MachineCapabilityDeviceType> for MachineCapabilityDeviceType {
 #[cfg(test)]
 mod tests {
 
+    use carbide_test_support::Check;
+
     use super::*;
     use crate::forge as rpc;
 
+    // Each per-attribute model -> rpc conversion is a distinct total `From` over a
+    // distinct pair of types, so each is one `Check` row exercising that `.into()`.
+
     #[test]
     fn test_model_cpu_capability_to_rpc_conversion() {
-        let req_type = rpc::MachineCapabilityAttributesCpu {
-            name: "pentium 4 HT".to_string(),
-            count: 1,
-            vendor: Some("intel".to_string()),
-            cores: Some(1),
-            threads: Some(2),
-        };
-
-        let machine_cap = MachineCapabilityCpu {
-            name: "pentium 4 HT".to_string(),
-            count: 1,
-            vendor: Some("intel".to_string()),
-            cores: Some(1),
-            threads: Some(2),
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::MachineCapabilityAttributesCpu::from(machine_cap)
-        );
+        Check {
+            scenario: "cpu capability converts field-for-field",
+            input: MachineCapabilityCpu {
+                name: "pentium 4 HT".to_string(),
+                count: 1,
+                vendor: Some("intel".to_string()),
+                cores: Some(1),
+                threads: Some(2),
+            },
+            expect: rpc::MachineCapabilityAttributesCpu {
+                name: "pentium 4 HT".to_string(),
+                count: 1,
+                vendor: Some("intel".to_string()),
+                cores: Some(1),
+                threads: Some(2),
+            },
+        }
+        .check(rpc::MachineCapabilityAttributesCpu::from);
     }
 
     #[test]
     fn test_model_gpu_capability_to_rpc_conversion() {
-        let req_type = rpc::MachineCapabilityAttributesGpu {
-            name: "RTX 6000".to_string(),
-            count: 1,
-            frequency: Some("1.2 giggawattz".to_string()),
-            vendor: Some("nvidia".to_string()),
-            cores: Some(1),
-            threads: Some(2),
-            capacity: Some("24 GB".to_string()),
-            device_type: Some(MachineCapabilityDeviceType::Unknown as i32),
-        };
-
-        let machine_cap = MachineCapabilityGpu {
-            name: "RTX 6000".to_string(),
-            count: 1,
-            frequency: Some("1.2 giggawattz".to_string()),
-            vendor: Some("nvidia".to_string()),
-            cores: Some(1),
-            threads: Some(2),
-            memory_capacity: Some("24 GB".to_string()),
-            device_type: Some(MachineCapabilityDeviceType::Unknown),
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::MachineCapabilityAttributesGpu::from(machine_cap)
-        );
+        Check {
+            scenario: "gpu capability converts (memory_capacity -> capacity, device_type mapped)",
+            input: MachineCapabilityGpu {
+                name: "RTX 6000".to_string(),
+                count: 1,
+                frequency: Some("1.2 giggawattz".to_string()),
+                vendor: Some("nvidia".to_string()),
+                cores: Some(1),
+                threads: Some(2),
+                memory_capacity: Some("24 GB".to_string()),
+                device_type: Some(MachineCapabilityDeviceType::Unknown),
+            },
+            expect: rpc::MachineCapabilityAttributesGpu {
+                name: "RTX 6000".to_string(),
+                count: 1,
+                frequency: Some("1.2 giggawattz".to_string()),
+                vendor: Some("nvidia".to_string()),
+                cores: Some(1),
+                threads: Some(2),
+                capacity: Some("24 GB".to_string()),
+                device_type: Some(MachineCapabilityDeviceType::Unknown as i32),
+            },
+        }
+        .check(rpc::MachineCapabilityAttributesGpu::from);
     }
 
     #[test]
     fn test_model_memory_capability_to_rpc_conversion() {
-        let req_type = rpc::MachineCapabilityAttributesMemory {
-            name: "DDR4".to_string(),
-            count: 1,
-            vendor: Some("crucial".to_string()),
-            capacity: Some("32 GB".to_string()),
-        };
-
-        let machine_cap = MachineCapabilityMemory {
-            name: "DDR4".to_string(),
-            count: 1,
-            vendor: Some("crucial".to_string()),
-            capacity: Some("32 GB".to_string()),
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::MachineCapabilityAttributesMemory::from(machine_cap)
-        );
+        Check {
+            scenario: "memory capability converts field-for-field",
+            input: MachineCapabilityMemory {
+                name: "DDR4".to_string(),
+                count: 1,
+                vendor: Some("crucial".to_string()),
+                capacity: Some("32 GB".to_string()),
+            },
+            expect: rpc::MachineCapabilityAttributesMemory {
+                name: "DDR4".to_string(),
+                count: 1,
+                vendor: Some("crucial".to_string()),
+                capacity: Some("32 GB".to_string()),
+            },
+        }
+        .check(rpc::MachineCapabilityAttributesMemory::from);
     }
 
     #[test]
     fn test_model_storage_capability_to_rpc_conversion() {
-        let req_type = rpc::MachineCapabilityAttributesStorage {
-            name: "Spinning Disk".to_string(),
-            count: 1,
-            vendor: Some("western digital".to_string()),
-            capacity: Some("1 TB".to_string()),
-        };
-
-        let machine_cap = MachineCapabilityStorage {
-            name: "Spinning Disk".to_string(),
-            count: 1,
-            vendor: Some("western digital".to_string()),
-            capacity: Some("1 TB".to_string()),
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::MachineCapabilityAttributesStorage::from(machine_cap)
-        );
+        Check {
+            scenario: "storage capability converts field-for-field",
+            input: MachineCapabilityStorage {
+                name: "Spinning Disk".to_string(),
+                count: 1,
+                vendor: Some("western digital".to_string()),
+                capacity: Some("1 TB".to_string()),
+            },
+            expect: rpc::MachineCapabilityAttributesStorage {
+                name: "Spinning Disk".to_string(),
+                count: 1,
+                vendor: Some("western digital".to_string()),
+                capacity: Some("1 TB".to_string()),
+            },
+        }
+        .check(rpc::MachineCapabilityAttributesStorage::from);
     }
 
     #[test]
     fn test_model_network_capability_to_rpc_conversion() {
-        let req_type = rpc::MachineCapabilityAttributesNetwork {
-            name: "BCM57414 NetXtreme-E 10Gb/25Gb RDMA Ethernet Controller".to_string(),
-            count: 1,
-            vendor: Some("0x14e4".to_string()),
-            device_type: Some(MachineCapabilityDeviceType::Unknown as i32),
-        };
-
-        let machine_cap = MachineCapabilityNetwork {
-            name: "BCM57414 NetXtreme-E 10Gb/25Gb RDMA Ethernet Controller".to_string(),
-            count: 1,
-            vendor: Some("0x14e4".to_string()),
-            device_type: Some(MachineCapabilityDeviceType::Unknown),
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::MachineCapabilityAttributesNetwork::from(machine_cap)
-        );
+        Check {
+            scenario: "network capability converts (device_type mapped)",
+            input: MachineCapabilityNetwork {
+                name: "BCM57414 NetXtreme-E 10Gb/25Gb RDMA Ethernet Controller".to_string(),
+                count: 1,
+                vendor: Some("0x14e4".to_string()),
+                device_type: Some(MachineCapabilityDeviceType::Unknown),
+            },
+            expect: rpc::MachineCapabilityAttributesNetwork {
+                name: "BCM57414 NetXtreme-E 10Gb/25Gb RDMA Ethernet Controller".to_string(),
+                count: 1,
+                vendor: Some("0x14e4".to_string()),
+                device_type: Some(MachineCapabilityDeviceType::Unknown as i32),
+            },
+        }
+        .check(rpc::MachineCapabilityAttributesNetwork::from);
     }
 
     #[test]
     fn test_model_infiniband_capability_to_rpc_conversion() {
-        let req_type = rpc::MachineCapabilityAttributesInfiniband {
-            name: "IB NIC".to_string(),
-            count: 4,
-            vendor: Some("IB NIC Vendor".to_string()),
-            inactive_devices: vec![0, 2],
-        };
-
-        let machine_cap = MachineCapabilityInfiniband {
-            name: "IB NIC".to_string(),
-            count: 4,
-            vendor: "IB NIC Vendor".to_string(),
-            inactive_devices: vec![0, 2],
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::MachineCapabilityAttributesInfiniband::from(machine_cap)
-        );
+        Check {
+            scenario: "infiniband capability converts (vendor wrapped in Some)",
+            input: MachineCapabilityInfiniband {
+                name: "IB NIC".to_string(),
+                count: 4,
+                vendor: "IB NIC Vendor".to_string(),
+                inactive_devices: vec![0, 2],
+            },
+            expect: rpc::MachineCapabilityAttributesInfiniband {
+                name: "IB NIC".to_string(),
+                count: 4,
+                vendor: Some("IB NIC Vendor".to_string()),
+                inactive_devices: vec![0, 2],
+            },
+        }
+        .check(rpc::MachineCapabilityAttributesInfiniband::from);
     }
 
     #[test]
     fn test_model_dpu_capability_to_rpc_conversion() {
-        let req_type = rpc::MachineCapabilityAttributesDpu {
-            name: "bf3".to_string(),
-            count: 1,
-            hardware_revision: Some("uh, 3?".to_string()),
-        };
-
-        let machine_cap = MachineCapabilityDpu {
-            name: "bf3".to_string(),
-            count: 1,
-            hardware_revision: Some("uh, 3?".to_string()),
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::MachineCapabilityAttributesDpu::from(machine_cap)
-        );
+        Check {
+            scenario: "dpu capability converts field-for-field",
+            input: MachineCapabilityDpu {
+                name: "bf3".to_string(),
+                count: 1,
+                hardware_revision: Some("uh, 3?".to_string()),
+            },
+            expect: rpc::MachineCapabilityAttributesDpu {
+                name: "bf3".to_string(),
+                count: 1,
+                hardware_revision: Some("uh, 3?".to_string()),
+            },
+        }
+        .check(rpc::MachineCapabilityAttributesDpu::from);
     }
 
+    // The whole-set conversion delegates to the per-attribute `From` impls above;
+    // one `Check` row exercises the aggregate `.into()` over a populated set.
     #[test]
     fn test_model_capability_set_to_rpc_conversion() {
-        let req_type = rpc::MachineCapabilitiesSet {
+        let expect = rpc::MachineCapabilitiesSet {
             cpu: vec![rpc::MachineCapabilityAttributesCpu {
                 name: "xeon".to_string(),
                 count: 2,
@@ -414,7 +407,7 @@ mod tests {
             }],
         };
 
-        let machine_cap = MachineCapabilitiesSet {
+        let input = MachineCapabilitiesSet {
             cpu: vec![MachineCapabilityCpu {
                 name: "xeon".to_string(),
                 count: 2,
@@ -471,6 +464,11 @@ mod tests {
             }],
         };
 
-        assert_eq!(req_type, rpc::MachineCapabilitiesSet::from(machine_cap));
+        Check {
+            scenario: "populated set converts each attribute vec",
+            input,
+            expect,
+        }
+        .check(rpc::MachineCapabilitiesSet::from);
     }
 }

--- a/crates/rpc/src/model/metadata.rs
+++ b/crates/rpc/src/model/metadata.rs
@@ -79,38 +79,45 @@ impl From<rpc::forge::Label> for LabelFilter {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
 
+    // `LabelFilter::from` is a total conversion: project to (key, value) — the two
+    // fields the originals asserted.
     #[test]
-    fn label_filter_from_rpc_with_value() {
-        let rpc_label = rpc::forge::Label {
-            key: "env".to_string(),
-            value: Some("prod".to_string()),
-        };
-        let filter = LabelFilter::from(rpc_label);
-        assert_eq!(filter.key, "env");
-        assert_eq!(filter.value, Some("prod".to_string()));
-    }
-
-    #[test]
-    fn label_filter_from_rpc_without_value() {
-        let rpc_label = rpc::forge::Label {
-            key: "env".to_string(),
-            value: None,
-        };
-        let filter = LabelFilter::from(rpc_label);
-        assert_eq!(filter.key, "env");
-        assert_eq!(filter.value, None);
-    }
-
-    #[test]
-    fn label_filter_from_rpc_empty_key() {
-        let rpc_label = rpc::forge::Label {
-            key: String::new(),
-            value: Some("prod".to_string()),
-        };
-        let filter = LabelFilter::from(rpc_label);
-        assert!(filter.key.is_empty());
-        assert_eq!(filter.value, Some("prod".to_string()));
+    fn label_filter_from_rpc() {
+        check_values(
+            [
+                Check {
+                    scenario: "with value",
+                    input: rpc::forge::Label {
+                        key: "env".to_string(),
+                        value: Some("prod".to_string()),
+                    },
+                    expect: ("env".to_string(), Some("prod".to_string())),
+                },
+                Check {
+                    scenario: "without value",
+                    input: rpc::forge::Label {
+                        key: "env".to_string(),
+                        value: None,
+                    },
+                    expect: ("env".to_string(), None),
+                },
+                Check {
+                    scenario: "empty key",
+                    input: rpc::forge::Label {
+                        key: String::new(),
+                        value: Some("prod".to_string()),
+                    },
+                    expect: (String::new(), Some("prod".to_string())),
+                },
+            ],
+            |label| {
+                let filter = LabelFilter::from(label);
+                (filter.key, filter.value)
+            },
+        );
     }
 }

--- a/crates/rpc/src/model/network_security_group.rs
+++ b/crates/rpc/src/model/network_security_group.rs
@@ -629,147 +629,144 @@ impl TryFrom<rpc::NetworkSecurityGroupStatus> for NetworkSecurityGroupStatusObse
 mod tests {
     use std::collections::HashMap;
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
     use config_version::ConfigVersion;
     use model::metadata::Metadata;
 
     use super::*;
     use crate::forge as rpc;
 
+    // `From<NetworkSecurityGroupPropagationObjectStatus>` derives the propagation
+    // status (and any details) from the applied-vs-expected interface counts.
     #[test]
     fn test_model_nsg_prop_obj_status_to_rpc_conversion() {
-        // Full
-        let req_type = rpc::NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusFull.into(),
-            details: None,
-            unpropagated_instance_ids: vec![],
-            related_instance_ids: vec![],
-        };
-
-        let status = NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            interfaces_expected: 0,
-            interfaces_applied: 0,
-            unpropagated_instance_ids: vec![],
-            related_instance_ids: vec![],
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::NetworkSecurityGroupPropagationObjectStatus::from(status)
-        );
-
-        let req_type = rpc::NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusFull.into(),
-            details: None,
-            related_instance_ids: vec![
-                "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+        check_values(
+            [
+                Check {
+                    scenario: "full, no interfaces",
+                    input: NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        interfaces_expected: 0,
+                        interfaces_applied: 0,
+                        unpropagated_instance_ids: vec![],
+                        related_instance_ids: vec![],
+                    },
+                    expect: rpc::NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusFull
+                            .into(),
+                        details: None,
+                        unpropagated_instance_ids: vec![],
+                        related_instance_ids: vec![],
+                    },
+                },
+                Check {
+                    scenario: "full, all interfaces applied",
+                    input: NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        interfaces_expected: 2,
+                        interfaces_applied: 2,
+                        related_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
+                        ],
+                        unpropagated_instance_ids: vec![],
+                    },
+                    expect: rpc::NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusFull
+                            .into(),
+                        details: None,
+                        related_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+                        ],
+                        unpropagated_instance_ids: vec![],
+                    },
+                },
+                Check {
+                    scenario: "partial, some interfaces applied",
+                    input: NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        interfaces_expected: 2,
+                        interfaces_applied: 1,
+                        related_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
+                        ],
+                        unpropagated_instance_ids: vec![
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
+                        ],
+                    },
+                    expect: rpc::NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusPartial
+                            .into(),
+                        details: None,
+                        related_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+                        ],
+                        unpropagated_instance_ids: vec![
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+                        ],
+                    },
+                },
+                Check {
+                    scenario: "none, no interfaces applied",
+                    input: NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        interfaces_expected: 2,
+                        interfaces_applied: 0,
+                        related_instance_ids: vec![],
+                        unpropagated_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
+                        ],
+                    },
+                    expect: rpc::NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusNone
+                            .into(),
+                        details: None,
+                        related_instance_ids: vec![],
+                        unpropagated_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+                        ],
+                    },
+                },
+                Check {
+                    scenario: "unknown, applied exceeds expected",
+                    input: NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        interfaces_expected: 1,
+                        interfaces_applied: 2,
+                        related_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
+                        ],
+                        unpropagated_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
+                        ],
+                    },
+                    expect: rpc::NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusUnknown
+                            .into(),
+                        details: Some("propagated objects exceeds expected objects".to_string()),
+                        related_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
+                        ],
+                        unpropagated_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+                        ],
+                    },
+                },
             ],
-            unpropagated_instance_ids: vec![],
-        };
-
-        let status = NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            interfaces_expected: 2,
-            interfaces_applied: 2,
-            related_instance_ids: vec![
-                "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
-            ],
-            unpropagated_instance_ids: vec![],
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::NetworkSecurityGroupPropagationObjectStatus::from(status)
-        );
-
-        // Partial
-        let req_type = rpc::NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusPartial.into(),
-            details: None,
-            related_instance_ids: vec![
-                "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
-            ],
-            unpropagated_instance_ids: vec!["fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string()],
-        };
-
-        let status = NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            interfaces_expected: 2,
-            interfaces_applied: 1,
-            related_instance_ids: vec![
-                "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
-            ],
-            unpropagated_instance_ids: vec![
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
-            ],
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::NetworkSecurityGroupPropagationObjectStatus::from(status)
-        );
-
-        // None
-        let req_type = rpc::NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusNone.into(),
-            details: None,
-            related_instance_ids: vec![],
-            unpropagated_instance_ids: vec![
-                "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
-            ],
-        };
-
-        let status = NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            interfaces_expected: 2,
-            interfaces_applied: 0,
-            related_instance_ids: vec![],
-            unpropagated_instance_ids: vec![
-                "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
-            ],
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::NetworkSecurityGroupPropagationObjectStatus::from(status)
-        );
-
-        // Unknown
-        let req_type = rpc::NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusUnknown.into(),
-            details: Some("propagated objects exceeds expected objects".to_string()),
-            related_instance_ids: vec!["200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap()],
-            unpropagated_instance_ids: vec![
-                "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
-            ],
-        };
-
-        let status = NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            interfaces_expected: 1,
-            interfaces_applied: 2,
-            related_instance_ids: vec!["200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap()],
-            unpropagated_instance_ids: vec![
-                "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
-            ],
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::NetworkSecurityGroupPropagationObjectStatus::from(status)
+            rpc::NetworkSecurityGroupPropagationObjectStatus::from,
         );
     }
 
@@ -854,182 +851,204 @@ mod tests {
         assert_eq!(req_type, rpc::NetworkSecurityGroup::try_from(nsg).unwrap());
     }
 
+    // `TryFrom<rpc::NetworkSecurityGroupRuleAttributes>` rejects ill-formed rules:
+    // ports on port-less protocols, and prefix/protocol IP-version mismatches.
     #[test]
     fn test_rpc_rule_to_nsg_model_rule_conversion_failures() {
-        // ICMP with ports should fail
-        let req = rpc::NetworkSecurityGroupRuleAttributes {
-            id: Some("anything".to_string()),
-            direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
-            ipv6: false,
-            src_port_start: Some(80),
-            src_port_end: Some(32768),
-            dst_port_start: Some(80),
-            dst_port_end: Some(32768),
-            protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
-            action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-            priority: 9001,
-            source_net: Some(
-                rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                    "0.0.0.0/0".to_string(),
-                ),
-            ),
-            destination_net: Some(
-                rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                    "0.0.0.0/0".to_string(),
-                ),
-            ),
-        };
-        NetworkSecurityGroupRule::try_from(req).unwrap_err();
-
-        // ICMP6 with ports should fail
-        let req = rpc::NetworkSecurityGroupRuleAttributes {
-            id: Some("anything".to_string()),
-            direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
-            ipv6: true,
-            src_port_start: Some(80),
-            src_port_end: Some(32768),
-            dst_port_start: Some(80),
-            dst_port_end: Some(32768),
-            protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
-            action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-            priority: 9001,
-            source_net: Some(
-                rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                    "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                ),
-            ),
-            destination_net: Some(
-                rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                    "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                ),
-            ),
-        };
-        NetworkSecurityGroupRule::try_from(req).unwrap_err();
-
-        // ANY with ports should fail
-        let req = rpc::NetworkSecurityGroupRuleAttributes {
-            id: Some("anything".to_string()),
-            direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
-            ipv6: true,
-            src_port_start: Some(80),
-            src_port_end: Some(32768),
-            dst_port_start: Some(80),
-            dst_port_end: Some(32768),
-            protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoAny.into(),
-            action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-            priority: 9001,
-            source_net: Some(
-                rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                    "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                ),
-            ),
-            destination_net: Some(
-                rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                    "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                ),
-            ),
-        };
-        NetworkSecurityGroupRule::try_from(req).unwrap_err();
-
-        // v4 prefixes with v6 rule should fail
-        let req = rpc::NetworkSecurityGroupRuleAttributes {
-            id: Some("anything".to_string()),
-            direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
-            ipv6: true,
-            src_port_start: Some(80),
-            src_port_end: Some(32768),
-            dst_port_start: Some(80),
-            dst_port_end: Some(32768),
-            protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoTcp.into(),
-            action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-            priority: 9001,
-            source_net: Some(
-                rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                    "0.0.0.0/0".to_string(),
-                ),
-            ),
-            destination_net: Some(
-                rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                    "0.0.0.0/0".to_string(),
-                ),
-            ),
-        };
-        NetworkSecurityGroupRule::try_from(req).unwrap_err();
-
-        // v6 prefixes with v4 rule should fail
-        let req = rpc::NetworkSecurityGroupRuleAttributes {
-            id: Some("anything".to_string()),
-            direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
-            ipv6: false,
-            src_port_start: Some(80),
-            src_port_end: Some(32768),
-            dst_port_start: Some(80),
-            dst_port_end: Some(32768),
-            protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoTcp.into(),
-            action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-            priority: 9001,
-            source_net: Some(
-                rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                    "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                ),
-            ),
-            destination_net: Some(
-                rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                    "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                ),
-            ),
-        };
-        NetworkSecurityGroupRule::try_from(req).unwrap_err();
-
-        // ICMP6 with v4 rule should fail
-        let req = rpc::NetworkSecurityGroupRuleAttributes {
-            id: Some("anything".to_string()),
-            direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
-            ipv6: false,
-            src_port_start: None,
-            src_port_end: None,
-            dst_port_start: None,
-            dst_port_end: None,
-            protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp6.into(),
-            action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-            priority: 9001,
-            source_net: Some(
-                rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                    "1.1.1.1/24".to_string(),
-                ),
-            ),
-            destination_net: Some(
-                rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                    "1.1.1.1/24".to_string(),
-                ),
-            ),
-        };
-        NetworkSecurityGroupRule::try_from(req).unwrap_err();
-
-        // ICMP6 with v4 rule should fail
-        let req = rpc::NetworkSecurityGroupRuleAttributes {
-            id: Some("anything".to_string()),
-            direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
-            ipv6: true,
-            src_port_start: None,
-            src_port_end: None,
-            dst_port_start: None,
-            dst_port_end: None,
-            protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
-            action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-            priority: 9001,
-            source_net: Some(
-                rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                    "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                ),
-            ),
-            destination_net: Some(
-                rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                    "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                ),
-            ),
-        };
-        NetworkSecurityGroupRule::try_from(req).unwrap_err();
+        check_cases(
+            [
+                Case {
+                    scenario: "ICMP with ports",
+                    input: rpc::NetworkSecurityGroupRuleAttributes {
+                        id: Some("anything".to_string()),
+                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                            .into(),
+                        ipv6: false,
+                        src_port_start: Some(80),
+                        src_port_end: Some(32768),
+                        dst_port_start: Some(80),
+                        dst_port_end: Some(32768),
+                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
+                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                        priority: 9001,
+                        source_net: Some(
+                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                                "0.0.0.0/0".to_string(),
+                            ),
+                        ),
+                        destination_net: Some(
+                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                                "0.0.0.0/0".to_string(),
+                            ),
+                        ),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ICMP6 with ports",
+                    input: rpc::NetworkSecurityGroupRuleAttributes {
+                        id: Some("anything".to_string()),
+                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                            .into(),
+                        ipv6: true,
+                        src_port_start: Some(80),
+                        src_port_end: Some(32768),
+                        dst_port_start: Some(80),
+                        dst_port_end: Some(32768),
+                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
+                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                        priority: 9001,
+                        source_net: Some(
+                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
+                            ),
+                        ),
+                        destination_net: Some(
+                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
+                            ),
+                        ),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ANY with ports",
+                    input: rpc::NetworkSecurityGroupRuleAttributes {
+                        id: Some("anything".to_string()),
+                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                            .into(),
+                        ipv6: true,
+                        src_port_start: Some(80),
+                        src_port_end: Some(32768),
+                        dst_port_start: Some(80),
+                        dst_port_end: Some(32768),
+                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoAny.into(),
+                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                        priority: 9001,
+                        source_net: Some(
+                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
+                            ),
+                        ),
+                        destination_net: Some(
+                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
+                            ),
+                        ),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "v4 prefixes with v6 rule",
+                    input: rpc::NetworkSecurityGroupRuleAttributes {
+                        id: Some("anything".to_string()),
+                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                            .into(),
+                        ipv6: true,
+                        src_port_start: Some(80),
+                        src_port_end: Some(32768),
+                        dst_port_start: Some(80),
+                        dst_port_end: Some(32768),
+                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoTcp.into(),
+                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                        priority: 9001,
+                        source_net: Some(
+                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                                "0.0.0.0/0".to_string(),
+                            ),
+                        ),
+                        destination_net: Some(
+                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                                "0.0.0.0/0".to_string(),
+                            ),
+                        ),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "v6 prefixes with v4 rule",
+                    input: rpc::NetworkSecurityGroupRuleAttributes {
+                        id: Some("anything".to_string()),
+                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                            .into(),
+                        ipv6: false,
+                        src_port_start: Some(80),
+                        src_port_end: Some(32768),
+                        dst_port_start: Some(80),
+                        dst_port_end: Some(32768),
+                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoTcp.into(),
+                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                        priority: 9001,
+                        source_net: Some(
+                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
+                            ),
+                        ),
+                        destination_net: Some(
+                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
+                            ),
+                        ),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ICMP6 with v4 prefixes on v4 rule",
+                    input: rpc::NetworkSecurityGroupRuleAttributes {
+                        id: Some("anything".to_string()),
+                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                            .into(),
+                        ipv6: false,
+                        src_port_start: None,
+                        src_port_end: None,
+                        dst_port_start: None,
+                        dst_port_end: None,
+                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp6.into(),
+                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                        priority: 9001,
+                        source_net: Some(
+                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                                "1.1.1.1/24".to_string(),
+                            ),
+                        ),
+                        destination_net: Some(
+                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                                "1.1.1.1/24".to_string(),
+                            ),
+                        ),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ICMP on v6 rule",
+                    input: rpc::NetworkSecurityGroupRuleAttributes {
+                        id: Some("anything".to_string()),
+                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                            .into(),
+                        ipv6: true,
+                        src_port_start: None,
+                        src_port_end: None,
+                        dst_port_start: None,
+                        dst_port_end: None,
+                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
+                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                        priority: 9001,
+                        source_net: Some(
+                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
+                            ),
+                        ),
+                        destination_net: Some(
+                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
+                            ),
+                        ),
+                    },
+                    expect: Fails,
+                },
+            ],
+            |req| NetworkSecurityGroupRule::try_from(req).map_err(drop),
+        );
     }
 
     #[test]

--- a/crates/rpc/src/model/network_segment.rs
+++ b/crates/rpc/src/model/network_segment.rs
@@ -253,6 +253,9 @@ impl TryFrom<NetworkSegment> for rpc::NetworkSegment {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     fn make_test_creation_request(
@@ -297,88 +300,91 @@ mod tests {
         }
     }
 
+    // Every row drives the same conversion (NewNetworkSegment::try_from): IPv6 and
+    // dual-stack prefixes are accepted (and the resulting prefix count / IPv6-ness
+    // preserved), while tenant segments reject too-small IPv4 (/31, /32) and IPv6
+    // (/127, /128) prefixes. Accepting rows project to (prefix count, first prefix
+    // is IPv6); rejecting rows assert only that the conversion fails.
     #[test]
-    fn test_ipv6_prefix_accepted() {
-        let request = make_test_creation_request(
-            vec![ipv6_prefix("2001:db8::/64")],
-            NetworkSegmentType::Admin,
-        );
-        let result = NewNetworkSegment::try_from(request);
-        assert!(result.is_ok(), "IPv6 prefix should be accepted: {result:?}");
-        let segment = result.unwrap();
-        assert_eq!(segment.prefixes.len(), 1);
-        assert!(segment.prefixes[0].prefix.is_ipv6());
-    }
-
-    #[test]
-    fn test_dual_stack_prefixes_accepted() {
-        let request = make_test_creation_request(
-            vec![
-                ipv4_prefix("192.0.2.0/24", Some("192.0.2.1")),
-                ipv6_prefix("2001:db8::/64"),
+    fn try_from_creation_request_validates_prefixes() {
+        check_cases(
+            [
+                Case {
+                    scenario: "ipv6 prefix accepted (admin)",
+                    input: make_test_creation_request(
+                        vec![ipv6_prefix("2001:db8::/64")],
+                        NetworkSegmentType::Admin,
+                    ),
+                    expect: Yields((1, true)),
+                },
+                Case {
+                    scenario: "dual-stack prefixes accepted (admin)",
+                    input: make_test_creation_request(
+                        vec![
+                            ipv4_prefix("192.0.2.0/24", Some("192.0.2.1")),
+                            ipv6_prefix("2001:db8::/64"),
+                        ],
+                        NetworkSegmentType::Admin,
+                    ),
+                    expect: Yields((2, false)),
+                },
+                Case {
+                    scenario: "tenant /64 IPv6 allowed",
+                    input: make_test_creation_request(
+                        vec![ipv6_prefix("2001:db8::/64")],
+                        NetworkSegmentType::Tenant,
+                    ),
+                    expect: Yields((1, true)),
+                },
+                Case {
+                    scenario: "tenant /127 IPv6 rejected",
+                    input: make_test_creation_request(
+                        vec![ipv6_prefix("2001:db8::1/127")],
+                        NetworkSegmentType::Tenant,
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "tenant /128 IPv6 rejected",
+                    input: make_test_creation_request(
+                        vec![ipv6_prefix("2001:db8::1/128")],
+                        NetworkSegmentType::Tenant,
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "tenant /24 IPv4 allowed",
+                    input: make_test_creation_request(
+                        vec![ipv4_prefix("192.0.2.0/24", Some("192.0.2.1"))],
+                        NetworkSegmentType::Tenant,
+                    ),
+                    expect: Yields((1, false)),
+                },
+                Case {
+                    scenario: "tenant /31 IPv4 rejected",
+                    input: make_test_creation_request(
+                        vec![ipv4_prefix("192.0.2.0/31", Some("192.0.2.1"))],
+                        NetworkSegmentType::Tenant,
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "tenant /32 IPv4 rejected",
+                    input: make_test_creation_request(
+                        vec![ipv4_prefix("192.0.2.0/32", None)],
+                        NetworkSegmentType::Tenant,
+                    ),
+                    expect: Fails,
+                },
             ],
-            NetworkSegmentType::Admin,
+            // The error type (RpcDataConversionError) is not asserted by these rows,
+            // so failing rows discard it; accepting rows project to the prefix count
+            // and whether the first prefix is IPv6.
+            |request| {
+                NewNetworkSegment::try_from(request)
+                    .map(|segment| (segment.prefixes.len(), segment.prefixes[0].prefix.is_ipv6()))
+                    .map_err(drop)
+            },
         );
-        let result = NewNetworkSegment::try_from(request);
-        assert!(result.is_ok(), "Dual-stack should be accepted: {result:?}");
-        let segment = result.unwrap();
-        assert_eq!(segment.prefixes.len(), 2);
-    }
-
-    #[test]
-    fn test_ipv6_tenant_prefix_size_validation() {
-        // /64 should be allowed for tenant segments
-        let request = make_test_creation_request(
-            vec![ipv6_prefix("2001:db8::/64")],
-            NetworkSegmentType::Tenant,
-        );
-        assert!(
-            NewNetworkSegment::try_from(request).is_ok(),
-            "/64 IPv6 prefix should be allowed for tenant segments"
-        );
-
-        // /127 should be rejected for tenant segments
-        let request = make_test_creation_request(
-            vec![ipv6_prefix("2001:db8::1/127")],
-            NetworkSegmentType::Tenant,
-        );
-        assert!(
-            NewNetworkSegment::try_from(request).is_err(),
-            "/127 IPv6 prefix should be rejected for tenant segments"
-        );
-
-        // /128 should be rejected for tenant segments
-        let request = make_test_creation_request(
-            vec![ipv6_prefix("2001:db8::1/128")],
-            NetworkSegmentType::Tenant,
-        );
-        assert!(
-            NewNetworkSegment::try_from(request).is_err(),
-            "/128 IPv6 prefix should be rejected for tenant segments"
-        );
-    }
-
-    #[test]
-    fn test_ipv4_tenant_prefix_size_validation_unchanged() {
-        // /24 should be allowed
-        let request = make_test_creation_request(
-            vec![ipv4_prefix("192.0.2.0/24", Some("192.0.2.1"))],
-            NetworkSegmentType::Tenant,
-        );
-        assert!(NewNetworkSegment::try_from(request).is_ok());
-
-        // /31 should be rejected
-        let request = make_test_creation_request(
-            vec![ipv4_prefix("192.0.2.0/31", Some("192.0.2.1"))],
-            NetworkSegmentType::Tenant,
-        );
-        assert!(NewNetworkSegment::try_from(request).is_err());
-
-        // /32 should be rejected
-        let request = make_test_creation_request(
-            vec![ipv4_prefix("192.0.2.0/32", None)],
-            NetworkSegmentType::Tenant,
-        );
-        assert!(NewNetworkSegment::try_from(request).is_err());
     }
 }

--- a/crates/rpc/src/model/rack.rs
+++ b/crates/rpc/src/model/rack.rs
@@ -71,42 +71,51 @@ impl From<rpc::forge::RackSearchFilter> for RackSearchFilter {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::{Check, check_values};
+    use model::metadata::LabelFilter;
     use model::rack::{LABEL_CHASSIS_MANUFACTURER, LABEL_LOCATION_DATACENTER};
 
     use super::*;
 
+    // `RackSearchFilter::from` maps the optional proto label onto the model's
+    // optional `LabelFilter`; project to that `label` field for each input.
     #[test]
-    fn rack_search_filter_from_rpc_with_label_key_and_value() {
-        let rpc_filter = rpc::forge::RackSearchFilter {
-            label: Some(rpc::forge::Label {
-                key: LABEL_LOCATION_DATACENTER.to_string(),
-                value: Some("az01".to_string()),
-            }),
-        };
-        let filter = RackSearchFilter::from(rpc_filter);
-        let label = filter.label.unwrap();
-        assert_eq!(label.key, LABEL_LOCATION_DATACENTER);
-        assert_eq!(label.value, Some("az01".to_string()));
-    }
-
-    #[test]
-    fn rack_search_filter_from_rpc_with_label_key_only() {
-        let rpc_filter = rpc::forge::RackSearchFilter {
-            label: Some(rpc::forge::Label {
-                key: LABEL_CHASSIS_MANUFACTURER.to_string(),
-                value: None,
-            }),
-        };
-        let filter = RackSearchFilter::from(rpc_filter);
-        let label = filter.label.unwrap();
-        assert_eq!(label.key, LABEL_CHASSIS_MANUFACTURER);
-        assert!(label.value.is_none());
-    }
-
-    #[test]
-    fn rack_search_filter_from_rpc_no_label() {
-        let rpc_filter = rpc::forge::RackSearchFilter { label: None };
-        let filter = RackSearchFilter::from(rpc_filter);
-        assert!(filter.label.is_none());
+    fn rack_search_filter_from_rpc() {
+        check_values(
+            [
+                Check {
+                    scenario: "label with key and value",
+                    input: rpc::forge::RackSearchFilter {
+                        label: Some(rpc::forge::Label {
+                            key: LABEL_LOCATION_DATACENTER.to_string(),
+                            value: Some("az01".to_string()),
+                        }),
+                    },
+                    expect: Some(LabelFilter {
+                        key: LABEL_LOCATION_DATACENTER.to_string(),
+                        value: Some("az01".to_string()),
+                    }),
+                },
+                Check {
+                    scenario: "label with key only",
+                    input: rpc::forge::RackSearchFilter {
+                        label: Some(rpc::forge::Label {
+                            key: LABEL_CHASSIS_MANUFACTURER.to_string(),
+                            value: None,
+                        }),
+                    },
+                    expect: Some(LabelFilter {
+                        key: LABEL_CHASSIS_MANUFACTURER.to_string(),
+                        value: None,
+                    }),
+                },
+                Check {
+                    scenario: "no label",
+                    input: rpc::forge::RackSearchFilter { label: None },
+                    expect: None,
+                },
+            ],
+            |rpc_filter| RackSearchFilter::from(rpc_filter).label,
+        );
     }
 }

--- a/crates/rpc/src/model/rack_type.rs
+++ b/crates/rpc/src/model/rack_type.rs
@@ -182,69 +182,125 @@ impl From<&RackProfile> for rpc::forge::RackProfile {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
     // Proto conversion tests.
 
+    // Each topology round-trips: model -> proto matches the expected proto, and the
+    // proto -> model TryFrom yields the original model. The op asserts the forward
+    // direction, then yields the recovered model so the row pins both directions.
     #[test]
     fn test_rack_hardware_topology_proto_round_trip() {
-        let cases = [
-            (
-                RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
-                rpc::forge::RackHardwareTopology::Gb200Nvl36r1C2g4,
-            ),
-            (
-                RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
-                rpc::forge::RackHardwareTopology::Gb300Nvl36r1C2g4,
-            ),
-            (
-                RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
-                rpc::forge::RackHardwareTopology::Gb200Nvl72r1C2g4,
-            ),
-            (
-                RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
-                rpc::forge::RackHardwareTopology::Gb300Nvl72r1C2g4,
-            ),
-            (
-                RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
-                rpc::forge::RackHardwareTopology::VrNvl8r1C2g4Rtf,
-            ),
-            (
-                RackHardwareTopology::VrNvl72r1C2g4Topology,
-                rpc::forge::RackHardwareTopology::VrNvl72r1C2g4,
-            ),
-        ];
-        for (model, proto) in cases {
-            let converted: rpc::forge::RackHardwareTopology = model.into();
-            assert_eq!(converted, proto);
-            let back: RackHardwareTopology = proto.try_into().unwrap();
-            assert_eq!(back, model);
+        struct Row {
+            scenario: &'static str,
+            model: RackHardwareTopology,
+            proto: rpc::forge::RackHardwareTopology,
         }
+
+        check_cases(
+            [
+                Row {
+                    scenario: "gb200 nvl36",
+                    model: RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
+                    proto: rpc::forge::RackHardwareTopology::Gb200Nvl36r1C2g4,
+                },
+                Row {
+                    scenario: "gb300 nvl36",
+                    model: RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
+                    proto: rpc::forge::RackHardwareTopology::Gb300Nvl36r1C2g4,
+                },
+                Row {
+                    scenario: "gb200 nvl72",
+                    model: RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
+                    proto: rpc::forge::RackHardwareTopology::Gb200Nvl72r1C2g4,
+                },
+                Row {
+                    scenario: "gb300 nvl72",
+                    model: RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
+                    proto: rpc::forge::RackHardwareTopology::Gb300Nvl72r1C2g4,
+                },
+                Row {
+                    scenario: "vr nvl8 rtf",
+                    model: RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
+                    proto: rpc::forge::RackHardwareTopology::VrNvl8r1C2g4Rtf,
+                },
+                Row {
+                    scenario: "vr nvl72",
+                    model: RackHardwareTopology::VrNvl72r1C2g4Topology,
+                    proto: rpc::forge::RackHardwareTopology::VrNvl72r1C2g4,
+                },
+            ]
+            .map(|row| Case {
+                scenario: row.scenario,
+                input: (row.model, row.proto),
+                expect: Yields(row.model),
+            }),
+            |(model, proto)| {
+                let converted: rpc::forge::RackHardwareTopology = model.into();
+                assert_eq!(converted, proto);
+                RackHardwareTopology::try_from(proto).map_err(drop)
+            },
+        );
     }
 
+    // The Unspecified proto value has no model counterpart, so TryFrom rejects it.
     #[test]
     fn test_rack_hardware_topology_proto_unspecified_errors() {
-        let result = RackHardwareTopology::try_from(rpc::forge::RackHardwareTopology::Unspecified);
-        assert!(result.is_err());
+        Case {
+            scenario: "unspecified topology rejected",
+            input: rpc::forge::RackHardwareTopology::Unspecified,
+            expect: Fails,
+        }
+        .check(|proto| RackHardwareTopology::try_from(proto).map_err(drop));
     }
 
+    // Each class round-trips: model -> proto matches, and proto -> model recovers the
+    // original. The op asserts the forward direction, then yields the model.
     #[test]
     fn test_rack_hardware_class_proto_round_trip() {
-        let cases = [
-            (RackHardwareClass::Dev, rpc::forge::RackHardwareClass::Dev),
-            (RackHardwareClass::Prod, rpc::forge::RackHardwareClass::Prod),
-        ];
-        for (model, proto) in cases {
-            let converted: rpc::forge::RackHardwareClass = model.into();
-            assert_eq!(converted, proto);
-            let back: RackHardwareClass = proto.try_into().unwrap();
-            assert_eq!(back, model);
+        struct Row {
+            scenario: &'static str,
+            model: RackHardwareClass,
+            proto: rpc::forge::RackHardwareClass,
         }
+
+        check_cases(
+            [
+                Row {
+                    scenario: "dev",
+                    model: RackHardwareClass::Dev,
+                    proto: rpc::forge::RackHardwareClass::Dev,
+                },
+                Row {
+                    scenario: "prod",
+                    model: RackHardwareClass::Prod,
+                    proto: rpc::forge::RackHardwareClass::Prod,
+                },
+            ]
+            .map(|row| Case {
+                scenario: row.scenario,
+                input: (row.model, row.proto),
+                expect: Yields(row.model),
+            }),
+            |(model, proto)| {
+                let converted: rpc::forge::RackHardwareClass = model.into();
+                assert_eq!(converted, proto);
+                RackHardwareClass::try_from(proto).map_err(drop)
+            },
+        );
     }
 
+    // The Unspecified proto value has no model counterpart, so TryFrom rejects it.
     #[test]
     fn test_rack_hardware_class_proto_unspecified_errors() {
-        let result = RackHardwareClass::try_from(rpc::forge::RackHardwareClass::Unspecified);
-        assert!(result.is_err());
+        Case {
+            scenario: "unspecified class rejected",
+            input: rpc::forge::RackHardwareClass::Unspecified,
+            expect: Fails,
+        }
+        .check(|proto| RackHardwareClass::try_from(proto).map_err(drop));
     }
 
     #[test]

--- a/crates/rpc/src/model/redfish.rs
+++ b/crates/rpc/src/model/redfish.rs
@@ -79,35 +79,56 @@ impl From<ActionRequest> for rpc::forge::RedfishAction {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
 
+    // `From<rpc::forge::RedfishActionId>` carries the request id through.
     #[test]
     fn redfish_action_id_from_rpc() {
-        let rpc_id = rpc::forge::RedfishActionId { request_id: 42 };
-        let id = RedfishActionId::from(rpc_id);
-        assert_eq!(id.request_id, 42);
+        Check {
+            scenario: "request id passes through",
+            input: rpc::forge::RedfishActionId { request_id: 42 },
+            expect: 42,
+        }
+        .check(|id| RedfishActionId::from(id).request_id);
     }
 
+    // `From<rpc::forge::RedfishListActionsRequest>` carries the machine ip filter through.
     #[test]
     fn redfish_list_actions_filter_from_rpc() {
-        let rpc_req = rpc::forge::RedfishListActionsRequest {
-            machine_ip: Some("10.0.0.1".to_string()),
-        };
-        let filter = RedfishListActionsFilter::from(rpc_req);
-        assert_eq!(filter.machine_ip, Some("10.0.0.1".to_string()));
+        Check {
+            scenario: "machine ip passes through",
+            input: rpc::forge::RedfishListActionsRequest {
+                machine_ip: Some("10.0.0.1".to_string()),
+            },
+            expect: Some("10.0.0.1".to_string()),
+        }
+        .check(|req| RedfishListActionsFilter::from(req).machine_ip);
     }
 
+    // `From<rpc::forge::RedfishCreateActionRequest>` maps action/target/parameters across.
     #[test]
     fn redfish_create_action_from_rpc() {
-        let rpc_req = rpc::forge::RedfishCreateActionRequest {
-            ips: vec!["10.0.0.1".to_string()],
-            action: "Reset".to_string(),
-            target: "/redfish/v1/Systems/1/Actions".to_string(),
-            parameters: r#"{"ResetType":"ForceRestart"}"#.to_string(),
-        };
-        let action = RedfishCreateAction::from(rpc_req);
-        assert_eq!(action.action, "Reset");
-        assert_eq!(action.target, "/redfish/v1/Systems/1/Actions");
-        assert_eq!(action.parameters, r#"{"ResetType":"ForceRestart"}"#);
+        check_values(
+            [Check {
+                scenario: "action, target, and parameters map across",
+                input: rpc::forge::RedfishCreateActionRequest {
+                    ips: vec!["10.0.0.1".to_string()],
+                    action: "Reset".to_string(),
+                    target: "/redfish/v1/Systems/1/Actions".to_string(),
+                    parameters: r#"{"ResetType":"ForceRestart"}"#.to_string(),
+                },
+                expect: (
+                    "Reset".to_string(),
+                    "/redfish/v1/Systems/1/Actions".to_string(),
+                    r#"{"ResetType":"ForceRestart"}"#.to_string(),
+                ),
+            }],
+            |req| {
+                let action = RedfishCreateAction::from(req);
+                (action.action, action.target, action.parameters)
+            },
+        );
     }
 }

--- a/crates/rpc/src/model/tenant.rs
+++ b/crates/rpc/src/model/tenant.rs
@@ -523,62 +523,99 @@ pub fn validate_identity_overlap_for_rotation(
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
     use model::tenant::{identity_config, validate_trust_domain_allowlist_patterns};
 
     use super::*;
     use crate::forge as rpc_forge;
     use crate::forge::token_delegation_response::AuthMethodConfig;
 
-    #[test]
-    fn test_stored_to_response_auth_config_none() {
-        assert!(stored_to_response_auth_config(TokenDelegationAuthMethod::None, None).is_none());
+    /// Builds identity-config validation bounds, varying only the two fields the
+    /// per-case tables exercise (trust-domain allowlist and master key id).
+    fn identity_bounds(
+        trust_domain_allowlist: Vec<String>,
+        encryption_key_id: &str,
+    ) -> IdentityConfigValidationBounds {
+        IdentityConfigValidationBounds {
+            token_ttl_min_sec: 60,
+            token_ttl_max_sec: 86400,
+            algorithm: identity_config::SigningAlgorithm::Es256,
+            encryption_key_id: encryption_key_id.parse().unwrap(),
+            trust_domain_allowlist,
+            signing_key_overlap_max_sec: 604_800,
+        }
     }
 
-    #[test]
-    fn test_stored_to_response_auth_config_client_secret_basic() {
-        let stored = ClientSecretBasic {
-            client_id: "my-client".to_string(),
-            client_secret: "secret".to_string(),
-        };
-        let out = stored_to_response_auth_config(
-            TokenDelegationAuthMethod::ClientSecretBasic,
-            Some(stored),
-        )
-        .unwrap();
-        let AuthMethodConfig::ClientSecretBasic(c) = &out;
-        assert_eq!(c.client_id, "my-client");
-        assert!(c.client_secret_hash.starts_with("sha256:"));
-        assert!(c.client_secret_hash.ends_with(".."));
-    }
-
-    #[test]
-    fn test_stored_to_response_auth_config_omits_cleartext() {
-        let stored = ClientSecretBasic {
-            client_id: "my-client".to_string(),
-            client_secret: "secret".to_string(),
-        };
-        let out = stored_to_response_auth_config(
-            TokenDelegationAuthMethod::ClientSecretBasic,
-            Some(stored),
-        )
-        .unwrap();
-        let AuthMethodConfig::ClientSecretBasic(c) = &out;
-        assert_eq!(c.client_id, "my-client");
-        assert!(!c.client_secret_hash.is_empty());
-    }
-
-    #[test]
-    fn test_stored_to_response_auth_config_client_secret_empty_returns_none() {
-        let stored = ClientSecretBasic {
-            client_id: "x".to_string(),
-            client_secret: String::new(),
-        };
-        assert!(
-            stored_to_response_auth_config(
-                TokenDelegationAuthMethod::ClientSecretBasic,
-                Some(stored),
+    /// Projects a stored auth config to the fields the originals asserted:
+    /// the client id and three display-hash properties.
+    fn project_auth_config(out: Option<AuthMethodConfig>) -> Option<(String, bool, bool, bool)> {
+        out.map(|AuthMethodConfig::ClientSecretBasic(c)| {
+            (
+                c.client_id,
+                c.client_secret_hash.starts_with("sha256:"),
+                c.client_secret_hash.ends_with(".."),
+                !c.client_secret_hash.is_empty(),
             )
-            .is_none()
+        })
+    }
+
+    // stored_to_response_auth_config: maps stored config to the response oneof,
+    // hashing/truncating the client secret and dropping empty/None secrets.
+    #[test]
+    fn stored_to_response_auth_config_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "auth method None yields no config",
+                    input: (TokenDelegationAuthMethod::None, None),
+                    expect: None,
+                },
+                Check {
+                    scenario: "client secret basic yields truncated hash",
+                    input: (
+                        TokenDelegationAuthMethod::ClientSecretBasic,
+                        Some(ClientSecretBasic {
+                            client_id: "my-client".to_string(),
+                            client_secret: "secret".to_string(),
+                        }),
+                    ),
+                    expect: Some(("my-client".to_string(), true, true, true)),
+                },
+                Check {
+                    scenario: "empty client secret yields no config",
+                    input: (
+                        TokenDelegationAuthMethod::ClientSecretBasic,
+                        Some(ClientSecretBasic {
+                            client_id: "x".to_string(),
+                            client_secret: String::new(),
+                        }),
+                    ),
+                    expect: None,
+                },
+            ],
+            |(auth_method, stored)| {
+                project_auth_config(stored_to_response_auth_config(auth_method, stored))
+            },
+        );
+    }
+
+    // The hashed client secret in the response never exposes the cleartext.
+    #[test]
+    fn stored_to_response_auth_config_hash_omits_cleartext() {
+        let out = stored_to_response_auth_config(
+            TokenDelegationAuthMethod::ClientSecretBasic,
+            Some(ClientSecretBasic {
+                client_id: "my-client".to_string(),
+                client_secret: "secret".to_string(),
+            }),
+        )
+        .expect("client secret basic yields a config");
+        let AuthMethodConfig::ClientSecretBasic(c) = out;
+        assert!(
+            !c.client_secret_hash.contains("secret"),
+            "hash must not expose the cleartext secret: {}",
+            c.client_secret_hash
         );
     }
 
@@ -635,297 +672,196 @@ mod tests {
         assert_eq!(config.encryption_key_id.as_str(), "test-master");
     }
 
+    // identity_config_try_from_proto success: each row asserts the normalized
+    // issuer and resolved SPIFFE subject_prefix produced from the proto + bounds.
     #[test]
-    fn identity_config_try_from_proto_stores_normalized_issuer() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "HTTPS://Issuer.EXAMPLE.COM/wl".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: None,
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test-master".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let config = identity_config_try_from_proto(proto, &bounds).unwrap();
-        assert_eq!(config.issuer.as_str(), "https://issuer.example.com/wl");
-        assert_eq!(config.subject_prefix, "spiffe://issuer.example.com");
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_empty_issuer() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: String::new(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: None,
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
-        assert!(err.0.contains("issuer is required"));
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_empty_default_audience() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://issuer.example.com".to_string(),
-            default_audience: String::new(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: None,
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
-        assert!(err.0.contains("default_audience is required"));
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_accepts_custom_subject_prefix_in_proto() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://issuer.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: Some("spiffe://issuer.example.com/workloads".to_string()),
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let config = identity_config_try_from_proto(proto, &bounds).unwrap();
-        assert_eq!(
-            config.subject_prefix,
-            "spiffe://issuer.example.com/workloads"
+    fn identity_config_try_from_proto_success_cases() {
+        struct Row {
+            scenario: &'static str,
+            issuer: &'static str,
+            subject_prefix: Option<&'static str>,
+            allowlist: Vec<String>,
+            expect_issuer: &'static str,
+            expect_subject_prefix: &'static str,
+        }
+        let rows = [
+            Row {
+                scenario: "issuer is lowercased and normalized",
+                issuer: "HTTPS://Issuer.EXAMPLE.COM/wl",
+                subject_prefix: None,
+                allowlist: vec![],
+                expect_issuer: "https://issuer.example.com/wl",
+                expect_subject_prefix: "spiffe://issuer.example.com",
+            },
+            Row {
+                scenario: "custom subject_prefix in proto is honored",
+                issuer: "https://issuer.example.com",
+                subject_prefix: Some("spiffe://issuer.example.com/workloads"),
+                allowlist: vec![],
+                expect_issuer: "https://issuer.example.com",
+                expect_subject_prefix: "spiffe://issuer.example.com/workloads",
+            },
+            Row {
+                scenario: "empty optional subject_prefix defaults",
+                issuer: "https://issuer.example.com",
+                subject_prefix: Some(""),
+                allowlist: vec![],
+                expect_issuer: "https://issuer.example.com",
+                expect_subject_prefix: "spiffe://issuer.example.com",
+            },
+            Row {
+                scenario: "trust domain matching wildcard allowlist",
+                issuer: "https://auth.login.example.com",
+                subject_prefix: None,
+                allowlist: vec!["**.login.example.com".to_string()],
+                expect_issuer: "https://auth.login.example.com",
+                expect_subject_prefix: "spiffe://auth.login.example.com",
+            },
+        ];
+        check_cases(
+            rows.map(|r| Case {
+                scenario: r.scenario,
+                input: (r.issuer, r.subject_prefix, r.allowlist),
+                expect: Yields((
+                    r.expect_issuer.to_string(),
+                    r.expect_subject_prefix.to_string(),
+                )),
+            }),
+            |(issuer, subject_prefix, allowlist)| {
+                let proto = rpc_forge::TenantIdentityConfig {
+                    enabled: true,
+                    issuer: issuer.to_string(),
+                    default_audience: "api".to_string(),
+                    allowed_audiences: vec![],
+                    token_ttl_sec: 3600,
+                    subject_prefix: subject_prefix.map(|s| s.to_string()),
+                    rotate_key: false,
+                    signing_key_overlap_sec: None,
+                };
+                let bounds = identity_bounds(allowlist, "test-master");
+                let config = identity_config_try_from_proto(proto, &bounds).map_err(drop)?;
+                Ok::<_, ()>((config.issuer.as_str().to_string(), config.subject_prefix))
+            },
         );
     }
 
+    // identity_config_try_from_proto rejections: each row's error message must
+    // contain every listed substring (the user-facing validation contract).
     #[test]
-    fn identity_config_try_from_proto_empty_optional_subject_prefix_defaults() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://issuer.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: Some(String::new()),
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let config = identity_config_try_from_proto(proto, &bounds).unwrap();
-        assert_eq!(config.subject_prefix, "spiffe://issuer.example.com");
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_rejects_non_spiffe_subject_prefix() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://issuer.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: Some("https://issuer.example.com/p".to_string()),
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
-        assert!(err.0.contains("spiffe://"));
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_rejects_subject_prefix_trust_domain_mismatch() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://issuer.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: Some("spiffe://other.example/wl".to_string()),
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
-        assert!(err.0.contains("does not match"));
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_token_ttl_zero() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://issuer.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 0,
-            subject_prefix: None,
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
-        assert!(err.0.contains("token_ttl_sec"));
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_token_ttl_below_min() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://issuer.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 30,
-            subject_prefix: None,
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
-        assert!(err.0.contains("token_ttl_sec must be between"));
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_token_ttl_above_max() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://issuer.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 100000,
-            subject_prefix: None,
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
-        assert!(err.0.contains("token_ttl_sec must be between"));
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_rejects_trust_domain_not_on_allowlist() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://evil.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: None,
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec!["login.example.com".to_string()],
-            signing_key_overlap_max_sec: 604_800,
-        };
-        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
-        assert!(err.0.contains("trust domain"));
-        assert!(err.0.contains("allowlist"));
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_accepts_trust_domain_matching_allowlist() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://auth.login.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: None,
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec!["**.login.example.com".to_string()],
-            signing_key_overlap_max_sec: 604_800,
-        };
-        let config = identity_config_try_from_proto(proto, &bounds).unwrap();
-        assert_eq!(config.subject_prefix, "spiffe://auth.login.example.com");
+    fn identity_config_try_from_proto_error_cases() {
+        struct Row {
+            scenario: &'static str,
+            proto: rpc_forge::TenantIdentityConfig,
+            allowlist: Vec<String>,
+            wants: Vec<&'static str>,
+        }
+        fn proto(
+            issuer: &str,
+            default_audience: &str,
+            token_ttl_sec: u32,
+            subject_prefix: Option<&str>,
+            signing_key_overlap_sec: Option<u32>,
+        ) -> rpc_forge::TenantIdentityConfig {
+            rpc_forge::TenantIdentityConfig {
+                enabled: true,
+                issuer: issuer.to_string(),
+                default_audience: default_audience.to_string(),
+                allowed_audiences: vec![],
+                token_ttl_sec,
+                subject_prefix: subject_prefix.map(|s| s.to_string()),
+                rotate_key: false,
+                signing_key_overlap_sec,
+            }
+        }
+        let rows = [
+            Row {
+                scenario: "empty issuer",
+                proto: proto("", "api", 3600, None, None),
+                allowlist: vec![],
+                wants: vec!["issuer is required"],
+            },
+            Row {
+                scenario: "empty default_audience",
+                proto: proto("https://issuer.example.com", "", 3600, None, None),
+                allowlist: vec![],
+                wants: vec!["default_audience is required"],
+            },
+            Row {
+                scenario: "non-spiffe subject_prefix",
+                proto: proto(
+                    "https://issuer.example.com",
+                    "api",
+                    3600,
+                    Some("https://issuer.example.com/p"),
+                    None,
+                ),
+                allowlist: vec![],
+                wants: vec!["spiffe://"],
+            },
+            Row {
+                scenario: "subject_prefix trust-domain mismatch",
+                proto: proto(
+                    "https://issuer.example.com",
+                    "api",
+                    3600,
+                    Some("spiffe://other.example/wl"),
+                    None,
+                ),
+                allowlist: vec![],
+                wants: vec!["does not match"],
+            },
+            Row {
+                scenario: "token_ttl_sec zero",
+                proto: proto("https://issuer.example.com", "api", 0, None, None),
+                allowlist: vec![],
+                wants: vec!["token_ttl_sec"],
+            },
+            Row {
+                scenario: "token_ttl_sec below min",
+                proto: proto("https://issuer.example.com", "api", 30, None, None),
+                allowlist: vec![],
+                wants: vec!["token_ttl_sec must be between"],
+            },
+            Row {
+                scenario: "token_ttl_sec above max",
+                proto: proto("https://issuer.example.com", "api", 100000, None, None),
+                allowlist: vec![],
+                wants: vec!["token_ttl_sec must be between"],
+            },
+            Row {
+                scenario: "trust domain not on allowlist",
+                proto: proto("https://evil.example.com", "api", 3600, None, None),
+                allowlist: vec!["login.example.com".to_string()],
+                wants: vec!["trust domain", "allowlist"],
+            },
+            Row {
+                scenario: "no allowlist entry matches",
+                proto: proto("https://idp.other.example/", "api", 3600, None, None),
+                allowlist: vec![
+                    "login.example.com".to_string(),
+                    "*.tenant.example.net".to_string(),
+                ],
+                wants: vec!["allowlist"],
+            },
+            Row {
+                scenario: "overlap set when not rotating",
+                proto: proto("https://issuer.example.com", "api", 3600, None, Some(120)),
+                allowlist: vec![],
+                wants: vec!["signing_key_overlap_sec may only be set"],
+            },
+        ];
+        check_values(
+            rows.map(|r| Check {
+                scenario: r.scenario,
+                input: (r.proto, r.allowlist, r.wants),
+                expect: true,
+            }),
+            |(proto, allowlist, wants)| {
+                let bounds = identity_bounds(allowlist, "test");
+                let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
+                wants.iter().all(|w| err.0.contains(w))
+            },
+        );
     }
 
     #[test]
@@ -1014,163 +950,190 @@ mod tests {
         assert!(err.0.contains("signing_key_overlap_sec may only be set"));
     }
 
+    // validate_identity_overlap_for_rotation: a missing overlap and an
+    // overlap shorter than token_ttl_sec are rejected (with the listed
+    // substring); a sufficient overlap is accepted (`None` want = Ok).
     #[test]
-    fn validate_identity_overlap_requires_value_when_rotating() {
-        let config = IdentityConfig {
-            issuer: "https://issuer.example.com".parse().unwrap(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: "spiffe://issuer.example.com".to_string(),
-            enabled: true,
-            rotate_key: true,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            signing_key_overlap_sec: None,
-        };
-        let err = validate_identity_overlap_for_rotation(&config).unwrap_err();
-        assert!(err.0.contains("signing_key_overlap_sec is required"));
-    }
-
-    #[test]
-    fn validate_identity_overlap_rejects_less_than_token_ttl() {
-        let config = IdentityConfig {
-            issuer: "https://issuer.example.com".parse().unwrap(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: "spiffe://issuer.example.com".to_string(),
-            enabled: true,
-            rotate_key: true,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            signing_key_overlap_sec: Some(120),
-        };
-        let err = validate_identity_overlap_for_rotation(&config).unwrap_err();
-        assert!(
-            err.0.contains("must be at least token_ttl_sec"),
-            "unexpected: {}",
-            err.0
+    fn validate_identity_overlap_cases() {
+        fn rotating_config(signing_key_overlap_sec: Option<i32>) -> IdentityConfig {
+            IdentityConfig {
+                issuer: "https://issuer.example.com".parse().unwrap(),
+                default_audience: "api".to_string(),
+                allowed_audiences: vec![],
+                token_ttl_sec: 3600,
+                subject_prefix: "spiffe://issuer.example.com".to_string(),
+                enabled: true,
+                rotate_key: true,
+                algorithm: identity_config::SigningAlgorithm::Es256,
+                encryption_key_id: "test".parse().unwrap(),
+                signing_key_overlap_sec,
+            }
+        }
+        check_values(
+            [
+                Check {
+                    scenario: "missing overlap is rejected",
+                    input: (None, Some("signing_key_overlap_sec is required")),
+                    expect: true,
+                },
+                Check {
+                    scenario: "overlap shorter than token_ttl_sec is rejected",
+                    input: (Some(120), Some("must be at least token_ttl_sec")),
+                    expect: true,
+                },
+                Check {
+                    scenario: "overlap at least token_ttl_sec is accepted",
+                    input: (Some(3600), None),
+                    expect: true,
+                },
+            ],
+            |(overlap, want): (Option<i32>, Option<&str>)| {
+                let result = validate_identity_overlap_for_rotation(&rotating_config(overlap));
+                match want {
+                    Some(substr) => result.unwrap_err().0.contains(substr),
+                    None => result.is_ok(),
+                }
+            },
         );
     }
 
-    #[test]
-    fn validate_identity_overlap_ok_when_rotating() {
-        let config = IdentityConfig {
-            issuer: "https://issuer.example.com".parse().unwrap(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: "spiffe://issuer.example.com".to_string(),
-            enabled: true,
-            rotate_key: true,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            signing_key_overlap_sec: Some(3600),
-        };
-        validate_identity_overlap_for_rotation(&config).unwrap();
-    }
-
-    #[test]
-    fn token_delegation_try_from_success_none() {
-        let proto = rpc_forge::TokenDelegation {
-            token_endpoint: "https://auth.example.com/token".to_string(),
-            subject_token_audience: "https://api.example.com".to_string(),
-            auth_method_config: None,
-        };
-        let config = TokenDelegation::try_from(proto).unwrap();
-        assert_eq!(config.token_endpoint, "https://auth.example.com/token");
-        assert_eq!(config.subject_token_audience, "https://api.example.com");
-        matches!(
-            config.auth_method_config,
-            TokenDelegationAuthMethodConfig::None
-        );
-    }
-
-    #[test]
-    fn token_delegation_try_from_success_client_secret_basic() {
-        let proto = rpc_forge::TokenDelegation {
-            token_endpoint: "https://auth.example.com/token".to_string(),
-            subject_token_audience: "https://api.example.com".to_string(),
-            auth_method_config: Some(
-                rpc_forge::token_delegation::AuthMethodConfig::ClientSecretBasic(
-                    rpc_forge::ClientSecretBasic {
-                        client_id: "my-client".to_string(),
-                        client_secret: "my-secret".to_string(),
-                    },
-                ),
-            ),
-        };
-        let config = TokenDelegation::try_from(proto).unwrap();
-        assert_eq!(config.token_endpoint, "https://auth.example.com/token");
-        assert_eq!(config.subject_token_audience, "https://api.example.com");
-        match &config.auth_method_config {
+    /// Projects a converted `TokenDelegation` to the endpoint, audience, and the
+    /// auth-method-config fields the originals asserted.
+    #[allow(clippy::type_complexity)]
+    fn project_token_delegation(
+        config: TokenDelegation,
+    ) -> (String, String, Option<(String, String)>) {
+        let auth = match config.auth_method_config {
+            TokenDelegationAuthMethodConfig::None => None,
             TokenDelegationAuthMethodConfig::ClientSecretBasic {
                 client_id,
                 client_secret,
-            } => {
-                assert_eq!(client_id, "my-client");
-                assert_eq!(client_secret, "my-secret");
-            }
-            _ => panic!("expected ClientSecretBasic"),
+            } => Some((client_id, client_secret)),
+        };
+        (config.token_endpoint, config.subject_token_audience, auth)
+    }
+
+    // TokenDelegation::try_from success: the endpoint and audience pass through,
+    // and the auth method config maps to None or the client-secret-basic pair.
+    #[test]
+    fn token_delegation_try_from_success_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "no auth method config",
+                    input: rpc_forge::TokenDelegation {
+                        token_endpoint: "https://auth.example.com/token".to_string(),
+                        subject_token_audience: "https://api.example.com".to_string(),
+                        auth_method_config: None,
+                    },
+                    expect: Yields((
+                        "https://auth.example.com/token".to_string(),
+                        "https://api.example.com".to_string(),
+                        None,
+                    )),
+                },
+                Case {
+                    scenario: "client secret basic",
+                    input: rpc_forge::TokenDelegation {
+                        token_endpoint: "https://auth.example.com/token".to_string(),
+                        subject_token_audience: "https://api.example.com".to_string(),
+                        auth_method_config: Some(
+                            rpc_forge::token_delegation::AuthMethodConfig::ClientSecretBasic(
+                                rpc_forge::ClientSecretBasic {
+                                    client_id: "my-client".to_string(),
+                                    client_secret: "my-secret".to_string(),
+                                },
+                            ),
+                        ),
+                    },
+                    expect: Yields((
+                        "https://auth.example.com/token".to_string(),
+                        "https://api.example.com".to_string(),
+                        Some(("my-client".to_string(), "my-secret".to_string())),
+                    )),
+                },
+            ],
+            |proto| {
+                let config = TokenDelegation::try_from(proto).map_err(drop)?;
+                Ok::<_, ()>(project_token_delegation(config))
+            },
+        );
+    }
+
+    // TokenDelegation::try_from rejections: each row's error message must contain
+    // the listed substring (the user-facing validation contract).
+    #[test]
+    fn token_delegation_try_from_error_cases() {
+        fn client_secret_basic(
+            client_id: &str,
+            client_secret: &str,
+        ) -> Option<rpc_forge::token_delegation::AuthMethodConfig> {
+            Some(
+                rpc_forge::token_delegation::AuthMethodConfig::ClientSecretBasic(
+                    rpc_forge::ClientSecretBasic {
+                        client_id: client_id.to_string(),
+                        client_secret: client_secret.to_string(),
+                    },
+                ),
+            )
         }
-    }
-
-    #[test]
-    fn token_delegation_try_from_empty_token_endpoint() {
-        let proto = rpc_forge::TokenDelegation {
-            token_endpoint: String::new(),
-            subject_token_audience: "https://api.example.com".to_string(),
-            auth_method_config: None,
-        };
-        let err = TokenDelegation::try_from(proto).unwrap_err();
-        assert!(err.0.contains("token_endpoint is required"));
-    }
-
-    #[test]
-    fn token_delegation_try_from_empty_subject_token_audience() {
-        let proto = rpc_forge::TokenDelegation {
-            token_endpoint: "https://auth.example.com/token".to_string(),
-            subject_token_audience: String::new(),
-            auth_method_config: None,
-        };
-        let err = TokenDelegation::try_from(proto).unwrap_err();
-        assert!(err.0.contains("subject_token_audience is required"));
-    }
-
-    #[test]
-    fn token_delegation_try_from_empty_client_id() {
-        let proto = rpc_forge::TokenDelegation {
-            token_endpoint: "https://auth.example.com/token".to_string(),
-            subject_token_audience: "https://api.example.com".to_string(),
-            auth_method_config: Some(
-                rpc_forge::token_delegation::AuthMethodConfig::ClientSecretBasic(
-                    rpc_forge::ClientSecretBasic {
-                        client_id: String::new(),
-                        client_secret: "secret".to_string(),
-                    },
-                ),
-            ),
-        };
-        let err = TokenDelegation::try_from(proto).unwrap_err();
-        assert!(err.0.contains("client_id is required"));
-    }
-
-    #[test]
-    fn token_delegation_try_from_empty_client_secret() {
-        let proto = rpc_forge::TokenDelegation {
-            token_endpoint: "https://auth.example.com/token".to_string(),
-            subject_token_audience: "https://api.example.com".to_string(),
-            auth_method_config: Some(
-                rpc_forge::token_delegation::AuthMethodConfig::ClientSecretBasic(
-                    rpc_forge::ClientSecretBasic {
-                        client_id: "client".to_string(),
-                        client_secret: String::new(),
-                    },
-                ),
-            ),
-        };
-        let err = TokenDelegation::try_from(proto).unwrap_err();
-        assert!(err.0.contains("client_secret is required"));
+        check_values(
+            [
+                Check {
+                    scenario: "empty token_endpoint",
+                    input: (
+                        rpc_forge::TokenDelegation {
+                            token_endpoint: String::new(),
+                            subject_token_audience: "https://api.example.com".to_string(),
+                            auth_method_config: None,
+                        },
+                        "token_endpoint is required",
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "empty subject_token_audience",
+                    input: (
+                        rpc_forge::TokenDelegation {
+                            token_endpoint: "https://auth.example.com/token".to_string(),
+                            subject_token_audience: String::new(),
+                            auth_method_config: None,
+                        },
+                        "subject_token_audience is required",
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "empty client_id",
+                    input: (
+                        rpc_forge::TokenDelegation {
+                            token_endpoint: "https://auth.example.com/token".to_string(),
+                            subject_token_audience: "https://api.example.com".to_string(),
+                            auth_method_config: client_secret_basic("", "secret"),
+                        },
+                        "client_id is required",
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "empty client_secret",
+                    input: (
+                        rpc_forge::TokenDelegation {
+                            token_endpoint: "https://auth.example.com/token".to_string(),
+                            subject_token_audience: "https://api.example.com".to_string(),
+                            auth_method_config: client_secret_basic("client", ""),
+                        },
+                        "client_secret is required",
+                    ),
+                    expect: true,
+                },
+            ],
+            |(proto, want): (rpc_forge::TokenDelegation, &str)| {
+                TokenDelegation::try_from(proto)
+                    .unwrap_err()
+                    .0
+                    .contains(want)
+            },
+        );
     }
 }

--- a/crates/rpc/src/model/vpc.rs
+++ b/crates/rpc/src/model/vpc.rs
@@ -233,52 +233,70 @@ impl From<VpcPeering> for rpc::forge::VpcPeering {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
 
+    // `VpcSearchFilter::from` is a total conversion, so we project its output to
+    // the fields the originals asserted: name, tenant_org_id, and the label as its
+    // (key, value) pair (None when no label is present).
     #[test]
-    fn vpc_search_filter_from_rpc_all_fields() {
-        let rpc_filter = rpc::forge::VpcSearchFilter {
-            name: Some("my-vpc".to_string()),
-            tenant_org_id: Some("org-123".to_string()),
-            label: Some(rpc::forge::Label {
-                key: "env".to_string(),
-                value: Some("prod".to_string()),
-            }),
-        };
-        let filter = VpcSearchFilter::from(rpc_filter);
-        assert_eq!(filter.name, Some("my-vpc".to_string()));
-        assert_eq!(filter.tenant_org_id, Some("org-123".to_string()));
-        let label = filter.label.unwrap();
-        assert_eq!(label.key, "env");
-        assert_eq!(label.value, Some("prod".to_string()));
-    }
+    fn vpc_search_filter_from_rpc() {
+        type Projected = (
+            Option<String>,
+            Option<String>,
+            Option<(String, Option<String>)>,
+        );
 
-    #[test]
-    fn vpc_search_filter_from_rpc_no_fields() {
-        let rpc_filter = rpc::forge::VpcSearchFilter {
-            name: None,
-            tenant_org_id: None,
-            label: None,
-        };
-        let filter = VpcSearchFilter::from(rpc_filter);
-        assert_eq!(filter.name, None);
-        assert_eq!(filter.tenant_org_id, None);
-        assert!(filter.label.is_none());
-    }
-
-    #[test]
-    fn vpc_search_filter_from_rpc_label_key_only() {
-        let rpc_filter = rpc::forge::VpcSearchFilter {
-            name: None,
-            tenant_org_id: None,
-            label: Some(rpc::forge::Label {
-                key: "team".to_string(),
-                value: None,
-            }),
-        };
-        let filter = VpcSearchFilter::from(rpc_filter);
-        let label = filter.label.unwrap();
-        assert_eq!(label.key, "team");
-        assert_eq!(label.value, None);
+        check_values(
+            [
+                Check {
+                    scenario: "all fields populated",
+                    input: rpc::forge::VpcSearchFilter {
+                        name: Some("my-vpc".to_string()),
+                        tenant_org_id: Some("org-123".to_string()),
+                        label: Some(rpc::forge::Label {
+                            key: "env".to_string(),
+                            value: Some("prod".to_string()),
+                        }),
+                    },
+                    expect: (
+                        Some("my-vpc".to_string()),
+                        Some("org-123".to_string()),
+                        Some(("env".to_string(), Some("prod".to_string()))),
+                    ),
+                },
+                Check {
+                    scenario: "no fields",
+                    input: rpc::forge::VpcSearchFilter {
+                        name: None,
+                        tenant_org_id: None,
+                        label: None,
+                    },
+                    expect: (None, None, None),
+                },
+                Check {
+                    scenario: "label key only",
+                    input: rpc::forge::VpcSearchFilter {
+                        name: None,
+                        tenant_org_id: None,
+                        label: Some(rpc::forge::Label {
+                            key: "team".to_string(),
+                            value: None,
+                        }),
+                    },
+                    expect: (None, None, Some(("team".to_string(), None))),
+                },
+            ],
+            |rpc_filter| {
+                let filter = VpcSearchFilter::from(rpc_filter);
+                let projected: Projected = (
+                    filter.name,
+                    filter.tenant_org_id,
+                    filter.label.map(|l| (l.key, l.value)),
+                );
+                projected
+            },
+        );
     }
 }

--- a/crates/rpc/src/network.rs
+++ b/crates/rpc/src/network.rs
@@ -72,48 +72,75 @@ pub fn vpc_virtualization_type_try_from_rpc(
 #[cfg(test)]
 mod test {
     use carbide_network::virtualization::VpcVirtualizationType;
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
 
     use super::*;
 
+    // proto -> model: `From<rpc::VpcVirtualizationType>` (infallible).
     #[test]
-    fn from_rpc_etv_with_nvue_maps_to_etv() {
+    fn from_rpc_maps_to_model() {
         #[allow(deprecated)]
-        let vtype: VpcVirtualizationType =
-            rpc::VpcVirtualizationType::EthernetVirtualizerWithNvue.into();
-        assert_eq!(vtype, VpcVirtualizationType::EthernetVirtualizer);
+        check_values(
+            [
+                Check {
+                    scenario: "etv-with-nvue maps to etv",
+                    input: rpc::VpcVirtualizationType::EthernetVirtualizerWithNvue,
+                    expect: VpcVirtualizationType::EthernetVirtualizer,
+                },
+                Check {
+                    scenario: "flat round-trips to flat",
+                    input: rpc::VpcVirtualizationType::Flat,
+                    expect: VpcVirtualizationType::Flat,
+                },
+            ],
+            |v| v.into(),
+        );
     }
 
+    // model -> proto: `From<VpcVirtualizationType>` (infallible).
     #[test]
-    fn to_rpc_etv_maps_to_proto_etv() {
-        let rpc_vtype: rpc::VpcVirtualizationType =
-            VpcVirtualizationType::EthernetVirtualizer.into();
-        assert_eq!(rpc_vtype, rpc::VpcVirtualizationType::EthernetVirtualizer);
+    fn to_rpc_maps_to_proto() {
+        check_values(
+            [
+                Check {
+                    scenario: "etv maps to proto etv",
+                    input: VpcVirtualizationType::EthernetVirtualizer,
+                    expect: rpc::VpcVirtualizationType::EthernetVirtualizer,
+                },
+                Check {
+                    scenario: "flat round-trips to proto flat",
+                    input: VpcVirtualizationType::Flat,
+                    expect: rpc::VpcVirtualizationType::Flat,
+                },
+            ],
+            |v| v.into(),
+        );
     }
 
+    // proto i32 -> model: `vpc_virtualization_type_try_from_rpc` (fallible).
     #[test]
-    fn proto_value_2_maps_to_etv() {
-        // Make sure our proto From implementation turns
-        // ETHERNET_VIRTUALIZER_WITH_NVUE into EthernetVirtualizer.
-        let vtype = vpc_virtualization_type_try_from_rpc(2).unwrap();
-        assert_eq!(vtype, VpcVirtualizationType::EthernetVirtualizer);
-    }
-
-    #[test]
-    fn proto_value_0_maps_to_etv() {
-        let vtype = vpc_virtualization_type_try_from_rpc(0).unwrap();
-        assert_eq!(vtype, VpcVirtualizationType::EthernetVirtualizer);
-    }
-
-    #[test]
-    fn flat_round_trips() {
-        let rpc_vtype: rpc::VpcVirtualizationType = VpcVirtualizationType::Flat.into();
-        assert_eq!(rpc_vtype, rpc::VpcVirtualizationType::Flat);
-
-        let vtype: VpcVirtualizationType = rpc::VpcVirtualizationType::Flat.into();
-        assert_eq!(vtype, VpcVirtualizationType::Flat);
-
-        let vtype =
-            vpc_virtualization_type_try_from_rpc(rpc::VpcVirtualizationType::Flat as i32).unwrap();
-        assert_eq!(vtype, VpcVirtualizationType::Flat);
+    fn try_from_rpc_i32_maps_to_model() {
+        check_cases(
+            [
+                Case {
+                    // proto field 2, ETHERNET_VIRTUALIZER_WITH_NVUE, maps to etv.
+                    scenario: "value 2 maps to etv",
+                    input: 2,
+                    expect: Yields(VpcVirtualizationType::EthernetVirtualizer),
+                },
+                Case {
+                    scenario: "value 0 maps to etv",
+                    input: 0,
+                    expect: Yields(VpcVirtualizationType::EthernetVirtualizer),
+                },
+                Case {
+                    scenario: "flat round-trips from i32",
+                    input: rpc::VpcVirtualizationType::Flat as i32,
+                    expect: Yields(VpcVirtualizationType::Flat),
+                },
+            ],
+            |value| vpc_virtualization_type_try_from_rpc(value).map_err(drop),
+        );
     }
 }


### PR DESCRIPTION
This supports #3914.

## Description

This refactors `rpc` proto <-> model conversion tests into the new table-driven test structuring from `carbide-test-support`, allowing us to replace a bunch of copy-pasted test boilerplate with a shared table-driven framework, so the test suite is ideally easier to read, maintain, and provide a pattern to follow. This is similar to https://github.com/NVIDIA/infra-controller/pull/2498, https://github.com/NVIDIA/infra-controller/pull/2499, and https://github.com/NVIDIA/infra-controller/pull/2502.

he conversions mix fallible (`TryFrom` -> `Result`) and total (`From`, getters) ops, so the tests use `check_cases` for the former and `check_values` for the latter -- each input a labeled row, the output projected to the fields the originals asserted.

Test count goes down 34% (from 134 to 88 functions), collapsing repeated build + convert + assert boilerplate testing while preserving every original case as a row. Most of crate lives behind the `model` feature, so this is verified under --all-features.

Coverage (cargo-llvm-cov --all-features), before (origin/main) vs after.

```
  ┌──────────┬──────────────────────┬───────────────┐
  │  Metric  │ Before (origin/main) │ After (this)  │
  ├──────────┼──────────────────────┼───────────────┤
  │ Region   │ 42.88%               │ 39.80%        │
  ├──────────┼──────────────────────┼───────────────┤
  │ Function │ 28.00%               │ 28.16%        │
  ├──────────┼──────────────────────┼───────────────┤
  │ Line     │ 44.87%               │ 45.77%        │
  └──────────┴──────────────────────┴───────────────┘
```

Function and line coverage rise; region's percentage dips only because rpc's tests are in-module unit tests, which llvm-cov counts. Planning on doing follow-up PRs to increase coverage in general after these though.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->