### PR TITLE
chore: default to RMS as the backend for component manager

### DIFF
--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -544,8 +544,19 @@ pub async fn start_api(
                 Some(cm)
             }
             Err(e) => {
-                tracing::warn!(
-                    "Failed to build component managers, component manager RPCs will be unavailable: {e}"
+                // The nv-switch, power-shelf, and compute-tray backends are
+                // currently required fields, so they are initialized all-or-
+                // nothing: if any one backend fails to build (for example,
+                // compute_tray_backend defaults to 'rms' but no RMS client is
+                // configured), the other two are discarded as well and the
+                // entire component manager is left uninitialized. All component
+                // manager RPCs (switch, power-shelf, and compute-tray) will be
+                // unavailable until the [component_manager] config is fixed.
+                // TODO: make the three backends individually optional so a bad
+                // config for one backend does not disable the others.
+                tracing::error!(
+                    "Component manager NOT initialized; failed to build one of the \
+                     nv-switch / power-shelf / compute-tray backends: {e}"
                 );
                 None
             }

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -1232,8 +1232,8 @@ pub async fn create_test_env_with_overrides(
     let rms_sim = Arc::new(RmsSim::default());
     let test_component_manager = component_manager::component_manager::build_component_manager(
         &component_manager::config::ComponentManagerConfig {
-            nv_switch_backend: "rms".into(),
-            power_shelf_backend: "rms".into(),
+            nv_switch_backend: component_manager::nv_switch_manager::Backend::Rms,
+            power_shelf_backend: component_manager::power_shelf_manager::Backend::Rms,
             compute_tray_backend: component_manager::compute_tray_manager::Backend::Mock,
             nv_switch_use_state_controller: true,
             ..Default::default()

--- a/crates/api-core/src/tests/power_shelf_state_controller/error_state.rs
+++ b/crates/api-core/src/tests/power_shelf_state_controller/error_state.rs
@@ -44,8 +44,8 @@ async fn services(
     env: &crate::tests::common::api_fixtures::TestEnv,
 ) -> PowerShelfStateHandlerServices {
     let config = component_manager::config::ComponentManagerConfig {
-        nv_switch_backend: "mock".into(),
-        power_shelf_backend: "rms".into(),
+        nv_switch_backend: component_manager::nv_switch_manager::Backend::Mock,
+        power_shelf_backend: component_manager::power_shelf_manager::Backend::Rms,
         compute_tray_backend: component_manager::compute_tray_manager::Backend::Mock,
         ..Default::default()
     };

--- a/crates/api-core/src/tests/power_shelf_state_controller/maintenance.rs
+++ b/crates/api-core/src/tests/power_shelf_state_controller/maintenance.rs
@@ -45,8 +45,10 @@ use carbide_secrets::credentials::Credentials;
 use carbide_secrets::test_support::credentials::TestCredentialManager;
 use carbide_uuid::power_shelf::PowerShelfId;
 use carbide_uuid::rack::RackId;
-use component_manager::compute_tray_manager::Backend;
+use component_manager::compute_tray_manager::Backend as ComputeBackend;
 use component_manager::config::ComponentManagerConfig;
+use component_manager::nv_switch_manager::Backend as NvSwitchBackend;
+use component_manager::power_shelf_manager::Backend as PowerShelfBackend;
 use db::{expected_power_shelf as db_expected_power_shelf, power_shelf as db_power_shelf};
 use librms::protos::rack_manager as rms;
 use mac_address::MacAddress;
@@ -89,13 +91,13 @@ async fn build_test_component_manager(
     rms_client: Option<Arc<dyn librms::RmsApi>>,
 ) -> Option<Arc<component_manager::component_manager::ComponentManager>> {
     let config = ComponentManagerConfig {
-        nv_switch_backend: "mock".into(),
+        nv_switch_backend: NvSwitchBackend::Mock,
         power_shelf_backend: if rms_client.is_some() {
-            "rms".into()
+            PowerShelfBackend::Rms
         } else {
-            "mock".into()
+            PowerShelfBackend::Mock
         },
-        compute_tray_backend: Backend::Mock,
+        compute_tray_backend: ComputeBackend::Mock,
         ..Default::default()
     };
     component_manager::component_manager::build_component_manager(

--- a/crates/api-core/src/tests/switch_state_controller/mod.rs
+++ b/crates/api-core/src/tests/switch_state_controller/mod.rs
@@ -22,8 +22,10 @@ use carbide_secrets::test_support::credentials::TestCredentialManager;
 use carbide_switch_controller::context::SwitchStateHandlerServices;
 use carbide_switch_controller::handler::SwitchStateHandler;
 use carbide_switch_controller::io::SwitchStateControllerIO;
-use component_manager::compute_tray_manager::Backend;
+use component_manager::compute_tray_manager::Backend as ComputeBackend;
 use component_manager::config::ComponentManagerConfig;
+use component_manager::nv_switch_manager::Backend as NvSwitchBackend;
+use component_manager::power_shelf_manager::Backend as PowerShelfBackend;
 use db::switch as db_switch;
 use model::switch::{ConfiguringState, SwitchControllerState};
 use rpc::forge::forge_server::Forge;
@@ -44,12 +46,12 @@ async fn build_test_component_manager(
 ) -> Option<Arc<component_manager::component_manager::ComponentManager>> {
     let config = ComponentManagerConfig {
         nv_switch_backend: if rms_client.is_some() {
-            "rms".into()
+            NvSwitchBackend::Rms
         } else {
-            "mock".into()
+            NvSwitchBackend::Mock
         },
-        power_shelf_backend: "mock".into(),
-        compute_tray_backend: Backend::Mock,
+        power_shelf_backend: PowerShelfBackend::Mock,
+        compute_tray_backend: ComputeBackend::Mock,
         nv_switch_use_state_controller: true,
         ..Default::default()
     };

--- a/crates/component-manager/src/component_manager.rs
+++ b/crates/component-manager/src/component_manager.rs
@@ -7,11 +7,11 @@ use carbide_redfish::libredfish::RedfishClientPool;
 use librms::RmsApi;
 use sqlx::PgPool;
 
-use crate::compute_tray_manager::{Backend, ComputeTrayManager};
+use crate::compute_tray_manager::{Backend as ComputeBackend, ComputeTrayManager};
 use crate::config::ComponentManagerConfig;
 use crate::error::ComponentManagerError;
-use crate::nv_switch_manager::NvSwitchManager;
-use crate::power_shelf_manager::PowerShelfManager;
+use crate::nv_switch_manager::{Backend as NvSwitchBackend, NvSwitchManager};
+use crate::power_shelf_manager::{Backend as PowerShelfBackend, PowerShelfManager};
 use crate::rms::RmsSwitchSystemImageStatusApi;
 
 /// Holds the configured backend implementations for each component type.
@@ -61,7 +61,7 @@ impl ComponentManager {
 ///
 /// The factory inspects `config.nv_switch_backend` and `config.power_shelf_backend`
 /// to decide which concrete implementation to instantiate. Unknown backend names
-/// return an error.
+/// are rejected at config-deserialization time by the backend enums.
 pub async fn build_component_manager(
     config: &ComponentManagerConfig,
     rms_client: Option<Arc<dyn RmsApi>>,
@@ -69,8 +69,8 @@ pub async fn build_component_manager(
     db: Option<PgPool>,
     redfish_pool: Option<Arc<dyn RedfishClientPool>>,
 ) -> Result<ComponentManager, ComponentManagerError> {
-    let nv_switch: Arc<dyn NvSwitchManager> = match config.nv_switch_backend.as_str() {
-        crate::nsm::NsmSwitchBackend::BACKEND_NAME => {
+    let nv_switch: Arc<dyn NvSwitchManager> = match config.nv_switch_backend {
+        NvSwitchBackend::Nsm => {
             let endpoint = config.nsm.as_ref().ok_or_else(|| {
                 ComponentManagerError::InvalidArgument(
                     "nv_switch_backend is 'nsm' but [component_manager.nsm] config is missing"
@@ -81,7 +81,7 @@ pub async fn build_component_manager(
                 crate::nsm::NsmSwitchBackend::connect(&endpoint.url, endpoint.tls.as_ref()).await?,
             )
         }
-        "rms" => {
+        NvSwitchBackend::Rms => {
             let client = rms_client.clone().ok_or_else(|| {
                 ComponentManagerError::InvalidArgument(
                     "nv_switch_backend is 'rms' but RMS client is not configured".into(),
@@ -98,16 +98,11 @@ pub async fn build_component_manager(
                 db,
             ))
         }
-        "mock" => Arc::new(crate::mock::MockNvSwitchManager),
-        other => {
-            return Err(ComponentManagerError::InvalidArgument(format!(
-                "unknown nv_switch_backend: {other}"
-            )));
-        }
+        NvSwitchBackend::Mock => Arc::new(crate::mock::MockNvSwitchManager),
     };
 
-    let power_shelf: Arc<dyn PowerShelfManager> = match config.power_shelf_backend.as_str() {
-        "psm" => {
+    let power_shelf: Arc<dyn PowerShelfManager> = match config.power_shelf_backend {
+        PowerShelfBackend::Psm => {
             let endpoint = config.psm.as_ref().ok_or_else(|| {
                 ComponentManagerError::InvalidArgument(
                     "power_shelf_backend is 'psm' but [component_manager.psm] config is missing"
@@ -119,7 +114,7 @@ pub async fn build_component_manager(
                     .await?,
             )
         }
-        "rms" => {
+        PowerShelfBackend::Rms => {
             let client = rms_client.clone().ok_or_else(|| {
                 ComponentManagerError::InvalidArgument(
                     "power_shelf_backend is 'rms' but RMS client is not configured".into(),
@@ -136,16 +131,11 @@ pub async fn build_component_manager(
                 db,
             ))
         }
-        "mock" => Arc::new(crate::mock::MockPowerShelfManager),
-        other => {
-            return Err(ComponentManagerError::InvalidArgument(format!(
-                "unknown power_shelf_backend: {other}"
-            )));
-        }
+        PowerShelfBackend::Mock => Arc::new(crate::mock::MockPowerShelfManager),
     };
 
     let compute_tray: Arc<dyn ComputeTrayManager> = match config.compute_tray_backend {
-        Backend::Rms => {
+        ComputeBackend::Rms => {
             let client = rms_client.clone().ok_or_else(|| {
                 ComponentManagerError::InvalidArgument(
                     "compute_tray_backend is 'rms' but RMS client is not configured".into(),
@@ -162,7 +152,7 @@ pub async fn build_component_manager(
                 db,
             ))
         }
-        Backend::Core => {
+        ComputeBackend::Core => {
             let pool = redfish_pool.ok_or_else(|| {
                 ComponentManagerError::InvalidArgument(
                     "compute_tray_backend is 'core' but Redfish client pool is not configured"
@@ -173,7 +163,7 @@ pub async fn build_component_manager(
                 pool,
             ))
         }
-        Backend::Mock => Arc::new(crate::mock::MockComputeTrayManager),
+        ComputeBackend::Mock => Arc::new(crate::mock::MockComputeTrayManager),
     };
 
     Ok(ComponentManager::new(
@@ -194,9 +184,9 @@ mod tests {
     #[tokio::test]
     async fn build_with_mock_backends() {
         let config = ComponentManagerConfig {
-            nv_switch_backend: "mock".into(),
-            power_shelf_backend: "mock".into(),
-            compute_tray_backend: Backend::Mock,
+            nv_switch_backend: NvSwitchBackend::Mock,
+            power_shelf_backend: PowerShelfBackend::Mock,
+            compute_tray_backend: ComputeBackend::Mock,
             ..Default::default()
         };
         let cm = build_component_manager(&config, None, None, None, None)
@@ -207,44 +197,26 @@ mod tests {
         assert_eq!(cm.compute_tray.name(), "mock-ctm");
     }
 
-    #[tokio::test]
-    async fn build_rejects_unknown_nv_switch_backend() {
-        let config = ComponentManagerConfig {
-            nv_switch_backend: "bogus".into(),
-            power_shelf_backend: "mock".into(),
-            compute_tray_backend: Backend::Mock,
-            ..Default::default()
-        };
-        let err = build_component_manager(&config, None, None, None, None)
-            .await
-            .unwrap_err();
-        assert!(
-            matches!(err, ComponentManagerError::InvalidArgument(msg) if msg.contains("bogus"))
-        );
-    }
+    #[test]
+    fn deserialize_rejects_unknown_backend_names() {
+        use serde::Deserialize;
+        use serde::de::IntoDeserializer;
+        use serde::de::value::{Error as DeError, StrDeserializer};
 
-    #[tokio::test]
-    async fn build_rejects_unknown_power_shelf_backend() {
-        let config = ComponentManagerConfig {
-            nv_switch_backend: "mock".into(),
-            power_shelf_backend: "bogus".into(),
-            compute_tray_backend: Backend::Mock,
-            ..Default::default()
-        };
-        let err = build_component_manager(&config, None, None, None, None)
-            .await
-            .unwrap_err();
-        assert!(
-            matches!(err, ComponentManagerError::InvalidArgument(msg) if msg.contains("bogus"))
-        );
+        let de: StrDeserializer<DeError> = "bogus".into_deserializer();
+        assert!(NvSwitchBackend::deserialize(de).is_err());
+        let de: StrDeserializer<DeError> = "bogus".into_deserializer();
+        assert!(PowerShelfBackend::deserialize(de).is_err());
+        let de: StrDeserializer<DeError> = "bogus".into_deserializer();
+        assert!(ComputeBackend::deserialize(de).is_err());
     }
 
     #[tokio::test]
     async fn build_nsm_without_config_returns_error() {
         let config = ComponentManagerConfig {
-            nv_switch_backend: "nsm".into(),
-            power_shelf_backend: "mock".into(),
-            compute_tray_backend: Backend::Mock,
+            nv_switch_backend: NvSwitchBackend::Nsm,
+            power_shelf_backend: PowerShelfBackend::Mock,
+            compute_tray_backend: ComputeBackend::Mock,
             ..Default::default()
         };
         let err = build_component_manager(&config, None, None, None, None)
@@ -256,14 +228,38 @@ mod tests {
     #[tokio::test]
     async fn build_psm_without_config_returns_error() {
         let config = ComponentManagerConfig {
-            nv_switch_backend: "mock".into(),
-            power_shelf_backend: "psm".into(),
-            compute_tray_backend: Backend::Mock,
+            nv_switch_backend: NvSwitchBackend::Mock,
+            power_shelf_backend: PowerShelfBackend::Psm,
+            compute_tray_backend: ComputeBackend::Mock,
             ..Default::default()
         };
         let err = build_component_manager(&config, None, None, None, None)
             .await
             .unwrap_err();
         assert!(matches!(err, ComponentManagerError::InvalidArgument(_)));
+    }
+
+    // A config that explicitly selects working switch/power-shelf backends but
+    // leaves `compute_tray_backend` at its default (now `Rms`) must not be able
+    // to silently come up half-configured: the RMS compute-tray arm fails when
+    // no RMS client is wired, and that error aborts the whole build via `?`,
+    // discarding the already-built switch/power-shelf backends. `setup.rs` then
+    // disables the component manager entirely. This pins that behavior so the
+    // default flip to RMS is a deliberate, visible choice.
+    #[tokio::test]
+    async fn rms_compute_tray_default_without_rms_client_fails_whole_build() {
+        let config = ComponentManagerConfig {
+            nv_switch_backend: NvSwitchBackend::Mock,
+            power_shelf_backend: PowerShelfBackend::Mock,
+            // compute_tray_backend intentionally left at its default.
+            ..Default::default()
+        };
+        assert_eq!(config.compute_tray_backend, ComputeBackend::Rms);
+
+        let err = build_component_manager(&config, None, None, None, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ComponentManagerError::InvalidArgument(msg)
+                if msg.contains("compute_tray_backend is 'rms'")));
     }
 }

--- a/crates/component-manager/src/compute_tray_manager.rs
+++ b/crates/component-manager/src/compute_tray_manager.rs
@@ -55,8 +55,8 @@ pub struct ComputeTrayFirmwareUpdateStatus {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Backend {
-    #[default]
     Core,
+    #[default]
     Rms,
     Mock,
 }

--- a/crates/component-manager/src/config.rs
+++ b/crates/component-manager/src/config.rs
@@ -3,16 +3,18 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::compute_tray_manager::Backend;
+use crate::compute_tray_manager::Backend as ComputeBackend;
+use crate::nv_switch_manager::Backend as NvSwitchBackend;
+use crate::power_shelf_manager::Backend as PowerShelfBackend;
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct ComponentManagerConfig {
-    #[serde(default = "default_nsm_backend")]
-    pub nv_switch_backend: String,
-    #[serde(default = "default_psm_backend")]
-    pub power_shelf_backend: String,
     #[serde(default)]
-    pub compute_tray_backend: Backend,
+    pub nv_switch_backend: NvSwitchBackend,
+    #[serde(default)]
+    pub power_shelf_backend: PowerShelfBackend,
+    #[serde(default)]
+    pub compute_tray_backend: ComputeBackend,
 
     #[serde(default)]
     pub nsm: Option<BackendEndpointConfig>,
@@ -104,32 +106,17 @@ impl BackendTlsConfig {
     }
 }
 
-fn default_nsm_backend() -> String {
-    "nsm".into()
-}
-
-fn default_psm_backend() -> String {
-    "psm".into()
-}
-
-impl Default for ComponentManagerConfig {
-    fn default() -> Self {
-        Self {
-            nv_switch_backend: default_nsm_backend(),
-            power_shelf_backend: default_psm_backend(),
-            compute_tray_backend: Backend::default(),
-            nsm: None,
-            psm: None,
-            nv_switch_use_state_controller: false,
-            power_shelf_use_state_controller: false,
-            compute_tray_use_state_controller: false,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_backends_are_rms() {
+        let cfg = ComponentManagerConfig::default();
+        assert_eq!(cfg.nv_switch_backend, NvSwitchBackend::Rms);
+        assert_eq!(cfg.power_shelf_backend, PowerShelfBackend::Rms);
+        assert_eq!(cfg.compute_tray_backend, ComputeBackend::Rms);
+    }
 
     fn tls_config(
         cert_dir: Option<&str>,

--- a/crates/component-manager/src/nv_switch_manager.rs
+++ b/crates/component-manager/src/nv_switch_manager.rs
@@ -11,6 +11,26 @@ use model::component_manager::{FirmwareState, NvSwitchComponent, PowerAction};
 use crate::error::ComponentManagerError;
 use crate::types::FirmwareUpdateOptions;
 
+/// Selects which `NvSwitchManager` backend is used
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Backend {
+    Nsm,
+    #[default]
+    Rms,
+    Mock,
+}
+
+impl std::fmt::Display for Backend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Nsm => f.write_str("nsm"),
+            Self::Rms => f.write_str("rms"),
+            Self::Mock => f.write_str("mock"),
+        }
+    }
+}
+
 /// Physical network identifiers for an NV-Switch, used to register with and
 /// operate against the backend service (NSM).
 #[derive(Debug, Clone)]

--- a/crates/component-manager/src/power_shelf_manager.rs
+++ b/crates/component-manager/src/power_shelf_manager.rs
@@ -11,6 +11,26 @@ use model::component_manager::{FirmwareState, PowerAction, PowerShelfComponent};
 use crate::error::ComponentManagerError;
 use crate::types::FirmwareUpdateOptions;
 
+/// Selects which `PowerShelfManager` backend is used
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Backend {
+    Psm,
+    #[default]
+    Rms,
+    Mock,
+}
+
+impl std::fmt::Display for Backend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Psm => f.write_str("psm"),
+            Self::Rms => f.write_str("rms"),
+            Self::Mock => f.write_str("mock"),
+        }
+    }
+}
+
 /// Physical network identifiers for a power shelf, used to register with and
 /// operate against the backend service (PSM).
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Description

chore: default to RMS as the backend for component manager

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

