### PR TITLE
feat: resolve the boot interface for machines awaiting their first lease

### DIFF
--- a/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
@@ -29,6 +29,8 @@ use model::expected_entity::ExpectedEntity;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{LoadSnapshotOptions, MachineInterfaceSnapshot};
 use model::machine_boot_interface::MachineBootInterface;
+use model::network_segment::NetworkSegmentType;
+use model::predicted_machine_interface::PredictedMachineInterface;
 use model::site_explorer::{NicMode, PreingestionState};
 use sqlx::PgConnection;
 use tokio::net::lookup_host;
@@ -47,87 +49,134 @@ use crate::api::{Api, log_machine_id, log_request_data};
 /// the MAC alone ([`BootInterfaceTarget::MacOnly`], no id fallback), exactly
 /// like the controller's `boot_interface_target`.
 ///
+/// A machine with no `machine_interfaces` rows yet (a zero-DPU/NIC-mode
+/// machine awaiting its first DHCP lease) resolves from its
+/// `predicted_machine_interfaces` instead: the predicted NIC's MAC and
+/// recorded Redfish interface id form the same [`MachineBootInterface`] the
+/// real row will hold once the lease promotes it. Predictions answer only
+/// when unambiguous -- exactly one non-underlay prediction. Predictions hold
+/// no primary flag, so with several (e.g. a host whose report lists SuperNICs
+/// alongside the boot NIC) the declared `ExpectedHostNic.primary` cannot be
+/// applied here; resolution refuses to guess and the action keeps requiring
+/// an explicit MAC, which the matching prediction's recorded id completes.
+/// The machine-controller does not consult predictions at all yet -- its
+/// boot states wait out this window -- a known follow-up.
+///
 /// Site-explorer's stored default (`ExploredEndpoint::boot_interface()`)
-/// answers only for endpoints no machine owns. Owned endpoints with no
-/// candidate rows (DPU machines, hosts that have only discovered their BMC)
-/// fall through to it as well, but the explorer never records a default for
-/// those, so in practice they run with no target -- also matching the
-/// controller.
+/// answers only for endpoints no machine owns. An owned machine resolves
+/// from its own rows and predictions alone -- when neither offers an
+/// unambiguous candidate, there is no target and the action requires an
+/// explicit MAC, matching the machine-controller (which never consults the
+/// explored default either).
 ///
 /// An explicitly entered MAC is always honored as given, never redirected to
