### PR TITLE
test(host-support): fold tests onto carbide-test-support + enumerate cases to raise coverage

### DIFF
--- a/crates/host-support/Cargo.toml
+++ b/crates/host-support/Cargo.toml
@@ -67,6 +67,7 @@ x509-parser = { workspace = true }
 serde_with = { workspace = true }
 
 [dev-dependencies]
+carbide-test-support = { path = "../test-support" }
 rcgen = { workspace = true }
 tempfile = { workspace = true }
 

--- a/crates/host-support/src/agent_config.rs
+++ b/crates/host-support/src/agent_config.rs
@@ -463,183 +463,274 @@ impl Default for IterationTime {
 mod tests {
     use std::fs;
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
     const TEST_DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/test");
 
-    #[test]
-    fn machine_identity_config_validate_accepts_defaults() {
-        assert!(MachineIdentityConfig::default().validate().is_ok());
+    /// PEM file that ships in-tree and parses to at least one certificate.
+    const VALID_PEM_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../dev/certs/forge_root.pem"
+    );
+
+    // Convenience: a `MachineIdentityConfig` with all numeric fields at defaults
+    // and the two proxy options threaded through.
+    fn mid(
+        requests_per_second: u8,
+        burst: u8,
+        wait_timeout_secs: u8,
+        sign_timeout_secs: u8,
+        sign_proxy_url: Option<&str>,
+        sign_proxy_tls_root_ca: Option<&str>,
+    ) -> MachineIdentityConfig {
+        MachineIdentityConfig {
+            requests_per_second,
+            burst,
+            wait_timeout_secs,
+            sign_timeout_secs,
+            sign_proxy_url: sign_proxy_url.map(ToString::to_string),
+            sign_proxy_tls_root_ca: sign_proxy_tls_root_ca.map(ToString::to_string),
+        }
     }
 
+    // `MachineIdentityConfig::validate` — one row per branch/boundary. The
+    // operation returns `Result<(), String>`; rows whose exact message is part
+    // of the contract use `FailsWith`, the rest assert only Ok-vs-Err.
     #[test]
-    fn machine_identity_config_validate_rejects_rps_out_of_range() {
-        let c = MachineIdentityConfig {
-            requests_per_second: 0,
-            ..Default::default()
-        };
-        assert!(c.validate().is_err());
-        let c = MachineIdentityConfig {
-            requests_per_second: 21,
-            ..Default::default()
-        };
-        assert!(c.validate().is_err());
-    }
-
-    #[test]
-    fn machine_identity_config_validate_rejects_burst_out_of_range() {
-        let c = MachineIdentityConfig {
-            burst: 0,
-            ..Default::default()
-        };
-        assert!(c.validate().is_err());
-        let c = MachineIdentityConfig {
-            burst: 41,
-            ..Default::default()
-        };
-        assert!(c.validate().is_err());
-    }
-
-    #[test]
-    fn machine_identity_config_validate_accepts_boundary_values() {
-        let c = MachineIdentityConfig {
-            requests_per_second: 20,
-            burst: 40,
-            wait_timeout_secs: 10,
-            sign_timeout_secs: 1,
-            ..Default::default()
-        };
-        assert!(c.validate().is_ok());
-        let c = MachineIdentityConfig {
-            sign_timeout_secs: 60,
-            ..c
-        };
-        assert!(c.validate().is_ok());
-    }
-
-    #[test]
-    fn machine_identity_config_validate_rejects_sign_timeout_out_of_range() {
-        let c = MachineIdentityConfig {
-            sign_timeout_secs: 0,
-            ..Default::default()
-        };
-        assert!(c.validate().is_err());
-        let c = MachineIdentityConfig {
-            sign_timeout_secs: 61,
-            ..Default::default()
-        };
-        assert!(c.validate().is_err());
-    }
-
-    #[test]
-    fn machine_identity_config_validate_accepts_sign_proxy_url() {
-        let c = MachineIdentityConfig {
-            sign_proxy_url: Some("https://idp.example.com/prefix".to_string()),
-            ..Default::default()
-        };
-        assert!(c.validate().is_ok());
-    }
-
-    #[test]
-    fn machine_identity_config_validate_rejects_sign_proxy_url_whitespace_only() {
-        let c = MachineIdentityConfig {
-            sign_proxy_url: Some("   ".to_string()),
-            ..Default::default()
-        };
-        assert!(c.validate().is_err());
-    }
-
-    #[test]
-    fn machine_identity_config_validate_rejects_sign_proxy_url_scheme() {
-        let c = MachineIdentityConfig {
-            sign_proxy_url: Some("ftp://x".to_string()),
-            ..Default::default()
-        };
-        assert!(c.validate().is_err());
-    }
-
-    #[test]
-    fn machine_identity_config_validate_rejects_sign_proxy_tls_root_ca_without_url() {
-        let c = MachineIdentityConfig {
-            sign_proxy_tls_root_ca: Some("/etc/forge/sign_proxy_ca.pem".to_string()),
-            ..Default::default()
-        };
-        let err = c.validate().unwrap_err();
-        assert!(err.contains("sign-proxy-url"));
-    }
-
-    #[test]
-    fn machine_identity_config_validate_rejects_sign_proxy_tls_root_ca_whitespace_only() {
-        let c = MachineIdentityConfig {
-            sign_proxy_url: Some("https://x.example".to_string()),
-            sign_proxy_tls_root_ca: Some("  \t  ".to_string()),
-            ..Default::default()
-        };
-        assert!(c.validate().is_err());
-    }
-
-    #[test]
-    fn machine_identity_config_validate_accepts_sign_proxy_tls_root_ca_with_pem_file() {
-        let pem_path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../dev/certs/forge_root.pem"
+    fn machine_identity_config_validate() {
+        let d = MachineIdentityConfig::default();
+        check_cases(
+            [
+                // ----- accepts -----
+                Case {
+                    scenario: "defaults are valid",
+                    input: MachineIdentityConfig::default(),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "all-min boundary",
+                    input: mid(1, 1, 1, 1, None, None),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "all-max boundary (sign-timeout low end)",
+                    input: mid(20, 40, 10, 1, None, None),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "sign-timeout at max",
+                    input: mid(20, 40, 10, 60, None, None),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "https sign-proxy-url accepted",
+                    input: mid(3, 8, 2, 5, Some("https://idp.example.com/prefix"), None),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "http sign-proxy-url accepted",
+                    input: mid(3, 8, 2, 5, Some("http://idp.example.com"), None),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "tls-root-ca with valid pem and url accepted",
+                    input: mid(
+                        3,
+                        8,
+                        2,
+                        5,
+                        Some("https://sign-proxy.example"),
+                        Some(VALID_PEM_PATH),
+                    ),
+                    expect: Yields(()),
+                },
+                // ----- requests-per-second range -----
+                Case {
+                    scenario: "rps below min (0)",
+                    input: mid(0, 8, 2, 5, None, None),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "rps above max (21)",
+                    input: mid(21, 8, 2, 5, None, None),
+                    expect: Fails,
+                },
+                // ----- burst range -----
+                Case {
+                    scenario: "burst below min (0)",
+                    input: mid(3, 0, 2, 5, None, None),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "burst above max (41)",
+                    input: mid(3, 41, 2, 5, None, None),
+                    expect: Fails,
+                },
+                // ----- wait-timeout range -----
+                Case {
+                    scenario: "wait-timeout below min (0)",
+                    input: mid(3, 8, 0, 5, None, None),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wait-timeout above max (11)",
+                    input: mid(3, 8, 11, 5, None, None),
+                    expect: Fails,
+                },
+                // ----- sign-timeout range -----
+                Case {
+                    scenario: "sign-timeout below min (0)",
+                    input: mid(3, 8, 2, 0, None, None),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "sign-timeout above max (61)",
+                    input: mid(3, 8, 2, 61, None, None),
+                    expect: Fails,
+                },
+                // ----- sign-proxy-url -----
+                Case {
+                    scenario: "sign-proxy-url whitespace-only rejected",
+                    input: mid(3, 8, 2, 5, Some("   "), None),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "sign-proxy-url empty rejected",
+                    input: mid(3, 8, 2, 5, Some(""), None),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "sign-proxy-url unsupported scheme rejected",
+                    input: mid(3, 8, 2, 5, Some("ftp://x"), None),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "sign-proxy-url unparseable rejected",
+                    input: mid(3, 8, 2, 5, Some("not a url"), None),
+                    expect: Fails,
+                },
+                // ----- sign-proxy-tls-root-ca -----
+                Case {
+                    scenario: "tls-root-ca without url rejected (exact message mentions sign-proxy-url)",
+                    input: mid(3, 8, 2, 5, None, Some("/etc/forge/sign_proxy_ca.pem")),
+                    expect: FailsWith(
+                        "machine-identity.sign-proxy-tls-root-ca: requires machine-identity.sign-proxy-url"
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "tls-root-ca whitespace-only rejected",
+                    input: mid(3, 8, 2, 5, Some("https://x.example"), Some("  \t  ")),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "tls-root-ca empty rejected",
+                    input: mid(3, 8, 2, 5, Some("https://x.example"), Some("")),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "tls-root-ca path that does not exist rejected",
+                    input: mid(
+                        3,
+                        8,
+                        2,
+                        5,
+                        Some("https://x.example"),
+                        Some("/nonexistent/path/to/ca.pem"),
+                    ),
+                    expect: Fails,
+                },
+            ],
+            |c| c.validate(),
         );
-        let c = MachineIdentityConfig {
-            sign_proxy_url: Some("https://sign-proxy.example".to_string()),
-            sign_proxy_tls_root_ca: Some(pem_path.to_string()),
-            ..Default::default()
-        };
-        assert!(c.validate().is_ok());
+        // `d` proves the default is reusable / unmodified by the table above.
+        assert!(d.validate().is_ok());
     }
 
+    // `validate` rejects a tls-root-ca file whose contents are not a certificate.
+    // Kept out of the table because it needs a runtime-created temp file.
     #[test]
-    fn machine_identity_config_validate_rejects_sign_proxy_tls_root_ca_invalid_pem() {
-        let mut f = tempfile::NamedTempFile::new().unwrap();
+    fn machine_identity_config_validate_rejects_invalid_pem_contents() {
         use std::io::Write;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
         f.write_all(b"not a certificate").unwrap();
-        let c = MachineIdentityConfig {
-            sign_proxy_url: Some("https://x".to_string()),
-            sign_proxy_tls_root_ca: Some(f.path().to_string_lossy().into_owned()),
-            ..Default::default()
-        };
+        let c = mid(
+            3,
+            8,
+            2,
+            5,
+            Some("https://x"),
+            Some(&f.path().to_string_lossy()),
+        );
         assert!(c.validate().is_err());
     }
 
+    // `validate` rejects a tls-root-ca file that exists but is empty.
     #[test]
-    fn machine_identity_config_validate_rejects_wait_timeout_out_of_range() {
-        let c = MachineIdentityConfig {
-            wait_timeout_secs: 0,
-            ..Default::default()
-        };
-        assert!(c.validate().is_err());
-        let c = MachineIdentityConfig {
-            wait_timeout_secs: 11,
-            ..Default::default()
-        };
+    fn machine_identity_config_validate_rejects_empty_pem_file() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+        let c = mid(
+            3,
+            8,
+            2,
+            5,
+            Some("https://x"),
+            Some(&f.path().to_string_lossy()),
+        );
         assert!(c.validate().is_err());
     }
 
+    // `is_default` predicates (total ops).
     #[test]
-    // Load up the input, which is a minimum barebones
-    // config, and then dump it back out to a string,
-    // which should then have defaults set (and match
-    // the expected output config).
-    fn test_load_forge_agent_config_defaults() {
-        let input_config: AgentConfig = toml::from_str(
-            fs::read_to_string(format!("{TEST_DATA_DIR}/min_agent_config/input.toml"))
-                .unwrap()
-                .as_str(),
-        )
-        .unwrap();
-        let observed_output = toml::to_string(&input_config).unwrap();
-        let expected_output =
-            fs::read_to_string(format!("{TEST_DATA_DIR}/min_agent_config/output.toml")).unwrap();
-        assert_eq!(observed_output, expected_output);
+    fn config_is_default_predicates() {
+        check_values(
+            [
+                Check {
+                    scenario: "machine-identity default is default",
+                    input: MachineIdentityConfig::default(),
+                    expect: true,
+                },
+                Check {
+                    scenario: "machine-identity with changed rps is not default",
+                    input: mid(7, 8, 2, 5, None, None),
+                    expect: false,
+                },
+                Check {
+                    scenario: "machine-identity with proxy url is not default",
+                    input: mid(3, 8, 2, 5, Some("https://x"), None),
+                    expect: false,
+                },
+            ],
+            |c| c.is_default(),
+        );
+
+        check_values(
+            [
+                Check {
+                    scenario: "update default is default",
+                    input: UpdateConfig::default(),
+                    expect: true,
+                },
+                Check {
+                    scenario: "update with override cmd is not default",
+                    input: UpdateConfig {
+                        override_upgrade_cmd: Some("update".to_string()),
+                    },
+                    expect: false,
+                },
+            ],
+            |c| c.is_default(),
+        );
     }
 
+    // TOML deserialization of `AgentConfig`: well-formed inputs parse, malformed
+    // ones fail. The operation is `toml::from_str::<AgentConfig>` (fallible).
     #[test]
-    fn test_load_forge_agent_config_full() {
-        let config = r#"[forge-system]
+    fn agent_config_from_toml() {
+        const FULL: &str = r#"[forge-system]
 api-server = "https://127.0.0.1:1234"
 root-ca = "/opt/forge/forge_root.pem"
 
@@ -673,30 +764,15 @@ override-upgrade-cmd = "update"
 addresses = ["168.254.169.254/30"]
 "#;
 
-        let config: AgentConfig = toml::from_str(config).unwrap();
+        const MIN_NO_SERVICES: &str = "[forge-system]
+api-server = \"https://127.0.0.1:1234\"
+root-ca = \"/opt/forge/forge_root.pem\"
 
-        assert_eq!(config.forge_system.api_server, "https://127.0.0.1:1234");
-        assert_eq!(
-            config.machine.interface_id,
-            Some(uuid::uuid!("91609f10-c91d-470d-a260-6293ea0c1200"))
-        );
-        assert!(config.machine.is_fake_dpu);
+[machine]
+interface-id = \"91609f10-c91d-470d-a260-6293ea0c1200\"
+";
 
-        assert_eq!(config.metadata_service.address, "0.0.0.0:7777");
-        assert_eq!(config.telemetry.metrics_address, "0.0.0.0:8888");
-
-        assert_eq!(config.hbn.root_dir, PathBuf::from("/tmp/hbn-root"));
-        assert!(config.hbn.skip_reload);
-
-        assert_eq!(
-            config.updates.override_upgrade_cmd,
-            Some("update".to_string())
-        );
-    }
-
-    #[test]
-    fn test_load_forge_agent_config_machine_identity_section() {
-        let raw = r#"[forge-system]
+        const MID_SECTION: &str = r#"[forge-system]
 api-server = "https://127.0.0.1:1234"
 root-ca = "/opt/forge/forge_root.pem"
 
@@ -710,44 +786,362 @@ wait-timeout-secs = 4
 sign-timeout-secs = 9
 "#;
 
-        let config: AgentConfig = toml::from_str(raw).unwrap();
-
-        assert_eq!(config.machine_identity.requests_per_second, 7);
-        assert_eq!(config.machine_identity.burst, 12);
-        assert_eq!(config.machine_identity.wait_timeout_secs, 4);
-        assert_eq!(config.machine_identity.sign_timeout_secs, 9);
-        assert!(config.machine_identity.sign_proxy_url.is_none());
-        assert!(config.machine_identity.sign_proxy_tls_root_ca.is_none());
-
-        config.machine_identity.validate().unwrap();
+        check_cases(
+            [
+                Case {
+                    scenario: "full config parses",
+                    input: FULL,
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "minimal config without optional service sections parses",
+                    input: MIN_NO_SERVICES,
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "machine-identity section parses",
+                    input: MID_SECTION,
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "completely empty config is rejected (a required field is missing)",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown top-level key is rejected (deny_unknown_fields)",
+                    input: "totally-unknown-key = 5\n",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "interface-id not a uuid fails",
+                    input: "[machine]\ninterface-id = \"not-a-uuid\"\n",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "machine-identity rps wrong type fails",
+                    input: "[machine-identity]\nrequests-per-second = \"seven\"\n",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "rps that overflows u8 fails",
+                    input: "[machine-identity]\nrequests-per-second = 999\n",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "syntactically invalid toml fails",
+                    input: "this is not = = toml",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "fmds addresses with bad cidr fails",
+                    input: "[fmds-armos-networking.config]\naddresses = [\"not-a-cidr\"]\n",
+                    expect: Fails,
+                },
+            ],
+            |raw| toml::from_str::<AgentConfig>(raw).map(drop).map_err(drop),
+        );
     }
 
+    // Field-level assertions on the FULL parse: each original `assert_eq!` becomes
+    // a `Yields(true)` row over a derived boolean, so one parse covers them all.
     #[test]
-    fn test_load_forge_agent_config_without_services() {
-        let config = "[forge-system]
+    fn agent_config_full_fields() {
+        const FULL: &str = r#"[forge-system]
+api-server = "https://127.0.0.1:1234"
+root-ca = "/opt/forge/forge_root.pem"
+
+[machine]
+is-fake-dpu = true
+interface-id = "91609f10-c91d-470d-a260-6293ea0c1200"
+
+[metadata-service]
+address = "0.0.0.0:7777"
+
+[telemetry]
+metrics-address = "0.0.0.0:8888"
+
+[hbn]
+root-dir = "/tmp/hbn-root"
+skip-reload = true
+
+[period]
+main-loop-active-secs = 10
+main-loop-idle-secs = 30
+network-config-fetch-secs = 20
+version-check-secs = 600
+inventory-update-secs = 3600
+discovery-retry-secs = 1
+discovery-retries-max = 1000
+
+[updates]
+override-upgrade-cmd = "update"
+
+[fmds-armos-networking.config]
+addresses = ["168.254.169.254/30"]
+"#;
+        let c: AgentConfig = toml::from_str(FULL).unwrap();
+        let expected_id = uuid::uuid!("91609f10-c91d-470d-a260-6293ea0c1200");
+
+        check_values(
+            [
+                Check {
+                    scenario: "api-server",
+                    input: c.forge_system.api_server == "https://127.0.0.1:1234",
+                    expect: true,
+                },
+                Check {
+                    scenario: "interface-id",
+                    input: c.machine.interface_id == Some(expected_id),
+                    expect: true,
+                },
+                Check {
+                    scenario: "is-fake-dpu",
+                    input: c.machine.is_fake_dpu,
+                    expect: true,
+                },
+                Check {
+                    scenario: "metadata-service address",
+                    input: c.metadata_service.address == "0.0.0.0:7777",
+                    expect: true,
+                },
+                Check {
+                    scenario: "telemetry metrics-address",
+                    input: c.telemetry.metrics_address == "0.0.0.0:8888",
+                    expect: true,
+                },
+                Check {
+                    scenario: "hbn root-dir",
+                    input: c.hbn.root_dir == Path::new("/tmp/hbn-root"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "hbn skip-reload",
+                    input: c.hbn.skip_reload,
+                    expect: true,
+                },
+                Check {
+                    scenario: "updates override-upgrade-cmd",
+                    input: c.updates.override_upgrade_cmd == Some("update".to_string()),
+                    expect: true,
+                },
+            ],
+            |b| b,
+        );
+    }
+
+    // The machine-identity section parse yields exactly the supplied values, and
+    // the proxy options remain unset.
+    #[test]
+    fn agent_config_machine_identity_fields() {
+        const MID_SECTION: &str = r#"[forge-system]
+api-server = "https://127.0.0.1:1234"
+root-ca = "/opt/forge/forge_root.pem"
+
+[machine]
+interface-id = "91609f10-c91d-470d-a260-6293ea0c1200"
+
+[machine-identity]
+requests-per-second = 7
+burst = 12
+wait-timeout-secs = 4
+sign-timeout-secs = 9
+"#;
+        let c: AgentConfig = toml::from_str(MID_SECTION).unwrap();
+        let m = &c.machine_identity;
+
+        check_values(
+            [
+                Check {
+                    scenario: "requests-per-second",
+                    input: m.requests_per_second == 7,
+                    expect: true,
+                },
+                Check {
+                    scenario: "burst",
+                    input: m.burst == 12,
+                    expect: true,
+                },
+                Check {
+                    scenario: "wait-timeout-secs",
+                    input: m.wait_timeout_secs == 4,
+                    expect: true,
+                },
+                Check {
+                    scenario: "sign-timeout-secs",
+                    input: m.sign_timeout_secs == 9,
+                    expect: true,
+                },
+                Check {
+                    scenario: "sign-proxy-url unset",
+                    input: m.sign_proxy_url.is_none(),
+                    expect: true,
+                },
+                Check {
+                    scenario: "sign-proxy-tls-root-ca unset",
+                    input: m.sign_proxy_tls_root_ca.is_none(),
+                    expect: true,
+                },
+            ],
+            |b| b,
+        );
+
+        // The parsed section validates.
+        c.machine_identity.validate().unwrap();
+    }
+
+    // The minimal (no optional service sections) parse defaults every omitted
+    // section, and validates.
+    #[test]
+    fn agent_config_minimal_defaults() {
+        const MIN_NO_SERVICES: &str = "[forge-system]
 api-server = \"https://127.0.0.1:1234\"
 root-ca = \"/opt/forge/forge_root.pem\"
 
 [machine]
 interface-id = \"91609f10-c91d-470d-a260-6293ea0c1200\"
 ";
+        let c: AgentConfig = toml::from_str(MIN_NO_SERVICES).unwrap();
+        let expected_id = uuid::uuid!("91609f10-c91d-470d-a260-6293ea0c1200");
 
-        let config: AgentConfig = toml::from_str(config).unwrap();
-
-        assert_eq!(config.forge_system.api_server, "https://127.0.0.1:1234");
-        assert_eq!(
-            config.machine.interface_id,
-            Some(uuid::uuid!("91609f10-c91d-470d-a260-6293ea0c1200"))
+        check_values(
+            [
+                Check {
+                    scenario: "api-server preserved",
+                    input: c.forge_system.api_server == "https://127.0.0.1:1234",
+                    expect: true,
+                },
+                Check {
+                    scenario: "interface-id preserved",
+                    input: c.machine.interface_id == Some(expected_id),
+                    expect: true,
+                },
+                Check {
+                    scenario: "is-fake-dpu defaults false",
+                    input: c.machine.is_fake_dpu,
+                    expect: false,
+                },
+                Check {
+                    scenario: "metadata-service defaults",
+                    input: c.metadata_service == MetadataServiceConfig::default(),
+                    expect: true,
+                },
+                Check {
+                    scenario: "telemetry defaults",
+                    input: c.telemetry == TelemetryConfig::default(),
+                    expect: true,
+                },
+                Check {
+                    scenario: "machine-identity defaults",
+                    input: c.machine_identity == MachineIdentityConfig::default(),
+                    expect: true,
+                },
+                Check {
+                    scenario: "hbn root-dir defaults",
+                    input: c.hbn.root_dir == Path::new(HBN_DEFAULT_ROOT),
+                    expect: true,
+                },
+                Check {
+                    scenario: "hbn skip-reload defaults false",
+                    input: c.hbn.skip_reload,
+                    expect: false,
+                },
+                Check {
+                    scenario: "updates override-upgrade-cmd defaults unset",
+                    input: c.updates.override_upgrade_cmd.is_none(),
+                    expect: true,
+                },
+            ],
+            |b| b,
         );
-        assert!(!config.machine.is_fake_dpu);
+    }
 
-        assert_eq!(config.metadata_service, MetadataServiceConfig::default());
-        assert_eq!(config.telemetry, TelemetryConfig::default());
-        assert_eq!(config.machine_identity, MachineIdentityConfig::default());
+    // Default constructors expose the documented default values.
+    #[test]
+    fn config_defaults() {
+        check_values(
+            [
+                Check {
+                    scenario: "forge-system api-server",
+                    input: ForgeSystemConfig::default().api_server == DEFAULT_API_SERVER,
+                    expect: true,
+                },
+                Check {
+                    scenario: "metadata-service address",
+                    input: MetadataServiceConfig::default().address
+                        == INSTANCE_METADATA_SERVICE_ADDRESS,
+                    expect: true,
+                },
+                Check {
+                    scenario: "telemetry metrics-address",
+                    input: TelemetryConfig::default().metrics_address
+                        == TELEMETRY_METRICS_SERVICE_ADDRESS,
+                    expect: true,
+                },
+                Check {
+                    scenario: "hbn root-dir",
+                    input: HBNConfig::default().root_dir == Path::new(HBN_DEFAULT_ROOT),
+                    expect: true,
+                },
+                Check {
+                    scenario: "hbn skip-reload",
+                    input: HBNConfig::default().skip_reload,
+                    expect: false,
+                },
+                Check {
+                    scenario: "machine-identity requests-per-second",
+                    input: MachineIdentityConfig::default().requests_per_second
+                        == REQUESTS_PER_SECOND,
+                    expect: true,
+                },
+                Check {
+                    scenario: "machine-identity burst",
+                    input: MachineIdentityConfig::default().burst == BURST,
+                    expect: true,
+                },
+                Check {
+                    scenario: "machine-identity wait-timeout-secs",
+                    input: MachineIdentityConfig::default().wait_timeout_secs == WAIT_TIMEOUT_SECS,
+                    expect: true,
+                },
+                Check {
+                    scenario: "machine-identity sign-timeout-secs",
+                    input: MachineIdentityConfig::default().sign_timeout_secs == SIGN_TIMEOUT_SECS,
+                    expect: true,
+                },
+                Check {
+                    scenario: "iteration-time inventory-update-secs",
+                    input: IterationTime::default().inventory_update_secs == 3600,
+                    expect: true,
+                },
+                Check {
+                    scenario: "iteration-time discovery-retry-secs",
+                    input: IterationTime::default().discovery_retry_secs == 60,
+                    expect: true,
+                },
+                Check {
+                    scenario: "iteration-time discovery-retries-max",
+                    input: IterationTime::default().discovery_retries_max == 10080,
+                    expect: true,
+                },
+            ],
+            |b| b,
+        );
+    }
 
-        assert_eq!(config.hbn.root_dir, PathBuf::from(HBN_DEFAULT_ROOT));
-        assert!(!config.hbn.skip_reload);
-
-        assert!(config.updates.override_upgrade_cmd.is_none());
+    // Load the barebones config and round-trip it back out; the dumped string
+    // (with defaults filled in) must match the recorded expected output.
+    #[test]
+    fn test_load_forge_agent_config_defaults() {
+        let input_config: AgentConfig = toml::from_str(
+            fs::read_to_string(format!("{TEST_DATA_DIR}/min_agent_config/input.toml"))
+                .unwrap()
+                .as_str(),
+        )
+        .unwrap();
+        let observed_output = toml::to_string(&input_config).unwrap();
+        let expected_output =
+            fs::read_to_string(format!("{TEST_DATA_DIR}/min_agent_config/output.toml")).unwrap();
+        assert_eq!(observed_output, expected_output);
     }
 }

--- a/crates/host-support/src/dpa_cmds.rs
+++ b/crates/host-support/src/dpa_cmds.rs
@@ -152,41 +152,320 @@ impl TryFrom<&fac::MlxDeviceAction> for DpaCommand<'static> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+    use rpc::protos::mlx_device::{
+        FirmwareFlasherProfile as FirmwareProfilePb, FirmwareSpec as FirmwareSpecPb,
+        FlashSpec as FlashSpecPb, SerializableMlxConfigProfile as SerializableProfilePb,
+    };
+
     use super::*;
 
-    #[test]
-    fn dpa_device_command_converts_to_rpc_lock_action() {
-        let action: fac::MlxDeviceAction = DpaDeviceCommand {
-            pci_name: "04:00.0".to_string(),
-            command: DpaCommand {
-                op: OpCode::Lock {
-                    key: "secret".to_string(),
-                },
-            },
+    // A short, observable discriminant for an `OpCode`, so conversions whose output
+    // types aren't `PartialEq` can still be asserted by table. Carries the key for
+    // Lock/Unlock so those rows can pin the round-tripped value.
+    fn op_tag(op: &OpCode<'_>) -> String {
+        match op {
+            OpCode::Noop => "noop".to_string(),
+            OpCode::Lock { key } => format!("lock:{key}"),
+            OpCode::Unlock { key } => format!("unlock:{key}"),
+            OpCode::ApplyProfile { serialized_profile } => {
+                format!("apply_profile:{}", serialized_profile.is_some())
+            }
+            OpCode::ApplyFirmware { profile } => {
+                format!("apply_firmware:{}", profile.is_some())
+            }
         }
-        .try_into()
-        .unwrap();
-
-        assert_eq!(action.pci_name, "04:00.0");
-        assert!(matches!(
-            action.command,
-            Some(fac::mlx_device_action::Command::Lock(fac::MlxDeviceLock { key }))
-                if key == "secret"
-        ));
     }
 
-    #[test]
-    fn rpc_unlock_action_converts_to_dpa_command() {
-        let action = fac::MlxDeviceAction {
-            pci_name: "04:00.0".to_string(),
-            command: Some(fac::mlx_device_action::Command::Unlock(
-                fac::MlxDeviceUnlock {
-                    key: "secret".to_string(),
-                },
-            )),
-        };
+    // The same discriminant for a wire `MlxDeviceAction`'s command oneof.
+    fn action_tag(command: &Option<fac::mlx_device_action::Command>) -> String {
+        use fac::mlx_device_action::Command as C;
+        match command {
+            None => "none".to_string(),
+            Some(C::Noop(_)) => "noop".to_string(),
+            Some(C::Lock(l)) => format!("lock:{}", l.key),
+            Some(C::Unlock(u)) => format!("unlock:{}", u.key),
+            Some(C::ApplyProfile(p)) => {
+                format!("apply_profile:{}", p.serialized_profile.is_some())
+            }
+            Some(C::ApplyFirmware(f)) => format!("apply_firmware:{}", f.profile.is_some()),
+        }
+    }
 
-        let command = DpaCommand::try_from(&action).unwrap();
-        assert!(matches!(command.op, OpCode::Unlock { key } if key == "secret"));
+    // A minimal proto profile whose every config value parses as YAML, so the
+    // SerializableProfile conversion round-trips cleanly.
+    fn valid_serializable_pb() -> SerializableProfilePb {
+        SerializableProfilePb {
+            name: "p".to_string(),
+            registry_name: "r".to_string(),
+            description: None,
+            config: HashMap::from([("k".to_string(), "42".to_string())]),
+        }
+    }
+
+    // A proto profile carrying a config value that is not valid YAML, so the
+    // SerializableProfile conversion rejects it.
+    fn invalid_serializable_pb() -> SerializableProfilePb {
+        SerializableProfilePb {
+            name: "p".to_string(),
+            registry_name: "r".to_string(),
+            description: None,
+            config: HashMap::from([("k".to_string(), "{unterminated".to_string())]),
+        }
+    }
+
+    // A complete proto firmware profile: both required specs present, so the
+    // FirmwareFlasherProfile conversion succeeds.
+    fn valid_firmware_pb() -> FirmwareProfilePb {
+        FirmwareProfilePb {
+            firmware_spec: Some(FirmwareSpecPb::default()),
+            flash_spec: Some(FlashSpecPb::default()),
+            flash_options: None,
+        }
+    }
+
+    // -- TryFrom<Command> for DpaCommand: every oneof arm + every profile sub-path.
+    #[test]
+    fn command_pb_converts_to_dpa_command() {
+        check_cases(
+            [
+                Case {
+                    scenario: "noop",
+                    input: Command::Noop(fac::MlxDeviceNoop {}),
+                    expect: Yields("noop".to_string()),
+                },
+                Case {
+                    scenario: "lock carries its key",
+                    input: Command::Lock(fac::MlxDeviceLock {
+                        key: "secret".to_string(),
+                    }),
+                    expect: Yields("lock:secret".to_string()),
+                },
+                Case {
+                    scenario: "lock with empty key",
+                    input: Command::Lock(fac::MlxDeviceLock { key: String::new() }),
+                    expect: Yields("lock:".to_string()),
+                },
+                Case {
+                    scenario: "unlock carries its key",
+                    input: Command::Unlock(fac::MlxDeviceUnlock {
+                        key: "secret".to_string(),
+                    }),
+                    expect: Yields("unlock:secret".to_string()),
+                },
+                Case {
+                    scenario: "apply_profile with no profile stays None",
+                    input: Command::ApplyProfile(fac::MlxDeviceApplyProfile {
+                        serialized_profile: None,
+                    }),
+                    expect: Yields("apply_profile:false".to_string()),
+                },
+                Case {
+                    scenario: "apply_profile with a valid profile",
+                    input: Command::ApplyProfile(fac::MlxDeviceApplyProfile {
+                        serialized_profile: Some(valid_serializable_pb()),
+                    }),
+                    expect: Yields("apply_profile:true".to_string()),
+                },
+                Case {
+                    scenario: "apply_profile rejects unparseable config",
+                    input: Command::ApplyProfile(fac::MlxDeviceApplyProfile {
+                        serialized_profile: Some(invalid_serializable_pb()),
+                    }),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "apply_firmware with no profile stays None",
+                    input: Command::ApplyFirmware(fac::MlxDeviceApplyFirmware { profile: None }),
+                    expect: Yields("apply_firmware:false".to_string()),
+                },
+                Case {
+                    scenario: "apply_firmware with a complete profile",
+                    input: Command::ApplyFirmware(fac::MlxDeviceApplyFirmware {
+                        profile: Some(valid_firmware_pb()),
+                    }),
+                    expect: Yields("apply_firmware:true".to_string()),
+                },
+                Case {
+                    scenario: "apply_firmware rejects a missing firmware_spec",
+                    input: Command::ApplyFirmware(fac::MlxDeviceApplyFirmware {
+                        profile: Some(FirmwareProfilePb {
+                            firmware_spec: None,
+                            flash_spec: Some(FlashSpecPb::default()),
+                            flash_options: None,
+                        }),
+                    }),
+                    expect: FailsWith("missing firmware_spec".to_string()),
+                },
+                Case {
+                    scenario: "apply_firmware rejects a missing flash_spec",
+                    input: Command::ApplyFirmware(fac::MlxDeviceApplyFirmware {
+                        profile: Some(FirmwareProfilePb {
+                            firmware_spec: Some(FirmwareSpecPb::default()),
+                            flash_spec: None,
+                            flash_options: None,
+                        }),
+                    }),
+                    expect: FailsWith("missing flash_spec".to_string()),
+                },
+            ],
+            |cmd: Command| DpaCommand::try_from(cmd).map(|c| op_tag(&c.op)),
+        );
+    }
+
+    // -- TryFrom<DpaDeviceCommand> for MlxDeviceAction: every OpCode arm. The
+    // pci_name is threaded through untouched, so each row also pins it.
+    #[test]
+    fn dpa_device_command_converts_to_rpc_action() {
+        check_cases(
+            [
+                Case {
+                    scenario: "noop",
+                    input: OpCode::Noop,
+                    expect: Yields(("04:00.0".to_string(), "noop".to_string())),
+                },
+                Case {
+                    scenario: "lock carries its key",
+                    input: OpCode::Lock {
+                        key: "secret".to_string(),
+                    },
+                    expect: Yields(("04:00.0".to_string(), "lock:secret".to_string())),
+                },
+                Case {
+                    scenario: "unlock carries its key",
+                    input: OpCode::Unlock {
+                        key: "secret".to_string(),
+                    },
+                    expect: Yields(("04:00.0".to_string(), "unlock:secret".to_string())),
+                },
+                Case {
+                    scenario: "apply_profile with no profile stays None",
+                    input: OpCode::ApplyProfile {
+                        serialized_profile: None,
+                    },
+                    expect: Yields(("04:00.0".to_string(), "apply_profile:false".to_string())),
+                },
+                Case {
+                    scenario: "apply_profile with a valid profile",
+                    input: OpCode::ApplyProfile {
+                        serialized_profile: Some(valid_serializable_pb().try_into().unwrap()),
+                    },
+                    expect: Yields(("04:00.0".to_string(), "apply_profile:true".to_string())),
+                },
+                Case {
+                    scenario: "apply_firmware with no profile stays None",
+                    input: OpCode::ApplyFirmware { profile: None },
+                    expect: Yields(("04:00.0".to_string(), "apply_firmware:false".to_string())),
+                },
+                Case {
+                    scenario: "apply_firmware with a profile",
+                    input: OpCode::ApplyFirmware {
+                        profile: Some(Box::new(Cow::Owned(
+                            valid_firmware_pb().try_into().unwrap(),
+                        ))),
+                    },
+                    expect: Yields(("04:00.0".to_string(), "apply_firmware:true".to_string())),
+                },
+            ],
+            |op: OpCode<'_>| {
+                let action: fac::MlxDeviceAction = DpaDeviceCommand {
+                    pci_name: "04:00.0".to_string(),
+                    command: DpaCommand { op },
+                }
+                .try_into()?;
+                Ok::<_, String>((action.pci_name, action_tag(&action.command)))
+            },
+        );
+    }
+
+    // -- TryFrom<&MlxDeviceAction> for DpaCommand: every command-oneof arm, plus the
+    // None arm that also lands on Noop, and the two profile rejection paths.
+    #[test]
+    fn rpc_action_converts_to_dpa_command() {
+        use fac::mlx_device_action::Command as C;
+        check_cases(
+            [
+                Case {
+                    scenario: "absent command is treated as noop",
+                    input: None,
+                    expect: Yields("noop".to_string()),
+                },
+                Case {
+                    scenario: "noop",
+                    input: Some(C::Noop(fac::MlxDeviceNoop {})),
+                    expect: Yields("noop".to_string()),
+                },
+                Case {
+                    scenario: "lock carries its key",
+                    input: Some(C::Lock(fac::MlxDeviceLock {
+                        key: "secret".to_string(),
+                    })),
+                    expect: Yields("lock:secret".to_string()),
+                },
+                Case {
+                    scenario: "unlock carries its key",
+                    input: Some(C::Unlock(fac::MlxDeviceUnlock {
+                        key: "secret".to_string(),
+                    })),
+                    expect: Yields("unlock:secret".to_string()),
+                },
+                Case {
+                    scenario: "apply_profile with no profile stays None",
+                    input: Some(C::ApplyProfile(fac::MlxDeviceApplyProfile {
+                        serialized_profile: None,
+                    })),
+                    expect: Yields("apply_profile:false".to_string()),
+                },
+                Case {
+                    scenario: "apply_profile with a valid profile",
+                    input: Some(C::ApplyProfile(fac::MlxDeviceApplyProfile {
+                        serialized_profile: Some(valid_serializable_pb()),
+                    })),
+                    expect: Yields("apply_profile:true".to_string()),
+                },
+                Case {
+                    scenario: "apply_profile rejects unparseable config",
+                    input: Some(C::ApplyProfile(fac::MlxDeviceApplyProfile {
+                        serialized_profile: Some(invalid_serializable_pb()),
+                    })),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "apply_firmware with no profile stays None",
+                    input: Some(C::ApplyFirmware(fac::MlxDeviceApplyFirmware {
+                        profile: None,
+                    })),
+                    expect: Yields("apply_firmware:false".to_string()),
+                },
+                Case {
+                    scenario: "apply_firmware with a complete profile",
+                    input: Some(C::ApplyFirmware(fac::MlxDeviceApplyFirmware {
+                        profile: Some(valid_firmware_pb()),
+                    })),
+                    expect: Yields("apply_firmware:true".to_string()),
+                },
+                Case {
+                    scenario: "apply_firmware rejects a missing firmware_spec",
+                    input: Some(C::ApplyFirmware(fac::MlxDeviceApplyFirmware {
+                        profile: Some(FirmwareProfilePb {
+                            firmware_spec: None,
+                            flash_spec: Some(FlashSpecPb::default()),
+                            flash_options: None,
+                        }),
+                    })),
+                    expect: FailsWith("missing firmware_spec".to_string()),
+                },
+            ],
+            |command: Option<fac::mlx_device_action::Command>| {
+                let action = fac::MlxDeviceAction {
+                    pci_name: "04:00.0".to_string(),
+                    command,
+                };
+                DpaCommand::try_from(&action).map(|c| op_tag(&c.op))
+            },
+        );
     }
 }

--- a/crates/host-support/src/hardware_enumeration.rs
+++ b/crates/host-support/src/hardware_enumeration.rs
@@ -995,6 +995,8 @@ fn parse_memtotal_kb(meminfo: &str) -> u32 {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
     use tempfile::NamedTempFile;
 
     use super::*;
@@ -1006,122 +1008,491 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_save_and_load_roundtrip() {
-        let tmp = NamedTempFile::new().unwrap();
-        let path = tmp.path().to_str().unwrap();
-
-        let info = minimal_discovery_info();
-        save_hardware_to(&info, path).expect("save should succeed");
-
-        let loaded = load_hardware_from(path).expect("load should succeed");
-        assert_eq!(loaded.machine_type, "aarch64");
-    }
-
-    #[test]
-    fn test_load_file_not_found() {
-        let err = load_hardware_from("/nonexistent/path/hw.json").unwrap_err();
-        assert!(
-            err.to_string().contains("/nonexistent/path/hw.json"),
-            "error should mention the path: {err}"
-        );
-    }
-
-    #[test]
-    fn test_load_invalid_json() {
-        let tmp = NamedTempFile::new().unwrap();
-        let path = tmp.path().to_str().unwrap();
-        fs::write(path, b"not valid json { {").unwrap();
-
-        let err = load_hardware_from(path).unwrap_err();
-        assert!(
-            err.to_string().contains("Failed to parse hardware cache"),
-            "error should indicate parse failure: {err}"
-        );
-    }
-
-    #[test]
-    fn test_save_roundtrip_preserves_fields() {
-        let tmp = NamedTempFile::new().unwrap();
-        let path = tmp.path().to_str().unwrap();
-
-        let info = rpc_discovery::DiscoveryInfo {
-            machine_type: "x86_64".to_string(),
-            block_devices: vec![rpc_discovery::BlockDevice {
-                model: "test-disk".to_string(),
-                serial: "SN123".to_string(),
+    /// Build a `PciDevicePropertiesExt` from the few fields the pure predicates
+    /// (`is_dpu`, `mlnx_ib_capable`) actually read.
+    fn props_ext(
+        device_id: &str,
+        vendor: &str,
+        slot: Option<&str>,
+        sub_class: &str,
+    ) -> PciDevicePropertiesExt {
+        PciDevicePropertiesExt {
+            sub_class: sub_class.to_string(),
+            pci_properties: rpc_discovery::PciDeviceProperties {
+                vendor: vendor.to_string(),
+                slot: slot.map(|s| s.to_string()),
                 ..Default::default()
-            }],
-            ..Default::default()
-        };
+            },
+            device_id: device_id.to_string(),
+        }
+    }
 
-        save_hardware_to(&info, path).unwrap();
-        let loaded = load_hardware_from(path).unwrap();
+    fn proc_cpu(
+        vendor: &str,
+        model: &str,
+        sockets: u32,
+        cores: u32,
+        threads: u32,
+    ) -> rpc_discovery::CpuInfo {
+        rpc_discovery::CpuInfo {
+            vendor: vendor.to_string(),
+            model: model.to_string(),
+            sockets,
+            cores,
+            threads,
+        }
+    }
 
-        assert_eq!(loaded.machine_type, "x86_64");
-        assert_eq!(loaded.block_devices.len(), 1);
-        assert_eq!(loaded.block_devices[0].model, "test-disk");
-        assert_eq!(loaded.block_devices[0].serial, "SN123");
+    // save_hardware_to + load_hardware_from round-trip and the load failure
+    // paths. Each row exercises the fallible save/load cluster against a temp
+    // path; `Yields(true)` means the round-tripped marker field survived, a
+    // `FailsWith` row pins the path/parse error text in the returned message.
+    #[test]
+    fn save_load_cluster() {
+        // round-trip: minimal info survives save -> load
+        Case {
+            scenario: "minimal info round-trips machine_type",
+            input: minimal_discovery_info(),
+            expect: Yields(true),
+        }
+        .check(|info| {
+            let tmp = NamedTempFile::new().map_err(drop)?;
+            let path = tmp.path().to_str().ok_or(())?;
+            save_hardware_to(&info, path).map_err(drop)?;
+            let loaded = load_hardware_from(path).map_err(drop)?;
+            Ok::<_, ()>(loaded.machine_type == "aarch64")
+        });
+
+        // round-trip: nested block_devices fields survive
+        Case {
+            scenario: "block device fields round-trip",
+            input: rpc_discovery::DiscoveryInfo {
+                machine_type: "x86_64".to_string(),
+                block_devices: vec![rpc_discovery::BlockDevice {
+                    model: "test-disk".to_string(),
+                    serial: "SN123".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            expect: Yields(true),
+        }
+        .check(|info| {
+            let tmp = NamedTempFile::new().map_err(drop)?;
+            let path = tmp.path().to_str().ok_or(())?;
+            save_hardware_to(&info, path).map_err(drop)?;
+            let loaded = load_hardware_from(path).map_err(drop)?;
+            Ok::<_, ()>(
+                loaded.machine_type == "x86_64"
+                    && loaded.block_devices.len() == 1
+                    && loaded.block_devices[0].model == "test-disk"
+                    && loaded.block_devices[0].serial == "SN123",
+            )
+        });
+
+        // load failure: missing file -> error mentions the path
+        Case {
+            scenario: "missing file error mentions path",
+            input: "/nonexistent/path/hw.json",
+            expect: Yields(true),
+        }
+        .check(|path| {
+            let err = load_hardware_from(path).unwrap_err();
+            Ok::<_, ()>(err.to_string().contains("/nonexistent/path/hw.json"))
+        });
+
+        // load failure: invalid JSON -> "Failed to parse" error
+        Case {
+            scenario: "invalid json reports parse failure",
+            input: &b"not valid json { {"[..],
+            expect: Yields(true),
+        }
+        .check(|bytes| {
+            let tmp = NamedTempFile::new().map_err(drop)?;
+            let path = tmp.path().to_str().ok_or(())?;
+            fs::write(path, bytes).map_err(drop)?;
+            let err = load_hardware_from(path).unwrap_err();
+            Ok::<_, ()>(err.to_string().contains("Failed to parse hardware cache"))
+        });
+    }
+
+    // Init-container bind-mount paths and the cache path are part of the
+    // daemonset contract; pin each constant exactly.
+    #[test]
+    fn init_container_path_constants() {
+        check_values(
+            [
+                Check {
+                    scenario: "init cpu info path",
+                    input: INIT_CPU_INFO_PATH,
+                    expect: "/host-cpu-info",
+                },
+                Check {
+                    scenario: "init mem info path",
+                    input: INIT_MEM_INFO_PATH,
+                    expect: "/host-mem-info",
+                },
+                Check {
+                    scenario: "hw cache path",
+                    input: HW_CACHE_PATH,
+                    expect: "/data/hw_output.json",
+                },
+            ],
+            // identity: the constant under test is handed in as the input
+            |c| c,
+        );
+    }
+
+    // parse_memtotal_kb: total fn returning the kB value, 0 when the line is
+    // absent or the value is unparseable. Covers each lines() / split branch.
+    #[test]
+    fn parse_memtotal_kb_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "typical first line",
+                    input: "MemTotal:       32572708 kB\nMemFree:        16000000 kB\n",
+                    expect: 32_572_708,
+                },
+                Check {
+                    scenario: "MemTotal absent -> 0",
+                    input: "MemFree:        16000000 kB\nSwapTotal:      0 kB\n",
+                    expect: 0,
+                },
+                Check {
+                    scenario: "empty input -> 0",
+                    input: "",
+                    expect: 0,
+                },
+                Check {
+                    scenario: "non-numeric value -> 0",
+                    input: "MemTotal:       not_a_number kB\n",
+                    expect: 0,
+                },
+                Check {
+                    scenario: "MemTotal not first line",
+                    input: "HugePages_Total: 0\nMemTotal:        8192000 kB\nMemFree:         4096000 kB\nBuffers:          512000 kB\n",
+                    expect: 8_192_000,
+                },
+                // boundary: only the key with no value field -> nth(1) None -> "0" -> 0
+                Check {
+                    scenario: "MemTotal key with no value -> 0",
+                    input: "MemTotal:\n",
+                    expect: 0,
+                },
+                // a line that merely starts with "MemTotal" but is not the
+                // "MemTotal:" key is NOT matched (starts_with check is "MemTotal:")
+                Check {
+                    scenario: "MemTotalSwap not matched -> 0",
+                    input: "MemTotalSwap:   123 kB\n",
+                    expect: 0,
+                },
+            ],
+            parse_memtotal_kb,
+        );
+    }
+
+    // can_parse_int: hex (0x-prefixed, base 16) or decimal i32. True only when
+    // the remaining text parses; false on bad hex digits, bad decimal, empty,
+    // or overflow.
+    #[test]
+    fn can_parse_int_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "plain decimal",
+                    input: "42",
+                    expect: true,
+                },
+                Check {
+                    scenario: "negative decimal",
+                    input: "-7",
+                    expect: true,
+                },
+                Check {
+                    scenario: "hex value",
+                    input: "0x10de",
+                    expect: true,
+                },
+                Check {
+                    scenario: "hex with no digits after prefix",
+                    input: "0x",
+                    expect: false,
+                },
+                Check {
+                    scenario: "non-numeric text",
+                    input: "GenuineIntel",
+                    expect: false,
+                },
+                Check {
+                    scenario: "empty string",
+                    input: "",
+                    expect: false,
+                },
+                Check {
+                    scenario: "decimal overflows i32",
+                    input: "9999999999",
+                    expect: false,
+                },
+                Check {
+                    scenario: "bad hex digit",
+                    input: "0xZZ",
+                    expect: false,
+                },
+            ],
+            can_parse_int,
+        );
+    }
+
+    // PciDevicePropertiesExt::is_dpu: device_id prefix decides. BlueField DPUs
+    // start 0xa2xx or 0xc2xx; everything else is not a DPU.
+    #[test]
+    fn is_dpu_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "0xa2 prefix is dpu",
+                    input: "0xa2d6",
+                    expect: true,
+                },
+                Check {
+                    scenario: "0xc2 prefix is dpu",
+                    input: "0xc2d2",
+                    expect: true,
+                },
+                Check {
+                    scenario: "other mellanox id not dpu",
+                    input: "0x1021",
+                    expect: false,
+                },
+                Check {
+                    scenario: "empty id not dpu",
+                    input: "",
+                    expect: false,
+                },
+                Check {
+                    scenario: "0xa not enough to match",
+                    input: "0xa1ff",
+                    expect: false,
+                },
+            ],
+            |id| {
+                props_ext(
+                    id,
+                    "Mellanox Technologies",
+                    Some("0000:08:00.0"),
+                    "Ethernet controller",
+                )
+                .is_dpu()
+            },
+        );
+    }
+
+    // PciDevicePropertiesExt::mlnx_ib_capable: true only when slot is present
+    // and non-empty, vendor is Mellanox (case-insensitive), and the subclass is
+    // "Infiniband controller" (case-insensitive). Any other combination false.
+    #[test]
+    fn mlnx_ib_capable_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "mellanox + slot + infiniband subclass",
+                    input: props_ext(
+                        "0xa2d6",
+                        "Mellanox Technologies",
+                        Some("0000:08:00.0"),
+                        "Infiniband controller",
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "vendor case-insensitive match",
+                    input: props_ext(
+                        "0xa2d6",
+                        "mellanox technologies",
+                        Some("0000:08:00.0"),
+                        "Infiniband controller",
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "subclass case-insensitive match",
+                    input: props_ext(
+                        "0xa2d6",
+                        "Mellanox Technologies",
+                        Some("0000:08:00.0"),
+                        "infiniband controller",
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "ethernet subclass -> false",
+                    input: props_ext(
+                        "0xa2d6",
+                        "Mellanox Technologies",
+                        Some("0000:08:00.0"),
+                        "Ethernet controller",
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "non-mellanox vendor -> false",
+                    input: props_ext(
+                        "0xa2d6",
+                        "Intel Corporation",
+                        Some("0000:08:00.0"),
+                        "Infiniband controller",
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "slot None -> false",
+                    input: props_ext(
+                        "0xa2d6",
+                        "Mellanox Technologies",
+                        None,
+                        "Infiniband controller",
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "empty slot -> false",
+                    input: props_ext(
+                        "0xa2d6",
+                        "Mellanox Technologies",
+                        Some(""),
+                        "Infiniband controller",
+                    ),
+                    expect: false,
+                },
+            ],
+            |p| p.mlnx_ib_capable(),
+        );
+    }
+
+    // convert_udev_to_mac: strips the leading "enx", chunks the rest into byte
+    // pairs, and colon-joins. Fails only on non-UTF-8 (unreachable for valid
+    // String input), so exercise the formatting branches here.
+    #[test]
+    fn convert_udev_to_mac_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "standard 6-octet udev name",
+                    input: "enx112233445566".to_string(),
+                    expect: Yields("11:22:33:44:55:66".to_string()),
+                },
+                Case {
+                    scenario: "single octet after prefix",
+                    input: "enxab".to_string(),
+                    expect: Yields("ab".to_string()),
+                },
+                Case {
+                    scenario: "exactly the prefix, no octets",
+                    input: "enx".to_string(),
+                    expect: Yields(String::new()),
+                },
+                // trailing odd nibble becomes its own one-char chunk
+                Case {
+                    scenario: "odd-length remainder",
+                    input: "enx112233445".to_string(),
+                    expect: Yields("11:22:33:44:5".to_string()),
+                },
+            ],
+            |s| convert_udev_to_mac(s).map_err(drop),
+        );
+    }
+
+    // get_cpu_info: lscpu values override procfs only under specific conditions.
+    // vendor/model override iff the procfs value is an unmapped integer AND
+    // lscpu has the key. Topology is all-or-nothing and threads becomes
+    // cores*threads-per-core.
+    #[test]
+    fn get_cpu_info_vendor_model_cases() {
+        // procfs vendor/model are integers -> lscpu values win
+        let mut lscpu = HashMap::new();
+        lscpu.insert(LSCPU_VENDOR, "ARM".to_string());
+        lscpu.insert(LSCPU_MODEL, "Neoverse-N1".to_string());
+        let got = get_cpu_info(&lscpu, proc_cpu("0x41", "0x1", 1, 1, 1));
+        assert_eq!(got.vendor, "ARM", "integer procfs vendor replaced by lscpu");
+        assert_eq!(
+            got.model, "Neoverse-N1",
+            "integer procfs model replaced by lscpu"
+        );
+
+        // procfs vendor/model already human-readable -> lscpu ignored
+        let got = get_cpu_info(&lscpu, proc_cpu("GenuineIntel", "Xeon", 1, 1, 1));
+        assert_eq!(got.vendor, "GenuineIntel", "named procfs vendor kept");
+        assert_eq!(got.model, "Xeon", "named procfs model kept");
+
+        // procfs integer but lscpu has no key -> procfs value kept
+        let empty = HashMap::new();
+        let got = get_cpu_info(&empty, proc_cpu("0x41", "0x1", 2, 4, 8));
+        assert_eq!(got.vendor, "0x41", "no lscpu vendor -> keep procfs");
+        assert_eq!(got.model, "0x1", "no lscpu model -> keep procfs");
     }
 
     #[test]
