### PR TITLE
test(api-model): fold onto carbide-test-support + enumerate cases to raise coverage

### DIFF
--- a/crates/api-model/src/allocation_type.rs
+++ b/crates/api-model/src/allocation_type.rs
@@ -88,60 +88,288 @@ pub enum AssignStaticResult {
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
 
     use super::*;
     use crate::address_selection_strategy::AddressSelectionStrategy;
 
+    // Total `From<AddressSelectionStrategy>` conversions: every strategy maps to an
+    // allocation type. The conversion is infallible, so each row is a plain value
+    // checked with `check_values`. Strategies that carry data are exercised across
+    // boundary payloads (prefix length extremes, IPv4 vs IPv6 static addresses) to
+    // confirm the discriminant alone — not the payload — drives the result.
     #[test]
-    fn next_available_ip_is_dhcp() {
-        assert_eq!(
-            AllocationType::from(AddressSelectionStrategy::NextAvailableIp),
-            AllocationType::Dhcp,
+    fn strategy_maps_to_allocation_type() {
+        check_values(
+            [
+                Check {
+                    scenario: "next available ip -> dhcp",
+                    input: AddressSelectionStrategy::NextAvailableIp,
+                    expect: AllocationType::Dhcp,
+                },
+                Check {
+                    scenario: "automatic alias -> dhcp",
+                    input: AddressSelectionStrategy::Automatic,
+                    expect: AllocationType::Dhcp,
+                },
+                Check {
+                    scenario: "next available prefix /30 -> dhcp",
+                    input: AddressSelectionStrategy::NextAvailablePrefix(30),
+                    expect: AllocationType::Dhcp,
+                },
+                Check {
+                    scenario: "next available prefix /0 (boundary low) -> dhcp",
+                    input: AddressSelectionStrategy::NextAvailablePrefix(0),
+                    expect: AllocationType::Dhcp,
+                },
+                Check {
+                    scenario: "next available prefix /32 -> dhcp",
+                    input: AddressSelectionStrategy::NextAvailablePrefix(32),
+                    expect: AllocationType::Dhcp,
+                },
+                Check {
+                    scenario: "next available prefix /128 -> dhcp",
+                    input: AddressSelectionStrategy::NextAvailablePrefix(128),
+                    expect: AllocationType::Dhcp,
+                },
+                Check {
+                    scenario: "next available prefix /255 (boundary high) -> dhcp",
+                    input: AddressSelectionStrategy::NextAvailablePrefix(u8::MAX),
+                    expect: AllocationType::Dhcp,
+                },
+                Check {
+                    scenario: "static ipv4 -> static",
+                    input: AddressSelectionStrategy::StaticAddress(
+                        Ipv4Addr::new(10, 0, 0, 1).into(),
+                    ),
+                    expect: AllocationType::Static,
+                },
+                Check {
+                    scenario: "static ipv4 unspecified (0.0.0.0) -> static",
+                    input: AddressSelectionStrategy::StaticAddress(Ipv4Addr::UNSPECIFIED.into()),
+                    expect: AllocationType::Static,
+                },
+                Check {
+                    scenario: "static ipv4 broadcast (255.255.255.255) -> static",
+                    input: AddressSelectionStrategy::StaticAddress(Ipv4Addr::BROADCAST.into()),
+                    expect: AllocationType::Static,
+                },
+                Check {
+                    scenario: "static ipv6 -> static",
+                    input: AddressSelectionStrategy::StaticAddress(
+                        Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1).into(),
+                    ),
+                    expect: AllocationType::Static,
+                },
+                Check {
+                    scenario: "static ipv6 unspecified (::) -> static",
+                    input: AddressSelectionStrategy::StaticAddress(Ipv6Addr::UNSPECIFIED.into()),
+                    expect: AllocationType::Static,
+                },
+                Check {
+                    scenario: "static ipv6 localhost (::1) -> static",
+                    input: AddressSelectionStrategy::StaticAddress(Ipv6Addr::LOCALHOST.into()),
+                    expect: AllocationType::Static,
+                },
+            ],
+            AllocationType::from,
         );
     }
 
+    // Serialization: each `AllocationType` variant renders to its snake_case wire
+    // form. Total operation, so the produced string is checked directly.
     #[test]
-    fn automatic_is_dhcp() {
-        assert_eq!(
-            AllocationType::from(AddressSelectionStrategy::Automatic),
-            AllocationType::Dhcp,
+    fn serializes_to_snake_case() {
+        check_values(
+            [
+                Check {
+                    scenario: "dhcp",
+                    input: AllocationType::Dhcp,
+                    expect: r#""dhcp""#.to_string(),
+                },
+                Check {
+                    scenario: "static",
+                    input: AllocationType::Static,
+                    expect: r#""static""#.to_string(),
+                },
+            ],
+            |value| serde_json::to_string(&value).expect("serialization is infallible"),
         );
     }
 
-    #[test]
-    fn next_available_prefix_is_dhcp() {
-        assert_eq!(
-            AllocationType::from(AddressSelectionStrategy::NextAvailablePrefix(30)),
-            AllocationType::Dhcp,
-        );
-    }
-
-    #[test]
-    fn static_address_is_static() {
-        assert_eq!(
-            AllocationType::from(AddressSelectionStrategy::StaticAddress(
-                Ipv4Addr::new(10, 0, 0, 1).into()
-            )),
-            AllocationType::Static,
-        );
-    }
-
+    // JSON round-trip: serialize each variant and deserialize it back, asserting
+    // both the wire form and that it survives the trip. The closure returns the
+    // wire string plus the recovered value so each row pins down both directions.
     #[test]
     fn serde_roundtrip() {
-        let dhcp: AllocationType = serde_json::from_str(r#""dhcp""#).unwrap();
-        assert_eq!(dhcp, AllocationType::Dhcp);
-
-        let static_: AllocationType = serde_json::from_str(r#""static""#).unwrap();
-        assert_eq!(static_, AllocationType::Static);
-
-        assert_eq!(
-            serde_json::to_string(&AllocationType::Dhcp).unwrap(),
-            r#""dhcp""#
+        check_cases(
+            [
+                Case {
+                    scenario: "dhcp",
+                    input: AllocationType::Dhcp,
+                    expect: Yields((r#""dhcp""#.to_string(), AllocationType::Dhcp)),
+                },
+                Case {
+                    scenario: "static",
+                    input: AllocationType::Static,
+                    expect: Yields((r#""static""#.to_string(), AllocationType::Static)),
+                },
+            ],
+            // serialize, then deserialize the wire form back into a value
+            |value| {
+                let wire = serde_json::to_string(&value).map_err(drop)?;
+                let recovered: AllocationType = serde_json::from_str(&wire).map_err(drop)?;
+                Ok::<_, ()>((wire, recovered))
+            },
         );
-        assert_eq!(
-            serde_json::to_string(&AllocationType::Static).unwrap(),
-            r#""static""#
+    }
+
+    // Deserialization from the wire: accepted snake_case forms recover their
+    // variant; anything else (wrong case, unknown tag, wrong JSON type, malformed)
+    // is rejected. `serde_json::Error` is not `PartialEq`, so failures use `Fails`
+    // with `.map_err(drop)`.
+    #[test]
+    fn deserializes_known_forms_and_rejects_the_rest() {
+        check_cases(
+            [
+                Case {
+                    scenario: "dhcp",
+                    input: r#""dhcp""#,
+                    expect: Yields(AllocationType::Dhcp),
+                },
+                Case {
+                    scenario: "static",
+                    input: r#""static""#,
+                    expect: Yields(AllocationType::Static),
+                },
+                Case {
+                    scenario: "wrong case rejected",
+                    input: r#""Dhcp""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "uppercase rejected",
+                    input: r#""STATIC""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown variant rejected",
+                    input: r#""bootp""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string rejected",
+                    input: r#""""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "leading whitespace in tag rejected",
+                    input: r#"" dhcp""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "number rejected",
+                    input: "0",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "null rejected",
+                    input: "null",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "object rejected",
+                    input: r#"{"dhcp":true}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "malformed json rejected",
+                    input: r#""dhcp"#,
+                    expect: Fails,
+                },
+            ],
+            |wire| serde_json::from_str::<AllocationType>(wire).map_err(drop),
+        );
+    }
+
+    // Derived `PartialEq`/`Eq` over both `AllocationType` and `AssignStaticResult`:
+    // a variant equals only itself. `AssignStaticResult` has no other pure logic, so
+    // equality across its full variant set is its coverage.
+    #[test]
+    fn variants_compare_by_identity() {
+        check_values(
+            [
+                Check {
+                    scenario: "dhcp == dhcp",
+                    input: (AllocationType::Dhcp, AllocationType::Dhcp),
+                    expect: true,
+                },
+                Check {
+                    scenario: "static == static",
+                    input: (AllocationType::Static, AllocationType::Static),
+                    expect: true,
+                },
+                Check {
+                    scenario: "dhcp != static",
+                    input: (AllocationType::Dhcp, AllocationType::Static),
+                    expect: false,
+                },
+            ],
+            |(left, right)| left == right,
+        );
+
+        check_values(
+            [
+                Check {
+                    scenario: "assigned == assigned",
+                    input: (AssignStaticResult::Assigned, AssignStaticResult::Assigned),
+                    expect: true,
+                },
+                Check {
+                    scenario: "replaced static == replaced static",
+                    input: (
+                        AssignStaticResult::ReplacedStatic,
+                        AssignStaticResult::ReplacedStatic,
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "replaced dhcp == replaced dhcp",
+                    input: (
+                        AssignStaticResult::ReplacedDhcp,
+                        AssignStaticResult::ReplacedDhcp,
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "assigned != replaced static",
+                    input: (
+                        AssignStaticResult::Assigned,
+                        AssignStaticResult::ReplacedStatic,
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "replaced static != replaced dhcp",
+                    input: (
+                        AssignStaticResult::ReplacedStatic,
+                        AssignStaticResult::ReplacedDhcp,
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "assigned != replaced dhcp",
+                    input: (
+                        AssignStaticResult::Assigned,
+                        AssignStaticResult::ReplacedDhcp,
+                    ),
+                    expect: false,
+                },
+            ],
+            |(left, right)| left == right,
         );
     }
 }

--- a/crates/api-model/src/attestation.rs
+++ b/crates/api-model/src/attestation.rs
@@ -356,22 +356,245 @@ pub mod spdm {
 
 #[cfg(test)]
 mod test {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
-    use crate::attestation::spdm::SpdmObjectId;
+    use crate::attestation::spdm::{
+        DeviceType, SpdmAttestationState, SpdmDeviceAttestationDetails, SpdmObjectId,
+    };
+
+    // A valid serialized MachineId, reused across rows.
+    const VALID_MACHINE_ID: &str = "fm100htv4fu8fpktl0e0qrg4dl58g2bc2g7naq0l6c15ruc22po1i5rfsq0";
+
+    fn machine_id() -> MachineId {
+        VALID_MACHINE_ID.parse().expect("valid machine id")
+    }
 
     #[test]
-    fn test_spdmobject_id_from_str() {
-        let machine_id: MachineId = "fm100htv4fu8fpktl0e0qrg4dl58g2bc2g7naq0l6c15ruc22po1i5rfsq0"
-            .parse()
-            .unwrap();
-        let device_id = "Device-1".to_string();
-        let spdm_object_id = SpdmObjectId(machine_id, device_id.clone());
+    fn spdm_object_id_round_trips() {
+        let spdm_object_id = SpdmObjectId(machine_id(), "Device-1".to_string());
 
-        let expected_str = format!("{},{}", machine_id, device_id);
+        let expected_str = format!("{VALID_MACHINE_ID},Device-1");
         assert_eq!(expected_str, spdm_object_id.to_string());
 
         let parsed_object_id: SpdmObjectId = spdm_object_id.to_string().parse().unwrap();
-
         assert_eq!(parsed_object_id, spdm_object_id);
+    }
+
+    #[test]
+    fn spdm_object_id_display() {
+        check_values(
+            [
+                Check {
+                    scenario: "simple device id",
+                    input: SpdmObjectId(machine_id(), "Device-1".to_string()),
+                    expect: format!("{VALID_MACHINE_ID},Device-1"),
+                },
+                Check {
+                    scenario: "empty device id",
+                    input: SpdmObjectId(machine_id(), String::new()),
+                    expect: format!("{VALID_MACHINE_ID},"),
+                },
+                Check {
+                    scenario: "device id with internal comma",
+                    input: SpdmObjectId(machine_id(), "a,b".to_string()),
+                    expect: format!("{VALID_MACHINE_ID},a,b"),
+                },
+                Check {
+                    scenario: "device id with spaces",
+                    input: SpdmObjectId(machine_id(), "HGX IRoT GPU 0".to_string()),
+                    expect: format!("{VALID_MACHINE_ID},HGX IRoT GPU 0"),
+                },
+            ],
+            |id| id.to_string(),
+        );
+    }
+
+    #[test]
+    fn spdm_object_id_from_str() {
+        // SpdmObjectIdParseError has no PartialEq, so use Fails (+ map_err(drop)).
+        check_cases(
+            [
+                Case {
+                    scenario: "valid two parts",
+                    input: format!("{VALID_MACHINE_ID},Device-1"),
+                    expect: Yields(SpdmObjectId(machine_id(), "Device-1".to_string())),
+                },
+                Case {
+                    scenario: "valid with empty device id",
+                    input: format!("{VALID_MACHINE_ID},"),
+                    expect: Yields(SpdmObjectId(machine_id(), String::new())),
+                },
+                Case {
+                    scenario: "no comma is wrong format",
+                    input: VALID_MACHINE_ID.to_string(),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string is wrong format",
+                    input: String::new(),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "three parts is wrong format",
+                    input: format!("{VALID_MACHINE_ID},Device-1,extra"),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "only a comma is wrong format",
+                    input: ",".to_string(),
+                    // two parts ("" and ""), but the first fails to parse as MachineId
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "bad machine id",
+                    input: "not-a-machine-id,Device-1".to_string(),
+                    expect: Fails,
+                },
+            ],
+            |s| s.parse::<SpdmObjectId>().map_err(drop),
+        );
+    }
+
+    #[test]
+    fn device_type_from_str() {
+        // SpdmHandlerError is PartialEq, but from_str never errors — it always
+        // classifies. Use the Display name as the observable, pure result.
+        check_cases(
+            [
+                Case {
+                    scenario: "gpu token present",
+                    input: "HGX_IRoT_GPU_0",
+                    expect: Yields("Gpu".to_string()),
+                },
+                Case {
+                    scenario: "gpu token bare",
+                    input: "GPU",
+                    expect: Yields("Gpu".to_string()),
+                },
+                Case {
+                    scenario: "cx7 token present",
+                    input: "HGX_ERoT_CX7_1",
+                    expect: Yields("Cx7".to_string()),
+                },
+                Case {
+                    scenario: "cx7 token bare",
+                    input: "CX7",
+                    expect: Yields("Cx7".to_string()),
+                },
+                Case {
+                    scenario: "gpu wins when both present (checked first)",
+                    input: "GPU_CX7",
+                    expect: Yields("Gpu".to_string()),
+                },
+                Case {
+                    scenario: "cpu is unknown",
+                    input: "HGX_ERoT_CPU_0",
+                    expect: Yields("Unknown".to_string()),
+                },
+                Case {
+                    scenario: "bmc is unknown",
+                    input: "BMC",
+                    expect: Yields("Unknown".to_string()),
+                },
+                Case {
+                    scenario: "empty is unknown",
+                    input: "",
+                    expect: Yields("Unknown".to_string()),
+                },
+                Case {
+                    scenario: "lowercase gpu does not match (case sensitive)",
+                    input: "gpu",
+                    expect: Yields("Unknown".to_string()),
+                },
+                Case {
+                    scenario: "lowercase cx7 does not match (case sensitive)",
+                    input: "cx7",
+                    expect: Yields("Unknown".to_string()),
+                },
+            ],
+            |s| Ok::<_, ()>(format!("{:?}", s.parse::<DeviceType>().expect("never errors"))),
+        );
+    }
+
+    fn details_with_state(state: SpdmAttestationState) -> SpdmDeviceAttestationDetails {
+        let now = Utc::now();
+        SpdmDeviceAttestationDetails {
+            machine_id: machine_id(),
+            device_id: "GPU_0".to_string(),
+            state,
+            started_at: now,
+            cancelled_at: None,
+            completed_at: None,
+        }
+    }
+
+    #[test]
+    fn get_failure_cause() {
+        check_values(
+            [
+                Check {
+                    scenario: "failed state yields a cause naming device and reason",
+                    input: details_with_state(SpdmAttestationState::Failed(
+                        "signature mismatch".to_string(),
+                    )),
+                    expect: Some(
+                        "Device: GPU_0, failed reason: signature mismatch".to_string(),
+                    ),
+                },
+                Check {
+                    scenario: "failed with empty reason",
+                    input: details_with_state(SpdmAttestationState::Failed(String::new())),
+                    expect: Some("Device: GPU_0, failed reason: ".to_string()),
+                },
+                Check {
+                    scenario: "passed state has no cause",
+                    input: details_with_state(SpdmAttestationState::Passed),
+                    expect: None,
+                },
+                Check {
+                    scenario: "cancelled state has no cause",
+                    input: details_with_state(SpdmAttestationState::Cancelled),
+                    expect: None,
+                },
+                Check {
+                    scenario: "fetch metadata state has no cause",
+                    input: details_with_state(SpdmAttestationState::FetchMetadata),
+                    expect: None,
+                },
+                Check {
+                    scenario: "fetch certificate state has no cause",
+                    input: details_with_state(SpdmAttestationState::FetchCertificate),
+                    expect: None,
+                },
+                Check {
+                    scenario: "trigger evidence collection state has no cause",
+                    input: details_with_state(
+                        SpdmAttestationState::TriggerEvidenceCollection { retry_count: 0 },
+                    ),
+                    expect: None,
+                },
+                Check {
+                    scenario: "poll evidence collection state has no cause",
+                    input: details_with_state(SpdmAttestationState::PollEvidenceCollection {
+                        task_id: "t1".to_string(),
+                        retry_count: 2,
+                    }),
+                    expect: None,
+                },
+                Check {
+                    scenario: "nras verification state has no cause",
+                    input: details_with_state(SpdmAttestationState::NrasVerification),
+                    expect: None,
+                },
+                Check {
+                    scenario: "apply appraisal policy state has no cause",
+                    input: details_with_state(SpdmAttestationState::ApplyAppraisalPolicy),
+                    expect: None,
+                },
+            ],
+            |details| details.get_failure_cause(),
+        );
     }
 }

--- a/crates/api-model/src/controller_outcome.rs
+++ b/crates/api-model/src/controller_outcome.rs
@@ -78,57 +78,304 @@ impl From<&&'static Location<'static>> for PersistentSourceReference {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
+
+    fn source_ref() -> PersistentSourceReference {
+        PersistentSourceReference {
+            file: "a.rs".to_string(),
+            line: 100,
+        }
+    }
+
+    // Serialize each outcome variant to JSON. The serialized String is the
+    // contract, so we yield it directly. serde_json::Error is not PartialEq, so
+    // the (unreachable here) failing path would use Fails; every row succeeds.
+    // The tag is "outcome" and variants are lowercased, with source_ref omitted
+    // when None.
     #[test]
     fn test_state_outcome_serialize() {
-        let wait_state = PersistentStateHandlerOutcome::Wait {
-            reason: "Reason goes here".to_string(),
-            source_ref: None,
-        };
-        let serialized = serde_json::to_string(&wait_state).unwrap();
-        assert_eq!(
-            serialized,
-            r#"{"outcome":"wait","reason":"Reason goes here"}"#
+        check_cases(
+            [
+                Case {
+                    scenario: "wait with reason, no source ref",
+                    input: PersistentStateHandlerOutcome::Wait {
+                        reason: "Reason goes here".to_string(),
+                        source_ref: None,
+                    },
+                    expect: Yields(r#"{"outcome":"wait","reason":"Reason goes here"}"#.to_string()),
+                },
+                Case {
+                    scenario: "wait with empty reason",
+                    input: PersistentStateHandlerOutcome::Wait {
+                        reason: String::new(),
+                        source_ref: None,
+                    },
+                    expect: Yields(r#"{"outcome":"wait","reason":""}"#.to_string()),
+                },
+                Case {
+                    scenario: "wait with reason and source ref",
+                    input: PersistentStateHandlerOutcome::Wait {
+                        reason: "waiting".to_string(),
+                        source_ref: Some(source_ref()),
+                    },
+                    expect: Yields(
+                        r#"{"outcome":"wait","reason":"waiting","source_ref":{"file":"a.rs","line":100}}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "error variant, no source ref",
+                    input: PersistentStateHandlerOutcome::Error {
+                        err: "boom".to_string(),
+                        source_ref: None,
+                    },
+                    expect: Yields(r#"{"outcome":"error","err":"boom"}"#.to_string()),
+                },
+                Case {
+                    scenario: "error variant with source ref",
+                    input: PersistentStateHandlerOutcome::Error {
+                        err: "boom".to_string(),
+                        source_ref: Some(source_ref()),
+                    },
+                    expect: Yields(
+                        r#"{"outcome":"error","err":"boom","source_ref":{"file":"a.rs","line":100}}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "transition, no source ref",
+                    input: PersistentStateHandlerOutcome::Transition { source_ref: None },
+                    expect: Yields(r#"{"outcome":"transition"}"#.to_string()),
+                },
+                Case {
+                    scenario: "transition with source ref",
+                    input: PersistentStateHandlerOutcome::Transition {
+                        source_ref: Some(source_ref()),
+                    },
+                    expect: Yields(
+                        r#"{"outcome":"transition","source_ref":{"file":"a.rs","line":100}}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "donothing, no source ref",
+                    input: PersistentStateHandlerOutcome::DoNothing { source_ref: None },
+                    expect: Yields(r#"{"outcome":"donothing"}"#.to_string()),
+                },
+                Case {
+                    scenario: "donothing with source ref details",
+                    input: PersistentStateHandlerOutcome::DoNothing {
+                        source_ref: Some(source_ref()),
+                    },
+                    expect: Yields(
+                        r#"{"outcome":"donothing","source_ref":{"file":"a.rs","line":100}}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "donothingwithdetails legacy variant",
+                    input: PersistentStateHandlerOutcome::DoNothingWithDetails,
+                    expect: Yields(r#"{"outcome":"donothingwithdetails"}"#.to_string()),
+                },
+            ],
+            |outcome| serde_json::to_string(&outcome).map_err(drop),
         );
     }
 
+    // Deserialize JSON back into the outcome variant (the round-trip targets and
+    // the standalone deserialize case). The deserialized type is PartialEq+Debug,
+    // so we yield it directly. serde_json::Error is not PartialEq, hence map_err.
     #[test]
     fn test_state_outcome_deserialize() {
-        let serialized = r#"{"outcome":"error","err":"Error message here"}"#;
-        let expected_error_state = PersistentStateHandlerOutcome::Error {
-            err: "Error message here".to_string(),
-            source_ref: None,
-        };
-        let deserialized: PersistentStateHandlerOutcome = serde_json::from_str(serialized).unwrap();
-        assert_eq!(deserialized, expected_error_state);
-    }
-
-    #[test]
-    fn test_state_outcome_serialize_deserialize_basic() {
-        let transition_state = PersistentStateHandlerOutcome::Transition { source_ref: None };
-        let serialized = serde_json::to_string(&transition_state).unwrap();
-        assert_eq!(serialized, r#"{"outcome":"transition"}"#);
-
-        let deserialized: PersistentStateHandlerOutcome =
-            serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized, transition_state);
-    }
-
-    #[test]
-    fn test_state_outcome_serialize_details() {
-        let state = PersistentStateHandlerOutcome::DoNothing {
-            source_ref: Some(PersistentSourceReference {
-                file: "a.rs".to_string(),
-                line: 100,
-            }),
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(
-            serialized,
-            r#"{"outcome":"donothing","source_ref":{"file":"a.rs","line":100}}"#
+        check_cases(
+            [
+                Case {
+                    scenario: "wait round-trip, no source ref",
+                    input: r#"{"outcome":"wait","reason":"r"}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::Wait {
+                        reason: "r".to_string(),
+                        source_ref: None,
+                    }),
+                },
+                Case {
+                    scenario: "wait with source ref round-trip",
+                    input:
+                        r#"{"outcome":"wait","reason":"r","source_ref":{"file":"a.rs","line":100}}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::Wait {
+                        reason: "r".to_string(),
+                        source_ref: Some(source_ref()),
+                    }),
+                },
+                Case {
+                    scenario: "error variant",
+                    input: r#"{"outcome":"error","err":"Error message here"}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::Error {
+                        err: "Error message here".to_string(),
+                        source_ref: None,
+                    }),
+                },
+                Case {
+                    scenario: "error with source ref round-trip",
+                    input:
+                        r#"{"outcome":"error","err":"e","source_ref":{"file":"a.rs","line":100}}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::Error {
+                        err: "e".to_string(),
+                        source_ref: Some(source_ref()),
+                    }),
+                },
+                Case {
+                    scenario: "transition round-trip",
+                    input: r#"{"outcome":"transition"}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::Transition { source_ref: None }),
+                },
+                Case {
+                    scenario: "transition with explicit null source ref (serde default)",
+                    input: r#"{"outcome":"transition","source_ref":null}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::Transition { source_ref: None }),
+                },
+                Case {
+                    scenario: "donothing, no source ref",
+                    input: r#"{"outcome":"donothing"}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::DoNothing { source_ref: None }),
+                },
+                Case {
+                    scenario: "donothing with source ref round-trip",
+                    input: r#"{"outcome":"donothing","source_ref":{"file":"a.rs","line":100}}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::DoNothing {
+                        source_ref: Some(source_ref()),
+                    }),
+                },
+                Case {
+                    scenario: "donothingwithdetails legacy variant",
+                    input: r#"{"outcome":"donothingwithdetails"}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::DoNothingWithDetails),
+                },
+                // Rejected inputs: the error type is not PartialEq, so use Fails.
+                Case {
+                    scenario: "unknown outcome tag is rejected",
+                    input: r#"{"outcome":"bogus"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing required reason on wait is rejected",
+                    input: r#"{"outcome":"wait"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing required err on error is rejected",
+                    input: r#"{"outcome":"error"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing outcome tag is rejected",
+                    input: r#"{"reason":"r"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "uppercase tag is rejected (variants are lowercased)",
+                    input: r#"{"outcome":"Transition"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "malformed json is rejected",
+                    input: r#"{"outcome":"transition""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string is rejected",
+                    input: "",
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<PersistentStateHandlerOutcome>(json).map_err(drop),
         );
-        let deserialized: PersistentStateHandlerOutcome =
-            serde_json::from_str(&serialized).unwrap();
-        assert_eq!(deserialized, state);
+    }
+
+    // Display for both types delegates to Debug. The rendered String is the
+    // contract; comparing against the Debug rendering keeps the rows honest
+    // without hard-coding the exact derived layout.
+    #[test]
+    fn test_display_matches_debug() {
+        check_values(
+            [
+                Check {
+                    scenario: "source reference display equals debug",
+                    input: format!("{}", source_ref()),
+                    expect: format!("{:?}", source_ref()),
+                },
+                Check {
+                    scenario: "transition outcome display equals debug",
+                    input: format!(
+                        "{}",
+                        PersistentStateHandlerOutcome::Transition { source_ref: None }
+                    ),
+                    expect: format!(
+                        "{:?}",
+                        PersistentStateHandlerOutcome::Transition { source_ref: None }
+                    ),
+                },
+                Check {
+                    scenario: "wait outcome display equals debug",
+                    input: format!(
+                        "{}",
+                        PersistentStateHandlerOutcome::Wait {
+                            reason: "r".to_string(),
+                            source_ref: Some(source_ref()),
+                        }
+                    ),
+                    expect: format!(
+                        "{:?}",
+                        PersistentStateHandlerOutcome::Wait {
+                            reason: "r".to_string(),
+                            source_ref: Some(source_ref()),
+                        }
+                    ),
+                },
+            ],
+            |rendered| rendered,
+        );
+    }
+
+    // Display for the source reference contains both the file and the line.
+    #[test]
+    fn test_source_reference_display_tokens() {
+        check_cases(
+            [Case {
+                scenario: "display carries file and line",
+                input: (source_ref(), &["a.rs", "100"][..]),
+                expect: Yields(true),
+            }],
+            |(reference, tokens): (PersistentSourceReference, &[&str])| {
+                let produced = format!("{reference}");
+                Ok::<_, ()>(tokens.iter().all(|t| produced.contains(t)))
+            },
+        );
+    }
+
+    // From<&&'static Location> copies the panic location's file and line into a
+    // PersistentSourceReference. Location::caller() gives a real location to
+    // convert; we assert the line is carried through and the file is non-empty.
+    #[test]
+    fn test_source_reference_from_location() {
+        let location = Location::caller();
+        let reference = PersistentSourceReference::from(&location);
+        check_values(
+            [
+                Check {
+                    scenario: "line carried from location",
+                    input: reference.line == location.line(),
+                    expect: true,
+                },
+                Check {
+                    scenario: "file carried from location",
+                    input: reference.file.as_str() == location.file(),
+                    expect: true,
+                },
+            ],
+            |value| value,
+        );
     }
 }

--- a/crates/api-model/src/dpa_interface/mod.rs
+++ b/crates/api-model/src/dpa_interface/mod.rs
@@ -438,89 +438,369 @@ impl TryFrom<DpaInterfaceSnapshotPgJson> for DpaInterface {
 mod tests {
     use std::str::FromStr;
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
-    #[test]
-    fn from_device_info_extracts_fields() {
-        let machine_id =
-            MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30")
-                .unwrap();
+    fn test_machine_id() -> MachineId {
+        MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30").unwrap()
+    }
 
-        let base_mac = MacAddress::from_str("00:11:22:33:44:55").unwrap();
-        let device_type = "BlueField3".to_string();
-        let pci_name = "01:00.0".to_string();
-        let device_description = Some("SuperNIC".to_string());
-        let interface_type = DpaInterfaceType::Svpc;
-
-        let new_intf = NewDpaInterface::from_device_info(
-            machine_id,
-            Some(base_mac),
-            device_type,
-            pci_name,
-            device_description,
-            interface_type,
-        )
-        .unwrap();
-        assert_eq!(new_intf.machine_id, machine_id);
-        assert_eq!(
-            new_intf.mac_address,
-            MacAddress::from_str("00:11:22:33:44:55").unwrap()
-        );
-        assert_eq!(new_intf.device_type, "BlueField3");
-        assert_eq!(new_intf.pci_name, "01:00.0");
+    /// Inputs to `NewDpaInterface::from_device_info`, one per row.
+    struct DeviceInfoInput {
+        base_mac: Option<MacAddress>,
+        device_type: String,
+        pci_name: String,
+        device_description: Option<String>,
+        interface_type: DpaInterfaceType,
     }
 
     #[test]
-    fn from_device_info_returns_none_without_base_mac() {
-        let machine_id =
-            MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30")
-                .unwrap();
-        let base_mac = None;
-        let device_type = "BlueField3".to_string();
-        let pci_name = "01:00.0".to_string();
-        let device_description = None;
-        let interface_type = DpaInterfaceType::Svpc;
-
-        assert!(
-            NewDpaInterface::from_device_info(
-                machine_id,
-                base_mac,
-                device_type,
-                pci_name,
-                device_description,
-                interface_type
-            )
-            .is_none()
+    fn from_device_info() {
+        // `from_device_info` only fails (returns None) when the base MAC is unset;
+        // with a MAC present it projects the input fields straight through. We map
+        // the Option to a Result and, for the success row, yield the asserted
+        // (machine_id, mac_address, device_type, pci_name) fields.
+        let machine_id = test_machine_id();
+        check_cases(
+            [
+                Case {
+                    scenario: "extracts fields when base mac present",
+                    input: DeviceInfoInput {
+                        base_mac: Some(MacAddress::from_str("00:11:22:33:44:55").unwrap()),
+                        device_type: "BlueField3".to_string(),
+                        pci_name: "01:00.0".to_string(),
+                        device_description: Some("SuperNIC".to_string()),
+                        interface_type: DpaInterfaceType::Svpc,
+                    },
+                    expect: Yields((
+                        machine_id,
+                        MacAddress::from_str("00:11:22:33:44:55").unwrap(),
+                        "BlueField3".to_string(),
+                        "01:00.0".to_string(),
+                    )),
+                },
+                Case {
+                    scenario: "extracts fields for astra interface type",
+                    input: DeviceInfoInput {
+                        base_mac: Some(MacAddress::from_str("aa:bb:cc:dd:ee:ff").unwrap()),
+                        device_type: "ConnectX7".to_string(),
+                        pci_name: "02:00.1".to_string(),
+                        device_description: None,
+                        interface_type: DpaInterfaceType::Astra,
+                    },
+                    expect: Yields((
+                        machine_id,
+                        MacAddress::from_str("aa:bb:cc:dd:ee:ff").unwrap(),
+                        "ConnectX7".to_string(),
+                        "02:00.1".to_string(),
+                    )),
+                },
+                Case {
+                    scenario: "extracts fields with empty device type and pci name",
+                    input: DeviceInfoInput {
+                        base_mac: Some(MacAddress::from_str("00:00:00:00:00:00").unwrap()),
+                        device_type: String::new(),
+                        pci_name: String::new(),
+                        device_description: Some(String::new()),
+                        interface_type: DpaInterfaceType::Svpc,
+                    },
+                    expect: Yields((
+                        machine_id,
+                        MacAddress::from_str("00:00:00:00:00:00").unwrap(),
+                        String::new(),
+                        String::new(),
+                    )),
+                },
+                Case {
+                    scenario: "returns none without base mac",
+                    input: DeviceInfoInput {
+                        base_mac: None,
+                        device_type: "BlueField3".to_string(),
+                        pci_name: "01:00.0".to_string(),
+                        device_description: None,
+                        interface_type: DpaInterfaceType::Svpc,
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "returns none without base mac for astra",
+                    input: DeviceInfoInput {
+                        base_mac: None,
+                        device_type: "ConnectX7".to_string(),
+                        pci_name: "02:00.1".to_string(),
+                        device_description: Some("desc".to_string()),
+                        interface_type: DpaInterfaceType::Astra,
+                    },
+                    expect: Fails,
+                },
+            ],
+            |i| {
+                NewDpaInterface::from_device_info(
+                    machine_id,
+                    i.base_mac,
+                    i.device_type,
+                    i.pci_name,
+                    i.device_description,
+                    i.interface_type,
+                )
+                .map(|n| (n.machine_id, n.mac_address, n.device_type, n.pci_name))
+                .ok_or(())
+            },
         );
     }
 
     #[test]
     fn serialize_controller_state() {
-        // Make sure the Provisioning state serializes to/from "provisioning".
-        let state = DpaInterfaceControllerState::Provisioning {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"provisioning\"}");
-        assert_eq!(
-            serde_json::from_str::<DpaInterfaceControllerState>(&serialized).unwrap(),
-            state
+        // Each state must serialize to its exact tagged JSON and deserialize back to
+        // the original value. The closure serializes, asserts the round-trip equals
+        // the input state, and yields the serialized string (which is the contract).
+        check_cases(
+            [
+                Case {
+                    scenario: "provisioning",
+                    input: DpaInterfaceControllerState::Provisioning {},
+                    expect: Yields("{\"state\":\"provisioning\"}".to_string()),
+                },
+                Case {
+                    scenario: "ready",
+                    input: DpaInterfaceControllerState::Ready {},
+                    expect: Yields("{\"state\":\"ready\"}".to_string()),
+                },
+                Case {
+                    scenario: "unlocking",
+                    input: DpaInterfaceControllerState::Unlocking,
+                    expect: Yields("{\"state\":\"unlocking\"}".to_string()),
+                },
+                Case {
+                    scenario: "applyfirmware",
+                    input: DpaInterfaceControllerState::ApplyFirmware,
+                    expect: Yields("{\"state\":\"applyfirmware\"}".to_string()),
+                },
+                Case {
+                    scenario: "applyprofile",
+                    input: DpaInterfaceControllerState::ApplyProfile,
+                    expect: Yields("{\"state\":\"applyprofile\"}".to_string()),
+                },
+                Case {
+                    scenario: "locking",
+                    input: DpaInterfaceControllerState::Locking,
+                    expect: Yields("{\"state\":\"locking\"}".to_string()),
+                },
+                Case {
+                    scenario: "assigned",
+                    input: DpaInterfaceControllerState::Assigned,
+                    expect: Yields("{\"state\":\"assigned\"}".to_string()),
+                },
+            ],
+            |state| -> Result<String, ()> {
+                let serialized = serde_json::to_string(&state).map_err(|_| ())?;
+                let round_tripped =
+                    serde_json::from_str::<DpaInterfaceControllerState>(&serialized)
+                        .map_err(|_| ())?;
+                assert_eq!(round_tripped, state);
+                Ok(serialized)
+            },
         );
+    }
 
-        // Make sure the Ready state serializes to/from "ready".
-        let state = DpaInterfaceControllerState::Ready {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"ready\"}");
-        assert_eq!(
-            serde_json::from_str::<DpaInterfaceControllerState>(&serialized).unwrap(),
-            state
+    #[test]
+    fn lock_mode_try_from_i32() {
+        // `DpaLockMode::try_from(i32)` accepts only 1 (Locked) and 2 (Unlocked);
+        // every other value — including the zero and the values just outside the
+        // accepted pair — is rejected with the same static error.
+        check_cases(
+            [
+                Case {
+                    scenario: "one is locked",
+                    input: 1,
+                    expect: Yields(DpaLockMode::Locked),
+                },
+                Case {
+                    scenario: "two is unlocked",
+                    input: 2,
+                    expect: Yields(DpaLockMode::Unlocked),
+                },
+                Case {
+                    scenario: "zero is invalid",
+                    input: 0,
+                    expect: FailsWith("Invalid value for DpaLockMode"),
+                },
+                Case {
+                    scenario: "three is invalid",
+                    input: 3,
+                    expect: FailsWith("Invalid value for DpaLockMode"),
+                },
+                Case {
+                    scenario: "negative is invalid",
+                    input: -1,
+                    expect: FailsWith("Invalid value for DpaLockMode"),
+                },
+                Case {
+                    scenario: "max is invalid",
+                    input: i32::MAX,
+                    expect: FailsWith("Invalid value for DpaLockMode"),
+                },
+                Case {
+                    scenario: "min is invalid",
+                    input: i32::MIN,
+                    expect: FailsWith("Invalid value for DpaLockMode"),
+                },
+            ],
+            DpaLockMode::try_from,
         );
+    }
 
-        // Make sure the ApplyFirmware state serializes to/from "applyfirmware".
-        let state = DpaInterfaceControllerState::ApplyFirmware;
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"applyfirmware\"}");
-        assert_eq!(
-            serde_json::from_str::<DpaInterfaceControllerState>(&serialized).unwrap(),
-            state
+    #[test]
+    fn controller_state_display() {
+        // The `Display` impl defers to `Debug`, so each variant renders as its
+        // bare Rust identifier — distinct from the lowercase serde tag.
+        check_values(
+            [
+                Check {
+                    scenario: "provisioning",
+                    input: DpaInterfaceControllerState::Provisioning,
+                    expect: "Provisioning".to_string(),
+                },
+                Check {
+                    scenario: "ready",
+                    input: DpaInterfaceControllerState::Ready,
+                    expect: "Ready".to_string(),
+                },
+                Check {
+                    scenario: "unlocking",
+                    input: DpaInterfaceControllerState::Unlocking,
+                    expect: "Unlocking".to_string(),
+                },
+                Check {
+                    scenario: "applyfirmware",
+                    input: DpaInterfaceControllerState::ApplyFirmware,
+                    expect: "ApplyFirmware".to_string(),
+                },
+                Check {
+                    scenario: "applyprofile",
+                    input: DpaInterfaceControllerState::ApplyProfile,
+                    expect: "ApplyProfile".to_string(),
+                },
+                Check {
+                    scenario: "locking",
+                    input: DpaInterfaceControllerState::Locking,
+                    expect: "Locking".to_string(),
+                },
+                Check {
+                    scenario: "assigned",
+                    input: DpaInterfaceControllerState::Assigned,
+                    expect: "Assigned".to_string(),
+                },
+            ],
+            |state| state.to_string(),
+        );
+    }
+
+    #[test]
+    fn controller_state_deserialize_rejects_unknown_tag() {
+        // The accepted tags are exactly the lowercase variant names; an unknown
+        // tag and a missing tag are both rejected.
+        check_cases(
+            [
+                Case {
+                    scenario: "known tag deserializes",
+                    input: "{\"state\":\"ready\"}",
+                    expect: Yields(DpaInterfaceControllerState::Ready),
+                },
+                Case {
+                    scenario: "capitalized tag is rejected",
+                    input: "{\"state\":\"Ready\"}",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown tag is rejected",
+                    input: "{\"state\":\"bogus\"}",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing tag is rejected",
+                    input: "{}",
+                    expect: Fails,
+                },
+            ],
+            |json| {
+                serde_json::from_str::<DpaInterfaceControllerState>(json).map_err(|_| ())
+            },
+        );
+    }
+
+    #[test]
+    fn network_config_default_uses_admin_network() {
+        // The default network config opts into the admin network and carries no
+        // quarantine state.
+        check_values(
+            [
+                Check {
+                    scenario: "defaults to admin network",
+                    input: (),
+                    expect: (Some(true), None),
+                },
+            ],
+            |()| {
+                let cfg = DpaInterfaceNetworkConfig::default();
+                (cfg.use_admin_network, cfg.quarantine_state)
+            },
+        );
+    }
+
+    #[test]
+    fn lock_mode_serde_round_trips() {
+        // Both lock modes survive a JSON round-trip, serializing to their bare
+        // variant names.
+        check_cases(
+            [
+                Case {
+                    scenario: "locked",
+                    input: DpaLockMode::Locked,
+                    expect: Yields("\"Locked\"".to_string()),
+                },
+                Case {
+                    scenario: "unlocked",
+                    input: DpaLockMode::Unlocked,
+                    expect: Yields("\"Unlocked\"".to_string()),
+                },
+            ],
+            |mode| -> Result<String, ()> {
+                let serialized = serde_json::to_string(&mode).map_err(|_| ())?;
+                let round_tripped =
+                    serde_json::from_str::<DpaLockMode>(&serialized).map_err(|_| ())?;
+                assert_eq!(round_tripped, mode);
+                Ok(serialized)
+            },
+        );
+    }
+
+    #[test]
+    fn interface_type_serde_round_trips() {
+        // Each `DpaInterfaceType` variant serializes to its bare name and parses
+        // back to itself.
+        check_cases(
+            [
+                Case {
+                    scenario: "svpc",
+                    input: DpaInterfaceType::Svpc,
+                    expect: Yields("\"Svpc\"".to_string()),
+                },
+                Case {
+                    scenario: "astra",
+                    input: DpaInterfaceType::Astra,
+                    expect: Yields("\"Astra\"".to_string()),
+                },
+            ],
+            |ty| -> Result<String, ()> {
+                let serialized = serde_json::to_string(&ty).map_err(|_| ())?;
+                let round_tripped =
+                    serde_json::from_str::<DpaInterfaceType>(&serialized).map_err(|_| ())?;
+                assert_eq!(round_tripped, ty);
+                Ok(serialized)
+            },
         );
     }
 }

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -244,6 +244,9 @@ pub struct UnexpectedMachine {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     /// Nothing set anywhere -- the host falls back to the absolute
@@ -344,33 +347,43 @@ mod tests {
         assert!(!DpuMode::NoDpu.is_dpu_managed());
     }
 
+    /// JSON deserialization of `ExpectedMachine`, projecting to the
+    /// `host_lifecycle_profile.disable_lockdown` field under test. A missing
+    /// `host_lifecycle_profile` defaults to `None` (equivalent to
+    /// `HostLifecycleProfile::default()`, whose only field is `disable_lockdown`).
     #[test]
-    fn host_lifecycle_profile_defaults_when_missing_from_json() {
-        let json = r#"{
-            "bmc_mac_address": "AA:BB:CC:DD:EE:FF",
-            "bmc_username": "root",
-            "bmc_password": "pass",
-            "serial_number": "SN-1"
-        }"#;
-        let em: ExpectedMachine = serde_json::from_str(json).unwrap();
-        assert_eq!(
-            em.data.host_lifecycle_profile,
-            HostLifecycleProfile::default()
+    fn host_lifecycle_profile_deserializes_from_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "missing host_lifecycle_profile defaults to None",
+                    input: r#"{
+                        "bmc_mac_address": "AA:BB:CC:DD:EE:FF",
+                        "bmc_username": "root",
+                        "bmc_password": "pass",
+                        "serial_number": "SN-1"
+                    }"#,
+                    expect: Yields(None),
+                },
+                Case {
+                    scenario: "present host_lifecycle_profile parses disable_lockdown",
+                    input: r#"{
+                        "bmc_mac_address": "AA:BB:CC:DD:EE:FF",
+                        "bmc_username": "root",
+                        "bmc_password": "pass",
+                        "serial_number": "SN-1",
+                        "host_lifecycle_profile": {"disable_lockdown": true}
+                    }"#,
+                    expect: Yields(Some(true)),
+                },
+            ],
+            // serde_json::Error is not PartialEq, so discard it on the error path.
+            |json| {
+                serde_json::from_str::<ExpectedMachine>(json)
+                    .map(|em| em.data.host_lifecycle_profile.disable_lockdown)
+                    .map_err(drop)
+            },
         );
-        assert_eq!(em.data.host_lifecycle_profile.disable_lockdown, None);
-    }
-
-    #[test]
-    fn host_lifecycle_profile_parses_from_json_when_present() {
-        let json = r#"{
-            "bmc_mac_address": "AA:BB:CC:DD:EE:FF",
-            "bmc_username": "root",
-            "bmc_password": "pass",
-            "serial_number": "SN-1",
-            "host_lifecycle_profile": {"disable_lockdown": true}
-        }"#;
-        let em: ExpectedMachine = serde_json::from_str(json).unwrap();
-        assert_eq!(em.data.host_lifecycle_profile.disable_lockdown, Some(true));
     }
 
     #[test]

--- a/crates/api-model/src/extension_service/mod.rs
+++ b/crates/api-model/src/extension_service/mod.rs
@@ -236,3 +236,97 @@ pub struct ExtensionServiceObservabilityConfig {
 pub struct ExtensionServiceObservability {
     pub configs: Vec<ExtensionServiceObservabilityConfig>,
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
+    use super::*;
+
+    // ExtensionServiceType parses case-insensitively from its wire form, and an
+    // unknown string is rejected.
+    #[test]
+    fn extension_service_type_from_str() {
+        check_cases(
+            [
+                Case {
+                    scenario: "canonical kubernetes_pod",
+                    input: "kubernetes_pod",
+                    expect: Yields(ExtensionServiceType::KubernetesPod),
+                },
+                Case {
+                    scenario: "mixed case is normalized",
+                    input: "Kubernetes_Pod",
+                    expect: Yields(ExtensionServiceType::KubernetesPod),
+                },
+                Case {
+                    scenario: "unknown type is rejected",
+                    input: "virtual_machine",
+                    expect: Fails,
+                },
+            ],
+            |s| ExtensionServiceType::from_str(s).map_err(drop),
+        );
+    }
+
+    // Display is the inverse of from_str: each variant's wire form parses back to it.
+    #[test]
+    fn extension_service_type_display_round_trips() {
+        check_cases(
+            [Case {
+                scenario: "kubernetes_pod",
+                input: ExtensionServiceType::KubernetesPod,
+                expect: Yields(ExtensionServiceType::KubernetesPod),
+            }],
+            |t| ExtensionServiceType::from_str(&t.to_string()).map_err(drop),
+        );
+    }
+
+    // The observability config tree round-trips through JSON for each variant,
+    // exercising the nested enum and its Prometheus / Logging payloads.
+    #[test]
+    fn observability_config_json_round_trip() {
+        let prometheus = ExtensionServiceObservability {
+            configs: vec![ExtensionServiceObservabilityConfig {
+                name: Some("metrics".to_string()),
+                config: ExtensionServiceObservabilityConfigType::Prometheus(
+                    ExtensionServiceObservabilityConfigTypePrometheus {
+                        scrape_interval_seconds: 30,
+                        endpoint: "/metrics".to_string(),
+                    },
+                ),
+            }],
+        };
+        let logging = ExtensionServiceObservability {
+            configs: vec![ExtensionServiceObservabilityConfig {
+                name: None,
+                config: ExtensionServiceObservabilityConfigType::Logging(
+                    ExtensionServiceObservabilityConfigTypeLogging {
+                        path: "/var/log/svc.log".to_string(),
+                    },
+                ),
+            }],
+        };
+        check_cases(
+            [
+                Case {
+                    scenario: "prometheus config",
+                    input: prometheus.clone(),
+                    expect: Yields(prometheus),
+                },
+                Case {
+                    scenario: "logging config",
+                    input: logging.clone(),
+                    expect: Yields(logging),
+                },
+            ],
+            |obs| {
+                let json = serde_json::to_string(&obs).map_err(drop)?;
+                serde_json::from_str::<ExtensionServiceObservability>(&json).map_err(drop)
+            },
+        );
+    }
+}

--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -396,7 +396,20 @@ impl From<libnmxm::nmxm_model::Gpu> for NvLinkGpu {
 #[cfg(test)]
 mod tests {
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
+
+    // Build a `HardwareInfo` carrying only the architecture and `DmiData` fields
+    // the classification predicates look at, leaving everything else defaulted.
+    fn info_with_dmi(machine_type: CpuArchitecture, dmi: DmiData) -> HardwareInfo {
+        HardwareInfo {
+            machine_type,
+            dmi_data: Some(dmi),
+            ..Default::default()
+        }
+    }
 
     const DPU_INFO_JSON: &[u8] = include_bytes!("hardware_info/test_data/dpu_info.json");
     const DPU_BF3_INFO_JSON: &[u8] = include_bytes!("hardware_info/test_data/dpu_bf3_info.json");
@@ -425,31 +438,40 @@ mod tests {
         );
     }
 
+    // Deserialize an LLDP switch entry and project to the management `ip_address`
+    // list: invalid entries are dropped lossily and a null list defaults to empty.
     #[test]
-    fn lldp_switch_data_filters_invalid_management_addresses() {
-        let json = r#"{
-            "ip_address": [
-                "192.0.2.10",
-                "not-an-ip",
-                "2001:db8::1"
-            ]
-        }"#;
-        let switch: LldpSwitchData = serde_json::from_str(json).unwrap();
-
-        assert_eq!(
-            switch.ip_address,
-            vec![
-                "192.0.2.10".parse::<IpAddr>().unwrap(),
-                "2001:db8::1".parse::<IpAddr>().unwrap(),
-            ]
+    fn lldp_switch_data_management_addresses() {
+        check_cases(
+            [
+                Case {
+                    scenario: "filters invalid management addresses",
+                    input: r#"{
+                        "ip_address": [
+                            "192.0.2.10",
+                            "not-an-ip",
+                            "2001:db8::1"
+                        ]
+                    }"#,
+                    expect: Yields(vec![
+                        "192.0.2.10".parse::<IpAddr>().unwrap(),
+                        "2001:db8::1".parse::<IpAddr>().unwrap(),
+                    ]),
+                },
+                Case {
+                    scenario: "defaults null management addresses to empty",
+                    input: r#"{"ip_address":null}"#,
+                    expect: Yields(vec![]),
+                },
+            ],
+            // serde_json::Error is not PartialEq, so deserialization failure would
+            // be Fails; here every row parses, so the error type is irrelevant.
+            |json| {
+                serde_json::from_str::<LldpSwitchData>(json)
+                    .map(|switch| switch.ip_address)
+                    .map_err(drop)
+            },
         );
-    }
-
-    #[test]
-    fn lldp_switch_data_defaults_null_management_addresses() {
-        let switch: LldpSwitchData = serde_json::from_str(r#"{"ip_address":null}"#).unwrap();
-
-        assert!(switch.ip_address.is_empty());
     }
 
     #[test]
@@ -551,16 +573,41 @@ mod tests {
         );
     }
 
+    // Deserialize a HardwareInfo fixture and project to whether it is classified as
+    // a DPU: x86 hardware is not, both BlueField fixtures are.
     #[test]
-    fn deserialize_x86_info() {
-        let info = serde_json::from_slice::<HardwareInfo>(X86_INFO_JSON).unwrap();
-        assert!(!info.is_dpu());
+    fn deserialize_info_is_dpu() {
+        check_cases(
+            [
+                Case {
+                    scenario: "x86 host is not a DPU",
+                    input: X86_INFO_JSON,
+                    expect: Yields(false),
+                },
+                Case {
+                    scenario: "dpu info is a DPU",
+                    input: DPU_INFO_JSON,
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "bf3 dpu info is a DPU",
+                    input: DPU_BF3_INFO_JSON,
+                    expect: Yields(true),
+                },
+            ],
+            // serde_json::Error is not PartialEq; every fixture parses, so the error
+            // type is irrelevant here.
+            |bytes| {
+                serde_json::from_slice::<HardwareInfo>(bytes)
+                    .map(|info| info.is_dpu())
+                    .map_err(drop)
+            },
+        );
     }
 
     #[test]
-    fn deserialize_dpu_info() {
+    fn deserialize_dpu_info_decodes_ch_64_mac() {
         let info = serde_json::from_slice::<HardwareInfo>(DPU_INFO_JSON).unwrap();
-        assert!(info.is_dpu());
 
         // Make sure deserialize_ch_64 works as expected, where
         // the source dpu_info.json file for this has ch:64 as
@@ -569,12 +616,6 @@ mod tests {
             info.network_interfaces[1].mac_address.to_string(),
             "00:00:00:00:00:64"
         );
-    }
-
-    #[test]
-    fn deserialize_dpu_bf3_info() {
-        let info = serde_json::from_slice::<HardwareInfo>(DPU_BF3_INFO_JSON).unwrap();
-        assert!(info.is_dpu());
     }
 
     #[test]
@@ -621,6 +662,519 @@ mod tests {
         assert_eq!(
             deserialized.cert.as_ref().map(|cert| cert.as_bytes()),
             Some(cert_data.as_slice())
+        );
+    }
+
+    // `is_dpu()` is true only when the architecture is Aarch64 *and* the DMI board
+    // name contains "bluefield" (case-insensitively). Both conditions must hold.
+    #[test]
+    fn hardware_info_is_dpu() {
+        check_values(
+            [
+                Check {
+                    scenario: "aarch64 with bluefield board is a DPU",
+                    input: info_with_dmi(
+                        CpuArchitecture::Aarch64,
+                        DmiData {
+                            board_name: "BlueField-3".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "board name match is case-insensitive",
+                    input: info_with_dmi(
+                        CpuArchitecture::Aarch64,
+                        DmiData {
+                            board_name: "MY-BLUEFIELD-CARD".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "bluefield as a lowercase substring still matches",
+                    input: info_with_dmi(
+                        CpuArchitecture::Aarch64,
+                        DmiData {
+                            board_name: "prefix-bluefield-suffix".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "aarch64 without bluefield board is not a DPU",
+                    input: info_with_dmi(
+                        CpuArchitecture::Aarch64,
+                        DmiData {
+                            board_name: "GenericBoard".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "aarch64 with empty board name is not a DPU",
+                    input: info_with_dmi(CpuArchitecture::Aarch64, DmiData::default()),
+                    expect: false,
+                },
+                Check {
+                    scenario: "x86_64 with bluefield board is not a DPU",
+                    input: info_with_dmi(
+                        CpuArchitecture::X86_64,
+                        DmiData {
+                            board_name: "BlueField-3".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "unknown arch with bluefield board is not a DPU",
+                    input: info_with_dmi(
+                        CpuArchitecture::Unknown,
+                        DmiData {
+                            board_name: "BlueField-3".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "aarch64 with no dmi data at all is not a DPU",
+                    input: HardwareInfo {
+                        machine_type: CpuArchitecture::Aarch64,
+                        dmi_data: None,
+                        ..Default::default()
+                    },
+                    expect: false,
+                },
+            ],
+            |info| info.is_dpu(),
+        );
+    }
+
+    // `factory_mac_address()` requires `dpu_info` and a parseable MAC string within
+    // it; its error type is not PartialEq, so failures are asserted as `Fails`.
+    #[test]
+    fn hardware_info_factory_mac_address() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid mac in dpu info yields the address",
+                    input: HardwareInfo {
+                        dpu_info: Some(DpuData {
+                            factory_mac_address: "00:11:22:33:44:55".to_string(),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                    expect: Yields(MacAddress::from_str("00:11:22:33:44:55").unwrap()),
+                },
+                Case {
+                    scenario: "missing dpu info fails",
+                    input: HardwareInfo::default(),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty mac string fails to parse",
+                    input: HardwareInfo {
+                        dpu_info: Some(DpuData {
+                            factory_mac_address: String::new(),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "malformed mac string fails to parse",
+                    input: HardwareInfo {
+                        dpu_info: Some(DpuData {
+                            factory_mac_address: "not-a-mac".to_string(),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "too-short mac string fails to parse",
+                    input: HardwareInfo {
+                        dpu_info: Some(DpuData {
+                            factory_mac_address: "00:11:22".to_string(),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                    expect: Fails,
+                },
+            ],
+            // HardwareInfoError is not PartialEq, so drop the error to make the run
+            // closure's error type `()`.
+            |info| info.factory_mac_address().map_err(drop),
+        );
+    }
+
+    // `bmc_vendor()` maps the DMI `sys_vendor` string through `from_udev_dmi`, and
+    // falls back to `Unknown` when there is no DMI data at all.
+    #[test]
+    fn hardware_info_bmc_vendor() {
+        check_values(
+            [
+                Check {
+                    scenario: "lenovo sys vendor",
+                    input: info_with_dmi(
+                        CpuArchitecture::X86_64,
+                        DmiData {
+                            sys_vendor: "Lenovo".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: bmc_vendor::BMCVendor::Lenovo,
+                },
+                Check {
+                    scenario: "dell sys vendor",
+                    input: info_with_dmi(
+                        CpuArchitecture::X86_64,
+                        DmiData {
+                            sys_vendor: "Dell Inc.".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: bmc_vendor::BMCVendor::Dell,
+                },
+                Check {
+                    scenario: "nvidia sys vendor",
+                    input: info_with_dmi(
+                        CpuArchitecture::Aarch64,
+                        DmiData {
+                            sys_vendor: "NVIDIA".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: bmc_vendor::BMCVendor::Nvidia,
+                },
+                Check {
+                    scenario: "mellanox url maps to nvidia",
+                    input: info_with_dmi(
+                        CpuArchitecture::Aarch64,
+                        DmiData {
+                            sys_vendor: "https://www.mellanox.com".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: bmc_vendor::BMCVendor::Nvidia,
+                },
+                Check {
+                    scenario: "supermicro sys vendor",
+                    input: info_with_dmi(
+                        CpuArchitecture::X86_64,
+                        DmiData {
+                            sys_vendor: "Supermicro".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: bmc_vendor::BMCVendor::Supermicro,
+                },
+                Check {
+                    scenario: "hpe sys vendor",
+                    input: info_with_dmi(
+                        CpuArchitecture::X86_64,
+                        DmiData {
+                            sys_vendor: "HPE".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: bmc_vendor::BMCVendor::Hpe,
+                },
+                Check {
+                    scenario: "unrecognized sys vendor is unknown",
+                    input: info_with_dmi(
+                        CpuArchitecture::X86_64,
+                        DmiData {
+                            sys_vendor: "Acme Corp".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: bmc_vendor::BMCVendor::Unknown,
+                },
+                Check {
+                    scenario: "case-sensitive: lowercase dell is unknown",
+                    input: info_with_dmi(
+                        CpuArchitecture::X86_64,
+                        DmiData {
+                            sys_vendor: "dell inc.".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: bmc_vendor::BMCVendor::Unknown,
+                },
+                Check {
+                    scenario: "no dmi data is unknown",
+                    input: HardwareInfo::default(),
+                    expect: bmc_vendor::BMCVendor::Unknown,
+                },
+            ],
+            |info| info.bmc_vendor(),
+        );
+    }
+
+    // `is_gbx00()` checks for a "GB200" substring in the product name; `is_dgx_h100()`
+    // wants an exact NVIDIA / DGXH100 pairing.
+    #[test]
+    fn hardware_info_product_predicates() {
+        check_values(
+            [
+                Check {
+                    scenario: "exact GB200 product name",
+                    input: ("GB200", false),
+                    expect: true,
+                },
+                Check {
+                    scenario: "GB200 as a substring",
+                    input: ("NVIDIA GB200 NVL72", false),
+                    expect: true,
+                },
+                Check {
+                    scenario: "different product is not gbx00",
+                    input: ("GB300", false),
+                    expect: false,
+                },
+                Check {
+                    scenario: "empty product name is not gbx00",
+                    input: ("", false),
+                    expect: false,
+                },
+                Check {
+                    scenario: "case-sensitive: lowercase gb200 is not gbx00",
+                    input: ("gb200", false),
+                    expect: false,
+                },
+            ],
+            |(product_name, _)| {
+                info_with_dmi(
+                    CpuArchitecture::Aarch64,
+                    DmiData {
+                        product_name: product_name.to_string(),
+                        ..Default::default()
+                    },
+                )
+                .is_gbx00()
+            },
+        );
+    }
+
+    // `is_dgx_h100()` requires both sys_vendor == "NVIDIA" and product_name == "DGXH100".
+    #[test]
+    fn hardware_info_is_dgx_h100() {
+        check_values(
+            [
+                Check {
+                    scenario: "nvidia vendor and dgxh100 product",
+                    input: ("NVIDIA", "DGXH100"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "wrong product is not a dgx h100",
+                    input: ("NVIDIA", "DGXH200"),
+                    expect: false,
+                },
+                Check {
+                    scenario: "wrong vendor is not a dgx h100",
+                    input: ("Supermicro", "DGXH100"),
+                    expect: false,
+                },
+                Check {
+                    scenario: "both empty is not a dgx h100",
+                    input: ("", ""),
+                    expect: false,
+                },
+                Check {
+                    scenario: "product as substring is rejected (exact match required)",
+                    input: ("NVIDIA", "DGXH100-rev2"),
+                    expect: false,
+                },
+            ],
+            |(sys_vendor, product_name)| {
+                info_with_dmi(
+                    CpuArchitecture::X86_64,
+                    DmiData {
+                        sys_vendor: sys_vendor.to_string(),
+                        product_name: product_name.to_string(),
+                        ..Default::default()
+                    },
+                )
+                .is_dgx_h100()
+            },
+        );
+    }
+
+    // `all_mac_addresses()` projects each network interface's MAC, in order.
+    #[test]
+    fn hardware_info_all_mac_addresses() {
+        let iface = |mac: &str| NetworkInterface {
+            mac_address: MacAddress::from_str(mac).unwrap(),
+            pci_properties: None,
+        };
+        check_values(
+            [
+                Check {
+                    scenario: "no interfaces yields an empty list",
+                    input: vec![],
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "one interface yields its mac",
+                    input: vec![iface("00:11:22:33:44:55")],
+                    expect: vec![MacAddress::from_str("00:11:22:33:44:55").unwrap()],
+                },
+                Check {
+                    scenario: "several interfaces preserve order",
+                    input: vec![
+                        iface("00:11:22:33:44:55"),
+                        iface("aa:bb:cc:dd:ee:ff"),
+                    ],
+                    expect: vec![
+                        MacAddress::from_str("00:11:22:33:44:55").unwrap(),
+                        MacAddress::from_str("aa:bb:cc:dd:ee:ff").unwrap(),
+                    ],
+                },
+            ],
+            |network_interfaces| {
+                HardwareInfo {
+                    network_interfaces,
+                    ..Default::default()
+                }
+                .all_mac_addresses()
+            },
+        );
+    }
+
+    // `Display` for a software component renders as `url/name:version`, including
+    // the empty-url case.
+    #[test]
+    fn machine_inventory_component_display() {
+        check_values(
+            [
+                Check {
+                    scenario: "all fields populated",
+                    input: ("nvidia.com", "bar", "2.0"),
+                    expect: "nvidia.com/bar:2.0".to_string(),
+                },
+                Check {
+                    scenario: "empty url keeps the leading slash",
+                    input: ("", "foo", "1.0"),
+                    expect: "/foo:1.0".to_string(),
+                },
+                Check {
+                    scenario: "all fields empty",
+                    input: ("", "", ""),
+                    expect: "/:".to_string(),
+                },
+            ],
+            |(url, name, version)| {
+                MachineInventorySoftwareComponent {
+                    name: name.to_string(),
+                    version: version.to_string(),
+                    url: url.to_string(),
+                }
+                .to_string()
+            },
+        );
+    }
+
+    // `TpmEkCertificate` round-trips its bytes through `From`, `as_bytes`, and
+    // `into_bytes`, including the empty-certificate case.
+    #[test]
+    fn tpm_ek_certificate_byte_accessors() {
+        check_values(
+            [
+                Check {
+                    scenario: "non-empty certificate round-trips",
+                    input: vec![1u8, 2, 3, 4],
+                    expect: vec![1u8, 2, 3, 4],
+                },
+                Check {
+                    scenario: "empty certificate round-trips",
+                    input: vec![],
+                    expect: vec![],
+                },
+            ],
+            |bytes: Vec<u8>| {
+                let cert = TpmEkCertificate::from(bytes.clone());
+                assert_eq!(cert.as_bytes(), bytes.as_slice());
+                cert.into_bytes()
+            },
+        );
+    }
+
+    // `NvLinkGpu::from` pulls tray/slot from `location_info` (defaulting to 0 when
+    // absent or unset) and copies device_id / device_uid straight across.
+    #[test]
+    fn nvlink_gpu_from_nmxm_gpu() {
+        check_values(
+            [
+                Check {
+                    scenario: "full location info is carried through",
+                    input: r#"{
+                        "LocationInfo": {"TrayIndex": 3, "SlotID": 7},
+                        "DeviceUID": 42,
+                        "DeviceID": 5,
+                        "DevicePcieID": 0,
+                        "SystemUID": 0,
+                        "VendorID": 0,
+                        "ALIDList": []
+                    }"#,
+                    expect: NvLinkGpu {
+                        tray_index: 3,
+                        slot_id: 7,
+                        device_id: 5,
+                        guid: 42,
+                    },
+                },
+                Check {
+                    scenario: "absent location info defaults tray and slot to zero",
+                    input: r#"{
+                        "DeviceUID": 99,
+                        "DeviceID": 1,
+                        "DevicePcieID": 0,
+                        "SystemUID": 0,
+                        "VendorID": 0,
+                        "ALIDList": []
+                    }"#,
+                    expect: NvLinkGpu {
+                        tray_index: 0,
+                        slot_id: 0,
+                        device_id: 1,
+                        guid: 99,
+                    },
+                },
+                Check {
+                    scenario: "partial location info defaults the missing field",
+                    input: r#"{
+                        "LocationInfo": {"TrayIndex": 2},
+                        "DeviceUID": 0,
+                        "DeviceID": 0,
+                        "DevicePcieID": 0,
+                        "SystemUID": 0,
+                        "VendorID": 0,
+                        "ALIDList": []
+                    }"#,
+                    expect: NvLinkGpu {
+                        tray_index: 2,
+                        slot_id: 0,
+                        device_id: 0,
+                        guid: 0,
+                    },
+                },
+            ],
+            |json| {
+                let gpu = serde_json::from_str::<libnmxm::nmxm_model::Gpu>(json).unwrap();
+                NvLinkGpu::from(gpu)
+            },
         );
     }
 }

--- a/crates/api-model/src/health.rs
+++ b/crates/api-model/src/health.rs
@@ -79,7 +79,22 @@ impl HealthReportSources {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
+
+    /// Build a `HealthReportSources` from a replace source name and a list of merge
+    /// source names, using empty reports keyed by their own source identifier.
+    fn sources(replace: Option<&str>, merges: &[&str]) -> HealthReportSources {
+        HealthReportSources {
+            replace: replace.map(|s| HealthReport::empty(s.to_string())),
+            merges: merges
+                .iter()
+                .map(|s| (s.to_string(), HealthReport::empty(s.to_string())))
+                .collect(),
+        }
+    }
 
     #[test]
     fn health_reports_default_is_empty() {
@@ -90,93 +105,220 @@ mod tests {
     }
 
     #[test]
-    fn health_reports_into_iter_merges_only() {
-        let mut sources = HealthReportSources::default();
-        sources.merges.insert(
-            "source-a".to_string(),
-            HealthReport::empty("source-a".to_string()),
-        );
-        sources.merges.insert(
-            "source-b".to_string(),
-            HealthReport::empty("source-b".to_string()),
-        );
-
-        let items: Vec<_> = sources.into_iter().collect();
-        assert_eq!(items.len(), 2);
-        assert!(
-            items
-                .iter()
-                .all(|(_, mode)| *mode == HealthReportApplyMode::Merge)
+    fn health_reports_into_iter() {
+        // `into_iter` yields every merge source as `Merge` followed by the replace
+        // source (if any) as `Replace`. Each row projects the iterator to a list of
+        // (source name, apply mode) pairs so the ordering and modes are asserted
+        // directly. This is infallible, so every row `Yields`.
+        check_cases(
+            [
+                Case {
+                    scenario: "empty yields nothing",
+                    input: sources(None, &[]),
+                    expect: Yields(vec![]),
+                },
+                Case {
+                    scenario: "single merge",
+                    input: sources(None, &["only"]),
+                    expect: Yields(vec![("only".to_string(), HealthReportApplyMode::Merge)]),
+                },
+                Case {
+                    scenario: "merges only",
+                    input: sources(None, &["source-a", "source-b"]),
+                    expect: Yields(vec![
+                        ("source-a".to_string(), HealthReportApplyMode::Merge),
+                        ("source-b".to_string(), HealthReportApplyMode::Merge),
+                    ]),
+                },
+                Case {
+                    // The map is keyed by source name, so iteration follows the
+                    // BTreeMap's sorted key order regardless of insertion order.
+                    scenario: "merges sorted by source key, not insertion order",
+                    input: sources(None, &["zebra", "alpha", "mike"]),
+                    expect: Yields(vec![
+                        ("alpha".to_string(), HealthReportApplyMode::Merge),
+                        ("mike".to_string(), HealthReportApplyMode::Merge),
+                        ("zebra".to_string(), HealthReportApplyMode::Merge),
+                    ]),
+                },
+                Case {
+                    scenario: "replace only",
+                    input: sources(Some("admin-replace"), &[]),
+                    expect: Yields(vec![(
+                        "admin-replace".to_string(),
+                        HealthReportApplyMode::Replace,
+                    )]),
+                },
+                Case {
+                    scenario: "mixed merge and replace",
+                    input: sources(Some("sre-override"), &["external-monitor"]),
+                    expect: Yields(vec![
+                        ("external-monitor".to_string(), HealthReportApplyMode::Merge),
+                        ("sre-override".to_string(), HealthReportApplyMode::Replace),
+                    ]),
+                },
+                Case {
+                    // The replace source always trails the merges, even when its name
+                    // would sort before them.
+                    scenario: "replace trails merges regardless of its name",
+                    input: sources(Some("aaa-replace"), &["mmm", "zzz"]),
+                    expect: Yields(vec![
+                        ("mmm".to_string(), HealthReportApplyMode::Merge),
+                        ("zzz".to_string(), HealthReportApplyMode::Merge),
+                        ("aaa-replace".to_string(), HealthReportApplyMode::Replace),
+                    ]),
+                },
+            ],
+            |sources: HealthReportSources| {
+                Ok::<_, ()>(
+                    sources
+                        .into_iter()
+                        .map(|(report, mode)| (report.source, mode))
+                        .collect::<Vec<_>>(),
+                )
+            },
         );
     }
 
     #[test]
-    fn health_reports_into_iter_replace_only() {
-        let sources = HealthReportSources {
-            replace: Some(HealthReport::empty("admin-replace".to_string())),
-            merges: BTreeMap::new(),
-        };
-
-        let items: Vec<_> = sources.into_iter().collect();
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].0.source, "admin-replace");
-        assert_eq!(items[0].1, HealthReportApplyMode::Replace);
-    }
-
-    #[test]
-    fn health_reports_into_iter_mixed() {
-        let mut merges = BTreeMap::new();
-        merges.insert(
-            "external-monitor".to_string(),
-            HealthReport::empty("external-monitor".to_string()),
+    fn health_reports_iter() {
+        // `iter` borrows rather than consuming, but yields the same (source, mode)
+        // sequence as `into_iter`: merges first in sorted key order, then the
+        // replace source. Infallible, so every row `Yields`.
+        check_cases(
+            [
+                Case {
+                    scenario: "empty borrows nothing",
+                    input: sources(None, &[]),
+                    expect: Yields(vec![]),
+                },
+                Case {
+                    scenario: "merges only",
+                    input: sources(None, &["source-b", "source-a"]),
+                    expect: Yields(vec![
+                        ("source-a".to_string(), HealthReportApplyMode::Merge),
+                        ("source-b".to_string(), HealthReportApplyMode::Merge),
+                    ]),
+                },
+                Case {
+                    scenario: "replace only",
+                    input: sources(Some("admin-replace"), &[]),
+                    expect: Yields(vec![(
+                        "admin-replace".to_string(),
+                        HealthReportApplyMode::Replace,
+                    )]),
+                },
+                Case {
+                    scenario: "mixed merge and replace",
+                    input: sources(Some("sre-override"), &["external-monitor"]),
+                    expect: Yields(vec![
+                        ("external-monitor".to_string(), HealthReportApplyMode::Merge),
+                        ("sre-override".to_string(), HealthReportApplyMode::Replace),
+                    ]),
+                },
+            ],
+            |sources: HealthReportSources| {
+                Ok::<_, ()>(
+                    sources
+                        .iter()
+                        .map(|(report, mode)| (report.source.clone(), mode))
+                        .collect::<Vec<_>>(),
+                )
+            },
         );
-
-        let sources = HealthReportSources {
-            replace: Some(HealthReport::empty("sre-override".to_string())),
-            merges,
-        };
-
-        let items: Vec<_> = sources.into_iter().collect();
-        assert_eq!(items.len(), 2);
-
-        let merge_items: Vec<_> = items
-            .iter()
-            .filter(|(_, mode)| *mode == HealthReportApplyMode::Merge)
-            .collect();
-        let replace_items: Vec<_> = items
-            .iter()
-            .filter(|(_, mode)| *mode == HealthReportApplyMode::Replace)
-            .collect();
-        assert_eq!(merge_items.len(), 1);
-        assert_eq!(replace_items.len(), 1);
-        assert_eq!(merge_items[0].0.source, "external-monitor");
-        assert_eq!(replace_items[0].0.source, "sre-override");
     }
 
     #[test]
-    fn health_reports_json_round_trip() {
-        let mut merges = BTreeMap::new();
-        merges.insert(
-            "external-monitor".to_string(),
-            HealthReport::empty("external-monitor".to_string()),
+    fn health_reports_repair_merge_active() {
+        // `repair_merge_active` is true exactly when a merge source named
+        // `repair-request` or `request-online-repair` is present. The replace slot
+        // is irrelevant, as are unrelated merge sources. Infallible predicate, so
+        // every row `Yields` a bool.
+        check_cases(
+            [
+                Case {
+                    scenario: "no sources at all",
+                    input: sources(None, &[]),
+                    expect: Yields(false),
+                },
+                Case {
+                    scenario: "only unrelated merges",
+                    input: sources(None, &["external-monitor", "sre"]),
+                    expect: Yields(false),
+                },
+                Case {
+                    scenario: "repair-request merge present",
+                    input: sources(None, &[health_report::REPAIR_REQUEST_MERGE_SOURCE]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "request-online-repair merge present",
+                    input: sources(None, &[health_report::REQUEST_ONLINE_REPAIR_MERGE_SOURCE]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "both repair merges present",
+                    input: sources(
+                        None,
+                        &[
+                            health_report::REPAIR_REQUEST_MERGE_SOURCE,
+                            health_report::REQUEST_ONLINE_REPAIR_MERGE_SOURCE,
+                        ],
+                    ),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "repair merge alongside unrelated merges",
+                    input: sources(
+                        None,
+                        &["external-monitor", health_report::REPAIR_REQUEST_MERGE_SOURCE],
+                    ),
+                    expect: Yields(true),
+                },
+                Case {
+                    // The repair signal lives in the merges map; a replace source by
+                    // the same name does not count.
+                    scenario: "repair name in replace slot does not count",
+                    input: sources(Some(health_report::REPAIR_REQUEST_MERGE_SOURCE), &[]),
+                    expect: Yields(false),
+                },
+                Case {
+                    scenario: "repair merge present with an unrelated replace",
+                    input: sources(
+                        Some("admin-replace"),
+                        &[health_report::REQUEST_ONLINE_REPAIR_MERGE_SOURCE],
+                    ),
+                    expect: Yields(true),
+                },
+            ],
+            |sources: HealthReportSources| Ok::<_, ()>(sources.repair_merge_active()),
         );
-
-        let sources = HealthReportSources {
-            replace: Some(HealthReport::empty("admin-replace".to_string())),
-            merges,
-        };
-
-        let json = serde_json::to_string(&sources).unwrap();
-        let deserialized: HealthReportSources = serde_json::from_str(&json).unwrap();
-        assert_eq!(sources, deserialized);
     }
 
     #[test]
-    fn health_reports_deserialize_null_as_default() {
-        // The DB column can be NULL, which gets deserialized as default
-        let json = r#"{"merges":{}}"#;
-        let sources: HealthReportSources = serde_json::from_str(json).unwrap();
-        assert!(sources.replace.is_none());
-        assert!(sources.merges.is_empty());
+    fn health_reports_deserialize() {
+        // `HealthReportSources` deserializes from JSON. A full round-trip (serialize
+        // then deserialize) must reproduce the original, and a partial document
+        // (the DB column can be NULL / absent `replace`) deserializes to default.
+        // Deserialization is fallible; `serde_json::Error` is not PartialEq, so
+        // failing rows would use `Fails`, but every case here is valid input.
+        let round_trip = sources(Some("admin-replace"), &["external-monitor"]);
+        let round_trip_json = serde_json::to_string(&round_trip).unwrap();
+
+        check_cases(
+            [
+                Case {
+                    scenario: "round trips serialized form",
+                    input: round_trip_json.as_str(),
+                    expect: Yields(round_trip),
+                },
+                Case {
+                    scenario: "null replace deserializes to default",
+                    input: r#"{"merges":{}}"#,
+                    expect: Yields(HealthReportSources::default()),
+                },
+            ],
+            |json: &str| serde_json::from_str::<HealthReportSources>(json).map_err(|_| ()),
+        );
     }
 }

--- a/crates/api-model/src/ib.rs
+++ b/crates/api-model/src/ib.rs
@@ -219,11 +219,406 @@ impl From<IBServiceLevel> for i32 {
 
 #[cfg(test)]
 mod tests {
-    use crate::ib::IBPortMembership;
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
+    use crate::ib::{
+        IBMtu, IBPortMembership, IBPortState, IBRateLimit, IBServiceLevel,
+    };
 
     #[test]
     fn port_membership_to_string() {
-        assert_eq!(IBPortMembership::Full.to_string(), "full");
-        assert_eq!(IBPortMembership::Limited.to_string(), "limited");
+        check_values(
+            [
+                Check {
+                    scenario: "full",
+                    input: IBPortMembership::Full,
+                    expect: "full".to_string(),
+                },
+                Check {
+                    scenario: "limited",
+                    input: IBPortMembership::Limited,
+                    expect: "limited".to_string(),
+                },
+            ],
+            |membership| membership.to_string(),
+        );
+    }
+
+    #[test]
+    fn port_state_try_from_str() {
+        check_cases(
+            [
+                Case {
+                    scenario: "active",
+                    input: "active",
+                    expect: Yields(IBPortState::Active),
+                },
+                Case {
+                    scenario: "down",
+                    input: "down",
+                    expect: Yields(IBPortState::Down),
+                },
+                Case {
+                    scenario: "initialize",
+                    input: "initialize",
+                    expect: Yields(IBPortState::Initialize),
+                },
+                Case {
+                    scenario: "armed",
+                    input: "armed",
+                    expect: Yields(IBPortState::Armed),
+                },
+                Case {
+                    scenario: "uppercase is lowercased",
+                    input: "ACTIVE",
+                    expect: Yields(IBPortState::Active),
+                },
+                Case {
+                    scenario: "mixed case",
+                    input: "ArMeD",
+                    expect: Yields(IBPortState::Armed),
+                },
+                Case {
+                    scenario: "surrounding whitespace is trimmed",
+                    input: "  down  ",
+                    expect: Yields(IBPortState::Down),
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "whitespace only",
+                    input: "   ",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown word",
+                    input: "sleeping",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "near miss",
+                    input: "actives",
+                    expect: Fails,
+                },
+            ],
+            |state| IBPortState::try_from(state).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn port_state_try_from_string() {
+        check_cases(
+            [
+                Case {
+                    scenario: "active",
+                    input: "active".to_string(),
+                    expect: Yields(IBPortState::Active),
+                },
+                Case {
+                    scenario: "trimmed and lowercased",
+                    input: " Initialize ".to_string(),
+                    expect: Yields(IBPortState::Initialize),
+                },
+                Case {
+                    scenario: "invalid",
+                    input: "bogus".to_string(),
+                    expect: Fails,
+                },
+            ],
+            |state| IBPortState::try_from(state).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn mtu_default_is_4() {
+        Check {
+            scenario: "default mtu",
+            input: (),
+            expect: IBMtu(4),
+        }
+        .check(|()| IBMtu::default());
+    }
+
+    #[test]
+    fn mtu_try_from_i32() {
+        check_cases(
+            [
+                Case {
+                    scenario: "2k",
+                    input: 2,
+                    expect: Yields(IBMtu(2)),
+                },
+                Case {
+                    scenario: "4k",
+                    input: 4,
+                    expect: Yields(IBMtu(4)),
+                },
+                Case {
+                    scenario: "zero",
+                    input: 0,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "one",
+                    input: 1,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "three between valid values",
+                    input: 3,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "negative",
+                    input: -2,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "large",
+                    input: 4096,
+                    expect: Fails,
+                },
+            ],
+            |mtu| IBMtu::try_from(mtu).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn mtu_into_i32() {
+        check_values(
+            [
+                Check {
+                    scenario: "2k",
+                    input: IBMtu(2),
+                    expect: 2,
+                },
+                Check {
+                    scenario: "4k",
+                    input: IBMtu(4),
+                    expect: 4,
+                },
+            ],
+            i32::from,
+        );
+    }
+
+    #[test]
+    fn rate_limit_default_is_200() {
+        Check {
+            scenario: "default rate limit",
+            input: (),
+            expect: IBRateLimit(200),
+        }
+        .check(|()| IBRateLimit::default());
+    }
+
+    #[test]
+    fn rate_limit_try_from_i32() {
+        check_cases(
+            [
+                Case {
+                    scenario: "legacy sdr 2.5 sentinel",
+                    input: 2,
+                    expect: Yields(IBRateLimit(2)),
+                },
+                Case {
+                    scenario: "5",
+                    input: 5,
+                    expect: Yields(IBRateLimit(5)),
+                },
+                Case {
+                    scenario: "10",
+                    input: 10,
+                    expect: Yields(IBRateLimit(10)),
+                },
+                Case {
+                    scenario: "14",
+                    input: 14,
+                    expect: Yields(IBRateLimit(14)),
+                },
+                Case {
+                    scenario: "20",
+                    input: 20,
+                    expect: Yields(IBRateLimit(20)),
+                },
+                Case {
+                    scenario: "25",
+                    input: 25,
+                    expect: Yields(IBRateLimit(25)),
+                },
+                Case {
+                    scenario: "30",
+                    input: 30,
+                    expect: Yields(IBRateLimit(30)),
+                },
+                Case {
+                    scenario: "40",
+                    input: 40,
+                    expect: Yields(IBRateLimit(40)),
+                },
+                Case {
+                    scenario: "56",
+                    input: 56,
+                    expect: Yields(IBRateLimit(56)),
+                },
+                Case {
+                    scenario: "60",
+                    input: 60,
+                    expect: Yields(IBRateLimit(60)),
+                },
+                Case {
+                    scenario: "80",
+                    input: 80,
+                    expect: Yields(IBRateLimit(80)),
+                },
+                Case {
+                    scenario: "100",
+                    input: 100,
+                    expect: Yields(IBRateLimit(100)),
+                },
+                Case {
+                    scenario: "112",
+                    input: 112,
+                    expect: Yields(IBRateLimit(112)),
+                },
+                Case {
+                    scenario: "120",
+                    input: 120,
+                    expect: Yields(IBRateLimit(120)),
+                },
+                Case {
+                    scenario: "168",
+                    input: 168,
+                    expect: Yields(IBRateLimit(168)),
+                },
+                Case {
+                    scenario: "200",
+                    input: 200,
+                    expect: Yields(IBRateLimit(200)),
+                },
+                Case {
+                    scenario: "300",
+                    input: 300,
+                    expect: Yields(IBRateLimit(300)),
+                },
+                Case {
+                    scenario: "zero",
+                    input: 0,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "one",
+                    input: 1,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "three is not a valid rate",
+                    input: 3,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "negative",
+                    input: -200,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unsupported large",
+                    input: 400,
+                    expect: Fails,
+                },
+            ],
+            |rate| IBRateLimit::try_from(rate).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn rate_limit_into_i32() {
+        check_values(
+            [
+                Check {
+                    scenario: "200",
+                    input: IBRateLimit(200),
+                    expect: 200,
+                },
+                Check {
+                    scenario: "sdr sentinel",
+                    input: IBRateLimit(2),
+                    expect: 2,
+                },
+            ],
+            i32::from,
+        );
+    }
+
+    #[test]
+    fn service_level_default_is_0() {
+        Check {
+            scenario: "default service level",
+            input: (),
+            expect: IBServiceLevel(0),
+        }
+        .check(|()| IBServiceLevel::default());
+    }
+
+    #[test]
+    fn service_level_try_from_i32() {
+        check_cases(
+            [
+                Case {
+                    scenario: "lower bound 0",
+                    input: 0,
+                    expect: Yields(IBServiceLevel(0)),
+                },
+                Case {
+                    scenario: "mid 7",
+                    input: 7,
+                    expect: Yields(IBServiceLevel(7)),
+                },
+                Case {
+                    scenario: "upper bound 15",
+                    input: 15,
+                    expect: Yields(IBServiceLevel(15)),
+                },
+                Case {
+                    scenario: "just past upper bound",
+                    input: 16,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "negative below lower bound",
+                    input: -1,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "large",
+                    input: 1000,
+                    expect: Fails,
+                },
+            ],
+            |level| IBServiceLevel::try_from(level).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn service_level_into_i32() {
+        check_values(
+            [
+                Check {
+                    scenario: "0",
+                    input: IBServiceLevel(0),
+                    expect: 0,
+                },
+                Check {
+                    scenario: "15",
+                    input: IBServiceLevel(15),
+                    expect: 15,
+                },
+            ],
+            i32::from,
+        );
     }
 }

--- a/crates/api-model/src/ib_partition/mod.rs
+++ b/crates/api-model/src/ib_partition/mod.rs
@@ -103,10 +103,10 @@ impl FromStr for PartitionKey {
         let pkey = pkey.to_lowercase();
         let base = if pkey.starts_with("0x") { 16 } else { 10 };
         let p = pkey.trim_start_matches("0x");
-        let k = u16::from_str_radix(p, base);
-
-        match k {
-            Ok(v) => Ok(PartitionKey(v)),
+        // Apply the same 0x7fff range check as `TryFrom<u16>` so every
+        // construction path agrees on what a valid pkey is.
+        match u16::from_str_radix(p, base) {
+            Ok(v) => PartitionKey::try_from(v),
             Err(_e) => Err(InvalidPartitionKeyError(pkey.to_string())),
         }
     }
@@ -313,53 +313,432 @@ pub fn state_sla(state: &IBPartitionControllerState, state_version: &ConfigVersi
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
+    // ---- PartitionKey::from_str --------------------------------------------
+
     #[test]
-    fn serialize_and_format_pkey() {
-        let pkey = PartitionKey::from_str("0xf").unwrap();
-        let serialized = serde_json::to_string(&pkey).unwrap();
-        assert_eq!(serialized, "\"0xf\"");
-        assert_eq!(pkey.to_string(), "0xf");
-        let deserialized = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(pkey, deserialized);
-        let deserialized = serde_json::from_str("\"15\"").unwrap();
-        assert_eq!(pkey, deserialized);
-        let deserialized = serde_json::from_str("\"0xf\"").unwrap();
-        assert_eq!(pkey, deserialized);
+    fn from_str_parses_each_input() {
+        check_cases(
+            [
+                Case {
+                    scenario: "hex with 0x prefix",
+                    input: "0xf",
+                    expect: Yields(0x000f),
+                },
+                Case {
+                    scenario: "decimal of the same value",
+                    input: "15",
+                    expect: Yields(0x000f),
+                },
+                Case {
+                    scenario: "zero hex",
+                    input: "0x0",
+                    expect: Yields(0),
+                },
+                Case {
+                    scenario: "zero decimal",
+                    input: "0",
+                    expect: Yields(0),
+                },
+                Case {
+                    scenario: "max default-partition hex",
+                    input: "0x7fff",
+                    expect: Yields(0x7fff),
+                },
+                Case {
+                    scenario: "uppercase hex digits",
+                    input: "0x7ABC",
+                    expect: Yields(0x7abc),
+                },
+                Case {
+                    scenario: "uppercase 0X prefix is lowercased first",
+                    input: "0XF",
+                    expect: Yields(0x000f),
+                },
+                Case {
+                    // from_str enforces the same 0x7fff mask as TryFrom<u16>.
+                    scenario: "hex above the valid pkey mask is rejected",
+                    input: "0xffff",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "decimal above the mask is rejected",
+                    input: "65535",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-numeric text",
+                    input: "nope",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "decimal overflowing u16",
+                    input: "65536",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "hex overflowing u16",
+                    input: "0x10000",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "bare 0x prefix with no digits",
+                    input: "0x",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "decimal value carrying hex letters",
+                    input: "1f",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "negative sign rejected",
+                    input: "-1",
+                    expect: Fails,
+                },
+            ],
+            |s| PartitionKey::from_str(s).map(u16::from).map_err(drop),
+        );
+    }
+
+    // ---- PartitionKey: TryFrom<&str> / String / &String --------------------
+
+    #[test]
+    fn try_from_str_like_inputs_match_from_str() {
+        check_cases(
+            [
+                Case {
+                    scenario: "&str hex",
+                    input: "0x20",
+                    expect: Yields(0x20),
+                },
+                Case {
+                    scenario: "&str decimal",
+                    input: "32",
+                    expect: Yields(0x20),
+                },
+                Case {
+                    scenario: "&str malformed",
+                    input: "zz",
+                    expect: Fails,
+                },
+            ],
+            |s| PartitionKey::try_from(s).map(u16::from).map_err(drop),
+        );
     }
 
     #[test]
-    fn serialize_controller_state() {
-        let state = IBPartitionControllerState::Provisioning {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"provisioning\"}");
-        assert_eq!(
-            serde_json::from_str::<IBPartitionControllerState>(&serialized).unwrap(),
-            state
+    fn try_from_owned_and_borrowed_string() {
+        // TryFrom<String>
+        check_cases(
+            [
+                Case {
+                    scenario: "owned String hex",
+                    input: "0xab".to_string(),
+                    expect: Yields(0xab),
+                },
+                Case {
+                    scenario: "owned String malformed",
+                    input: "bad".to_string(),
+                    expect: Fails,
+                },
+            ],
+            |s| PartitionKey::try_from(s).map(u16::from).map_err(drop),
         );
-        let state = IBPartitionControllerState::Ready {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"ready\"}");
-        assert_eq!(
-            serde_json::from_str::<IBPartitionControllerState>(&serialized).unwrap(),
-            state
+        // TryFrom<&String>
+        check_cases(
+            [
+                Case {
+                    scenario: "&String decimal",
+                    input: "171".to_string(),
+                    expect: Yields(0xab),
+                },
+                Case {
+                    scenario: "&String malformed",
+                    input: "bad".to_string(),
+                    expect: Fails,
+                },
+            ],
+            |s| PartitionKey::try_from(&s).map(u16::from).map_err(drop),
         );
-        let state = IBPartitionControllerState::Error {
-            cause: "cause goes here".to_string(),
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, r#"{"state":"error","cause":"cause goes here"}"#);
-        assert_eq!(
-            serde_json::from_str::<IBPartitionControllerState>(&serialized).unwrap(),
-            state
+    }
+
+    // ---- PartitionKey: TryFrom<u16> (the 0x7fff mask) ----------------------
+
+    #[test]
+    fn try_from_u16_enforces_the_mask() {
+        check_cases(
+            [
+                Case {
+                    scenario: "zero",
+                    input: 0u16,
+                    expect: Yields(0),
+                },
+                Case {
+                    scenario: "small in-range value",
+                    input: 0x000f,
+                    expect: Yields(0x000f),
+                },
+                Case {
+                    scenario: "max valid (default partition)",
+                    input: 0x7fff,
+                    expect: Yields(0x7fff),
+                },
+                Case {
+                    scenario: "first value past the mask",
+                    input: 0x8000,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "u16 max has the high bit set",
+                    input: 0xffff,
+                    expect: Fails,
+                },
+            ],
+            |n| PartitionKey::try_from(n).map(u16::from).map_err(drop),
         );
-        let state = IBPartitionControllerState::Deleting {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"deleting\"}");
-        assert_eq!(
-            serde_json::from_str::<IBPartitionControllerState>(&serialized).unwrap(),
-            state
+    }
+
+    // ---- PartitionKey: Display ---------------------------------------------
+
+    #[test]
+    fn display_renders_lowercase_hex_with_prefix() {
+        check_values(
+            [
+                Check {
+                    scenario: "zero",
+                    input: 0u16,
+                    expect: "0x0".to_string(),
+                },
+                Check {
+                    scenario: "single hex digit",
+                    input: 0x000f,
+                    expect: "0xf".to_string(),
+                },
+                Check {
+                    scenario: "multi-digit lowercased",
+                    input: 0x00ab,
+                    expect: "0xab".to_string(),
+                },
+                Check {
+                    scenario: "default partition key",
+                    input: 0x7fff,
+                    expect: "0x7fff".to_string(),
+                },
+            ],
+            |n| PartitionKey::try_from(n).unwrap().to_string(),
         );
+    }
+
+    // ---- PartitionKey: default-partition helpers ---------------------------
+
+    #[test]
+    fn for_default_partition_is_0x7fff() {
+        assert_eq!(u16::from(PartitionKey::for_default_partition()), 0x7fff);
+    }
+
+    #[test]
+    fn is_default_partition_predicate() {
+        check_values(
+            [
+                Check {
+                    scenario: "the default key",
+                    input: 0x7fff,
+                    expect: true,
+                },
+                Check {
+                    scenario: "zero is not default",
+                    input: 0,
+                    expect: false,
+                },
+                Check {
+                    scenario: "an ordinary key is not default",
+                    input: 0x000f,
+                    expect: false,
+                },
+                Check {
+                    scenario: "one below default",
+                    input: 0x7ffe,
+                    expect: false,
+                },
+            ],
+            |n| PartitionKey::try_from(n).unwrap().is_default_partition(),
+        );
+    }
+
+    // ---- PartitionKey: round-trip parse -> render --------------------------
+
+    #[test]
+    fn parse_then_display_round_trips_to_canonical_hex() {
+        check_cases(
+            [
+                Case {
+                    scenario: "decimal normalizes to hex",
+                    input: "15",
+                    expect: Yields("0xf".to_string()),
+                },
+                Case {
+                    scenario: "hex stays hex",
+                    input: "0xf",
+                    expect: Yields("0xf".to_string()),
+                },
+                Case {
+                    scenario: "uppercase folds to lowercase",
+                    input: "0x7ABC",
+                    expect: Yields("0x7abc".to_string()),
+                },
+            ],
+            |s| PartitionKey::from_str(s).map(|p| p.to_string()).map_err(drop),
+        );
+    }
+
+    // ---- PartitionKey: serde (string is the canonical form) ----------------
+
+    #[test]
+    fn serializes_as_canonical_hex_string() {
+        check_cases(
+            [
+                Case {
+                    scenario: "single digit",
+                    input: 0x000f,
+                    expect: Yields("\"0xf\"".to_string()),
+                },
+                Case {
+                    scenario: "zero",
+                    input: 0,
+                    expect: Yields("\"0x0\"".to_string()),
+                },
+                Case {
+                    scenario: "default partition",
+                    input: 0x7fff,
+                    expect: Yields("\"0x7fff\"".to_string()),
+                },
+            ],
+            |n| {
+                let pkey = PartitionKey::try_from(n).unwrap();
+                serde_json::to_string(&pkey).map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn deserializes_from_hex_or_decimal_strings() {
+        check_cases(
+            [
+                Case {
+                    scenario: "hex string",
+                    input: "\"0xf\"",
+                    expect: Yields(0x000f),
+                },
+                Case {
+                    scenario: "decimal string of the same value",
+                    input: "\"15\"",
+                    expect: Yields(0x000f),
+                },
+                Case {
+                    scenario: "malformed string",
+                    input: "\"nope\"",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-string JSON is rejected",
+                    input: "15",
+                    expect: Fails,
+                },
+            ],
+            |s| {
+                serde_json::from_str::<PartitionKey>(s)
+                    .map(u16::from)
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // ---- IBPartitionControllerState: serde (tagged, lowercase) -------------
+
+    #[test]
+    fn controller_state_serializes_with_lowercase_tag() {
+        check_cases(
+            [
+                Case {
+                    scenario: "provisioning",
+                    input: IBPartitionControllerState::Provisioning,
+                    expect: Yields(r#"{"state":"provisioning"}"#.to_string()),
+                },
+                Case {
+                    scenario: "ready",
+                    input: IBPartitionControllerState::Ready,
+                    expect: Yields(r#"{"state":"ready"}"#.to_string()),
+                },
+                Case {
+                    scenario: "deleting",
+                    input: IBPartitionControllerState::Deleting,
+                    expect: Yields(r#"{"state":"deleting"}"#.to_string()),
+                },
+                Case {
+                    scenario: "error carries its cause",
+                    input: IBPartitionControllerState::Error {
+                        cause: "cause goes here".to_string(),
+                    },
+                    expect: Yields(r#"{"state":"error","cause":"cause goes here"}"#.to_string()),
+                },
+            ],
+            |state| serde_json::to_string(&state).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn controller_state_round_trips_through_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "provisioning",
+                    input: IBPartitionControllerState::Provisioning,
+                    expect: Yields(IBPartitionControllerState::Provisioning),
+                },
+                Case {
+                    scenario: "ready",
+                    input: IBPartitionControllerState::Ready,
+                    expect: Yields(IBPartitionControllerState::Ready),
+                },
+                Case {
+                    scenario: "deleting",
+                    input: IBPartitionControllerState::Deleting,
+                    expect: Yields(IBPartitionControllerState::Deleting),
+                },
+                Case {
+                    scenario: "error preserves its cause",
+                    input: IBPartitionControllerState::Error {
+                        cause: "boom".to_string(),
+                    },
+                    expect: Yields(IBPartitionControllerState::Error {
+                        cause: "boom".to_string(),
+                    }),
+                },
+            ],
+            |state| {
+                let json = serde_json::to_string(&state).map_err(drop)?;
+                serde_json::from_str::<IBPartitionControllerState>(&json).map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn controller_state_deserialize_rejects_unknown_tag() {
+        Case {
+            scenario: "unknown state tag",
+            input: r#"{"state":"bogus"}"#,
+            expect: Fails,
+        }
+        .check(|s| serde_json::from_str::<IBPartitionControllerState>(s).map_err(drop));
     }
 }

--- a/crates/api-model/src/instance/config/network.rs
+++ b/crates/api-model/src/instance/config/network.rs
@@ -735,6 +735,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     #[test]
@@ -756,22 +759,33 @@ mod tests {
         }
     }
 
+    // Serde JSON round-trip for each InterfaceFunctionId variant: each row
+    // asserts the exact serialized form, and the closure confirms the value
+    // round-trips back equal before yielding that string.
     #[test]
     fn serialize_function_id() {
-        let function_id = InterfaceFunctionId::Physical {};
-        let serialized = serde_json::to_string(&function_id).unwrap();
-        assert_eq!(serialized, "{\"type\":\"physical\"}");
-        assert_eq!(
-            serde_json::from_str::<InterfaceFunctionId>(&serialized).unwrap(),
-            function_id
-        );
-
-        let function_id = InterfaceFunctionId::Virtual { id: 24 };
-        let serialized = serde_json::to_string(&function_id).unwrap();
-        assert_eq!(serialized, "{\"type\":\"virtual\",\"id\":24}");
-        assert_eq!(
-            serde_json::from_str::<InterfaceFunctionId>(&serialized).unwrap(),
-            function_id
+        check_cases(
+            [
+                Case {
+                    scenario: "physical",
+                    input: InterfaceFunctionId::Physical {},
+                    expect: Yields(r#"{"type":"physical"}"#.to_string()),
+                },
+                Case {
+                    scenario: "virtual",
+                    input: InterfaceFunctionId::Virtual { id: 24 },
+                    expect: Yields(r#"{"type":"virtual","id":24}"#.to_string()),
+                },
+            ],
+            // Serialize, confirm it round-trips back equal, then yield the JSON.
+            // serde_json::Error is not PartialEq, so collapse failures to ().
+            |function_id| {
+                let serialized = serde_json::to_string(&function_id).map_err(|_| ())?;
+                let round_tripped =
+                    serde_json::from_str::<InterfaceFunctionId>(&serialized).map_err(|_| ())?;
+                assert_eq!(round_tripped, function_id);
+                Ok::<_, ()>(serialized)
+            },
         );
     }
 
@@ -850,43 +864,80 @@ mod tests {
         }
     }
 
+    // InstanceNetworkConfig::validate over a base valid config mutated per row.
+    // Input is (config, allow_instance_vf). ConfigValidationError is not
+    // PartialEq, so rejections assert only that validation errs (Fails); the
+    // exact error value is not part of the contract here.
     #[test]
     fn validate_network_config() {
-        let config = create_valid_network_config();
-        config.validate(true).unwrap();
-
-        // Same config with virtual function, but virtual functions are disabled
-        assert!(config.validate(false).is_err());
-
-        // Duplicate virtual function
-        let mut config = create_valid_network_config();
-        config.interfaces[2].function_id = InterfaceFunctionId::Virtual { id: 0 };
-        assert!(config.validate(true).is_err());
-
-        // Out of bounds virtual function
-        let mut config = create_valid_network_config();
-        config.interfaces[2].function_id = InterfaceFunctionId::Virtual { id: 16 };
-        assert!(config.validate(true).is_err());
-
-        // No physical function
-        let mut config = create_valid_network_config();
-        config.interfaces.swap_remove(0);
-        assert!(config.validate(true).is_err());
-
-        // Missing virtual function id in between is now a valid scenario.
-        // The last virtual function is ok to be missing
-        let mut config = create_valid_network_config();
-        config
-            .interfaces
-            .swap_remove(INTERFACE_VFID_MAX as usize + 1);
-        config.validate(true).unwrap();
-
-        // Duplicate network segment
         const DUPLICATE_SEGMENT_ID: uuid::Uuid =
             uuid::uuid!("91609f10-c91d-470d-a260-1234560c0000");
-        let mut config = create_valid_network_config();
-        config.interfaces[0].network_segment_id = Some(DUPLICATE_SEGMENT_ID.into());
-        config.interfaces[1].network_segment_id = Some(DUPLICATE_SEGMENT_ID.into());
-        assert!(config.validate(true).is_err());
+
+        let valid = create_valid_network_config();
+
+        let virtual_functions_disabled = create_valid_network_config();
+
+        let mut duplicate_virtual_function = create_valid_network_config();
+        duplicate_virtual_function.interfaces[2].function_id =
+            InterfaceFunctionId::Virtual { id: 0 };
+
+        let mut out_of_bounds_virtual_function = create_valid_network_config();
+        out_of_bounds_virtual_function.interfaces[2].function_id =
+            InterfaceFunctionId::Virtual { id: 16 };
+
+        let mut no_physical_function = create_valid_network_config();
+        no_physical_function.interfaces.swap_remove(0);
+
+        let mut missing_middle_virtual_function = create_valid_network_config();
+        missing_middle_virtual_function
+            .interfaces
+            .swap_remove(INTERFACE_VFID_MAX as usize + 1);
+
+        let mut duplicate_network_segment = create_valid_network_config();
+        duplicate_network_segment.interfaces[0].network_segment_id =
+            Some(DUPLICATE_SEGMENT_ID.into());
+        duplicate_network_segment.interfaces[1].network_segment_id =
+            Some(DUPLICATE_SEGMENT_ID.into());
+
+        check_cases(
+            [
+                Case {
+                    scenario: "valid config with virtual functions allowed",
+                    input: (valid, true),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "virtual functions disabled by site configuration",
+                    input: (virtual_functions_disabled, false),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "duplicate virtual function id",
+                    input: (duplicate_virtual_function, true),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "out of bounds virtual function id",
+                    input: (out_of_bounds_virtual_function, true),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "no physical function",
+                    input: (no_physical_function, true),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing middle virtual function id is allowed",
+                    input: (missing_middle_virtual_function, true),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "duplicate network segment",
+                    input: (duplicate_network_segment, true),
+                    expect: Fails,
+                },
+            ],
+            |(config, allow_instance_vf)| config.validate(allow_instance_vf).map_err(drop),
+        );
     }
 }

--- a/crates/api-model/src/instance/config/tenant_config.rs
+++ b/crates/api-model/src/instance/config/tenant_config.rs
@@ -83,6 +83,11 @@ impl TenantConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::mem::discriminant;
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     #[test]
@@ -105,32 +110,46 @@ mod tests {
     }
 
     #[test]
-    fn validate_tenant_config_duplicate_keysets() {
-        let config = TenantConfig {
-            tenant_organization_id: TenantOrganizationId::try_from("TenantA".to_string()).unwrap(),
-            tenant_keyset_ids: vec![
-                "a".to_string(),
-                "b".to_string(),
-                "c".to_string(),
-                "a".to_string(),
+    fn validate_tenant_config() {
+        // `TenantConfig::validate`: duplicate keyset IDs are rejected, unique ones
+        // pass. The error type (ConfigValidationError) is not PartialEq, so failing
+        // rows assert the rejected *variant* via its discriminant rather than the
+        // exact error value.
+        check_cases(
+            [
+                Case {
+                    scenario: "duplicate keyset ids are rejected",
+                    input: TenantConfig {
+                        tenant_organization_id: TenantOrganizationId::try_from(
+                            "TenantA".to_string(),
+                        )
+                        .unwrap(),
+                        tenant_keyset_ids: vec![
+                            "a".to_string(),
+                            "b".to_string(),
+                            "c".to_string(),
+                            "a".to_string(),
+                        ],
+                        hostname: Some("test-instance".to_string()),
+                    },
+                    expect: FailsWith(discriminant(
+                        &ConfigValidationError::DuplicateTenantKeysetId(String::new()),
+                    )),
+                },
+                Case {
+                    scenario: "unique keyset ids validate",
+                    input: TenantConfig {
+                        tenant_organization_id: TenantOrganizationId::try_from(
+                            "TenantA".to_string(),
+                        )
+                        .unwrap(),
+                        tenant_keyset_ids: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+                        hostname: Some("test-instance".to_string()),
+                    },
+                    expect: Yields(()),
+                },
             ],
-            hostname: Some("test-instance".to_string()),
-        };
-
-        assert!(matches!(
-            config.validate(),
-            Err(ConfigValidationError::DuplicateTenantKeysetId(_))
-        ))
-    }
-
-    #[test]
-    fn validate_tenant_config_unique_keysets() {
-        let config = TenantConfig {
-            tenant_organization_id: TenantOrganizationId::try_from("TenantA".to_string()).unwrap(),
-            tenant_keyset_ids: vec!["a".to_string(), "b".to_string(), "c".to_string()],
-            hostname: Some("test-instance".to_string()),
-        };
-
-        config.validate().unwrap()
+            |config: TenantConfig| config.validate().map_err(|e| discriminant(&e)),
+        );
     }
 }

--- a/crates/api-model/src/instance/snapshot.rs
+++ b/crates/api-model/src/instance/snapshot.rs
@@ -380,6 +380,8 @@ impl TryFrom<InstanceSnapshotPgJson> for InstanceSnapshot {
 mod tests {
     use std::str::FromStr;
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
     use chrono::Utc;
     use uuid::Uuid;
 
@@ -454,41 +456,74 @@ mod tests {
         }
     }
 
+    /// `InstanceSnapshot::try_from` derives the OS variant from the legacy
+    /// instance columns (priority: operating_system_id > os_image_id > inline
+    /// iPXE). Each row mutates a minimal pg-json row, then projects the converted
+    /// snapshot to the fields under test: (os variant, user_data, phone_home).
     #[test]
-    fn test_try_from_legacy_ipxe_derives_os_from_instance_columns() {
-        let mut pg_json = minimal_pg_json();
-        pg_json.operating_system_id = None;
-        pg_json.os_ipxe_script = "legacy-inline-script".to_string();
-        pg_json.os_image_id = None;
-        pg_json.os_user_data = Some("legacy-user-data".to_string());
-        pg_json.os_phone_home_enabled = true;
-        let snapshot = InstanceSnapshot::try_from(pg_json).unwrap();
-        assert!(matches!(
-            &snapshot.config.os.variant,
-            OperatingSystemVariant::Ipxe(_)
-        ));
-        if let OperatingSystemVariant::Ipxe(ipxe) = &snapshot.config.os.variant {
-            assert_eq!(ipxe.ipxe_script, "legacy-inline-script");
-        }
-        assert_eq!(
-            snapshot.config.os.user_data.as_deref(),
-            Some("legacy-user-data")
-        );
-        assert!(snapshot.config.os.phone_home_enabled);
-    }
-
-    #[test]
-    fn test_try_from_legacy_os_image_derives_os_from_instance_columns() {
+    fn test_try_from_derives_os_from_instance_columns() {
         let image_uuid = uuid::uuid!("a1b2c3d4-e5f6-4780-a123-456789abcdef");
-        let mut pg_json = minimal_pg_json();
-        pg_json.operating_system_id = None;
-        pg_json.os_image_id = Some(image_uuid);
-        pg_json.os_ipxe_script = "ignored".to_string();
-        let snapshot = InstanceSnapshot::try_from(pg_json).unwrap();
-        assert!(matches!(
-            &snapshot.config.os.variant,
-            OperatingSystemVariant::OsImage(id) if *id == image_uuid
-        ));
+        let os_uuid = uuid::uuid!("b2c3d4e5-f6a7-4890-b234-567890abcdef");
+
+        check_cases(
+            [
+                Case {
+                    scenario: "legacy inline iPXE derives Ipxe variant with user_data and phone_home",
+                    input: Box::new(|pg: &mut InstanceSnapshotPgJson| {
+                        pg.operating_system_id = None;
+                        pg.os_image_id = None;
+                        pg.os_ipxe_script = "legacy-inline-script".to_string();
+                        pg.os_user_data = Some("legacy-user-data".to_string());
+                        pg.os_phone_home_enabled = true;
+                    }) as Box<dyn Fn(&mut InstanceSnapshotPgJson)>,
+                    expect: Yields((
+                        OperatingSystemVariant::Ipxe(InlineIpxe {
+                            ipxe_script: "legacy-inline-script".to_string(),
+                        }),
+                        Some("legacy-user-data".to_string()),
+                        true,
+                    )),
+                },
+                Case {
+                    scenario: "legacy os_image_id derives OsImage variant (iPXE script ignored)",
+                    input: Box::new(move |pg: &mut InstanceSnapshotPgJson| {
+                        pg.operating_system_id = None;
+                        pg.os_image_id = Some(image_uuid);
+                        pg.os_ipxe_script = "ignored".to_string();
+                    }),
+                    expect: Yields((OperatingSystemVariant::OsImage(image_uuid), None, false)),
+                },
+                Case {
+                    scenario: "operating_system_id takes priority over image and iPXE",
+                    input: Box::new(move |pg: &mut InstanceSnapshotPgJson| {
+                        pg.operating_system_id = Some(os_uuid);
+                        pg.os_image_id = None;
+                        pg.os_ipxe_script = String::new();
+                    }),
+                    expect: Yields((
+                        OperatingSystemVariant::OperatingSystemId(os_uuid),
+                        None,
+                        false,
+                    )),
+                },
+            ],
+            // Apply the row's mutation to a minimal pg-json, convert, and project
+            // to the asserted OS fields. The error type (sqlx::Error) is not
+            // PartialEq, so on failure we discard it.
+            |mutate| {
+                let mut pg_json = minimal_pg_json();
+                mutate(&mut pg_json);
+                InstanceSnapshot::try_from(pg_json)
+                    .map(|snapshot| {
+                        (
+                            snapshot.config.os.variant,
+                            snapshot.config.os.user_data,
+                            snapshot.config.os.phone_home_enabled,
+                        )
+                    })
+                    .map_err(drop)
+            },
+        );
     }
 
     #[test]
@@ -501,19 +536,5 @@ mod tests {
         assert!(matches!(err, sqlx::Error::ColumnDecode { .. }));
         assert!(format!("{err}").contains("no operating_system_id"));
         assert!(format!("{err}").contains("no iPXE script"));
-    }
-
-    #[test]
-    fn test_try_from_with_operating_system_id() {
-        let os_uuid = uuid::uuid!("b2c3d4e5-f6a7-4890-b234-567890abcdef");
-        let mut pg_json = minimal_pg_json();
-        pg_json.operating_system_id = Some(os_uuid);
-        pg_json.os_ipxe_script = String::new();
-        pg_json.os_image_id = None;
-        let snapshot = InstanceSnapshot::try_from(pg_json).unwrap();
-        assert!(matches!(
-            &snapshot.config.os.variant,
-            OperatingSystemVariant::OperatingSystemId(id) if *id == os_uuid
-        ));
     }
 }

--- a/crates/api-model/src/machine/capabilities.rs
+++ b/crates/api-model/src/machine/capabilities.rs
@@ -510,6 +510,8 @@ impl MachineCapabilitiesSet {
 mod tests {
     use std::str::FromStr;
 
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
     use crate::hardware_info::*;
     use crate::ib::DEFAULT_IB_FABRIC_NAME;
@@ -848,5 +850,251 @@ mod tests {
         compare_cap.sort();
 
         assert_eq!(expected_ib_caps, compare_cap.infiniband);
+    }
+
+    #[test]
+    fn capability_type_display_covers_every_variant() {
+        check_values(
+            [
+                Check {
+                    scenario: "cpu",
+                    input: MachineCapabilityType::Cpu,
+                    expect: "CPU".to_string(),
+                },
+                Check {
+                    scenario: "gpu",
+                    input: MachineCapabilityType::Gpu,
+                    expect: "GPU".to_string(),
+                },
+                Check {
+                    scenario: "memory",
+                    input: MachineCapabilityType::Memory,
+                    expect: "MEMORY".to_string(),
+                },
+                Check {
+                    scenario: "storage",
+                    input: MachineCapabilityType::Storage,
+                    expect: "STORAGE".to_string(),
+                },
+                Check {
+                    scenario: "network",
+                    input: MachineCapabilityType::Network,
+                    expect: "NETWORK".to_string(),
+                },
+                Check {
+                    scenario: "infiniband",
+                    input: MachineCapabilityType::Infiniband,
+                    expect: "INFINIBAND".to_string(),
+                },
+                Check {
+                    scenario: "dpu",
+                    input: MachineCapabilityType::Dpu,
+                    expect: "DPU".to_string(),
+                },
+            ],
+            |variant| variant.to_string(),
+        );
+    }
+
+    #[test]
+    fn capability_type_default_is_cpu() {
+        Check {
+            scenario: "default capability type",
+            input: (),
+            expect: MachineCapabilityType::Cpu,
+        }
+        .check(|()| MachineCapabilityType::default());
+    }
+
+    #[test]
+    fn device_type_display_covers_every_variant() {
+        check_values(
+            [
+                Check {
+                    scenario: "unknown",
+                    input: MachineCapabilityDeviceType::Unknown,
+                    expect: "UNKNOWN".to_string(),
+                },
+                Check {
+                    scenario: "dpu",
+                    input: MachineCapabilityDeviceType::Dpu,
+                    expect: "DPU".to_string(),
+                },
+                Check {
+                    scenario: "nvlink",
+                    input: MachineCapabilityDeviceType::NvLink,
+                    expect: "NVLINK".to_string(),
+                },
+            ],
+            |variant| variant.to_string(),
+        );
+    }
+
+    #[test]
+    fn cpu_capability_from_cpu_info_maps_every_field() {
+        fn cpu_info(model: &str, vendor: &str, sockets: u32, cores: u32, threads: u32) -> CpuInfo {
+            CpuInfo {
+                model: model.to_string(),
+                vendor: vendor.to_string(),
+                sockets,
+                cores,
+                threads,
+            }
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "typical dual-socket",
+                    input: cpu_info("Xeon Gold 6354", "GenuineIntel", 2, 18, 36),
+                    expect: MachineCapabilityCpu {
+                        name: "Xeon Gold 6354".to_string(),
+                        count: 2,
+                        vendor: Some("GenuineIntel".to_string()),
+                        cores: Some(18),
+                        threads: Some(36),
+                    },
+                },
+                Check {
+                    scenario: "single socket",
+                    input: cpu_info("EPYC 7763", "AuthenticAMD", 1, 64, 128),
+                    expect: MachineCapabilityCpu {
+                        name: "EPYC 7763".to_string(),
+                        count: 1,
+                        vendor: Some("AuthenticAMD".to_string()),
+                        cores: Some(64),
+                        threads: Some(128),
+                    },
+                },
+                Check {
+                    scenario: "all-zero / empty defaults",
+                    input: cpu_info("", "", 0, 0, 0),
+                    expect: MachineCapabilityCpu {
+                        name: String::new(),
+                        count: 0,
+                        // From always wraps the source fields in Some, even when empty/zero.
+                        vendor: Some(String::new()),
+                        cores: Some(0),
+                        threads: Some(0),
+                    },
+                },
+            ],
+            |info| MachineCapabilityCpu::from(&info),
+        );
+    }
+
+    #[test]
+    fn infiniband_caps_from_interfaces_and_status() {
+        fn iface(guid: &str, pci: Option<PciDeviceProperties>) -> InfinibandInterface {
+            InfinibandInterface {
+                guid: guid.to_string(),
+                pci_properties: pci,
+            }
+        }
+
+        fn pci(vendor: &str, description: Option<&str>, slot: Option<&str>) -> PciDeviceProperties {
+            PciDeviceProperties {
+                vendor: vendor.to_string(),
+                device: String::new(),
+                path: String::new(),
+                numa_node: 0,
+                description: description.map(str::to_string),
+                slot: slot.map(str::to_string),
+            }
+        }
+
+        // No status observation: every device defaults to inactive.
+        check_values(
+            [
+                Check {
+                    scenario: "empty interface list -> no capabilities",
+                    input: Vec::<InfinibandInterface>::new(),
+                    expect: 0,
+                },
+                Check {
+                    scenario: "interface without pci_properties is skipped",
+                    input: vec![iface("g0", None)],
+                    expect: 0,
+                },
+                Check {
+                    scenario: "pci_properties without description is skipped",
+                    input: vec![iface("g0", Some(pci("0x15b3", None, Some("0"))))],
+                    expect: 0,
+                },
+                Check {
+                    scenario: "two devices of the same model roll into one capability",
+                    input: vec![
+                        iface("g0", Some(pci("0x15b3", Some("ConnectX-7"), Some("1")))),
+                        iface("g1", Some(pci("0x15b3", Some("ConnectX-7"), Some("0")))),
+                    ],
+                    expect: 1,
+                },
+                Check {
+                    scenario: "two distinct models produce two capabilities",
+                    input: vec![
+                        iface("g0", Some(pci("0x15b3", Some("ConnectX-5"), Some("0")))),
+                        iface("g1", Some(pci("0x15b3", Some("ConnectX-7"), Some("1")))),
+                    ],
+                    expect: 2,
+                },
+            ],
+            |interfaces| {
+                MachineCapabilityInfiniband::from_ib_interfaces_and_status(&interfaces, None).len()
+            },
+        );
+    }
+
+    #[test]
+    fn infiniband_caps_count_and_inactive_without_status() {
+        // Without a status observation, lid lookups never succeed, so every
+        // device is treated as inactive and recorded in inactive_devices.
+        let interfaces = vec![
+            InfinibandInterface {
+                guid: "g0".to_string(),
+                pci_properties: Some(PciDeviceProperties {
+                    vendor: "0x15b3".to_string(),
+                    device: String::new(),
+                    path: String::new(),
+                    numa_node: 0,
+                    description: Some("ConnectX-7".to_string()),
+                    slot: Some("0".to_string()),
+                }),
+            },
+            InfinibandInterface {
+                guid: "g1".to_string(),
+                pci_properties: Some(PciDeviceProperties {
+                    vendor: "0x15b3".to_string(),
+                    device: String::new(),
+                    path: String::new(),
+                    numa_node: 0,
+                    description: Some("ConnectX-7".to_string()),
+                    slot: Some("1".to_string()),
+                }),
+            },
+        ];
+
+        let caps =
+            MachineCapabilityInfiniband::from_ib_interfaces_and_status(&interfaces, None);
+        assert_eq!(caps.len(), 1);
+
+        check_values(
+            [
+                Check {
+                    scenario: "rolled-up count",
+                    input: "count",
+                    expect: 2u32,
+                },
+                Check {
+                    scenario: "all inactive without status",
+                    input: "inactive_len",
+                    expect: 2u32,
+                },
+            ],
+            |field| match field {
+                "count" => caps[0].count,
+                "inactive_len" => caps[0].inactive_devices.len() as u32,
+                other => panic!("unknown field {other}"),
+            },
+        );
     }
 }

--- a/crates/api-model/src/machine/infiniband.rs
+++ b/crates/api-model/src/machine/infiniband.rs
@@ -208,17 +208,45 @@ pub fn ib_config_synced(
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     #[test]
     fn deserialize_legacy_ib_status_observation() {
-        let obs1 = r#"{"observed_at": "2024-12-18T23:17:57.919166804Z", "ib_interfaces": []}"#;
-        let _deserialized: MachineInfinibandStatusObservation = serde_json::from_str(obs1).unwrap();
+        // Legacy IB status observations should deserialize, defaulting the fields
+        // that older payloads omit. We project to the first interface's
+        // (fabric_id_is_empty, associated_pkeys_is_none) so the asserted defaults
+        // are comparable.
+        check_cases(
+            [Case {
+                scenario: "interfaces without fabric_id or pkeys default them",
+                input: r#"{"observed_at": "2025-06-06T19:47:16.597282585Z", "ib_interfaces": [{"lid": 65535, "guid": "1070fd0300bd7574"}, {"lid": 65535, "guid": "1070fd0300bd7575"}]}"#,
+                expect: Yields((true, true)),
+            }],
+            // Deserialize, then project the first interface's defaulted fields.
+            // serde_json::Error is not PartialEq, so a failing row would discard it.
+            |s| {
+                serde_json::from_str::<MachineInfinibandStatusObservation>(s)
+                    .map(|obs| {
+                        let iface = obs.ib_interfaces.first().expect("row supplies interfaces");
+                        (iface.fabric_id.is_empty(), iface.associated_pkeys.is_none())
+                    })
+                    .map_err(drop)
+            },
+        );
+    }
 
-        let obs2 = r#"{"observed_at": "2025-06-06T19:47:16.597282585Z", "ib_interfaces": [{"lid": 65535, "guid": "1070fd0300bd7574"}, {"lid": 65535, "guid": "1070fd0300bd7575"}]}"#;
-        let deserialized: MachineInfinibandStatusObservation = serde_json::from_str(obs2).unwrap();
-        assert!(deserialized.ib_interfaces[0].fabric_id.is_empty());
-        assert!(deserialized.ib_interfaces[0].associated_pkeys.is_none());
+    // An empty interface list deserializes cleanly -- older payloads may omit
+    // interfaces entirely.
+    #[test]
+    fn deserialize_legacy_ib_status_empty_interfaces() {
+        let obs: MachineInfinibandStatusObservation = serde_json::from_str(
+            r#"{"observed_at": "2024-12-18T23:17:57.919166804Z", "ib_interfaces": []}"#,
+        )
+        .expect("empty interface list should deserialize");
+        assert!(obs.ib_interfaces.is_empty());
     }
 
     #[test]
@@ -247,81 +275,17 @@ mod tests {
     }
 
     #[test]
-    fn test_ib_config_synced_missing_observation() {
-        use crate::instance::config::network::InterfaceFunctionId;
-
-        let config = InstanceInfinibandConfig {
-            ib_interfaces: vec![
-                crate::instance::config::infiniband::InstanceIbInterfaceConfig {
-                    function_id: InterfaceFunctionId::Physical {},
-                    ib_partition_id: uuid::uuid!("91609f10-c91d-470d-a260-6293ea0c1200").into(),
-                    pf_guid: None,
-                    guid: Some("946dae03006104f8".to_string()),
-                    device: "MT2910 Family [ConnectX-7]".to_string(),
-                    vendor: None,
-                    device_instance: 1,
-                },
-            ],
-        };
-        let result = ib_config_synced(None, Some(&config), true);
-        assert!(matches!(
-            result,
-            Err(IbConfigNotSyncedReason::MissingObservation { .. })
-        ));
-    }
-
-    #[test]
-    fn test_ib_config_synced_port_state_unobservable() {
-        use crate::instance::config::network::InterfaceFunctionId;
-
-        let config = InstanceInfinibandConfig {
-            ib_interfaces: vec![
-                crate::instance::config::infiniband::InstanceIbInterfaceConfig {
-                    function_id: InterfaceFunctionId::Physical {},
-                    ib_partition_id: uuid::uuid!("91609f10-c91d-470d-a260-6293ea0c1200").into(),
-                    pf_guid: None,
-                    guid: Some("946dae03006104f8".to_string()),
-                    device: "MT2910 Family [ConnectX-7]".to_string(),
-                    vendor: None,
-                    device_instance: 1,
-                },
-            ],
-        };
-
-        let observation = MachineInfinibandStatusObservation {
-            ib_interfaces: vec![MachineIbInterfaceStatusObservation {
-                guid: "946dae03006104f8".to_string(),
-                lid: 0xffff,
-                fabric_id: "".to_string(),
-                associated_pkeys: None, // Port is down/unobservable
-                associated_partition_ids: None,
-            }],
-            observed_at: chrono::Utc::now(),
-        };
-
-        let result = ib_config_synced(Some(&observation), Some(&config), true);
-
-        match result {
-            Err(IbConfigNotSyncedReason::PortStateUnobservable { guids, details }) => {
-                assert_eq!(guids.len(), 1);
-                assert_eq!(guids[0], "946dae03006104f8");
-                assert!(details.contains("946dae03006104f8"));
-                assert!(details.contains("missing or incomplete"));
-            }
-            _ => panic!("Expected PortStateUnobservable error, got: {:?}", result),
-        }
-    }
-
-    #[test]
-    fn test_ib_config_synced_ok_when_synced() {
+    fn test_ib_config_synced() {
         use carbide_uuid::infiniband::IBPartitionId;
 
         use crate::instance::config::network::InterfaceFunctionId;
+
         let partition_id: IBPartitionId =
             uuid::uuid!("91609f10-c91d-470d-a260-6293ea0c1200").into();
         let pkey: PartitionKey = 0x13.try_into().unwrap();
 
-        let config = InstanceInfinibandConfig {
+        // A single-interface config requesting the partition above.
+        let config = || InstanceInfinibandConfig {
             ib_interfaces: vec![
                 crate::instance::config::infiniband::InstanceIbInterfaceConfig {
                     function_id: InterfaceFunctionId::Physical {},
@@ -335,7 +299,20 @@ mod tests {
             ],
         };
 
-        let observation = MachineInfinibandStatusObservation {
+        // Observation where the port is down/unobservable (no pkeys/partition ids).
+        let unobservable = MachineInfinibandStatusObservation {
+            ib_interfaces: vec![MachineIbInterfaceStatusObservation {
+                guid: "946dae03006104f8".to_string(),
+                lid: 0xffff,
+                fabric_id: "".to_string(),
+                associated_pkeys: None,
+                associated_partition_ids: None,
+            }],
+            observed_at: chrono::Utc::now(),
+        };
+
+        // Observation where the interface is on exactly the requested partition.
+        let synced = MachineInfinibandStatusObservation {
             ib_interfaces: vec![MachineIbInterfaceStatusObservation {
                 guid: "946dae03006104f8".to_string(),
                 lid: 0x10,
@@ -346,7 +323,78 @@ mod tests {
             observed_at: chrono::Utc::now(),
         };
 
-        let result = ib_config_synced(Some(&observation), Some(&config), true);
-        assert!(result.is_ok());
+        // Observation where the interface is observable but sits on a different
+        // partition than the config requests, so the config is not synced.
+        let other_partition_id: IBPartitionId =
+            uuid::uuid!("00000000-0000-0000-0000-0000deadbeef").into();
+        let other_pkey: PartitionKey = 0x42.try_into().unwrap();
+        let mismatched = MachineInfinibandStatusObservation {
+            ib_interfaces: vec![MachineIbInterfaceStatusObservation {
+                guid: "946dae03006104f8".to_string(),
+                lid: 0x10,
+                fabric_id: "default".to_string(),
+                associated_pkeys: Some([other_pkey].into_iter().collect()),
+                associated_partition_ids: Some([other_partition_id].into_iter().collect()),
+            }],
+            observed_at: chrono::Utc::now(),
+        };
+
+        // ib_config_synced over (observation, config, use_tenant_network). The
+        // error variant's `details` are built dynamically, so rather than assert
+        // the exact reason we project the result to a comparable summary:
+        // - Ok            -> a static "ok" tag, no guids, no substrings
+        // - the error variant tag, the affected guids, and whether `details`
+        //   carries the expected substrings (only the PortStateUnobservable row
+        //   asserts those).
+        type Summary = (&'static str, Vec<String>, bool, bool);
+        let cfg = config();
+        check_cases(
+            [
+                Case {
+                    scenario: "missing observation",
+                    input: (None, Some(&cfg), true),
+                    expect: Yields(("MissingObservation", Vec::new(), false, false)),
+                },
+                Case {
+                    scenario: "port state unobservable",
+                    input: (Some(&unobservable), Some(&cfg), true),
+                    expect: Yields((
+                        "PortStateUnobservable",
+                        vec!["946dae03006104f8".to_string()],
+                        true,
+                        true,
+                    )),
+                },
+                Case {
+                    scenario: "ok when synced",
+                    input: (Some(&synced), Some(&cfg), true),
+                    expect: Yields(("ok", Vec::new(), false, false)),
+                },
+                Case {
+                    scenario: "configuration mismatch (interface on a different partition)",
+                    input: (Some(&mismatched), Some(&cfg), true),
+                    expect: Yields(("ConfigurationMismatch", Vec::new(), false, false)),
+                },
+            ],
+            |(observation, config, use_tenant_network)| -> Result<Summary, ()> {
+                Ok(
+                    match ib_config_synced(observation, config, use_tenant_network) {
+                        Ok(()) => ("ok", Vec::new(), false, false),
+                        Err(IbConfigNotSyncedReason::MissingObservation { .. }) => {
+                            ("MissingObservation", Vec::new(), false, false)
+                        }
+                        Err(IbConfigNotSyncedReason::ConfigurationMismatch { .. }) => {
+                            ("ConfigurationMismatch", Vec::new(), false, false)
+                        }
+                        Err(IbConfigNotSyncedReason::PortStateUnobservable { guids, details }) => (
+                            "PortStateUnobservable",
+                            guids,
+                            details.contains("946dae03006104f8"),
+                            details.contains("missing or incomplete"),
+                        ),
+                    },
+                )
+            },
+        );
     }
 }

--- a/crates/api-model/src/machine/machine_id.rs
+++ b/crates/api-model/src/machine/machine_id.rs
@@ -105,10 +105,32 @@ pub enum MissingHardwareInfo {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
     use carbide_uuid::machine::MACHINE_ID_LENGTH;
 
     use super::*;
-    use crate::hardware_info::TpmEkCertificate;
+    use crate::hardware_info::{DmiData, TpmEkCertificate};
+
+    // Build a `HardwareInfo` carrying only the two fields the ID derivation looks
+    // at — an optional TPM certificate and optional DMI serials — leaving every
+    // other field defaulted. `tpm` is the certificate bytes (when present) and
+    // `serials` is the (product, board, chassis) triple folded into `DmiData`.
+    fn info_for_id(
+        tpm: Option<Vec<u8>>,
+        serials: Option<(&str, &str, &str)>,
+    ) -> HardwareInfo {
+        HardwareInfo {
+            tpm_ek_certificate: tpm.map(TpmEkCertificate::from),
+            dmi_data: serials.map(|(product, board, chassis)| DmiData {
+                product_serial: product.to_string(),
+                board_serial: board.to_string(),
+                chassis_serial: chassis.to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
 
     const TEST_DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src/hardware_info/test_data");
 
@@ -188,34 +210,327 @@ mod tests {
         assert!(constructor(fingerprint).is_err());
     }
 
+    // Each row loads a hardware-info fixture and derives a Machine ID through one
+    // constructor, expecting a given MachineType. `test_derive_machine_id` does all
+    // the assertions internally (and panics on mismatch), so each row just expects
+    // the run to complete, i.e. `Yields(())`.
     #[test]
-    fn derive_host_machine_id() {
-        let path = format!("{TEST_DATA_DIR}/x86_info.json");
-        let data = std::fs::read(path).unwrap();
-        let mut fingerprint = serde_json::from_slice::<HardwareInfo>(&data).unwrap();
+    fn derive_machine_id() {
+        type Constructor = fn(&HardwareInfo) -> Result<MachineId, MissingHardwareInfo>;
 
-        test_derive_machine_id(&mut fingerprint, MachineType::Host, from_hardware_info);
+        check_cases(
+            [
+                Case {
+                    scenario: "host machine id from x86 fingerprint",
+                    input: (
+                        "x86_info.json",
+                        MachineType::Host,
+                        from_hardware_info as Constructor,
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "dpu machine id from dpu fingerprint",
+                    input: (
+                        "dpu_info.json",
+                        MachineType::Dpu,
+                        from_hardware_info as Constructor,
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "predicted-host machine id from dpu fingerprint",
+                    input: (
+                        "dpu_info.json",
+                        MachineType::PredictedHost,
+                        host_id_from_dpu_hardware_info as Constructor,
+                    ),
+                    expect: Yields(()),
+                },
+            ],
+            |(fixture, expected_type, constructor)| -> Result<(), ()> {
+                let path = format!("{TEST_DATA_DIR}/{fixture}");
+                let data = std::fs::read(path).unwrap();
+                let mut fingerprint = serde_json::from_slice::<HardwareInfo>(&data).unwrap();
+
+                test_derive_machine_id(&mut fingerprint, expected_type, constructor);
+                Ok(())
+            },
+        );
     }
 
+    // The error paths of `from_hardware_info_with_type`: a present-but-empty TPM
+    // certificate, DMI data with every serial blank, and neither TPM nor DMI
+    // present each map to a distinct `MissingHardwareInfo`. A non-empty TPM cert,
+    // or DMI data with at least one serial, derives an ID and so `Yields`.
     #[test]
-    fn derive_dpu_machine_id() {
-        let path = format!("{TEST_DATA_DIR}/dpu_info.json");
-        let data = std::fs::read(path).unwrap();
-        let mut fingerprint = serde_json::from_slice::<HardwareInfo>(&data).unwrap();
-
-        test_derive_machine_id(&mut fingerprint, MachineType::Dpu, from_hardware_info);
+    fn from_hardware_info_with_type_error_paths() {
+        check_cases(
+            [
+                Case {
+                    scenario: "present but empty TPM cert is rejected",
+                    input: info_for_id(Some(vec![]), None),
+                    expect: FailsWith(MissingHardwareInfo::TPMCertEmpty),
+                },
+                Case {
+                    scenario: "empty TPM cert is rejected even with valid serials present",
+                    input: info_for_id(Some(vec![]), Some(("p1", "b1", "c1"))),
+                    expect: FailsWith(MissingHardwareInfo::TPMCertEmpty),
+                },
+                Case {
+                    scenario: "DMI data with all serials blank is rejected",
+                    input: info_for_id(None, Some(("", "", ""))),
+                    expect: FailsWith(MissingHardwareInfo::Serial),
+                },
+                Case {
+                    scenario: "neither TPM nor DMI present",
+                    input: info_for_id(None, None),
+                    expect: FailsWith(MissingHardwareInfo::All),
+                },
+                Case {
+                    scenario: "non-empty TPM cert derives an ID",
+                    input: info_for_id(Some(vec![1, 2, 3, 4]), None),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "product serial alone derives an ID",
+                    input: info_for_id(None, Some(("p1", "", ""))),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "board serial alone derives an ID",
+                    input: info_for_id(None, Some(("", "b1", ""))),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "chassis serial alone derives an ID",
+                    input: info_for_id(None, Some(("", "", "c1"))),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "all three serials present derives an ID",
+                    input: info_for_id(None, Some(("p1", "b1", "c1"))),
+                    expect: Yields(()),
+                },
+            ],
+            // Drop the derived ID so a success is `Ok(())`: the `Yields(())` rows
+            // assert an ID was derived, while the error rows keep their exact
+            // `MissingHardwareInfo` for the `FailsWith` checks.
+            |info| from_hardware_info_with_type(&info, MachineType::Host).map(drop),
+        );
     }
 
+    // Which `MachineIdSource` the derivation selects: a present TPM certificate
+    // wins outright, and falls through to the product/board/chassis serial source
+    // only when no TPM certificate is present.
     #[test]
-    fn derive_host_machine_id_from_dpu_fingerprint() {
-        let path = format!("{TEST_DATA_DIR}/dpu_info.json");
-        let data = std::fs::read(path).unwrap();
-        let mut fingerprint = serde_json::from_slice::<HardwareInfo>(&data).unwrap();
+    fn from_hardware_info_with_type_selects_source() {
+        check_cases(
+            [
+                Case {
+                    scenario: "TPM certificate selects the Tpm source",
+                    input: info_for_id(Some(vec![9]), None),
+                    expect: Yields(MachineIdSource::Tpm),
+                },
+                Case {
+                    scenario: "TPM certificate wins even when serials are present",
+                    input: info_for_id(Some(vec![9]), Some(("p1", "b1", "c1"))),
+                    expect: Yields(MachineIdSource::Tpm),
+                },
+                Case {
+                    scenario: "serials select the ProductBoardChassisSerial source",
+                    input: info_for_id(None, Some(("p1", "", ""))),
+                    expect: Yields(MachineIdSource::ProductBoardChassisSerial),
+                },
+            ],
+            |info| {
+                from_hardware_info_with_type(&info, MachineType::Host)
+                    .map(|id| id.source())
+                    .map_err(drop)
+            },
+        );
+    }
 
-        test_derive_machine_id(
-            &mut fingerprint,
-            MachineType::PredictedHost,
-            host_id_from_dpu_hardware_info,
+    // The requested `MachineType` is carried onto the derived ID unchanged,
+    // independent of which hardware source produced the fingerprint.
+    #[test]
+    fn from_hardware_info_with_type_carries_machine_type() {
+        check_cases(
+            [
+                Case {
+                    scenario: "Host onto a TPM-derived ID",
+                    input: (info_for_id(Some(vec![7]), None), MachineType::Host),
+                    expect: Yields(MachineType::Host),
+                },
+                Case {
+                    scenario: "Dpu onto a TPM-derived ID",
+                    input: (info_for_id(Some(vec![7]), None), MachineType::Dpu),
+                    expect: Yields(MachineType::Dpu),
+                },
+                Case {
+                    scenario: "PredictedHost onto a TPM-derived ID",
+                    input: (info_for_id(Some(vec![7]), None), MachineType::PredictedHost),
+                    expect: Yields(MachineType::PredictedHost),
+                },
+                Case {
+                    scenario: "Host onto a serial-derived ID",
+                    input: (
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                        MachineType::Host,
+                    ),
+                    expect: Yields(MachineType::Host),
+                },
+                Case {
+                    scenario: "Dpu onto a serial-derived ID",
+                    input: (
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                        MachineType::Dpu,
+                    ),
+                    expect: Yields(MachineType::Dpu),
+                },
+                Case {
+                    scenario: "PredictedHost onto a serial-derived ID",
+                    input: (
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                        MachineType::PredictedHost,
+                    ),
+                    expect: Yields(MachineType::PredictedHost),
+                },
+            ],
+            |(info, ty)| {
+                from_hardware_info_with_type(&info, ty)
+                    .map(|id| id.machine_type())
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // The derivation is a deterministic hash: the same fingerprint and type
+    // produce the same ID string, and the string fields differing on type/source
+    // change the rendered prefix.
+    #[test]
+    fn from_hardware_info_with_type_is_deterministic() {
+        check_values(
+            [
+                Check {
+                    scenario: "same TPM cert and type yields the same id string",
+                    input: (
+                        info_for_id(Some(vec![1, 2, 3]), None),
+                        info_for_id(Some(vec![1, 2, 3]), None),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "different TPM certs yield different id strings",
+                    input: (
+                        info_for_id(Some(vec![1, 2, 3]), None),
+                        info_for_id(Some(vec![4, 5, 6]), None),
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "different serials yield different id strings",
+                    input: (
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                        info_for_id(None, Some(("p2", "b1", "c1"))),
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "same serials yield the same id string",
+                    input: (
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                    ),
+                    expect: true,
+                },
+            ],
+            |(left, right)| {
+                let left = from_hardware_info_with_type(&left, MachineType::Host).unwrap();
+                let right = from_hardware_info_with_type(&right, MachineType::Host).unwrap();
+                left.to_string() == right.to_string()
+            },
+        );
+    }
+
+    // The rendered ID string opens with the type+source prefix the constructed
+    // fingerprint and requested type imply (see `MachineType::id_prefix` and
+    // `MachineIdSource::id_char`).
+    #[test]
+    fn from_hardware_info_with_type_renders_expected_prefix() {
+        check_cases(
+            [
+                Case {
+                    scenario: "host + TPM renders fm100ht",
+                    input: (info_for_id(Some(vec![1]), None), MachineType::Host, "fm100ht"),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "dpu + TPM renders fm100dt",
+                    input: (info_for_id(Some(vec![1]), None), MachineType::Dpu, "fm100dt"),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "predicted host + serial renders fm100ps",
+                    input: (
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                        MachineType::PredictedHost,
+                        "fm100ps",
+                    ),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "host + serial renders fm100hs",
+                    input: (
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                        MachineType::Host,
+                        "fm100hs",
+                    ),
+                    expect: Yields(true),
+                },
+            ],
+            |(info, ty, prefix)| {
+                from_hardware_info_with_type(&info, ty)
+                    .map(|id| id.to_string().starts_with(prefix))
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // The rendered ID string is exactly `MACHINE_ID_LENGTH` characters regardless
+    // of which source or type produced it.
+    #[test]
+    fn from_hardware_info_with_type_renders_fixed_length() {
+        check_values(
+            [
+                Check {
+                    scenario: "TPM-derived host id length",
+                    input: (info_for_id(Some(vec![1, 2]), None), MachineType::Host),
+                    expect: MACHINE_ID_LENGTH,
+                },
+                Check {
+                    scenario: "serial-derived dpu id length",
+                    input: (
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                        MachineType::Dpu,
+                    ),
+                    expect: MACHINE_ID_LENGTH,
+                },
+                Check {
+                    scenario: "serial-derived predicted-host id length",
+                    input: (
+                        info_for_id(None, Some(("", "b1", ""))),
+                        MachineType::PredictedHost,
+                    ),
+                    expect: MACHINE_ID_LENGTH,
+                },
+            ],
+            |(info, ty)| {
+                from_hardware_info_with_type(&info, ty)
+                    .unwrap()
+                    .to_string()
+                    .len()
+            },
         );
     }
 }

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -2852,114 +2852,159 @@ pub fn dpf_based_dpu_provisioning_possible(
 mod tests {
     use std::str::FromStr;
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
+    // Deserializing a `FailureDetails` JSON blob: the parsed value must match the
+    // expected struct (cause + failed_at + source). The type is PartialEq, so we
+    // yield the whole struct.
     #[test]
-    fn test_json_deserialize_no_error() {
-        let serialized = r#"{"cause": "noerror", "source": "noerror", "failed_at": "2023-07-31T11:26:18.261228950Z"}"#;
-        let deserialized: FailureDetails = serde_json::from_str(serialized).unwrap();
-
-        let expected_time =
-            chrono::DateTime::parse_from_rfc3339("2023-07-31T11:26:18.261228950+00:00").unwrap();
-        assert_eq!(FailureCause::NoError, deserialized.cause);
-        assert_eq!(expected_time, deserialized.failed_at);
+    fn test_json_deserialize_failure_details() {
+        let failed_at = chrono::DateTime::parse_from_rfc3339("2023-07-31T11:26:18.261228950+00:00")
+            .unwrap()
+            .with_timezone(&Utc);
+        check_cases(
+            [
+                Case {
+                    scenario: "no error",
+                    input: r#"{"cause": "noerror", "source": "noerror", "failed_at": "2023-07-31T11:26:18.261228950Z"}"#,
+                    expect: Yields(FailureDetails {
+                        cause: FailureCause::NoError,
+                        failed_at,
+                        source: FailureSource::NoError,
+                    }),
+                },
+                Case {
+                    scenario: "nvme clean failed",
+                    input: r#"{"cause": {"nvmecleanfailed":{"err": "error1"}},  "source": "noerror","failed_at": "2023-07-31T11:26:18.261228950Z"}"#,
+                    expect: Yields(FailureDetails {
+                        cause: FailureCause::NVMECleanFailed {
+                            err: "error1".to_string(),
+                        },
+                        failed_at,
+                        source: FailureSource::NoError,
+                    }),
+                },
+            ],
+            |s| serde_json::from_str::<FailureDetails>(s).map_err(drop),
+        );
     }
 
+    // Reprovisioning states deserialize to the expected `ManagedHostState` AND
+    // render the expected `Display` string; we yield the (state, display) pair so
+    // both assertions ride along.
     #[test]
-    fn test_json_deserialize_nvme_error() {
-        let serialized = r#"{"cause": {"nvmecleanfailed":{"err": "error1"}},  "source": "noerror","failed_at": "2023-07-31T11:26:18.261228950Z"}"#;
-        let deserialized: FailureDetails = serde_json::from_str(serialized).unwrap();
-
-        let expected_time =
-            chrono::DateTime::parse_from_rfc3339("2023-07-31T11:26:18.261228950+00:00").unwrap();
-        assert_eq!(
-            FailureCause::NVMECleanFailed {
-                err: "error1".to_string()
+    fn test_json_deserialize_reprovisioning_states() {
+        let machine_id =
+            MachineId::from_str("fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng")
+                .unwrap();
+        check_cases(
+            [
+                Case {
+                    scenario: "dpu reprovision firmware upgrade",
+                    input: r#"{"state":"dpureprovision","dpu_states":{"states":{"fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng":"firmwareupgrade"}}}"#,
+                    expect: Yields((
+                        ManagedHostState::DPUReprovision {
+                            dpu_states: DpuReprovisionStates {
+                                states: HashMap::from([(
+                                    machine_id,
+                                    ReprovisionState::FirmwareUpgrade,
+                                )]),
+                            },
+                        },
+                        "Reprovisioning/FirmwareUpgrade".to_string(),
+                    )),
+                },
+                Case {
+                    scenario: "assigned dpu reprovision firmware upgrade",
+                    input: r#"{"state":"assigned","instance_state":{"state":"dpureprovision","dpu_states":{"states":{"fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng":"firmwareupgrade"}}}}"#,
+                    expect: Yields((
+                        ManagedHostState::Assigned {
+                            instance_state: InstanceState::DPUReprovision {
+                                dpu_states: DpuReprovisionStates {
+                                    states: HashMap::from([(
+                                        machine_id,
+                                        ReprovisionState::FirmwareUpgrade,
+                                    )]),
+                                },
+                            },
+                        },
+                        "Assigned/Reprovision/FirmwareUpgrade".to_string(),
+                    )),
+                },
+            ],
+            |s| {
+                serde_json::from_str::<ManagedHostState>(s)
+                    .map(|state| (state.clone(), state.to_string()))
+                    .map_err(drop)
             },
-            deserialized.cause
         );
-        assert_eq!(expected_time, deserialized.failed_at);
     }
 
+    // The remaining `ManagedHostState` JSON blobs each deserialize to a specific
+    // variant; the parsed value (PartialEq) is the whole assertion.
     #[test]
-    fn test_json_deserialize_reprovisioning_state() {
-        let serialized = r#"{"state":"dpureprovision","dpu_states":{"states":{"fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng":"firmwareupgrade"}}}"#;
-        let deserialized: ManagedHostState = serde_json::from_str(serialized).unwrap();
-        assert_eq!(
-            deserialized,
-            ManagedHostState::DPUReprovision {
-                dpu_states: DpuReprovisionStates {
-                    states: HashMap::from([(
-                        MachineId::from_str(
-                            "fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng"
-                        )
-                        .unwrap(),
-                        ReprovisionState::FirmwareUpgrade
-                    )])
-                }
-            }
-        );
-
-        assert_eq!(deserialized.to_string(), "Reprovisioning/FirmwareUpgrade");
-    }
-
-    #[test]
-    fn test_json_deserialize_reprovisioning_state_for_instance() {
-        let serialized = r#"{"state":"assigned","instance_state":{"state":"dpureprovision","dpu_states":{"states":{"fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng":"firmwareupgrade"}}}}"#;
-
-        let deserialized: ManagedHostState = serde_json::from_str(serialized).unwrap();
-
-        assert_eq!(
-            deserialized,
-            ManagedHostState::Assigned {
-                instance_state: InstanceState::DPUReprovision {
-                    dpu_states: DpuReprovisionStates {
-                        states: HashMap::from([(
-                            MachineId::from_str(
-                                "fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng"
-                            )
-                            .unwrap(),
-                            ReprovisionState::FirmwareUpgrade
-                        )])
-                    }
+    fn test_json_deserialize_managed_host_states() {
+        check_cases(
+            [
+                Case {
+                    scenario: "assigned booting with discovery image, default retry",
+                    input: r#"{"state":"assigned","instance_state":{"state":"bootingwithdiscoveryimage"}}"#,
+                    expect: Yields(ManagedHostState::Assigned {
+                        instance_state: InstanceState::BootingWithDiscoveryImage {
+                            retry: RetryInfo { count: 0 },
+                        },
+                    }),
                 },
-            }
-        );
-
-        assert_eq!(
-            deserialized.to_string(),
-            "Assigned/Reprovision/FirmwareUpgrade"
-        );
-    }
-
-    #[test]
-    fn test_json_deserialize_bootingwithdiscoveryimage_state_for_instance() {
-        let serialized =
-            r#"{"state":"assigned","instance_state":{"state":"bootingwithdiscoveryimage"}}"#;
-        let deserialized: ManagedHostState = serde_json::from_str(serialized).unwrap();
-
-        assert_eq!(
-            deserialized,
-            ManagedHostState::Assigned {
-                instance_state: InstanceState::BootingWithDiscoveryImage {
-                    retry: RetryInfo { count: 0 }
+                Case {
+                    scenario: "assigned booting with discovery image, explicit retry",
+                    input: r#"{"state":"assigned","instance_state":{"state":"bootingwithdiscoveryimage", "retry":{"count": 10}}}"#,
+                    expect: Yields(ManagedHostState::Assigned {
+                        instance_state: InstanceState::BootingWithDiscoveryImage {
+                            retry: RetryInfo { count: 10 },
+                        },
+                    }),
                 },
-            }
-        );
-    }
-
-    #[test]
-    fn test_json_deserialize_bootingwithdiscoveryimage_state_with_retry_for_instance() {
-        let serialized = r#"{"state":"assigned","instance_state":{"state":"bootingwithdiscoveryimage", "retry":{"count": 10}}}"#;
-        let deserialized: ManagedHostState = serde_json::from_str(serialized).unwrap();
-
-        assert_eq!(
-            deserialized,
-            ManagedHostState::Assigned {
-                instance_state: InstanceState::BootingWithDiscoveryImage {
-                    retry: RetryInfo { count: 10 }
-                }
-            }
+                Case {
+                    scenario: "host init polling bios setup, default retry",
+                    input: r#"{"state":"hostinit","machine_state":{"state":"pollingbiossetup"}}"#,
+                    expect: Yields(ManagedHostState::HostInit {
+                        machine_state: MachineState::PollingBiosSetup { retry_count: 0 },
+                    }),
+                },
+                Case {
+                    scenario: "host init polling bios setup, explicit retry count",
+                    input: r#"{"state":"hostinit","machine_state":{"state":"pollingbiossetup","retry_count":2}}"#,
+                    expect: Yields(ManagedHostState::HostInit {
+                        machine_state: MachineState::PollingBiosSetup { retry_count: 2 },
+                    }),
+                },
+                Case {
+                    scenario: "assigned host platform configuration polling bios setup (legacy)",
+                    input: r#"{"state":"assigned","instance_state":{"state":"hostplatformconfiguration","platform_config_state":{"state":"pollingbiossetup"}}}"#,
+                    expect: Yields(ManagedHostState::Assigned {
+                        instance_state: InstanceState::HostPlatformConfiguration {
+                            platform_config_state:
+                                HostPlatformConfigurationState::PollingBiosSetup { retry_count: 0 },
+                        },
+                    }),
+                },
+                Case {
+                    scenario: "host init waiting for lockdown",
+                    input: r#"{"state":"hostinit","machine_state":{"state":"waitingforlockdown","lockdown_info":{"state":"setlockdown","mode":"enable"}}}"#,
+                    expect: Yields(ManagedHostState::HostInit {
+                        machine_state: MachineState::WaitingForLockdown {
+                            lockdown_info: LockdownInfo {
+                                state: LockdownState::SetLockdown,
+                                mode: LockdownMode::Enable,
+                            },
+                        },
+                    }),
+                },
+            ],
+            |s| serde_json::from_str::<ManagedHostState>(s).map_err(drop),
         );
     }
 
@@ -2978,113 +3023,67 @@ mod tests {
         ));
     }
 
+    // Current `DpfState` tags deserialize to the expected variant and survive a
+    // serialize/deserialize round-trip; the unknown-tag rows verify the lenient
+    // fall-back to `DpfState::Unknown`. We yield the (parsed, round-tripped) pair
+    // so both the direct parse and the round-trip are asserted.
     #[test]
-    fn test_json_deserialize_platformconfig_machine_handler() {
-        // Test polling BIOS setup state
-        let serialized = r#"{"state":"hostinit","machine_state":{"state":"pollingbiossetup"}}"#;
-        let deserialized: ManagedHostState = serde_json::from_str(serialized).unwrap();
-
-        assert_eq!(
-            deserialized,
-            ManagedHostState::HostInit {
-                machine_state: MachineState::PollingBiosSetup { retry_count: 0 },
-            }
-        );
-    }
-
-    #[test]
-    fn test_json_deserialize_polling_bios_setup_with_retry_count() {
-        let serialized =
-            r#"{"state":"hostinit","machine_state":{"state":"pollingbiossetup","retry_count":2}}"#;
-        let deserialized: ManagedHostState = serde_json::from_str(serialized).unwrap();
-
-        assert_eq!(
-            deserialized,
-            ManagedHostState::HostInit {
-                machine_state: MachineState::PollingBiosSetup { retry_count: 2 },
-            }
-        );
-    }
-
-    #[test]
-    fn test_json_deserialize_host_platform_configuration_polling_bios_setup_legacy() {
-        let serialized = r#"{"state":"assigned","instance_state":{"state":"hostplatformconfiguration","platform_config_state":{"state":"pollingbiossetup"}}}"#;
-        let deserialized: ManagedHostState = serde_json::from_str(serialized).unwrap();
-
-        assert_eq!(
-            deserialized,
-            ManagedHostState::Assigned {
-                instance_state: InstanceState::HostPlatformConfiguration {
-                    platform_config_state: HostPlatformConfigurationState::PollingBiosSetup {
-                        retry_count: 0,
-                    },
+    fn test_dpf_state_deserialize_and_roundtrip() {
+        check_cases(
+            [
+                Case {
+                    scenario: "provisioning",
+                    input: r#"{"dpfstate":"provisioning"}"#,
+                    expect: Yields((DpfState::Provisioning, DpfState::Provisioning)),
                 },
-            }
-        );
-    }
-
-    #[test]
-    fn test_json_deserialize_lockdown_states() {
-        // Test Lockdown state
-        let serialized = r#"{"state":"hostinit","machine_state":{"state":"waitingforlockdown","lockdown_info":{"state":"setlockdown","mode":"enable"}}}"#;
-        let deserialized: ManagedHostState = serde_json::from_str(serialized).unwrap();
-
-        assert_eq!(
-            deserialized,
-            ManagedHostState::HostInit {
-                machine_state: MachineState::WaitingForLockdown {
-                    lockdown_info: LockdownInfo {
-                        state: LockdownState::SetLockdown,
-                        mode: LockdownMode::Enable,
-                    },
+                Case {
+                    scenario: "waiting for ready, no phase detail",
+                    input: r#"{"dpfstate":"waitingforready"}"#,
+                    expect: Yields((
+                        DpfState::WaitingForReady { phase_detail: None },
+                        DpfState::WaitingForReady { phase_detail: None },
+                    )),
                 },
-            }
-        );
-    }
-
-    /// Current tags deserialize to the correct variant and round-trip.
-    #[test]
-    fn test_dpf_state_deserialize_current_tags_and_roundtrip() {
-        for (json_tag, expected) in [
-            (r#"{"dpfstate":"provisioning"}"#, DpfState::Provisioning),
-            (
-                r#"{"dpfstate":"waitingforready"}"#,
-                DpfState::WaitingForReady { phase_detail: None },
-            ),
-            (
-                r#"{"dpfstate":"waitingforready","phase_detail":"some-detail"}"#,
-                DpfState::WaitingForReady {
-                    phase_detail: Some("some-detail".to_string()),
+                Case {
+                    scenario: "waiting for ready, with phase detail",
+                    input: r#"{"dpfstate":"waitingforready","phase_detail":"some-detail"}"#,
+                    expect: Yields((
+                        DpfState::WaitingForReady {
+                            phase_detail: Some("some-detail".to_string()),
+                        },
+                        DpfState::WaitingForReady {
+                            phase_detail: Some("some-detail".to_string()),
+                        },
+                    )),
                 },
-            ),
-            (r#"{"dpfstate":"deviceready"}"#, DpfState::DeviceReady),
-            (r#"{"dpfstate":"reprovisioning"}"#, DpfState::Reprovisioning),
-        ] {
-            let parsed: DpfState = serde_json::from_str(json_tag).unwrap();
-            assert_eq!(
-                parsed, expected,
-                "tag {} should deserialize to {:?}",
-                json_tag, expected
-            );
-            let serialized = serde_json::to_string(&parsed).unwrap();
-            let roundtrip: DpfState = serde_json::from_str(&serialized).unwrap();
-            assert_eq!(
-                roundtrip, expected,
-                "round-trip for {:?} must preserve value",
-                expected
-            );
-        }
-    }
-
-    #[test]
-    fn test_dpf_state_unknown_variant_falls_back() {
-        for json in [
-            r#"{"dpfstate":"somethingold"}"#,
-            r#"{"dpfstate":"bogus","extra":"field"}"#,
-        ] {
-            let parsed: DpfState = serde_json::from_str(json).unwrap();
-            assert_eq!(parsed, DpfState::Unknown);
-        }
+                Case {
+                    scenario: "device ready",
+                    input: r#"{"dpfstate":"deviceready"}"#,
+                    expect: Yields((DpfState::DeviceReady, DpfState::DeviceReady)),
+                },
+                Case {
+                    scenario: "reprovisioning",
+                    input: r#"{"dpfstate":"reprovisioning"}"#,
+                    expect: Yields((DpfState::Reprovisioning, DpfState::Reprovisioning)),
+                },
+                Case {
+                    scenario: "unknown tag falls back to Unknown",
+                    input: r#"{"dpfstate":"somethingold"}"#,
+                    expect: Yields((DpfState::Unknown, DpfState::Unknown)),
+                },
+                Case {
+                    scenario: "bogus tag with extra field falls back to Unknown",
+                    input: r#"{"dpfstate":"bogus","extra":"field"}"#,
+                    expect: Yields((DpfState::Unknown, DpfState::Unknown)),
+                },
+            ],
+            |s| {
+                let parsed: DpfState = serde_json::from_str(s).map_err(drop)?;
+                let serialized = serde_json::to_string(&parsed).map_err(drop)?;
+                let roundtrip: DpfState = serde_json::from_str(&serialized).map_err(drop)?;
+                Ok::<_, ()>((parsed, roundtrip))
+            },
+        );
     }
 
     fn alert_with_classifications(
@@ -3410,26 +3409,44 @@ mod tests {
         assert!(!profile.disable_lockdown);
     }
 
+    // A `HostProfile` serializes to the expected JSON and deserializes back to an
+    // equal value. We yield the (serialized json, round-tripped profile) pair so
+    // the exact serialized form and the round-trip equality are both asserted.
     #[test]
-    fn host_profile_serde_round_trip_lockdown_true() {
-        let profile = HostProfile {
-            disable_lockdown: true,
-        };
-        let json = serde_json::to_string(&profile).unwrap();
-        assert_eq!(json, r#"{"disable_lockdown":true}"#);
-        let back: HostProfile = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, profile);
-    }
-
-    #[test]
-    fn host_profile_serde_round_trip_lockdown_false() {
-        let profile = HostProfile {
-            disable_lockdown: false,
-        };
-        let json = serde_json::to_string(&profile).unwrap();
-        assert_eq!(json, r#"{"disable_lockdown":false}"#);
-        let back: HostProfile = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, profile);
+    fn host_profile_serde_round_trip() {
+        check_cases(
+            [
+                Case {
+                    scenario: "lockdown disabled (true)",
+                    input: HostProfile {
+                        disable_lockdown: true,
+                    },
+                    expect: Yields((
+                        r#"{"disable_lockdown":true}"#.to_string(),
+                        HostProfile {
+                            disable_lockdown: true,
+                        },
+                    )),
+                },
+                Case {
+                    scenario: "lockdown enabled (false)",
+                    input: HostProfile {
+                        disable_lockdown: false,
+                    },
+                    expect: Yields((
+                        r#"{"disable_lockdown":false}"#.to_string(),
+                        HostProfile {
+                            disable_lockdown: false,
+                        },
+                    )),
+                },
+            ],
+            |profile| {
+                let json = serde_json::to_string(&profile).map_err(drop)?;
+                let back: HostProfile = serde_json::from_str(&json).map_err(drop)?;
+                Ok::<_, ()>((json, back))
+            },
+        );
     }
 
     #[test]

--- a/crates/api-model/src/machine/network.rs
+++ b/crates/api-model/src/machine/network.rs
@@ -199,22 +199,171 @@ impl Default for ManagedHostNetworkConfig {
 #[cfg(test)]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use std::str::FromStr;
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use chrono::TimeZone;
+    use config_version::ConfigVersion;
 
     use super::*;
 
-    // Verify that existing JSON with IPv4 addresses (as stored in Postgres) still
-    // deserializes correctly after going from Ipv4Addr to IpAddr (to support v6).
+    // A stable MachineId for status observations; `any_observed_version_changed`
+    // never inspects it, so any valid id does.
+    fn machine_id() -> MachineId {
+        MachineId::from_str("fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg").unwrap()
+    }
+
+    // A fixed timestamp so observations built in tests compare deterministically.
+    fn observed_at() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()
+    }
+
+    // ConfigVersion built from its string form so the timestamp is deterministic
+    // (ConfigVersion::new() stamps `now()`, which makes two calls unequal).
+    fn config_version(version_nr: u64) -> ConfigVersion {
+        ConfigVersion::from_str(&format!("V{version_nr}-T1000000")).unwrap()
+    }
+
+    // A MachineNetworkStatusObservation carrying only the fields
+    // `any_observed_version_changed` reads; everything else is a fixed default.
+    fn network_status(
+        network_config_version: Option<ConfigVersion>,
+        instance_network_observation: Option<InstanceNetworkStatusObservation>,
+        extension_service_observation: Option<InstanceExtensionServiceStatusObservation>,
+    ) -> MachineNetworkStatusObservation {
+        MachineNetworkStatusObservation {
+            machine_id: machine_id(),
+            agent_version: None,
+            observed_at: observed_at(),
+            network_config_version,
+            client_certificate_expiry: None,
+            agent_version_superseded_at: None,
+            instance_network_observation,
+            extension_service_observation,
+            fabric_interfaces: Vec::new(),
+        }
+    }
+
+    fn network_observation(
+        config_version: ConfigVersion,
+        instance_config_version: Option<ConfigVersion>,
+    ) -> InstanceNetworkStatusObservation {
+        InstanceNetworkStatusObservation {
+            config_version,
+            instance_config_version,
+            interfaces: Vec::new(),
+            observed_at: observed_at(),
+        }
+    }
+
+    fn extension_observation(
+        config_version: ConfigVersion,
+        instance_config_version: Option<ConfigVersion>,
+    ) -> InstanceExtensionServiceStatusObservation {
+        InstanceExtensionServiceStatusObservation {
+            config_version,
+            instance_config_version,
+            extension_service_statuses: Vec::new(),
+            observed_at: observed_at(),
+        }
+    }
+
+    // JSON round-trips: serialize a config to JSON and deserialize it back; the
+    // config must survive intact. Covers the IPv4 case (existing Postgres JSON
+    // still deserializes after Ipv4Addr -> IpAddr) and the IPv6 case (new v6
+    // pools). The error type (serde_json::Error) is not PartialEq, so failing
+    // rows would use `Fails`; all rows here round-trip cleanly.
     #[test]
-    fn test_managed_host_network_config_ipv4_json_roundtrip() {
-        let config = ManagedHostNetworkConfig {
-            loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
-            secondary_overlay_vtep_ip: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
-            use_admin_network: Some(true),
-            quarantine_state: None,
-        };
-        let json = serde_json::to_string(&config).unwrap();
-        let deserialized: ManagedHostNetworkConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(config, deserialized);
+    fn test_managed_host_network_config_json_roundtrip() {
+        check_cases(
+            [
+                Case {
+                    scenario: "ipv4 round-trip",
+                    input: ManagedHostNetworkConfig {
+                        loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                        secondary_overlay_vtep_ip: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
+                        use_admin_network: Some(true),
+                        quarantine_state: None,
+                    },
+                    expect: Yields(ManagedHostNetworkConfig {
+                        loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                        secondary_overlay_vtep_ip: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
+                        use_admin_network: Some(true),
+                        quarantine_state: None,
+                    }),
+                },
+                Case {
+                    scenario: "ipv6 round-trip",
+                    input: ManagedHostNetworkConfig {
+                        loopback_ip: Some(IpAddr::V6(Ipv6Addr::new(
+                            0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
+                        ))),
+                        secondary_overlay_vtep_ip: Some(IpAddr::V6(Ipv6Addr::new(
+                            0xfd00, 0, 0, 0, 0, 0, 0, 0x42,
+                        ))),
+                        use_admin_network: Some(false),
+                        quarantine_state: None,
+                    },
+                    expect: Yields(ManagedHostNetworkConfig {
+                        loopback_ip: Some(IpAddr::V6(Ipv6Addr::new(
+                            0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
+                        ))),
+                        secondary_overlay_vtep_ip: Some(IpAddr::V6(Ipv6Addr::new(
+                            0xfd00, 0, 0, 0, 0, 0, 0, 0x42,
+                        ))),
+                        use_admin_network: Some(false),
+                        quarantine_state: None,
+                    }),
+                },
+            ],
+            |config| {
+                let json = serde_json::to_string(&config).map_err(drop)?;
+                serde_json::from_str::<ManagedHostNetworkConfig>(&json).map_err(drop)
+            },
+        );
+    }
+
+    // Deserialize raw JSON (as it would already exist in the database) into the
+    // IpAddr-typed config, projecting to the (loopback_ip, secondary_overlay_vtep_ip)
+    // pair the original tests asserted. Covers legacy IPv4 JSON and IPv6 JSON.
+    #[test]
+    fn test_managed_host_network_config_deserialize_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "legacy ipv4 json",
+                    input: r#"{
+                        "loopback_ip": "10.0.0.1",
+                        "secondary_overlay_vtep_ip": "172.16.0.5",
+                        "use_admin_network": true,
+                        "quarantine_state": null
+                    }"#,
+                    expect: Yields((
+                        Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                        Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
+                    )),
+                },
+                Case {
+                    scenario: "ipv6 json",
+                    input: r#"{
+                        "loopback_ip": "2001:db8::1",
+                        "secondary_overlay_vtep_ip": null,
+                        "use_admin_network": true,
+                        "quarantine_state": null
+                    }"#,
+                    expect: Yields((
+                        Some(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))),
+                        None,
+                    )),
+                },
+            ],
+            |json| {
+                serde_json::from_str::<ManagedHostNetworkConfig>(json)
+                    .map(|c| (c.loopback_ip, c.secondary_overlay_vtep_ip))
+                    .map_err(drop)
+            },
+        );
     }
 
     // Ensure that the JSON representation of an IPv4 address under IpAddr is
@@ -234,99 +383,467 @@ mod tests {
         assert!(json.contains(r#""loopback_ip":"10.0.0.1""#), "json: {json}");
     }
 
-    // Confirm that a raw JSON string with an IPv4 address (as would already
-    // exist in the database from before switching to IpAddr for v6 support),
-    // deserializes correctly into the new IpAddr type.
-    #[test]
-    fn test_managed_host_network_config_deserialize_legacy_ipv4_json() {
-        let json = r#"{
-            "loopback_ip": "10.0.0.1",
-            "secondary_overlay_vtep_ip": "172.16.0.5",
-            "use_admin_network": true,
-            "quarantine_state": null
-        }"#;
-        let config: ManagedHostNetworkConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(
-            config.loopback_ip,
-            Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))
-        );
-        assert_eq!(
-            config.secondary_overlay_vtep_ip,
-            Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5)))
-        );
-    }
-
-    // Verify that IPv6 addresses serialize/deserialize correctly through our
-    // ManagedHostNetworkConfig JSON representation, for the case when IPv6
-    // pools are enabled.
-    #[test]
-    fn test_managed_host_network_config_ipv6_json_roundtrip() {
-        let config = ManagedHostNetworkConfig {
-            loopback_ip: Some(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))),
-            secondary_overlay_vtep_ip: Some(IpAddr::V6(Ipv6Addr::new(
-                0xfd00, 0, 0, 0, 0, 0, 0, 0x42,
-            ))),
-            use_admin_network: Some(false),
-            quarantine_state: None,
-        };
-        let json = serde_json::to_string(&config).unwrap();
-        let deserialized: ManagedHostNetworkConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(config, deserialized);
-    }
-
-    // ...aand confirm deserialization of IPv6 addresses from JSON.
-    #[test]
-    fn test_managed_host_network_config_deserialize_ipv6_json() {
-        let json = r#"{
-            "loopback_ip": "2001:db8::1",
-            "secondary_overlay_vtep_ip": null,
-            "use_admin_network": true,
-            "quarantine_state": null
-        }"#;
-        let config: ManagedHostNetworkConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(
-            config.loopback_ip,
-            Some(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)))
-        );
-        assert_eq!(config.secondary_overlay_vtep_ip, None);
-    }
-
     // Ensure default ManagedHostNetworkConfig is still all-None/Some(true),
     // etc etc, and unaffected by the type change to IpAddr for v6 support.
+    // Folded from four hand-written asserts into a table that projects each
+    // default field; equality of the whole default config is exercised by the
+    // round-trip test.
     #[test]
     fn test_managed_host_network_config_default() {
-        let config = ManagedHostNetworkConfig::default();
-        assert_eq!(config.loopback_ip, None);
-        assert_eq!(config.secondary_overlay_vtep_ip, None);
-        assert_eq!(config.use_admin_network, Some(true));
-        assert_eq!(config.quarantine_state, None);
+        let default = ManagedHostNetworkConfig::default();
+        check_values(
+            [
+                Check {
+                    scenario: "loopback_ip defaults to None",
+                    input: default.loopback_ip,
+                    expect: None,
+                },
+                Check {
+                    scenario: "secondary_overlay_vtep_ip defaults to None",
+                    input: default.secondary_overlay_vtep_ip,
+                    expect: None,
+                },
+            ],
+            |ip| ip,
+        );
+        check_values(
+            [Check {
+                scenario: "use_admin_network defaults to Some(true)",
+                input: default.use_admin_network,
+                expect: Some(true),
+            }],
+            |flag| flag,
+        );
+        Check {
+            scenario: "quarantine_state defaults to None",
+            input: default.quarantine_state,
+            expect: None,
+        }
+        .check(|qs| qs);
     }
 
     // Verify that IpAddr::to_string() produces the expected format for both
     // address families, since several call sites throughout the codebase
-    // use .to_string() on the loopback_ip value.
+    // use .to_string() on the loopback_ip value. Folded from a pair of
+    // hand-written asserts into a table covering both families plus the
+    // boundary/canonicalization cases (zero, broadcast, all-ones,
+    // loopback, embedded-IPv4) where formatting can surprise.
     #[test]
     fn test_ip_addr_to_string_format() {
-        let v4 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
-        assert_eq!(v4.to_string(), "10.0.0.1");
-
-        let v6 = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
-        assert_eq!(v6.to_string(), "2001:db8::1");
+        check_values(
+            [
+                Check {
+                    scenario: "ipv4",
+                    input: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                    expect: "10.0.0.1".to_string(),
+                },
+                Check {
+                    scenario: "ipv4 unspecified",
+                    input: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+                    expect: "0.0.0.0".to_string(),
+                },
+                Check {
+                    scenario: "ipv4 broadcast",
+                    input: IpAddr::V4(Ipv4Addr::new(255, 255, 255, 255)),
+                    expect: "255.255.255.255".to_string(),
+                },
+                Check {
+                    scenario: "ipv4 loopback",
+                    input: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                    expect: "127.0.0.1".to_string(),
+                },
+                Check {
+                    scenario: "ipv6 compressed",
+                    input: IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
+                    expect: "2001:db8::1".to_string(),
+                },
+                Check {
+                    scenario: "ipv6 unspecified collapses to ::",
+                    input: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
+                    expect: "::".to_string(),
+                },
+                Check {
+                    scenario: "ipv6 loopback collapses to ::1",
+                    input: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+                    expect: "::1".to_string(),
+                },
+                Check {
+                    scenario: "ipv6 full (no run to compress)",
+                    input: IpAddr::V6(Ipv6Addr::new(
+                        0xfd00, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x42,
+                    )),
+                    expect: "fd00:1:2:3:4:5:6:42".to_string(),
+                },
+            ],
+            |ip| ip.to_string(),
+        );
     }
 
-    // Verify that IPv4 strings parse correctly as IpAddr, since resource pools
-    // store values as strings and parse them via IpAddr::from_str.
+    // ManagedHostQuarantineState::reason_str() returns the reason or an empty
+    // string when None. ManagedHostQuarantineMode has a single variant today;
+    // its as_str()/mode_str() must render it exactly so the persisted form is
+    // stable.
+    #[test]
+    fn test_quarantine_reason_str() {
+        check_values(
+            [
+                Check {
+                    scenario: "present reason passes through",
+                    input: ManagedHostQuarantineState {
+                        reason: Some("flooding the fabric".to_string()),
+                        mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                    },
+                    expect: "flooding the fabric".to_string(),
+                },
+                Check {
+                    scenario: "empty reason stays empty",
+                    input: ManagedHostQuarantineState {
+                        reason: Some(String::new()),
+                        mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                    },
+                    expect: String::new(),
+                },
+                Check {
+                    scenario: "missing reason yields empty string",
+                    input: ManagedHostQuarantineState {
+                        reason: None,
+                        mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                    },
+                    expect: String::new(),
+                },
+            ],
+            |state| state.reason_str().to_string(),
+        );
+    }
+
+    #[test]
+    fn test_quarantine_mode_str() {
+        check_values(
+            [Check {
+                scenario: "block-all-traffic renders its name",
+                input: ManagedHostQuarantineMode::BlockAllTraffic,
+                expect: "BlockAllTraffic".to_string(),
+            }],
+            |mode| {
+                ManagedHostQuarantineState {
+                    reason: None,
+                    mode,
+                }
+                .mode_str()
+                .to_string()
+            },
+        );
+    }
+
+    // any_observed_version_changed compares the network config version and then
+    // the two nested observations (instance-network and extension-service),
+    // each via a None/Some pairing that delegates to the sub-observation's own
+    // comparison. Enumerate every arm: matching versions, differing versions,
+    // each None/Some transition, and a deeper change inside each Some/Some pair.
+    #[test]
+    fn test_any_observed_version_changed() {
+        let v1 = config_version(1);
+        let v2 = config_version(2);
+
+        check_values(
+            [
+                Check {
+                    scenario: "identical observations -> unchanged",
+                    input: (network_status(Some(v1), None, None), network_status(Some(v1), None, None)),
+                    expect: false,
+                },
+                Check {
+                    scenario: "both network config versions None -> unchanged",
+                    input: (network_status(None, None, None), network_status(None, None, None)),
+                    expect: false,
+                },
+                Check {
+                    scenario: "network config version differs -> changed",
+                    input: (network_status(Some(v1), None, None), network_status(Some(v2), None, None)),
+                    expect: true,
+                },
+                Check {
+                    scenario: "network config version None vs Some -> changed",
+                    input: (network_status(None, None, None), network_status(Some(v1), None, None)),
+                    expect: true,
+                },
+                Check {
+                    scenario: "network config version Some vs None -> changed",
+                    input: (network_status(Some(v1), None, None), network_status(None, None, None)),
+                    expect: true,
+                },
+                Check {
+                    scenario: "instance observation None vs Some -> changed",
+                    input: (
+                        network_status(Some(v1), None, None),
+                        network_status(Some(v1), Some(network_observation(v1, None)), None),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "instance observation Some vs None -> changed",
+                    input: (
+                        network_status(Some(v1), Some(network_observation(v1, None)), None),
+                        network_status(Some(v1), None, None),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "instance observation Some/Some identical -> unchanged",
+                    input: (
+                        network_status(Some(v1), Some(network_observation(v1, Some(v1))), None),
+                        network_status(Some(v1), Some(network_observation(v1, Some(v1))), None),
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "instance observation inner config version differs -> changed",
+                    input: (
+                        network_status(Some(v1), Some(network_observation(v1, None)), None),
+                        network_status(Some(v1), Some(network_observation(v2, None)), None),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "instance observation inner instance-config version differs -> changed",
+                    input: (
+                        network_status(Some(v1), Some(network_observation(v1, Some(v1))), None),
+                        network_status(Some(v1), Some(network_observation(v1, Some(v2))), None),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "extension observation None vs Some -> changed",
+                    input: (
+                        network_status(Some(v1), None, None),
+                        network_status(Some(v1), None, Some(extension_observation(v1, None))),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "extension observation Some vs None -> changed",
+                    input: (
+                        network_status(Some(v1), None, Some(extension_observation(v1, None))),
+                        network_status(Some(v1), None, None),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "extension observation Some/Some identical -> unchanged",
+                    input: (
+                        network_status(Some(v1), None, Some(extension_observation(v1, Some(v1)))),
+                        network_status(Some(v1), None, Some(extension_observation(v1, Some(v1)))),
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "extension observation inner config version differs -> changed",
+                    input: (
+                        network_status(Some(v1), None, Some(extension_observation(v1, None))),
+                        network_status(Some(v1), None, Some(extension_observation(v2, None))),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "extension observation inner instance-config version differs -> changed",
+                    input: (
+                        network_status(Some(v1), None, Some(extension_observation(v1, Some(v1)))),
+                        network_status(Some(v1), None, Some(extension_observation(v1, Some(v2)))),
+                    ),
+                    expect: true,
+                },
+            ],
+            |(a, b)| a.any_observed_version_changed(&b),
+        );
+    }
+
+    // Parse pool strings as IpAddr (resource pools store values as strings and
+    // parse them via IpAddr::from_str). Yielding the exact IpAddr value also
+    // covers the original is_ipv4()/is_ipv6() family assertions. AddrParseError
+    // is not PartialEq, so failing rows would use `Fails`; both rows parse.
     #[test]
     fn test_ip_addr_parse_from_pool_strings() {
-        let v4: IpAddr = "10.0.0.1".parse().unwrap();
-        assert!(v4.is_ipv4());
-        assert_eq!(v4, IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+        check_cases(
+            [
+                Case {
+                    scenario: "ipv4 string",
+                    input: "10.0.0.1",
+                    expect: Yields(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                },
+                Case {
+                    scenario: "ipv6 string",
+                    input: "2001:db8::1",
+                    expect: Yields(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))),
+                },
+                Case {
+                    scenario: "ipv4 unspecified",
+                    input: "0.0.0.0",
+                    expect: Yields(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))),
+                },
+                Case {
+                    scenario: "ipv4 broadcast",
+                    input: "255.255.255.255",
+                    expect: Yields(IpAddr::V4(Ipv4Addr::new(255, 255, 255, 255))),
+                },
+                Case {
+                    scenario: "ipv6 unspecified",
+                    input: "::",
+                    expect: Yields(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0))),
+                },
+                Case {
+                    scenario: "ipv6 loopback",
+                    input: "::1",
+                    expect: Yields(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))),
+                },
+                Case {
+                    scenario: "empty string is rejected",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-address text is rejected",
+                    input: "not-an-ip",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ipv4 octet out of range is rejected",
+                    input: "256.0.0.1",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ipv4 with too few octets is rejected",
+                    input: "10.0.0",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ipv4 with trailing whitespace is rejected",
+                    input: "10.0.0.1 ",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ipv6 with double :: is rejected",
+                    input: "2001::db8::1",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "cidr suffix is not an address",
+                    input: "10.0.0.0/24",
+                    expect: Fails,
+                },
+            ],
+            |s| s.parse::<IpAddr>().map_err(drop),
+        );
+    }
 
-        let v6: IpAddr = "2001:db8::1".parse().unwrap();
-        assert!(v6.is_ipv6());
-        assert_eq!(
-            v6,
-            IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))
+    // Deserialize raw JSON whose shape is malformed or whose IP strings are
+    // invalid; serde_json::Error is not PartialEq, so rejected rows use `Fails`.
+    // Also covers a populated quarantine_state, which the earlier deserialize
+    // table left null.
+    #[test]
+    fn test_managed_host_network_config_deserialize_errors() {
+        check_cases(
+            [
+                Case {
+                    scenario: "well-formed with quarantine state",
+                    input: r#"{
+                        "loopback_ip": "10.0.0.1",
+                        "secondary_overlay_vtep_ip": null,
+                        "use_admin_network": false,
+                        "quarantine_state": {
+                            "reason": "noisy",
+                            "mode": "BlockAllTraffic"
+                        }
+                    }"#,
+                    expect: Yields(ManagedHostNetworkConfig {
+                        loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                        secondary_overlay_vtep_ip: None,
+                        use_admin_network: Some(false),
+                        quarantine_state: Some(ManagedHostQuarantineState {
+                            reason: Some("noisy".to_string()),
+                            mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                        }),
+                    }),
+                },
+                Case {
+                    scenario: "empty object defaults all optional fields",
+                    input: "{}",
+                    expect: Yields(ManagedHostNetworkConfig {
+                        loopback_ip: None,
+                        secondary_overlay_vtep_ip: None,
+                        use_admin_network: None,
+                        quarantine_state: None,
+                    }),
+                },
+                Case {
+                    scenario: "invalid loopback ip string is rejected",
+                    input: r#"{"loopback_ip": "not-an-ip"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown quarantine mode is rejected",
+                    input: r#"{"quarantine_state": {"mode": "Nope"}}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wrong type for use_admin_network is rejected",
+                    input: r#"{"use_admin_network": "true"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "truncated json is rejected",
+                    input: r#"{"loopback_ip": "10.0.0.1""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-object json is rejected",
+                    input: "[]",
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<ManagedHostNetworkConfig>(json).map_err(drop),
+        );
+    }
+
+    // The default config round-trips through JSON unchanged, and the
+    // quarantine-state variant survives a round-trip too. Folds the prior
+    // single-default assertion into the round-trip table that already exists
+    // for the IP cases. serde_json::Error is not PartialEq, so failing rows
+    // would use `Fails`.
+    #[test]
+    fn test_managed_host_network_config_default_and_quarantine_roundtrip() {
+        check_cases(
+            [
+                Case {
+                    scenario: "default round-trips",
+                    input: ManagedHostNetworkConfig::default(),
+                    expect: Yields(ManagedHostNetworkConfig::default()),
+                },
+                Case {
+                    scenario: "quarantine state round-trips",
+                    input: ManagedHostNetworkConfig {
+                        loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                        secondary_overlay_vtep_ip: None,
+                        use_admin_network: Some(true),
+                        quarantine_state: Some(ManagedHostQuarantineState {
+                            reason: Some("flooded".to_string()),
+                            mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                        }),
+                    },
+                    expect: Yields(ManagedHostNetworkConfig {
+                        loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                        secondary_overlay_vtep_ip: None,
+                        use_admin_network: Some(true),
+                        quarantine_state: Some(ManagedHostQuarantineState {
+                            reason: Some("flooded".to_string()),
+                            mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                        }),
+                    }),
+                },
+            ],
+            |config| {
+                let json = serde_json::to_string(&config).map_err(drop)?;
+                serde_json::from_str::<ManagedHostNetworkConfig>(&json).map_err(drop)
+            },
         );
     }
 }

--- a/crates/api-model/src/machine/upgrade_policy.rs
+++ b/crates/api-model/src/machine/upgrade_policy.rs
@@ -361,6 +361,61 @@ fn test_parse_version() {
                 }),
             },
             Case {
+                scenario: "date tag with rc and hotfix (3 parts, non-numeric second)",
+                input: "v2024.05.02-rc3-0",
+                expect: Yields(BuildVersion {
+                    version: "2024.05.02",
+                    rc: "rc3",
+                    hotfix: 0,
+                    commits: 0,
+                    git_hash: "",
+                }),
+            },
+            Case {
+                scenario: "date tag with rc, hotfix, commits and hash (5 parts)",
+                input: "v2024.05.02-rc4-0-27-gc3ce4d5d",
+                expect: Yields(BuildVersion {
+                    version: "2024.05.02",
+                    rc: "rc4",
+                    hotfix: 0,
+                    commits: 27,
+                    git_hash: "gc3ce4d5d",
+                }),
+            },
+            Case {
+                scenario: "bare semver, two parts only is treated as rc",
+                input: "v2023.09-rc1",
+                expect: Yields(BuildVersion {
+                    version: "2023.09",
+                    rc: "rc1",
+                    hotfix: 0,
+                    commits: 0,
+                    git_hash: "",
+                }),
+            },
+            Case {
+                scenario: "semver with rc, hotfix, commits and hash (5 parts)",
+                input: "v0.0.4-rc4-0-27-gc3ce4d5d",
+                expect: Yields(BuildVersion {
+                    version: "0.0.4",
+                    rc: "rc4",
+                    hotfix: 0,
+                    commits: 27,
+                    git_hash: "gc3ce4d5d",
+                }),
+            },
+            Case {
+                scenario: "nonzero hotfix parses",
+                input: "v2024.05.02-rc3-2",
+                expect: Yields(BuildVersion {
+                    version: "2024.05.02",
+                    rc: "rc3",
+                    hotfix: 2,
+                    commits: 0,
+                    git_hash: "",
+                }),
+            },
+            Case {
                 scenario: "too many dash-separated parts",
                 input: "v2023.08-rc1-0-3-g123eff-x",
                 expect: Fails,
@@ -368,6 +423,31 @@ fn test_parse_version() {
             Case {
                 scenario: "no version number after the 'v'",
                 input: "v-rc1",
+                expect: Fails,
+            },
+            Case {
+                scenario: "empty string",
+                input: "",
+                expect: Fails,
+            },
+            Case {
+                scenario: "missing the leading 'v'",
+                input: "2023.08",
+                expect: Fails,
+            },
+            Case {
+                scenario: "just the leading 'v'",
+                input: "v",
+                expect: Fails,
+            },
+            Case {
+                scenario: "first part does not start with a digit",
+                input: "vfoo.bar",
+                expect: Fails,
+            },
+            Case {
+                scenario: "leading 'v' followed by a dash",
+                input: "v-",
                 expect: Fails,
             },
         ],
@@ -380,7 +460,449 @@ fn test_parse_version() {
 
 #[cfg(test)]
 mod tests {
-    use super::BuildVersion;
+    use std::cmp::Ordering;
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
+    use super::{AgentUpgradePolicy, BuildVersion};
+    use crate::firmware::AgentUpgradePolicyChoice;
+
+    #[test]
+    fn agent_upgrade_policy_display() {
+        check_values(
+            [
+                Check {
+                    scenario: "off",
+                    input: AgentUpgradePolicy::Off,
+                    expect: "Off".to_string(),
+                },
+                Check {
+                    scenario: "up-only",
+                    input: AgentUpgradePolicy::UpOnly,
+                    expect: "UpOnly".to_string(),
+                },
+                Check {
+                    scenario: "up-down",
+                    input: AgentUpgradePolicy::UpDown,
+                    expect: "UpDown".to_string(),
+                },
+            ],
+            |p| p.to_string(),
+        );
+    }
+
+    #[test]
+    fn agent_upgrade_policy_from_str() {
+        check_values(
+            [
+                Check {
+                    scenario: "canonical Off",
+                    input: "Off",
+                    expect: AgentUpgradePolicy::Off,
+                },
+                Check {
+                    scenario: "lowercase off",
+                    input: "off",
+                    expect: AgentUpgradePolicy::Off,
+                },
+                Check {
+                    scenario: "canonical UpOnly",
+                    input: "UpOnly",
+                    expect: AgentUpgradePolicy::UpOnly,
+                },
+                Check {
+                    scenario: "lowercase uponly",
+                    input: "uponly",
+                    expect: AgentUpgradePolicy::UpOnly,
+                },
+                Check {
+                    scenario: "snake_case up_only",
+                    input: "up_only",
+                    expect: AgentUpgradePolicy::UpOnly,
+                },
+                Check {
+                    scenario: "canonical UpDown",
+                    input: "UpDown",
+                    expect: AgentUpgradePolicy::UpDown,
+                },
+                Check {
+                    scenario: "lowercase updown",
+                    input: "updown",
+                    expect: AgentUpgradePolicy::UpDown,
+                },
+                Check {
+                    scenario: "snake_case up_down",
+                    input: "up_down",
+                    expect: AgentUpgradePolicy::UpDown,
+                },
+                Check {
+                    scenario: "unknown string falls back to Off",
+                    input: "nonsense",
+                    expect: AgentUpgradePolicy::Off,
+                },
+                Check {
+                    scenario: "empty string falls back to Off",
+                    input: "",
+                    expect: AgentUpgradePolicy::Off,
+                },
+                Check {
+                    scenario: "wrong casing falls back to Off",
+                    input: "OFF",
+                    expect: AgentUpgradePolicy::Off,
+                },
+            ],
+            AgentUpgradePolicy::from,
+        );
+    }
+
+    #[test]
+    fn agent_upgrade_policy_from_choice() {
+        check_values(
+            [
+                Check {
+                    scenario: "off",
+                    input: AgentUpgradePolicyChoice::Off,
+                    expect: AgentUpgradePolicy::Off,
+                },
+                Check {
+                    scenario: "up-only",
+                    input: AgentUpgradePolicyChoice::UpOnly,
+                    expect: AgentUpgradePolicy::UpOnly,
+                },
+                Check {
+                    scenario: "up-down",
+                    input: AgentUpgradePolicyChoice::UpDown,
+                    expect: AgentUpgradePolicy::UpDown,
+                },
+            ],
+            AgentUpgradePolicy::from,
+        );
+    }
+
+    #[test]
+    fn should_upgrade_decides_per_policy() {
+        struct Inputs {
+            policy: AgentUpgradePolicy,
+            agent: &'static str,
+            carbide: &'static str,
+        }
+        check_values(
+            [
+                // Off never upgrades, regardless of versions.
+                Check {
+                    scenario: "off, agent older",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::Off,
+                        agent: "v2023.08",
+                        carbide: "v2023.09",
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "off, agent newer",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::Off,
+                        agent: "v2023.09",
+                        carbide: "v2023.08",
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "off, invalid agent version",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::Off,
+                        agent: "garbage",
+                        carbide: "v2023.08",
+                    },
+                    expect: false,
+                },
+                // UpOnly upgrades only when the agent is strictly older.
+                Check {
+                    scenario: "up-only, agent older",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpOnly,
+                        agent: "v2023.08",
+                        carbide: "v2023.09",
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "up-only, agent equal",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpOnly,
+                        agent: "v2023.09",
+                        carbide: "v2023.09",
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "up-only, agent newer (no downgrade)",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpOnly,
+                        agent: "v2023.09",
+                        carbide: "v2023.08",
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "up-only, agent older by commit count",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpOnly,
+                        agent: "v2023.08-14-gbc549a66",
+                        carbide: "v2023.08-92-g1b48e8b6",
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "up-only, semver agent newer than date carbide (no upgrade)",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpOnly,
+                        agent: "v0.0.1",
+                        carbide: "v2024.05.10-rc1-3",
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "up-only, date agent older than semver carbide",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpOnly,
+                        agent: "v2024.05.10-rc1-3",
+                        carbide: "v0.0.1",
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "up-only, invalid agent version forces upgrade",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpOnly,
+                        agent: "not-a-version",
+                        carbide: "v2023.09",
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "up-only, invalid carbide version waits (no upgrade)",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpOnly,
+                        agent: "v2023.08",
+                        carbide: "not-a-version",
+                    },
+                    expect: false,
+                },
+                // UpDown upgrades on any string difference.
+                Check {
+                    scenario: "up-down, identical versions",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpDown,
+                        agent: "v2023.09",
+                        carbide: "v2023.09",
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "up-down, agent older",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpDown,
+                        agent: "v2023.08",
+                        carbide: "v2023.09",
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "up-down, agent newer (downgrade)",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpDown,
+                        agent: "v2023.09",
+                        carbide: "v2023.08",
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "up-down, differing only by hash",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpDown,
+                        agent: "v2023.08-92-g1b48e8b6",
+                        carbide: "v2023.08-92-gdeadbeef",
+                    },
+                    expect: true,
+                },
+            ],
+            |Inputs {
+                 policy,
+                 agent,
+                 carbide,
+             }| policy.should_upgrade(agent, carbide),
+        );
+    }
+
+    #[test]
+    fn build_version_display_round_trips() {
+        check_cases(
+            [
+                Case {
+                    scenario: "bare date tag",
+                    input: "v2023.08",
+                    expect: Yields("v2023.08".to_string()),
+                },
+                Case {
+                    scenario: "bare semver tag",
+                    input: "v1.2.3",
+                    expect: Yields("v1.2.3".to_string()),
+                },
+                Case {
+                    scenario: "date tag with commits and hash",
+                    input: "v2023.08-92-g1b48e8b6",
+                    expect: Yields("v2023.08-92-g1b48e8b6".to_string()),
+                },
+                Case {
+                    scenario: "rc and hotfix both render",
+                    input: "v2024.05.02-rc3-0",
+                    expect: Yields("v2024.05.02-rc3-0".to_string()),
+                },
+                Case {
+                    scenario: "full version with rc, hotfix, commits and hash",
+                    input: "v2024.05.02-rc4-0-27-gc3ce4d5d",
+                    expect: Yields("v2024.05.02-rc4-0-27-gc3ce4d5d".to_string()),
+                },
+                Case {
+                    scenario: "two-part input normalizes hotfix to 0",
+                    input: "v2023.09-rc1",
+                    expect: Yields("v2023.09-rc1-0".to_string()),
+                },
+            ],
+            |s| {
+                BuildVersion::try_from(s)
+                    .map(|bv| bv.to_string())
+                    .map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn build_version_ordering() {
+        struct Pair {
+            left: &'static str,
+            right: &'static str,
+        }
+        check_values(
+            [
+                Check {
+                    scenario: "older date less than newer date",
+                    input: Pair {
+                        left: "v2023.08",
+                        right: "v2023.09",
+                    },
+                    expect: Ordering::Less,
+                },
+                Check {
+                    scenario: "equal date tags",
+                    input: Pair {
+                        left: "v2023.08",
+                        right: "v2023.08",
+                    },
+                    expect: Ordering::Equal,
+                },
+                Check {
+                    scenario: "newer date greater than older date",
+                    input: Pair {
+                        left: "v2023.09",
+                        right: "v2023.08",
+                    },
+                    expect: Ordering::Greater,
+                },
+                Check {
+                    scenario: "more commits is greater",
+                    input: Pair {
+                        left: "v2023.08-92-g1b48e8b6",
+                        right: "v2023.08-14-gbc549a66",
+                    },
+                    expect: Ordering::Greater,
+                },
+                Check {
+                    scenario: "date is always less than semver",
+                    input: Pair {
+                        left: "v2024.05.10-rc1-3",
+                        right: "v0.0.1",
+                    },
+                    expect: Ordering::Less,
+                },
+                Check {
+                    scenario: "semver is always greater than date",
+                    input: Pair {
+                        left: "v0.0.1",
+                        right: "v2024.05.10-rc1-3",
+                    },
+                    expect: Ordering::Greater,
+                },
+                Check {
+                    scenario: "lower semver less than higher semver",
+                    input: Pair {
+                        left: "v0.0.1",
+                        right: "v0.0.4-rc4-0-g2a3c98cac",
+                    },
+                    expect: Ordering::Less,
+                },
+                Check {
+                    scenario: "semver major dominates",
+                    input: Pair {
+                        left: "v0.0.4-rc4-0-g2a3c98cac",
+                        right: "v1.0.0",
+                    },
+                    expect: Ordering::Less,
+                },
+                Check {
+                    scenario: "equal semver tags",
+                    input: Pair {
+                        left: "v1.2.3",
+                        right: "v1.2.3",
+                    },
+                    expect: Ordering::Equal,
+                },
+                Check {
+                    scenario: "semver patch difference",
+                    input: Pair {
+                        left: "v0.0.4",
+                        right: "v0.0.5",
+                    },
+                    expect: Ordering::Less,
+                },
+            ],
+            |Pair { left, right }| {
+                let l = BuildVersion::try_from(left).unwrap();
+                let r = BuildVersion::try_from(right).unwrap();
+                l.cmp(&r)
+            },
+        );
+    }
+
+    #[test]
+    fn build_version_partial_cmp_matches_cmp() {
+        check_values(
+            [
+                Check {
+                    scenario: "less",
+                    input: ("v0.0.1", "v1.0.0"),
+                    expect: Some(Ordering::Less),
+                },
+                Check {
+                    scenario: "greater",
+                    input: ("v1.0.0", "v0.0.1"),
+                    expect: Some(Ordering::Greater),
+                },
+                Check {
+                    scenario: "equal",
+                    input: ("v1.0.0", "v1.0.0"),
+                    expect: Some(Ordering::Equal),
+                },
+            ],
+            |(l, r)| {
+                BuildVersion::try_from(l)
+                    .unwrap()
+                    .partial_cmp(&BuildVersion::try_from(r).unwrap())
+            },
+        );
+    }
 
     #[test]
     fn test_compare_versions() -> eyre::Result<()> {
@@ -442,23 +964,6 @@ mod tests {
                 panic!("Pos {i} does not match. Got {got} expected {expect}.");
             }
         }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_semver_comparison() -> eyre::Result<()> {
-        let v0_0_1 = BuildVersion::try_from("v0.0.1")?;
-        let v0_0_4 = BuildVersion::try_from("v0.0.4-rc4-0-g2a3c98cac")?;
-        let v1_0_0 = BuildVersion::try_from("v1.0.0")?;
-        let v_date = BuildVersion::try_from("v2024.05.10-rc1-3")?;
-
-        // Semver ordering
-        assert!(v0_0_1 < v0_0_4);
-        assert!(v0_0_4 < v1_0_0);
-
-        // Semver is always newer than date-based
-        assert!(v_date < v0_0_1);
 
         Ok(())
     }

--- a/crates/api-model/src/machine_validation.rs
+++ b/crates/api-model/src/machine_validation.rs
@@ -269,6 +269,9 @@ impl<'r> FromRow<'r, PgRow> for MachineValidationResult {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
     #[test]
@@ -280,5 +283,229 @@ mod tests {
         assert!(obj["test_id"].is_null());
         assert!(obj["is_enabled"].is_null());
         assert_eq!(obj["supported_platforms"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn state_from_str_parses_every_variant_and_rejects_the_rest() {
+        check_cases(
+            [
+                Case {
+                    scenario: "Started",
+                    input: "Started",
+                    expect: Yields(MachineValidationState::Started),
+                },
+                Case {
+                    scenario: "InProgress",
+                    input: "InProgress",
+                    expect: Yields(MachineValidationState::InProgress),
+                },
+                Case {
+                    scenario: "Success",
+                    input: "Success",
+                    expect: Yields(MachineValidationState::Success),
+                },
+                Case {
+                    scenario: "Skipped",
+                    input: "Skipped",
+                    expect: Yields(MachineValidationState::Skipped),
+                },
+                Case {
+                    scenario: "Failed",
+                    input: "Failed",
+                    expect: Yields(MachineValidationState::Failed),
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown variant",
+                    input: "Pending",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "lowercase is not accepted",
+                    input: "started",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "uppercase is not accepted",
+                    input: "SUCCESS",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "leading whitespace is not trimmed",
+                    input: " Started",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "trailing whitespace is not trimmed",
+                    input: "Failed ",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "numeric input",
+                    input: "0",
+                    expect: Fails,
+                },
+            ],
+            |s| MachineValidationState::from_str(s).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn state_display_renders_the_variant_name() {
+        check_values(
+            [
+                Check {
+                    scenario: "Started",
+                    input: MachineValidationState::Started,
+                    expect: "Started".to_string(),
+                },
+                Check {
+                    scenario: "InProgress",
+                    input: MachineValidationState::InProgress,
+                    expect: "InProgress".to_string(),
+                },
+                Check {
+                    scenario: "Success",
+                    input: MachineValidationState::Success,
+                    expect: "Success".to_string(),
+                },
+                Check {
+                    scenario: "Skipped",
+                    input: MachineValidationState::Skipped,
+                    expect: "Skipped".to_string(),
+                },
+                Check {
+                    scenario: "Failed",
+                    input: MachineValidationState::Failed,
+                    expect: "Failed".to_string(),
+                },
+            ],
+            |state| state.to_string(),
+        );
+    }
+
+    #[test]
+    fn state_display_round_trips_through_from_str() {
+        check_cases(
+            [
+                Case {
+                    scenario: "Started",
+                    input: MachineValidationState::Started,
+                    expect: Yields(MachineValidationState::Started),
+                },
+                Case {
+                    scenario: "InProgress",
+                    input: MachineValidationState::InProgress,
+                    expect: Yields(MachineValidationState::InProgress),
+                },
+                Case {
+                    scenario: "Success",
+                    input: MachineValidationState::Success,
+                    expect: Yields(MachineValidationState::Success),
+                },
+                Case {
+                    scenario: "Skipped",
+                    input: MachineValidationState::Skipped,
+                    expect: Yields(MachineValidationState::Skipped),
+                },
+                Case {
+                    scenario: "Failed",
+                    input: MachineValidationState::Failed,
+                    expect: Yields(MachineValidationState::Failed),
+                },
+            ],
+            |state| MachineValidationState::from_str(&state.to_string()).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn state_default_is_started() {
+        Check {
+            scenario: "default state",
+            input: (),
+            expect: MachineValidationState::Started,
+        }
+        .check(|()| MachineValidationState::default());
+    }
+
+    #[test]
+    fn status_default_is_started_with_zero_counts() {
+        check_values(
+            [
+                Check {
+                    scenario: "default state is Started",
+                    input: MachineValidationStatus::default(),
+                    expect: MachineValidationStatus {
+                        state: MachineValidationState::Started,
+                        total: 0,
+                        completed: 0,
+                    },
+                },
+                Check {
+                    scenario: "matches an explicitly built default",
+                    input: MachineValidationStatus {
+                        state: MachineValidationState::Started,
+                        total: 0,
+                        completed: 0,
+                    },
+                    expect: MachineValidationStatus::default(),
+                },
+            ],
+            |status| status,
+        );
+    }
+
+    #[test]
+    fn status_equality_distinguishes_each_field() {
+        let base = MachineValidationStatus {
+            state: MachineValidationState::InProgress,
+            total: 10,
+            completed: 4,
+        };
+        check_values(
+            [
+                Check {
+                    scenario: "identical is equal",
+                    input: MachineValidationStatus {
+                        state: MachineValidationState::InProgress,
+                        total: 10,
+                        completed: 4,
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "differing state is unequal",
+                    input: MachineValidationStatus {
+                        state: MachineValidationState::Success,
+                        total: 10,
+                        completed: 4,
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "differing total is unequal",
+                    input: MachineValidationStatus {
+                        state: MachineValidationState::InProgress,
+                        total: 11,
+                        completed: 4,
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "differing completed is unequal",
+                    input: MachineValidationStatus {
+                        state: MachineValidationState::InProgress,
+                        total: 10,
+                        completed: 5,
+                    },
+                    expect: false,
+                },
+            ],
+            |status| status == base,
+        );
     }
 }

--- a/crates/api-model/src/metadata.rs
+++ b/crates/api-model/src/metadata.rs
@@ -120,133 +120,297 @@ pub struct LabelFilter {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
-    #[test]
-    fn fail_invalid_metadata() {
-        // Good metadata
-        let metadata = Metadata {
-            name: "nice_name".to_string(),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([("key1".to_string(), "val1".to_string())]),
-        };
-
-        assert!(metadata.validate(true).is_ok());
-
-        // And now lots of bad metadata
-
-        // name too short
-        let metadata = Metadata {
-            name: "x".to_string(),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([("key1".to_string(), "val1".to_string())]),
-        };
-
-        assert!(matches!(
-            metadata.validate(true),
-            Err(ConfigValidationError::InvalidValue(_))
-        ));
-
-        // name too short without requiring min length is ok
-        let metadata = Metadata {
-            name: "".to_string(),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([("key1".to_string(), "val1".to_string())]),
-        };
-
-        assert!(metadata.validate(false).is_ok());
-
-        // name too long
-        let metadata = Metadata {
-            name: [0; 257].iter().fold(String::new(), |name, _| name + "a"),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([("key1".to_string(), "val1".to_string())]),
-        };
-
-        assert!(matches!(
-            metadata.validate(true),
-            Err(ConfigValidationError::InvalidValue(_))
-        ));
-
-        // non-ascii name
-        let metadata = Metadata {
-            name: "것봐".to_string(),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([("key1".to_string(), "val1".to_string())]),
-        };
-
-        assert!(matches!(
-            metadata.validate(true),
-            Err(ConfigValidationError::InvalidValue(_))
-        ));
-
-        // Empty key
-        let metadata = Metadata {
-            name: "nice name".to_string(),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([("".to_string(), "val1".to_string())]),
-        };
-
-        assert!(matches!(
-            metadata.validate(true),
-            Err(ConfigValidationError::InvalidValue(_))
-        ));
-
-        // Non-ascii key
-        let metadata = Metadata {
-            name: "nice name".to_string(),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([("것봐".to_string(), "val1".to_string())]),
-        };
-
-        assert!(matches!(
-            metadata.validate(true),
-            Err(ConfigValidationError::InvalidValue(_))
-        ));
-
-        // Key too big
-        let metadata = Metadata {
-            name: "nice name".to_string(),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([(
-                [0; 256].iter().fold(String::new(), |name, _| name + "a"),
-                "val1".to_string(),
-            )]),
-        };
-
-        assert!(matches!(
-            metadata.validate(true),
-            Err(ConfigValidationError::InvalidValue(_))
-        ));
-
-        // Value too big
-        let metadata = Metadata {
-            name: "nice name".to_string(),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([(
-                "key1".to_string(),
-                [0; 256].iter().fold(String::new(), |name, _| name + "a"),
-            )]),
-        };
-
-        assert!(matches!(
-            metadata.validate(true),
-            Err(ConfigValidationError::InvalidValue(_))
-        ));
-
-        // Too many labels (17 > 16)
-        let metadata = Metadata {
-            name: "nice name".to_string(),
-            description: "anything is fine".to_string(),
-            labels: "abcdefghijklmnopq"
-                .chars()
-                .map(|c| (c.to_string(), "x".to_string()))
+    /// Build a `Metadata` from parts, with sensible defaults so each row only
+    /// names the field it is exercising.
+    fn meta(name: &str, description: &str, labels: &[(&str, &str)]) -> Metadata {
+        Metadata {
+            name: name.to_string(),
+            description: description.to_string(),
+            labels: labels
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
-        };
+        }
+    }
 
-        assert!(matches!(
-            metadata.validate(true),
-            Err(ConfigValidationError::InvalidValue(_))
-        ));
+    /// A string of `n` repeated `'a'` characters.
+    fn long(n: usize) -> String {
+        "a".repeat(n)
+    }
+
+    #[test]
+    fn validate_with_min_length_required() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid name, description, and label",
+                    input: meta("nice_name", "anything is fine", &[("key1", "val1")]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "no labels is fine",
+                    input: meta("nice_name", "", &[]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "name at min length (2)",
+                    input: meta("ab", "", &[]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "name one below min length (1)",
+                    input: meta("x", "", &[]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty name rejected when min length required",
+                    input: meta("", "", &[]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "name at max length (256)",
+                    input: Metadata {
+                        name: long(256),
+                        ..Metadata::default()
+                    },
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "name one over max length (257)",
+                    input: Metadata {
+                        name: long(257),
+                        ..Metadata::default()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-ascii name rejected",
+                    input: meta("것봐", "", &[]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "description at max length (1024)",
+                    input: Metadata {
+                        name: "nice name".to_string(),
+                        description: long(1024),
+                        ..Metadata::default()
+                    },
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "description one over max length (1025)",
+                    input: Metadata {
+                        name: "nice name".to_string(),
+                        description: long(1025),
+                        ..Metadata::default()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty label key rejected",
+                    input: meta("nice name", "", &[("", "val1")]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-ascii label key rejected",
+                    input: meta("nice name", "", &[("것봐", "val1")]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "label key at max length (255)",
+                    input: Metadata {
+                        name: "nice name".to_string(),
+                        labels: HashMap::from([(long(255), "val1".to_string())]),
+                        ..Metadata::default()
+                    },
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "label key one over max length (256)",
+                    input: Metadata {
+                        name: "nice name".to_string(),
+                        labels: HashMap::from([(long(256), "val1".to_string())]),
+                        ..Metadata::default()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "label value at max length (255)",
+                    input: Metadata {
+                        name: "nice name".to_string(),
+                        labels: HashMap::from([("key1".to_string(), long(255))]),
+                        ..Metadata::default()
+                    },
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "label value one over max length (256)",
+                    input: Metadata {
+                        name: "nice name".to_string(),
+                        labels: HashMap::from([("key1".to_string(), long(256))]),
+                        ..Metadata::default()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty label value is fine",
+                    input: meta("nice name", "", &[("key1", "")]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "labels at max count (16)",
+                    input: Metadata {
+                        name: "nice name".to_string(),
+                        labels: "abcdefghijklmnop"
+                            .chars()
+                            .map(|c| (c.to_string(), "x".to_string()))
+                            .collect(),
+                        ..Metadata::default()
+                    },
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "labels one over max count (17)",
+                    input: Metadata {
+                        name: "nice name".to_string(),
+                        labels: "abcdefghijklmnopq"
+                            .chars()
+                            .map(|c| (c.to_string(), "x".to_string()))
+                            .collect(),
+                        ..Metadata::default()
+                    },
+                    expect: Fails,
+                },
+            ],
+            |m| m.validate(true).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn validate_without_min_length_required() {
+        check_cases(
+            [
+                Case {
+                    scenario: "empty name allowed when min length not required",
+                    input: meta("", "anything is fine", &[("key1", "val1")]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "single-char name allowed when min length not required",
+                    input: meta("x", "", &[]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "name still capped at max length (257 rejected)",
+                    input: Metadata {
+                        name: long(257),
+                        ..Metadata::default()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-ascii name still rejected",
+                    input: meta("것봐", "", &[]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "label checks still apply (empty key rejected)",
+                    input: meta("", "", &[("", "val1")]),
+                    expect: Fails,
+                },
+            ],
+            |m| m.validate(false).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn validate_error_message_names_the_offending_field() {
+        check_cases(
+            [
+                Case {
+                    scenario: "short-name error mentions length bounds",
+                    input: (meta("x", "", &[]), &["between", "256"][..]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "non-ascii name error mentions ASCII",
+                    input: (meta("것봐", "", &[]), &["ASCII"][..]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "long-description error mentions Description",
+                    input: (
+                        Metadata {
+                            name: "nice name".to_string(),
+                            description: long(1025),
+                            ..Metadata::default()
+                        },
+                        &["Description", "1024"][..],
+                    ),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "empty-key error mentions empty",
+                    input: (meta("nice name", "", &[("", "v")]), &["empty"][..]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "too-many-labels error mentions the count",
+                    input: (
+                        Metadata {
+                            name: "nice name".to_string(),
+                            labels: "abcdefghijklmnopq"
+                                .chars()
+                                .map(|c| (c.to_string(), "x".to_string()))
+                                .collect(),
+                            ..Metadata::default()
+                        },
+                        &["more than 16", "17"][..],
+                    ),
+                    expect: Yields(true),
+                },
+            ],
+            |(m, tokens)| {
+                let message = m.validate(true).unwrap_err().to_string();
+                Ok::<_, ()>(tokens.iter().all(|t| message.contains(t)))
+            },
+        );
+    }
+
+    #[test]
+    fn constructors_produce_expected_metadata() {
+        check_values(
+            [
+                Check {
+                    scenario: "new_with_default_name sets the default name",
+                    input: Metadata::new_with_default_name(),
+                    expect: Metadata {
+                        name: "default_name".to_string(),
+                        description: String::new(),
+                        labels: HashMap::new(),
+                    },
+                },
+                Check {
+                    scenario: "default is fully empty",
+                    input: Metadata::default(),
+                    expect: Metadata {
+                        name: String::new(),
+                        description: String::new(),
+                        labels: HashMap::new(),
+                    },
+                },
+                Check {
+                    scenario: "deserializer default matches Metadata::default",
+                    input: default_metadata_for_deserializer(),
+                    expect: Metadata::default(),
+                },
+            ],
+            |m| m,
+        );
     }
 }

--- a/crates/api-model/src/network_segment/mod.rs
+++ b/crates/api-model/src/network_segment/mod.rs
@@ -364,40 +364,327 @@ impl NewNetworkSegment {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
+    fn drain_state() -> NetworkSegmentControllerState {
+        let delete_at: DateTime<Utc> = "2022-12-13T04:41:38Z".parse().unwrap();
+        NetworkSegmentControllerState::Deleting {
+            deletion_state: NetworkSegmentDeletionState::DrainAllocatedIps { delete_at },
+        }
+    }
+
+    fn dbdelete_state() -> NetworkSegmentControllerState {
+        NetworkSegmentControllerState::Deleting {
+            deletion_state: NetworkSegmentDeletionState::DBDelete,
+        }
+    }
+
     #[test]
-    fn serialize_controller_state() {
-        let state = NetworkSegmentControllerState::Provisioning {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"provisioning\"}");
-        assert_eq!(
-            serde_json::from_str::<NetworkSegmentControllerState>(&serialized).unwrap(),
-            state
+    fn controller_state_serializes_to_tagged_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "provisioning",
+                    input: NetworkSegmentControllerState::Provisioning,
+                    expect: Yields(r#"{"state":"provisioning"}"#.to_string()),
+                },
+                Case {
+                    scenario: "ready",
+                    input: NetworkSegmentControllerState::Ready,
+                    expect: Yields(r#"{"state":"ready"}"#.to_string()),
+                },
+                Case {
+                    scenario: "deleting / drain allocated ips",
+                    input: drain_state(),
+                    expect: Yields(
+                        r#"{"state":"deleting","deletion_state":{"state":"drainallocatedips","delete_at":"2022-12-13T04:41:38Z"}}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "deleting / db delete",
+                    input: dbdelete_state(),
+                    expect: Yields(
+                        r#"{"state":"deleting","deletion_state":{"state":"dbdelete"}}"#.to_string(),
+                    ),
+                },
+            ],
+            |state| serde_json::to_string(&state).map_err(drop),
         );
+    }
 
-        let state = NetworkSegmentControllerState::Ready {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"ready\"}");
-        assert_eq!(
-            serde_json::from_str::<NetworkSegmentControllerState>(&serialized).unwrap(),
-            state
-        );
-
-        let deletion_time: DateTime<Utc> = "2022-12-13T04:41:38Z".parse().unwrap();
-        let state = NetworkSegmentControllerState::Deleting {
-            deletion_state: NetworkSegmentDeletionState::DrainAllocatedIps {
-                delete_at: deletion_time,
+    #[test]
+    fn controller_state_round_trips_through_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "provisioning",
+                    input: NetworkSegmentControllerState::Provisioning,
+                    expect: Yields(NetworkSegmentControllerState::Provisioning),
+                },
+                Case {
+                    scenario: "ready",
+                    input: NetworkSegmentControllerState::Ready,
+                    expect: Yields(NetworkSegmentControllerState::Ready),
+                },
+                Case {
+                    scenario: "deleting / drain allocated ips",
+                    input: drain_state(),
+                    expect: Yields(drain_state()),
+                },
+                Case {
+                    scenario: "deleting / db delete",
+                    input: dbdelete_state(),
+                    expect: Yields(dbdelete_state()),
+                },
+            ],
+            |state| {
+                let json = serde_json::to_string(&state).map_err(drop)?;
+                serde_json::from_str::<NetworkSegmentControllerState>(&json).map_err(drop)
             },
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(
-            serialized,
-            "{\"state\":\"deleting\",\"deletion_state\":{\"state\":\"drainallocatedips\",\"delete_at\":\"2022-12-13T04:41:38Z\"}}"
         );
-        assert_eq!(
-            serde_json::from_str::<NetworkSegmentControllerState>(&serialized).unwrap(),
-            state
+    }
+
+    #[test]
+    fn segment_type_parses_from_db_string() {
+        check_cases(
+            [
+                Case {
+                    scenario: "tenant",
+                    input: "tenant",
+                    expect: Yields(NetworkSegmentType::Tenant),
+                },
+                Case {
+                    scenario: "admin",
+                    input: "admin",
+                    expect: Yields(NetworkSegmentType::Admin),
+                },
+                Case {
+                    scenario: "tor maps to underlay",
+                    input: "tor",
+                    expect: Yields(NetworkSegmentType::Underlay),
+                },
+                Case {
+                    scenario: "host_inband",
+                    input: "host_inband",
+                    expect: Yields(NetworkSegmentType::HostInband),
+                },
+                Case {
+                    scenario: "unknown token",
+                    input: "bogus",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wrong-case admin",
+                    input: "Admin",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "display name underlay, not parse name",
+                    input: "underlay",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "whitespace padded",
+                    input: " tenant ",
+                    expect: Fails,
+                },
+            ],
+            |s| NetworkSegmentType::from_str(s).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn segment_type_parse_error_names_the_input() {
+        check_cases(
+            [
+                Case {
+                    scenario: "error mentions the offending token",
+                    input: ("bogus", &["Invalid segment type", "bogus"][..]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "error mentions an empty token",
+                    input: ("", &["Invalid segment type"][..]),
+                    expect: Yields(true),
+                },
+            ],
+            |(s, tokens)| {
+                let msg = NetworkSegmentType::from_str(s)
+                    .map(|_| String::new())
+                    .unwrap_or_else(|e| e.to_string());
+                Ok::<_, ()>(tokens.iter().all(|t| msg.contains(t)))
+            },
+        );
+    }
+
+    #[test]
+    fn segment_type_round_trips_through_display_and_parse() {
+        check_cases(
+            [
+                Case {
+                    scenario: "tenant",
+                    input: NetworkSegmentType::Tenant,
+                    expect: Yields(NetworkSegmentType::Tenant),
+                },
+                Case {
+                    scenario: "admin",
+                    input: NetworkSegmentType::Admin,
+                    expect: Yields(NetworkSegmentType::Admin),
+                },
+                Case {
+                    scenario: "underlay",
+                    input: NetworkSegmentType::Underlay,
+                    expect: Yields(NetworkSegmentType::Underlay),
+                },
+                Case {
+                    scenario: "host_inband",
+                    input: NetworkSegmentType::HostInband,
+                    expect: Yields(NetworkSegmentType::HostInband),
+                },
+            ],
+            |ty| NetworkSegmentType::from_str(&ty.to_string()).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn segment_type_displays_its_db_token() {
+        check_values(
+            [
+                Check {
+                    scenario: "tenant",
+                    input: NetworkSegmentType::Tenant,
+                    expect: "tenant".to_string(),
+                },
+                Check {
+                    scenario: "admin",
+                    input: NetworkSegmentType::Admin,
+                    expect: "admin".to_string(),
+                },
+                Check {
+                    scenario: "underlay renders as tor",
+                    input: NetworkSegmentType::Underlay,
+                    expect: "tor".to_string(),
+                },
+                Check {
+                    scenario: "host_inband",
+                    input: NetworkSegmentType::HostInband,
+                    expect: "host_inband".to_string(),
+                },
+            ],
+            |ty| ty.to_string(),
+        );
+    }
+
+    #[test]
+    fn is_tenant_is_true_for_tenant_facing_segments() {
+        check_values(
+            [
+                Check {
+                    scenario: "tenant is tenant-facing",
+                    input: NetworkSegmentType::Tenant,
+                    expect: true,
+                },
+                Check {
+                    scenario: "host_inband is tenant-facing",
+                    input: NetworkSegmentType::HostInband,
+                    expect: true,
+                },
+                Check {
+                    scenario: "admin is not tenant-facing",
+                    input: NetworkSegmentType::Admin,
+                    expect: false,
+                },
+                Check {
+                    scenario: "underlay is not tenant-facing",
+                    input: NetworkSegmentType::Underlay,
+                    expect: false,
+                },
+            ],
+            |ty| ty.is_tenant(),
+        );
+    }
+
+    #[test]
+    fn segment_type_converts_from_definition_type() {
+        check_values(
+            [
+                Check {
+                    scenario: "admin",
+                    input: NetworkDefinitionSegmentType::Admin,
+                    expect: NetworkSegmentType::Admin,
+                },
+                Check {
+                    scenario: "underlay",
+                    input: NetworkDefinitionSegmentType::Underlay,
+                    expect: NetworkSegmentType::Underlay,
+                },
+                Check {
+                    scenario: "host_inband",
+                    input: NetworkDefinitionSegmentType::HostInband,
+                    expect: NetworkSegmentType::HostInband,
+                },
+            ],
+            NetworkSegmentType::from,
+        );
+    }
+
+    #[test]
+    fn allocation_strategy_round_trips_through_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "dynamic serializes to its snake-case token",
+                    input: AllocationStrategy::Dynamic,
+                    expect: Yields(r#""dynamic""#.to_string()),
+                },
+                Case {
+                    scenario: "reserved serializes to its snake-case token",
+                    input: AllocationStrategy::Reserved,
+                    expect: Yields(r#""reserved""#.to_string()),
+                },
+            ],
+            |s| serde_json::to_string(&s).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn allocation_strategy_defaults_to_dynamic() {
+        check_values(
+            [Check {
+                scenario: "default",
+                input: (),
+                expect: AllocationStrategy::Dynamic,
+            }],
+            |()| AllocationStrategy::default(),
+        );
+    }
+
+    #[test]
+    fn is_marked_as_deleted_follows_the_deleted_timestamp() {
+        let stamp: DateTime<Utc> = "2022-12-13T04:41:38Z".parse().unwrap();
+        check_values(
+            [
+                Check {
+                    scenario: "no timestamp means live",
+                    input: None,
+                    expect: false,
+                },
+                Check {
+                    scenario: "timestamp means deleted",
+                    input: Some(stamp),
+                    expect: true,
+                },
+            ],
+            |deleted| deleted.is_some(),
         );
     }
 }

--- a/crates/api-model/src/power_shelf/mod.rs
+++ b/crates/api-model/src/power_shelf/mod.rs
@@ -230,122 +230,170 @@ pub struct PowerShelfSearchFilter {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
     #[test]
     fn serialize_controller_state() {
-        let state = PowerShelfControllerState::Initializing {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"initializing\"}");
-        assert_eq!(
-            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = PowerShelfControllerState::FetchingData {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"fetchingdata\"}");
-        assert_eq!(
-            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = PowerShelfControllerState::Configuring {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"configuring\"}");
-        assert_eq!(
-            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = PowerShelfControllerState::Ready {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"ready\"}");
-        assert_eq!(
-            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = PowerShelfControllerState::Error {
-            cause: "cause goes here".to_string(),
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, r#"{"state":"error","cause":"cause goes here"}"#);
-        assert_eq!(
-            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = PowerShelfControllerState::Deleting {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"deleting\"}");
-        assert_eq!(
-            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = PowerShelfControllerState::Maintenance {
-            operation: PowerShelfMaintenanceOperation::PowerOn,
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(
-            serialized,
-            r#"{"state":"maintenance","operation":{"operation":"poweron"}}"#
-        );
-        assert_eq!(
-            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = PowerShelfControllerState::Maintenance {
-            operation: PowerShelfMaintenanceOperation::PowerOff,
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(
-            serialized,
-            r#"{"state":"maintenance","operation":{"operation":"poweroff"}}"#
-        );
-        assert_eq!(
-            serde_json::from_str::<PowerShelfControllerState>(&serialized).unwrap(),
-            state
+        // Each controller-state variant serializes to its tagged JSON and round-trips
+        // back to the same value. The op yields (serialized, deserialized) so both the
+        // exact JSON string and the round-trip equality are asserted per row.
+        check_cases(
+            [
+                Case {
+                    scenario: "initializing",
+                    input: PowerShelfControllerState::Initializing {},
+                    expect: Yields((
+                        "{\"state\":\"initializing\"}".to_string(),
+                        PowerShelfControllerState::Initializing {},
+                    )),
+                },
+                Case {
+                    scenario: "fetching data",
+                    input: PowerShelfControllerState::FetchingData {},
+                    expect: Yields((
+                        "{\"state\":\"fetchingdata\"}".to_string(),
+                        PowerShelfControllerState::FetchingData {},
+                    )),
+                },
+                Case {
+                    scenario: "configuring",
+                    input: PowerShelfControllerState::Configuring {},
+                    expect: Yields((
+                        "{\"state\":\"configuring\"}".to_string(),
+                        PowerShelfControllerState::Configuring {},
+                    )),
+                },
+                Case {
+                    scenario: "ready",
+                    input: PowerShelfControllerState::Ready {},
+                    expect: Yields((
+                        "{\"state\":\"ready\"}".to_string(),
+                        PowerShelfControllerState::Ready {},
+                    )),
+                },
+                Case {
+                    scenario: "error with cause",
+                    input: PowerShelfControllerState::Error {
+                        cause: "cause goes here".to_string(),
+                    },
+                    expect: Yields((
+                        r#"{"state":"error","cause":"cause goes here"}"#.to_string(),
+                        PowerShelfControllerState::Error {
+                            cause: "cause goes here".to_string(),
+                        },
+                    )),
+                },
+                Case {
+                    scenario: "deleting",
+                    input: PowerShelfControllerState::Deleting {},
+                    expect: Yields((
+                        "{\"state\":\"deleting\"}".to_string(),
+                        PowerShelfControllerState::Deleting {},
+                    )),
+                },
+                Case {
+                    scenario: "maintenance power-on",
+                    input: PowerShelfControllerState::Maintenance {
+                        operation: PowerShelfMaintenanceOperation::PowerOn,
+                    },
+                    expect: Yields((
+                        r#"{"state":"maintenance","operation":{"operation":"poweron"}}"#
+                            .to_string(),
+                        PowerShelfControllerState::Maintenance {
+                            operation: PowerShelfMaintenanceOperation::PowerOn,
+                        },
+                    )),
+                },
+                Case {
+                    scenario: "maintenance power-off",
+                    input: PowerShelfControllerState::Maintenance {
+                        operation: PowerShelfMaintenanceOperation::PowerOff,
+                    },
+                    expect: Yields((
+                        r#"{"state":"maintenance","operation":{"operation":"poweroff"}}"#
+                            .to_string(),
+                        PowerShelfControllerState::Maintenance {
+                            operation: PowerShelfMaintenanceOperation::PowerOff,
+                        },
+                    )),
+                },
+            ],
+            // Serialize the state, then deserialize the produced JSON back.
+            |state: PowerShelfControllerState| {
+                let serialized = serde_json::to_string(&state).map_err(drop)?;
+                let parsed =
+                    serde_json::from_str::<PowerShelfControllerState>(&serialized).map_err(drop)?;
+                Ok::<_, ()>((serialized, parsed))
+            },
         );
     }
 
     #[test]
-    fn serialize_maintenance_operation_round_trip() {
-        for operation in [
-            PowerShelfMaintenanceOperation::PowerOn,
-            PowerShelfMaintenanceOperation::PowerOff,
-        ] {
-            let serialized = serde_json::to_string(&operation).unwrap();
-            let parsed: PowerShelfMaintenanceOperation = serde_json::from_str(&serialized).unwrap();
-            assert_eq!(parsed, operation);
-        }
-    }
-
-    #[test]
-    fn serialize_maintenance_operation_lowercase_tags() {
-        assert_eq!(
-            serde_json::to_string(&PowerShelfMaintenanceOperation::PowerOn).unwrap(),
-            r#"{"operation":"poweron"}"#
-        );
-        assert_eq!(
-            serde_json::to_string(&PowerShelfMaintenanceOperation::PowerOff).unwrap(),
-            r#"{"operation":"poweroff"}"#
+    fn serialize_maintenance_operation() {
+        // Each maintenance operation serializes to its lowercase-tagged JSON and
+        // round-trips back. The op yields (serialized, deserialized), folding the
+        // exact-tag and round-trip assertions into one table.
+        check_cases(
+            [
+                Case {
+                    scenario: "power on",
+                    input: PowerShelfMaintenanceOperation::PowerOn,
+                    expect: Yields((
+                        r#"{"operation":"poweron"}"#.to_string(),
+                        PowerShelfMaintenanceOperation::PowerOn,
+                    )),
+                },
+                Case {
+                    scenario: "power off",
+                    input: PowerShelfMaintenanceOperation::PowerOff,
+                    expect: Yields((
+                        r#"{"operation":"poweroff"}"#.to_string(),
+                        PowerShelfMaintenanceOperation::PowerOff,
+                    )),
+                },
+            ],
+            |operation: PowerShelfMaintenanceOperation| {
+                let serialized = serde_json::to_string(&operation).map_err(drop)?;
+                let parsed = serde_json::from_str::<PowerShelfMaintenanceOperation>(&serialized)
+                    .map_err(drop)?;
+                Ok::<_, ()>((serialized, parsed))
+            },
         );
     }
 
     #[test]
     fn serialize_maintenance_request_round_trip() {
+        // A maintenance request round-trips through JSON for each operation. Only the
+        // operation varies; the timestamp and initiator are fixed across rows.
         let now = chrono::DateTime::parse_from_rfc3339("2026-05-13T12:00:00Z")
             .unwrap()
             .with_timezone(&chrono::Utc);
-        for operation in [
-            PowerShelfMaintenanceOperation::PowerOn,
-            PowerShelfMaintenanceOperation::PowerOff,
-        ] {
-            let request = PowerShelfMaintenanceRequest {
-                requested_at: now,
-                initiator: "operator (TICKET-1)".to_string(),
-                operation,
-            };
-            let serialized = serde_json::to_string(&request).unwrap();
-            let parsed: PowerShelfMaintenanceRequest = serde_json::from_str(&serialized).unwrap();
-            assert_eq!(parsed, request);
-        }
+        let request = |operation| PowerShelfMaintenanceRequest {
+            requested_at: now,
+            initiator: "operator (TICKET-1)".to_string(),
+            operation,
+        };
+        check_cases(
+            [
+                Case {
+                    scenario: "power on",
+                    input: PowerShelfMaintenanceOperation::PowerOn,
+                    expect: Yields(request(PowerShelfMaintenanceOperation::PowerOn)),
+                },
+                Case {
+                    scenario: "power off",
+                    input: PowerShelfMaintenanceOperation::PowerOff,
+                    expect: Yields(request(PowerShelfMaintenanceOperation::PowerOff)),
+                },
+            ],
+            |operation| {
+                let serialized = serde_json::to_string(&request(operation)).map_err(drop)?;
+                serde_json::from_str::<PowerShelfMaintenanceRequest>(&serialized).map_err(drop)
+            },
+        );
     }
 
     #[test]
@@ -357,5 +405,366 @@ mod tests {
             operation: PowerShelfMaintenanceOperation::PowerOff,
         };
         assert_ne!(on, off);
+    }
+
+    #[test]
+    fn controller_state_deserializes_from_tagged_json() {
+        // Each tagged-JSON form parses back to its variant; malformed or unknown
+        // tags are rejected. The op yields the parsed variant so both the accepted
+        // shapes and the rejected ones are pinned in one table.
+        check_cases(
+            [
+                Case {
+                    scenario: "initializing tag",
+                    input: r#"{"state":"initializing"}"#,
+                    expect: Yields(PowerShelfControllerState::Initializing),
+                },
+                Case {
+                    scenario: "fetchingdata tag",
+                    input: r#"{"state":"fetchingdata"}"#,
+                    expect: Yields(PowerShelfControllerState::FetchingData),
+                },
+                Case {
+                    scenario: "configuring tag",
+                    input: r#"{"state":"configuring"}"#,
+                    expect: Yields(PowerShelfControllerState::Configuring),
+                },
+                Case {
+                    scenario: "ready tag",
+                    input: r#"{"state":"ready"}"#,
+                    expect: Yields(PowerShelfControllerState::Ready),
+                },
+                Case {
+                    scenario: "deleting tag",
+                    input: r#"{"state":"deleting"}"#,
+                    expect: Yields(PowerShelfControllerState::Deleting),
+                },
+                Case {
+                    scenario: "error with cause",
+                    input: r#"{"state":"error","cause":"boom"}"#,
+                    expect: Yields(PowerShelfControllerState::Error {
+                        cause: "boom".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "error with empty cause",
+                    input: r#"{"state":"error","cause":""}"#,
+                    expect: Yields(PowerShelfControllerState::Error {
+                        cause: String::new(),
+                    }),
+                },
+                Case {
+                    scenario: "maintenance power-on",
+                    input: r#"{"state":"maintenance","operation":{"operation":"poweron"}}"#,
+                    expect: Yields(PowerShelfControllerState::Maintenance {
+                        operation: PowerShelfMaintenanceOperation::PowerOn,
+                    }),
+                },
+                Case {
+                    scenario: "maintenance power-off",
+                    input: r#"{"state":"maintenance","operation":{"operation":"poweroff"}}"#,
+                    expect: Yields(PowerShelfControllerState::Maintenance {
+                        operation: PowerShelfMaintenanceOperation::PowerOff,
+                    }),
+                },
+                Case {
+                    scenario: "unknown tag is rejected",
+                    input: r#"{"state":"running"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wrong-case tag is rejected",
+                    input: r#"{"state":"Initializing"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "error without cause is rejected",
+                    input: r#"{"state":"error"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "maintenance without operation is rejected",
+                    input: r#"{"state":"maintenance"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing state tag is rejected",
+                    input: r#"{}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "not an object is rejected",
+                    input: r#""initializing""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "malformed json is rejected",
+                    input: r#"{"state":"#,
+                    expect: Fails,
+                },
+            ],
+            |json: &str| serde_json::from_str::<PowerShelfControllerState>(json).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn maintenance_operation_deserializes_from_tagged_json() {
+        // The lowercase operation tags parse back to their variants; unknown or
+        // wrong-case tags are rejected.
+        check_cases(
+            [
+                Case {
+                    scenario: "poweron tag",
+                    input: r#"{"operation":"poweron"}"#,
+                    expect: Yields(PowerShelfMaintenanceOperation::PowerOn),
+                },
+                Case {
+                    scenario: "poweroff tag",
+                    input: r#"{"operation":"poweroff"}"#,
+                    expect: Yields(PowerShelfMaintenanceOperation::PowerOff),
+                },
+                Case {
+                    scenario: "unknown operation is rejected",
+                    input: r#"{"operation":"reset"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wrong-case operation is rejected",
+                    input: r#"{"operation":"PowerOn"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing operation tag is rejected",
+                    input: r#"{}"#,
+                    expect: Fails,
+                },
+            ],
+            |json: &str| serde_json::from_str::<PowerShelfMaintenanceOperation>(json).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn config_round_trips_through_json() {
+        // PowerShelfConfig round-trips for present/absent optionals, empty names, and
+        // numeric boundaries. The op yields the value parsed back from its own JSON.
+        check_cases(
+            [
+                Case {
+                    scenario: "all fields present",
+                    input: PowerShelfConfig {
+                        name: "shelf-1".to_string(),
+                        capacity: Some(5000),
+                        voltage: Some(48),
+                    },
+                    expect: Yields(PowerShelfConfig {
+                        name: "shelf-1".to_string(),
+                        capacity: Some(5000),
+                        voltage: Some(48),
+                    }),
+                },
+                Case {
+                    scenario: "optionals absent",
+                    input: PowerShelfConfig {
+                        name: "shelf-2".to_string(),
+                        capacity: None,
+                        voltage: None,
+                    },
+                    expect: Yields(PowerShelfConfig {
+                        name: "shelf-2".to_string(),
+                        capacity: None,
+                        voltage: None,
+                    }),
+                },
+                Case {
+                    scenario: "empty name and zero values",
+                    input: PowerShelfConfig {
+                        name: String::new(),
+                        capacity: Some(0),
+                        voltage: Some(0),
+                    },
+                    expect: Yields(PowerShelfConfig {
+                        name: String::new(),
+                        capacity: Some(0),
+                        voltage: Some(0),
+                    }),
+                },
+                Case {
+                    scenario: "u32 maxima",
+                    input: PowerShelfConfig {
+                        name: "max".to_string(),
+                        capacity: Some(u32::MAX),
+                        voltage: Some(u32::MAX),
+                    },
+                    expect: Yields(PowerShelfConfig {
+                        name: "max".to_string(),
+                        capacity: Some(u32::MAX),
+                        voltage: Some(u32::MAX),
+                    }),
+                },
+            ],
+            |config: PowerShelfConfig| {
+                let serialized = serde_json::to_string(&config).map_err(drop)?;
+                serde_json::from_str::<PowerShelfConfig>(&serialized).map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn status_round_trips_through_json() {
+        // PowerShelfStatus round-trips across each power/health string the field is
+        // documented to hold, plus empty strings.
+        check_cases(
+            [
+                Case {
+                    scenario: "on / ok",
+                    input: PowerShelfStatus {
+                        shelf_name: "psu-a".to_string(),
+                        power_state: "on".to_string(),
+                        health_status: "ok".to_string(),
+                    },
+                    expect: Yields(PowerShelfStatus {
+                        shelf_name: "psu-a".to_string(),
+                        power_state: "on".to_string(),
+                        health_status: "ok".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "off / warning",
+                    input: PowerShelfStatus {
+                        shelf_name: "psu-b".to_string(),
+                        power_state: "off".to_string(),
+                        health_status: "warning".to_string(),
+                    },
+                    expect: Yields(PowerShelfStatus {
+                        shelf_name: "psu-b".to_string(),
+                        power_state: "off".to_string(),
+                        health_status: "warning".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "standby / critical",
+                    input: PowerShelfStatus {
+                        shelf_name: "psu-c".to_string(),
+                        power_state: "standby".to_string(),
+                        health_status: "critical".to_string(),
+                    },
+                    expect: Yields(PowerShelfStatus {
+                        shelf_name: "psu-c".to_string(),
+                        power_state: "standby".to_string(),
+                        health_status: "critical".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "empty strings",
+                    input: PowerShelfStatus {
+                        shelf_name: String::new(),
+                        power_state: String::new(),
+                        health_status: String::new(),
+                    },
+                    expect: Yields(PowerShelfStatus {
+                        shelf_name: String::new(),
+                        power_state: String::new(),
+                        health_status: String::new(),
+                    }),
+                },
+            ],
+            |status: PowerShelfStatus| {
+                let serialized = serde_json::to_string(&status).map_err(drop)?;
+                serde_json::from_str::<PowerShelfStatus>(&serialized).map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn state_sla_reports_whether_an_sla_applies() {
+        // `state_sla` selects an SLA bucket per controller state. Driven from an
+        // epoch-old `ConfigVersion` (via `invalid()`), the time-in-state is far past
+        // any finite SLA, so each SLA-bearing state reports its exact SLA duration and
+        // an `above_sla` of true, while the no-SLA states report `None`/false. The op
+        // yields `(sla, time_in_state_above_sla)`.
+        let stale = ConfigVersion::invalid();
+        let secs = |s: u64| Some(std::time::Duration::from_secs(s));
+        check_values(
+            [
+                Check {
+                    scenario: "initializing has an SLA and is overdue",
+                    input: PowerShelfControllerState::Initializing,
+                    expect: (secs(slas::INITIALIZING), true),
+                },
+                Check {
+                    scenario: "fetching-data has an SLA and is overdue",
+                    input: PowerShelfControllerState::FetchingData,
+                    expect: (secs(slas::FETCHING_DATA), true),
+                },
+                Check {
+                    scenario: "configuring has an SLA and is overdue",
+                    input: PowerShelfControllerState::Configuring,
+                    expect: (secs(slas::CONFIGURING), true),
+                },
+                Check {
+                    scenario: "deleting has an SLA and is overdue",
+                    input: PowerShelfControllerState::Deleting,
+                    expect: (secs(slas::DELETING), true),
+                },
+                Check {
+                    scenario: "maintenance power-on has the maintenance SLA",
+                    input: PowerShelfControllerState::Maintenance {
+                        operation: PowerShelfMaintenanceOperation::PowerOn,
+                    },
+                    expect: (secs(slas::MAINTENANCE), true),
+                },
+                Check {
+                    scenario: "maintenance power-off has the maintenance SLA",
+                    input: PowerShelfControllerState::Maintenance {
+                        operation: PowerShelfMaintenanceOperation::PowerOff,
+                    },
+                    expect: (secs(slas::MAINTENANCE), true),
+                },
+                Check {
+                    scenario: "ready carries no SLA",
+                    input: PowerShelfControllerState::Ready,
+                    expect: (None, false),
+                },
+                Check {
+                    scenario: "error carries no SLA",
+                    input: PowerShelfControllerState::Error {
+                        cause: "boom".to_string(),
+                    },
+                    expect: (None, false),
+                },
+            ],
+            |state: PowerShelfControllerState| {
+                let result = state_sla(&state, &stale);
+                (result.sla, result.time_in_state_above_sla)
+            },
+        );
+    }
+
+    #[test]
+    fn aggregate_health_prefers_the_replace_source() {
+        // When a `replace` source is set, `derive_power_shelf_aggregate_health` returns
+        // it verbatim (its `observed_at` untouched), short-circuiting the merge path.
+        // The op yields the derived report's source name.
+        let with_replace = |source: &str| HealthReportSources {
+            replace: Some(health_report::HealthReport::empty(source.to_string())),
+            ..Default::default()
+        };
+        check_cases(
+            [
+                Case {
+                    scenario: "replace source wins",
+                    input: with_replace("override.sre"),
+                    expect: Yields("override.sre".to_string()),
+                },
+                Case {
+                    scenario: "no replace falls back to the aggregate name",
+                    input: HealthReportSources::default(),
+                    expect: Yields("power-shelf-aggregate-health".to_string()),
+                },
+            ],
+            |sources: HealthReportSources| {
+                Ok::<_, ()>(derive_power_shelf_aggregate_health(&sources).source)
+            },
+        );
     }
 }

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -821,6 +821,8 @@ pub fn state_sla(state: &RackState, state_version: &ConfigVersion) -> StateSla {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
     use carbide_uuid::machine::{MachineIdSource, MachineType};
     use carbide_uuid::power_shelf::{PowerShelfIdSource, PowerShelfType};
     use carbide_uuid::switch::{SwitchIdSource, SwitchType};
@@ -1026,54 +1028,69 @@ mod tests {
         }
     }
 
+    // check_accepts_maintenance: Ready/Error (with no pending request) accept;
+    // every other state is rejected as NotReadyOrError, and a state that already
+    // has a pending request is rejected as AlreadyPending. The originals only
+    // asserted the rejection variant (via matches!), so we compare the error's
+    // discriminant rather than its full value. The input is the (state, pending)
+    // pair handed to `test_rack`.
     #[test]
-    fn accepts_maintenance_in_ready_state() {
-        let rack = test_rack(RackState::Ready, None);
-        assert!(rack.check_accepts_maintenance().is_ok());
-    }
-
-    #[test]
-    fn accepts_maintenance_in_error_state() {
-        let rack = test_rack(
-            RackState::Error {
-                cause: "something broke".into(),
-            },
-            None,
+    fn check_accepts_maintenance_cases() {
+        // Discriminant sentinels for the two rejection variants.
+        let not_ready_or_error = std::mem::discriminant(
+            &RackMaintenanceRejection::NotReadyOrError(RackState::Created),
         );
-        assert!(rack.check_accepts_maintenance().is_ok());
-    }
+        let already_pending = std::mem::discriminant(&RackMaintenanceRejection::AlreadyPending);
 
-    #[test]
-    fn rejects_maintenance_in_created_state() {
-        let rack = test_rack(RackState::Created, None);
-        let err = rack.check_accepts_maintenance().unwrap_err();
-        assert!(matches!(err, RackMaintenanceRejection::NotReadyOrError(_)));
-    }
-
-    #[test]
-    fn rejects_maintenance_in_discovering_state() {
-        let rack = test_rack(RackState::Discovering, None);
-        let err = rack.check_accepts_maintenance().unwrap_err();
-        assert!(matches!(err, RackMaintenanceRejection::NotReadyOrError(_)));
-    }
-
-    #[test]
-    fn rejects_maintenance_in_maintenance_state() {
-        let rack = test_rack(
-            RackState::Maintenance {
-                maintenance_state: RackMaintenanceState::Completed,
+        check_cases(
+            [
+                Case {
+                    scenario: "accepts in ready state",
+                    input: (RackState::Ready, None),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "accepts in error state",
+                    input: (
+                        RackState::Error {
+                            cause: "something broke".into(),
+                        },
+                        None,
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "rejects in created state",
+                    input: (RackState::Created, None),
+                    expect: FailsWith(not_ready_or_error),
+                },
+                Case {
+                    scenario: "rejects in discovering state",
+                    input: (RackState::Discovering, None),
+                    expect: FailsWith(not_ready_or_error),
+                },
+                Case {
+                    scenario: "rejects in maintenance state",
+                    input: (
+                        RackState::Maintenance {
+                            maintenance_state: RackMaintenanceState::Completed,
+                        },
+                        None,
+                    ),
+                    expect: FailsWith(not_ready_or_error),
+                },
+                Case {
+                    scenario: "rejects when already pending",
+                    input: (RackState::Ready, Some(MaintenanceScope::default())),
+                    expect: FailsWith(already_pending),
+                },
+            ],
+            |(state, maintenance_requested)| {
+                test_rack(state, maintenance_requested)
+                    .check_accepts_maintenance()
+                    .map_err(|e| std::mem::discriminant(&e))
             },
-            None,
         );
-        let err = rack.check_accepts_maintenance().unwrap_err();
-        assert!(matches!(err, RackMaintenanceRejection::NotReadyOrError(_)));
-    }
-
-    #[test]
-    fn rejects_maintenance_when_already_pending() {
-        let rack = test_rack(RackState::Ready, Some(MaintenanceScope::default()));
-        let err = rack.check_accepts_maintenance().unwrap_err();
-        assert!(matches!(err, RackMaintenanceRejection::AlreadyPending));
     }
 
     // ── RackMaintenanceRejection display ────────────────────────────────

--- a/crates/api-model/src/rack_type.rs
+++ b/crates/api-model/src/rack_type.rs
@@ -279,6 +279,9 @@ impl RackProfileConfig {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
     #[test]
@@ -412,28 +415,117 @@ count = 2
 
     // RackHardwareType tests.
 
+    // JSON round-trip: each variant serializes to its expected string and
+    // deserializes back to itself. Projected to (json, value_back); the closure
+    // discards the (non-PartialEq) serde_json error since every row succeeds.
     #[test]
     fn test_rack_hardware_type_serde_round_trip() {
-        let hw_type = RackHardwareType::from("dsx_gb200nvl_72x1");
-        let json = serde_json::to_string(&hw_type).unwrap();
-        assert_eq!(json, "\"dsx_gb200nvl_72x1\"");
-        let deserialized: RackHardwareType = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized, hw_type);
-    }
-
-    #[test]
-    fn test_rack_hardware_type_display() {
-        assert_eq!(RackHardwareType::any().to_string(), "any");
-        assert_eq!(
-            RackHardwareType::from("dsx_gb200nvl_72x1").to_string(),
-            "dsx_gb200nvl_72x1"
+        check_cases(
+            [Case {
+                scenario: "dsx hardware type round-trips through json",
+                input: RackHardwareType::from("dsx_gb200nvl_72x1"),
+                expect: Yields((
+                    "\"dsx_gb200nvl_72x1\"".to_string(),
+                    RackHardwareType::from("dsx_gb200nvl_72x1"),
+                )),
+            }],
+            |hw_type| {
+                let json = serde_json::to_string(&hw_type).map_err(drop)?;
+                let back: RackHardwareType = serde_json::from_str(&json).map_err(drop)?;
+                Ok::<_, ()>((json, back))
+            },
         );
     }
 
+    // Display forwards the inner string verbatim, including for the wildcard
+    // and for empty/odd inputs.
+    #[test]
+    fn test_rack_hardware_type_display() {
+        check_values(
+            [
+                Check {
+                    scenario: "wildcard any",
+                    input: RackHardwareType::any(),
+                    expect: "any".to_string(),
+                },
+                Check {
+                    scenario: "dsx hardware type",
+                    input: RackHardwareType::from("dsx_gb200nvl_72x1"),
+                    expect: "dsx_gb200nvl_72x1".to_string(),
+                },
+                Check {
+                    scenario: "empty string",
+                    input: RackHardwareType::from(""),
+                    expect: String::new(),
+                },
+                Check {
+                    scenario: "uppercase verbatim",
+                    input: RackHardwareType::from("ANY"),
+                    expect: "ANY".to_string(),
+                },
+                Check {
+                    scenario: "whitespace preserved",
+                    input: RackHardwareType::from("  spaced  "),
+                    expect: "  spaced  ".to_string(),
+                },
+                Check {
+                    scenario: "default renders as any",
+                    input: RackHardwareType::default(),
+                    expect: "any".to_string(),
+                },
+            ],
+            |hw_type| hw_type.to_string(),
+        );
+    }
+
+    // is_any is an exact, case-sensitive match against the literal "any".
     #[test]
     fn test_rack_hardware_type_is_any() {
-        assert!(RackHardwareType::any().is_any());
-        assert!(!RackHardwareType::from("dsx_gb200nvl_72x1").is_any());
+        check_values(
+            [
+                Check {
+                    scenario: "constructed via any()",
+                    input: RackHardwareType::any(),
+                    expect: true,
+                },
+                Check {
+                    scenario: "default is any",
+                    input: RackHardwareType::default(),
+                    expect: true,
+                },
+                Check {
+                    scenario: "literal any from str",
+                    input: RackHardwareType::from("any"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "concrete hardware type",
+                    input: RackHardwareType::from("dsx_gb200nvl_72x1"),
+                    expect: false,
+                },
+                Check {
+                    scenario: "empty is not any",
+                    input: RackHardwareType::from(""),
+                    expect: false,
+                },
+                Check {
+                    scenario: "uppercase is not any",
+                    input: RackHardwareType::from("ANY"),
+                    expect: false,
+                },
+                Check {
+                    scenario: "any with trailing space is not any",
+                    input: RackHardwareType::from("any "),
+                    expect: false,
+                },
+                Check {
+                    scenario: "substring is not any",
+                    input: RackHardwareType::from("anything"),
+                    expect: false,
+                },
+            ],
+            |hw_type| hw_type.is_any(),
+        );
     }
 
     #[test]
@@ -441,79 +533,286 @@ count = 2
         assert_eq!(RackHardwareType::default(), RackHardwareType::any());
     }
 
-    // RackHardwareTopology serde.
-
+    // Both From conversions wrap the input verbatim and agree with each other.
     #[test]
-    fn test_rack_hardware_topology_serde_round_trip() {
-        let cases = [
-            (
-                RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
-                "\"gb200_nvl36r1_c2g4_topology\"",
-            ),
-            (
-                RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
-                "\"gb300_nvl36r1_c2g4_topology\"",
-            ),
-            (
-                RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
-                "\"gb200_nvl72r1_c2g4_topology\"",
-            ),
-            (
-                RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
-                "\"gb300_nvl72r1_c2g4_topology\"",
-            ),
-            (
-                RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
-                "\"vr_nvl8r1_c2g4_rtf_topology\"",
-            ),
-            (
-                RackHardwareTopology::VrNvl72r1C2g4Topology,
-                "\"vr_nvl72r1_c2g4_topology\"",
-            ),
-        ];
-        for (variant, expected_json) in cases {
-            let json = serde_json::to_string(&variant).unwrap();
-            assert_eq!(json, expected_json, "serialize {:?}", variant);
-            let deserialized: RackHardwareTopology = serde_json::from_str(&json).unwrap();
-            assert_eq!(deserialized, variant, "deserialize {:?}", variant);
-        }
+    fn test_rack_hardware_type_from_conversions() {
+        check_values(
+            [
+                Check {
+                    scenario: "from owned string",
+                    input: RackHardwareType::from("dsx".to_string()),
+                    expect: RackHardwareType("dsx".to_string()),
+                },
+                Check {
+                    scenario: "from str slice",
+                    input: RackHardwareType::from("dsx"),
+                    expect: RackHardwareType("dsx".to_string()),
+                },
+                Check {
+                    scenario: "from empty str",
+                    input: RackHardwareType::from(""),
+                    expect: RackHardwareType(String::new()),
+                },
+                Check {
+                    scenario: "owned and borrowed agree",
+                    input: RackHardwareType::from("any".to_string()),
+                    expect: RackHardwareType::from("any"),
+                },
+            ],
+            |hw_type| hw_type,
+        );
     }
 
+    // RackHardwareTopology serde.
+
+    // JSON round-trip: each topology variant serializes to its expected
+    // snake_case string and deserializes back to itself. Projected to
+    // (json, value_back); the (non-PartialEq) serde_json error is discarded.
+    #[test]
+    fn test_rack_hardware_topology_serde_round_trip() {
+        check_cases(
+            [
+                Case {
+                    scenario: "gb200 nvl36 round-trips",
+                    input: RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
+                    expect: Yields((
+                        "\"gb200_nvl36r1_c2g4_topology\"".to_string(),
+                        RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
+                    )),
+                },
+                Case {
+                    scenario: "gb300 nvl36 round-trips",
+                    input: RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
+                    expect: Yields((
+                        "\"gb300_nvl36r1_c2g4_topology\"".to_string(),
+                        RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
+                    )),
+                },
+                Case {
+                    scenario: "gb200 nvl72 round-trips",
+                    input: RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
+                    expect: Yields((
+                        "\"gb200_nvl72r1_c2g4_topology\"".to_string(),
+                        RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
+                    )),
+                },
+                Case {
+                    scenario: "gb300 nvl72 round-trips",
+                    input: RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
+                    expect: Yields((
+                        "\"gb300_nvl72r1_c2g4_topology\"".to_string(),
+                        RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
+                    )),
+                },
+                Case {
+                    scenario: "vr nvl8 rtf round-trips",
+                    input: RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
+                    expect: Yields((
+                        "\"vr_nvl8r1_c2g4_rtf_topology\"".to_string(),
+                        RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
+                    )),
+                },
+                Case {
+                    scenario: "vr nvl72 round-trips",
+                    input: RackHardwareTopology::VrNvl72r1C2g4Topology,
+                    expect: Yields((
+                        "\"vr_nvl72r1_c2g4_topology\"".to_string(),
+                        RackHardwareTopology::VrNvl72r1C2g4Topology,
+                    )),
+                },
+            ],
+            |variant| {
+                let json = serde_json::to_string(&variant).map_err(drop)?;
+                let back: RackHardwareTopology = serde_json::from_str(&json).map_err(drop)?;
+                Ok::<_, ()>((json, back))
+            },
+        );
+    }
+
+    // Display covers every topology variant; the rendered string matches the
+    // snake_case serde form.
     #[test]
     fn test_rack_hardware_topology_display() {
-        assert_eq!(
-            RackHardwareTopology::Gb200Nvl36r1C2g4Topology.to_string(),
-            "gb200_nvl36r1_c2g4_topology"
+        check_values(
+            [
+                Check {
+                    scenario: "gb200 nvl36",
+                    input: RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
+                    expect: "gb200_nvl36r1_c2g4_topology".to_string(),
+                },
+                Check {
+                    scenario: "gb300 nvl36",
+                    input: RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
+                    expect: "gb300_nvl36r1_c2g4_topology".to_string(),
+                },
+                Check {
+                    scenario: "gb200 nvl72",
+                    input: RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
+                    expect: "gb200_nvl72r1_c2g4_topology".to_string(),
+                },
+                Check {
+                    scenario: "gb300 nvl72",
+                    input: RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
+                    expect: "gb300_nvl72r1_c2g4_topology".to_string(),
+                },
+                Check {
+                    scenario: "vr nvl8 rtf",
+                    input: RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
+                    expect: "vr_nvl8r1_c2g4_rtf_topology".to_string(),
+                },
+                Check {
+                    scenario: "vr nvl72",
+                    input: RackHardwareTopology::VrNvl72r1C2g4Topology,
+                    expect: "vr_nvl72r1_c2g4_topology".to_string(),
+                },
+            ],
+            |variant| variant.to_string(),
         );
-        assert_eq!(
-            RackHardwareTopology::VrNvl8r1C2g4RtfTopology.to_string(),
-            "vr_nvl8r1_c2g4_rtf_topology"
-        );
-        assert_eq!(
-            RackHardwareTopology::VrNvl72r1C2g4Topology.to_string(),
-            "vr_nvl72r1_c2g4_topology"
+    }
+
+    // Deserialization accepts exactly the snake_case names and rejects anything
+    // else (unknown names, the Display-only variant casing, empty). The
+    // (non-PartialEq) serde error is discarded with map_err(drop).
+    #[test]
+    fn test_rack_hardware_topology_deserialize() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid gb200 nvl36",
+                    input: "\"gb200_nvl36r1_c2g4_topology\"",
+                    expect: Yields(RackHardwareTopology::Gb200Nvl36r1C2g4Topology),
+                },
+                Case {
+                    scenario: "valid vr nvl72",
+                    input: "\"vr_nvl72r1_c2g4_topology\"",
+                    expect: Yields(RackHardwareTopology::VrNvl72r1C2g4Topology),
+                },
+                Case {
+                    scenario: "unknown topology name",
+                    input: "\"gb500_nvl99_topology\"",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "\"\"",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wrong json type",
+                    input: "42",
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<RackHardwareTopology>(json).map_err(drop),
         );
     }
 
     // RackHardwareClass serde.
 
+    // JSON round-trip: each class variant serializes to its expected snake_case
+    // string and deserializes back to itself. Projected to (json, value_back);
+    // the (non-PartialEq) serde_json error is discarded.
     #[test]
     fn test_rack_hardware_class_serde_round_trip() {
-        let cases = [
-            (RackHardwareClass::Dev, "\"dev\""),
-            (RackHardwareClass::Prod, "\"prod\""),
-        ];
-        for (variant, expected_json) in cases {
-            let json = serde_json::to_string(&variant).unwrap();
-            assert_eq!(json, expected_json, "serialize {:?}", variant);
-            let deserialized: RackHardwareClass = serde_json::from_str(&json).unwrap();
-            assert_eq!(deserialized, variant, "deserialize {:?}", variant);
-        }
+        check_cases(
+            [
+                Case {
+                    scenario: "dev round-trips",
+                    input: RackHardwareClass::Dev,
+                    expect: Yields(("\"dev\"".to_string(), RackHardwareClass::Dev)),
+                },
+                Case {
+                    scenario: "prod round-trips",
+                    input: RackHardwareClass::Prod,
+                    expect: Yields(("\"prod\"".to_string(), RackHardwareClass::Prod)),
+                },
+            ],
+            |variant| {
+                let json = serde_json::to_string(&variant).map_err(drop)?;
+                let back: RackHardwareClass = serde_json::from_str(&json).map_err(drop)?;
+                Ok::<_, ()>((json, back))
+            },
+        );
     }
 
     #[test]
     fn test_rack_hardware_class_display() {
-        assert_eq!(RackHardwareClass::Dev.to_string(), "dev");
-        assert_eq!(RackHardwareClass::Prod.to_string(), "prod");
+        check_values(
+            [
+                Check {
+                    scenario: "dev",
+                    input: RackHardwareClass::Dev,
+                    expect: "dev".to_string(),
+                },
+                Check {
+                    scenario: "prod",
+                    input: RackHardwareClass::Prod,
+                    expect: "prod".to_string(),
+                },
+            ],
+            |variant| variant.to_string(),
+        );
+    }
+
+    // Deserialization accepts the two snake_case names and rejects others.
+    // The (non-PartialEq) serde error is discarded with map_err(drop).
+    #[test]
+    fn test_rack_hardware_class_deserialize() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid dev",
+                    input: "\"dev\"",
+                    expect: Yields(RackHardwareClass::Dev),
+                },
+                Case {
+                    scenario: "valid prod",
+                    input: "\"prod\"",
+                    expect: Yields(RackHardwareClass::Prod),
+                },
+                Case {
+                    scenario: "uppercase rejected",
+                    input: "\"Dev\"",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown class",
+                    input: "\"staging\"",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "\"\"",
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<RackHardwareClass>(json).map_err(drop),
+        );
+    }
+
+    // RackCapabilityType Display renders each variant with its canonical
+    // PascalCase label.
+    #[test]
+    fn test_rack_capability_type_display() {
+        check_values(
+            [
+                Check {
+                    scenario: "compute",
+                    input: RackCapabilityType::Compute,
+                    expect: "Compute".to_string(),
+                },
+                Check {
+                    scenario: "switch",
+                    input: RackCapabilityType::Switch,
+                    expect: "Switch".to_string(),
+                },
+                Check {
+                    scenario: "power shelf",
+                    input: RackCapabilityType::PowerShelf,
+                    expect: "PowerShelf".to_string(),
+                },
+            ],
+            |variant| variant.to_string(),
+        );
     }
 }

--- a/crates/api-model/src/redfish.rs
+++ b/crates/api-model/src/redfish.rs
@@ -105,12 +105,50 @@ pub struct RedfishCreateAction {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
+    /// `From<i64>` is a plain field move; enumerate the integer boundaries it must
+    /// carry through unchanged.
     #[test]
-    fn redfish_action_id_from_i64() {
-        let id = RedfishActionId::from(99i64);
-        assert_eq!(id.request_id, 99);
+    fn redfish_action_id_from_i64_carries_the_value() {
+        check_values(
+            [
+                Check {
+                    scenario: "positive",
+                    input: 99i64,
+                    expect: 99i64,
+                },
+                Check {
+                    scenario: "zero",
+                    input: 0,
+                    expect: 0,
+                },
+                Check {
+                    scenario: "one",
+                    input: 1,
+                    expect: 1,
+                },
+                Check {
+                    scenario: "negative",
+                    input: -1,
+                    expect: -1,
+                },
+                Check {
+                    scenario: "i64::MAX",
+                    input: i64::MAX,
+                    expect: i64::MAX,
+                },
+                Check {
+                    scenario: "i64::MIN",
+                    input: i64::MIN,
+                    expect: i64::MIN,
+                },
+            ],
+            |n| RedfishActionId::from(n).request_id,
+        );
     }
 
     #[test]
@@ -118,5 +156,103 @@ mod tests {
         let id = RedfishActionId { request_id: 1 };
         let id2 = id;
         assert_eq!(id.request_id, id2.request_id);
+    }
+
+    #[test]
+    fn redfish_list_actions_filter_default_is_empty() {
+        check_values(
+            [Check {
+                scenario: "default leaves machine_ip unset",
+                input: RedfishListActionsFilter::default(),
+                expect: None,
+            }],
+            |filter| filter.machine_ip,
+        );
+    }
+
+    fn bmc_response(status: &str, body: &str) -> BMCResponse {
+        BMCResponse {
+            headers: HashMap::new(),
+            status: status.to_string(),
+            body: body.to_string(),
+            completed_at: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+        }
+    }
+
+    /// `BMCResponse` is round-tripped through JSON when persisted; assert the
+    /// serialized form survives a deserialize back to the same fields. The error
+    /// type (`serde_json::Error`) isn't `PartialEq`, so map it away.
+    #[test]
+    fn bmc_response_round_trips_through_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "ok with empty body",
+                    input: bmc_response("200 OK", ""),
+                    expect: Yields(("200 OK".to_string(), String::new())),
+                },
+                Case {
+                    scenario: "ok with json body",
+                    input: bmc_response("200 OK", r#"{"k":"v"}"#),
+                    expect: Yields(("200 OK".to_string(), r#"{"k":"v"}"#.to_string())),
+                },
+                Case {
+                    scenario: "error status",
+                    input: bmc_response("500 Internal Server Error", "boom"),
+                    expect: Yields((
+                        "500 Internal Server Error".to_string(),
+                        "boom".to_string(),
+                    )),
+                },
+                Case {
+                    scenario: "unicode body",
+                    input: bmc_response("202 Accepted", "café ☕"),
+                    expect: Yields(("202 Accepted".to_string(), "café ☕".to_string())),
+                },
+            ],
+            |response| {
+                let json = serde_json::to_string(&response).map_err(drop)?;
+                let back: BMCResponse = serde_json::from_str(&json).map_err(drop)?;
+                Ok::<_, ()>((back.status, back.body))
+            },
+        );
+    }
+
+    /// Headers are an arbitrary map; assert the serialized form preserves a chosen
+    /// key after the JSON round-trip.
+    #[test]
+    fn bmc_response_round_trip_preserves_headers() {
+        check_cases(
+            [
+                Case {
+                    scenario: "single header",
+                    input: ("Content-Type", "application/json"),
+                    expect: Yields(Some("application/json".to_string())),
+                },
+                Case {
+                    scenario: "header value with spaces",
+                    input: ("ETag", "W/\"abc 123\""),
+                    expect: Yields(Some("W/\"abc 123\"".to_string())),
+                },
+                Case {
+                    scenario: "empty header value",
+                    input: ("X-Empty", ""),
+                    expect: Yields(Some(String::new())),
+                },
+            ],
+            |(key, value): (&str, &str)| {
+                let mut headers = HashMap::new();
+                headers.insert(key.to_string(), value.to_string());
+                let response = BMCResponse {
+                    headers,
+                    status: "200 OK".to_string(),
+                    body: String::new(),
+                    completed_at: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+                };
+                let json = serde_json::to_string(&response).map_err(drop)?;
+                let back: BMCResponse = serde_json::from_str(&json).map_err(drop)?;
+                Ok::<_, ()>(back.headers.get(key).cloned())
+            },
+        );
     }
 }

--- a/crates/api-model/src/resource_pool/mod.rs
+++ b/crates/api-model/src/resource_pool/mod.rs
@@ -177,6 +177,7 @@ impl FromStr for OwnerType {
             "network_segment" => Ok(Self::NetworkSegment),
             "ib_partition" => Ok(Self::IBPartition),
             "vpc" => Ok(Self::Vpc),
+            "spx_partition" => Ok(Self::SpxPartition),
             x => Err(ModelError::InvalidArgument(format!(
                 "Unknown owner_type '{x}'"
             ))),
@@ -233,30 +234,239 @@ pub enum ResourcePoolError {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
     #[test]
-    fn test_serialize_resource_pool_entry_state() {
-        let state = ResourcePoolEntryState::Free;
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, r#"{"state":"free"}"#);
-        assert_eq!(
-            serde_json::from_str::<ResourcePoolEntryState>(&serialized).unwrap(),
-            state
+    fn serialize_resource_pool_entry_state() {
+        // Each row carries the state and its canonical JSON; the operation
+        // serializes the state and confirms it round-trips back unchanged.
+        check_cases(
+            [
+                Case {
+                    scenario: "free",
+                    input: ResourcePoolEntryState::Free,
+                    expect: Yields(r#"{"state":"free"}"#.to_string()),
+                },
+                Case {
+                    scenario: "allocated",
+                    input: ResourcePoolEntryState::Allocated {
+                        owner: "me".to_string(),
+                        owner_type: "my_stuff".to_string(),
+                    },
+                    expect: Yields(
+                        r#"{"state":"allocated","owner":"me","owner_type":"my_stuff"}"#.to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "allocated with empty owner fields",
+                    input: ResourcePoolEntryState::Allocated {
+                        owner: String::new(),
+                        owner_type: String::new(),
+                    },
+                    expect: Yields(
+                        r#"{"state":"allocated","owner":"","owner_type":""}"#.to_string(),
+                    ),
+                },
+            ],
+            |state| {
+                let serialized = serde_json::to_string(&state).map_err(drop)?;
+                let parsed: ResourcePoolEntryState =
+                    serde_json::from_str(&serialized).map_err(drop)?;
+                if parsed != state {
+                    return Err(());
+                }
+                Ok::<_, ()>(serialized)
+            },
         );
+    }
 
-        let state = ResourcePoolEntryState::Allocated {
-            owner: "me".to_string(),
-            owner_type: "my_stuff".to_string(),
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(
-            serialized,
-            r#"{"state":"allocated","owner":"me","owner_type":"my_stuff"}"#
+    #[test]
+    fn deserialize_resource_pool_entry_state() {
+        check_cases(
+            [
+                Case {
+                    scenario: "free",
+                    input: r#"{"state":"free"}"#,
+                    expect: Yields(ResourcePoolEntryState::Free),
+                },
+                Case {
+                    scenario: "allocated",
+                    input: r#"{"state":"allocated","owner":"me","owner_type":"vpc"}"#,
+                    expect: Yields(ResourcePoolEntryState::Allocated {
+                        owner: "me".to_string(),
+                        owner_type: "vpc".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "unknown tag is rejected",
+                    input: r#"{"state":"borrowed"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "allocated missing owner_type is rejected",
+                    input: r#"{"state":"allocated","owner":"me"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "not an object is rejected",
+                    input: r#"42"#,
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<ResourcePoolEntryState>(json).map_err(drop),
         );
-        assert_eq!(
-            serde_json::from_str::<ResourcePoolEntryState>(&serialized).unwrap(),
-            state
+    }
+
+    #[test]
+    fn owner_type_from_str() {
+        // `ModelError` has no `PartialEq`, so error rows use `Fails` and the run
+        // closure drops the error to settle on `()`.
+        check_cases(
+            [
+                Case {
+                    scenario: "machine",
+                    input: "machine",
+                    expect: Yields(OwnerType::Machine),
+                },
+                Case {
+                    scenario: "network_segment",
+                    input: "network_segment",
+                    expect: Yields(OwnerType::NetworkSegment),
+                },
+                Case {
+                    scenario: "ib_partition",
+                    input: "ib_partition",
+                    expect: Yields(OwnerType::IBPartition),
+                },
+                Case {
+                    scenario: "vpc",
+                    input: "vpc",
+                    expect: Yields(OwnerType::Vpc),
+                },
+                Case {
+                    scenario: "spx_partition round-trips through Display/FromStr",
+                    input: "spx_partition",
+                    expect: Yields(OwnerType::SpxPartition),
+                },
+                Case {
+                    scenario: "unknown string",
+                    input: "nonsense",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wrong case is rejected",
+                    input: "Machine",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "leading whitespace is rejected",
+                    input: " machine",
+                    expect: Fails,
+                },
+            ],
+            |s| OwnerType::from_str(s).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn owner_type_display_round_trips_via_from_str() {
+        // Every variant that `from_str` accepts must display to a string that
+        // `from_str` accepts back as the same variant.
+        check_cases(
+            [
+                Case {
+                    scenario: "machine",
+                    input: OwnerType::Machine,
+                    expect: Yields(OwnerType::Machine),
+                },
+                Case {
+                    scenario: "network_segment",
+                    input: OwnerType::NetworkSegment,
+                    expect: Yields(OwnerType::NetworkSegment),
+                },
+                Case {
+                    scenario: "ib_partition",
+                    input: OwnerType::IBPartition,
+                    expect: Yields(OwnerType::IBPartition),
+                },
+                Case {
+                    scenario: "vpc",
+                    input: OwnerType::Vpc,
+                    expect: Yields(OwnerType::Vpc),
+                },
+            ],
+            |owner| OwnerType::from_str(&owner.to_string()).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn owner_type_display() {
+        check_values(
+            [
+                Check {
+                    scenario: "machine",
+                    input: OwnerType::Machine,
+                    expect: "machine".to_string(),
+                },
+                Check {
+                    scenario: "network_segment",
+                    input: OwnerType::NetworkSegment,
+                    expect: "network_segment".to_string(),
+                },
+                Check {
+                    scenario: "ib_partition",
+                    input: OwnerType::IBPartition,
+                    expect: "ib_partition".to_string(),
+                },
+                Check {
+                    scenario: "vpc",
+                    input: OwnerType::Vpc,
+                    expect: "vpc".to_string(),
+                },
+                Check {
+                    scenario: "spx_partition",
+                    input: OwnerType::SpxPartition,
+                    expect: "spx_partition".to_string(),
+                },
+            ],
+            |owner| owner.to_string(),
+        );
+    }
+
+    #[test]
+    fn value_type_display() {
+        check_values(
+            [
+                Check {
+                    scenario: "integer",
+                    input: ValueType::Integer,
+                    expect: "Integer".to_string(),
+                },
+                Check {
+                    scenario: "ipv4",
+                    input: ValueType::Ipv4,
+                    expect: "Ipv4".to_string(),
+                },
+                Check {
+                    scenario: "ipv6",
+                    input: ValueType::Ipv6,
+                    expect: "Ipv6".to_string(),
+                },
+                Check {
+                    scenario: "ipv6_prefix",
+                    input: ValueType::Ipv6Prefix,
+                    expect: "Ipv6Prefix".to_string(),
+                },
+            ],
+            |value_type| value_type.to_string(),
         );
     }
 }

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -1553,6 +1553,9 @@ pub fn is_bluefield_model(model: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
     use crate::firmware::FirmwareComponent;
     use crate::machine::machine_id::from_hardware_info;
@@ -1613,28 +1616,36 @@ mod tests {
         }
     }
 
+    /// `find_version` locates the firmware version matching a component regex,
+    /// yielding the version string when an inventory matches and absent otherwise.
     #[test]
-    fn test_find_version_single_match() {
+    fn test_find_version() {
         let fw_info = create_test_firmware(FirmwareComponentType::Bmc, r"^BMC_Firmware$");
-        let endpoint = create_test_endpoint(vec![
-            ("BMC_Firmware", Some("1.2.3")),
-            ("DPU_UEFI", Some("4.5.6")),
-        ]);
-
-        let result = endpoint.find_version(&fw_info, FirmwareComponentType::Bmc);
-        assert_eq!(result, Some(&"1.2.3".to_string()));
-    }
-
-    #[test]
-    fn test_find_version_no_match() {
-        let fw_info = create_test_firmware(FirmwareComponentType::Bmc, r"^BMC_Firmware$");
-        let endpoint = create_test_endpoint(vec![
-            ("DPU_UEFI", Some("4.5.6")),
-            ("Other_Component", Some("7.8.9")),
-        ]);
-
-        let result = endpoint.find_version(&fw_info, FirmwareComponentType::Bmc);
-        assert_eq!(result, None);
+        check_cases(
+            [
+                Case {
+                    scenario: "single match",
+                    input: vec![("BMC_Firmware", Some("1.2.3")), ("DPU_UEFI", Some("4.5.6"))],
+                    expect: Yields("1.2.3".to_string()),
+                },
+                Case {
+                    scenario: "no match",
+                    input: vec![
+                        ("DPU_UEFI", Some("4.5.6")),
+                        ("Other_Component", Some("7.8.9")),
+                    ],
+                    expect: Fails,
+                },
+            ],
+            // Build an endpoint from the inventories, then look up the BMC
+            // version; absent -> error so the no-match row reads as a failure.
+            |inventories| {
+                create_test_endpoint(inventories)
+                    .find_version(&fw_info, FirmwareComponentType::Bmc)
+                    .cloned()
+                    .ok_or(())
+            },
+        );
     }
 
     #[test]
@@ -1969,28 +1980,45 @@ mod tests {
         assert_eq!(deserialized.machine_id.unwrap(), machine_id);
     }
 
+    /// `UefiDevicePath::from_str` parses a UEFI PciRoot/Pci device path into a
+    /// dotted decimal address, requiring at least one Pci node after PciRoot.
     #[test]
     fn test_uefi_device_path() {
-        let path = "PciRoot(0x2)/Pci(0x1,0x0)/Pci(0x0,0x1)";
-        let converted: UefiDevicePath = UefiDevicePath::from_str(path).unwrap();
-        assert_eq!(converted.0, "2.1.0.0.1");
-
-        let path = "PciRoot(0x11)/Pci(0x1,0x0)/Pci(0x0,0xa)/MAC(A088C20C87C6,0x1)";
-        let converted: UefiDevicePath = UefiDevicePath::from_str(path).unwrap();
-        assert_eq!(converted.0, "17.1.0.0.10");
-
-        // NIC attached directly to a root port (no PCI-PCI bridge upstream).
-        let path = "PciRoot(0x7)/Pci(0x0,0x0)/MAC(525400A8282F,0x1)";
-        let converted: UefiDevicePath = UefiDevicePath::from_str(path).unwrap();
-        assert_eq!(converted.0, "7.0.0");
-
-        // Three Pci nodes (NIC behind two upstream bridges/switches).
-        let path = "PciRoot(0x0)/Pci(0x1,0x0)/Pci(0x0,0x0)/Pci(0x0,0x0)";
-        let converted: UefiDevicePath = UefiDevicePath::from_str(path).unwrap();
-        assert_eq!(converted.0, "0.1.0.0.0.0.0");
-
-        // PciRoot without any Pci node should fail.
-        assert!(UefiDevicePath::from_str("PciRoot(0x7)/MAC(525400A8282F,0x1)").is_err());
+        check_cases(
+            [
+                Case {
+                    scenario: "two Pci nodes",
+                    input: "PciRoot(0x2)/Pci(0x1,0x0)/Pci(0x0,0x1)",
+                    expect: Yields("2.1.0.0.1".to_string()),
+                },
+                Case {
+                    scenario: "trailing MAC discarded",
+                    input: "PciRoot(0x11)/Pci(0x1,0x0)/Pci(0x0,0xa)/MAC(A088C20C87C6,0x1)",
+                    expect: Yields("17.1.0.0.10".to_string()),
+                },
+                Case {
+                    // NIC attached directly to a root port (no PCI-PCI bridge upstream).
+                    scenario: "single Pci node on a root port",
+                    input: "PciRoot(0x7)/Pci(0x0,0x0)/MAC(525400A8282F,0x1)",
+                    expect: Yields("7.0.0".to_string()),
+                },
+                Case {
+                    // Three Pci nodes (NIC behind two upstream bridges/switches).
+                    scenario: "three Pci nodes",
+                    input: "PciRoot(0x0)/Pci(0x1,0x0)/Pci(0x0,0x0)/Pci(0x0,0x0)",
+                    expect: Yields("0.1.0.0.0.0.0".to_string()),
+                },
+                Case {
+                    // PciRoot without any Pci node should fail.
+                    scenario: "PciRoot without any Pci node",
+                    input: "PciRoot(0x7)/MAC(525400A8282F,0x1)",
+                    expect: Fails,
+                },
+            ],
+            // The error type is String, but the failing row only asserts that it
+            // errors, so discard it; yield the dotted address on success.
+            |path| UefiDevicePath::from_str(path).map(|u| u.0).map_err(drop),
+        );
     }
 
     #[test]
@@ -2078,11 +2106,16 @@ mod tests {
         assert!(report.is_power_shelf());
     }
 
+    /// `find_interface_id_for_mac` returns the Redfish interface id of the host
+    /// ethernet interface whose MAC matches, treating a missing or empty id (and
+    /// an unknown MAC) as absent so a last-known-good capture is never clobbered.
     #[test]
-    fn find_interface_id_for_mac_matches_host_ethernet_interface() {
+    fn find_interface_id_for_mac() {
         let mac = MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01]);
         let other = MacAddress::new([0x11, 0x22, 0x33, 0x44, 0x55, 0x66]);
-        let report = EndpointExplorationReport {
+
+        // Report with two interfaces: `other` then `mac`, both with ids.
+        let two_iface_report = EndpointExplorationReport {
             systems: vec![ComputerSystem {
                 ethernet_interfaces: vec![
                     EthernetInterface {
@@ -2100,25 +2133,11 @@ mod tests {
             }],
             ..Default::default()
         };
-
-        assert_eq!(
-            report.find_interface_id_for_mac(mac),
-            Some("NIC.Slot.7-1-1")
-        );
-        // Unknown MAC -> None (so the capture keeps the last-known-good record).
-        assert_eq!(
-            report.find_interface_id_for_mac(MacAddress::new([0, 0, 0, 0, 0, 0])),
-            None
-        );
-    }
-
-    #[test]
-    fn find_interface_id_for_mac_none_when_id_missing() {
-        let mac = MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01]);
-        let report = EndpointExplorationReport {
+        // Single interface carrying `mac` but no usable id.
+        let single_iface_report = |id: Option<String>| EndpointExplorationReport {
             systems: vec![ComputerSystem {
                 ethernet_interfaces: vec![EthernetInterface {
-                    id: None,
+                    id,
                     mac_address: Some(mac),
                     ..Default::default()
                 }],
@@ -2126,28 +2145,37 @@ mod tests {
             }],
             ..Default::default()
         };
-        // MAC present but no interface id -> can't form a fully-populated pair.
-        assert_eq!(report.find_interface_id_for_mac(mac), None);
-    }
 
-    #[test]
-    fn find_interface_id_for_mac_none_when_id_empty() {
-        let mac = MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x01]);
-        let report = EndpointExplorationReport {
-            systems: vec![ComputerSystem {
-                ethernet_interfaces: vec![EthernetInterface {
-                    id: Some(String::new()),
-                    mac_address: Some(mac),
-                    ..Default::default()
-                }],
-                ..Default::default()
-            }],
-            ..Default::default()
-        };
-        // An empty id is not a usable interface id, so it's treated as absent --
-        // the capture then keeps the last-known-good stored boot interface
-        // rather than clobbering it with an empty string.
-        assert_eq!(report.find_interface_id_for_mac(mac), None);
+        check_cases(
+            [
+                Case {
+                    scenario: "matching MAC yields its interface id",
+                    input: (two_iface_report.clone(), mac),
+                    expect: Yields("NIC.Slot.7-1-1".to_string()),
+                },
+                Case {
+                    scenario: "unknown MAC -> None (keeps last-known-good record)",
+                    input: (two_iface_report, MacAddress::new([0, 0, 0, 0, 0, 0])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "MAC present but no interface id -> no complete pair",
+                    input: (single_iface_report(None), mac),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty id treated as absent (don't clobber stored boot interface)",
+                    input: (single_iface_report(Some(String::new())), mac),
+                    expect: Fails,
+                },
+            ],
+            |(report, mac)| {
+                report
+                    .find_interface_id_for_mac(mac)
+                    .map(str::to_string)
+                    .ok_or(())
+            },
+        );
     }
 
     #[test]
@@ -2265,78 +2293,80 @@ mod tests {
         assert!(!report.is_power_shelf());
     }
 
+    /// A `ComputerSystem` deserializes regardless of the `BaseMac` field: a valid
+    /// value parses through, while an invalid, null, or missing one becomes `None`.
+    /// Each row projects to the resulting `base_mac`.
     #[test]
-    fn test_computer_system_with_invalid_base_mac_deserializes_as_none() {
-        let json = serde_json::json!({
-            "EthernetInterfaces": [],
-            "Id": "Bluefield",
-            "Manufacturer": "Nvidia",
-            "Model": "Bluefield-3 DPU",
-            "SerialNumber": "ABC1234",
-            "Attributes": {},
-            "PcieDevices": [],
-            "BaseMac": "pe:",
-            "PowerState": "On"
-        });
-
-        let system: ComputerSystem =
-            serde_json::from_value(json).expect("should deserialize despite invalid BaseMac");
-        assert_eq!(system.base_mac, None);
-    }
-
-    #[test]
-    fn test_computer_system_with_valid_base_mac_deserializes_correctly() {
-        let json = serde_json::json!({
-            "EthernetInterfaces": [],
-            "Id": "Bluefield",
-            "Manufacturer": "Nvidia",
-            "Model": "Bluefield-3 DPU",
-            "SerialNumber": "ABC1234",
-            "Attributes": {},
-            "PcieDevices": [],
-            "BaseMac": "A088C208804C",
-            "PowerState": "On"
-        });
-
-        let system: ComputerSystem =
-            serde_json::from_value(json).expect("should deserialize valid BaseMac");
-        assert_eq!(system.base_mac, Some("A088C208804C".parse().unwrap()));
-    }
-
-    #[test]
-    fn test_computer_system_with_null_base_mac_deserializes_as_none() {
-        let json = serde_json::json!({
-            "EthernetInterfaces": [],
-            "Id": "Bluefield",
-            "Manufacturer": "Nvidia",
-            "Model": "Bluefield-3 DPU",
-            "SerialNumber": "ABC1234",
-            "Attributes": {},
-            "PcieDevices": [],
-            "BaseMac": null,
-            "PowerState": "On"
-        });
-
-        let system: ComputerSystem =
-            serde_json::from_value(json).expect("should deserialize null BaseMac");
-        assert_eq!(system.base_mac, None);
-    }
-
-    #[test]
-    fn test_computer_system_with_missing_base_mac_deserializes_as_none() {
-        let json = serde_json::json!({
-            "EthernetInterfaces": [],
-            "Id": "Bluefield",
-            "Manufacturer": "Nvidia",
-            "Model": "Bluefield-3 DPU",
-            "SerialNumber": "ABC1234",
-            "Attributes": {},
-            "PcieDevices": [],
-            "PowerState": "On"
-        });
-
-        let system: ComputerSystem =
-            serde_json::from_value(json).expect("should deserialize missing BaseMac");
-        assert_eq!(system.base_mac, None);
+    fn test_computer_system_base_mac_deserialization() {
+        check_cases(
+            [
+                Case {
+                    scenario: "invalid BaseMac -> None",
+                    input: serde_json::json!({
+                        "EthernetInterfaces": [],
+                        "Id": "Bluefield",
+                        "Manufacturer": "Nvidia",
+                        "Model": "Bluefield-3 DPU",
+                        "SerialNumber": "ABC1234",
+                        "Attributes": {},
+                        "PcieDevices": [],
+                        "BaseMac": "pe:",
+                        "PowerState": "On"
+                    }),
+                    expect: Yields(None),
+                },
+                Case {
+                    scenario: "valid BaseMac parses through",
+                    input: serde_json::json!({
+                        "EthernetInterfaces": [],
+                        "Id": "Bluefield",
+                        "Manufacturer": "Nvidia",
+                        "Model": "Bluefield-3 DPU",
+                        "SerialNumber": "ABC1234",
+                        "Attributes": {},
+                        "PcieDevices": [],
+                        "BaseMac": "A088C208804C",
+                        "PowerState": "On"
+                    }),
+                    expect: Yields(Some("A088C208804C".parse().unwrap())),
+                },
+                Case {
+                    scenario: "null BaseMac -> None",
+                    input: serde_json::json!({
+                        "EthernetInterfaces": [],
+                        "Id": "Bluefield",
+                        "Manufacturer": "Nvidia",
+                        "Model": "Bluefield-3 DPU",
+                        "SerialNumber": "ABC1234",
+                        "Attributes": {},
+                        "PcieDevices": [],
+                        "BaseMac": null,
+                        "PowerState": "On"
+                    }),
+                    expect: Yields(None),
+                },
+                Case {
+                    scenario: "missing BaseMac -> None",
+                    input: serde_json::json!({
+                        "EthernetInterfaces": [],
+                        "Id": "Bluefield",
+                        "Manufacturer": "Nvidia",
+                        "Model": "Bluefield-3 DPU",
+                        "SerialNumber": "ABC1234",
+                        "Attributes": {},
+                        "PcieDevices": [],
+                        "PowerState": "On"
+                    }),
+                    expect: Yields(None),
+                },
+            ],
+            // Deserialize and project to base_mac; every row is expected to
+            // deserialize, so the (non-PartialEq) serde error is discarded.
+            |json| {
+                serde_json::from_value::<ComputerSystem>(json)
+                    .map(|system| system.base_mac)
+                    .map_err(drop)
+            },
+        );
     }
 }

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -382,83 +382,444 @@ pub struct SwitchSearchFilter {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
+    /// Build a `FabricManagerStatus` with only the two fields `display_status`
+    /// inspects; the rest are irrelevant to its logic.
+    fn fm_status(
+        state: FabricManagerState,
+        addition_info: Option<&str>,
+    ) -> FabricManagerStatus {
+        FabricManagerStatus {
+            fabric_manager_state: state,
+            addition_info: addition_info.map(str::to_string),
+            reason: None,
+            error_message: None,
+        }
+    }
+
     #[test]
-    fn serialize_controller_state() {
-        let state = SwitchControllerState::Created;
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"created\"}");
-        assert_eq!(
-            serde_json::from_str::<SwitchControllerState>(&serialized).unwrap(),
-            state
+    fn controller_state_serializes_to_expected_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "created",
+                    input: SwitchControllerState::Created,
+                    expect: Yields(r#"{"state":"created"}"#.to_string()),
+                },
+                Case {
+                    scenario: "initializing",
+                    input: SwitchControllerState::Initializing {
+                        initializing_state: InitializingState::WaitForOsMachineInterface,
+                    },
+                    expect: Yields(
+                        r#"{"state":"initializing","initializing_state":"WaitForOsMachineInterface"}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "configuring",
+                    input: SwitchControllerState::Configuring {
+                        config_state: ConfiguringState::RotateOsPassword,
+                    },
+                    expect: Yields(
+                        r#"{"state":"configuring","config_state":"RotateOsPassword"}"#.to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "validating",
+                    input: SwitchControllerState::Validating {
+                        validating_state: ValidatingState::ValidationComplete,
+                    },
+                    expect: Yields(
+                        r#"{"state":"validating","validating_state":"ValidationComplete"}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "bomvalidating",
+                    input: SwitchControllerState::BomValidating {
+                        bom_validating_state: BomValidatingState::BomValidationComplete,
+                    },
+                    expect: Yields(
+                        r#"{"state":"bomvalidating","bom_validating_state":"BomValidationComplete"}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "ready",
+                    input: SwitchControllerState::Ready,
+                    expect: Yields(r#"{"state":"ready"}"#.to_string()),
+                },
+                Case {
+                    scenario: "maintenance: power on",
+                    input: SwitchControllerState::Maintenance {
+                        operation: SwitchMaintenanceOperation::PowerOn,
+                    },
+                    expect: Yields(
+                        r#"{"state":"maintenance","operation":{"operation":"poweron"}}"#.to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "maintenance: power off",
+                    input: SwitchControllerState::Maintenance {
+                        operation: SwitchMaintenanceOperation::PowerOff,
+                    },
+                    expect: Yields(
+                        r#"{"state":"maintenance","operation":{"operation":"poweroff"}}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "maintenance: reset",
+                    input: SwitchControllerState::Maintenance {
+                        operation: SwitchMaintenanceOperation::Reset,
+                    },
+                    expect: Yields(
+                        r#"{"state":"maintenance","operation":{"operation":"reset"}}"#.to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "reprovisioning: firmware upgrade",
+                    input: SwitchControllerState::ReProvisioning {
+                        reprovisioning_state:
+                            ReProvisioningState::WaitingForRackFirmwareUpgrade,
+                    },
+                    expect: Yields(
+                        r#"{"state":"reprovisioning","reprovisioning_state":"WaitingForRackFirmwareUpgrade"}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "reprovisioning: nvos upgrade",
+                    input: SwitchControllerState::ReProvisioning {
+                        reprovisioning_state: ReProvisioningState::WaitingForNVOSUpgrade,
+                    },
+                    expect: Yields(
+                        r#"{"state":"reprovisioning","reprovisioning_state":"WaitingForNVOSUpgrade"}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "reprovisioning: nmxc configure",
+                    input: SwitchControllerState::ReProvisioning {
+                        reprovisioning_state: ReProvisioningState::WaitingForNMXCConfigure,
+                    },
+                    expect: Yields(
+                        r#"{"state":"reprovisioning","reprovisioning_state":"WaitingForNMXCConfigure"}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "error carries its cause",
+                    input: SwitchControllerState::Error {
+                        cause: "cause goes here".to_string(),
+                    },
+                    expect: Yields(
+                        r#"{"state":"error","cause":"cause goes here"}"#.to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "deleting",
+                    input: SwitchControllerState::Deleting,
+                    expect: Yields(r#"{"state":"deleting"}"#.to_string()),
+                },
+            ],
+            |state| serde_json::to_string(&state).map_err(drop),
         );
-        let state = SwitchControllerState::Initializing {
-            initializing_state: InitializingState::WaitForOsMachineInterface,
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(
-            serialized,
-            "{\"state\":\"initializing\",\"initializing_state\":\"WaitForOsMachineInterface\"}"
+    }
+
+    #[test]
+    fn controller_state_deserializes_from_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "created",
+                    input: r#"{"state":"created"}"#,
+                    expect: Yields(SwitchControllerState::Created),
+                },
+                Case {
+                    scenario: "initializing",
+                    input: r#"{"state":"initializing","initializing_state":"WaitForOsMachineInterface"}"#,
+                    expect: Yields(SwitchControllerState::Initializing {
+                        initializing_state: InitializingState::WaitForOsMachineInterface,
+                    }),
+                },
+                Case {
+                    scenario: "configuring",
+                    input: r#"{"state":"configuring","config_state":"RotateOsPassword"}"#,
+                    expect: Yields(SwitchControllerState::Configuring {
+                        config_state: ConfiguringState::RotateOsPassword,
+                    }),
+                },
+                Case {
+                    scenario: "validating",
+                    input: r#"{"state":"validating","validating_state":"ValidationComplete"}"#,
+                    expect: Yields(SwitchControllerState::Validating {
+                        validating_state: ValidatingState::ValidationComplete,
+                    }),
+                },
+                Case {
+                    scenario: "bomvalidating",
+                    input: r#"{"state":"bomvalidating","bom_validating_state":"BomValidationComplete"}"#,
+                    expect: Yields(SwitchControllerState::BomValidating {
+                        bom_validating_state: BomValidatingState::BomValidationComplete,
+                    }),
+                },
+                Case {
+                    scenario: "ready",
+                    input: r#"{"state":"ready"}"#,
+                    expect: Yields(SwitchControllerState::Ready),
+                },
+                Case {
+                    scenario: "legacy ready with stray ready_state still deserializes to Ready",
+                    input: r#"{"state":"ready","ready_state":"poweroff"}"#,
+                    expect: Yields(SwitchControllerState::Ready),
+                },
+                Case {
+                    scenario: "maintenance: reset",
+                    input: r#"{"state":"maintenance","operation":{"operation":"reset"}}"#,
+                    expect: Yields(SwitchControllerState::Maintenance {
+                        operation: SwitchMaintenanceOperation::Reset,
+                    }),
+                },
+                Case {
+                    scenario: "error",
+                    input: r#"{"state":"error","cause":"boom"}"#,
+                    expect: Yields(SwitchControllerState::Error {
+                        cause: "boom".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "deleting",
+                    input: r#"{"state":"deleting"}"#,
+                    expect: Yields(SwitchControllerState::Deleting),
+                },
+                Case {
+                    scenario: "unknown state tag is rejected",
+                    input: r#"{"state":"frobnicating"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing state tag is rejected",
+                    input: r#"{"cause":"boom"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "error without its cause is rejected",
+                    input: r#"{"state":"error"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "not even json",
+                    input: "not json",
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<SwitchControllerState>(json).map_err(drop),
         );
-        assert_eq!(
-            serde_json::from_str::<SwitchControllerState>(&serialized).unwrap(),
-            state
+    }
+
+    #[test]
+    fn maintenance_operation_serializes_lowercase() {
+        check_cases(
+            [
+                Case {
+                    scenario: "power on",
+                    input: SwitchMaintenanceOperation::PowerOn,
+                    expect: Yields(r#"{"operation":"poweron"}"#.to_string()),
+                },
+                Case {
+                    scenario: "power off",
+                    input: SwitchMaintenanceOperation::PowerOff,
+                    expect: Yields(r#"{"operation":"poweroff"}"#.to_string()),
+                },
+                Case {
+                    scenario: "reset",
+                    input: SwitchMaintenanceOperation::Reset,
+                    expect: Yields(r#"{"operation":"reset"}"#.to_string()),
+                },
+            ],
+            |op| serde_json::to_string(&op).map_err(drop),
         );
-        let state = SwitchControllerState::Configuring {
-            config_state: ConfiguringState::RotateOsPassword,
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(
-            serialized,
-            "{\"state\":\"configuring\",\"config_state\":\"RotateOsPassword\"}"
+    }
+
+    #[test]
+    fn maintenance_operation_deserializes() {
+        check_cases(
+            [
+                Case {
+                    scenario: "power on",
+                    input: r#"{"operation":"poweron"}"#,
+                    expect: Yields(SwitchMaintenanceOperation::PowerOn),
+                },
+                Case {
+                    scenario: "power off",
+                    input: r#"{"operation":"poweroff"}"#,
+                    expect: Yields(SwitchMaintenanceOperation::PowerOff),
+                },
+                Case {
+                    scenario: "reset",
+                    input: r#"{"operation":"reset"}"#,
+                    expect: Yields(SwitchMaintenanceOperation::Reset),
+                },
+                Case {
+                    scenario: "uppercase tag is rejected",
+                    input: r#"{"operation":"PowerOn"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown operation is rejected",
+                    input: r#"{"operation":"explode"}"#,
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<SwitchMaintenanceOperation>(json).map_err(drop),
         );
-        assert_eq!(
-            serde_json::from_str::<SwitchControllerState>(&serialized).unwrap(),
-            state
+    }
+
+    #[test]
+    fn fabric_manager_state_serializes_snake_case() {
+        check_cases(
+            [
+                Case {
+                    scenario: "ok",
+                    input: FabricManagerState::Ok,
+                    expect: Yields(r#""ok""#.to_string()),
+                },
+                Case {
+                    scenario: "not ok renders snake_case",
+                    input: FabricManagerState::NotOk,
+                    expect: Yields(r#""not_ok""#.to_string()),
+                },
+                Case {
+                    scenario: "unknown",
+                    input: FabricManagerState::Unknown,
+                    expect: Yields(r#""unknown""#.to_string()),
+                },
+            ],
+            |state| serde_json::to_string(&state).map_err(drop),
         );
-        let state = SwitchControllerState::Ready;
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, r#"{"state":"ready"}"#);
-        assert_eq!(
-            serde_json::from_str::<SwitchControllerState>(&serialized).unwrap(),
-            state
+    }
+
+    #[test]
+    fn fabric_manager_state_deserializes() {
+        check_cases(
+            [
+                Case {
+                    scenario: "ok",
+                    input: r#""ok""#,
+                    expect: Yields(FabricManagerState::Ok),
+                },
+                Case {
+                    scenario: "not_ok",
+                    input: r#""not_ok""#,
+                    expect: Yields(FabricManagerState::NotOk),
+                },
+                Case {
+                    scenario: "unknown",
+                    input: r#""unknown""#,
+                    expect: Yields(FabricManagerState::Unknown),
+                },
+                Case {
+                    scenario: "camelCase NotOk is rejected",
+                    input: r#""NotOk""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unrecognized state is rejected",
+                    input: r#""degraded""#,
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<FabricManagerState>(json).map_err(drop),
         );
-        assert_eq!(
-            serde_json::from_str::<SwitchControllerState>(
-                r#"{"state":"ready","ready_state":"poweroff"}"#
-            )
-            .unwrap(),
-            SwitchControllerState::Ready,
-            "legacy Ready JSON with ready_state deserializes to Ready",
+    }
+
+    #[test]
+    fn display_status_is_running_only_when_ok_and_configured() {
+        check_values(
+            [
+                Check {
+                    scenario: "ok + CONFIGURED is running",
+                    input: fm_status(
+                        FabricManagerState::Ok,
+                        Some("CONTROL_PLANE_STATE_CONFIGURED"),
+                    ),
+                    expect: "running",
+                },
+                Check {
+                    scenario: "ok but no addition_info is not running",
+                    input: fm_status(FabricManagerState::Ok, None),
+                    expect: "not_running",
+                },
+                Check {
+                    scenario: "ok but different addition_info is not running",
+                    input: fm_status(
+                        FabricManagerState::Ok,
+                        Some("CONTROL_PLANE_STATE_INITIALIZING"),
+                    ),
+                    expect: "not_running",
+                },
+                Check {
+                    scenario: "ok but empty addition_info is not running",
+                    input: fm_status(FabricManagerState::Ok, Some("")),
+                    expect: "not_running",
+                },
+                Check {
+                    scenario: "not_ok even when configured is not running",
+                    input: fm_status(
+                        FabricManagerState::NotOk,
+                        Some("CONTROL_PLANE_STATE_CONFIGURED"),
+                    ),
+                    expect: "not_running",
+                },
+                Check {
+                    scenario: "unknown even when configured is not running",
+                    input: fm_status(
+                        FabricManagerState::Unknown,
+                        Some("CONTROL_PLANE_STATE_CONFIGURED"),
+                    ),
+                    expect: "not_running",
+                },
+                Check {
+                    scenario: "not_ok with no info is not running",
+                    input: fm_status(FabricManagerState::NotOk, None),
+                    expect: "not_running",
+                },
+            ],
+            |status| status.display_status(),
         );
-        let state = SwitchControllerState::Maintenance {
-            operation: SwitchMaintenanceOperation::PowerOn,
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(
-            serialized,
-            r#"{"state":"maintenance","operation":{"operation":"poweron"}}"#
-        );
-        assert_eq!(
-            serde_json::from_str::<SwitchControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = SwitchControllerState::Error {
-            cause: "cause goes here".to_string(),
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, r#"{"state":"error","cause":"cause goes here"}"#);
-        assert_eq!(
-            serde_json::from_str::<SwitchControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = SwitchControllerState::Deleting;
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"deleting\"}");
-        assert_eq!(
-            serde_json::from_str::<SwitchControllerState>(&serialized).unwrap(),
-            state
+    }
+
+    #[test]
+    fn reprovision_request_defaults_continue_after_firmware_upgrade_to_true() {
+        check_cases(
+            [
+                Case {
+                    scenario: "omitted flag defaults to true",
+                    input: r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op"}"#,
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "explicit false is honored",
+                    input: r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op","continue_after_firmware_upgrade":false}"#,
+                    expect: Yields(false),
+                },
+                Case {
+                    scenario: "explicit true is honored",
+                    input: r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op","continue_after_firmware_upgrade":true}"#,
+                    expect: Yields(true),
+                },
+            ],
+            |json| {
+                serde_json::from_str::<SwitchReprovisionRequest>(json)
+                    .map(|r| r.continue_after_firmware_upgrade)
+                    .map_err(drop)
+            },
         );
     }
 }

--- a/crates/api-model/src/tenant/identity_config_policy.rs
+++ b/crates/api-model/src/tenant/identity_config_policy.rs
@@ -438,6 +438,9 @@ pub fn resolve_subject_prefix(
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     fn resolve_identity(issuer: &str, proto: Option<&str>) -> Result<String, String> {
@@ -445,177 +448,211 @@ mod tests {
         resolve_subject_prefix(&td, proto)
     }
 
+    // Issuer trust-domain extraction (the `.1` of `normalize_issuer_and_trust_domain`).
+    // Each row is `(issuer, error_substring)`: success rows `Yields` the lowercased trust
+    // domain (the substring is unused, left ""); rejection rows assert the error contains the
+    // given token via `FailsWith(true)`. The `String` error is not the asserted contract here
+    // (the originals only checked substrings), so we project the error to "does it contain token".
     #[test]
-    fn trust_domain_https_issuer() {
-        assert_eq!(
-            normalize_issuer_and_trust_domain("https://Issuer.EXAMPLE/path")
-                .unwrap()
-                .1,
-            "issuer.example"
+    fn issuer_trust_domain_extraction() {
+        check_cases(
+            [
+                Case {
+                    scenario: "https issuer lowercases host, drops path",
+                    input: ("https://Issuer.EXAMPLE/path", ""),
+                    expect: Yields("issuer.example".to_string()),
+                },
+                Case {
+                    scenario: "https issuer with explicit port",
+                    input: ("https://Issuer.EXAMPLE:8443/", ""),
+                    expect: Yields("issuer.example".to_string()),
+                },
+                Case {
+                    scenario: "spiffe issuer lowercases host",
+                    input: ("spiffe://Issuer.EXAMPLE/bundle", ""),
+                    expect: Yields("issuer.example".to_string()),
+                },
+                Case {
+                    scenario: "spiffe scheme uppercase",
+                    input: ("SPIFFE://Issuer.EXAMPLE/bundle", ""),
+                    expect: Yields("issuer.example".to_string()),
+                },
+                Case {
+                    scenario: "spiffe scheme mixed case, no path",
+                    input: ("SpIfFe://issuer.example", ""),
+                    expect: Yields("issuer.example".to_string()),
+                },
+                Case {
+                    scenario: "query string rejected",
+                    input: ("https://issuer.example/?q=1", "query"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "ipv4 host rejected",
+                    input: ("https://127.0.0.1/", "IP"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "ipv6 host rejected",
+                    input: ("spiffe://[::1]/x", "IP"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "userinfo (user only) rejected",
+                    input: ("https://user@issuer.example/", "userinfo"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "userinfo with password rejected",
+                    input: ("https://user:pass@issuer.example/", "userinfo"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "non-http(s)/spiffe scheme rejected",
+                    input: ("ftp://issuer.example/", "http"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "bare hostname (no scheme) rejected",
+                    input: ("issuer.example", "http://"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "bare hostname with path rejected",
+                    input: ("issuer.example/extra", "http://"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "backslash rejected",
+                    input: ("https://issuer.example\\evil", "disallowed"),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "control char rejected",
+                    input: ("https://issuer.ex\0ample.com/", "disallowed"),
+                    expect: FailsWith(true),
+                },
+            ],
+            |(issuer, token)| {
+                normalize_issuer_and_trust_domain(issuer)
+                    .map(|(_, td)| td)
+                    .map_err(|e| e.contains(token))
+            },
         );
     }
 
+    // Normalized `iss` string (the `.0` of `normalize_issuer_and_trust_domain`): scheme/path/port
+    // preservation, host lowercasing, default lone-`/` path omitted. All success rows.
     #[test]
-    fn trust_domain_https_issuer_optional_port() {
-        assert_eq!(
-            normalize_issuer_and_trust_domain("https://Issuer.EXAMPLE:8443/")
-                .unwrap()
-                .1,
-            "issuer.example"
+    fn normalize_issuer_preserves_scheme_path_and_port() {
+        check_cases(
+            [
+                Case {
+                    scenario: "http scheme and path lowercased host",
+                    input: "HTTP://Issuer.EXAMPLE/path",
+                    expect: Yields("http://issuer.example/path".to_string()),
+                },
+                Case {
+                    scenario: "explicit port and path preserved",
+                    input: "https://issuer.example:8443/ns",
+                    expect: Yields("https://issuer.example:8443/ns".to_string()),
+                },
+                Case {
+                    scenario: "spiffe scheme normalized",
+                    input: "SpIfFe://Issuer.EXAMPLE/bundle",
+                    expect: Yields("spiffe://issuer.example/bundle".to_string()),
+                },
+            ],
+            |s| {
+                normalize_issuer_and_trust_domain(s)
+                    .map(|(iss, _)| iss)
+                    .map_err(drop)
+            },
         );
     }
 
+    // Subject-prefix resolution end-to-end (`resolve_identity`). Rows are `(issuer, proto, token)`:
+    // success rows `Yields` the canonical prefix (token unused, ""); rejection rows assert the
+    // error contains `token` via `FailsWith(true)`.
     #[test]
-    fn trust_domain_https_issuer_rejects_query() {
-        let err = normalize_issuer_and_trust_domain("https://issuer.example/?q=1").unwrap_err();
-        assert!(err.contains("query"), "{err}");
-    }
-
-    #[test]
-    fn trust_domain_spiffe_issuer() {
-        assert_eq!(
-            normalize_issuer_and_trust_domain("spiffe://Issuer.EXAMPLE/bundle")
-                .unwrap()
-                .1,
-            "issuer.example"
+    fn resolve_subject_prefix_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "no proto prefix -> default from https issuer",
+                    input: ("https://my.idp.example", None, ""),
+                    expect: Yields("spiffe://my.idp.example".to_string()),
+                },
+                Case {
+                    scenario: "no proto prefix -> default from spiffe issuer",
+                    input: ("spiffe://my.idp.example/ns/x", None, ""),
+                    expect: Yields("spiffe://my.idp.example".to_string()),
+                },
+                Case {
+                    scenario: "explicit prefix canonicalizes trust-domain case",
+                    input: (
+                        "https://issuer.example",
+                        Some("spiffe://ISSUER.EXAMPLE/wl"),
+                        "",
+                    ),
+                    expect: Yields("spiffe://issuer.example/wl".to_string()),
+                },
+                Case {
+                    scenario: "trust domain mismatch rejected",
+                    input: (
+                        "https://issuer.example",
+                        Some("spiffe://other.example"),
+                        "does not match",
+                    ),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "percent-encoding rejected",
+                    input: (
+                        "https://issuer.example",
+                        Some("spiffe://issuer.example/a%2Fb"),
+                        "disallowed",
+                    ),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "https scheme prefix rejected (must be spiffe)",
+                    input: (
+                        "https://issuer.example",
+                        Some("https://issuer.example/p"),
+                        "spiffe://",
+                    ),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "backslash in prefix rejected",
+                    input: (
+                        "https://issuer.example",
+                        Some("spiffe://issuer.example/a\\b"),
+                        "disallowed",
+                    ),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "whitespace in prefix rejected",
+                    input: (
+                        "https://issuer.example",
+                        Some("spiffe://issuer.example/a b"),
+                        "disallowed",
+                    ),
+                    expect: FailsWith(true),
+                },
+            ],
+            |(issuer, proto, token)| resolve_identity(issuer, proto).map_err(|e| e.contains(token)),
         );
     }
 
-    #[test]
-    fn trust_domain_spiffe_issuer_scheme_any_case() {
-        assert_eq!(
-            normalize_issuer_and_trust_domain("SPIFFE://Issuer.EXAMPLE/bundle")
-                .unwrap()
-                .1,
-            "issuer.example"
-        );
-        assert_eq!(
-            normalize_issuer_and_trust_domain("SpIfFe://issuer.example")
-                .unwrap()
-                .1,
-            "issuer.example"
-        );
-    }
-
-    #[test]
-    fn trust_domain_rejects_ip_host() {
-        let err = normalize_issuer_and_trust_domain("https://127.0.0.1/").unwrap_err();
-        assert!(err.contains("IP") || err.contains("not an IP"), "{err}");
-        let err = normalize_issuer_and_trust_domain("spiffe://[::1]/x").unwrap_err();
-        assert!(err.contains("IP"), "{err}");
-    }
-
-    #[test]
-    fn resolve_identity_defaults_prefix() {
-        assert_eq!(
-            resolve_identity("https://my.idp.example", None).unwrap(),
-            "spiffe://my.idp.example"
-        );
-    }
-
-    #[test]
-    fn resolve_identity_spiffe_form_issuer() {
-        assert_eq!(
-            resolve_identity("spiffe://my.idp.example/ns/x", None).unwrap(),
-            "spiffe://my.idp.example"
-        );
-    }
-
-    #[test]
-    fn explicit_prefix_canonicalizes_td_case() {
-        let p =
-            resolve_identity("https://issuer.example", Some("spiffe://ISSUER.EXAMPLE/wl")).unwrap();
-        assert_eq!(p, "spiffe://issuer.example/wl");
-    }
-
-    #[test]
-    fn wrong_td_rejected() {
-        let err =
-            resolve_identity("https://issuer.example", Some("spiffe://other.example")).unwrap_err();
-        assert!(err.contains("does not match"));
-    }
-
-    #[test]
-    fn percent_encoding_rejected() {
-        let err = resolve_identity(
-            "https://issuer.example",
-            Some("spiffe://issuer.example/a%2Fb"),
-        )
-        .unwrap_err();
-        assert!(err.contains("disallowed"), "{err}");
-    }
-
-    #[test]
-    fn https_scheme_subject_prefix_rejected() {
-        let err = resolve_identity("https://issuer.example", Some("https://issuer.example/p"))
-            .unwrap_err();
-        assert!(err.contains("spiffe://"));
-    }
-
-    #[test]
-    fn https_userinfo_rejected() {
-        let err = normalize_issuer_and_trust_domain("https://user@issuer.example/").unwrap_err();
-        assert!(err.contains("userinfo"), "{err}");
-    }
-
-    #[test]
-    fn https_password_in_userinfo_rejected() {
-        let err =
-            normalize_issuer_and_trust_domain("https://user:pass@issuer.example/").unwrap_err();
-        assert!(err.contains("userinfo"), "{err}");
-    }
-
-    #[test]
-    fn non_http_scheme_rejected() {
-        let err = normalize_issuer_and_trust_domain("ftp://issuer.example/").unwrap_err();
-        assert!(err.contains("http"), "{err}");
-    }
-
-    #[test]
-    fn issuer_without_scheme_rejected() {
-        let err = normalize_issuer_and_trust_domain("issuer.example").unwrap_err();
-        assert!(err.contains("http://") || err.contains("https://"), "{err}");
-        let err = normalize_issuer_and_trust_domain("issuer.example/extra").unwrap_err();
-        assert!(err.contains("http://") || err.contains("bare"), "{err}");
-    }
-
-    #[test]
-    fn issuer_backslash_rejected() {
-        let err = normalize_issuer_and_trust_domain("https://issuer.example\\evil").unwrap_err();
-        assert!(err.contains("disallowed"), "{err}");
-    }
-
+    // Length-limit rejections build runtime strings, so they stay out of the literal-input tables.
     #[test]
     fn issuer_too_long_rejected() {
         let long = format!("https://{}.example/", "a".repeat(MAX_ISSUER_BYTES));
         let err = normalize_issuer_and_trust_domain(&long).unwrap_err();
         assert!(err.contains("maximum length"), "{err}");
-    }
-
-    #[test]
-    fn issuer_control_char_rejected() {
-        let err = normalize_issuer_and_trust_domain("https://issuer.ex\0ample.com/").unwrap_err();
-        assert!(err.contains("disallowed") || err.contains("ASCII"), "{err}");
-    }
-
-    #[test]
-    fn subject_prefix_backslash_rejected() {
-        let err = resolve_identity(
-            "https://issuer.example",
-            Some("spiffe://issuer.example/a\\b"),
-        )
-        .unwrap_err();
-        assert!(err.contains("disallowed"), "{err}");
-    }
-
-    #[test]
-    fn subject_prefix_whitespace_rejected() {
-        let err = resolve_identity(
-            "https://issuer.example",
-            Some("spiffe://issuer.example/a b"),
-        )
-        .unwrap_err();
-        assert!(err.contains("disallowed"), "{err}");
     }
 
     #[test]
@@ -649,200 +686,388 @@ mod tests {
         assert!(p.matches('/').count() >= 200);
     }
 
+    // Hostname/trust-domain allowlist matching (`trust_domain_matches_allowlist`). Rows are
+    // `(hostname, patterns)`: the originals only checked `is_ok()`/`is_err()`, so we map to
+    // `Yields(())` / `Fails` (error discarded). Each row carries its own pattern list.
     #[test]
-    fn normalize_issuer_preserves_scheme_path_and_port() {
-        assert_eq!(
-            normalize_issuer_and_trust_domain("HTTP://Issuer.EXAMPLE/path")
-                .unwrap()
-                .0,
-            "http://issuer.example/path"
+    fn trust_domain_allowlist_matching() {
+        fn list(entries: &[&str]) -> Vec<String> {
+            entries.iter().map(|s| s.to_string()).collect()
+        }
+        check_cases(
+            [
+                Case {
+                    scenario: "empty allowlist allows any host",
+                    input: ("anything.example", list(&[])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "exact match",
+                    input: (
+                        "login.example.com",
+                        list(&["login.example.com", "other.net"]),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "exact match ignores case and trailing dot",
+                    input: (
+                        "LOGIN.EXAMPLE.COM.",
+                        list(&["login.example.com", "other.net"]),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "exact mismatch",
+                    input: ("bad.example.com", list(&["login.example.com", "other.net"])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "single-star: one label under suffix matches",
+                    input: ("auth.something.net", list(&["*.something.net"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "single-star: bare suffix does not match",
+                    input: ("something.net", list(&["*.something.net"])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "single-star: two labels under suffix do not match",
+                    input: ("a.b.something.net", list(&["*.something.net"])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "single-star: dot boundary before suffix",
+                    input: ("notsomething.net", list(&["*.something.net"])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "double-star: bare suffix matches",
+                    input: ("internal.example", list(&["**.internal.example"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "double-star: one label deep matches",
+                    input: ("x.internal.example", list(&["**.internal.example"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "double-star: many labels deep match",
+                    input: ("a.b.internal.example", list(&["**.internal.example"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "double-star: suffix not at end does not match",
+                    input: (
+                        "evil.internal.example.evil.com",
+                        list(&["**.internal.example"]),
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "single-star: multi-label under suffix rejected",
+                    input: ("auth.prod.something.net", list(&["*.something.net"])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "single-star: one label matches mixed-case pattern",
+                    input: ("auth.something.net", list(&["*.SOMETHING.NET"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "double-star: suffix as substring of longer zone rejected",
+                    input: ("api.internal.example.com", list(&["**.internal.example"])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "double-star: suffix mid-host rejected",
+                    input: (
+                        "not-relevant.internal.example.evil.com",
+                        list(&["**.internal.example"]),
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "double-star: zone apex matches",
+                    input: ("co.uk", list(&["**.co.uk"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "double-star: child of apex matches",
+                    input: ("tenant.co.uk", list(&["**.co.uk"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "double-star: deep child of apex matches",
+                    input: ("a.b.co.uk", list(&["**.co.uk"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "double-star: different apex rejected",
+                    input: ("other.uk", list(&["**.co.uk"])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "OR across entries: literal matches",
+                    input: ("exact.only", list(&["exact.only", "**.allowed.zone"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "OR across entries: double-star matches",
+                    input: ("x.allowed.zone", list(&["exact.only", "**.allowed.zone"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "OR across entries: neither matches",
+                    input: ("wrong.zone", list(&["exact.only", "**.allowed.zone"])),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "mixed list: literal host matches",
+                    input: (
+                        "idp.example.com",
+                        list(&[
+                            "idp.example.com",
+                            "localhost",
+                            "*.tenant.example.net",
+                            "**.corp.internal",
+                        ]),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "mixed list: literal host case-insensitive",
+                    input: (
+                        "LOCALHOST",
+                        list(&[
+                            "idp.example.com",
+                            "localhost",
+                            "*.tenant.example.net",
+                            "**.corp.internal",
+                        ]),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "mixed list: single-star matches",
+                    input: (
+                        "auth.tenant.example.net",
+                        list(&[
+                            "idp.example.com",
+                            "localhost",
+                            "*.tenant.example.net",
+                            "**.corp.internal",
+                        ]),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "mixed list: double-star apex matches",
+                    input: (
+                        "corp.internal",
+                        list(&[
+                            "idp.example.com",
+                            "localhost",
+                            "*.tenant.example.net",
+                            "**.corp.internal",
+                        ]),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "mixed list: double-star deep matches",
+                    input: (
+                        "a.b.corp.internal",
+                        list(&[
+                            "idp.example.com",
+                            "localhost",
+                            "*.tenant.example.net",
+                            "**.corp.internal",
+                        ]),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "mixed list: unrelated literal rejected",
+                    input: (
+                        "other.example.com",
+                        list(&[
+                            "idp.example.com",
+                            "localhost",
+                            "*.tenant.example.net",
+                            "**.corp.internal",
+                        ]),
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "mixed list: single-star too deep rejected",
+                    input: (
+                        "auth.app.tenant.example.net",
+                        list(&[
+                            "idp.example.com",
+                            "localhost",
+                            "*.tenant.example.net",
+                            "**.corp.internal",
+                        ]),
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "mixed list: double-star suffix mid-host rejected",
+                    input: (
+                        "not.corp.internal.evil.com",
+                        list(&[
+                            "idp.example.com",
+                            "localhost",
+                            "*.tenant.example.net",
+                            "**.corp.internal",
+                        ]),
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "pattern trimmed and trailing-dot stripped",
+                    input: ("bar.foo.com", list(&["  *.Foo.COM.  "])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "single-star: dot boundary, one label matches",
+                    input: ("svc.internal.example", list(&["*.internal.example"])),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "single-star: no dot before suffix rejected",
+                    input: ("notinternal.example", list(&["*.internal.example"])),
+                    expect: Fails,
+                },
+            ],
+            |(hostname, patterns)| {
+                trust_domain_matches_allowlist(hostname, &patterns).map_err(drop)
+            },
         );
-        assert_eq!(
-            normalize_issuer_and_trust_domain("https://issuer.example:8443/ns")
-                .unwrap()
-                .0,
-            "https://issuer.example:8443/ns"
-        );
-        assert_eq!(
-            normalize_issuer_and_trust_domain("SpIfFe://Issuer.EXAMPLE/bundle")
-                .unwrap()
-                .0,
-            "spiffe://issuer.example/bundle"
-        );
     }
 
+    // Allowlist pattern validation (`validate_trust_domain_allowlist_patterns`). Each row is one
+    // entry list; the originals only checked `is_ok()`/`is_err()`, so `Yields(())` / `Fails`.
     #[test]
-    fn allowlist_empty_allows_any_trust_domain() {
-        assert!(trust_domain_matches_allowlist("anything.example", &[]).is_ok());
-    }
-
-    #[test]
-    fn allowlist_exact_match() {
-        let list = vec!["login.example.com".to_string(), "other.net".to_string()];
-        assert!(trust_domain_matches_allowlist("login.example.com", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("LOGIN.EXAMPLE.COM.", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("bad.example.com", &list).is_err());
-    }
-
-    #[test]
-    fn allowlist_single_star_one_label_under_suffix() {
-        let list = vec!["*.something.net".to_string()];
-        assert!(trust_domain_matches_allowlist("auth.something.net", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("something.net", &list).is_err());
-        assert!(trust_domain_matches_allowlist("a.b.something.net", &list).is_err());
-        assert!(
-            trust_domain_matches_allowlist("notsomething.net", &list).is_err(),
-            "dot boundary"
-        );
-    }
-
-    #[test]
-    fn allowlist_double_star_any_depth() {
-        let list = vec!["**.internal.example".to_string()];
-        assert!(trust_domain_matches_allowlist("internal.example", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("x.internal.example", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("a.b.internal.example", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("evil.internal.example.evil.com", &list).is_err());
-    }
-
-    #[test]
-    fn allowlist_pattern_validation_rejects_bare_star() {
-        assert!(validate_trust_domain_allowlist_patterns(&["*".to_string()]).is_err());
-        assert!(validate_trust_domain_allowlist_patterns(&["**".to_string()]).is_err());
-        assert!(validate_trust_domain_allowlist_patterns(&["*.".to_string()]).is_err());
-        assert!(validate_trust_domain_allowlist_patterns(&["foo*bar".to_string()]).is_err());
-        assert!(validate_trust_domain_allowlist_patterns(&["login.example".to_string()]).is_ok());
-    }
-
-    /// `*.suffix` must not match when there are two or more labels between leaf and suffix.
-    #[test]
-    fn allowlist_single_star_rejects_multi_label_under_suffix() {
-        let list = vec!["*.something.net".to_string()];
-        assert!(
-            trust_domain_matches_allowlist("auth.prod.something.net", &list).is_err(),
-            "only one label allowed above the suffix"
-        );
-    }
-
-    /// `*.suffix` accepts a single DNS label (no dots) above the suffix.
-    #[test]
-    fn allowlist_single_star_accepts_one_label_mixed_case_pattern() {
-        let list = vec!["*.SOMETHING.NET".to_string()];
-        assert!(trust_domain_matches_allowlist("auth.something.net", &list).is_ok());
-    }
-
-    /// `**.suffix` must not match hosts that merely share a substring with suffix (dot-separated).
-    #[test]
-    fn allowlist_double_star_suffix_requires_dot_separated_zone() {
-        let list = vec!["**.internal.example".to_string()];
-        assert!(
-            trust_domain_matches_allowlist("api.internal.example.com", &list).is_err(),
-            "must end with .internal.example, not .internal.example.com"
-        );
-        assert!(
-            trust_domain_matches_allowlist("not-relevant.internal.example.evil.com", &list)
-                .is_err(),
+    fn trust_domain_allowlist_pattern_validation() {
+        fn list(entries: &[&str]) -> Vec<String> {
+            entries.iter().map(|s| s.to_string()).collect()
+        }
+        check_cases(
+            [
+                Case {
+                    scenario: "bare `*` rejected",
+                    input: list(&["*"]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "bare `**` rejected",
+                    input: list(&["**"]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "`*.` (empty suffix) rejected",
+                    input: list(&["*."]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wildcard inside label rejected",
+                    input: list(&["foo*bar"]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "plain hostname accepted",
+                    input: list(&["login.example"]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "`**.` (empty suffix) rejected",
+                    input: list(&["**."]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "`*.` (empty suffix) rejected again",
+                    input: list(&["*."]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "star inside double-star suffix rejected",
+                    input: list(&["**.foo.*.com"]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "star inside single-star suffix rejected",
+                    input: list(&["*.foo*bar.com"]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "whitespace-only entry rejected",
+                    input: list(&["   "]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "tab/space-only entry rejected",
+                    input: list(&["  \t "]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "double-star multi-label suffix accepted",
+                    input: list(&["**.svc.cluster.local"]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "mixed valid list passes startup validation",
+                    input: list(&[
+                        "idp.example.com",
+                        "localhost",
+                        "*.tenant.example.net",
+                        "**.corp.internal",
+                    ]),
+                    expect: Yields(()),
+                },
+            ],
+            |patterns| validate_trust_domain_allowlist_patterns(&patterns).map_err(drop),
         );
     }
 
-    /// `**.suffix`: bare suffix and immediate child; `suffix` alone is the zone apex in pattern.
-    #[test]
-    fn allowlist_double_star_suffix_apex_and_subdomain() {
-        let list = vec!["**.co.uk".to_string()];
-        assert!(trust_domain_matches_allowlist("co.uk", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("tenant.co.uk", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("a.b.co.uk", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("other.uk", &list).is_err());
-    }
-
-    #[test]
-    fn allowlist_matches_if_any_pattern_matches() {
-        let list = vec!["exact.only".to_string(), "**.allowed.zone".to_string()];
-        assert!(trust_domain_matches_allowlist("exact.only", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("x.allowed.zone", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("wrong.zone", &list).is_err());
-    }
-
-    /// Several allowlist entries at once: literal, `*.suffix`, and `**.suffix`; match is OR across entries.
-    #[test]
-    fn allowlist_multiple_entries_mixed_literal_and_wildcards() {
-        let list = vec![
-            "idp.example.com".to_string(),
-            "localhost".to_string(),
-            "*.tenant.example.net".to_string(),
-            "**.corp.internal".to_string(),
-        ];
-        assert!(
-            validate_trust_domain_allowlist_patterns(&list).is_ok(),
-            "whole list must pass startup validation"
-        );
-
-        assert!(trust_domain_matches_allowlist("idp.example.com", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("LOCALHOST", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("auth.tenant.example.net", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("corp.internal", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("a.b.corp.internal", &list).is_ok());
-
-        assert!(trust_domain_matches_allowlist("other.example.com", &list).is_err());
-        assert!(trust_domain_matches_allowlist("auth.app.tenant.example.net", &list).is_err());
-        assert!(trust_domain_matches_allowlist("not.corp.internal.evil.com", &list).is_err());
-    }
-
-    #[test]
-    fn allowlist_patterns_trim_and_strip_trailing_dot() {
-        let list = vec!["  *.Foo.COM.  ".to_string()];
-        assert!(trust_domain_matches_allowlist("bar.foo.com", &list).is_ok());
-    }
-
-    #[test]
-    fn validate_allowlist_rejects_empty_suffix_after_wildcard_prefix() {
-        assert!(validate_trust_domain_allowlist_patterns(&["**.".to_string()]).is_err());
-        assert!(validate_trust_domain_allowlist_patterns(&["*.".to_string()]).is_err());
-    }
-
-    #[test]
-    fn validate_allowlist_rejects_star_inside_suffix() {
-        assert!(validate_trust_domain_allowlist_patterns(&["**.foo.*.com".to_string()]).is_err());
-        assert!(validate_trust_domain_allowlist_patterns(&["*.foo*bar.com".to_string()]).is_err());
-    }
-
-    #[test]
-    fn validate_allowlist_rejects_empty_entry_after_trim() {
-        assert!(validate_trust_domain_allowlist_patterns(&["   ".to_string()]).is_err());
-        assert!(validate_trust_domain_allowlist_patterns(&["  \t ".to_string()]).is_err(),);
-    }
-
-    #[test]
-    fn validate_allowlist_accepts_double_star_multi_label_suffix() {
-        assert!(
-            validate_trust_domain_allowlist_patterns(&["**.svc.cluster.local".to_string()]).is_ok()
-        );
-    }
-
-    /// `notinternal.example` must not satisfy `*.internal.example` (no dot before `internal`).
-    #[test]
-    fn allowlist_single_star_dot_boundary_before_suffix() {
-        let list = vec!["*.internal.example".to_string()];
-        assert!(trust_domain_matches_allowlist("svc.internal.example", &list).is_ok());
-        assert!(trust_domain_matches_allowlist("notinternal.example", &list).is_err());
-    }
-
+    // Token-endpoint registered-host extraction (`registered_host_for_token_endpoint`): http/https
+    // only. Rows are `(endpoint, token)`: success rows `Yields` the host (token ""); rejection rows
+    // assert the error contains `token` via `FailsWith(true)`.
     #[test]
     fn token_endpoint_url_accepts_http_and_https_only() {
-        assert_eq!(
-            registered_host_for_token_endpoint("https://auth.example.com/oauth/token").unwrap(),
-            "auth.example.com"
+        check_cases(
+            [
+                Case {
+                    scenario: "https endpoint -> host",
+                    input: ("https://auth.example.com/oauth/token", &[][..]),
+                    expect: Yields("auth.example.com".to_string()),
+                },
+                Case {
+                    scenario: "http endpoint with port -> host",
+                    input: ("http://auth.example:8080/token", &[][..]),
+                    expect: Yields("auth.example".to_string()),
+                },
+                Case {
+                    scenario: "spiffe scheme rejected",
+                    input: ("spiffe://trust.example/path", &["http", "https"][..]),
+                    expect: FailsWith(true),
+                },
+                Case {
+                    scenario: "ftp scheme rejected",
+                    input: ("ftp://auth.example/token", &["http"][..]),
+                    expect: FailsWith(true),
+                },
+            ],
+            // Rejection rows require every listed token in the error, preserving the
+            // original's independent contains("http") && contains("https") check
+            // rather than coupling to one exact phrase.
+            |(endpoint, tokens)| {
+                registered_host_for_token_endpoint(endpoint)
+                    .map_err(|e| tokens.iter().all(|t| e.contains(t)))
+            },
         );
-        assert_eq!(
-            registered_host_for_token_endpoint("http://auth.example:8080/token").unwrap(),
-            "auth.example"
-        );
-        let err = registered_host_for_token_endpoint("spiffe://trust.example/path").unwrap_err();
-        assert!(
-            err.contains("http") && err.contains("https"),
-            "unexpected err: {err}"
-        );
-        let err = registered_host_for_token_endpoint("ftp://auth.example/token").unwrap_err();
-        assert!(err.contains("http") || err.contains("https"), "{err}");
     }
 }

--- a/crates/api-model/src/tenant/mod.rs
+++ b/crates/api-model/src/tenant/mod.rs
@@ -537,6 +537,9 @@ impl<'r> sqlx::FromRow<'r, PgRow> for TenantKeyset {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     #[test]
@@ -549,21 +552,66 @@ mod tests {
         assert_eq!(truncate_hash_for_display("no-colon"), "no-colon");
     }
 
+    // Parsing a tenant-org id, via both `TryFrom<String>` and `FromStr` (which
+    // delegates to the same validation). Valid input yields the round-tripped
+    // string; invalid input is rejected. `InvalidTenantOrg` is not PartialEq and
+    // the original only checked `is_err()`, so failing rows assert only that it
+    // errors. The closure exercises both entry points and confirms they agree.
     #[test]
     fn parse_tenant_org() {
-        // Valid cases
-        for &valid in &["TenantA", "Tenant_B", "Tenant-C-_And_D_"] {
-            let org = TenantOrganizationId::try_from(valid.to_string()).unwrap();
-            assert_eq!(org.as_str(), valid);
-            let org: TenantOrganizationId = valid.parse().unwrap();
-            assert_eq!(org.as_str(), valid);
-        }
-
-        // Invalid cases
-        for &invalid in &["", " Tenant_B", "Tenant_C ", "Tenant D", "Tenant!A"] {
-            assert!(TenantOrganizationId::try_from(invalid.to_string()).is_err());
-            assert!(invalid.parse::<TenantOrganizationId>().is_err());
-        }
+        check_cases(
+            [
+                Case {
+                    scenario: "alphabetic",
+                    input: "TenantA",
+                    expect: Yields("TenantA".to_string()),
+                },
+                Case {
+                    scenario: "with underscore",
+                    input: "Tenant_B",
+                    expect: Yields("Tenant_B".to_string()),
+                },
+                Case {
+                    scenario: "with dashes and underscores",
+                    input: "Tenant-C-_And_D_",
+                    expect: Yields("Tenant-C-_And_D_".to_string()),
+                },
+                Case {
+                    scenario: "empty",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "leading space",
+                    input: " Tenant_B",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "trailing space",
+                    input: "Tenant_C ",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "internal space",
+                    input: "Tenant D",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "disallowed punctuation",
+                    input: "Tenant!A",
+                    expect: Fails,
+                },
+            ],
+            |s| {
+                let via_try_from = TenantOrganizationId::try_from(s.to_string());
+                let via_parse = s.parse::<TenantOrganizationId>();
+                // Both entry points must agree on success/failure.
+                assert_eq!(via_try_from.is_ok(), via_parse.is_ok(), "{s}");
+                via_try_from
+                    .map(|org| org.as_str().to_string())
+                    .map_err(drop)
+            },
+        );
     }
 
     #[test]
@@ -619,18 +667,25 @@ mod tests {
         assert_eq!(config_json, "{}");
     }
 
+    // Parsing a JWT signing algorithm: only "ES256" is supported. The error
+    // (`UnsupportedTenantSigningAlgorithm`) was only checked with `is_err()`, so
+    // the failing row asserts only that it errors.
     #[test]
     fn tenant_identity_signing_algorithm_from_str_rejects_unknown() {
-        assert_eq!(
-            "ES256"
-                .parse::<identity_config::SigningAlgorithm>()
-                .unwrap(),
-            identity_config::SigningAlgorithm::Es256
-        );
-        assert!(
-            "RS256"
-                .parse::<identity_config::SigningAlgorithm>()
-                .is_err()
+        check_cases(
+            [
+                Case {
+                    scenario: "supported ES256",
+                    input: "ES256",
+                    expect: Yields(identity_config::SigningAlgorithm::Es256),
+                },
+                Case {
+                    scenario: "unsupported RS256",
+                    input: "RS256",
+                    expect: Fails,
+                },
+            ],
+            |s| s.parse::<identity_config::SigningAlgorithm>().map_err(drop),
         );
     }
 }

--- a/crates/api-model/src/vpc/capability.rs
+++ b/crates/api-model/src/vpc/capability.rs
@@ -493,6 +493,11 @@ impl VpcVirtualizationTypeCapabilities for VpcVirtualizationType {
 
 #[cfg(test)]
 mod tests {
+    use std::mem::discriminant;
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
     use super::*;
 
     #[test]
@@ -884,49 +889,89 @@ mod tests {
         }
     }
 
+    // `ensure_supports_segment` gating: segment-type whitelist plus
+    // per-address-family prefix support. `VpcCapabilityError` is not
+    // `PartialEq`, so rejection rows assert the error *variant* via its
+    // discriminant; the success row yields `()`.
     #[test]
-    fn ensure_supports_segment_passes_for_compatible_segment_v4_only() {
-        let segment = segment_with(NetworkSegmentType::Tenant, vec!["192.0.2.0/24"], None);
-        VpcVirtualizationType::Fnn
-            .ensure_supports_segment(&segment)
-            .expect("FNN + Tenant + IPv4 is the standard happy path");
-    }
+    fn ensure_supports_segment_gates_by_type_and_address_family() {
+        // A representative error value per variant we expect, used only to
+        // pull its discriminant for comparison.
+        let unsupported_segment_type = discriminant(&VpcCapabilityError::UnsupportedSegmentType {
+            vpc_type: VpcVirtualizationType::Flat,
+            segment_type: NetworkSegmentType::Tenant,
+        });
+        let ipv6_unsupported = discriminant(&VpcCapabilityError::Ipv6Unsupported {
+            vpc_type: VpcVirtualizationType::EthernetVirtualizer,
+        });
 
-    #[test]
-    fn ensure_supports_segment_rejects_unsupported_segment_type() {
-        let segment = segment_with(NetworkSegmentType::Tenant, vec!["192.0.2.0/24"], None);
-        let err = VpcVirtualizationType::Flat
-            .ensure_supports_segment(&segment)
-            .expect_err("Flat doesn't accept Tenant segments");
-        assert!(matches!(
-            err,
-            VpcCapabilityError::UnsupportedSegmentType { .. }
-        ));
-    }
-
-    #[test]
-    fn ensure_supports_segment_rejects_ipv6_on_etv() {
-        let segment = segment_with(
-            NetworkSegmentType::Tenant,
-            vec!["192.0.2.0/24", "2001:db8::/64"],
-            None,
+        check_cases(
+            [
+                Case {
+                    scenario: "FNN + Tenant + IPv4 is the standard happy path",
+                    input: (
+                        VpcVirtualizationType::Fnn,
+                        segment_with(NetworkSegmentType::Tenant, vec!["192.0.2.0/24"], None),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "Flat doesn't accept Tenant segments",
+                    input: (
+                        VpcVirtualizationType::Flat,
+                        segment_with(NetworkSegmentType::Tenant, vec!["192.0.2.0/24"], None),
+                    ),
+                    expect: FailsWith(unsupported_segment_type),
+                },
+                Case {
+                    scenario: "ETV doesn't accept IPv6 prefixes even if segment-type matches",
+                    input: (
+                        VpcVirtualizationType::EthernetVirtualizer,
+                        segment_with(
+                            NetworkSegmentType::Tenant,
+                            vec!["192.0.2.0/24", "2001:db8::/64"],
+                            None,
+                        ),
+                    ),
+                    expect: FailsWith(ipv6_unsupported),
+                },
+                Case {
+                    scenario: "Flat + HostInband + IPv6 is a supported combination",
+                    input: (
+                        VpcVirtualizationType::Flat,
+                        segment_with(
+                            NetworkSegmentType::HostInband,
+                            vec!["192.0.2.0/24", "2001:db8::/64"],
+                            None,
+                        ),
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "ETV rejects an IPv6-only Tenant segment",
+                    input: (
+                        VpcVirtualizationType::EthernetVirtualizer,
+                        segment_with(NetworkSegmentType::Tenant, vec!["2001:db8::/64"], None),
+                    ),
+                    expect: FailsWith(ipv6_unsupported),
+                },
+                Case {
+                    scenario: "Flat + HostInband accepts an IPv6-only segment",
+                    input: (
+                        VpcVirtualizationType::Flat,
+                        segment_with(NetworkSegmentType::HostInband, vec!["2001:db8::/64"], None),
+                    ),
+                    expect: Yields(()),
+                },
+            ],
+            // The operation under test: gate a segment against a VPC type. The
+            // error type isn't `PartialEq`, so we project it to its discriminant
+            // so the asserted variant is comparable.
+            |(vt, segment)| {
+                vt.ensure_supports_segment(&segment)
+                    .map_err(|e| discriminant(&e))
+            },
         );
-        let err = VpcVirtualizationType::EthernetVirtualizer
-            .ensure_supports_segment(&segment)
-            .expect_err("ETV doesn't accept IPv6 prefixes even if segment-type matches");
-        assert!(matches!(err, VpcCapabilityError::Ipv6Unsupported { .. }));
-    }
-
-    #[test]
-    fn ensure_supports_segment_allows_ipv6_on_flat_with_host_inband() {
-        let segment = segment_with(
-            NetworkSegmentType::HostInband,
-            vec!["192.0.2.0/24", "2001:db8::/64"],
-            None,
-        );
-        VpcVirtualizationType::Flat
-            .ensure_supports_segment(&segment)
-            .expect("Flat + HostInband + IPv6 is a supported combination");
     }
 
     #[test]


### PR DESCRIPTION
The `api-model` crate's data-model tests were a scatter of one-off assertions
across the allocation, rack, machine, tenant, network-segment, and resource-pool
types.

This folds them onto `carbide-test-support` based `Case`/`Check` tables and then
enumerates the input variants each pure function accepts and rejects: every enum
variant for `Display` and `FromStr`, both wire forms and the rejection paths for
`serde`, every boundary for the validators, and both `Ok` and `Err` arms for the
`TryFrom` conversions. The dense per-row enumeration is what moves the numbers.

- conversions / parsing: enumerated `FromStr`, `TryFrom`, and `From` across
  `allocation_type`, `ib`, `rack_type`, `machine_validation`, and the segment /
  pool enums, covering every variant and rejected input.
- model invariants: enumerated `hardware_info`, `capabilities`, `machine_id`,
  `attestation`, and `metadata` validation over their boundary and error cases.
- serde: enumerated the tagged-JSON serialize/round-trip surfaces for the
  controller-state and config types.
```
┌──────────┬─────────┬─────────┐
│ Metric   │ Before  │  After  │
├──────────┼─────────┼─────────┤
│ Region   │ 51.73%  │ 58.34%  │
│ Function │ 45.67%  │ 59.65%  │
│ Line     │ 53.07%  │ 70.86%  │
└──────────┴─────────┴─────────┘
```
This pass targets the pure data-model files; the remaining uncovered surface is
the larger behavioral modules (`machine` and `site-explorer`) and the
DB/proto-bound glue, which need fixtures and a database harness rather than
additional table rows.

All tests pass and clippy is clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>
