### PR TITLE
Limit the number of resets after firmware upgrade to avoid endless loops

### DIFF
--- a/crates/api-core/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api-core/src/tests/host_bmc_firmware_test.rs
@@ -23,7 +23,9 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use carbide_machine_controller::config::{FirmwareGlobal, TimePeriod};
-use carbide_machine_controller::handler::MAX_FIRMWARE_UPGRADE_RETRIES;
+use carbide_machine_controller::handler::{
+    MAX_FIRMWARE_UPGRADE_RETRIES, MAX_NEW_FIRMWARE_REPORTED_RESET_RETRIES,
+};
 use carbide_preingestion_manager::PreingestionManager;
 use carbide_redfish::libredfish::test_support::RedfishSimAction;
 use carbide_uuid::machine::MachineId;
@@ -3373,6 +3375,100 @@ async fn put_in_waiting_for_scout_upgrade(
         .await
         .unwrap();
     txn.commit().await.unwrap();
+}
+
+async fn put_in_new_firmware_reported_wait(
+    env: &TestEnv,
+    mh: &TestManagedHost,
+    previous_reset_time: i64,
+    reset_retry_count: u32,
+) {
+    let mut txn = env.pool.begin().await.unwrap();
+    let machine = mh.host().db_machine(&mut txn).await;
+    let state = ManagedHostState::HostReprovision {
+        reprovision_state: HostReprovisionState::NewFirmwareReportedWait {
+            firmware_type: FirmwareComponentType::Uefi,
+            firmware_number: Some(0),
+            final_version: "1.13.2".to_string(),
+            previous_reset_time: Some(previous_reset_time),
+            reset_retry_count,
+        },
+        retry_count: 0,
+    };
+    db::machine::advance(&machine, &mut txn, &state, None)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+}
+
+#[crate::sqlx_test]
+async fn test_new_firmware_reported_wait_retries_reset_after_timeout(
+    pool: sqlx::PgPool,
+) -> CarbideResult<()> {
+    let env = create_test_env(pool).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+    put_in_new_firmware_reported_wait(&env, &mh, chrono::Utc::now().timestamp() - 31 * 60, 0).await;
+
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    let ManagedHostState::HostReprovision {
+        reprovision_state, ..
+    } = host.current_state()
+    else {
+        panic!("Not in HostReprovision");
+    };
+    let HostReprovisionState::NewFirmwareReportedWait {
+        reset_retry_count, ..
+    } = reprovision_state
+    else {
+        panic!("expected NewFirmwareReportedWait, got {reprovision_state:?}");
+    };
+    assert_eq!(*reset_retry_count, 1);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_new_firmware_reported_wait_fails_after_reset_retry_limit(
+    pool: sqlx::PgPool,
+) -> CarbideResult<()> {
+    let env = create_test_env(pool).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+    put_in_new_firmware_reported_wait(
+        &env,
+        &mh,
+        chrono::Utc::now().timestamp() - 31 * 60,
+        MAX_NEW_FIRMWARE_REPORTED_RESET_RETRIES,
+    )
+    .await;
+
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    let host = mh.host().db_machine(&mut txn).await;
+    let ManagedHostState::HostReprovision {
+        reprovision_state, ..
+    } = host.current_state()
+    else {
+        panic!("Not in HostReprovision");
+    };
+    let HostReprovisionState::FailedFirmwareUpgrade { reason, .. } = reprovision_state else {
+        panic!("expected FailedFirmwareUpgrade, got {reprovision_state:?}");
+    };
+    let reason = reason.as_deref().unwrap_or_default();
+    assert!(
+        reason.contains("Firmware version did not converge after completed update"),
+        "unexpected reason: {reason}",
+    );
+    assert!(
+        reason.contains("expected 1.13.2"),
+        "unexpected reason: {reason}",
+    );
+    assert!(reason.contains("1.12.0"), "unexpected reason: {reason}",);
+
+    Ok(())
 }
 
 #[crate::sqlx_test]

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1482,12 +1482,16 @@ pub enum HostReprovisionState {
         power_drains_needed: Option<u32>,
         delay_until: Option<i64>,
         last_power_drain_operation: Option<PowerDrainState>,
+        #[serde(default)]
+        reset_retry_count: u32,
     },
     NewFirmwareReportedWait {
         final_version: String,
         firmware_type: FirmwareComponentType,
         firmware_number: Option<u32>,
         previous_reset_time: Option<i64>,
+        #[serde(default)]
+        reset_retry_count: u32,
     },
     FailedFirmwareUpgrade {
         firmware_type: FirmwareComponentType,

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -143,6 +143,12 @@ pub const MAX_FIRMWARE_UPGRADE_RETRIES: u32 = 5;
 #[cfg(test)]
 pub const MAX_FIRMWARE_UPGRADE_RETRIES: u32 = 2; // Faster for tests
 
+#[cfg(not(test))]
+pub const MAX_NEW_FIRMWARE_REPORTED_RESET_RETRIES: u32 = 5;
+
+#[cfg(test)]
+pub const MAX_NEW_FIRMWARE_REPORTED_RESET_RETRIES: u32 = 2; // Faster for tests
+
 // Compute the API-side deadline for a scout firmware upgrade from scout's
 // timeout envelope: fixed script download timeout, script execution timeout,
 // one artifact download timeout per file artifact, and report/slack time.
@@ -7146,6 +7152,7 @@ impl HostUpgradeState {
                             power_drains_needed: *power_drains_needed,
                             delay_until: None,
                             last_power_drain_operation: None,
+                            reset_retry_count: 0,
                         };
                         Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                             next_reprov_state,
@@ -8224,6 +8231,7 @@ impl HostUpgradeState {
                             power_drains_needed: *power_drains_needed,
                             delay_until: None,
                             last_power_drain_operation: None,
+                            reset_retry_count: 0,
                         };
                         Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                             reprovision_state,
@@ -8353,6 +8361,7 @@ impl HostUpgradeState {
             power_drains_needed,
             delay_until,
             last_power_drain_operation,
+            reset_retry_count,
         ) = match details {
             HostReprovisionState::ResetForNewFirmware {
                 final_version,
@@ -8361,6 +8370,7 @@ impl HostUpgradeState {
                 power_drains_needed,
                 delay_until,
                 last_power_drain_operation,
+                reset_retry_count,
             } => (
                 final_version,
                 firmware_type,
@@ -8368,6 +8378,7 @@ impl HostUpgradeState {
                 power_drains_needed,
                 delay_until,
                 last_power_drain_operation,
+                reset_retry_count,
             ),
             _ => {
                 return Err(StateHandlerError::GenericError(eyre!(
@@ -8416,6 +8427,7 @@ impl HostUpgradeState {
                             power_drains_needed: Some(*power_drains_needed),
                             delay_until: Some(chrono::Utc::now().timestamp() + delay),
                             last_power_drain_operation: Some(PowerDrainState::Off),
+                            reset_retry_count: *reset_retry_count,
                         };
                         return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                             reprovision_state,
@@ -8436,6 +8448,7 @@ impl HostUpgradeState {
                         power_drains_needed: Some(*power_drains_needed),
                         delay_until: Some(chrono::Utc::now().timestamp() + delay),
                         last_power_drain_operation: Some(PowerDrainState::Powercycle),
+                        reset_retry_count: *reset_retry_count,
                     };
                     return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                         reprovision_state,
@@ -8454,6 +8467,7 @@ impl HostUpgradeState {
                         power_drains_needed: Some(power_drains_needed - 1),
                         delay_until: Some(chrono::Utc::now().timestamp() + delay),
                         last_power_drain_operation: Some(PowerDrainState::On),
+                        reset_retry_count: *reset_retry_count,
                     };
                     return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
                         reprovision_state,
@@ -8523,6 +8537,7 @@ impl HostUpgradeState {
             firmware_number: *firmware_number,
             final_version: final_version.to_string(),
             previous_reset_time: Some(Utc::now().timestamp()),
+            reset_retry_count: *reset_retry_count,
         };
         Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
             reprovision_state,
@@ -8538,24 +8553,27 @@ impl HostUpgradeState {
         machine_id: &MachineId,
         scenario: HostFirmwareScenario,
     ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-        let (final_version, firmware_type, firmware_number, previous_reset_time) = match details {
-            HostReprovisionState::NewFirmwareReportedWait {
-                final_version,
-                firmware_type,
-                firmware_number,
-                previous_reset_time,
-            } => (
-                final_version,
-                firmware_type,
-                firmware_number,
-                previous_reset_time,
-            ),
-            _ => {
-                return Err(StateHandlerError::GenericError(eyre!(
-                    "Wrong enum in host_new_firmware_reported_wait"
-                )));
-            }
-        };
+        let (final_version, firmware_type, firmware_number, previous_reset_time, reset_retry_count) =
+            match details {
+                HostReprovisionState::NewFirmwareReportedWait {
+                    final_version,
+                    firmware_type,
+                    firmware_number,
+                    previous_reset_time,
+                    reset_retry_count,
+                } => (
+                    final_version,
+                    firmware_type,
+                    firmware_number,
+                    previous_reset_time,
+                    reset_retry_count,
+                ),
+                _ => {
+                    return Err(StateHandlerError::GenericError(eyre!(
+                        "Wrong enum in host_new_firmware_reported_wait"
+                    )));
+                }
+            };
 
         let Some(endpoint) = find_explored_refreshed_endpoint(state, machine_id, ctx).await? else {
             tracing::debug!("Waiting for site explorer to revisit {machine_id}");
@@ -8613,6 +8631,21 @@ impl HostUpgradeState {
                 && let Some(previous_reset_time) = previous_reset_time
                 && previous_reset_time + 30 * 60 <= Utc::now().timestamp()
             {
+                if *reset_retry_count >= MAX_NEW_FIRMWARE_REPORTED_RESET_RETRIES {
+                    let reason = format!(
+                        "Firmware version did not converge after completed update for {firmware_type}: expected {final_version}, found {current_versions:?} after {reset_retry_count} reset retries"
+                    );
+                    tracing::warn!(%machine_id, "{reason}");
+                    return Ok(StateHandlerOutcome::transition(scenario.actual_new_state(
+                        HostReprovisionState::FailedFirmwareUpgrade {
+                            firmware_type: *firmware_type,
+                            report_time: Some(Utc::now()),
+                            reason: Some(reason),
+                        },
+                        state.managed_state.get_host_repro_retry_count(),
+                    )));
+                }
+
                 tracing::info!(
                     "Upgrade for {} {:?} has taken more than 30 minutes to report new version; resetting again.",
                     &endpoint.address,
@@ -8625,6 +8658,7 @@ impl HostUpgradeState {
                     power_drains_needed: None,
                     delay_until: None,
                     last_power_drain_operation: None,
+                    reset_retry_count: *reset_retry_count + 1,
                 };
                 return self
                     .host_reset_for_new_firmware(state, ctx, machine_id, details, scenario)


### PR DESCRIPTION
## Description
Sometimes machines can get stuck in an endless loop of resets. These changes limit the number of resets so that a machine moves to a failed state if it retried enough times.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