-    fn test_init_container_paths_match_daemonset_mounts() {
-        assert_eq!(INIT_CPU_INFO_PATH, "/host-cpu-info");
-        assert_eq!(INIT_MEM_INFO_PATH, "/host-mem-info");
-        assert_eq!(HW_CACHE_PATH, "/data/hw_output.json");
+    fn get_cpu_info_topology_cases() {
+        // complete lscpu topology -> threads = cores_per_socket * threads_per_core
+        let mut full = HashMap::new();
+        full.insert(LSCPU_SOCKETS, "2".to_string());
+        full.insert(LSCPU_CORES_PER_SOCKET, "16".to_string());
+        full.insert(LSCPU_THREADS_PER_CORE, "2".to_string());
+        let got = get_cpu_info(&full, proc_cpu("0x41", "0x1", 9, 9, 9));
+        assert_eq!(got.sockets, 2, "lscpu sockets win");
+        assert_eq!(got.cores, 16, "lscpu cores win");
+        assert_eq!(got.threads, 32, "threads = cores * threads_per_core");
+
+        // partial topology (missing threads-per-core) -> all procfs values kept
+        let mut partial = HashMap::new();
+        partial.insert(LSCPU_SOCKETS, "2".to_string());
+        partial.insert(LSCPU_CORES_PER_SOCKET, "16".to_string());
+        let got = get_cpu_info(&partial, proc_cpu("0x41", "0x1", 9, 9, 9));
+        assert_eq!(got.sockets, 9, "incomplete topology -> keep procfs sockets");
+        assert_eq!(got.cores, 9, "incomplete topology -> keep procfs cores");
+        assert_eq!(got.threads, 9, "incomplete topology -> keep procfs threads");
+
+        // unparseable topology value -> all procfs values kept
+        let mut bad = HashMap::new();
+        bad.insert(LSCPU_SOCKETS, "two".to_string());
+        bad.insert(LSCPU_CORES_PER_SOCKET, "16".to_string());
+        bad.insert(LSCPU_THREADS_PER_CORE, "2".to_string());
+        let got = get_cpu_info(&bad, proc_cpu("0x41", "0x1", 9, 9, 9));
+        assert_eq!(
+            got.sockets, 9,
+            "unparseable topology -> keep procfs sockets"
+        );
+        assert_eq!(
+            got.threads, 9,
+            "unparseable topology -> keep procfs threads"
+        );
     }
 
+    // validate_enumerated: the sole required field today is dpu_info. None ->
+    // Err, Some -> Ok(()). Error is not PartialEq so use Fails + Yields(()).
     #[test]
-    fn test_parse_memtotal_kb_typical() {
-        let meminfo = "MemTotal:       32572708 kB\nMemFree:        16000000 kB\n";
-        assert_eq!(parse_memtotal_kb(meminfo), 32572708);
-    }
-
-    #[test]
-    fn test_parse_memtotal_kb_missing_returns_zero() {
-        let meminfo = "MemFree:        16000000 kB\nSwapTotal:      0 kB\n";
-        assert_eq!(parse_memtotal_kb(meminfo), 0);
-    }
-
-    #[test]
-    fn test_parse_memtotal_kb_empty_returns_zero() {
-        assert_eq!(parse_memtotal_kb(""), 0);
-    }
-
-    #[test]
-    fn test_parse_memtotal_kb_malformed_value_returns_zero() {
-        let meminfo = "MemTotal:       not_a_number kB\n";
-        assert_eq!(parse_memtotal_kb(meminfo), 0);
-    }
-
-    #[test]
-    fn test_parse_memtotal_kb_realistic_meminfo() {
-        let meminfo = "\
-HugePages_Total: 0
-MemTotal:        8192000 kB
-MemFree:         4096000 kB
-Buffers:          512000 kB
-";
-        assert_eq!(parse_memtotal_kb(meminfo), 8192000);
-    }
-
-    #[test]
-    fn test_enumerate_and_save_writes_readable_cache() {
-        use std::fs;
-        let tmp_dir = tempfile::tempdir().unwrap();
-        let cache_path = tmp_dir.path().join("hw_output.json");
-        let cache_path_str = cache_path.to_str().unwrap();
-
-        let info = minimal_discovery_info();
-        save_hardware_to(&info, cache_path_str).unwrap();
-
-        let loaded = load_hardware_from(cache_path_str).unwrap();
-        assert_eq!(loaded.machine_type, info.machine_type);
-
-        let raw = fs::read_to_string(cache_path_str).unwrap();
-        assert!(
-            raw.contains("machine_type"),
-            "cache should be JSON with known field"
+    fn validate_enumerated_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "missing dpu_info fails",
+                    input: rpc_discovery::DiscoveryInfo {
+                        dpu_info: None,
+                        ..Default::default()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "present dpu_info passes",
+                    input: rpc_discovery::DiscoveryInfo {
+                        dpu_info: Some(Default::default()),
+                        ..Default::default()
+                    },
+                    expect: Yields(()),
+                },
+            ],
+            |info| validate_enumerated(&info).map_err(drop),
         );
     }
 }

