### PR TITLE
fix(admin-cli): work with API servers that predate renamed health RPCs

### DIFF
--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -57,6 +57,23 @@ use crate::machine::MachineAutoupdate;
 #[derive(Clone)]
 pub struct ApiClient(pub ForgeApiClient);
 
+/// Returns `True` when `status` *can* mean the server does not implement
+/// the requested RPC, telling the caller to retry through the deprecated alias.
+///
+/// API servers that predate a renamed RPC answer it in one of two ways:
+///
+/// - `Unimplemented`, when the request reaches the gRPC router.
+/// - A bare HTTP 403 with no `grpc-status` trailer, when `carbide-api` RBAC
+///   rules reject a method name missing from its permission table (which
+///   happens before the gRPC router is even consulted). tonic maps that 403 to
+///   `PermissionDenied` on the client.
+fn maybe_unimplemented(status: &tonic::Status) -> bool {
+    matches!(
+        status.code(),
+        tonic::Code::Unimplemented | tonic::Code::PermissionDenied
+    )
+}
+
 // Note: You do *not* need to add every gRPC method to this wrapper. Callers can use `.0` to get
 // access to the underlying ForgeApiClient, if they want to simply call the gRPC methods themselves.
 // Add methods here if there's some value to it, like constructing rpc request objects from simpler
@@ -483,7 +500,7 @@ impl ApiClient {
         };
         match self.0.insert_machine_health_report(request.clone()).await {
             Ok(()) => Ok(()),
-            Err(status) if status.code() == tonic::Code::Unimplemented => {
+            Err(status) if maybe_unimplemented(&status) => {
                 // Fall back to the deprecated alias for older API servers
                 // that don't have the renamed RPC yet.
                 #[allow(deprecated)]
@@ -499,7 +516,7 @@ impl ApiClient {
     ) -> CarbideCliResult<rpc::ListHealthReportResponse> {
         match self.0.list_machine_health_reports(machine_id).await {
             Ok(response) => Ok(response),
-            Err(status) if status.code() == tonic::Code::Unimplemented => {
+            Err(status) if maybe_unimplemented(&status) => {
                 // Fall back to the deprecated alias for older API servers.
                 #[allow(deprecated)]
                 Ok(self.0.list_health_report_overrides(machine_id).await?)
@@ -519,7 +536,7 @@ impl ApiClient {
         };
         match self.0.remove_machine_health_report(request.clone()).await {
             Ok(()) => Ok(()),
-            Err(status) if status.code() == tonic::Code::Unimplemented => {
+            Err(status) if maybe_unimplemented(&status) => {
                 // Fall back to the deprecated alias for older API servers.
                 #[allow(deprecated)]
                 Ok(self.0.remove_health_report_override(request).await?)
@@ -558,7 +575,7 @@ impl ApiClient {
         let endpoint_ids = match self.0.find_explored_endpoint_ids().await {
             Ok(endpoint_ids) => endpoint_ids,
             Err(status) => {
-                return if status.code() == tonic::Code::Unimplemented {
+                return if maybe_unimplemented(&status) {
                     Ok(self.0.get_site_exploration_report().await?)
                 } else {
                     Err(status.into())
@@ -598,7 +615,7 @@ impl ApiClient {
     ) -> CarbideCliResult<Vec<::rpc::site_explorer::ExploredManagedHost>> {
         let host_ids = match self.0.find_explored_managed_host_ids().await {
             Ok(host_ids) => host_ids,
-            Err(status) if status.code() == tonic::Code::Unimplemented => {
+            Err(status) if maybe_unimplemented(&status) => {
                 let hosts = self.0.get_site_exploration_report().await?.managed_hosts;
                 return Ok(hosts);
             }
@@ -2322,5 +2339,38 @@ impl ApiClient {
     pub async fn get_dpf_service_versions(&self) -> CarbideCliResult<Vec<rpc::DpfServiceVersion>> {
         let response = self.0.get_dpf_service_versions().await?;
         Ok(response.services)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::maybe_unimplemented;
+
+    /// `PermissionDenied` must trigger the deprecated-alias fallback: servers
+    /// that predate a renamed RPC reject its unknown method name with a bare
+    /// HTTP 403 based on our internal RBAC rules, which tonic surfaces as
+    /// `PermissionDenied` rather than `Unimplemented`.
+    #[test]
+    fn maybe_unimplemented_accepts_both_unknown_rpc_signals() {
+        assert!(maybe_unimplemented(&tonic::Status::unimplemented("")));
+        assert!(maybe_unimplemented(&tonic::Status::permission_denied("")));
+    }
+
+    #[test]
+    fn maybe_unimplemented_rejects_other_errors() {
+        for status in [
+            tonic::Status::not_found(""),
+            tonic::Status::unavailable(""),
+            tonic::Status::internal(""),
+            tonic::Status::invalid_argument(""),
+            tonic::Status::unauthenticated(""),
+            tonic::Status::failed_precondition(""),
+        ] {
+            assert!(
+                !maybe_unimplemented(&status),
+                "{:?} must not trigger the deprecated-alias fallback",
+                status.code()
+            );
+        }
     }
 }


### PR DESCRIPTION
## Description

This supports https://github.com/NVIDIA/infra-controller/issues/2512 and https://github.com/NVIDIA/infra-controller/issues/995.

An older `carbide-api` answers a renamed RPC with `Unimplemented`, BUT, its RBAC layer rejects the unknown method name first, as a bare HTTP 403 that tonic reports as `PermissionDenied`; our deprecated-alias fallbacks need to be updated to treat that rejection as cue to retry the old name.

All five fallback sites now share one helper, `maybe_unimplemented`, that recognizes both signals.

Generally speaking:
  - This restores `machine health-report add/show/remove` (plus the `dpu` equivalents and `dpu/host reprovision set`, which insert health reports) against API servers older than the health-report rename (#1214).
  - The `site-explorer get-report` fallbacks to the deprecated aggregate report RPC had the same gap and get the same fix.
  - Current servers keep serving the deprecated aliases with unchanged permissions, so the retry path stays valid until the aliases are removed.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

