### PR TITLE
test(dpf): fold onto carbide-test-support + enumerate flavor/types cases

### DIFF
--- a/crates/dpf/Cargo.toml
+++ b/crates/dpf/Cargo.toml
@@ -55,6 +55,7 @@ tracing-subscriber = { workspace = true, features = [
 libredfish = { workspace = true, optional = true }
 
 [dev-dependencies]
+carbide-test-support = { path = "../test-support" }
 dashmap = { workspace = true }
 tower-test = { workspace = true }
 hyper = { features = ["client", "http1"], workspace = true }

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -179,13 +179,13 @@ fn get_config_files(
             "[Service]\nEnvironment=\"HTTPS_PROXY={0}\"\nEnvironment=\"https_proxy={0}\"\n",
             proxy.https_proxy
         );
-        if !proxy.no_proxy.is_empty() {
-            let mut entries: Vec<&str> = proxy
-                .no_proxy
-                .iter()
-                .map(|e| e.trim())
-                .filter(|e| !e.is_empty())
-                .collect();
+        let mut entries: Vec<&str> = proxy
+            .no_proxy
+            .iter()
+            .map(|e| e.trim())
+            .filter(|e| !e.is_empty())
+            .collect();
+        if !entries.is_empty() {
             for entry in &entries {
                 validate_proxy_string(entry, "no_proxy entry")?;
             }
@@ -252,6 +252,9 @@ fn dhcp_acl_rules() -> String {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
     use crate::types::DpfProxyDetails;
 
@@ -262,226 +265,706 @@ mod tests {
         })
     }
 
+    /// The `raw` body of the trailing (proxy) config file built by `default_flavor`.
+    fn proxy_file_raw(https_proxy: &str, no_proxy: &[&str]) -> String {
+        let flavor = default_flavor("ns", &proxy(https_proxy, no_proxy)).unwrap();
+        let files = flavor.spec.config_files.unwrap();
+        files.last().unwrap().raw.clone().unwrap()
+    }
+
+    /// `unique_name` of the default flavor for the given proxy, with the standard prefix.
+    fn name_for(proxy: &Option<DpfProxyDetails>) -> String {
+        default_flavor("ns", proxy)
+            .unwrap()
+            .unique_name("dpu-flavor")
+            .unwrap()
+    }
+
+    // ── validate_proxy_string ──────────────────────────────────────────────
+    //
+    // The pure validator at the heart of the proxy path. `DpfError` is not
+    // `PartialEq`, so error rows use `Fails` (with `.map_err(drop)`).
+
+    #[test]
+    fn validate_proxy_string_accepts_and_rejects() {
+        check_cases(
+            [
+                Case {
+                    scenario: "typical proxy url",
+                    input: "http://proxy.corp.example.com:3128",
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "cidr no_proxy entry",
+                    input: "10.0.0.0/8",
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "hostname no_proxy entry",
+                    input: "localhost",
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "dns suffix no_proxy entry",
+                    input: ".svc.cluster.local",
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "high ascii printable is allowed",
+                    input: "host~name",
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "space is allowed (>= 0x20, not quote/control)",
+                    input: "has space",
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "tilde 0x7e is the last printable allowed",
+                    input: "~",
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "double quote rejected",
+                    input: "http://proxy:3128/\"evil",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "newline rejected",
+                    input: "http://proxy:3128\nEvil: injected",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "carriage return rejected",
+                    input: "http://proxy:3128\rinjected",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "tab (control char) rejected",
+                    input: "http://proxy:3128\tx",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "null byte rejected",
+                    input: "10.0.0.0/8\x00bad",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "0x01 control char rejected",
+                    input: "10.0.0.0/8\x01bad",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "0x1f (last control below 0x20) rejected",
+                    input: "x\x1fy",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "DEL 0x7f rejected",
+                    input: "x\x7fy",
+                    expect: Fails,
+                },
+            ],
+            |value| validate_proxy_string(value, "field").map_err(drop),
+        );
+    }
+
+    #[test]
+    fn validate_proxy_string_error_names_the_field() {
+        // The rejected-string error message mentions the field name passed in.
+        check_cases(
+            [
+                Case {
+                    scenario: "field name appears in the error",
+                    input: ("\"", "https_proxy", &["https_proxy", "systemd"][..]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "no_proxy field name appears in the error",
+                    input: ("\n", "no_proxy entry", &["no_proxy entry"][..]),
+                    expect: Yields(true),
+                },
+            ],
+            |(value, field, tokens): (&str, &str, &[&str])| {
+                let msg = match validate_proxy_string(value, field) {
+                    Err(crate::error::DpfError::ConfigError(m)) => m,
+                    other => return Err(format!("expected ConfigError, got {other:?}")),
+                };
+                Ok(tokens.iter().all(|t| msg.contains(t)))
+            },
+        );
+    }
+
+    // ── default_flavor: proxy validation flows through ─────────────────────
+
+    #[test]
+    fn default_flavor_accepts_or_rejects_proxy() {
+        check_cases(
+            [
+                Case {
+                    scenario: "no proxy",
+                    input: None,
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "typical proxy with no_proxy list",
+                    input: proxy(
+                        "http://proxy.corp.example.com:3128",
+                        &["10.0.0.0/8", "localhost", ".svc.cluster.local"],
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "proxy with empty no_proxy",
+                    input: proxy("http://proxy:3128", &[]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "https_proxy with quote rejected",
+                    input: proxy("http://proxy:3128/\"evil", &[]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "https_proxy with newline rejected",
+                    input: proxy("http://proxy:3128\nEvil: injected", &[]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "https_proxy with carriage return rejected",
+                    input: proxy("http://proxy:3128\rx", &[]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "no_proxy entry with control char rejected",
+                    input: proxy("http://proxy:3128", &["10.0.0.0/8\x01bad"]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "no_proxy entry with DEL rejected",
+                    input: proxy("http://proxy:3128", &["ok", "bad\x7f"]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "blank/whitespace-only no_proxy entries are skipped, not rejected",
+                    input: proxy("http://proxy:3128", &["", "  ", "\t"]),
+                    expect: Yields(()),
+                },
+            ],
+            |p| default_flavor("ns", &p).map(drop).map_err(drop),
+        );
+    }
+
+    // ── default_flavor: structural getters ─────────────────────────────────
+
+    #[test]
+    fn default_flavor_namespace_is_passed_through() {
+        check_values(
+            [
+                Check {
+                    scenario: "plain namespace",
+                    input: "my-ns",
+                    expect: Some("my-ns".to_string()),
+                },
+                Check {
+                    scenario: "empty namespace is still set verbatim",
+                    input: "",
+                    expect: Some(String::new()),
+                },
+                Check {
+                    scenario: "namespace with hyphens",
+                    input: "dpf-system-test",
+                    expect: Some("dpf-system-test".to_string()),
+                },
+            ],
+            |ns| default_flavor(ns, &None).unwrap().metadata.namespace,
+        );
+    }
+
+    #[test]
+    fn default_flavor_metadata_name_is_always_none() {
+        // The caller must set the name via unique_name(); the builder leaves it unset.
+        check_values(
+            [
+                Check {
+                    scenario: "no proxy",
+                    input: None,
+                    expect: true,
+                },
+                Check {
+                    scenario: "with proxy",
+                    input: proxy("http://proxy:3128", &["localhost"]),
+                    expect: true,
+                },
+            ],
+            |p| default_flavor("ns", &p).unwrap().metadata.name.is_none(),
+        );
+    }
+
+    #[test]
+    fn default_flavor_spec_invariants() {
+        // Structural shape of the default spec that callers depend on.
+        let flavor = default_flavor("ns", &None).unwrap();
+        check_values(
+            [
+                Check {
+                    scenario: "dpu_mode is ZeroTrust",
+                    input: matches!(flavor.spec.dpu_mode, Some(DpuFlavorDpuMode::ZeroTrust)),
+                    expect: true,
+                },
+                Check {
+                    scenario: "bfcfg has three parameters",
+                    input: flavor.spec.bfcfg_parameters.as_ref().map(|v| v.len()) == Some(3),
+                    expect: true,
+                },
+                Check {
+                    scenario: "exactly one nvconfig entry",
+                    input: flavor.spec.nvconfig.as_ref().map(|v| v.len()) == Some(1),
+                    expect: true,
+                },
+                Check {
+                    scenario: "ovs raw config script is present",
+                    input: flavor
+                        .spec
+                        .ovs
+                        .as_ref()
+                        .and_then(|o| o.raw_config_script.as_ref())
+                        .is_some(),
+                    expect: true,
+                },
+                Check {
+                    scenario: "dpu_resources unset",
+                    input: flavor.spec.dpu_resources.is_none(),
+                    expect: true,
+                },
+                Check {
+                    scenario: "containerd_config unset",
+                    input: flavor.spec.containerd_config.is_none(),
+                    expect: true,
+                },
+            ],
+            |present| present,
+        );
+    }
+
+    // ── get_config_files: count and trailing-file fields ───────────────────
+
+    #[test]
+    fn config_file_count_depends_on_proxy() {
+        check_values(
+            [
+                Check {
+                    scenario: "no proxy yields five base files",
+                    input: None,
+                    expect: 5,
+                },
+                Check {
+                    scenario: "proxy with empty no_proxy appends a sixth",
+                    input: proxy("http://proxy:3128", &[]),
+                    expect: 6,
+                },
+                Check {
+                    scenario: "proxy with no_proxy list still appends exactly one",
+                    input: proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]),
+                    expect: 6,
+                },
+            ],
+            |p| {
+                default_flavor("ns", &p)
+                    .unwrap()
+                    .spec
+                    .config_files
+                    .unwrap()
+                    .len()
+            },
+        );
+    }
+
+    #[test]
+    fn proxy_file_fields_are_fixed() {
+        // path, permissions, operation of the trailing proxy drop-in.
+        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[])).unwrap();
+        let files = flavor.spec.config_files.unwrap();
+        let f = files.last().unwrap();
+        check_values(
+            [
+                Check {
+                    scenario: "path",
+                    input: f.path.is_some()
+                        && f.path.as_deref()
+                            == Some("/etc/systemd/system/containerd.service.d/socks-proxy.conf"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "permissions 0644",
+                    input: f.permissions.as_deref() == Some("0644"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "override operation",
+                    input: matches!(f.operation, Some(DpuFlavorConfigFilesOperation::Override)),
+                    expect: true,
+                },
+            ],
+            |ok| ok,
+        );
+    }
+
+    #[test]
+    fn base_config_file_paths_are_present() {
+        // The five base files always exist regardless of proxy, with these paths.
+        let files = default_flavor("ns", &None)
+            .unwrap()
+            .spec
+            .config_files
+            .unwrap();
+        let paths: Vec<&str> = files.iter().filter_map(|f| f.path.as_deref()).collect();
+        check_values(
+            [
+                Check {
+                    scenario: "acltool.conf",
+                    input: "/var/lib/hbn/etc/supervisor/conf.d/acltool.conf",
+                    expect: true,
+                },
+                Check {
+                    scenario: "10-dhcp.rules",
+                    input: "/var/lib/hbn/etc/cumulus/acl/policy.d/10-dhcp.rules",
+                    expect: true,
+                },
+                Check {
+                    scenario: "mlnx-bf.conf",
+                    input: "/etc/mellanox/mlnx-bf.conf",
+                    expect: true,
+                },
+                Check {
+                    scenario: "mlnx-ovs.conf",
+                    input: "/etc/mellanox/mlnx-ovs.conf",
+                    expect: true,
+                },
+                Check {
+                    scenario: "mlnx-sf.conf",
+                    input: "/etc/mellanox/mlnx-sf.conf",
+                    expect: true,
+                },
+            ],
+            |path| paths.contains(&path),
+        );
+    }
+
+    // ── proxy drop-in raw body content ─────────────────────────────────────
+    //
+    // `.contains(...)` substring checks folded into (value, &[tokens]) rows.
+
+    #[test]
+    fn proxy_raw_contains_expected_tokens() {
+        check_cases(
+            [Case {
+                scenario: "uppercase and lowercase HTTPS_PROXY env set under [Service]",
+                input: (
+                    proxy_file_raw("http://proxy.example.com:3128", &[]),
+                    &[
+                        "[Service]",
+                        "HTTPS_PROXY=http://proxy.example.com:3128",
+                        "https_proxy=http://proxy.example.com:3128",
+                    ][..],
+                ),
+                expect: Yields(true),
+            }],
+            |(raw, tokens): (String, &[&str])| Ok::<_, ()>(tokens.iter().all(|t| raw.contains(t))),
+        );
+    }
+
+    #[test]
+    fn proxy_raw_no_proxy_handling() {
+        // When no_proxy is empty the NO_PROXY env lines are omitted; when set they
+        // appear sorted+deduped. Each row: (raw body, tokens that must all appear).
+        check_cases(
+            [
+                Case {
+                    scenario: "no_proxy lines present, sorted and deduped",
+                    input: (
+                        proxy_file_raw(
+                            "http://proxy:3128",
+                            &["localhost", "10.0.0.0/8", "10.0.0.0/8"],
+                        ),
+                        &[
+                            "NO_PROXY=10.0.0.0/8,localhost",
+                            "no_proxy=10.0.0.0/8,localhost",
+                        ][..],
+                    ),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "single no_proxy entry",
+                    input: (
+                        proxy_file_raw("http://proxy:3128", &["10.0.0.0/8"]),
+                        &["NO_PROXY=10.0.0.0/8", "no_proxy=10.0.0.0/8"][..],
+                    ),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "whitespace around entries is trimmed",
+                    input: (
+                        proxy_file_raw("http://proxy:3128", &["  localhost  ", " 10.0.0.0/8 "]),
+                        &["NO_PROXY=10.0.0.0/8,localhost"][..],
+                    ),
+                    expect: Yields(true),
+                },
+            ],
+            |(raw, tokens): (String, &[&str])| Ok::<_, ()>(tokens.iter().all(|t| raw.contains(t))),
+        );
+    }
+
+    #[test]
+    fn proxy_raw_omits_no_proxy_when_effectively_empty() {
+        // Empty or blank-only no_proxy lists produce no NO_PROXY env lines at all.
+        check_values(
+            [
+                Check {
+                    scenario: "empty list",
+                    input: proxy_file_raw("http://proxy:3128", &[]),
+                    expect: false,
+                },
+                Check {
+                    scenario: "blank and whitespace-only entries are filtered out",
+                    input: proxy_file_raw("http://proxy:3128", &["", "   ", "\t"]),
+                    expect: false,
+                },
+            ],
+            |raw| raw.contains("NO_PROXY") || raw.contains("no_proxy"),
+        );
+    }
+
     // ── unique_name ────────────────────────────────────────────────────────
 
     #[test]
     fn unique_name_has_expected_format() {
+        // "<prefix>-<16 lowercase hex chars>" for several prefixes.
+        check_cases(
+            [
+                Case {
+                    scenario: "standard prefix",
+                    input: "dpu-flavor",
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "empty prefix still yields prefix-<hash>",
+                    input: "",
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "prefix containing hyphens",
+                    input: "a-b-c",
+                    expect: Yields(true),
+                },
+            ],
+            |prefix: &str| {
+                let flavor = default_flavor("ns", &None).map_err(drop)?;
+                let name = flavor.unique_name(prefix).map_err(drop)?;
+                let (got_prefix, hash) = name.rsplit_once('-').ok_or(())?;
+                Ok::<bool, ()>(
+                    got_prefix == prefix
+                        && hash.len() == 16
+                        && hash
+                            .chars()
+                            .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()),
+                )
+            },
+        );
+    }
+
+    #[test]
+    fn unique_name_equality_across_specs() {
+        // true  => the two specs hash to the same name (stable / order- & dup-insensitive)
+        // false => the specs differ, so the names must differ
+        check_values(
+            [
+                Check {
+                    scenario: "deterministic for identical specs",
+                    input: (name_for(&None), name_for(&None)),
+                    expect: true,
+                },
+                Check {
+                    scenario: "no_proxy order does not affect the name",
+                    input: (
+                        name_for(&proxy("http://proxy:3128", &["localhost", "10.0.0.0/8"])),
+                        name_for(&proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"])),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "duplicate no_proxy entries do not affect the name",
+                    input: (
+                        name_for(&proxy("http://proxy:3128", &["10.0.0.0/8"])),
+                        name_for(&proxy("http://proxy:3128", &["10.0.0.0/8", "10.0.0.0/8"])),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "adding a proxy changes the name",
+                    input: (name_for(&None), name_for(&proxy("http://proxy:3128", &[]))),
+                    expect: false,
+                },
+                Check {
+                    scenario: "extending the no_proxy list changes the name",
+                    input: (
+                        name_for(&proxy("http://proxy:3128", &["10.0.0.0/8"])),
+                        name_for(&proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"])),
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "changing the https_proxy url changes the name",
+                    input: (
+                        name_for(&proxy("http://a:3128", &[])),
+                        name_for(&proxy("http://b:3128", &[])),
+                    ),
+                    expect: false,
+                },
+            ],
+            |(a, b)| a == b,
+        );
+    }
+
+    #[test]
+    fn unique_name_prefix_changes_the_output() {
+        // The same spec under different prefixes yields different names.
         let flavor = default_flavor("ns", &None).unwrap();
-        let name = flavor.unique_name("dpu-flavor").unwrap();
-        // "<prefix>-<16 lowercase hex chars>"
-        let (prefix, hash) = name.rsplit_once('-').expect("name contains '-'");
-        assert_eq!(prefix, "dpu-flavor");
-        assert_eq!(hash.len(), 16);
-        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
-    }
-
-    #[test]
-    fn unique_name_is_deterministic() {
-        let f1 = default_flavor("ns", &None).unwrap();
-        let f2 = default_flavor("ns", &None).unwrap();
-        assert_eq!(
-            f1.unique_name("dpu-flavor").unwrap(),
-            f2.unique_name("dpu-flavor").unwrap()
+        check_values(
+            [
+                Check {
+                    scenario: "different prefixes differ",
+                    input: (
+                        flavor.unique_name("a").unwrap(),
+                        flavor.unique_name("b").unwrap(),
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "same prefix matches",
+                    input: (
+                        flavor.unique_name("x").unwrap(),
+                        flavor.unique_name("x").unwrap(),
+                    ),
+                    expect: true,
+                },
+            ],
+            |(a, b)| a == b,
         );
     }
 
+    // ── dhcp_acl_rules (pure formatter) ────────────────────────────────────
+
     #[test]
-    fn unique_name_changes_when_proxy_added() {
-        let no_proxy = default_flavor("ns", &None).unwrap();
-        let with_proxy = default_flavor("ns", &proxy("http://proxy:3128", &[])).unwrap();
-        assert_ne!(
-            no_proxy.unique_name("dpu-flavor").unwrap(),
-            with_proxy.unique_name("dpu-flavor").unwrap()
+    fn dhcp_acl_rules_shape() {
+        let rules = dhcp_acl_rules();
+        check_values(
+            [
+                Check {
+                    scenario: "starts with the iptables header",
+                    input: rules.starts_with("[iptables]\n"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "covers the host-facing pf0hpf interface",
+                    input: rules.contains("--physdev-in pf0hpf_if "),
+                    expect: true,
+                },
+                Check {
+                    scenario: "covers vf0",
+                    input: rules.contains("--physdev-in pf0vf0_if "),
+                    expect: true,
+                },
+                Check {
+                    scenario: "covers vf15 (last in range)",
+                    input: rules.contains("--physdev-in pf0vf15_if "),
+                    expect: true,
+                },
+                Check {
+                    scenario: "does not over-run to vf16",
+                    input: rules.contains("pf0vf16_if"),
+                    expect: false,
+                },
+                Check {
+                    scenario: "header line plus 17 rule lines (hpf + vf0..15)",
+                    input: rules.lines().count() == 18,
+                    expect: true,
+                },
+                Check {
+                    scenario: "every rule drops DHCP broadcast to .255",
+                    input: rules.matches("-d 255.255.255.255").count() == 17,
+                    expect: true,
+                },
+            ],
+            |v| v,
         );
     }
 
+    // ── get_default_ovs_defaults (pure formatter) ──────────────────────────
+
     #[test]
-    fn unique_name_changes_when_no_proxy_list_changes() {
-        let p1 = default_flavor("ns", &proxy("http://proxy:3128", &["10.0.0.0/8"])).unwrap();
-        let p2 = default_flavor(
-            "ns",
-            &proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]),
-        )
-        .unwrap();
-        assert_ne!(
-            p1.unique_name("dpu-flavor").unwrap(),
-            p2.unique_name("dpu-flavor").unwrap()
+    fn ovs_defaults_contains_key_lines() {
+        check_cases(
+            [Case {
+                scenario: "doca/offload/br-sfc setup lines present",
+                input: (
+                    get_default_ovs_defaults(),
+                    &[
+                        "other_config:doca-init=true",
+                        "other_config:hw-offload=true",
+                        "add-br br-sfc",
+                        "datapath_type=netdev",
+                        "type=dpdk",
+                        "mtu_request=9216",
+                    ][..],
+                ),
+                expect: Yields(true),
+            }],
+            |(raw, tokens): (String, &[&str])| Ok::<_, ()>(tokens.iter().all(|t| raw.contains(t))),
         );
     }
 
+    // ── get_default_nvconfig (pure constructor) ────────────────────────────
+
     #[test]
-    fn unique_name_stable_regardless_of_no_proxy_order() {
-        let p1 = default_flavor(
-            "ns",
-            &proxy("http://proxy:3128", &["localhost", "10.0.0.0/8"]),
-        )
-        .unwrap();
-        let p2 = default_flavor(
-            "ns",
-            &proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]),
-        )
-        .unwrap();
-        assert_eq!(
-            p1.unique_name("dpu-flavor").unwrap(),
-            p2.unique_name("dpu-flavor").unwrap(),
-            "no_proxy order must not affect the flavor name"
+    fn default_nvconfig_shape() {
+        let nv = get_default_nvconfig();
+        check_values(
+            [
+                Check {
+                    scenario: "device is the only allowed wildcard variant",
+                    input: matches!(nv.device, Some(DpuFlavorNvconfigDevice::KopiumVariant0)),
+                    expect: true,
+                },
+                Check {
+                    scenario: "parameter count",
+                    input: nv.parameters.as_ref().map(|p| p.len()) == Some(16),
+                    expect: true,
+                },
+                Check {
+                    scenario: "carries the SRIOV enable flag",
+                    input: nv
+                        .parameters
+                        .as_ref()
+                        .map(|p| p.iter().any(|s| s == "SRIOV_EN=1"))
+                        == Some(true),
+                    expect: true,
+                },
+                Check {
+                    scenario: "carries NUM_OF_VFS=16",
+                    input: nv
+                        .parameters
+                        .as_ref()
+                        .map(|p| p.iter().any(|s| s == "NUM_OF_VFS=16"))
+                        == Some(true),
+                    expect: true,
+                },
+            ],
+            |v| v,
         );
-    }
-
-    #[test]
-    fn unique_name_stable_with_duplicate_no_proxy_entries() {
-        let p1 = default_flavor("ns", &proxy("http://proxy:3128", &["10.0.0.0/8"])).unwrap();
-        let p2 = default_flavor(
-            "ns",
-            &proxy("http://proxy:3128", &["10.0.0.0/8", "10.0.0.0/8"]),
-        )
-        .unwrap();
-        assert_eq!(
-            p1.unique_name("dpu-flavor").unwrap(),
-            p2.unique_name("dpu-flavor").unwrap(),
-            "duplicate no_proxy entries must not affect the flavor name"
-        );
-    }
-
-    #[test]
-    fn proxy_config_file_no_proxy_entries_are_sorted_and_deduped() {
-        let flavor = default_flavor(
-            "ns",
-            &proxy(
-                "http://proxy:3128",
-                &["localhost", "10.0.0.0/8", "10.0.0.0/8"],
-            ),
-        )
-        .unwrap();
-        let files = flavor.spec.config_files.unwrap();
-        let raw = files.last().unwrap().raw.as_deref().unwrap();
-        assert!(
-            raw.contains("NO_PROXY=10.0.0.0/8,localhost"),
-            "no_proxy must be sorted and deduped; got: {raw}"
-        );
-    }
-
-    // ── default_flavor ─────────────────────────────────────────────────────
-
-    #[test]
-    fn default_flavor_metadata_name_is_none() {
-        let flavor = default_flavor("test-ns", &None).unwrap();
-        assert!(
-            flavor.metadata.name.is_none(),
-            "name must be set by the caller via unique_name()"
-        );
-    }
-
-    #[test]
-    fn default_flavor_namespace_is_set() {
-        let flavor = default_flavor("my-ns", &None).unwrap();
-        assert_eq!(flavor.metadata.namespace.as_deref(), Some("my-ns"));
-    }
-
-    // ── get_config_files ───────────────────────────────────────────────────
-
-    #[test]
-    fn no_proxy_yields_five_config_files() {
-        let flavor = default_flavor("ns", &None).unwrap();
-        let files = flavor.spec.config_files.unwrap();
-        assert_eq!(files.len(), 5);
-    }
-
-    #[test]
-    fn proxy_appends_sixth_config_file() {
-        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[])).unwrap();
-        let files = flavor.spec.config_files.unwrap();
-        assert_eq!(files.len(), 6);
-    }
-
-    #[test]
-    fn proxy_config_file_has_correct_path() {
-        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[])).unwrap();
-        let files = flavor.spec.config_files.unwrap();
-        let proxy_file = files.last().unwrap();
-        assert_eq!(
-            proxy_file.path.as_deref(),
-            Some("/etc/systemd/system/containerd.service.d/socks-proxy.conf")
-        );
-    }
-
-    #[test]
-    fn proxy_config_file_contains_https_proxy_env() {
-        let flavor = default_flavor("ns", &proxy("http://proxy.example.com:3128", &[])).unwrap();
-        let files = flavor.spec.config_files.unwrap();
-        let raw = files.last().unwrap().raw.as_deref().unwrap();
-        assert!(raw.contains("HTTPS_PROXY=http://proxy.example.com:3128"));
-        assert!(raw.contains("https_proxy=http://proxy.example.com:3128"));
-    }
-
-    #[test]
-    fn proxy_config_file_omits_no_proxy_when_empty() {
-        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[])).unwrap();
-        let files = flavor.spec.config_files.unwrap();
-        let raw = files.last().unwrap().raw.as_deref().unwrap();
-        assert!(!raw.contains("NO_PROXY"));
-        assert!(!raw.contains("no_proxy"));
-    }
-
-    #[test]
-    fn proxy_config_file_includes_no_proxy_when_set() {
-        let flavor = default_flavor(
-            "ns",
-            &proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]),
-        )
-        .unwrap();
-        let files = flavor.spec.config_files.unwrap();
-        let raw = files.last().unwrap().raw.as_deref().unwrap();
-        assert!(raw.contains("NO_PROXY=10.0.0.0/8,localhost"));
-        assert!(raw.contains("no_proxy=10.0.0.0/8,localhost"));
-    }
-
-    #[test]
-    fn proxy_config_file_has_override_operation() {
-        let flavor = default_flavor("ns", &proxy("http://proxy:3128", &[])).unwrap();
-        let files = flavor.spec.config_files.unwrap();
-        let proxy_file = files.last().unwrap();
-        assert!(matches!(
-            proxy_file.operation,
-            Some(DpuFlavorConfigFilesOperation::Override)
-        ));
-        assert_eq!(proxy_file.permissions.as_deref(), Some("0644"));
-    }
-
-    // ── validate_proxy_string ──────────────────────────────────────────────
-
-    #[test]
-    fn proxy_rejected_when_https_proxy_contains_quote() {
-        let err = default_flavor("ns", &proxy("http://proxy:3128/\"evil", &[])).unwrap_err();
-        assert!(
-            matches!(err, crate::error::DpfError::ConfigError(_)),
-            "expected ConfigError, got: {err:?}"
-        );
-    }
-
-    #[test]
-    fn proxy_rejected_when_https_proxy_contains_newline() {
-        let err =
-            default_flavor("ns", &proxy("http://proxy:3128\nEvil: injected", &[])).unwrap_err();
-        assert!(matches!(err, crate::error::DpfError::ConfigError(_)));
-    }
-
-    #[test]
-    fn proxy_rejected_when_no_proxy_entry_contains_control_char() {
-        let err =
-            default_flavor("ns", &proxy("http://proxy:3128", &["10.0.0.0/8\x01bad"])).unwrap_err();
-        assert!(matches!(err, crate::error::DpfError::ConfigError(_)));
-    }
-
-    #[test]
-    fn proxy_accepted_with_typical_values() {
-        default_flavor(
-            "ns",
-            &proxy(
-                "http://proxy.corp.example.com:3128",
-                &["10.0.0.0/8", "localhost", ".svc.cluster.local"],
-            ),
-        )
-        .unwrap();
     }
 }

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -455,50 +455,511 @@ pub struct ServiceTemplateVersion {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
 
+    /// `DpuPhase::from(DpuStatusPhase)` is a total conversion; every operator
+    /// status phase maps to exactly one simplified `DpuPhase`. This folds the
+    /// old `test_dpu_phase_from_status` and enumerates all 17 source variants,
+    /// including each provisioning sub-phase that collapses into
+    /// `Provisioning(detail)`.
     #[test]
-    fn test_dpu_phase_from_status() {
-        assert_eq!(DpuPhase::from(DpuStatusPhase::Ready), DpuPhase::Ready);
-        assert_eq!(DpuPhase::from(DpuStatusPhase::Error), DpuPhase::Error);
-        assert_eq!(DpuPhase::from(DpuStatusPhase::Deleting), DpuPhase::Deleting);
-        assert_eq!(
-            DpuPhase::from(DpuStatusPhase::Rebooting),
-            DpuPhase::Rebooting
-        );
-        assert_eq!(
-            DpuPhase::from(DpuStatusPhase::Initializing),
-            DpuPhase::Provisioning("Initializing".into())
-        );
-        assert_eq!(
-            DpuPhase::from(DpuStatusPhase::Pending),
-            DpuPhase::Provisioning("Pending".into())
-        );
-        assert_eq!(
-            DpuPhase::from(DpuStatusPhase::OsInstalling),
-            DpuPhase::Provisioning("OsInstalling".into())
-        );
-        assert_eq!(
-            DpuPhase::from(DpuStatusPhase::NodeEffect),
-            DpuPhase::NodeEffect
-        );
-        assert_eq!(
-            DpuPhase::from(DpuStatusPhase::CheckingHostRebootRequired),
-            DpuPhase::Rebooting
-        );
-        assert_eq!(
-            DpuPhase::from(DpuStatusPhase::NodeEffectRemoval),
-            DpuPhase::NodeEffect
+    fn dpu_phase_from_status_maps_every_variant() {
+        check_values(
+            [
+                Check {
+                    scenario: "Initializing -> Provisioning",
+                    input: DpuStatusPhase::Initializing,
+                    expect: DpuPhase::Provisioning("Initializing".into()),
+                },
+                Check {
+                    scenario: "Pending -> Provisioning",
+                    input: DpuStatusPhase::Pending,
+                    expect: DpuPhase::Provisioning("Pending".into()),
+                },
+                Check {
+                    scenario: "ConfigFwParameters -> Provisioning",
+                    input: DpuStatusPhase::ConfigFwParameters,
+                    expect: DpuPhase::Provisioning("ConfigFwParameters".into()),
+                },
+                Check {
+                    scenario: "PrepareBfb -> Provisioning",
+                    input: DpuStatusPhase::PrepareBfb,
+                    expect: DpuPhase::Provisioning("PrepareBfb".into()),
+                },
+                Check {
+                    scenario: "OsInstalling -> Provisioning",
+                    input: DpuStatusPhase::OsInstalling,
+                    expect: DpuPhase::Provisioning("OsInstalling".into()),
+                },
+                Check {
+                    scenario: "DpuClusterConfig -> Provisioning",
+                    input: DpuStatusPhase::DpuClusterConfig,
+                    expect: DpuPhase::Provisioning("DpuClusterConfig".into()),
+                },
+                Check {
+                    scenario: "HostNetworkConfiguration -> Provisioning",
+                    input: DpuStatusPhase::HostNetworkConfiguration,
+                    expect: DpuPhase::Provisioning("HostNetworkConfiguration".into()),
+                },
+                Check {
+                    scenario: "InitializeInterface -> Provisioning",
+                    input: DpuStatusPhase::InitializeInterface,
+                    expect: DpuPhase::Provisioning("InitializeInterface".into()),
+                },
+                Check {
+                    scenario: "DpuConfig -> Provisioning",
+                    input: DpuStatusPhase::DpuConfig,
+                    expect: DpuPhase::Provisioning("DpuConfig".into()),
+                },
+                Check {
+                    scenario: "PerformArmForceRestart -> Provisioning",
+                    input: DpuStatusPhase::PerformArmForceRestart,
+                    expect: DpuPhase::Provisioning("PerformArmForceRestart".into()),
+                },
+                Check {
+                    scenario: "NodeEffect -> NodeEffect",
+                    input: DpuStatusPhase::NodeEffect,
+                    expect: DpuPhase::NodeEffect,
+                },
+                Check {
+                    scenario: "NodeEffectRemoval -> NodeEffect",
+                    input: DpuStatusPhase::NodeEffectRemoval,
+                    expect: DpuPhase::NodeEffect,
+                },
+                Check {
+                    scenario: "Rebooting -> Rebooting",
+                    input: DpuStatusPhase::Rebooting,
+                    expect: DpuPhase::Rebooting,
+                },
+                Check {
+                    scenario: "CheckingHostRebootRequired -> Rebooting",
+                    input: DpuStatusPhase::CheckingHostRebootRequired,
+                    expect: DpuPhase::Rebooting,
+                },
+                Check {
+                    scenario: "Ready -> Ready",
+                    input: DpuStatusPhase::Ready,
+                    expect: DpuPhase::Ready,
+                },
+                Check {
+                    scenario: "Error -> Error",
+                    input: DpuStatusPhase::Error,
+                    expect: DpuPhase::Error,
+                },
+                Check {
+                    scenario: "Deleting -> Deleting",
+                    input: DpuStatusPhase::Deleting,
+                    expect: DpuPhase::Deleting,
+                },
+            ],
+            DpuPhase::from,
         );
     }
 
+    /// `AsRef<str>` for `DpuPhase` renders each variant to its canonical name;
+    /// a provisioning phase renders its detail string verbatim. Covers all six
+    /// `DpuPhase` variants, including an empty-detail provisioning phase.
     #[test]
-    fn test_dpu_phase_equality() {
-        assert_eq!(DpuPhase::Ready, DpuPhase::Ready);
-        assert_ne!(
-            DpuPhase::Ready,
-            DpuPhase::Provisioning("Initializing".into())
+    fn dpu_phase_as_ref_renders_each_variant() {
+        check_values(
+            [
+                Check {
+                    scenario: "provisioning renders its detail",
+                    input: DpuPhase::Provisioning("OsInstalling".into()),
+                    expect: "OsInstalling".to_string(),
+                },
+                Check {
+                    scenario: "provisioning with empty detail renders empty",
+                    input: DpuPhase::Provisioning(String::new()),
+                    expect: String::new(),
+                },
+                Check {
+                    scenario: "node effect",
+                    input: DpuPhase::NodeEffect,
+                    expect: "NodeEffect".to_string(),
+                },
+                Check {
+                    scenario: "rebooting",
+                    input: DpuPhase::Rebooting,
+                    expect: "Rebooting".to_string(),
+                },
+                Check {
+                    scenario: "ready",
+                    input: DpuPhase::Ready,
+                    expect: "Ready".to_string(),
+                },
+                Check {
+                    scenario: "error",
+                    input: DpuPhase::Error,
+                    expect: "Error".to_string(),
+                },
+                Check {
+                    scenario: "deleting",
+                    input: DpuPhase::Deleting,
+                    expect: "Deleting".to_string(),
+                },
+            ],
+            |phase| phase.as_ref().to_string(),
         );
-        assert_eq!(DpuPhase::Rebooting, DpuPhase::Rebooting);
+    }
+
+    /// `Display` for `DpuPhase` delegates to `AsRef<str>`, so `to_string()`
+    /// yields the same canonical name for every variant.
+    #[test]
+    fn dpu_phase_display_matches_as_ref() {
+        check_values(
+            [
+                Check {
+                    scenario: "provisioning renders its detail",
+                    input: DpuPhase::Provisioning("Pending".into()),
+                    expect: "Pending".to_string(),
+                },
+                Check {
+                    scenario: "node effect",
+                    input: DpuPhase::NodeEffect,
+                    expect: "NodeEffect".to_string(),
+                },
+                Check {
+                    scenario: "rebooting",
+                    input: DpuPhase::Rebooting,
+                    expect: "Rebooting".to_string(),
+                },
+                Check {
+                    scenario: "ready",
+                    input: DpuPhase::Ready,
+                    expect: "Ready".to_string(),
+                },
+                Check {
+                    scenario: "error",
+                    input: DpuPhase::Error,
+                    expect: "Error".to_string(),
+                },
+                Check {
+                    scenario: "deleting",
+                    input: DpuPhase::Deleting,
+                    expect: "Deleting".to_string(),
+                },
+            ],
+            |phase| phase.to_string(),
+        );
+    }
+
+    /// `PartialEq` for `DpuPhase`: same variant compares equal, different
+    /// variants differ, and `Provisioning` discriminates on its detail string.
+    /// Folds the old `test_dpu_phase_equality`.
+    #[test]
+    fn dpu_phase_equality_distinguishes_variants() {
+        check_values(
+            [
+                Check {
+                    scenario: "ready equals ready",
+                    input: (DpuPhase::Ready, DpuPhase::Ready),
+                    expect: true,
+                },
+                Check {
+                    scenario: "rebooting equals rebooting",
+                    input: (DpuPhase::Rebooting, DpuPhase::Rebooting),
+                    expect: true,
+                },
+                Check {
+                    scenario: "error equals error",
+                    input: (DpuPhase::Error, DpuPhase::Error),
+                    expect: true,
+                },
+                Check {
+                    scenario: "deleting equals deleting",
+                    input: (DpuPhase::Deleting, DpuPhase::Deleting),
+                    expect: true,
+                },
+                Check {
+                    scenario: "node effect equals node effect",
+                    input: (DpuPhase::NodeEffect, DpuPhase::NodeEffect),
+                    expect: true,
+                },
+                Check {
+                    scenario: "provisioning equals same-detail provisioning",
+                    input: (
+                        DpuPhase::Provisioning("Pending".into()),
+                        DpuPhase::Provisioning("Pending".into()),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "ready differs from provisioning",
+                    input: (
+                        DpuPhase::Ready,
+                        DpuPhase::Provisioning("Initializing".into()),
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "ready differs from error",
+                    input: (DpuPhase::Ready, DpuPhase::Error),
+                    expect: false,
+                },
+                Check {
+                    scenario: "rebooting differs from node effect",
+                    input: (DpuPhase::Rebooting, DpuPhase::NodeEffect),
+                    expect: false,
+                },
+                Check {
+                    scenario: "provisioning differs by detail",
+                    input: (
+                        DpuPhase::Provisioning("Pending".into()),
+                        DpuPhase::Provisioning("OsInstalling".into()),
+                    ),
+                    expect: false,
+                },
+            ],
+            |(a, b)| a == b,
+        );
+    }
+
+    /// `ConfigPortsServiceType` derives `PartialEq`; each variant equals itself
+    /// and differs from the others.
+    #[test]
+    fn config_ports_service_type_equality() {
+        check_values(
+            [
+                Check {
+                    scenario: "node port equals node port",
+                    input: (
+                        ConfigPortsServiceType::NodePort,
+                        ConfigPortsServiceType::NodePort,
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "cluster ip equals cluster ip",
+                    input: (
+                        ConfigPortsServiceType::ClusterIp,
+                        ConfigPortsServiceType::ClusterIp,
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "none equals none",
+                    input: (ConfigPortsServiceType::None, ConfigPortsServiceType::None),
+                    expect: true,
+                },
+                Check {
+                    scenario: "node port differs from cluster ip",
+                    input: (
+                        ConfigPortsServiceType::NodePort,
+                        ConfigPortsServiceType::ClusterIp,
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "cluster ip differs from none",
+                    input: (
+                        ConfigPortsServiceType::ClusterIp,
+                        ConfigPortsServiceType::None,
+                    ),
+                    expect: false,
+                },
+            ],
+            |(a, b)| a == b,
+        );
+    }
+
+    /// `ServiceConfigPortProtocol` derives `PartialEq`; Tcp and Udp are
+    /// distinct and each equals itself.
+    #[test]
+    fn service_config_port_protocol_equality() {
+        check_values(
+            [
+                Check {
+                    scenario: "tcp equals tcp",
+                    input: (
+                        ServiceConfigPortProtocol::Tcp,
+                        ServiceConfigPortProtocol::Tcp,
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "udp equals udp",
+                    input: (
+                        ServiceConfigPortProtocol::Udp,
+                        ServiceConfigPortProtocol::Udp,
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "tcp differs from udp",
+                    input: (
+                        ServiceConfigPortProtocol::Tcp,
+                        ServiceConfigPortProtocol::Udp,
+                    ),
+                    expect: false,
+                },
+            ],
+            |(a, b)| a == b,
+        );
+    }
+
+    /// `InitDpfResourcesConfig::default()` seeds the documented defaults: an
+    /// empty BFB URL and services list, the `dpu-deployment` name, the crate
+    /// default flavor, and no proxy. Probe each field independently.
+    #[test]
+    fn init_dpf_resources_config_default_fields() {
+        check_values(
+            [Check {
+                scenario: "bfb url is empty",
+                input: (),
+                expect: true,
+            }],
+            |()| InitDpfResourcesConfig::default().bfb_url.is_empty(),
+        );
+        check_values(
+            [Check {
+                scenario: "deployment name",
+                input: (),
+                expect: "dpu-deployment".to_string(),
+            }],
+            |()| InitDpfResourcesConfig::default().deployment_name,
+        );
+        check_values(
+            [Check {
+                scenario: "flavor name uses crate default",
+                input: (),
+                expect: crate::flavor::DEFAULT_FLAVOR_NAME.to_string(),
+            }],
+            |()| InitDpfResourcesConfig::default().flavor_name,
+        );
+        check_values(
+            [Check {
+                scenario: "services is empty",
+                input: (),
+                expect: 0usize,
+            }],
+            |()| InitDpfResourcesConfig::default().services.len(),
+        );
+        check_values(
+            [Check {
+                scenario: "proxy is none",
+                input: (),
+                expect: true,
+            }],
+            |()| InitDpfResourcesConfig::default().proxy.is_none(),
+        );
+    }
+
+    /// `ServiceDefinition::new` records the four required helm fields and
+    /// leaves every optional field at its `Default`. Each row reads one field
+    /// off the freshly constructed value.
+    #[test]
+    fn service_definition_new_records_required_fields() {
+        let build = || ServiceDefinition::new("dts", "https://repo.example", "dts-chart", "1.2.3");
+
+        check_values(
+            [Check {
+                scenario: "name",
+                input: (),
+                expect: "dts".to_string(),
+            }],
+            |()| build().name,
+        );
+        check_values(
+            [Check {
+                scenario: "helm repo url",
+                input: (),
+                expect: "https://repo.example".to_string(),
+            }],
+            |()| build().helm_repo_url,
+        );
+        check_values(
+            [Check {
+                scenario: "helm chart",
+                input: (),
+                expect: "dts-chart".to_string(),
+            }],
+            |()| build().helm_chart,
+        );
+        check_values(
+            [Check {
+                scenario: "helm version",
+                input: (),
+                expect: "1.2.3".to_string(),
+            }],
+            |()| build().helm_version,
+        );
+        // Each row reads one optional field off the freshly built definition
+        // and asserts it sits at its `Default` (None / empty).
+        enum OptionalField {
+            HelmValuesIsNone,
+            ConfigValuesIsNone,
+            ConfigPortsIsNone,
+            ConfigPortsServiceTypeIsNone,
+            ServiceNadIsNone,
+            ServiceDaemonSetAnnotationsIsNone,
+            InterfacesEmpty,
+            ServiceChainSwitchesEmpty,
+        }
+        check_values(
+            [
+                Check {
+                    scenario: "helm values default to none",
+                    input: OptionalField::HelmValuesIsNone,
+                    expect: true,
+                },
+                Check {
+                    scenario: "config values default to none",
+                    input: OptionalField::ConfigValuesIsNone,
+                    expect: true,
+                },
+                Check {
+                    scenario: "config ports default to none",
+                    input: OptionalField::ConfigPortsIsNone,
+                    expect: true,
+                },
+                Check {
+                    scenario: "config ports service type defaults to none",
+                    input: OptionalField::ConfigPortsServiceTypeIsNone,
+                    expect: true,
+                },
+                Check {
+                    scenario: "service nad defaults to none",
+                    input: OptionalField::ServiceNadIsNone,
+                    expect: true,
+                },
+                Check {
+                    scenario: "daemon set annotations default to none",
+                    input: OptionalField::ServiceDaemonSetAnnotationsIsNone,
+                    expect: true,
+                },
+                Check {
+                    scenario: "interfaces default to empty",
+                    input: OptionalField::InterfacesEmpty,
+                    expect: true,
+                },
+                Check {
+                    scenario: "service chain switches default to empty",
+                    input: OptionalField::ServiceChainSwitchesEmpty,
+                    expect: true,
+                },
+            ],
+            |field| {
+                let svc = build();
+                match field {
+                    OptionalField::HelmValuesIsNone => svc.helm_values.is_none(),
+                    OptionalField::ConfigValuesIsNone => svc.config_values.is_none(),
+                    OptionalField::ConfigPortsIsNone => svc.config_ports.is_none(),
+                    OptionalField::ConfigPortsServiceTypeIsNone => {
+                        svc.config_ports_service_type.is_none()
+                    }
+                    OptionalField::ServiceNadIsNone => svc.service_nad.is_none(),
+                    OptionalField::ServiceDaemonSetAnnotationsIsNone => {
+                        svc.service_daemon_set_annotations.is_none()
+                    }
+                    OptionalField::InterfacesEmpty => svc.interfaces.is_empty(),
+                    OptionalField::ServiceChainSwitchesEmpty => {
+                        svc.service_chain_switches.is_empty()
+                    }
+                }
+            },
+        );
     }
 }


### PR DESCRIPTION
This supports #3914.

The `dpf` crate's pure logic — the DPU flavor builder and the `DpuPhase` type
conversions — had only a handful of one-off tests.

This folds them onto `carbide-test-support` based `Case`/`Check` tables and then
enumerates the input variants each function handles: every proxy-string
accept/reject path, the default-flavor spec invariants and config-file shapes,
the DHCP ACL rule lines, and the full `DpuStatusPhase` to `DpuPhase` mapping
across all variants. The async SDK and watcher flows are left as-is; those need
the existing mock harness, not table rows, so the crate-level delta is modest
while the targeted files move sharply.

Enumerating the proxy path also tightened one behavior: a `no_proxy` list of only
blank/whitespace entries used to emit an empty `NO_PROXY=` drop-in line, because
the guard tested the unfiltered list. Filtering first and guarding on the result
omits the line entirely, which is what the surrounding tests expect.

- `types.rs`: enumerated the phase conversion, `as_ref`/`Display`, and the
  service config/definition constructors, to full coverage.
- `flavor.rs`: enumerated proxy validation, default-flavor invariants, and the
  ovs/nvconfig formatters.
```
┌──────────────────┬─────────┬─────────┐
│ Region coverage  │ Before  │  After  │
├──────────────────┼─────────┼─────────┤
│ types.rs         │ 77.08%  │ 100.00% │
│ flavor.rs        │ 99.03%  │  98.43% │
│ crate total      │ 83.96%  │  84.63% │
└──────────────────┴─────────┴─────────┘
```
Crate function coverage moved 68.17% to 70.36% and line 83.85% to 86.35%; the
remaining surface is the async SDK/watcher machinery that the mock harness
covers separately.

All tests pass and clippy is clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>