--- a/crates/host-support/src/hardware_enumeration/dpu.rs
+++ b/crates/host-support/src/hardware_enumeration/dpu.rs
@@ -334,28 +334,155 @@ pub fn get_dpu_info() -> Result<DpuData, DpuEnumerationError> {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use crate::hardware_enumeration::dpu;
 
+    // `is_lldp_working` is currently stubbed to always return `false` (the
+    // firmware-version parse is commented out pending a real LLDP fix). Every
+    // input -- valid versions, boundary `40`, and garbage -- must yield `false`.
     #[test]
-    fn check_fw_versions_for_lldp() {
-        assert!(!dpu::is_lldp_working("xx.39.yyyy"));
-        assert!(!dpu::is_lldp_working("xx.40.yyyy"));
-        assert!(!dpu::is_lldp_working("xx.41.yyyy"));
-
-        //broken data should return false
-        assert!(!dpu::is_lldp_working("xx.zz.yyyy"));
-        assert!(!dpu::is_lldp_working("junk"));
+    fn is_lldp_working_always_false() {
+        check_values(
+            [
+                Check {
+                    scenario: "below the 40 boundary",
+                    input: "xx.39.yyyy",
+                    expect: false,
+                },
+                Check {
+                    scenario: "at the 40 boundary",
+                    input: "xx.40.yyyy",
+                    expect: false,
+                },
+                Check {
+                    scenario: "above the 40 boundary",
+                    input: "xx.41.yyyy",
+                    expect: false,
+                },
+                Check {
+                    scenario: "non-numeric middle chunk",
+                    input: "xx.zz.yyyy",
+                    expect: false,
+                },
+                Check {
+                    scenario: "no dots at all",
+                    input: "junk",
+                    expect: false,
+                },
+                Check {
+                    scenario: "empty string",
+                    input: "",
+                    expect: false,
+                },
+                Check {
+                    scenario: "well-formed high version",
+                    input: "22.99.1000",
+                    expect: false,
+                },
+                Check {
+                    scenario: "single leading dot",
+                    input: ".40.",
+                    expect: false,
+                },
+            ],
+            dpu::is_lldp_working,
+        );
     }
 
+    // `get_port_lldp_info` reads the `test/lldp_query.json` fixture (in `cfg(test)`
+    // it ignores the live `lldpcli` command) and then looks the requested port up
+    // in `lldp.interface`. The lookup, the `OneOrMany` mgmt-ip flattening, and the
+    // tor/port field formatting are all pure given that fixture, so we pin the
+    // facts each known port produces and the not-found rejection path.
+    //
+    // The yielded value for each row is `(first_ip, ip_count, name, remote_port)`.
     #[test]
-    fn validate_mgmt_ip_lldp_with_mixed_mgmt_ip_results() {
-        let oob_lldp = dpu::get_port_lldp_info("oob_net0").unwrap();
-        let p0_lldp = dpu::get_port_lldp_info("p0").unwrap();
+    fn get_port_lldp_info_translates_fixture() {
+        check_cases(
+            [
+                Case {
+                    scenario: "oob_net0: single (scalar) mgmt-ip",
+                    input: "oob_net0",
+                    expect: Yields((
+                        "10.180.253.66".to_string(),
+                        1,
+                        "RNO1-M03-B17-IPMI-01".to_string(),
+                        "ifname=swp7".to_string(),
+                    )),
+                },
+                Case {
+                    scenario: "p0: array mgmt-ip keeps first (v4) and counts both",
+                    input: "p0",
+                    expect: Yields((
+                        "10.180.253.67".to_string(),
+                        2,
+                        "RNO1-M03-B17-IPMI-01".to_string(),
+                        "ifname=swp7".to_string(),
+                    )),
+                },
+                Case {
+                    scenario: "p1: distinct array mgmt-ip, first is v4",
+                    input: "p1",
+                    expect: Yields((
+                        "10.180.253.66".to_string(),
+                        2,
+                        "RNO1-M03-B17-IPMI-01".to_string(),
+                        "ifname=swp7".to_string(),
+                    )),
+                },
+                Case {
+                    scenario: "unknown port: not present in the fixture interface map",
+                    input: "p99",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty port name: also absent",
+                    input: "",
+                    expect: Fails,
+                },
+            ],
+            |port| {
+                let info = dpu::get_port_lldp_info(port).map_err(drop)?;
+                let first_ip = info.ip_address.first().cloned().unwrap_or_default();
+                Ok::<_, ()>((first_ip, info.ip_address.len(), info.name, info.remote_port))
+            },
+        );
+    }
 
-        assert_eq!(oob_lldp.ip_address[0], "10.180.253.66");
-        assert_eq!(oob_lldp.ip_address.len(), 1);
-
-        assert_eq!(p0_lldp.ip_address[0], "10.180.253.67");
-        assert_eq!(p0_lldp.ip_address.len(), 2);
+    // The tor-id and description formatting on the resolved switch is its own
+    // contract: `id` is rendered `"{id_type}={value}"` and `description`/`local_port`
+    // are copied verbatim. Token-contains keeps this robust to fixture churn.
+    //
+    // The yielded value is whether every expected token appears in the rendered field.
+    #[test]
+    fn get_port_lldp_info_formats_fields() {
+        check_cases(
+            [
+                Case {
+                    scenario: "id renders mac type=value for oob_net0",
+                    input: ("oob_net0", &["mac=", "0c:29:ef:d9:1c:20"][..]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "description carried verbatim for p0",
+                    input: ("p0", &["Cumulus Linux", "DELL S3048ON"][..]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "local_port echoes the requested port",
+                    input: ("p1", &["p1"][..]),
+                    expect: Yields(true),
+                },
+            ],
+            |(port, tokens): (&str, &[&str])| {
+                let info = dpu::get_port_lldp_info(port).map_err(drop)?;
+                // Concatenate the formatted fields this row may inspect; every token
+                // must appear somewhere across id / description / local_port.
+                let haystack = format!("{} {} {}", info.id, info.description, info.local_port);
+                Ok::<_, ()>(tokens.iter().all(|t| haystack.contains(t)))
+            },
+        );
     }
 }

--- a/crates/host-support/src/hardware_enumeration/tpm.rs
+++ b/crates/host-support/src/hardware_enumeration/tpm.rs
@@ -174,6 +174,8 @@ mod tests {
     use std::collections::VecDeque;
     use std::io;
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
     use rcgen::{CertifiedKey, generate_simple_self_signed};
 
     use super::*;
@@ -267,100 +269,320 @@ mod tests {
         nv_read_call(index, Ok(failed_output("NV index not available")))
     }
 
-    #[test]
-    fn get_ek_certificate_returns_primary_tool_certificate() {
-        let test_ek_cert_der = test_ek_cert_der("primary");
-        let runner = FakeRunner::new(vec![FakeCall {
-            program: TPM2_GET_EK_CERTIFICATE,
-            args: vec![],
-            result: Ok(successful_output(&test_ek_cert_der)),
-        }]);
-
-        assert_eq!(
-            get_ek_certificate_with_runner(&runner).unwrap(),
-            test_ek_cert_der
-        );
-        assert!(runner.calls.borrow().is_empty());
+    /// All NV indices after `first_n` fail; helper to build the tail of a
+    /// fallback call sequence.
+    fn failing_nv_tail(first_n: usize) -> Vec<FakeCall> {
+        TPM_EK_CERT_NV_INDICES[first_n..]
+            .iter()
+            .map(|&index| failed_nv_read_call(index))
+            .collect()
     }
 
+    /// `get_ek_certificate_with_runner`: primary-tool path, NV fallback,
+    /// invalid-NV skipping, multi-cert concatenation, plus the no-cert-anywhere
+    /// failure path the original tests omitted. The runner is consumed in full
+    /// (asserted empty) by `FakeRunner`'s `expect("unexpected call")`. Error type
+    /// (`TpmError`) is not `PartialEq`, so failures use `Fails`.
     #[test]
-    fn get_ek_certificate_falls_back_to_nv_indices() {
-        let test_ek_cert_der = test_ek_cert_der("fallback");
-        let nv_stdout = cert_with_trailing_nv_bytes(&test_ek_cert_der);
-        let mut calls = vec![
-            primary_tool_failed_call(),
-            nv_read_call(TPM_EK_CERT_NV_INDICES[0], Ok(successful_output(&nv_stdout))),
-        ];
-        calls.extend(
-            TPM_EK_CERT_NV_INDICES[1..]
-                .iter()
-                .map(|&index| failed_nv_read_call(index)),
-        );
-        let runner = FakeRunner::new(calls);
-
-        assert_eq!(
-            get_ek_certificate_with_runner(&runner).unwrap(),
-            test_ek_cert_der
-        );
-        assert!(runner.calls.borrow().is_empty());
-    }
-
-    #[test]
-    fn get_ek_certificate_skips_invalid_nv_data() {
-        let test_ek_cert_der = test_ek_cert_der("valid");
-        let mut calls = vec![
-            primary_tool_failed_call(),
-            nv_read_call(
-                TPM_EK_CERT_NV_INDICES[0],
-                Ok(successful_output(b"not a certificate")),
-            ),
-            nv_read_call(
-                TPM_EK_CERT_NV_INDICES[1],
-                Ok(successful_output(&test_ek_cert_der)),
-            ),
-        ];
-        calls.extend(
-            TPM_EK_CERT_NV_INDICES[2..]
-                .iter()
-                .map(|&index| failed_nv_read_call(index)),
-        );
-        let runner = FakeRunner::new(calls);
-
-        assert_eq!(
-            get_ek_certificate_with_runner(&runner).unwrap(),
-            test_ek_cert_der
-        );
-        assert!(runner.calls.borrow().is_empty());
-    }
-
-    #[test]
-    fn get_ek_certificate_concatenates_multiple_nv_certs_in_tool_order() {
+    fn get_ek_certificate_with_runner_cases() {
+        // Built lazily inside each input closure because the expected `Vec<u8>`
+        // and the runner's fake certs must be derived from the same DER bytes.
+        let primary_cert = test_ek_cert_der("primary");
+        let fallback_cert = test_ek_cert_der("fallback");
+        let valid_cert = test_ek_cert_der("valid");
         let first_cert = test_ek_cert_der("first");
         let second_cert = test_ek_cert_der("second");
-        let first_nv_stdout = cert_with_trailing_nv_bytes(&first_cert);
-        let second_nv_stdout = cert_with_trailing_nv_bytes(&second_cert);
-        let mut calls = vec![
-            primary_tool_failed_call(),
-            nv_read_call(
-                TPM_EK_CERT_NV_INDICES[0],
-                Ok(successful_output(&first_nv_stdout)),
-            ),
-            nv_read_call(
-                TPM_EK_CERT_NV_INDICES[1],
-                Ok(successful_output(&second_nv_stdout)),
-            ),
-        ];
-        calls.extend(
-            TPM_EK_CERT_NV_INDICES[2..]
-                .iter()
-                .map(|&index| failed_nv_read_call(index)),
+
+        let mut concatenated = first_cert.clone();
+        concatenated.extend_from_slice(&second_cert);
+
+        // Input is a (runner, expected-bytes-if-any) pair; the closure runs the
+        // runner and returns the cert vec, dropping the non-PartialEq error.
+        check_cases(
+            [
+                Case {
+                    scenario: "primary tool returns the certificate; no NV probing",
+                    input: FakeRunner::new(vec![FakeCall {
+                        program: TPM2_GET_EK_CERTIFICATE,
+                        args: vec![],
+                        result: Ok(successful_output(&primary_cert)),
+                    }]),
+                    expect: Yields(primary_cert.clone()),
+                },
+                Case {
+                    scenario: "primary fails, falls back to first NV index",
+                    input: {
+                        let nv_stdout = cert_with_trailing_nv_bytes(&fallback_cert);
+                        let mut calls = vec![
+                            primary_tool_failed_call(),
+                            nv_read_call(
+                                TPM_EK_CERT_NV_INDICES[0],
+                                Ok(successful_output(&nv_stdout)),
+                            ),
+                        ];
+                        calls.extend(failing_nv_tail(1));
+                        FakeRunner::new(calls)
+                    },
+                    expect: Yields(fallback_cert),
+                },
+                Case {
+                    scenario: "skips NV index whose stdout is not a certificate",
+                    input: {
+                        let mut calls = vec![
+                            primary_tool_failed_call(),
+                            nv_read_call(
+                                TPM_EK_CERT_NV_INDICES[0],
+                                Ok(successful_output(b"not a certificate")),
+                            ),
+                            nv_read_call(
+                                TPM_EK_CERT_NV_INDICES[1],
+                                Ok(successful_output(&valid_cert)),
+                            ),
+                        ];
+                        calls.extend(failing_nv_tail(2));
+                        FakeRunner::new(calls)
+                    },
+                    expect: Yields(valid_cert),
+                },
+                Case {
+                    scenario: "concatenates multiple NV certs in tool order",
+                    input: {
+                        let first_nv = cert_with_trailing_nv_bytes(&first_cert);
+                        let second_nv = cert_with_trailing_nv_bytes(&second_cert);
+                        let mut calls = vec![
+                            primary_tool_failed_call(),
+                            nv_read_call(
+                                TPM_EK_CERT_NV_INDICES[0],
+                                Ok(successful_output(&first_nv)),
+                            ),
+                            nv_read_call(
+                                TPM_EK_CERT_NV_INDICES[1],
+                                Ok(successful_output(&second_nv)),
+                            ),
+                        ];
+                        calls.extend(failing_nv_tail(2));
+                        FakeRunner::new(calls)
+                    },
+                    expect: Yields(concatenated.clone()),
+                },
+                Case {
+                    scenario: "primary fails and every NV index fails: no cert found",
+                    input: {
+                        let mut calls = vec![primary_tool_failed_call()];
+                        calls.extend(failing_nv_tail(0));
+                        FakeRunner::new(calls)
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "primary subprocess spawn errors, every NV index fails",
+                    input: {
+                        let mut calls = vec![FakeCall {
+                            program: TPM2_GET_EK_CERTIFICATE,
+                            args: vec![],
+                            result: Err(io::Error::new(io::ErrorKind::NotFound, "missing")),
+                        }];
+                        calls.extend(failing_nv_tail(0));
+                        FakeRunner::new(calls)
+                    },
+                    expect: Fails,
+                },
+            ],
+            |runner| {
+                let cert = get_ek_certificate_with_runner(&runner).map_err(drop)?;
+                assert!(runner.calls.borrow().is_empty(), "runner not drained");
+                Ok::<_, ()>(cert)
+            },
         );
-        let runner = FakeRunner::new(calls);
+    }
 
-        let mut expected = first_cert;
-        expected.extend_from_slice(&second_cert);
+    /// `checked_stdout`: success passes stdout through unchanged; any non-success
+    /// status is an error regardless of code or stderr validity. Pure over a
+    /// `CommandOutput`. Error type is not `PartialEq`, so failures use `Fails`.
+    #[test]
+    fn checked_stdout_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "success returns stdout verbatim",
+                    input: CommandOutput {
+                        status_success: true,
+                        status_code: Some(0),
+                        stdout: b"payload".to_vec(),
+                        stderr: vec![],
+                    },
+                    expect: Yields(b"payload".to_vec()),
+                },
+                Case {
+                    scenario: "success with empty stdout returns empty",
+                    input: CommandOutput {
+                        status_success: true,
+                        status_code: Some(0),
+                        stdout: vec![],
+                        stderr: b"warning".to_vec(),
+                    },
+                    expect: Yields(vec![]),
+                },
+                Case {
+                    scenario: "non-success with utf8 stderr fails",
+                    input: failed_output("boom"),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-success with no status code fails",
+                    input: CommandOutput {
+                        status_success: false,
+                        status_code: None,
+                        stdout: vec![],
+                        stderr: vec![],
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-success with invalid utf8 stderr still fails (no panic)",
+                    input: CommandOutput {
+                        status_success: false,
+                        status_code: Some(1),
+                        stdout: vec![],
+                        stderr: vec![0xff, 0xfe],
+                    },
+                    expect: Fails,
+                },
+            ],
+            |output| checked_stdout(output).map_err(drop),
+        );
+    }
 
-        assert_eq!(get_ek_certificate_with_runner(&runner).unwrap(), expected);
-        assert!(runner.calls.borrow().is_empty());
+    /// `cert_from_output`: requires a valid DER X.509 in stdout and returns the
+    /// full stdout buffer. Non-success status and unparseable bytes both fail.
+    #[test]
+    fn cert_from_output_cases() {
+        let cert = test_ek_cert_der("tool");
+        let cert_with_trailing = cert_with_trailing_nv_bytes(&cert);
+
+        check_cases(
+            [
+                Case {
+                    scenario: "valid DER returns the full stdout",
+                    input: successful_output(&cert),
+                    expect: Yields(cert.clone()),
+                },
+                Case {
+                    scenario: "trailing bytes are NOT trimmed (full stdout returned)",
+                    input: successful_output(&cert_with_trailing),
+                    expect: Yields(cert_with_trailing.clone()),
+                },
+                Case {
+                    scenario: "non-certificate stdout fails to parse",
+                    input: successful_output(b"not a certificate"),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty stdout fails to parse",
+                    input: successful_output(b""),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "subprocess non-success fails before parsing",
+                    input: failed_output("tool error"),
+                    expect: Fails,
+                },
+            ],
+            |output| cert_from_output(TPM2_GET_EK_CERTIFICATE, output).map_err(drop),
+        );
+    }
+
+    /// `cert_from_nv_output`: parses a DER X.509 from the front of stdout and
+    /// trims any trailing NV padding, returning only the certificate bytes.
+    #[test]
+    fn cert_from_nv_output_cases() {
+        let cert = test_ek_cert_der("nv");
+        let cert_with_trailing = cert_with_trailing_nv_bytes(&cert);
+
+        check_cases(
+            [
+                Case {
+                    scenario: "exact-length DER returns it unchanged",
+                    input: successful_output(&cert),
+                    expect: Yields(cert.clone()),
+                },
+                Case {
+                    scenario: "trailing NV padding is trimmed to the cert bytes",
+                    input: successful_output(&cert_with_trailing),
+                    expect: Yields(cert.clone()),
+                },
+                Case {
+                    scenario: "non-certificate stdout fails to parse",
+                    input: successful_output(b"not a certificate"),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty stdout fails to parse",
+                    input: successful_output(b""),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "subprocess non-success fails before parsing",
+                    input: failed_output("nv error"),
+                    expect: Fails,
+                },
+            ],
+            |output| cert_from_nv_output(TPM2_NV_READ, output).map_err(drop),
+        );
+    }
+
+    /// `TpmError` Display formatting: each variant's message must mention its
+    /// salient tokens. Total over the error value, so `check_values` with a
+    /// token-contains predicate.
+    #[test]
+    fn tpm_error_display_contains_tokens() {
+        check_values(
+            [
+                Check {
+                    scenario: "Subprocess names the program",
+                    input: (
+                        TpmError::Subprocess(
+                            TPM2_NV_READ,
+                            io::Error::new(io::ErrorKind::NotFound, "x"),
+                        ),
+                        &[TPM2_NV_READ, "Unable to invoke"][..],
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "SubprocessStatusNotOk names the stderr",
+                    input: (
+                        TpmError::SubprocessStatusNotOk(Some(2), "boom".to_string()),
+                        &["boom", "exit code"][..],
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "InvalidEkCertificate names the source",
+                    input: (
+                        TpmError::InvalidEkCertificate(TPM2_GET_EK_CERTIFICATE),
+                        &[TPM2_GET_EK_CERTIFICATE, "DER X.509"][..],
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "EkCertificateNotFound names primary and nv errors",
+                    input: (
+                        TpmError::EkCertificateNotFound {
+                            primary_error: Box::new(TpmError::InvalidEkCertificate(
+                                TPM2_GET_EK_CERTIFICATE,
+                            )),
+                            nv_errors: "0x01c00002: nope".to_string(),
+                        },
+                        &["NV fallback errors", "0x01c00002: nope"][..],
+                    ),
+                    expect: true,
+                },
+            ],
+            |(error, tokens)| {
+                let rendered = error.to_string();
+                tokens.iter().all(|t| rendered.contains(t))
+            },
+        );
     }
 }


### PR DESCRIPTION
This supports #3914.

## Description

The `host-support` tests mixed assertions across config parsing, hardware enumeration, TPM EK-cert reading, and DPU/DPA command building.

This folds them onto `carbide-test-support` table-driven `Case`/`Check` rows and, with that boilerplate work in place, enumerates the input variants each parser, validator, and converter actually accepts and rejects — empty and partial TOML, unknown keys, malformed values, missing or non-certificate NV indices, fallback paths, etc.

- `agent_config`: folded the config-parsing tests into rows and enumerated the TOML accept/reject surface (empty, unknown-key, defaults, HBN root override).
- `hardware_enumeration` + `tpm`: folded onto the table and drove the EK-cert reader through a FakeRunner over primary/fallback/multi-index paths.
- `dpu` / `dpa_cmds`: folded the command-building tests into check_values rows.

```
┌──────────┬─────────┬─────────┐
│ Metric   │ Before  │  After  │
├──────────┼─────────┼─────────┤
│ Region   │ 35.35%  │ 51.44%  │
│ Function │ 39.27%  │ 56.45%  │
│ Line     │ 40.30%  │ 68.30%  │
└──────────┴─────────┴─────────┘
```

The remaining uncovered surface is mostly IO related — udev/procfs/smbios enumeration and subprocess execution — which needs dry-run/mock harnessing rather than additional table rows.

All tests pass and clippy is clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->