### PR TITLE
fix: don't request re-exploration after preingestion BMC reset

### DIFF
--- a/crates/preingestion-manager/src/lib.rs
+++ b/crates/preingestion-manager/src/lib.rs
@@ -1425,21 +1425,16 @@ impl PreingestionManagerStatic {
                 };
                 match redfish_client.get_service_root().await {
                     Ok(_) => {
-                        // BMC is back. Force a fresh exploration and wait for it
-                        // before running checks, so pairing/ingestion reads the
-                        // post-reset inventory (e.g. a DPU that reappeared), not the
-                        // stale pre-reset report.
+                        // BMC is back. Wait for a fresh exploration before running
+                        // checks, so pairing/ingestion reads the post-reset
+                        // inventory (e.g. a DPU that reappeared), not the stale
+                        // pre-reset report.
                         let address = endpoint.address;
                         db.with_txn(|txn| {
                             async move {
                                 db::explored_endpoints::set_preingestion_initial_bmc_reset(
                                     address,
                                     InitialBmcResetPhase::WaitForExplorerRefresh,
-                                    txn,
-                                )
-                                .await?;
-                                db::explored_endpoints::request_exploration_for_addresses(
-                                    &[address],
                                     txn,
                                 )
                                 .await?;


### PR DESCRIPTION
## Description
In the `InitialBMCReset` phase, we no longer set `exploration_requested` once the BMC returns. We keep `waiting_for_explorer_refresh` and let site explorer's regular interval refresh re-read the BMC. This is needed since `exploration_requested` bypasses the per-run exploration budget. During bulk ingestion, hundreds of BMCs finishing this reset at once would all get explored within a single site-explorer iteration and create a thundering herd.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