-/// another NIC; either store may complete it with the id recorded for that
-/// exact MAC.
+/// another NIC; any of the stores may complete it with the id recorded for
+/// that exact MAC.
 fn resolve_admin_boot_interface_target(
     stored: Option<MachineBootInterface>,
-    machine_interfaces: Option<&[MachineInterfaceSnapshot]>,
+    candidates: Option<&BootInterfaceCandidates>,
     entered_mac: Option<MacAddress>,
 ) -> Option<BootInterfaceTarget> {
-    // The full `MachineBootInterface` for `mac` from the machine's own
-    // interface rows, if known.
-    let row_pair_for = |mac: MacAddress| -> Option<MachineBootInterface> {
-        machine_interfaces?
+    // The machine's `MachineBootInterface` for `mac`, if known -- its own row
+    // first, then its predictions.
+    let known_pair_for = |mac: MacAddress| -> Option<MachineBootInterface> {
+        let candidates = candidates?;
+        candidates
+            .interfaces
             .iter()
             .find(|row| row.mac_address == mac)
-            .and_then(|row| {
-                MachineBootInterface::from_parts(
-                    Some(row.mac_address),
-                    row.boot_interface_id.clone(),
-                )
+            .and_then(MachineInterfaceSnapshot::boot_interface)
+            .or_else(|| {
+                candidates
+                    .predicted
+                    .iter()
+                    .find(|predicted| predicted.mac_address == mac)
+                    .and_then(PredictedMachineInterface::boot_interface)
             })
+    };
+    // Resolution chose `mac`; its `MachineBootInterface` is the target, or the
+    // MAC alone when no interface id has been captured (no id fallback).
+    let target_for = |mac: MacAddress, pair: Option<MachineBootInterface>| -> BootInterfaceTarget {
+        pair.map_or(BootInterfaceTarget::MacOnly(mac), BootInterfaceTarget::Pair)
     };
 
     match entered_mac {
-        Some(mac) => row_pair_for(mac)
-            .or_else(|| stored.filter(|pair| pair.mac_address == mac))
-            .map(BootInterfaceTarget::Pair)
-            .or(Some(BootInterfaceTarget::MacOnly(mac))),
+        Some(mac) => Some(target_for(
+            mac,
+            known_pair_for(mac).or_else(|| stored.filter(|pair| pair.mac_address == mac)),
+        )),
         None => {
-            if let Some(interfaces) = machine_interfaces
-                && let Some(picked) = model::machine::pick_boot_interface(interfaces)
-            {
+            let Some(candidates) = candidates else {
+                // No machine owns the endpoint -- the explored default
+                // answers, when site-explorer has recorded one.
+                return stored.map(BootInterfaceTarget::Pair);
+            };
+            if let Some(picked) = model::machine::pick_boot_interface(&candidates.interfaces) {
                 // The machine's own row decides, exactly like the
-                // machine-controller's boot_interface_target: the row's
-                // captured id completes the pair, or the MAC is targeted
-                // alone. The explored default is not consulted for an owned
-                // machine.
-                return Some(
-                    match MachineBootInterface::from_parts(
-                        Some(picked.mac_address),
-                        picked.boot_interface_id.clone(),
-                    ) {
-                        Some(pair) => BootInterfaceTarget::Pair(pair),
-                        None => BootInterfaceTarget::MacOnly(picked.mac_address),
-                    },
-                );
+                // machine-controller's boot_interface_target.
+                return Some(target_for(picked.mac_address, picked.boot_interface()));
             }
-            // No machine, or no candidate rows yet (e.g. only the BMC has been
-            // discovered) -- fall through to the explored default.
-            stored.map(BootInterfaceTarget::Pair)
+            // The rows offered no boot candidate: the machine's predicted
+            // NICs answer, but only when unambiguous -- exactly one
+            // non-underlay prediction. Predictions hold no primary flag, so
+            // with several the declared intent is unknowable here.
+            let mut bootable = candidates.predicted.iter().filter(|predicted| {
+                predicted.expected_network_segment_type != NetworkSegmentType::Underlay
+            });
+            if let (Some(predicted), None) = (bootable.next(), bootable.next()) {
+                return Some(target_for(
+                    predicted.mac_address,
+                    predicted.boot_interface(),
+                ));
+            }
+            // An owned machine resolves from its own data alone: no
+            // unambiguous candidate means no target, and the action requires
+            // an explicit MAC -- never a guess from the explored default.
+            None
         }
     }
 }
 
-/// The `machine_interfaces` rows boot-interface resolution selects from, when
-/// the BMC endpoint belongs to a (predicted or confirmed) host machine.
+/// What a host machine offers boot-interface resolution to select from: its
+/// real `machine_interfaces` rows, and -- for the window before a NIC's first
+/// DHCP lease creates a real row -- its `predicted_machine_interfaces`.
+pub(crate) struct BootInterfaceCandidates {
+    /// The machine's non-BMC `machine_interfaces` rows. When they offer a
+    /// boot candidate (the machine-controller's own `pick_boot_interface`
+    /// selection), it alone decides.
+    pub interfaces: Vec<MachineInterfaceSnapshot>,
+    /// The machine's predicted interfaces, consulted only when the rows
+    /// offer no boot candidate -- none exist yet (zero-DPU/NIC-mode machines
+    /// awaiting their first lease), or none are selectable (e.g. only
+    /// underlay-typed declared NICs).
+    pub predicted: Vec<PredictedMachineInterface>,
+}
+
+/// Load what boot-interface resolution selects from, when the BMC endpoint
+/// belongs to a (predicted or confirmed) host machine.
 ///
 /// Returns `None` -- meaning resolution falls through to the explored
-/// default -- for endpoints with no machine; for DPU machines, whose own
+/// default -- for endpoints with no machine, and for DPU machines, whose own
 /// setup runs without a boot-interface target, exactly like the
-/// machine-controller path; and for a host with no candidate rows yet
-/// (`find_by_machine_ids` filters BMC rows, so a host whose only discovered
-/// interface is its BMC yields none).
+/// machine-controller path. A host machine always gets `Some`, though both
+/// lists can be empty (`find_by_machine_ids` filters BMC rows, so a host
+/// whose only discovered interface is its BMC offers no real candidates).
 pub(crate) async fn boot_interface_candidates(
     txn: &mut PgConnection,
     machine_id: Option<MachineId>,
-) -> Result<Option<Vec<MachineInterfaceSnapshot>>, CarbideError> {
+) -> Result<Option<BootInterfaceCandidates>, CarbideError> {
     let Some(machine_id) = machine_id.filter(|id| !id.machine_type().is_dpu()) else {
         return Ok(None);
     };
-    Ok(
-        db::machine_interface::find_by_machine_ids(txn, &[machine_id])
-            .await?
-            .remove(&machine_id),
-    )
+    let interfaces = db::machine_interface::find_by_machine_ids(txn, &[machine_id])
+        .await?
+        .remove(&machine_id)
+        .unwrap_or_default();
+    let predicted = db::predicted_machine_interface::find_by_machine_id(txn, &machine_id).await?;
+    Ok(Some(BootInterfaceCandidates {
+        interfaces,
+        predicted,
+    }))
 }
 
 pub(crate) async fn admin_bmc_reset(
@@ -377,7 +426,7 @@ pub(crate) async fn machine_setup(
     let (bmc_endpoint_request, owning_machine_id) =
         validate_and_complete_bmc_endpoint_request(&mut txn, req.bmc_endpoint_request, machine_id)
             .await?;
-    let machine_interfaces = boot_interface_candidates(&mut txn, owning_machine_id).await?;
+    let candidates = boot_interface_candidates(&mut txn, owning_machine_id).await?;
 
     txn.commit().await?;
 
@@ -402,7 +451,7 @@ pub(crate) async fn machine_setup(
         .next()
         .and_then(|ep| ep.boot_interface());
     let boot_interface =
-        resolve_admin_boot_interface_target(stored, machine_interfaces.as_deref(), entered_mac);
+        resolve_admin_boot_interface_target(stored, candidates.as_ref(), entered_mac);
 
     api.endpoint_explorer
         .machine_setup(bmc_addr, &machine_interface, boot_interface.as_ref())
@@ -433,7 +482,7 @@ pub(crate) async fn set_dpu_first_boot_order(
     let (bmc_endpoint_request, owning_machine_id) =
         validate_and_complete_bmc_endpoint_request(&mut txn, req.bmc_endpoint_request, machine_id)
             .await?;
-    let machine_interfaces = boot_interface_candidates(&mut txn, owning_machine_id).await?;
+    let candidates = boot_interface_candidates(&mut txn, owning_machine_id).await?;
 
     txn.commit().await?;
 
@@ -462,13 +511,14 @@ pub(crate) async fn set_dpu_first_boot_order(
         .next()
         .and_then(|ep| ep.boot_interface());
     let boot_interface =
-        resolve_admin_boot_interface_target(stored, machine_interfaces.as_deref(), entered_mac)
-            .ok_or_else(|| {
+        resolve_admin_boot_interface_target(stored, candidates.as_ref(), entered_mac).ok_or_else(
+            || {
                 CarbideError::InvalidArgument(
                     "no boot interface available: enter a MAC or explore the host first"
                         .to_string(),
                 )
-            })?;
+            },
+        )?;
 
     api.endpoint_explorer
         .set_boot_order_dpu_first(bmc_addr, &machine_interface, &boot_interface)
@@ -1080,6 +1130,19 @@ mod tests {
         row
     }
 
+    fn predicted(mac: &str, boot_interface_id: Option<&str>) -> PredictedMachineInterface {
+        PredictedMachineInterface {
+            id: uuid::Uuid::nil(),
+            // Any valid machine id -- the resolver never reads it.
+            machine_id: "fm100ds27v4uuq7sgs4gsjummskt0b3tedugtpevjrbfh6su081n9jufcq0"
+                .parse()
+                .unwrap(),
+            mac_address: mac.parse().unwrap(),
+            expected_network_segment_type: NetworkSegmentType::HostInband,
+            boot_interface_id: boot_interface_id.map(String::from),
+        }
+    }
+
     fn pair(mac: &str, interface_id: &str) -> MachineBootInterface {
         MachineBootInterface {
             mac_address: mac.parse().unwrap(),
@@ -1092,14 +1155,17 @@ mod tests {
         // The operator picked a NIC; its machine_interface row holds the Redfish
         // id, so the target is the full pair -- even though the explored default
         // names a different NIC.
-        let rows = [
-            row("00:00:5e:00:53:01", true, Some("NIC.Integrated.1-1-1")),
-            row("00:00:5e:00:53:02", false, Some("NIC.Slot.7-1-1")),
-        ];
+        let c = BootInterfaceCandidates {
+            interfaces: vec![
+                row("00:00:5e:00:53:01", true, Some("NIC.Integrated.1-1-1")),
+                row("00:00:5e:00:53:02", false, Some("NIC.Slot.7-1-1")),
+            ],
+            predicted: vec![],
+        };
         let stored = Some(pair("00:00:5e:00:53:01", "NIC.Integrated.1-1-1"));
         let target = resolve_admin_boot_interface_target(
             stored,
-            Some(&rows),
+            Some(&c),
             Some("00:00:5e:00:53:02".parse().unwrap()),
         );
         assert_eq!(
@@ -1112,8 +1178,31 @@ mod tests {
     }
 
     #[test]
+    fn entered_mac_upgrades_to_a_pair_from_a_predicted_interface() {
+        // The named NIC has no machine_interfaces row yet (its first lease is
+        // still pending), but the machine's prediction for it recorded the
+        // Redfish id -- the entered MAC is completed from there.
+        let c = BootInterfaceCandidates {
+            interfaces: vec![],
+            predicted: vec![predicted("00:00:5e:00:53:02", Some("NIC.Embedded.1-1-1"))],
+        };
+        let target = resolve_admin_boot_interface_target(
+            None,
+            Some(&c),
+            Some("00:00:5e:00:53:02".parse().unwrap()),
+        );
+        assert_eq!(
+            target,
+            Some(BootInterfaceTarget::Pair(pair(
+                "00:00:5e:00:53:02",
+                "NIC.Embedded.1-1-1"
+            ))),
+        );
+    }
+
+    #[test]
     fn entered_mac_falls_back_to_the_explored_default_then_mac_only() {
-        // No machine rows: the explored default completes the pair only when it
+        // No machine: the explored default completes the pair only when it
         // names the entered MAC; any other entered MAC is targeted alone.
         let stored = pair("00:00:5e:00:53:01", "NIC.Integrated.1-1-1");
         assert_eq!(
@@ -1140,13 +1229,33 @@ mod tests {
     fn no_mac_prefers_the_machines_designation_over_the_explored_default() {
         // The machine's primary row is the authority; the explored default
         // (site-explorer's automatic pick) names a different NIC and loses.
-        let rows = [
-            row("00:00:5e:00:53:01", false, Some("NIC.Integrated.1-1-1")),
-            row("00:00:5e:00:53:02", true, Some("NIC.Slot.7-1-1")),
-        ];
+        let c = BootInterfaceCandidates {
+            interfaces: vec![
+                row("00:00:5e:00:53:01", false, Some("NIC.Integrated.1-1-1")),
+                row("00:00:5e:00:53:02", true, Some("NIC.Slot.7-1-1")),
+            ],
+            predicted: vec![],
+        };
         let stored = Some(pair("00:00:5e:00:53:01", "NIC.Integrated.1-1-1"));
         assert_eq!(
-            resolve_admin_boot_interface_target(stored, Some(&rows), None),
+            resolve_admin_boot_interface_target(stored, Some(&c), None),
+            Some(BootInterfaceTarget::Pair(pair(
+                "00:00:5e:00:53:02",
+                "NIC.Slot.7-1-1"
+            ))),
+        );
+    }
+
+    #[test]
+    fn no_mac_real_rows_beat_predicted_interfaces() {
+        // Once any real machine_interfaces row exists, predictions are out of
+        // the running -- even a fully-populated one.
+        let c = BootInterfaceCandidates {
+            interfaces: vec![row("00:00:5e:00:53:02", true, Some("NIC.Slot.7-1-1"))],
+            predicted: vec![predicted("00:00:5e:00:53:01", Some("NIC.Embedded.1-1-1"))],
+        };
+        assert_eq!(
+            resolve_admin_boot_interface_target(None, Some(&c), None),
             Some(BootInterfaceTarget::Pair(pair(
                 "00:00:5e:00:53:02",
                 "NIC.Slot.7-1-1"
@@ -1160,14 +1269,17 @@ mod tests {
         // MAC alone, exactly like the machine-controller's
         // boot_interface_target. The explored default is not consulted for an
         // owned machine -- even when it holds an id for the very same NIC.
-        let rows = [row("00:00:5e:00:53:02", true, None)];
+        let c = BootInterfaceCandidates {
+            interfaces: vec![row("00:00:5e:00:53:02", true, None)],
+            predicted: vec![],
+        };
         for stored in [
             Some(pair("00:00:5e:00:53:02", "NIC.Slot.7-1-1")),
             Some(pair("00:00:5e:00:53:01", "NIC.Integrated.1-1-1")),
             None,
         ] {
             assert_eq!(
-                resolve_admin_boot_interface_target(stored, Some(&rows), None),
+                resolve_admin_boot_interface_target(stored, Some(&c), None),
                 Some(BootInterfaceTarget::MacOnly(
                     "00:00:5e:00:53:02".parse().unwrap()
                 )),
@@ -1176,18 +1288,109 @@ mod tests {
     }
 
     #[test]
-    fn no_mac_without_candidate_rows_falls_through_to_the_explored_default() {
-        // A machine that owns no candidate interface rows yet (or no machine at
-        // all) resolves from the explored default; with neither, there is no
-        // target.
-        let stored = pair("00:00:5e:00:53:01", "NIC.Integrated.1-1-1");
+    fn no_mac_a_sole_prediction_decides_when_no_rows_exist() {
+        // A machine awaiting its first lease resolves from its prediction when
+        // there is exactly one: the recorded id completes the pair, and a
+        // prediction without an id is targeted by MAC alone.
+        let c = BootInterfaceCandidates {
+            interfaces: vec![],
+            predicted: vec![predicted("00:00:5e:00:53:01", Some("NIC.Embedded.1-1-1"))],
+        };
         assert_eq!(
-            resolve_admin_boot_interface_target(Some(stored.clone()), Some(&[]), None),
-            Some(BootInterfaceTarget::Pair(stored.clone())),
+            resolve_admin_boot_interface_target(None, Some(&c), None),
+            Some(BootInterfaceTarget::Pair(pair(
+                "00:00:5e:00:53:01",
+                "NIC.Embedded.1-1-1"
+            ))),
+        );
+
+        let idless = BootInterfaceCandidates {
+            interfaces: vec![],
+            predicted: vec![predicted("00:00:5e:00:53:01", None)],
+        };
+        assert_eq!(
+            resolve_admin_boot_interface_target(None, Some(&idless), None),
+            Some(BootInterfaceTarget::MacOnly(
+                "00:00:5e:00:53:01".parse().unwrap()
+            )),
+        );
+    }
+
+    #[test]
+    fn no_mac_multiple_predictions_refuse_to_guess_a_boot_device() {
+        // Predictions hold no primary flag, so with several (a report listing
+        // SuperNICs alongside the boot NIC) the declared intent is unknowable:
+        // resolution refuses to guess rather than silently programming boot
+        // order against whichever NIC sorts lowest. The operator's explicit
+        // MAC still resolves, completed from the matching prediction.
+        let c = BootInterfaceCandidates {
+            interfaces: vec![],
+            predicted: vec![
+                predicted("00:00:5e:00:53:02", Some("NIC.Slot.7-1-1")),
+                predicted("00:00:5e:00:53:01", Some("NIC.Embedded.1-1-1")),
+            ],
+        };
+        assert_eq!(
+            resolve_admin_boot_interface_target(None, Some(&c), None),
+            None
+        );
+        let stored = Some(pair("00:00:5e:00:53:09", "NIC.Other.9-9-9"));
+        assert_eq!(
+            resolve_admin_boot_interface_target(stored, Some(&c), None),
+            None,
+            "an explored default must never answer for an owned machine",
         );
         assert_eq!(
+            resolve_admin_boot_interface_target(
+                None,
+                Some(&c),
+                Some("00:00:5e:00:53:02".parse().unwrap()),
+            ),
+            Some(BootInterfaceTarget::Pair(pair(
+                "00:00:5e:00:53:02",
+                "NIC.Slot.7-1-1"
+            ))),
+        );
+    }
+
+    #[test]
+    fn no_mac_underlay_only_rows_let_a_sole_prediction_answer() {
+        // Real rows exist but none is a boot candidate (declared bmc/oob NICs
+        // land on Underlay segments); the sole prediction answers, ahead of
+        // the explored default.
+        let mut underlay = row("00:00:5e:00:53:09", false, None);
+        underlay.network_segment_type = Some(NetworkSegmentType::Underlay);
+        let c = BootInterfaceCandidates {
+            interfaces: vec![underlay],
+            predicted: vec![predicted("00:00:5e:00:53:01", Some("NIC.Embedded.1-1-1"))],
+        };
+        let stored = Some(pair("00:00:5e:00:53:09", "NIC.Other.9-9-9"));
+        assert_eq!(
+            resolve_admin_boot_interface_target(stored, Some(&c), None),
+            Some(BootInterfaceTarget::Pair(pair(
+                "00:00:5e:00:53:01",
+                "NIC.Embedded.1-1-1"
+            ))),
+        );
+    }
+
+    #[test]
+    fn no_mac_only_an_unowned_endpoint_uses_the_explored_default() {
+        // The explored default answers for endpoints no machine owns. An
+        // owned machine resolves from its own data alone: with no candidate
+        // at all there is no target, even when a stored default exists.
+        let stored = pair("00:00:5e:00:53:01", "NIC.Integrated.1-1-1");
+        assert_eq!(
             resolve_admin_boot_interface_target(Some(stored.clone()), None, None),
-            Some(BootInterfaceTarget::Pair(stored)),
+            Some(BootInterfaceTarget::Pair(stored.clone())),
+        );
+        let empty = BootInterfaceCandidates {
+            interfaces: vec![],
+            predicted: vec![],
+        };
+        assert_eq!(
+            resolve_admin_boot_interface_target(Some(stored), Some(&empty), None),
+            None,
         );
         assert_eq!(resolve_admin_boot_interface_target(None, None, None), None);
     }

--- a/crates/api-core/src/tests/boot_interface_resolution.rs
+++ b/crates/api-core/src/tests/boot_interface_resolution.rs
@@ -281,12 +281,77 @@ async fn test_boot_interface_candidates_skips_dpu_machines(
             .is_none(),
         "an unowned endpoint should not resolve boot-interface rows",
     );
-    let rows = boot_interface_candidates(txn.as_mut(), Some(host_id))
+    let candidates = boot_interface_candidates(txn.as_mut(), Some(host_id))
         .await?
-        .expect("a host machine should resolve its interface rows");
+        .expect("a host machine should resolve its boot-interface candidates");
     assert!(
-        rows.iter().any(|i| i.primary_interface),
+        candidates.interfaces.iter().any(|i| i.primary_interface),
         "the host's rows should include its primary interface",
+    );
+    assert!(
+        candidates.predicted.is_empty(),
+        "a fully-leased DPU host should have no pending predictions",
+    );
+
+    Ok(())
+}
+
+// The window this PR exists for: a zero-DPU machine has been ingested, but its
+// in-band NIC has not taken its first DHCP lease -- no machine_interfaces row
+// exists yet, and site-explorer records no explored default for zero-DPU
+// hosts, so a no-MAC set_dpu_first_boot_order used to have nothing to resolve.
+// The machine's predicted interface (mac + report-derived Redfish id, kept
+// fresh every exploration since #2448) now answers.
+#[crate::sqlx_test]
+async fn test_set_dpu_first_resolves_a_machine_awaiting_its_first_lease(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = api_fixtures::create_test_env_with_host_inband(pool.clone()).await;
+
+    let mock_host = ManagedHostConfig {
+        dpus: vec![],
+        ..ManagedHostConfig::default()
+    };
+    let inband_mac = *mock_host.non_dpu_macs.first().unwrap();
+
+    let _mock =
+        api_fixtures::site_explorer::ingest_zero_dpu_host_awaiting_first_lease(&env, mock_host)
+            .await?;
+
+    // Precondition: the machine owns a prediction for the NIC and no real
+    // interface row. (The prediction's content is the site-explorer ingest
+    // tests' contract; here it only locates the machine.)
+    let machine_id = {
+        let mut txn = env.pool.begin().await?;
+        let predicted = db::predicted_machine_interface::find_by_mac_address(&mut txn, inband_mac)
+            .await?
+            .expect("zero-DPU ingest should have minted a predicted interface");
+        assert!(
+            db::machine_interface::find_by_mac_address(txn.as_mut(), inband_mac)
+                .await?
+                .is_empty(),
+            "the in-band NIC should not have a machine_interfaces row yet",
+        );
+        predicted.machine_id
+    };
+
+    let timepoint = env.redfish_sim.timepoint();
+
+    env.api
+        .set_dpu_first_boot_order(tonic::Request::new(forge::SetDpuFirstBootOrderRequest {
+            machine_id: Some(machine_id.to_string()),
+            bmc_endpoint_request: None,
+            boot_interface_mac: None,
+        }))
+        .await?;
+
+    let actions = env.redfish_sim.actions_since(&timepoint).all_hosts();
+    assert_eq!(
+        actions,
+        vec![RedfishSimAction::SetBootOrderDpuFirst {
+            boot_interface_mac: inband_mac.to_string(),
+        }],
+        "the machine awaiting its first lease should resolve from its predicted interface",
     );
 
     Ok(())

--- a/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
@@ -1356,6 +1356,58 @@ pub async fn register_expected_machine(
         .expect("Expect expected machine to get registered");
 }
 
+/// Seeds the vault with the BMC root credential for the host's BMC and every
+/// DPU BMC in the config -- required by anything that reaches a BMC through
+/// the real endpoint explorer.
+pub async fn seed_bmc_root_credentials(
+    env: &TestEnv,
+    config: &ManagedHostConfig,
+) -> eyre::Result<()> {
+    for bmc_mac_address in
+        std::iter::once(config.bmc_mac_address).chain(config.dpus.iter().map(|d| d.bmc_mac_address))
+    {
+        env.api
+            .credential_manager
+            .set_credentials(
+                &CredentialKey::BmcCredentials {
+                    credential_type: BmcCredentialType::BmcRoot { bmc_mac_address },
+                },
+                &Credentials::UsernamePassword {
+                    username: "root".to_string(),
+                    password: "notforprod".to_string(),
+                },
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+/// Ingests a zero-DPU host via site-explorer and stops BEFORE its in-band
+/// NIC's first DHCP lease: the machine exists with predicted interfaces only,
+/// no real `machine_interfaces` rows. Registers the expected machine and
+/// seeds BMC credentials; the caller drives anything past this window.
+pub async fn ingest_zero_dpu_host_awaiting_first_lease<'a>(
+    env: &'a TestEnv,
+    config: ManagedHostConfig,
+) -> eyre::Result<MockExploredHost<'a>> {
+    register_expected_machine(env, &config, None).await;
+    seed_bmc_root_credentials(env, &config).await?;
+
+    Ok(MockExploredHost::new(env, config)
+        .discover_dhcp_host_bmc(|result, _| {
+            assert!(result.is_ok());
+            Ok(())
+        })
+        .await?
+        .insert_site_exploration_results()?
+        .run_site_explorer_iteration()
+        .await
+        .mark_preingestion_complete()
+        .await?
+        .run_site_explorer_iteration()
+        .await)
+}
+
 /// Use this function to make a new managed host with a given number of DPUs, using site-explorer
 /// to ingest it into the database. Returns a MockExploredHost that you can call more methods on
 /// before finishing.
@@ -1373,23 +1425,7 @@ pub async fn new_mock_host(
     register_expected_machine(env, &config, None).await;
 
     // Set BMC credentials in vault
-    for bmc_mac_address in vec![config.bmc_mac_address]
-        .into_iter()
-        .chain(config.dpus.iter().map(|d| d.bmc_mac_address))
-    {
-        env.api
-            .credential_manager
-            .set_credentials(
-                &CredentialKey::BmcCredentials {
-                    credential_type: BmcCredentialType::BmcRoot { bmc_mac_address },
-                },
-                &Credentials::UsernamePassword {
-                    username: "root".to_string(),
-                    password: "notforprod".to_string(),
-                },
-            )
-            .await?;
-    }
+    seed_bmc_root_credentials(env, &config).await?;
 
     let dpu_count = config.dpus.len() as u8;
     let mut mock_explored_host = MockExploredHost::new(env, config);
@@ -1822,23 +1858,7 @@ pub async fn new_mock_host_with_dpf(
     register_expected_machine(env, &config, Some(true)).await;
 
     // Set BMC credentials in vault
-    for bmc_mac_address in vec![config.bmc_mac_address]
-        .into_iter()
-        .chain(config.dpus.iter().map(|d| d.bmc_mac_address))
-    {
-        env.api
-            .credential_manager
-            .set_credentials(
-                &CredentialKey::BmcCredentials {
-                    credential_type: BmcCredentialType::BmcRoot { bmc_mac_address },
-                },
-                &Credentials::UsernamePassword {
-                    username: "root".to_string(),
-                    password: "notforprod".to_string(),
-                },
-            )
-            .await?;
-    }
+    seed_bmc_root_credentials(env, &config).await?;
 
     let dpu_count = config.dpus.len() as u8;
     let mut mock_explored_host = MockExploredHost::new(env, config);

--- a/crates/api-db/src/predicted_machine_interface.rs
+++ b/crates/api-db/src/predicted_machine_interface.rs
@@ -87,6 +87,15 @@ pub async fn delete(
     Ok(())
 }
 
+/// All predicted interfaces for a machine -- the boot-interface candidates a
+/// host offers while it awaits its first DHCP lease.
+pub async fn find_by_machine_id(
+    txn: &mut PgConnection,
+    machine_id: &carbide_uuid::machine::MachineId,
+) -> Result<Vec<PredictedMachineInterface>, DatabaseError> {
+    find_by(txn, ObjectColumnFilter::One(MachineIdColumn, machine_id)).await
+}
+
 pub async fn find_by_mac_address(
     txn: &mut PgConnection,
     mac_address: MacAddress,

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -276,8 +276,7 @@ impl From<ManagedHostStateSnapshotError> for sqlx::Error {
 ///
 /// Public because admin boot-interface resolution (api-core) applies the same
 /// selection to a machine's interface rows when targeting a host by BMC
-/// endpoint -- the designation must resolve identically no matter which door
-/// the Redfish action comes through.
+/// endpoint.
 pub fn pick_boot_interface(
     interfaces: &[MachineInterfaceSnapshot],
 ) -> Option<&MachineInterfaceSnapshot> {
@@ -298,18 +297,13 @@ fn pick_boot_interface_mac(
     pick_boot_interface(interfaces).map(|x| x.mac_address)
 }
 
-/// Resolves the boot interface to a fully-populated [`MachineBootInterface`]
-/// (MAC + Redfish interface id) from the picked interface's own row. Split out
-/// like `pick_boot_interface_mac` so it's unit-testable without a full snapshot.
+/// Resolves the boot interface to the picked interface's own
+/// [`MachineBootInterface`]. Split out like `pick_boot_interface_mac` so it's
+/// unit-testable without a full snapshot.
 fn pick_boot_interface_pair(
     interfaces: &[MachineInterfaceSnapshot],
 ) -> Option<MachineBootInterface> {
-    pick_boot_interface(interfaces).and_then(|interface| {
-        MachineBootInterface::from_parts(
-            Some(interface.mac_address),
-            interface.boot_interface_id.clone(),
-        )
-    })
+    pick_boot_interface(interfaces).and_then(MachineInterfaceSnapshot::boot_interface)
 }
 
 impl ManagedHostStateSnapshot {
@@ -2381,6 +2375,13 @@ pub struct MachineInterfaceSnapshot {
 }
 
 impl MachineInterfaceSnapshot {
+    /// This row's [`MachineBootInterface`]: its MAC plus its captured Redfish
+    /// interface id. `None` until site-explorer has recorded the id from an
+    /// exploration report.
+    pub fn boot_interface(&self) -> Option<MachineBootInterface> {
+        MachineBootInterface::for_mac(self.mac_address, self.boot_interface_id.clone())
+    }
+
     pub fn mock_with_mac(mac_address: MacAddress) -> Self {
         Self {
             id: MachineInterfaceId::from(uuid::Uuid::nil()),

--- a/crates/api-model/src/machine_boot_interface.rs
+++ b/crates/api-model/src/machine_boot_interface.rs
@@ -57,6 +57,12 @@ impl MachineBootInterface {
             interface_id: interface_id.filter(|s| !s.is_empty())?,
         })
     }
+
+    /// [`Self::from_parts`] for records whose MAC is always present (interface
+    /// rows, predictions): only the interface id can be missing.
+    pub fn for_mac(mac_address: MacAddress, interface_id: Option<String>) -> Option<Self> {
+        Self::from_parts(Some(mac_address), interface_id)
+    }
 }
 
 #[cfg(test)]

--- a/crates/api-model/src/predicted_machine_interface.rs
+++ b/crates/api-model/src/predicted_machine_interface.rs
@@ -19,6 +19,7 @@ use mac_address::MacAddress;
 use sqlx::FromRow;
 use uuid::Uuid;
 
+use crate::machine_boot_interface::MachineBootInterface;
 use crate::network_segment::NetworkSegmentType;
 
 #[derive(Debug, Clone, FromRow)]
@@ -31,6 +32,16 @@ pub struct PredictedMachineInterface {
     /// MAC, handed to the `machine_interfaces` row at DHCP promotion so
     /// the host's boot target is a full pair from its first owned interface.
     pub boot_interface_id: Option<String>,
+}
+
+impl PredictedMachineInterface {
+    /// The predicted [`MachineBootInterface`]: this NIC's MAC plus its last
+    /// recorded Redfish interface id -- the same pair the promoted
+    /// `machine_interfaces` row holds once the NIC's first lease lands.
+    /// `None` until the id has been captured from an exploration report.
+    pub fn boot_interface(&self) -> Option<MachineBootInterface> {
+        MachineBootInterface::for_mac(self.mac_address, self.boot_interface_id.clone())
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Description

The admin boot-interface actions (`machine_setup`, `set_dpu_first_boot_order`) now resolve machines that are still waiting on their first DHCP lease: when a machine owns no `machine_interfaces` rows yet, its predicted `MachineBootInterface` decides (`PredictedMachineInterface::boot_interface()`) -- the same interface the actual machine receives when the lease promotes it (see: #2448).

The actual boot interface takes priority over the predicted one the moment one exists, and predictions answer only when unambiguous: exactly one non-underlay prediction. With several (a report listing SuperNICs alongside the boot NIC), predictions have no primary flag to choose by, so resolution refuses to guess -- the action keeps requiring an explicit MAC, completed from the matching predicted boot interface ID.

Before this, a machine in that window gave these actions nothing to resolve -- no `machine_interfaces` rows existed yet, and `site-explorer` recorded no explored "default" for zero-DPU/NIC-mode hosts -- so calling them without a MAC failed with "enter a MAC or explore the host first", e.g. right after a DPU-to-NIC-mode migration's force-delete and re-ingest.

Unit tests cover the new resolution cases; an end-to-end sqlx test ingests a zero-DPU machine, stops before its first lease, and proves a no-MAC `set_dpu_first_boot_order` targets the predicted NIC.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
<!-- Check one that best describes this PR -->
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->

