### PR TITLE
network test support

### DIFF
--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -50,7 +50,11 @@ sqlx = { workspace = true, features = [
 thiserror = { workspace = true }
 
 [dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+carbide-macros = { path = "../macros" }
+carbide-sqlx-testing = { path = "../sqlx-testing", default-features = false }
 serde_json = { workspace = true }
+sqlx = { workspace = true, features = ["runtime-tokio", "tls-rustls", "postgres"] }
 
 [lints]
 workspace = true

--- a/crates/network/src/base_mac.rs
+++ b/crates/network/src/base_mac.rs
@@ -85,102 +85,358 @@ impl<'de> Deserialize<'de> for BaseMac {
 #[cfg(test)]
 mod test {
     use super::*;
+    use carbide_test_support::{Case, Check, Outcome::*, check_cases, check_values};
+
+    fn mac(bytes: [u8; 6]) -> BaseMac {
+        BaseMac(MacAddress::new(bytes))
+    }
+
+    // --- Display: total, uppercase hex, no colons ---
 
     #[test]
-    fn base_mac_display_formats_without_colons() {
-        let mac = BaseMac(MacAddress::new([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]));
-        assert_eq!(format!("{}", mac), "010203040506");
+    fn display_formats_uppercase_hex_without_colons() {
+        check_values(
+            [
+                Check {
+                    scenario: "ascending low bytes",
+                    input: mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
+                    expect: "010203040506".to_string(),
+                },
+                Check {
+                    scenario: "high bytes uppercase",
+                    input: mac([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]),
+                    expect: "AABBCCDDEEFF".to_string(),
+                },
+                Check {
+                    scenario: "all zeros",
+                    input: mac([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+                    expect: "000000000000".to_string(),
+                },
+                Check {
+                    scenario: "all ones",
+                    input: mac([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
+                    expect: "FFFFFFFFFFFF".to_string(),
+                },
+                Check {
+                    scenario: "single-digit bytes zero-padded",
+                    input: mac([0x00, 0x0A, 0x00, 0x0B, 0x00, 0x0C]),
+                    expect: "000A000B000C".to_string(),
+                },
+                Check {
+                    scenario: "lowercase-hex digits rendered uppercase",
+                    input: mac([0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f]),
+                    expect: "0A0B0C0D0E0F".to_string(),
+                },
+                Check {
+                    scenario: "mixed bytes",
+                    input: mac([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]),
+                    expect: "FEDCBA987654".to_string(),
+                },
+            ],
+            |m| m.to_string(),
+        );
+    }
+
+    // --- to_mac: total getter, returns the wrapped MacAddress ---
+
+    #[test]
+    fn to_mac_returns_wrapped_address() {
+        check_values(
+            [
+                Check {
+                    scenario: "ascending bytes",
+                    input: mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
+                    expect: MacAddress::new([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
+                },
+                Check {
+                    scenario: "zeros",
+                    input: mac([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+                    expect: MacAddress::new([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+                },
+                Check {
+                    scenario: "high bytes",
+                    input: mac([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]),
+                    expect: MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]),
+                },
+            ],
+            |m| m.to_mac(),
+        );
+    }
+
+    // --- From<MacAddress>: total conversion ---
+
+    #[test]
+    fn from_macaddress_wraps_unchanged() {
+        check_values(
+            [
+                Check {
+                    scenario: "ascending bytes",
+                    input: MacAddress::new([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
+                    expect: mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
+                },
+                Check {
+                    scenario: "high bytes",
+                    input: MacAddress::new([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]),
+                    expect: mac([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]),
+                },
+            ],
+            BaseMac::from,
+        );
+    }
+
+    // --- FromStr: fallible. eyre::Error is not PartialEq -> Fails + map_err(drop). ---
+    // Ok rows compare on the rendered Display form; Err rows assert failure.
+
+    #[test]
+    fn from_str_parses_accepted_forms() {
+        check_cases(
+            [
+                Case {
+                    scenario: "raw hex, no separators",
+                    input: "010203040506",
+                    expect: Yields("010203040506".to_string()),
+                },
+                Case {
+                    scenario: "colon separated",
+                    input: "01:02:03:04:05:06",
+                    expect: Yields("010203040506".to_string()),
+                },
+                Case {
+                    scenario: "space separated",
+                    input: "01 02 03 04 05 06",
+                    expect: Yields("010203040506".to_string()),
+                },
+                Case {
+                    scenario: "hyphen separated",
+                    input: "01-02-03-04-05-06",
+                    expect: Yields("010203040506".to_string()),
+                },
+                Case {
+                    scenario: "mixed case normalized to uppercase",
+                    input: "AaBbCcDdEeFf",
+                    expect: Yields("AABBCCDDEEFF".to_string()),
+                },
+                Case {
+                    scenario: "lowercase normalized to uppercase",
+                    input: "aabbccddeeff",
+                    expect: Yields("AABBCCDDEEFF".to_string()),
+                },
+                Case {
+                    scenario: "all zeros",
+                    input: "000000000000",
+                    expect: Yields("000000000000".to_string()),
+                },
+                Case {
+                    scenario: "all ff",
+                    input: "ffffffffffff",
+                    expect: Yields("FFFFFFFFFFFF".to_string()),
+                },
+                Case {
+                    scenario: "runs of whitespace between bytes",
+                    input: "a088c2    460c68",
+                    expect: Yields("A088C2460C68".to_string()),
+                },
+                Case {
+                    scenario: "non-hex separators stripped",
+                    input: "0a.0b.0c.0d.0e.0f",
+                    expect: Yields("0A0B0C0D0E0F".to_string()),
+                },
+                Case {
+                    scenario: "empty string has zero hex digits",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "too short by one byte",
+                    input: "0102030405",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "too long by one byte",
+                    input: "0102030405060708",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "one extra hex digit",
+                    input: "0102030405067",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "only non-hex characters",
+                    input: "invalid-mac",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-hex letters dropped leaving too few digits",
+                    input: "gg:hh:ii:jj:kk:ll",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "whitespace only",
+                    input: "   ",
+                    expect: Fails,
+                },
+            ],
+            |s| BaseMac::from_str(s).map(|m| m.to_string()).map_err(drop),
+        );
     }
 
     #[test]
-    fn base_mac_display_uppercase_hex() {
-        let mac = BaseMac(MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]));
-        assert_eq!(format!("{}", mac), "AABBCCDDEEFF");
+    fn from_str_rejects_with_invalid_length_message() {
+        check_cases(
+            [
+                Case {
+                    scenario: "too short reports invalid length",
+                    input: ("0102030405", &["Invalid stripped MAC length"][..]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "too long reports invalid length",
+                    input: ("0102030405060708", &["Invalid stripped MAC length"][..]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "empty reports invalid length",
+                    input: ("", &["Invalid stripped MAC length"][..]),
+                    expect: Yields(true),
+                },
+            ],
+            |(value, tokens)| {
+                let produced = BaseMac::from_str(value).unwrap_err().to_string();
+                Ok::<_, ()>(tokens.iter().all(|t| produced.contains(t)))
+            },
+        );
+    }
+
+    // --- Serialize: produces the colon-free uppercase Display string, JSON-quoted. ---
+
+    #[test]
+    fn serialize_emits_quoted_display_string() {
+        check_cases(
+            [
+                Case {
+                    scenario: "ascending bytes",
+                    input: mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
+                    expect: Yields("\"010203040506\"".to_string()),
+                },
+                Case {
+                    scenario: "high bytes uppercase",
+                    input: mac([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]),
+                    expect: Yields("\"FEDCBA987654\"".to_string()),
+                },
+                Case {
+                    scenario: "zeros",
+                    input: mac([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+                    expect: Yields("\"000000000000\"".to_string()),
+                },
+            ],
+            |m| serde_json::to_string(&m).map_err(drop),
+        );
+    }
+
+    // --- Deserialize: fallible. serde_json::Error is not relied on for equality. ---
+
+    #[test]
+    fn deserialize_parses_accepted_json_strings() {
+        check_cases(
+            [
+                Case {
+                    scenario: "raw hex string",
+                    input: "\"0a0b0c0d0e0f\"",
+                    expect: Yields("0A0B0C0D0E0F".to_string()),
+                },
+                Case {
+                    scenario: "colon separated string",
+                    input: "\"11:22:33:44:55:66\"",
+                    expect: Yields("112233445566".to_string()),
+                },
+                Case {
+                    scenario: "uppercase round-trips",
+                    input: "\"FEDCBA987654\"",
+                    expect: Yields("FEDCBA987654".to_string()),
+                },
+                Case {
+                    scenario: "non-string json number",
+                    input: "1234",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "null",
+                    input: "null",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "invalid mac text",
+                    input: "\"invalid-mac\"",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "too-short string",
+                    input: "\"0102030405\"",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "\"\"",
+                    expect: Fails,
+                },
+            ],
+            |json| {
+                serde_json::from_str::<BaseMac>(json)
+                    .map(|m| m.to_string())
+                    .map_err(drop)
+            },
+        );
     }
 
     #[test]
-    fn base_mac_from_str_parses_raw_hex() {
-        let mac = BaseMac::from_str("010203040506").expect("valid MAC");
-        assert_eq!(mac.0, MacAddress::new([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]));
+    fn deserialize_failure_carries_invalid_length_message() {
+        check_cases(
+            [
+                Case {
+                    scenario: "invalid text reports length",
+                    input: ("\"invalid-mac\"", &["Invalid stripped MAC length"][..]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "short string reports length",
+                    input: ("\"0102030405\"", &["Invalid stripped MAC length"][..]),
+                    expect: Yields(true),
+                },
+            ],
+            |(json, tokens)| {
+                let produced = serde_json::from_str::<BaseMac>(json).unwrap_err().to_string();
+                Ok::<_, ()>(tokens.iter().all(|t| produced.contains(t)))
+            },
+        );
     }
 
-    #[test]
-    fn base_mac_from_str_parses_colon_separated() {
-        let mac = BaseMac::from_str("01:02:03:04:05:06").expect("valid MAC");
-        assert_eq!(mac.0, MacAddress::new([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]));
-    }
+    // --- Round trip: serialize then deserialize yields the original value. ---
 
     #[test]
-    fn base_mac_from_str_parses_with_spaces() {
-        let mac = BaseMac::from_str("01 02 03 04 05 06").expect("valid MAC");
-        assert_eq!(mac.0, MacAddress::new([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]));
-    }
-
-    #[test]
-    fn base_mac_from_str_parses_mixed_case() {
-        let mac = BaseMac::from_str("AaBbCcDdEeFf").expect("valid MAC");
-        assert_eq!(mac.0, MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]));
-    }
-
-    #[test]
-    fn base_mac_from_str_rejects_invalid_length() {
-        let err = BaseMac::from_str("0102030405").unwrap_err();
-        assert!(err.to_string().contains("Invalid stripped MAC length"));
-    }
-
-    #[test]
-    fn base_mac_from_str_rejects_too_long() {
-        let err = BaseMac::from_str("0102030405060708").unwrap_err();
-        assert!(err.to_string().contains("Invalid stripped MAC length"));
-    }
-
-    #[test]
-    fn base_mac_serialization_without_colons() {
-        let mac = BaseMac(MacAddress::new([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]));
-        let serialized = serde_json::to_string(&mac).expect("serialization");
-        assert_eq!(serialized, "\"010203040506\"");
-    }
-
-    #[test]
-    fn base_mac_serialization_uppercase_hex() {
-        let mac = BaseMac(MacAddress::new([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]));
-        let serialized = serde_json::to_string(&mac).expect("serialization");
-        assert_eq!(serialized, "\"FEDCBA987654\"");
-    }
-
-    #[test]
-    fn base_mac_deserialization_parses_raw_hex_string() {
-        let json = "\"0a0b0c0d0e0f\"";
-        let mac: BaseMac = serde_json::from_str(json).expect("deserialize raw hex");
-        assert_eq!(mac.to_string(), "0A0B0C0D0E0F");
-    }
-
-    #[test]
-    fn base_mac_deserialization_parses_colon_separated() {
-        let json = "\"11:22:33:44:55:66\"";
-        let mac: BaseMac = serde_json::from_str(json).expect("deserialize json");
-        assert_eq!(mac.to_string(), "112233445566");
-    }
-
-    #[test]
-    fn base_mac_round_trip_serialization() {
-        let original = BaseMac(MacAddress::new([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]));
-        let serialized = serde_json::to_string(&original).unwrap();
-        let deserialized: BaseMac = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(original, deserialized);
-    }
-
-    #[test]
-    fn base_mac_deserialization_fails_on_invalid_input() {
-        let json = "\"invalid-mac\"";
-        let err = serde_json::from_str::<BaseMac>(json).unwrap_err();
-        assert!(err.to_string().contains("Invalid stripped MAC length"));
-    }
-
-    #[test]
-    fn base_mac_deserialization_fails_on_short_input() {
-        let json = "\"0102030405\"";
-        let err = serde_json::from_str::<BaseMac>(json).unwrap_err();
-        assert!(err.to_string().contains("Invalid stripped MAC length"));
+    fn round_trips_through_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "high bytes",
+                    input: mac([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]),
+                    expect: Yields(mac([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54])),
+                },
+                Case {
+                    scenario: "ascending bytes",
+                    input: mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
+                    expect: Yields(mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06])),
+                },
+                Case {
+                    scenario: "zeros",
+                    input: mac([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+                    expect: Yields(mac([0x00, 0x00, 0x00, 0x00, 0x00, 0x00])),
+                },
+            ],
+            |original| {
+                let serialized = serde_json::to_string(&original).map_err(drop)?;
+                serde_json::from_str::<BaseMac>(&serialized).map_err(drop)
+            },
+        );
     }
 }

--- a/crates/network/src/ip/address_family.rs
+++ b/crates/network/src/ip/address_family.rs
@@ -101,47 +101,254 @@ impl IdentifyAddressFamily for ipnetwork::IpNetwork {
 #[cfg(test)]
 mod tests {
     use std::net::IpAddr;
-    use std::str::FromStr;
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use ipnet::IpNet;
 
     use super::*;
 
     #[test]
-    fn test_require_address_family_or_else() {
-        let addr = IpAddr::from_str("127.0.0.1").unwrap();
-
-        // The above is an IPv4 address, so it should come out the other side
-        // as an Ok variant.
-        assert_eq!(
-            addr.require_address_family_or_else(IpAddressFamily::Ipv4, |_| {}),
-            Ok(addr),
-        );
-
-        assert_eq!(
-            addr.require_address_family_or_else(IpAddressFamily::Ipv6, |_| 42),
-            Err(42)
-        )
-    }
-
-    #[test]
     fn test_interface_prefix_len() {
-        assert_eq!(IpAddressFamily::Ipv4.interface_prefix_len(), 32);
-        assert_eq!(IpAddressFamily::Ipv6.interface_prefix_len(), 128);
-
-        // Also test via the IdentifyAddressFamily trait on IpAddr.
-        let v4: IpAddr = "10.0.0.1".parse().unwrap();
-        let v6: IpAddr = "fd00::1".parse().unwrap();
-        assert_eq!(v4.address_family().interface_prefix_len(), 32);
-        assert_eq!(v6.address_family().interface_prefix_len(), 128);
+        check_values(
+            [
+                Check {
+                    scenario: "ipv4 is /32",
+                    input: IpAddressFamily::Ipv4,
+                    expect: 32,
+                },
+                Check {
+                    scenario: "ipv6 is /128",
+                    input: IpAddressFamily::Ipv6,
+                    expect: 128,
+                },
+            ],
+            |family| family.interface_prefix_len(),
+        );
     }
 
     #[test]
     fn test_pg_family() {
-        assert_eq!(IpAddressFamily::Ipv4.pg_family(), 4);
-        assert_eq!(IpAddressFamily::Ipv6.pg_family(), 6);
+        check_values(
+            [
+                Check {
+                    scenario: "ipv4 is postgres family 4",
+                    input: IpAddressFamily::Ipv4,
+                    expect: 4,
+                },
+                Check {
+                    scenario: "ipv6 is postgres family 6",
+                    input: IpAddressFamily::Ipv6,
+                    expect: 6,
+                },
+            ],
+            |family| family.pg_family(),
+        );
+    }
 
-        let v4: IpAddr = "10.0.0.1".parse().unwrap();
-        let v6: IpAddr = "fd00::1".parse().unwrap();
-        assert_eq!(v4.address_family().pg_family(), 4);
-        assert_eq!(v6.address_family().pg_family(), 6);
+    #[test]
+    fn test_ipaddr_address_family() {
+        check_values(
+            [
+                Check {
+                    scenario: "ipv4 loopback",
+                    input: "127.0.0.1",
+                    expect: IpAddressFamily::Ipv4,
+                },
+                Check {
+                    scenario: "ipv4 unspecified",
+                    input: "0.0.0.0",
+                    expect: IpAddressFamily::Ipv4,
+                },
+                Check {
+                    scenario: "ipv4 broadcast",
+                    input: "255.255.255.255",
+                    expect: IpAddressFamily::Ipv4,
+                },
+                Check {
+                    scenario: "ipv4 routable",
+                    input: "10.0.0.1",
+                    expect: IpAddressFamily::Ipv4,
+                },
+                Check {
+                    scenario: "ipv6 loopback",
+                    input: "::1",
+                    expect: IpAddressFamily::Ipv6,
+                },
+                Check {
+                    scenario: "ipv6 unspecified",
+                    input: "::",
+                    expect: IpAddressFamily::Ipv6,
+                },
+                Check {
+                    scenario: "ipv6 unique-local",
+                    input: "fd00::1",
+                    expect: IpAddressFamily::Ipv6,
+                },
+                Check {
+                    scenario: "ipv6 link-local",
+                    input: "fe80::1",
+                    expect: IpAddressFamily::Ipv6,
+                },
+                Check {
+                    scenario: "ipv4-mapped ipv6 stays ipv6",
+                    input: "::ffff:192.0.2.1",
+                    expect: IpAddressFamily::Ipv6,
+                },
+            ],
+            |s| s.parse::<IpAddr>().unwrap().address_family(),
+        );
+    }
+
+    #[test]
+    fn test_ipnet_address_family() {
+        check_values(
+            [
+                Check {
+                    scenario: "ipv4 host route",
+                    input: "10.0.0.1/32",
+                    expect: IpAddressFamily::Ipv4,
+                },
+                Check {
+                    scenario: "ipv4 default route",
+                    input: "0.0.0.0/0",
+                    expect: IpAddressFamily::Ipv4,
+                },
+                Check {
+                    scenario: "ipv4 subnet",
+                    input: "192.168.0.0/24",
+                    expect: IpAddressFamily::Ipv4,
+                },
+                Check {
+                    scenario: "ipv6 host route",
+                    input: "fd00::1/128",
+                    expect: IpAddressFamily::Ipv6,
+                },
+                Check {
+                    scenario: "ipv6 default route",
+                    input: "::/0",
+                    expect: IpAddressFamily::Ipv6,
+                },
+                Check {
+                    scenario: "ipv6 subnet",
+                    input: "2001:db8::/64",
+                    expect: IpAddressFamily::Ipv6,
+                },
+            ],
+            |s| s.parse::<IpNet>().unwrap().address_family(),
+        );
+    }
+
+    #[test]
+    fn test_is_address_family() {
+        struct Row {
+            value: &'static str,
+            family: IpAddressFamily,
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "ipv4 matches ipv4",
+                    input: Row {
+                        value: "10.0.0.1",
+                        family: IpAddressFamily::Ipv4,
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "ipv4 does not match ipv6",
+                    input: Row {
+                        value: "10.0.0.1",
+                        family: IpAddressFamily::Ipv6,
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "ipv6 matches ipv6",
+                    input: Row {
+                        value: "fd00::1",
+                        family: IpAddressFamily::Ipv6,
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "ipv6 does not match ipv4",
+                    input: Row {
+                        value: "fd00::1",
+                        family: IpAddressFamily::Ipv4,
+                    },
+                    expect: false,
+                },
+            ],
+            |row| {
+                row.value
+                    .parse::<IpAddr>()
+                    .unwrap()
+                    .is_address_family(row.family)
+            },
+        );
+    }
+
+    #[test]
+    fn test_require_address_family_or_else() {
+        struct Row {
+            value: &'static str,
+            required: IpAddressFamily,
+        }
+
+        check_cases(
+            [
+                Case {
+                    scenario: "ipv4 required and present yields the address",
+                    input: Row {
+                        value: "127.0.0.1",
+                        required: IpAddressFamily::Ipv4,
+                    },
+                    expect: Yields("127.0.0.1".parse::<IpAddr>().unwrap()),
+                },
+                Case {
+                    scenario: "ipv6 required and present yields the address",
+                    input: Row {
+                        value: "fd00::1",
+                        required: IpAddressFamily::Ipv6,
+                    },
+                    expect: Yields("fd00::1".parse::<IpAddr>().unwrap()),
+                },
+                Case {
+                    scenario: "ipv6 required but ipv4 given fails",
+                    input: Row {
+                        value: "127.0.0.1",
+                        required: IpAddressFamily::Ipv6,
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ipv4 required but ipv6 given fails",
+                    input: Row {
+                        value: "fd00::1",
+                        required: IpAddressFamily::Ipv4,
+                    },
+                    expect: Fails,
+                },
+            ],
+            |row| {
+                let addr = row.value.parse::<IpAddr>().unwrap();
+                addr.require_address_family_or_else(row.required, |_| ())
+            },
+        );
+    }
+
+    #[test]
+    fn test_require_address_family_or_else_passes_value_to_err() {
+        // The error closure receives the rejected value; assert it is threaded
+        // through so callers can fold the original address into their error.
+        let addr: IpAddr = "127.0.0.1".parse().unwrap();
+        Case {
+            scenario: "rejected value reaches the error closure",
+            input: addr,
+            expect: FailsWith(addr),
+        }
+        .check(|addr| addr.require_address_family_or_else(IpAddressFamily::Ipv6, |rejected| rejected));
     }
 }

--- a/crates/network/src/ip/ipset.rs
+++ b/crates/network/src/ip/ipset.rs
@@ -178,32 +178,265 @@ mod tests {
     use std::net::Ipv4Addr;
     use std::str::FromStr;
 
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
 
-    #[test]
-    fn test_contains() {
-        let ten_net = IpPrefix::from_str("10.0.0.0/8").unwrap();
-        let last_ten_addr = IpPrefix::from_str("10.255.255.255/32").unwrap();
-        let ipset = IpSet::from(ten_net);
-        assert!(ipset.contains(ten_net));
-        assert!(ipset.contains(last_ten_addr));
+    /// Parse a prefix string into an `IpPrefix`, panicking on malformed input.
+    /// All the strings below are test literals known to be valid.
+    fn pfx(s: &str) -> IpPrefix {
+        IpPrefix::from_str(s).unwrap_or_else(|e| panic!("bad test prefix {s:?}: {e}"))
+    }
 
-        let one_before = IpPrefix::from_str("9.255.255.255/32").unwrap();
-        assert!(!ipset.contains(one_before));
+    /// Parse a slice of prefix strings into owned `IpPrefix` values.
+    fn pfxs(strs: &[&str]) -> Vec<IpPrefix> {
+        strs.iter().map(|s| pfx(s)).collect()
+    }
 
-        let one_after = IpPrefix::from_str("11.0.0.0/32").unwrap();
-        assert!(!ipset.contains(one_after));
+    /// Build an `IpSet` by adding each of the given prefix strings, then return
+    /// its aggregate prefixes as strings for easy table comparison.
+    fn add_all_and_dump(strs: &[&str]) -> Vec<String> {
+        let mut ipset = IpSet::new_empty();
+        for s in strs {
+            ipset.add(pfx(s));
+        }
+        ipset.get_prefixes().iter().map(|p| p.to_string()).collect()
     }
 
     #[test]
-    fn test_remove() {
+    fn membership_covers_set_and_gaps() {
+        // The set is the whole 10/8 net; check addresses and prefixes inside it,
+        // on each boundary, and just outside on either side.
+        let ipset = IpSet::from(pfx("10.0.0.0/8"));
+        check_values(
+            [
+                Check {
+                    scenario: "the defining prefix itself",
+                    input: "10.0.0.0/8",
+                    expect: true,
+                },
+                Check {
+                    scenario: "first address in range",
+                    input: "10.0.0.0/32",
+                    expect: true,
+                },
+                Check {
+                    scenario: "last address in range",
+                    input: "10.255.255.255/32",
+                    expect: true,
+                },
+                Check {
+                    scenario: "an interior subprefix",
+                    input: "10.128.0.0/9",
+                    expect: true,
+                },
+                Check {
+                    scenario: "a deep interior address",
+                    input: "10.1.2.3/32",
+                    expect: true,
+                },
+                Check {
+                    scenario: "one address before the range",
+                    input: "9.255.255.255/32",
+                    expect: false,
+                },
+                Check {
+                    scenario: "one address after the range",
+                    input: "11.0.0.0/32",
+                    expect: false,
+                },
+                Check {
+                    scenario: "a wider prefix that is not contained",
+                    input: "10.0.0.0/7",
+                    expect: false,
+                },
+                Check {
+                    scenario: "an unrelated v4 prefix",
+                    input: "192.168.0.0/16",
+                    expect: false,
+                },
+                Check {
+                    scenario: "an IPv6 prefix is never in a v4-only set",
+                    input: "2001:db8::/32",
+                    expect: false,
+                },
+            ],
+            |s| ipset.contains(pfx(s)),
+        );
+    }
+
+    #[test]
+    fn membership_of_the_empty_set_is_always_false() {
+        let ipset = IpSet::new_empty();
+        check_values(
+            [
+                Check {
+                    scenario: "v4 address",
+                    input: "10.0.0.1/32",
+                    expect: false,
+                },
+                Check {
+                    scenario: "v4 prefix",
+                    input: "0.0.0.0/0",
+                    expect: false,
+                },
+                Check {
+                    scenario: "v6 prefix",
+                    input: "::/0",
+                    expect: false,
+                },
+            ],
+            |s| ipset.contains(pfx(s)),
+        );
+    }
+
+    #[test]
+    fn membership_of_disjoint_v4_v6_set() {
+        // A set holding both a v4 and a v6 prefix; each family answers
+        // independently and never crosses over.
+        let ipset = IpSet::from([pfx("10.0.0.0/8"), pfx("2001:db8::/32")]);
+        check_values(
+            [
+                Check {
+                    scenario: "inside the v4 member",
+                    input: "10.5.5.5/32",
+                    expect: true,
+                },
+                Check {
+                    scenario: "inside the v6 member",
+                    input: "2001:db8:abcd::/48",
+                    expect: true,
+                },
+                Check {
+                    scenario: "outside the v4 member",
+                    input: "11.0.0.0/8",
+                    expect: false,
+                },
+                Check {
+                    scenario: "outside the v6 member",
+                    input: "2001:db9::/32",
+                    expect: false,
+                },
+            ],
+            |s| ipset.contains(pfx(s)),
+        );
+    }
+
+    #[test]
+    fn adding_prefixes_aggregates_and_dedups() {
+        // Each row builds a fresh set from the given inputs and asserts the
+        // resulting aggregate prefixes. Order of insertion must not matter.
+        check_values(
+            [
+                Check {
+                    scenario: "single prefix is stored verbatim",
+                    input: &["10.0.0.0/24"][..],
+                    expect: vec!["10.0.0.0/24".to_string()],
+                },
+                Check {
+                    scenario: "exact duplicate is a no-op",
+                    input: &["10.0.0.0/24", "10.0.0.0/24"][..],
+                    expect: vec!["10.0.0.0/24".to_string()],
+                },
+                Check {
+                    scenario: "a subprefix already covered is absorbed",
+                    input: &["10.0.0.0/8", "10.1.2.0/24"][..],
+                    expect: vec!["10.0.0.0/8".to_string()],
+                },
+                Check {
+                    scenario: "a superprefix swallows an existing entry",
+                    input: &["10.1.2.0/24", "10.0.0.0/8"][..],
+                    expect: vec!["10.0.0.0/8".to_string()],
+                },
+                Check {
+                    scenario: "two siblings aggregate into their supernet",
+                    input: &["10.0.0.0/24", "10.0.1.0/24"][..],
+                    expect: vec!["10.0.0.0/23".to_string()],
+                },
+                Check {
+                    scenario: "siblings aggregate regardless of insertion order",
+                    input: &["10.0.1.0/24", "10.0.0.0/24"][..],
+                    expect: vec!["10.0.0.0/23".to_string()],
+                },
+                Check {
+                    scenario: "non-sibling neighbors stay separate",
+                    input: &["10.0.1.0/24", "10.0.2.0/24"][..],
+                    expect: vec!["10.0.1.0/24".to_string(), "10.0.2.0/24".to_string()],
+                },
+                Check {
+                    scenario: "cascading aggregation up several levels",
+                    input: &[
+                        "10.0.0.0/26",
+                        "10.0.0.64/26",
+                        "10.0.0.128/26",
+                        "10.0.0.192/26",
+                    ][..],
+                    expect: vec!["10.0.0.0/24".to_string()],
+                },
+                Check {
+                    scenario: "filling a /24 from a /25 plus power-of-two pieces",
+                    input: &[
+                        "10.0.1.4/30",
+                        "10.0.1.8/29",
+                        "10.0.1.16/28",
+                        "10.0.1.32/27",
+                        "10.0.1.64/26",
+                        "10.0.1.128/25",
+                        "10.0.0.0/24",
+                        "10.0.1.0/30",
+                    ][..],
+                    expect: vec!["10.0.0.0/23".to_string()],
+                },
+                Check {
+                    scenario: "a v4 and a v6 prefix coexist, v4 sorts first",
+                    input: &["2001:db8::/32", "10.0.0.0/8"][..],
+                    expect: vec!["10.0.0.0/8".to_string(), "2001:db8::/32".to_string()],
+                },
+                Check {
+                    scenario: "v6 siblings aggregate too",
+                    input: &["2001:db8:0000::/34", "2001:db8:4000::/34"][..],
+                    expect: vec!["2001:db8::/33".to_string()],
+                },
+                Check {
+                    scenario: "a default route swallows everything in its family",
+                    input: &["0.0.0.0/0", "10.0.0.0/8", "192.168.0.0/16"][..],
+                    expect: vec!["0.0.0.0/0".to_string()],
+                },
+            ],
+            add_all_and_dump,
+        );
+    }
+
+    #[test]
+    fn auto_aggregation_collapses_a_full_supernet() {
+        // The original `test_auto_aggregation`: a /24 plus the pieces of its
+        // sibling /24 collapse to a single /23.
+        let mut ipset = IpSet::from(pfx("10.0.0.0/24"));
+        for s in [
+            "10.0.1.4/30",
+            "10.0.1.8/29",
+            "10.0.1.16/28",
+            "10.0.1.32/27",
+            "10.0.1.64/26",
+            "10.0.1.128/25",
+            "10.0.1.0/30",
+        ] {
+            ipset.add(pfx(s));
+        }
+        ipset.add(pfx("10.0.1.0/24"));
+        assert_eq!(ipset.get_prefixes(), pfxs(&["10.0.0.0/23"]));
+    }
+
+    #[test]
+    fn removing_fragments_the_containing_prefix() {
+        // The original `test_remove`: removing the last /32 from a /24 leaves a
+        // descending staircase of fragments; removing it again is a no-op.
         let mut ipset = IpSet::new_empty();
-        ipset.add(IpPrefix::from_str("10.0.0.0/24").unwrap());
-        let last_addr = IpPrefix::from_str("10.0.0.255/32").unwrap();
+        ipset.add(pfx("10.0.0.0/24"));
+        let last_addr = pfx("10.0.0.255/32");
         ipset.remove(&last_addr);
-        // We already removed this, doing it again should be a no-op.
         ipset.remove(&last_addr);
-        let expected_prefixes: Vec<IpPrefix> = [
+        let expected = pfxs(&[
             "10.0.0.0/25",
             "10.0.0.128/26",
             "10.0.0.192/27",
@@ -212,59 +445,195 @@ mod tests {
             "10.0.0.248/30",
             "10.0.0.252/31",
             "10.0.0.254/32",
-        ]
-        .into_iter()
-        .map(|p| IpPrefix::from_str(p).unwrap())
-        .collect();
-        assert_eq!(ipset.get_prefixes(), expected_prefixes);
+        ]);
+        assert_eq!(ipset.get_prefixes(), expected);
     }
 
     #[test]
-    fn test_auto_aggregation() {
-        let mut ipset = IpSet::from(IpPrefix::from_str("10.0.0.0/24").unwrap());
-        for p in [
-            "10.0.1.4/30",
-            "10.0.1.8/29",
-            "10.0.1.16/28",
-            "10.0.1.32/27",
-            "10.0.1.64/26",
-            "10.0.1.128/25",
-        ] {
-            ipset.add(IpPrefix::from_str(p).unwrap());
+    fn remove_outcomes() {
+        // Each row starts from a set built from the first slice, removes the
+        // second prefix, then dumps the resulting aggregate prefixes.
+        struct Case {
+            scenario: &'static str,
+            start: &'static [&'static str],
+            remove: &'static str,
+            expect: Vec<String>,
         }
-
-        ipset.add(IpPrefix::from_str("10.0.1.0/24").unwrap());
-        let expected_aggregate = IpPrefix::from_str("10.0.0.0/23").unwrap();
-        assert_eq!(ipset.get_prefixes().as_slice(), &[expected_aggregate]);
+        let cases = [
+            Case {
+                scenario: "removing a member empties the set",
+                start: &["10.0.0.0/24"],
+                remove: "10.0.0.0/24",
+                expect: vec![],
+            },
+            Case {
+                scenario: "removing something absent is a no-op",
+                start: &["10.0.0.0/24"],
+                remove: "192.168.0.0/24",
+                expect: vec!["10.0.0.0/24".to_string()],
+            },
+            Case {
+                scenario: "removing from the empty set is a no-op",
+                start: &[],
+                remove: "10.0.0.0/24",
+                expect: vec![],
+            },
+            Case {
+                scenario: "removing a half leaves the other half",
+                start: &["10.0.0.0/23"],
+                remove: "10.0.0.0/24",
+                expect: vec!["10.0.1.0/24".to_string()],
+            },
+            Case {
+                scenario: "removing the high half leaves the low half",
+                start: &["10.0.0.0/23"],
+                remove: "10.0.1.0/24",
+                expect: vec!["10.0.0.0/24".to_string()],
+            },
+            Case {
+                scenario: "removing one member leaves disjoint others untouched",
+                start: &["10.0.0.0/24", "192.168.0.0/24"],
+                remove: "10.0.0.0/24",
+                expect: vec!["192.168.0.0/24".to_string()],
+            },
+            Case {
+                scenario: "removing a v6 member leaves the v4 member",
+                start: &["10.0.0.0/8", "2001:db8::/32"],
+                remove: "2001:db8::/32",
+                expect: vec!["10.0.0.0/8".to_string()],
+            },
+        ];
+        check_values(
+            cases.map(|c| Check {
+                scenario: c.scenario,
+                input: (c.start, c.remove),
+                expect: c.expect,
+            }),
+            |(start, remove)| {
+                let mut ipset = IpSet::from(pfxs(start));
+                ipset.remove(&pfx(remove));
+                ipset.get_prefixes().iter().map(|p| p.to_string()).collect()
+            },
+        );
     }
 
     #[test]
-    fn test_bulk_address_aggregation() {
+    fn family_filtered_getters_split_by_address_family() {
+        // get_ipv4_prefixes / get_ipv6_prefixes each keep only their family.
+        let ipset = IpSet::from([
+            pfx("10.0.0.0/8"),
+            pfx("192.168.0.0/16"),
+            pfx("2001:db8::/32"),
+            pfx("fd00::/8"),
+        ]);
+
+        let v4: Vec<String> = ipset
+            .get_ipv4_prefixes()
+            .iter()
+            .map(|p| p.to_string())
+            .collect();
+        assert_eq!(v4, vec!["10.0.0.0/8".to_string(), "192.168.0.0/16".to_string()]);
+
+        let v6: Vec<String> = ipset
+            .get_ipv6_prefixes()
+            .iter()
+            .map(|p| p.to_string())
+            .collect();
+        assert_eq!(v6, vec!["2001:db8::/32".to_string(), "fd00::/8".to_string()]);
+
+        // A v4-only set yields nothing from the v6 getter, and vice versa.
+        let v4_only = IpSet::from(pfx("10.0.0.0/8"));
+        assert!(v4_only.get_ipv6_prefixes().is_empty());
+        assert_eq!(v4_only.get_ipv4_prefixes().len(), 1);
+
+        let v6_only = IpSet::from(pfx("2001:db8::/32"));
+        assert!(v6_only.get_ipv4_prefixes().is_empty());
+        assert_eq!(v6_only.get_ipv6_prefixes().len(), 1);
+
+        // Empty set yields nothing from either getter.
+        let empty = IpSet::new_empty();
+        assert!(empty.get_ipv4_prefixes().is_empty());
+        assert!(empty.get_ipv6_prefixes().is_empty());
+        assert!(empty.get_prefixes().is_empty());
+    }
+
+    #[test]
+    fn from_iterator_constructs_an_aggregated_set() {
+        // The `From<IntoIterator>` impl runs every item through `add`, so the
+        // result is already aggregated and deduplicated.
+        check_values(
+            [
+                Check {
+                    scenario: "empty iterator yields the empty set",
+                    input: &[][..],
+                    expect: Vec::<String>::new(),
+                },
+                Check {
+                    scenario: "duplicates collapse",
+                    input: &["10.0.0.0/24", "10.0.0.0/24", "10.0.0.0/24"][..],
+                    expect: vec!["10.0.0.0/24".to_string()],
+                },
+                Check {
+                    scenario: "siblings aggregate",
+                    input: &["10.0.0.0/24", "10.0.1.0/24"][..],
+                    expect: vec!["10.0.0.0/23".to_string()],
+                },
+            ],
+            |strs: &[&str]| {
+                let ipset = IpSet::from(pfxs(strs));
+                ipset.get_prefixes().iter().map(|p| p.to_string()).collect()
+            },
+        );
+    }
+
+    #[test]
+    fn bulk_address_aggregation_merges_a_full_run() {
+        // The original `test_bulk_address_aggregation`: every /32 from 10.0.0.0
+        // up to (excluding) 10.1.0.0 covers exactly 10.0.0.0/16.
         let start_addr = Ipv4Addr::from_str("10.0.0.0").unwrap();
         let end_addr = Ipv4Addr::from_str("10.1.0.0").unwrap();
-        let mut ipv4_address_prefixes: Vec<_> =
-            (start_addr..end_addr).map(|a| a.to_prefix()).collect();
-        ipv4_address_prefixes.as_mut_slice().reverse();
-        let ipset = IpSet::from(ipv4_address_prefixes.as_slice());
-        let expected_address_space = IpPrefix::from_str("10.0.0.0/16").unwrap();
-        assert_eq!(ipset.get_prefixes().as_slice(), &[expected_address_space]);
+        let mut prefixes: Vec<_> = (start_addr..end_addr).map(|a| a.to_prefix()).collect();
+        prefixes.as_mut_slice().reverse();
+        let ipset = IpSet::from(prefixes.as_slice());
+        assert_eq!(ipset.get_prefixes(), pfxs(&["10.0.0.0/16"]));
     }
 
     #[test]
-    fn test_aggregate_prefixes() {
-        let p1 = IpPrefix::from_str("10.0.0.0/24").unwrap();
-        let p2 = IpPrefix::from_str("10.0.1.0/24").unwrap();
-        let p3 = IpPrefix::from_str("10.0.2.0/23").unwrap();
-        let p4 = IpPrefix::from_str("2001:db8:0000::/34").unwrap();
-        let p5 = IpPrefix::from_str("2001:db8:4000::/34").unwrap();
-        let p6 = IpPrefix::from_str("2001:db8:8000::/33").unwrap();
-        let mut before = vec![p1, p2, p3, p4, p5, p6];
-        // Let's not make it too easy.
-        before.reverse();
-
-        let after = aggregate_prefixes(before.as_slice());
-        let a1 = IpPrefix::from_str("10.0.0.0/22").unwrap();
-        let a2 = IpPrefix::from_str("2001:db8::/32").unwrap();
-        assert_eq!(after.as_slice(), &[a1, a2]);
+    fn aggregate_prefixes_merges_and_sorts() {
+        // The original `test_aggregate_prefixes`, generalized: each row feeds a
+        // (deliberately scrambled) list through the free `aggregate_prefixes`
+        // helper and asserts the merged, v4-before-v6 result.
+        check_values(
+            [
+                Check {
+                    scenario: "empty input yields nothing",
+                    input: &[][..],
+                    expect: Vec::<String>::new(),
+                },
+                Check {
+                    scenario: "a single prefix passes through",
+                    input: &["10.0.0.0/24"][..],
+                    expect: vec!["10.0.0.0/24".to_string()],
+                },
+                Check {
+                    scenario: "mixed v4 and v6 merge within each family and sort",
+                    input: &[
+                        "2001:db8:8000::/33",
+                        "2001:db8:4000::/34",
+                        "2001:db8:0000::/34",
+                        "10.0.2.0/23",
+                        "10.0.1.0/24",
+                        "10.0.0.0/24",
+                    ][..],
+                    expect: vec!["10.0.0.0/22".to_string(), "2001:db8::/32".to_string()],
+                },
+            ],
+            |strs: &[&str]| {
+                aggregate_prefixes(pfxs(strs))
+                    .iter()
+                    .map(|p| p.to_string())
+                    .collect()
+            },
+        );
     }
 }

--- a/crates/network/src/ip/prefix.rs
+++ b/crates/network/src/ip/prefix.rs
@@ -231,7 +231,7 @@ impl Ipv6Prefix {
                 // with the prefix one longer, but the other (the "odd" branch)
                 // needs to have a bit flipped to 1 first.
                 let even_addr_bits = self.prefix.addr().to_bits();
-                let single_bit_flip = 0x8000_0000_0000_0000u128 >> n;
+                let single_bit_flip = 0x8000_0000_0000_0000_0000_0000_0000_0000u128 >> n;
                 let odd_addr_bits = even_addr_bits | single_bit_flip;
 
                 let even_addr = Ipv6Addr::from_bits(even_addr_bits);
@@ -632,78 +632,752 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
 
-    #[test]
-    fn test_parse_prefix() {
-        let good_v4 = "192.168.0.0/16";
-        Ipv4Prefix::from_str(good_v4).expect("Couldn't parse good IPv4 prefix");
-
-        let bad_v4 = "192.168.1.2/16"; // should be 192.168.0.0/16 as in `good_v4` above.
-        Ipv4Prefix::from_str(bad_v4)
-            .expect_err("Unexpectedly parsed IPv4 prefix with non-canonical representation");
-
-        let bad_v4 = "192.168.0.0/33";
-        Ipv4Prefix::from_str(bad_v4)
-            .expect_err("Unexpectedly parsed IPv4 prefix with an invalid length");
-
-        let good_v6 = "2001:DB8::/48";
-        Ipv6Prefix::from_str(good_v6).expect("Couldn't parse good IPv6 prefix");
-
-        let bad_v6 = "2001:DB8::2/64";
-        Ipv6Prefix::from_str(bad_v6)
-            .expect_err("Unexpectedly parsed IPv6 prefix with non-canonical representation");
+    /// Parse an `IpPrefix` in a test, panicking on failure with a useful label.
+    fn prefix(s: &str) -> IpPrefix {
+        IpPrefix::from_str(s).unwrap_or_else(|e| panic!("couldn't parse prefix {s:?}: {e}"))
     }
 
     #[test]
-    fn test_address_family() {
-        let v4_prefix = IpPrefix::from_str("10.0.0.0/8").expect("Couldn't parse prefix");
-        assert!(v4_prefix.is_address_family(IpAddressFamily::Ipv4));
-
-        let wrong_address_family_error =
-            v4_prefix.require_address_family_or_else(IpAddressFamily::Ipv6, |_| 42);
-        assert_eq!(wrong_address_family_error, Err(42));
+    fn ipv4_prefix_from_str_accepts_and_rejects() {
+        check_cases(
+            [
+                Case {
+                    scenario: "canonical /16",
+                    input: "192.168.0.0/16",
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "canonical /0",
+                    input: "0.0.0.0/0",
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "host /32",
+                    input: "10.0.0.1/32",
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "non-canonical host bits set",
+                    input: "192.168.1.2/16",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-canonical single low bit",
+                    input: "10.0.0.1/24",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "prefix length out of range",
+                    input: "192.168.0.0/33",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "garbage address",
+                    input: "not-an-ip/16",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing prefix length",
+                    input: "192.168.0.0",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ipv6 text rejected by v4 parser",
+                    input: "2001:db8::/48",
+                    expect: Fails,
+                },
+            ],
+            // The Ok payload (the parsed prefix) varies per row, so success is
+            // collapsed to the unit value; the contract under test is which
+            // inputs parse and which are rejected.
+            |s| Ipv4Prefix::from_str(s).map(|_| ()).map_err(drop),
+        );
     }
 
     #[test]
-    fn test_contains() {
-        let v4_prefix = IpPrefix::from_str("10.0.0.0/8").expect("Couldn't parse prefix");
-        let v4_addr = IpAddr::from_str("10.0.0.1").expect("Couldn't parse IPv4 address");
-        assert!(v4_prefix.contains(v4_addr));
-        let v6_addr = IpAddr::from_str("2001:DB8::1").expect("Couldn't parse IPv6 address");
-        assert!(!v4_prefix.contains(v6_addr));
+    fn ipv4_prefix_from_str_round_trips_canonical_inputs() {
+        check_values(
+            [
+                Check {
+                    scenario: "canonical /16 parses",
+                    input: "192.168.0.0/16",
+                    expect: true,
+                },
+                Check {
+                    scenario: "non-canonical /16 rejected",
+                    input: "192.168.1.2/16",
+                    expect: false,
+                },
+                Check {
+                    scenario: "length 33 rejected",
+                    input: "192.168.0.0/33",
+                    expect: false,
+                },
+                Check {
+                    scenario: "garbage rejected",
+                    input: "x/16",
+                    expect: false,
+                },
+            ],
+            |s| Ipv4Prefix::from_str(s).is_ok(),
+        );
     }
 
     #[test]
-    fn test_ordering() {
-        let p1 = IpPrefix::from_str("10.0.0.0/8").unwrap();
-        let p2 = IpPrefix::from_str("10.0.0.0/16").unwrap();
-        let p3 = IpPrefix::from_str("2001:DB8::/32").unwrap();
-        // Two prefixes with the same address but different lengths should be
-        // ordered such that the shorter prefix is first.
-        assert_eq!(p1.cmp(&p2), Ordering::Less);
-        // An IPv4 prefix should be ordered before an IPv6 prefix.
-        assert_eq!(p2.cmp(&p3), Ordering::Less);
+    fn ipv6_prefix_from_str_round_trips_canonical_inputs() {
+        check_values(
+            [
+                Check {
+                    scenario: "canonical /48 parses",
+                    input: "2001:db8::/48",
+                    expect: true,
+                },
+                Check {
+                    scenario: "canonical /0 parses",
+                    input: "::/0",
+                    expect: true,
+                },
+                Check {
+                    scenario: "host /128 parses",
+                    input: "2001:db8::1/128",
+                    expect: true,
+                },
+                Check {
+                    scenario: "non-canonical host bits set",
+                    input: "2001:db8::2/64",
+                    expect: false,
+                },
+                Check {
+                    scenario: "length 129 rejected",
+                    input: "2001:db8::/129",
+                    expect: false,
+                },
+                Check {
+                    scenario: "garbage rejected",
+                    input: "nope/48",
+                    expect: false,
+                },
+                Check {
+                    scenario: "ipv4 text rejected by v6 parser",
+                    input: "10.0.0.0/8",
+                    expect: false,
+                },
+                Check {
+                    scenario: "empty string rejected",
+                    input: "",
+                    expect: false,
+                },
+            ],
+            |s| Ipv6Prefix::from_str(s).is_ok(),
+        );
     }
 
     #[test]
-    fn test_bifurcate() {
-        let p1 = IpPrefix::from_str("10.0.0.0/24").unwrap();
-        let children = p1.bifurcate().expect("Could not bifurcate p1");
-        let (p2, p3) = children;
-        let p2_expected = IpPrefix::from_str("10.0.0.0/25").unwrap();
-        let p3_expected = IpPrefix::from_str("10.0.0.128/25").unwrap();
-        assert_eq!(p2, p2_expected);
-        assert_eq!(p3, p3_expected);
+    fn ip_prefix_from_str_accepts_both_families() {
+        check_values(
+            [
+                Check {
+                    scenario: "ipv4 canonical",
+                    input: "10.0.0.0/8",
+                    expect: true,
+                },
+                Check {
+                    scenario: "ipv6 canonical",
+                    input: "2001:db8::/32",
+                    expect: true,
+                },
+                Check {
+                    scenario: "ipv4 non-canonical",
+                    input: "10.0.0.1/8",
+                    expect: false,
+                },
+                Check {
+                    scenario: "ipv6 non-canonical",
+                    input: "2001:db8::2/64",
+                    expect: false,
+                },
+                Check {
+                    scenario: "ipv4 bad length",
+                    input: "10.0.0.0/33",
+                    expect: false,
+                },
+                Check {
+                    scenario: "empty",
+                    input: "",
+                    expect: false,
+                },
+            ],
+            |s| IpPrefix::from_str(s).is_ok(),
+        );
     }
 
     #[test]
-    fn test_sibling() {
-        let p1 = IpPrefix::from_str("10.0.0.0/24").unwrap();
-        let p2 = IpPrefix::from_str("10.0.1.0/24").unwrap();
-        assert_eq!(p1.get_sibling(), Some(p2));
+    fn try_from_ipnet_validates_canonical_representation() {
+        check_cases(
+            [
+                Case {
+                    scenario: "canonical v4 accepted",
+                    input: "10.0.0.0/8",
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "non-canonical v4 rejected",
+                    input: "10.0.0.1/8",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "canonical v6 accepted",
+                    input: "2001:db8::/32",
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "non-canonical v6 rejected",
+                    input: "2001:db8::1/32",
+                    expect: Fails,
+                },
+            ],
+            |s| {
+                let net = IpNet::from_str(s).expect("test net should parse");
+                IpPrefix::try_from(net).map(|_| ()).map_err(drop)
+            },
+        );
+    }
 
-        let p3 = IpPrefix::from_str("2001:db8:0000::/34").unwrap();
-        let p4 = IpPrefix::from_str("2001:db8:4000::/34").unwrap();
-        assert_eq!(p3.get_sibling(), Some(p4));
+    #[test]
+    fn try_from_addr_and_length_validates() {
+        check_cases(
+            [
+                Case {
+                    scenario: "canonical v4",
+                    input: (IpAddr::from([10, 0, 0, 0]), 8u8),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "non-canonical v4",
+                    input: (IpAddr::from([10, 0, 0, 1]), 8u8),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "v4 length too long",
+                    input: (IpAddr::from([10, 0, 0, 0]), 33u8),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "v4 host /32",
+                    input: (IpAddr::from([10, 0, 0, 1]), 32u8),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "v6 length too long",
+                    input: (IpAddr::from(Ipv6Addr::LOCALHOST), 129u8),
+                    expect: Fails,
+                },
+            ],
+            |(addr, len)| IpPrefix::try_from((addr, len)).map(|_| ()).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn address_family_reports_variant() {
+        check_values(
+            [
+                Check {
+                    scenario: "v4 prefix",
+                    input: "10.0.0.0/8",
+                    expect: IpAddressFamily::Ipv4,
+                },
+                Check {
+                    scenario: "v6 prefix",
+                    input: "2001:db8::/32",
+                    expect: IpAddressFamily::Ipv6,
+                },
+            ],
+            |s| prefix(s).address_family(),
+        );
+    }
+
+    #[test]
+    fn is_address_family_matches_only_its_own() {
+        check_values(
+            [
+                Check {
+                    scenario: "v4 is v4",
+                    input: ("10.0.0.0/8", IpAddressFamily::Ipv4),
+                    expect: true,
+                },
+                Check {
+                    scenario: "v4 is not v6",
+                    input: ("10.0.0.0/8", IpAddressFamily::Ipv6),
+                    expect: false,
+                },
+                Check {
+                    scenario: "v6 is v6",
+                    input: ("2001:db8::/32", IpAddressFamily::Ipv6),
+                    expect: true,
+                },
+                Check {
+                    scenario: "v6 is not v4",
+                    input: ("2001:db8::/32", IpAddressFamily::Ipv4),
+                    expect: false,
+                },
+            ],
+            |(s, family)| prefix(s).is_address_family(family),
+        );
+    }
+
+    #[test]
+    fn require_address_family_or_else_passes_or_runs_fallback() {
+        check_cases(
+            [
+                Case {
+                    scenario: "v4 required and present",
+                    input: ("10.0.0.0/8", IpAddressFamily::Ipv4),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "v6 required but is v4",
+                    input: ("10.0.0.0/8", IpAddressFamily::Ipv6),
+                    expect: FailsWith(42),
+                },
+                Case {
+                    scenario: "v6 required and present",
+                    input: ("2001:db8::/32", IpAddressFamily::Ipv6),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "v4 required but is v6",
+                    input: ("2001:db8::/32", IpAddressFamily::Ipv4),
+                    expect: FailsWith(42),
+                },
+            ],
+            |(s, family)| {
+                prefix(s)
+                    .require_address_family_or_else(family, |_| 42)
+                    .map(|_| ())
+            },
+        );
+    }
+
+    #[test]
+    fn contains_checks_membership_across_families() {
+        check_values(
+            [
+                Check {
+                    scenario: "v4 prefix holds member address",
+                    input: ("10.0.0.0/8", IpAddr::from([10, 0, 0, 1])),
+                    expect: true,
+                },
+                Check {
+                    scenario: "v4 prefix holds its own network address",
+                    input: ("10.0.0.0/8", IpAddr::from([10, 0, 0, 0])),
+                    expect: true,
+                },
+                Check {
+                    scenario: "v4 prefix excludes outside address",
+                    input: ("10.0.0.0/8", IpAddr::from([11, 0, 0, 1])),
+                    expect: false,
+                },
+                Check {
+                    scenario: "v4 prefix does not hold a v6 address",
+                    input: ("10.0.0.0/8", IpAddr::from(Ipv6Addr::LOCALHOST)),
+                    expect: false,
+                },
+                Check {
+                    scenario: "default route holds anything v4",
+                    input: ("0.0.0.0/0", IpAddr::from([200, 1, 2, 3])),
+                    expect: true,
+                },
+                Check {
+                    scenario: "v6 prefix holds member address",
+                    input: ("2001:db8::/32", IpAddr::from_str("2001:db8::1").unwrap()),
+                    expect: true,
+                },
+                Check {
+                    scenario: "v6 prefix excludes outside address",
+                    input: ("2001:db8::/32", IpAddr::from_str("2001:db9::1").unwrap()),
+                    expect: false,
+                },
+                Check {
+                    scenario: "v6 prefix does not hold a v4 address",
+                    input: ("2001:db8::/32", IpAddr::from([10, 0, 0, 1])),
+                    expect: false,
+                },
+            ],
+            |(p, addr)| prefix(p).contains(addr),
+        );
+    }
+
+    #[test]
+    fn contains_subprefix_relationships() {
+        check_values(
+            [
+                Check {
+                    scenario: "broader holds narrower",
+                    input: ("10.0.0.0/8", "10.1.0.0/16"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "prefix holds itself",
+                    input: ("10.0.0.0/8", "10.0.0.0/8"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "narrower does not hold broader",
+                    input: ("10.0.0.0/16", "10.0.0.0/8"),
+                    expect: false,
+                },
+                Check {
+                    scenario: "disjoint v4 prefixes",
+                    input: ("10.0.0.0/8", "11.0.0.0/8"),
+                    expect: false,
+                },
+                Check {
+                    scenario: "v4 never holds v6",
+                    input: ("10.0.0.0/8", "2001:db8::/32"),
+                    expect: false,
+                },
+                Check {
+                    scenario: "v6 broader holds narrower",
+                    input: ("2001:db8::/32", "2001:db8:1::/48"),
+                    expect: true,
+                },
+            ],
+            |(outer, inner)| prefix(outer).contains(prefix(inner)),
+        );
+    }
+
+    #[test]
+    fn prefix_length_reports_mask_bits() {
+        check_values(
+            [
+                Check {
+                    scenario: "v4 /8",
+                    input: "10.0.0.0/8",
+                    expect: 8usize,
+                },
+                Check {
+                    scenario: "v4 /0",
+                    input: "0.0.0.0/0",
+                    expect: 0usize,
+                },
+                Check {
+                    scenario: "v4 /32",
+                    input: "10.0.0.1/32",
+                    expect: 32usize,
+                },
+                Check {
+                    scenario: "v6 /48",
+                    input: "2001:db8::/48",
+                    expect: 48usize,
+                },
+                Check {
+                    scenario: "v6 /128",
+                    input: "2001:db8::1/128",
+                    expect: 128usize,
+                },
+            ],
+            |s| prefix(s).prefix_length(),
+        );
+    }
+
+    #[test]
+    fn ordering_sorts_by_family_then_prefix() {
+        check_values(
+            [
+                Check {
+                    scenario: "shorter prefix sorts before longer at same address",
+                    input: ("10.0.0.0/8", "10.0.0.0/16"),
+                    expect: Ordering::Less,
+                },
+                Check {
+                    scenario: "longer prefix sorts after shorter",
+                    input: ("10.0.0.0/16", "10.0.0.0/8"),
+                    expect: Ordering::Greater,
+                },
+                Check {
+                    scenario: "equal prefixes compare equal",
+                    input: ("10.0.0.0/8", "10.0.0.0/8"),
+                    expect: Ordering::Equal,
+                },
+                Check {
+                    scenario: "lower address sorts first",
+                    input: ("10.0.0.0/8", "11.0.0.0/8"),
+                    expect: Ordering::Less,
+                },
+                Check {
+                    scenario: "v4 always sorts before v6",
+                    input: ("10.0.0.0/16", "2001:db8::/32"),
+                    expect: Ordering::Less,
+                },
+                Check {
+                    scenario: "v6 always sorts after v4",
+                    input: ("2001:db8::/32", "10.0.0.0/16"),
+                    expect: Ordering::Greater,
+                },
+                Check {
+                    scenario: "two v6 by address",
+                    input: ("2001:db8::/32", "2001:db9::/32"),
+                    expect: Ordering::Less,
+                },
+            ],
+            |(a, b)| prefix(a).cmp(&prefix(b)),
+        );
+    }
+
+    #[test]
+    fn display_renders_canonical_text() {
+        check_values(
+            [
+                Check {
+                    scenario: "v4 prefix",
+                    input: "10.0.0.0/8",
+                    expect: "10.0.0.0/8".to_string(),
+                },
+                Check {
+                    scenario: "v4 default route",
+                    input: "0.0.0.0/0",
+                    expect: "0.0.0.0/0".to_string(),
+                },
+                Check {
+                    scenario: "v6 prefix lowercased",
+                    input: "2001:DB8::/32",
+                    expect: "2001:db8::/32".to_string(),
+                },
+            ],
+            |s| prefix(s).to_string(),
+        );
+    }
+
+    #[test]
+    fn bifurcate_splits_into_two_halves() {
+        check_values(
+            [
+                Check {
+                    scenario: "v4 /24 splits at the midpoint",
+                    input: "10.0.0.0/24",
+                    expect: Some(("10.0.0.0/25".to_string(), "10.0.0.128/25".to_string())),
+                },
+                Check {
+                    scenario: "v4 /0 splits the whole space",
+                    input: "0.0.0.0/0",
+                    expect: Some(("0.0.0.0/1".to_string(), "128.0.0.0/1".to_string())),
+                },
+                Check {
+                    scenario: "v4 /32 cannot split",
+                    input: "10.0.0.1/32",
+                    expect: None,
+                },
+                Check {
+                    scenario: "v6 /32 splits at the midpoint",
+                    input: "2001:db8::/32",
+                    expect: Some(("2001:db8::/33".to_string(), "2001:db8:8000::/33".to_string())),
+                },
+                Check {
+                    scenario: "v6 /128 cannot split",
+                    input: "2001:db8::1/128",
+                    expect: None,
+                },
+            ],
+            |s| {
+                prefix(s)
+                    .bifurcate()
+                    .map(|(even, odd)| (even.to_string(), odd.to_string()))
+            },
+        );
+    }
+
+    #[test]
+    fn get_sibling_flips_the_last_prefix_bit() {
+        check_values(
+            [
+                Check {
+                    scenario: "v4 /24 even sibling",
+                    input: "10.0.0.0/24",
+                    expect: Some("10.0.1.0/24".to_string()),
+                },
+                Check {
+                    scenario: "v4 /24 odd sibling flips back",
+                    input: "10.0.1.0/24",
+                    expect: Some("10.0.0.0/24".to_string()),
+                },
+                Check {
+                    scenario: "v4 /1 sibling",
+                    input: "0.0.0.0/1",
+                    expect: Some("128.0.0.0/1".to_string()),
+                },
+                Check {
+                    scenario: "v4 /0 has no sibling",
+                    input: "0.0.0.0/0",
+                    expect: None,
+                },
+                Check {
+                    scenario: "v6 /34 even sibling",
+                    input: "2001:db8::/34",
+                    expect: Some("2001:db8:4000::/34".to_string()),
+                },
+                Check {
+                    scenario: "v6 /34 odd sibling flips back",
+                    input: "2001:db8:4000::/34",
+                    expect: Some("2001:db8::/34".to_string()),
+                },
+                Check {
+                    scenario: "v6 /0 has no sibling",
+                    input: "::/0",
+                    expect: None,
+                },
+            ],
+            |s| prefix(s).get_sibling().map(|p| p.to_string()),
+        );
+    }
+
+    #[test]
+    fn get_last_subprefix_is_the_all_ones_host() {
+        check_values(
+            [
+                Check {
+                    scenario: "v4 /24 last host",
+                    input: "10.0.0.0/24",
+                    expect: "10.0.0.255/32".to_string(),
+                },
+                Check {
+                    scenario: "v4 /8 last host",
+                    input: "10.0.0.0/8",
+                    expect: "10.255.255.255/32".to_string(),
+                },
+                Check {
+                    scenario: "v4 /32 is its own last host",
+                    input: "10.0.0.1/32",
+                    expect: "10.0.0.1/32".to_string(),
+                },
+                Check {
+                    scenario: "v6 /32 last host",
+                    input: "2001:db8::/32",
+                    expect: "2001:db8:ffff:ffff:ffff:ffff:ffff:ffff/128".to_string(),
+                },
+            ],
+            |s| prefix(s).get_last_subprefix().to_string(),
+        );
+    }
+
+    #[test]
+    fn try_aggregate_combines_or_declines() {
+        check_values(
+            [
+                Check {
+                    scenario: "siblings aggregate to their supernet",
+                    input: ("10.0.0.0/25", "10.0.0.128/25"),
+                    expect: Some("10.0.0.0/24".to_string()),
+                },
+                Check {
+                    scenario: "containing prefix absorbs the contained",
+                    input: ("10.0.0.0/8", "10.1.0.0/16"),
+                    expect: Some("10.0.0.0/8".to_string()),
+                },
+                Check {
+                    scenario: "contained side absorbed by container",
+                    input: ("10.1.0.0/16", "10.0.0.0/8"),
+                    expect: Some("10.0.0.0/8".to_string()),
+                },
+                Check {
+                    scenario: "non-adjacent prefixes do not aggregate",
+                    input: ("10.0.0.0/24", "10.0.2.0/24"),
+                    expect: None,
+                },
+                Check {
+                    scenario: "sibling /24s aggregate to their /23 supernet",
+                    input: ("10.0.0.0/24", "10.0.1.0/24"),
+                    expect: Some("10.0.0.0/23".to_string()),
+                },
+                Check {
+                    scenario: "different families do not aggregate",
+                    input: ("10.0.0.0/8", "2001:db8::/32"),
+                    expect: None,
+                },
+                Check {
+                    scenario: "v6 siblings aggregate",
+                    input: ("2001:db8::/33", "2001:db8:8000::/33"),
+                    expect: Some("2001:db8::/32".to_string()),
+                },
+            ],
+            |(a, b)| {
+                prefix(a)
+                    .try_aggregate(&prefix(b))
+                    .map(|p| p.to_string())
+            },
+        );
+    }
+
+    #[test]
+    fn to_prefix_from_addresses_and_nets() {
+        check_values(
+            [
+                Check {
+                    scenario: "ipv4 address becomes /32",
+                    input: "10.0.0.1",
+                    expect: "10.0.0.1/32".to_string(),
+                },
+                Check {
+                    scenario: "ipv6 address becomes /128",
+                    input: "2001:db8::1",
+                    expect: "2001:db8::1/128".to_string(),
+                },
+            ],
+            |s| IpAddr::from_str(s).unwrap().to_prefix().to_string(),
+        );
+    }
+
+    #[test]
+    fn to_prefix_from_ipnet_truncates_host_bits() {
+        check_values(
+            [
+                Check {
+                    scenario: "v4 net truncated to network address",
+                    input: "10.0.0.1/8",
+                    expect: "10.0.0.0/8".to_string(),
+                },
+                Check {
+                    scenario: "v4 already canonical",
+                    input: "10.0.0.0/8",
+                    expect: "10.0.0.0/8".to_string(),
+                },
+                Check {
+                    scenario: "v6 net truncated to network address",
+                    input: "2001:db8::1/32",
+                    expect: "2001:db8::/32".to_string(),
+                },
+            ],
+            |s| IpNet::from_str(s).unwrap().to_prefix().to_string(),
+        );
+    }
+
+    #[test]
+    fn into_inner_round_trips_through_ipnet() {
+        check_values(
+            [
+                Check {
+                    scenario: "v4 round-trips",
+                    input: "10.0.0.0/8",
+                    expect: true,
+                },
+                Check {
+                    scenario: "v6 round-trips",
+                    input: "2001:db8::/32",
+                    expect: true,
+                },
+            ],
+            |s| {
+                let net = IpNet::from_str(s).unwrap();
+                let prefix = IpPrefix::try_from(net).unwrap();
+                IpNet::from(prefix) == net
+            },
+        );
     }
 }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -33,6 +33,11 @@ pub mod virtualization;
 #[doc(inline)]
 pub use base_mac::BaseMac;
 
+// Lets the database round-trip tests use `#[crate::sqlx_test]` to get a per-test
+// Postgres pool from the shared harness (DATABASE_URL via .envrc).
+#[cfg(all(test, feature = "sqlx"))]
+pub(crate) use carbide_macros::sqlx_test;
+
 const STRIPPED_MAC_LENGTH: usize = 12;
 
 /// MELLANOX_SF_VF_MAC_ADDRESS_IN exists to really make it obvious
@@ -165,68 +170,179 @@ pub fn deserialize_input_mac_to_address(input_value: &str) -> Result<MacAddress,
 }
 #[cfg(test)]
 mod tests {
-    use super::{MELLANOX_SF_VF_MAC_ADDRESS_OUT, deserialize_input_mac_to_address, sanitized_mac};
+    use super::*;
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
 
+    // `sanitized_mac` returns `eyre::Result`, whose error does not implement
+    // `PartialEq`, so error rows use `Fails` and the run closure maps the
+    // success arm to the canonical `to_string()` form (and drops the error).
     #[test]
-    fn test_gross_redfish_mac() {
-        let gross_redfish_mac = "\"a088c2    460c68\"";
-        assert_eq!(
-            &sanitized_mac(gross_redfish_mac).unwrap().to_string(),
-            "A0:88:C2:46:0C:68"
+    fn sanitized_mac_normalizes_or_rejects() {
+        check_cases(
+            [
+                // The motivating example: a quoted Redfish MAC riddled with
+                // interior whitespace, normalized to a colon-grouped MAC.
+                Case {
+                    scenario: "gross redfish mac with quotes and spaces",
+                    input: "\"a088c2    460c68\"",
+                    expect: Yields("A0:88:C2:46:0C:68".to_string()),
+                },
+                Case {
+                    scenario: "smashed hex, no separators",
+                    input: "000000ABC789",
+                    expect: Yields("00:00:00:AB:C7:89".to_string()),
+                },
+                Case {
+                    scenario: "already clean, colon-separated",
+                    input: "DE:ED:0F:BE:EF:99",
+                    expect: Yields("DE:ED:0F:BE:EF:99".to_string()),
+                },
+                Case {
+                    scenario: "mixed case, no separators (uppercased out)",
+                    input: "AabBCcdDEefF",
+                    expect: Yields("AA:BB:CC:DD:EE:FF".to_string()),
+                },
+                Case {
+                    scenario: "all zeros",
+                    input: "000000000000",
+                    expect: Yields("00:00:00:00:00:00".to_string()),
+                },
+                Case {
+                    scenario: "all f's, lowercase in",
+                    input: "ffffffffffff",
+                    expect: Yields("FF:FF:FF:FF:FF:FF".to_string()),
+                },
+                Case {
+                    scenario: "dash-separated separators stripped",
+                    input: "a0-88-c2-46-0c-68",
+                    expect: Yields("A0:88:C2:46:0C:68".to_string()),
+                },
+                Case {
+                    scenario: "dot-separated (cisco style) separators stripped",
+                    input: "a088.c246.0c68",
+                    expect: Yields("A0:88:C2:46:0C:68".to_string()),
+                },
+                Case {
+                    scenario: "leading and trailing whitespace",
+                    input: "  a088c2460c68  ",
+                    expect: Yields("A0:88:C2:46:0C:68".to_string()),
+                },
+                Case {
+                    scenario: "embedded non-hex letters dropped but length stays valid",
+                    input: "a0g88hc2460c68",
+                    expect: Yields("A0:88:C2:46:0C:68".to_string()),
+                },
+                // Error arms: any stripped length other than 12 hex digits.
+                Case {
+                    scenario: "empty input — zero hex digits",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "no hex digits at all",
+                    input: "ghijklmnopqr",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "too short — eleven hex digits",
+                    input: "a088c2460c6",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "too short by one — ten hex digits",
+                    input: "a088c2460c",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "too long — thirteen hex digits",
+                    input: "a088c2460c688",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "way too long with junk",
+                    input: "aabbccddeeffgg00112233445566778899",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "only whitespace",
+                    input: "        ",
+                    expect: Fails,
+                },
+            ],
+            |input| sanitized_mac(input).map(|mac| mac.to_string()).map_err(drop),
         );
     }
 
+    // `deserialize_input_mac_to_address` returns `Result<_, MacParseError>`;
+    // mapping the success arm to `to_string()` and dropping the error keeps the
+    // error type as `()`, so reject rows use `Fails`.
     #[test]
-    fn test_smashed_mac() {
-        let smashed_mac = "000000ABC789";
-        assert_eq!(
-            &sanitized_mac(smashed_mac).unwrap().to_string(),
-            "00:00:00:AB:C7:89"
+    fn deserialize_input_mac_rewrites_or_rejects() {
+        check_cases(
+            [
+                Case {
+                    scenario: "ordinary colon-separated mac passes through",
+                    input: "00:11:22:33:44:55",
+                    expect: Yields("00:11:22:33:44:55".to_string()),
+                },
+                Case {
+                    scenario: "mellanox ch:64 sentinel rewritten to the OUT form",
+                    input: MELLANOX_SF_VF_MAC_ADDRESS_IN,
+                    expect: Yields(MELLANOX_SF_VF_MAC_ADDRESS_OUT.to_string()),
+                },
+                Case {
+                    scenario: "empty string rewritten to the all-zero mac",
+                    input: "",
+                    expect: Yields("00:00:00:00:00:00".to_string()),
+                },
+                Case {
+                    scenario: "uppercase hex normalized on parse",
+                    input: "AA:BB:CC:DD:EE:FF",
+                    expect: Yields("AA:BB:CC:DD:EE:FF".to_string()),
+                },
+                Case {
+                    scenario: "lowercase hex uppercased on display",
+                    input: "aa:bb:cc:dd:ee:ff",
+                    expect: Yields("AA:BB:CC:DD:EE:FF".to_string()),
+                },
+                Case {
+                    scenario: "dash-separated mac parses",
+                    input: "00-11-22-33-44-55",
+                    expect: Yields("00:11:22:33:44:55".to_string()),
+                },
+                // Reject arms: real garbage that isn't the ch:64/empty sentinels.
+                Case {
+                    scenario: "non-sentinel garbage rejected",
+                    input: "not-a-mac",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "too few octets",
+                    input: "00:11:22:33:44",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "too many octets",
+                    input: "00:11:22:33:44:55:66",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "octet out of hex range",
+                    input: "zz:11:22:33:44:55",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "bare 12-hex parses and renders with colons",
+                    input: "001122334455",
+                    expect: Yields("00:11:22:33:44:55".to_string()),
+                },
+            ],
+            |input| {
+                deserialize_input_mac_to_address(input)
+                    .map(|mac| mac.to_string())
+                    .map_err(drop)
+            },
         );
-    }
-
-    #[test]
-    fn test_clean_mac() {
-        let clean_mac = "DE:ED:0F:BE:EF:99";
-        assert_eq!(
-            &sanitized_mac(clean_mac).unwrap().to_string(),
-            "DE:ED:0F:BE:EF:99"
-        );
-    }
-
-    #[test]
-    fn test_casey_mac() {
-        let casey_mac = "AabBCcdDEefF".to_string();
-        assert_eq!(
-            &sanitized_mac(&casey_mac).unwrap().to_string(),
-            "AA:BB:CC:DD:EE:FF"
-        );
-    }
-
-    #[test]
-    fn test_too_long_mac() {
-        let too_long_mac = "aabbccddeeffgg00112233445566778899";
-        assert!(sanitized_mac(too_long_mac).is_err());
-    }
-
-    #[test]
-    fn test_deserialize_happy_mac() {
-        let happy_mac = "00:11:22:33:44:55".to_string();
-        let mac_address = deserialize_input_mac_to_address(&happy_mac).unwrap();
-        assert_eq!(happy_mac, mac_address.to_string());
-    }
-
-    #[test]
-    fn test_deserialize_ch64_mac() {
-        let silly_mac = "ch:64".to_string();
-        let mac_address = deserialize_input_mac_to_address(&silly_mac).unwrap();
-        assert_eq!(MELLANOX_SF_VF_MAC_ADDRESS_OUT, mac_address.to_string());
-    }
-
-    #[test]
-    fn test_deserialize_empty_mac() {
-        let empty_mac = "".to_string();
-        let mac_address = deserialize_input_mac_to_address(&empty_mac).unwrap();
-        assert_eq!("00:00:00:00:00:00", mac_address.to_string());
     }
 }

--- a/crates/network/src/virtualization.rs
+++ b/crates/network/src/virtualization.rs
@@ -134,6 +134,7 @@ impl sqlx::Decode<'_, sqlx::Postgres> for VpcVirtualizationType {
 
 #[cfg(all(test, feature = "sqlx"))]
 mod sqlx_tests {
+    use carbide_test_support::{Check, check_values};
     use sqlx::Encode;
     use sqlx::postgres::PgArgumentBuffer;
 
@@ -146,29 +147,93 @@ mod sqlx_tests {
     }
 
     #[test]
-    fn encode_etv_writes_etv() {
-        assert_eq!(
-            encode_to_string(VpcVirtualizationType::EthernetVirtualizer),
-            "etv"
+    fn encode_writes_the_wire_string_for_each_variant() {
+        check_values(
+            [
+                Check {
+                    scenario: "EthernetVirtualizer encodes as etv",
+                    input: VpcVirtualizationType::EthernetVirtualizer,
+                    expect: "etv".to_string(),
+                },
+                Check {
+                    scenario: "EthernetVirtualizerWithNvue encodes as legacy etv",
+                    input: VpcVirtualizationType::EthernetVirtualizerWithNvue,
+                    expect: "etv".to_string(),
+                },
+                Check {
+                    scenario: "Fnn encodes as fnn",
+                    input: VpcVirtualizationType::Fnn,
+                    expect: "fnn".to_string(),
+                },
+                Check {
+                    scenario: "Flat encodes as flat",
+                    input: VpcVirtualizationType::Flat,
+                    expect: "flat".to_string(),
+                },
+            ],
+            encode_to_string,
         );
     }
+}
 
-    #[test]
-    fn encode_etv_nvue_writes_etv() {
-        assert_eq!(
-            encode_to_string(VpcVirtualizationType::EthernetVirtualizerWithNvue),
-            "etv"
-        );
-    }
+// Real Postgres round-trips for the sqlx `Encode`/`Decode` impls. Each case binds
+// a value (`Encode`) and reads it back (`Decode`) through a live connection, which
+// is the half the buffer-only `encode` test above can't reach. The per-test pool
+// comes from the shared harness (`DATABASE_URL` via `.envrc`); the closure does
+// the database work, so `carbide-test-support` itself stays db-agnostic.
+#[cfg(all(test, feature = "sqlx"))]
+mod sqlx_db_tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases_async};
 
-    #[test]
-    fn encode_fnn_writes_fnn() {
-        assert_eq!(encode_to_string(VpcVirtualizationType::Fnn), "fnn");
-    }
+    use super::VpcVirtualizationType;
 
-    #[test]
-    fn encode_flat_writes_flat() {
-        assert_eq!(encode_to_string(VpcVirtualizationType::Flat), "flat");
+    #[crate::sqlx_test]
+    async fn vpc_virtualization_type_round_trips_through_postgres(
+        pool: sqlx::PgPool,
+    ) -> eyre::Result<()> {
+        // The custom `network_virtualization_type_t` enum already exists in the
+        // harness's schema, so we go straight to the round-trip.
+        check_cases_async(
+            [
+                Case {
+                    scenario: "etv round-trips",
+                    input: VpcVirtualizationType::EthernetVirtualizer,
+                    expect: Yields(VpcVirtualizationType::EthernetVirtualizer),
+                },
+                Case {
+                    // Encodes to the shared `etv` label, so it decodes back to the
+                    // canonical EthernetVirtualizer rather than the nvue alias.
+                    scenario: "etv-with-nvue collapses onto etv on the way back",
+                    input: VpcVirtualizationType::EthernetVirtualizerWithNvue,
+                    expect: Yields(VpcVirtualizationType::EthernetVirtualizer),
+                },
+                Case {
+                    scenario: "fnn round-trips",
+                    input: VpcVirtualizationType::Fnn,
+                    expect: Yields(VpcVirtualizationType::Fnn),
+                },
+                Case {
+                    scenario: "flat round-trips",
+                    input: VpcVirtualizationType::Flat,
+                    expect: Yields(VpcVirtualizationType::Flat),
+                },
+            ],
+            |v: VpcVirtualizationType| {
+                let pool = pool.clone();
+                async move {
+                    sqlx::query_scalar::<_, VpcVirtualizationType>(
+                        "SELECT $1::network_virtualization_type_t",
+                    )
+                    .bind(v)
+                    .fetch_one(&pool)
+                    .await
+                    .map_err(drop)
+                }
+            },
+        )
+        .await;
+        Ok(())
     }
 }
 
@@ -259,87 +324,472 @@ pub fn get_svi_ip(
 
 #[cfg(test)]
 mod tests {
-    use std::net::IpAddr;
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
 
     use super::*;
 
     #[test]
-    fn from_str_etv_nvue_maps_to_etv() {
-        assert_eq!(
-            "etv_nvue".parse::<VpcVirtualizationType>().unwrap(),
-            VpcVirtualizationType::EthernetVirtualizer
+    fn from_str_maps_known_strings_and_rejects_the_rest() {
+        check_cases(
+            [
+                Case {
+                    scenario: "etv -> EthernetVirtualizer",
+                    input: "etv",
+                    expect: Yields(VpcVirtualizationType::EthernetVirtualizer),
+                },
+                Case {
+                    scenario: "etv_nvue is an alias for EthernetVirtualizer",
+                    input: "etv_nvue",
+                    expect: Yields(VpcVirtualizationType::EthernetVirtualizer),
+                },
+                Case {
+                    scenario: "fnn -> Fnn",
+                    input: "fnn",
+                    expect: Yields(VpcVirtualizationType::Fnn),
+                },
+                Case {
+                    scenario: "flat -> Flat",
+                    input: "flat",
+                    expect: Yields(VpcVirtualizationType::Flat),
+                },
+                Case {
+                    scenario: "unknown token is rejected",
+                    input: "bogus",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string is rejected",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wrong case is rejected (match is exact)",
+                    input: "ETV",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "leading whitespace is not trimmed",
+                    input: " etv",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "trailing whitespace is not trimmed",
+                    input: "flat ",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "etv-nvue with a hyphen is not the alias",
+                    input: "etv-nvue",
+                    expect: Fails,
+                },
+            ],
+            |s| s.parse::<VpcVirtualizationType>().map_err(drop),
         );
     }
 
     #[test]
-    fn from_str_etv_maps_to_etv() {
-        assert_eq!(
-            "etv".parse::<VpcVirtualizationType>().unwrap(),
-            VpcVirtualizationType::EthernetVirtualizer
+    fn from_str_unknown_token_reports_the_input() {
+        check_cases(
+            [
+                Case {
+                    scenario: "error names the unknown token",
+                    input: ("bogus", &["Unknown virt type", "bogus"][..]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "error echoes a numeric token",
+                    input: ("42", &["Unknown virt type", "42"][..]),
+                    expect: Yields(true),
+                },
+            ],
+            |(value, tokens)| {
+                let produced = value
+                    .parse::<VpcVirtualizationType>()
+                    .map_err(|e| e.to_string())
+                    .expect_err("unknown token must fail");
+                Ok::<_, ()>(tokens.iter().all(|t| produced.contains(t)))
+            },
         );
     }
 
     #[test]
-    fn display_etv_with_nvue_shows_etv() {
-        assert_eq!(
-            VpcVirtualizationType::EthernetVirtualizerWithNvue.to_string(),
-            "etv"
+    fn as_str_renders_each_variant() {
+        check_values(
+            [
+                Check {
+                    scenario: "EthernetVirtualizer -> etv",
+                    input: VpcVirtualizationType::EthernetVirtualizer,
+                    expect: "etv",
+                },
+                Check {
+                    scenario: "EthernetVirtualizerWithNvue -> etv",
+                    input: VpcVirtualizationType::EthernetVirtualizerWithNvue,
+                    expect: "etv",
+                },
+                Check {
+                    scenario: "Fnn -> fnn",
+                    input: VpcVirtualizationType::Fnn,
+                    expect: "fnn",
+                },
+                Check {
+                    scenario: "Flat -> flat",
+                    input: VpcVirtualizationType::Flat,
+                    expect: "flat",
+                },
+            ],
+            |v| v.as_str(),
         );
     }
 
     #[test]
-    fn from_str_flat_maps_to_flat() {
-        assert_eq!(
-            "flat".parse::<VpcVirtualizationType>().unwrap(),
-            VpcVirtualizationType::Flat
+    fn display_renders_each_variant() {
+        check_values(
+            [
+                Check {
+                    scenario: "EthernetVirtualizer displays etv",
+                    input: VpcVirtualizationType::EthernetVirtualizer,
+                    expect: "etv".to_string(),
+                },
+                Check {
+                    scenario: "EthernetVirtualizerWithNvue displays etv",
+                    input: VpcVirtualizationType::EthernetVirtualizerWithNvue,
+                    expect: "etv".to_string(),
+                },
+                Check {
+                    scenario: "Fnn displays fnn",
+                    input: VpcVirtualizationType::Fnn,
+                    expect: "fnn".to_string(),
+                },
+                Check {
+                    scenario: "Flat displays flat",
+                    input: VpcVirtualizationType::Flat,
+                    expect: "flat".to_string(),
+                },
+            ],
+            |v| v.to_string(),
         );
     }
 
     #[test]
-    fn display_flat_shows_flat() {
-        assert_eq!(VpcVirtualizationType::Flat.to_string(), "flat");
+    fn display_agrees_with_as_str_for_every_variant() {
+        check_values(
+            [
+                Check {
+                    scenario: "EthernetVirtualizer",
+                    input: VpcVirtualizationType::EthernetVirtualizer,
+                    expect: true,
+                },
+                Check {
+                    scenario: "EthernetVirtualizerWithNvue",
+                    input: VpcVirtualizationType::EthernetVirtualizerWithNvue,
+                    expect: true,
+                },
+                Check {
+                    scenario: "Fnn",
+                    input: VpcVirtualizationType::Fnn,
+                    expect: true,
+                },
+                Check {
+                    scenario: "Flat",
+                    input: VpcVirtualizationType::Flat,
+                    expect: true,
+                },
+            ],
+            |v| v.to_string() == v.as_str(),
+        );
     }
 
     #[test]
-    fn test_get_host_ip_ipv4_slash32() {
-        let network = IpNetwork::new("10.0.0.5".parse().unwrap(), 32).unwrap();
-        let result = get_host_ip(&network).unwrap();
-        assert_eq!(result, "10.0.0.5".parse::<IpAddr>().unwrap());
+    fn default_is_ethernet_virtualizer() {
+        check_values(
+            [
+                Check {
+                    scenario: "Default trait yields EthernetVirtualizer",
+                    input: (),
+                    expect: VpcVirtualizationType::EthernetVirtualizer,
+                },
+                Check {
+                    scenario: "the DEFAULT_* constant agrees with Default",
+                    input: (),
+                    expect: DEFAULT_NETWORK_VIRTUALIZATION_TYPE,
+                },
+            ],
+            |()| VpcVirtualizationType::default(),
+        );
     }
 
     #[test]
-    fn test_get_host_ip_ipv6_slash128() {
-        let network = IpNetwork::new("2001:db8::1".parse().unwrap(), 128).unwrap();
-        let result = get_host_ip(&network).unwrap();
-        assert_eq!(result, "2001:db8::1".parse::<IpAddr>().unwrap());
+    fn from_str_round_trips_through_as_str() {
+        check_cases(
+            [
+                Case {
+                    scenario: "EthernetVirtualizer",
+                    input: VpcVirtualizationType::EthernetVirtualizer,
+                    expect: Yields(VpcVirtualizationType::EthernetVirtualizer),
+                },
+                Case {
+                    scenario: "Fnn",
+                    input: VpcVirtualizationType::Fnn,
+                    expect: Yields(VpcVirtualizationType::Fnn),
+                },
+                Case {
+                    scenario: "Flat",
+                    input: VpcVirtualizationType::Flat,
+                    expect: Yields(VpcVirtualizationType::Flat),
+                },
+            ],
+            |v| v.as_str().parse::<VpcVirtualizationType>().map_err(drop),
+        );
     }
 
     #[test]
-    fn test_get_host_ip_ipv4_slash31_point_to_point() {
-        let network = IpNetwork::new("10.0.0.0".parse().unwrap(), 31).unwrap();
-        let result = get_host_ip(&network).unwrap();
-        assert_eq!(result, "10.0.0.1".parse::<IpAddr>().unwrap());
+    fn serde_round_trips_through_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "EthernetVirtualizer serializes to \"etv\"",
+                    input: VpcVirtualizationType::EthernetVirtualizer,
+                    expect: Yields("\"etv\"".to_string()),
+                },
+                Case {
+                    scenario: "EthernetVirtualizerWithNvue also serializes to \"etv\"",
+                    input: VpcVirtualizationType::EthernetVirtualizerWithNvue,
+                    expect: Yields("\"etv\"".to_string()),
+                },
+                Case {
+                    scenario: "Fnn serializes to \"fnn\"",
+                    input: VpcVirtualizationType::Fnn,
+                    expect: Yields("\"fnn\"".to_string()),
+                },
+                Case {
+                    scenario: "Flat serializes to \"flat\"",
+                    input: VpcVirtualizationType::Flat,
+                    expect: Yields("\"flat\"".to_string()),
+                },
+            ],
+            |v| serde_json::to_string(&v).map_err(drop),
+        );
     }
 
     #[test]
-    fn test_get_host_ip_ipv6_slash127_point_to_point() {
-        let network = IpNetwork::new("2001:db8::0".parse().unwrap(), 127).unwrap();
-        let result = get_host_ip(&network).unwrap();
-        assert_eq!(result, "2001:db8::1".parse::<IpAddr>().unwrap());
+    fn deserialize_accepts_known_strings_and_rejects_the_rest() {
+        check_cases(
+            [
+                Case {
+                    scenario: "\"etv\" -> EthernetVirtualizer",
+                    input: "\"etv\"",
+                    expect: Yields(VpcVirtualizationType::EthernetVirtualizer),
+                },
+                Case {
+                    scenario: "\"etv_nvue\" alias -> EthernetVirtualizer",
+                    input: "\"etv_nvue\"",
+                    expect: Yields(VpcVirtualizationType::EthernetVirtualizer),
+                },
+                Case {
+                    scenario: "\"fnn\" -> Fnn",
+                    input: "\"fnn\"",
+                    expect: Yields(VpcVirtualizationType::Fnn),
+                },
+                Case {
+                    scenario: "\"flat\" -> Flat",
+                    input: "\"flat\"",
+                    expect: Yields(VpcVirtualizationType::Flat),
+                },
+                Case {
+                    scenario: "unknown string is rejected",
+                    input: "\"bogus\"",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "a JSON number is rejected (expects a string)",
+                    input: "7",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "a JSON null is rejected",
+                    input: "null",
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<VpcVirtualizationType>(json).map_err(drop),
+        );
     }
 
     #[test]
-    fn test_get_host_ip_ipv4_slash30_legacy() {
-        let network = IpNetwork::new("10.0.0.0".parse().unwrap(), 30).unwrap();
-        let result = get_host_ip(&network).unwrap();
-        assert_eq!(result, "10.0.0.3".parse::<IpAddr>().unwrap());
+    fn build_dual_stack_list_assembles_the_address_list() {
+        check_values(
+            [
+                Check {
+                    scenario: "v4 only when v6 is absent",
+                    input: ("10.0.0.1".to_string(), None),
+                    expect: vec!["10.0.0.1".to_string()],
+                },
+                Check {
+                    scenario: "v4 then v6 when both present",
+                    input: ("10.0.0.1".to_string(), Some("2001:db8::1".to_string())),
+                    expect: vec!["10.0.0.1".to_string(), "2001:db8::1".to_string()],
+                },
+                Check {
+                    scenario: "empty v6 string is filtered out",
+                    input: ("10.0.0.1".to_string(), Some(String::new())),
+                    expect: vec!["10.0.0.1".to_string()],
+                },
+                Check {
+                    scenario: "v4 is kept even when empty (it is required)",
+                    input: (String::new(), None),
+                    expect: vec![String::new()],
+                },
+                Check {
+                    scenario: "empty v4 with a real v6 keeps both",
+                    input: (String::new(), Some("2001:db8::1".to_string())),
+                    expect: vec![String::new(), "2001:db8::1".to_string()],
+                },
+            ],
+            |(v4, v6)| build_dual_stack_list(v4, v6),
+        );
     }
 
-    #[test]
-    fn test_get_host_ip_unsupported_prefix() {
-        let network = IpNetwork::new("10.0.0.0".parse().unwrap(), 29).unwrap();
-        let result = get_host_ip(&network);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("unsupported"));
+    #[cfg(feature = "ipnetwork")]
+    mod ip {
+        use std::net::IpAddr;
+
+        use carbide_test_support::Outcome::*;
+        use carbide_test_support::{Case, check_cases};
+
+        use super::super::*;
+
+        fn net(ip: &str, prefix: u8) -> IpNetwork {
+            IpNetwork::new(ip.parse().unwrap(), prefix).unwrap()
+        }
+
+        #[test]
+        fn get_host_ip_picks_the_right_address_per_prefix() {
+            check_cases(
+                [
+                    Case {
+                        scenario: "ipv4 /32 single host is itself",
+                        input: net("10.0.0.5", 32),
+                        expect: Yields("10.0.0.5".parse::<IpAddr>().unwrap()),
+                    },
+                    Case {
+                        scenario: "ipv6 /128 single host is itself",
+                        input: net("2001:db8::1", 128),
+                        expect: Yields("2001:db8::1".parse::<IpAddr>().unwrap()),
+                    },
+                    Case {
+                        scenario: "ipv4 /31 point-to-point uses the second address",
+                        input: net("10.0.0.0", 31),
+                        expect: Yields("10.0.0.1".parse::<IpAddr>().unwrap()),
+                    },
+                    Case {
+                        scenario: "ipv6 /127 point-to-point uses the second address",
+                        input: net("2001:db8::0", 127),
+                        expect: Yields("2001:db8::1".parse::<IpAddr>().unwrap()),
+                    },
+                    Case {
+                        scenario: "ipv4 /30 legacy uses the fourth address",
+                        input: net("10.0.0.0", 30),
+                        expect: Yields("10.0.0.3".parse::<IpAddr>().unwrap()),
+                    },
+                    Case {
+                        scenario: "ipv4 /29 is too large to be supported",
+                        input: net("10.0.0.0", 29),
+                        expect: Fails,
+                    },
+                    Case {
+                        scenario: "ipv4 /24 is unsupported",
+                        input: net("10.0.0.0", 24),
+                        expect: Fails,
+                    },
+                    Case {
+                        scenario: "ipv4 /0 is unsupported",
+                        input: net("0.0.0.0", 0),
+                        expect: Fails,
+                    },
+                    Case {
+                        scenario: "ipv6 /64 is unsupported",
+                        input: net("2001:db8::", 64),
+                        expect: Fails,
+                    },
+                    Case {
+                        scenario: "ipv6 /126 is unsupported",
+                        input: net("2001:db8::", 126),
+                        expect: Fails,
+                    },
+                ],
+                |network| get_host_ip(&network).map_err(drop),
+            );
+        }
+
+        #[test]
+        fn get_host_ip_unsupported_prefix_names_the_problem() {
+            check_cases(
+                [Case {
+                    scenario: "error mentions it is unsupported",
+                    input: (net("10.0.0.0", 29), &["unsupported"][..]),
+                    expect: Yields(true),
+                }],
+                |(network, tokens)| {
+                    let produced = get_host_ip(&network)
+                        .map_err(|e| e.to_string())
+                        .expect_err("oversized prefix must fail");
+                    Ok::<_, ()>(tokens.iter().all(|t| produced.contains(t)))
+                },
+            );
+        }
+
+        #[test]
+        fn get_svi_ip_only_yields_for_fnn_l2_segments() {
+            let svi_ip: IpAddr = "10.0.0.1".parse().unwrap();
+            let svi: Option<IpAddr> = Some(svi_ip);
+            check_cases(
+                [
+                    Case {
+                        scenario: "fnn + l2 + allocated svi yields the network",
+                        input: (svi, VpcVirtualizationType::Fnn, true, 24u8),
+                        expect: Yields(Some(IpNetwork::new(svi_ip, 24).unwrap())),
+                    },
+                    Case {
+                        scenario: "fnn + l2 but no svi allocated fails",
+                        input: (None, VpcVirtualizationType::Fnn, true, 24u8),
+                        expect: Fails,
+                    },
+                    Case {
+                        scenario: "fnn but not an l2 segment yields none",
+                        input: (svi, VpcVirtualizationType::Fnn, false, 24u8),
+                        expect: Yields(None),
+                    },
+                    Case {
+                        scenario: "l2 but not fnn yields none",
+                        input: (svi, VpcVirtualizationType::EthernetVirtualizer, true, 24u8),
+                        expect: Yields(None),
+                    },
+                    Case {
+                        scenario: "flat l2 segment yields none",
+                        input: (svi, VpcVirtualizationType::Flat, true, 24u8),
+                        expect: Yields(None),
+                    },
+                    Case {
+                        scenario: "neither fnn nor l2 yields none",
+                        input: (
+                            svi,
+                            VpcVirtualizationType::EthernetVirtualizer,
+                            false,
+                            24u8,
+                        ),
+                        expect: Yields(None),
+                    },
+                    Case {
+                        scenario: "fnn + l2 + invalid prefix for ipv4 fails",
+                        input: (svi, VpcVirtualizationType::Fnn, true, 33u8),
+                        expect: Fails,
+                    },
+                ],
+                |(svi_ip, virt, is_l2, prefix)| {
+                    get_svi_ip(&svi_ip, virt, is_l2, prefix).map_err(drop)
+                },
+            );
+        }
     }
 }


### PR DESCRIPTION
- **fix(rest-api): Treat instance status consistently across reporting, filtering, and statistics (#2342)**
- **test(libmlx): add enumerated table-driven cases to raise coverage (#2516)**
- **chore: default to RMS as the backend for component manager (#2517)**
- **test(network): fold onto carbide-test-support + enumerate cases to raise coverage**
