### PR TITLE
test(rpc): fold onto carbide-test-support + enumerate conversion cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,6 +2628,7 @@ dependencies = [
  "carbide-network",
  "carbide-prost-builder",
  "carbide-secrets",
+ "carbide-test-support",
  "carbide-tls",
  "carbide-utils",
  "carbide-uuid",

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -120,6 +120,7 @@ base64 = { workspace = true, optional = true }
 
 [dev-dependencies]
 carbide-libmlx-model = { path = "../libmlx-model", features = ["test-support"] }
+carbide-test-support = { path = "../test-support" }
 
 [build-dependencies]
 tonic-prost-build = "0.14"

--- a/crates/rpc/src/forge_tls_client.rs
+++ b/crates/rpc/src/forge_tls_client.rs
@@ -749,6 +749,7 @@ pub type ForgeHttpsClientResult<T> = Result<T, ForgeTlsClientError>;
 mod tests {
     use std::net::SocketAddr;
 
+    use carbide_test_support::{Check, check_values};
     use forge_http_connector::connector::ConnectorMetrics;
     use hyper_rustls::HttpsConnector;
 
@@ -855,7 +856,7 @@ mod tests {
     }
 
     #[test]
-    fn format_error_chain_walks_source_chain() {
+    fn format_error_chain_formats_each_error() {
         #[derive(thiserror::Error, Debug)]
         #[error("invalid peer certificate: UnknownIssuer")]
         struct Inner;
@@ -864,19 +865,27 @@ mod tests {
         #[error("client error (Connect)")]
         struct Outer(#[from] Inner);
 
-        let err: Outer = Inner.into();
-        assert_eq!(
-            format_error_chain(&err),
-            "client error (Connect): invalid peer certificate: UnknownIssuer"
-        );
-    }
-
-    #[test]
-    fn format_error_chain_with_no_source_returns_top_message() {
         #[derive(thiserror::Error, Debug)]
         #[error("only message")]
         struct Plain;
 
-        assert_eq!(format_error_chain(&Plain), "only message");
+        // `format_error_chain` appends the deepest `source()` when it differs
+        // from the top-level message, otherwise returns the top message alone.
+        check_values(
+            [
+                Check {
+                    scenario: "walks source chain to the root cause",
+                    input: Box::new(Outer::from(Inner)) as Box<dyn std::error::Error>,
+                    expect: "client error (Connect): invalid peer certificate: UnknownIssuer"
+                        .to_string(),
+                },
+                Check {
+                    scenario: "no source returns top message",
+                    input: Box::new(Plain) as Box<dyn std::error::Error>,
+                    expect: "only message".to_string(),
+                },
+            ],
+            |err| format_error_chain(err.as_ref()),
+        );
     }
 }

--- a/crates/rpc/src/libmlx.rs
+++ b/crates/rpc/src/libmlx.rs
@@ -118,117 +118,450 @@ impl From<FirmwareFlashReportPb> for FirmwareFlashReport {
 
 #[cfg(test)]
 mod test {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
+    // Proto -> model `TryFrom`: every input proto should convert back to the
+    // expected `MlxDeviceInfo`, with empty proto strings (and an empty MAC)
+    // becoming `None`. The roundtrip rows feed a model through its own
+    // `Into<MlxDeviceInfoPb>` first.
     #[test]
-    fn test_device_info_roundtrip_conversion() {
-        let original = MlxDeviceInfo::create_test_device();
-        let proto: MlxDeviceInfoPb = original.clone().into();
-        let converted: MlxDeviceInfo = proto.try_into().unwrap();
-        assert_eq!(original, converted);
+    fn device_info_proto_to_model() {
+        check_cases(
+            [
+                Case {
+                    scenario: "full device roundtrips",
+                    input: MlxDeviceInfo::create_test_device().into(),
+                    expect: Yields(MlxDeviceInfo::create_test_device()),
+                },
+                Case {
+                    scenario: "missing-data device roundtrips",
+                    input: MlxDeviceInfo::create_test_device_with_missing_data().into(),
+                    expect: Yields(MlxDeviceInfo::create_test_device_with_missing_data()),
+                },
+                Case {
+                    scenario: "empty string fields become none",
+                    input: MlxDeviceInfoPb {
+                        pci_name: "01:00.0".to_string(),
+                        device_type: "BlueField3".to_string(),
+                        psid: "".to_string(), // Empty string should become None
+                        device_description: "".to_string(),
+                        part_number: "".to_string(),
+                        fw_version_current: "".to_string(),
+                        pxe_version_current: "".to_string(),
+                        uefi_version_current: "".to_string(),
+                        uefi_version_virtio_blk_current: "".to_string(),
+                        uefi_version_virtio_net_current: "".to_string(),
+                        base_mac: "".to_string(), // Empty MAC becomes None
+                        status: "".to_string(),
+                    },
+                    expect: Yields(MlxDeviceInfo {
+                        pci_name: "01:00.0".to_string(),
+                        device_type: "BlueField3".to_string(),
+                        psid: None,
+                        device_description: None,
+                        part_number: None,
+                        fw_version_current: None,
+                        pxe_version_current: None,
+                        uefi_version_current: None,
+                        uefi_version_virtio_blk_current: None,
+                        uefi_version_virtio_net_current: None,
+                        base_mac: None,
+                        status: None,
+                    }),
+                },
+                Case {
+                    scenario: "populated mac parses",
+                    input: MlxDeviceInfoPb {
+                        pci_name: "01:00.0".to_string(),
+                        device_type: "BlueField3".to_string(),
+                        psid: "".to_string(),
+                        device_description: "".to_string(),
+                        part_number: "".to_string(),
+                        fw_version_current: "".to_string(),
+                        pxe_version_current: "".to_string(),
+                        uefi_version_current: "".to_string(),
+                        uefi_version_virtio_blk_current: "".to_string(),
+                        uefi_version_virtio_net_current: "".to_string(),
+                        base_mac: "b8:3f:d2:12:34:56".to_string(),
+                        status: "".to_string(),
+                    },
+                    expect: Yields(MlxDeviceInfo {
+                        pci_name: "01:00.0".to_string(),
+                        device_type: "BlueField3".to_string(),
+                        psid: None,
+                        device_description: None,
+                        part_number: None,
+                        fw_version_current: None,
+                        pxe_version_current: None,
+                        uefi_version_current: None,
+                        uefi_version_virtio_blk_current: None,
+                        uefi_version_virtio_net_current: None,
+                        base_mac: Some(MacAddress::from_str("b8:3f:d2:12:34:56").unwrap()),
+                        status: None,
+                    }),
+                },
+                Case {
+                    scenario: "every optional string field present",
+                    input: MlxDeviceInfoPb {
+                        pci_name: "01:00.0".to_string(),
+                        device_type: "ConnectX-6 Dx".to_string(),
+                        psid: "MT_00000055".to_string(),
+                        device_description: "desc".to_string(),
+                        part_number: "MCX623106AN-CDAT".to_string(),
+                        fw_version_current: "22.32.1010".to_string(),
+                        pxe_version_current: "3.6.0502".to_string(),
+                        uefi_version_current: "14.25.1020".to_string(),
+                        uefi_version_virtio_blk_current: "1.0.0".to_string(),
+                        uefi_version_virtio_net_current: "1.0.0".to_string(),
+                        base_mac: "".to_string(),
+                        status: "ok".to_string(),
+                    },
+                    expect: Yields(MlxDeviceInfo {
+                        pci_name: "01:00.0".to_string(),
+                        device_type: "ConnectX-6 Dx".to_string(),
+                        psid: Some("MT_00000055".to_string()),
+                        device_description: Some("desc".to_string()),
+                        part_number: Some("MCX623106AN-CDAT".to_string()),
+                        fw_version_current: Some("22.32.1010".to_string()),
+                        pxe_version_current: Some("3.6.0502".to_string()),
+                        uefi_version_current: Some("14.25.1020".to_string()),
+                        uefi_version_virtio_blk_current: Some("1.0.0".to_string()),
+                        uefi_version_virtio_net_current: Some("1.0.0".to_string()),
+                        base_mac: None,
+                        status: Some("ok".to_string()),
+                    }),
+                },
+                Case {
+                    scenario: "malformed mac fails",
+                    input: MlxDeviceInfoPb {
+                        pci_name: "01:00.0".to_string(),
+                        device_type: "BlueField3".to_string(),
+                        psid: "".to_string(),
+                        device_description: "".to_string(),
+                        part_number: "".to_string(),
+                        fw_version_current: "".to_string(),
+                        pxe_version_current: "".to_string(),
+                        uefi_version_current: "".to_string(),
+                        uefi_version_virtio_blk_current: "".to_string(),
+                        uefi_version_virtio_net_current: "".to_string(),
+                        base_mac: "not-a-mac".to_string(),
+                        status: "".to_string(),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "mac with too few octets fails",
+                    input: MlxDeviceInfoPb {
+                        pci_name: "01:00.0".to_string(),
+                        device_type: "BlueField3".to_string(),
+                        psid: "".to_string(),
+                        device_description: "".to_string(),
+                        part_number: "".to_string(),
+                        fw_version_current: "".to_string(),
+                        pxe_version_current: "".to_string(),
+                        uefi_version_current: "".to_string(),
+                        uefi_version_virtio_blk_current: "".to_string(),
+                        uefi_version_virtio_net_current: "".to_string(),
+                        base_mac: "b8:3f:d2".to_string(),
+                        status: "".to_string(),
+                    },
+                    expect: Fails,
+                },
+            ],
+            |proto: MlxDeviceInfoPb| MlxDeviceInfo::try_from(proto).map_err(drop),
+        );
     }
 
+    // Model -> proto `From`: the total mapping that fills each absent
+    // `Option` with the proto's empty-string default and renders the MAC via
+    // `to_string`. Each row pins the produced proto fields as one tuple.
     #[test]
-    fn test_device_info_with_missing_data_conversion() {
-        let original = MlxDeviceInfo::create_test_device_with_missing_data();
-        let proto: MlxDeviceInfoPb = original.clone().into();
-        let converted: MlxDeviceInfo = proto.try_into().unwrap();
-
-        // Required fields should be preserved
-        assert_eq!(original.pci_name, converted.pci_name);
-        assert_eq!(original.device_type, converted.device_type);
-
-        // Optional fields should become None
-        assert_eq!(converted.psid, None);
-        assert_eq!(converted.part_number, None);
-        assert_eq!(converted.base_mac, None);
-        assert_eq!(converted.status, Some("Failed to open device".to_string()));
-    }
-
-    #[test]
-    fn test_empty_string_fields_become_none() {
-        let proto = MlxDeviceInfoPb {
-            pci_name: "01:00.0".to_string(),
-            device_type: "BlueField3".to_string(),
-            psid: "".to_string(), // Empty string should become None
-            device_description: "".to_string(),
-            part_number: "".to_string(),
-            fw_version_current: "".to_string(),
-            pxe_version_current: "".to_string(),
-            uefi_version_current: "".to_string(),
-            uefi_version_virtio_blk_current: "".to_string(),
-            uefi_version_virtio_net_current: "".to_string(),
-            base_mac: "".to_string(), // Empty MAC becomes None
-            status: "".to_string(),
+    fn device_info_model_to_proto() {
+        type Fields = (
+            String,
+            String,
+            String,
+            String,
+            String,
+            String,
+            String,
+            String,
+            String,
+            String,
+            String,
+            String,
+        );
+        let project = |info: MlxDeviceInfo| -> Fields {
+            let pb: MlxDeviceInfoPb = info.into();
+            (
+                pb.pci_name,
+                pb.device_type,
+                pb.psid,
+                pb.device_description,
+                pb.part_number,
+                pb.fw_version_current,
+                pb.pxe_version_current,
+                pb.uefi_version_current,
+                pb.uefi_version_virtio_blk_current,
+                pb.uefi_version_virtio_net_current,
+                pb.base_mac,
+                pb.status,
+            )
         };
-
-        let converted: MlxDeviceInfo = proto.try_into().unwrap();
-
-        assert_eq!(converted.psid, None);
-        assert_eq!(converted.part_number, None);
-        assert_eq!(converted.base_mac, None);
-        assert_eq!(converted.fw_version_current, None);
-        assert_eq!(converted.status, None);
+        check_values(
+            [
+                Check {
+                    scenario: "fully populated model maps every field",
+                    input: MlxDeviceInfo::create_test_device(),
+                    expect: (
+                        "01:00.0".to_string(),
+                        "ConnectX-6 Dx".to_string(),
+                        "MT_00000055".to_string(),
+                        "Mellanox ConnectX-6 Dx EN 100GbE dual port".to_string(),
+                        "MCX623106AN-CDAT".to_string(),
+                        "22.32.1010".to_string(),
+                        "3.6.0502".to_string(),
+                        "14.25.1020".to_string(),
+                        "1.0.0".to_string(),
+                        "1.0.0".to_string(),
+                        "B8:3F:D2:12:34:56".to_string(),
+                        // status is None on the test device -> empty string
+                        "".to_string(),
+                    ),
+                },
+                Check {
+                    scenario: "missing-data model defaults absent options to empty",
+                    input: MlxDeviceInfo::create_test_device_with_missing_data(),
+                    expect: (
+                        "b4:00.0".to_string(),
+                        "BlueField3".to_string(),
+                        "".to_string(),
+                        "".to_string(),
+                        "".to_string(),
+                        "".to_string(),
+                        "".to_string(),
+                        "".to_string(),
+                        "".to_string(),
+                        "".to_string(),
+                        // base_mac is None -> empty string
+                        "".to_string(),
+                        "Failed to open device".to_string(),
+                    ),
+                },
+            ],
+            project,
+        );
     }
 
+    // `FirmwareFlashReport` -> proto -> `FirmwareFlashReport` roundtrip. The
+    // report isn't `PartialEq`, so project to the tuple of fields the originals
+    // asserted; the conversions are total (`From`), hence `check_values`.
     #[test]
-    fn test_flasher_result_all_steps_success() {
-        let original = FirmwareFlashReport {
-            flashed: true,
-            reset: Some(true),
-            verified_image: Some(true),
-            verified_version: Some(true),
-            observed_version: Some("32.43.1014".to_string()),
-            expected_version: Some("32.43.1014".to_string()),
-        };
-        let proto: FirmwareFlashReportPb = original.clone().into();
-        let converted: FirmwareFlashReport = proto.into();
-
-        assert_eq!(original.flashed, converted.flashed);
-        assert_eq!(original.reset, converted.reset);
-        assert_eq!(original.verified_image, converted.verified_image);
-        assert_eq!(original.verified_version, converted.verified_version);
-        assert_eq!(original.observed_version, converted.observed_version);
-        assert_eq!(original.expected_version, converted.expected_version);
+    fn firmware_flash_report_roundtrip() {
+        check_values(
+            [
+                Check {
+                    scenario: "all steps success",
+                    input: FirmwareFlashReport {
+                        flashed: true,
+                        reset: Some(true),
+                        verified_image: Some(true),
+                        verified_version: Some(true),
+                        observed_version: Some("32.43.1014".to_string()),
+                        expected_version: Some("32.43.1014".to_string()),
+                    },
+                    expect: (
+                        true,
+                        Some(true),
+                        Some(true),
+                        Some(true),
+                        Some("32.43.1014".to_string()),
+                        Some("32.43.1014".to_string()),
+                    ),
+                },
+                Check {
+                    scenario: "flash only",
+                    input: FirmwareFlashReport {
+                        flashed: true,
+                        reset: None,
+                        verified_image: None,
+                        verified_version: None,
+                        observed_version: None,
+                        expected_version: None,
+                    },
+                    expect: (true, None, None, None, None, None),
+                },
+                Check {
+                    scenario: "partial failure",
+                    input: FirmwareFlashReport {
+                        flashed: true,
+                        reset: Some(false),
+                        verified_image: Some(false),
+                        verified_version: Some(false),
+                        observed_version: Some("32.42.900".to_string()),
+                        expected_version: Some("32.43.1014".to_string()),
+                    },
+                    expect: (
+                        true,
+                        Some(false),
+                        Some(false),
+                        Some(false),
+                        Some("32.42.900".to_string()),
+                        Some("32.43.1014".to_string()),
+                    ),
+                },
+            ],
+            |original: FirmwareFlashReport| {
+                let proto: FirmwareFlashReportPb = original.into();
+                let converted: FirmwareFlashReport = proto.into();
+                (
+                    converted.flashed,
+                    converted.reset,
+                    converted.verified_image,
+                    converted.verified_version,
+                    converted.observed_version,
+                    converted.expected_version,
+                )
+            },
+        );
     }
 
+    // Proto -> model `From` for `FirmwareFlashReport`, exercised directly
+    // (not via the roundtrip above). The report isn't `PartialEq`, so project
+    // to its field tuple; the conversion is total, hence `check_values`.
     #[test]
-    fn test_flasher_result_flash_only() {
-        let original = FirmwareFlashReport {
-            flashed: true,
-            reset: None,
-            verified_image: None,
-            verified_version: None,
-            observed_version: None,
-            expected_version: None,
+    fn firmware_flash_report_proto_to_model() {
+        type Fields = (
+            bool,
+            Option<bool>,
+            Option<bool>,
+            Option<bool>,
+            Option<String>,
+            Option<String>,
+        );
+        let project = |proto: FirmwareFlashReportPb| -> Fields {
+            let model: FirmwareFlashReport = proto.into();
+            (
+                model.flashed,
+                model.reset,
+                model.verified_image,
+                model.verified_version,
+                model.observed_version,
+                model.expected_version,
+            )
         };
-        let proto: FirmwareFlashReportPb = original.into();
-        let converted: FirmwareFlashReport = proto.into();
-
-        assert!(converted.flashed);
-        assert!(converted.reset.is_none());
-        assert!(converted.verified_image.is_none());
-        assert!(converted.verified_version.is_none());
-        assert!(converted.observed_version.is_none());
+        check_values(
+            [
+                Check {
+                    scenario: "every field populated",
+                    input: FirmwareFlashReportPb {
+                        flashed: true,
+                        reset: Some(true),
+                        verified_image: Some(true),
+                        verified_version: Some(true),
+                        observed_version: Some("32.43.1014".to_string()),
+                        expected_version: Some("32.43.1014".to_string()),
+                    },
+                    expect: (
+                        true,
+                        Some(true),
+                        Some(true),
+                        Some(true),
+                        Some("32.43.1014".to_string()),
+                        Some("32.43.1014".to_string()),
+                    ),
+                },
+                Check {
+                    scenario: "all optionals absent",
+                    input: FirmwareFlashReportPb {
+                        flashed: false,
+                        reset: None,
+                        verified_image: None,
+                        verified_version: None,
+                        observed_version: None,
+                        expected_version: None,
+                    },
+                    expect: (false, None, None, None, None, None),
+                },
+                Check {
+                    scenario: "false flags pass through distinct from none",
+                    input: FirmwareFlashReportPb {
+                        flashed: true,
+                        reset: Some(false),
+                        verified_image: Some(false),
+                        verified_version: Some(false),
+                        observed_version: Some("32.42.900".to_string()),
+                        expected_version: Some("32.43.1014".to_string()),
+                    },
+                    expect: (
+                        true,
+                        Some(false),
+                        Some(false),
+                        Some(false),
+                        Some("32.42.900".to_string()),
+                        Some("32.43.1014".to_string()),
+                    ),
+                },
+            ],
+            project,
+        );
     }
 
+    // Model -> proto `From` for `FirmwareFlashReport`, exercised directly. The
+    // proto carries the same field shape, so the mapping is a straight copy.
     #[test]
-    fn test_flasher_result_partial_failure() {
-        let original = FirmwareFlashReport {
-            flashed: true,
-            reset: Some(false),
-            verified_image: Some(false),
-            verified_version: Some(false),
-            observed_version: Some("32.42.900".to_string()),
-            expected_version: Some("32.43.1014".to_string()),
+    fn firmware_flash_report_model_to_proto() {
+        type Fields = (
+            bool,
+            Option<bool>,
+            Option<bool>,
+            Option<bool>,
+            Option<String>,
+            Option<String>,
+        );
+        let project = |model: FirmwareFlashReport| -> Fields {
+            let pb: FirmwareFlashReportPb = model.into();
+            (
+                pb.flashed,
+                pb.reset,
+                pb.verified_image,
+                pb.verified_version,
+                pb.observed_version,
+                pb.expected_version,
+            )
         };
-        let proto: FirmwareFlashReportPb = original.into();
-        let converted: FirmwareFlashReport = proto.into();
-
-        assert!(converted.flashed);
-        assert_eq!(converted.reset, Some(false));
-        assert_eq!(converted.verified_image, Some(false));
-        assert_eq!(converted.verified_version, Some(false));
+        check_values(
+            [
+                Check {
+                    scenario: "fully populated report",
+                    input: FirmwareFlashReport {
+                        flashed: true,
+                        reset: Some(true),
+                        verified_image: Some(true),
+                        verified_version: Some(true),
+                        observed_version: Some("32.43.1014".to_string()),
+                        expected_version: Some("32.43.1014".to_string()),
+                    },
+                    expect: (
+                        true,
+                        Some(true),
+                        Some(true),
+                        Some(true),
+                        Some("32.43.1014".to_string()),
+                        Some("32.43.1014".to_string()),
+                    ),
+                },
+                Check {
+                    scenario: "default report maps to all-absent proto",
+                    input: FirmwareFlashReport::default(),
+                    expect: (false, None, None, None, None, None),
+                },
+            ],
+            project,
+        );
     }
 
     #[test]

--- a/crates/rpc/src/model/compute_allocation.rs
+++ b/crates/rpc/src/model/compute_allocation.rs
@@ -66,57 +66,240 @@ impl TryFrom<ComputeAllocation> for rpc::ComputeAllocation {
 mod tests {
     use std::collections::HashMap;
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
     use config_version::ConfigVersion;
     use model::metadata::Metadata;
 
     use super::*;
     use crate::forge as rpc;
 
-    #[test]
-    fn test_model_compute_allocation_to_rpc_conversion() {
-        let version = ConfigVersion::initial();
+    // A fixed, deterministic version so the domain and proto builders agree
+    // byte-for-byte; the real `initial()` constructor stamps the current time.
+    fn fixed_version() -> ConfigVersion {
+        use std::str::FromStr;
+        ConfigVersion::from_str("V1-T1700000000000000").unwrap()
+    }
 
-        let req_type = rpc::ComputeAllocation {
+    /// Build a domain `ComputeAllocation` whose every conversion-relevant field is
+    /// overridable, so a table row can vary one variant at a time. Anything not
+    /// passed gets a fixed, well-formed default.
+    fn domain_alloc(
+        count: u32,
+        name: &str,
+        description: &str,
+        labels: HashMap<String, String>,
+        created_by: Option<&str>,
+        updated_by: Option<&str>,
+    ) -> ComputeAllocation {
+        ComputeAllocation {
+            id: "dbe71f32-1bdc-11f1-8101-3b10d91c938c".parse().unwrap(),
+            deleted: None,
+            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
+            version: fixed_version(),
+            metadata: Metadata {
+                name: name.to_string(),
+                description: description.to_string(),
+                labels,
+            },
+            tenant_organization_id: "theorg".parse().unwrap(),
+            instance_type_id: "12345".parse().unwrap(),
+            count,
+            created_by: created_by.map(str::to_string),
+            updated_by: updated_by.map(str::to_string),
+        }
+    }
+
+    /// The matching proto value for [`domain_alloc`]'s fixed defaults; callers
+    /// override the fields their row exercises.
+    fn rpc_alloc(
+        count: u32,
+        name: &str,
+        description: &str,
+        labels: Vec<rpc::Label>,
+        created_by: Option<&str>,
+        updated_by: Option<&str>,
+    ) -> rpc::ComputeAllocation {
+        rpc::ComputeAllocation {
             id: Some("dbe71f32-1bdc-11f1-8101-3b10d91c938c".parse().unwrap()),
-            version: version.to_string(),
+            version: fixed_version().to_string(),
             metadata: Some(rpc::Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: vec![],
+                name: name.to_string(),
+                description: description.to_string(),
+                labels,
             }),
             tenant_organization_id: "theorg".to_string(),
             attributes: Some(rpc::ComputeAllocationAttributes {
                 instance_type_id: "12345".to_string(),
-                count: 10,
+                count,
             }),
             created_at: Some("2023-01-01 00:00:00 UTC".to_string()),
-            created_by: Some("user1".to_string()),
-            updated_by: Some("user2".to_string()),
+            created_by: created_by.map(str::to_string),
+            updated_by: updated_by.map(str::to_string),
+        }
+    }
+
+    /// Whole-message round trips for every scalar / optional-field variant. Labels
+    /// here are at most a single entry, so the proto `Vec<Label>` ordering is
+    /// deterministic and the full message can be compared directly.
+    #[test]
+    fn converts_each_field_variant() {
+        check_cases(
+            [
+                Case {
+                    scenario: "both audit fields present, no labels",
+                    input: domain_alloc(10, "fancy name", "", HashMap::new(), Some("u1"), Some("u2")),
+                    expect: Yields(rpc_alloc(10, "fancy name", "", vec![], Some("u1"), Some("u2"))),
+                },
+                Case {
+                    scenario: "created_by present, updated_by absent",
+                    input: domain_alloc(10, "n", "", HashMap::new(), Some("u1"), None),
+                    expect: Yields(rpc_alloc(10, "n", "", vec![], Some("u1"), None)),
+                },
+                Case {
+                    scenario: "created_by absent, updated_by present",
+                    input: domain_alloc(10, "n", "", HashMap::new(), None, Some("u2")),
+                    expect: Yields(rpc_alloc(10, "n", "", vec![], None, Some("u2"))),
+                },
+                Case {
+                    scenario: "both audit fields absent",
+                    input: domain_alloc(10, "n", "", HashMap::new(), None, None),
+                    expect: Yields(rpc_alloc(10, "n", "", vec![], None, None)),
+                },
+                Case {
+                    scenario: "zero count",
+                    input: domain_alloc(0, "n", "", HashMap::new(), None, None),
+                    expect: Yields(rpc_alloc(0, "n", "", vec![], None, None)),
+                },
+                Case {
+                    scenario: "large count",
+                    input: domain_alloc(100_000, "n", "", HashMap::new(), None, None),
+                    expect: Yields(rpc_alloc(100_000, "n", "", vec![], None, None)),
+                },
+                Case {
+                    scenario: "non-empty description carried through",
+                    input: domain_alloc(1, "n", "a useful note", HashMap::new(), None, None),
+                    expect: Yields(rpc_alloc(1, "n", "a useful note", vec![], None, None)),
+                },
+                Case {
+                    scenario: "empty name carried through",
+                    input: domain_alloc(1, "", "", HashMap::new(), None, None),
+                    expect: Yields(rpc_alloc(1, "", "", vec![], None, None)),
+                },
+                Case {
+                    scenario: "single label with non-empty value keeps the value",
+                    input: domain_alloc(
+                        1,
+                        "n",
+                        "",
+                        HashMap::from([("k".to_string(), "v".to_string())]),
+                        None,
+                        None,
+                    ),
+                    expect: Yields(rpc_alloc(
+                        1,
+                        "n",
+                        "",
+                        vec![rpc::Label {
+                            key: "k".to_string(),
+                            value: Some("v".to_string()),
+                        }],
+                        None,
+                        None,
+                    )),
+                },
+                Case {
+                    scenario: "single label with empty value maps to None",
+                    input: domain_alloc(
+                        1,
+                        "n",
+                        "",
+                        HashMap::from([("k".to_string(), "".to_string())]),
+                        None,
+                        None,
+                    ),
+                    expect: Yields(rpc_alloc(
+                        1,
+                        "n",
+                        "",
+                        vec![rpc::Label {
+                            key: "k".to_string(),
+                            value: None,
+                        }],
+                        None,
+                        None,
+                    )),
+                },
+            ],
+            |alloc| rpc::ComputeAllocation::try_from(alloc).map_err(drop),
+        );
+    }
+
+    /// Label-set shapes whose proto `Vec<Label>` ordering is not deterministic
+    /// (more than one entry): convert, then assert on order-independent
+    /// projections of the resulting label list.
+    #[test]
+    fn maps_multi_label_sets() {
+        let convert = |labels: HashMap<String, String>| -> Vec<rpc::Label> {
+            let mut out = rpc::ComputeAllocation::try_from(domain_alloc(
+                1,
+                "n",
+                "",
+                labels,
+                None,
+                None,
+            ))
+            .unwrap()
+            .metadata
+            .unwrap()
+            .labels;
+            out.sort_by(|a, b| a.key.cmp(&b.key));
+            out
         };
 
-        let compute_alloc = ComputeAllocation {
-            id: "dbe71f32-1bdc-11f1-8101-3b10d91c938c".parse().unwrap(),
-            deleted: None,
-            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
-            version,
-            metadata: Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: HashMap::new(),
-            },
-            tenant_organization_id: "theorg".parse().unwrap(),
-
-            instance_type_id: "12345".parse().unwrap(),
-            count: 10,
-            created_by: Some("user1".to_string()),
-            updated_by: Some("user2".to_string()),
-        };
-
-        // Verify that we can go from an internal compute allocation to the
-        // protobuf ComputeAllocation message
-        assert_eq!(
-            req_type,
-            rpc::ComputeAllocation::try_from(compute_alloc).unwrap()
+        check_values(
+            [
+                Check {
+                    scenario: "empty label map yields no labels",
+                    input: HashMap::new(),
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "two labels, both values preserved (sorted by key)",
+                    input: HashMap::from([
+                        ("a".to_string(), "1".to_string()),
+                        ("b".to_string(), "2".to_string()),
+                    ]),
+                    expect: vec![
+                        rpc::Label {
+                            key: "a".to_string(),
+                            value: Some("1".to_string()),
+                        },
+                        rpc::Label {
+                            key: "b".to_string(),
+                            value: Some("2".to_string()),
+                        },
+                    ],
+                },
+                Check {
+                    scenario: "mixed empty and non-empty values across labels",
+                    input: HashMap::from([
+                        ("a".to_string(), "".to_string()),
+                        ("b".to_string(), "2".to_string()),
+                    ]),
+                    expect: vec![
+                        rpc::Label {
+                            key: "a".to_string(),
+                            value: None,
+                        },
+                        rpc::Label {
+                            key: "b".to_string(),
+                            value: Some("2".to_string()),
+                        },
+                    ],
+                },
+            ],
+            convert,
         );
     }
 }

--- a/crates/rpc/src/model/dpu_remediation.rs
+++ b/crates/rpc/src/model/dpu_remediation.rs
@@ -195,36 +195,579 @@ impl RpcTryFrom<(DisableRemediationRequest, String)> for DisableRemediation {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_uuid::dpu_remediations::RemediationId;
+    use carbide_uuid::machine::MachineId;
+    use std::str::FromStr;
+    use chrono::{TimeZone, Utc};
+
     use super::*;
 
-    #[test]
-    fn remediation_application_status_from_rpc_success_no_metadata() {
-        let rpc_status = rpc::forge::RemediationApplicationStatus {
-            succeeded: true,
-            metadata: None,
-        };
-        let status = RemediationApplicationStatus::try_from(rpc_status).unwrap();
-        assert!(status.succeeded);
-        assert!(status.metadata.is_none());
+    fn label(key: &str, value: Option<&str>) -> rpc::forge::Label {
+        rpc::forge::Label {
+            key: key.to_string(),
+            value: value.map(str::to_string),
+        }
     }
 
+    fn metadata(name: &str, description: &str, labels: Vec<rpc::forge::Label>) -> rpc::Metadata {
+        rpc::Metadata {
+            name: name.to_string(),
+            description: description.to_string(),
+            labels,
+        }
+    }
+
+    // `rpc::forge::RemediationApplicationStatus -> RemediationApplicationStatus` is
+    // fallible only through its inner `Metadata` conversion. Project the Ok result
+    // to (succeeded, name, sorted labels); a duplicate label key is the one error
+    // arm and the conversion error is not `PartialEq`, so it uses `Fails`.
     #[test]
-    fn remediation_application_status_from_rpc_with_metadata() {
-        let rpc_status = rpc::forge::RemediationApplicationStatus {
-            succeeded: false,
-            metadata: Some(rpc::Metadata {
-                name: "test".to_string(),
-                description: "desc".to_string(),
-                labels: vec![rpc::forge::Label {
-                    key: "status".to_string(),
-                    value: Some("failed".to_string()),
-                }],
-            }),
-        };
-        let status = RemediationApplicationStatus::try_from(rpc_status).unwrap();
-        assert!(!status.succeeded);
-        let metadata = status.metadata.unwrap();
-        assert_eq!(metadata.name, "test");
-        assert_eq!(metadata.labels.get("status"), Some(&"failed".to_string()));
+    fn remediation_application_status_try_from_rpc() {
+        type Projected = (bool, Option<(String, Vec<(String, String)>)>);
+
+        check_cases(
+            [
+                Case {
+                    scenario: "succeeded, no metadata",
+                    input: rpc::forge::RemediationApplicationStatus {
+                        succeeded: true,
+                        metadata: None,
+                    },
+                    expect: Yields((true, None)),
+                },
+                Case {
+                    scenario: "failed, no metadata",
+                    input: rpc::forge::RemediationApplicationStatus {
+                        succeeded: false,
+                        metadata: None,
+                    },
+                    expect: Yields((false, None)),
+                },
+                Case {
+                    scenario: "failed, metadata with one label",
+                    input: rpc::forge::RemediationApplicationStatus {
+                        succeeded: false,
+                        metadata: Some(metadata(
+                            "test",
+                            "desc",
+                            vec![label("status", Some("failed"))],
+                        )),
+                    },
+                    expect: Yields((
+                        false,
+                        Some((
+                            "test".to_string(),
+                            vec![("status".to_string(), "failed".to_string())],
+                        )),
+                    )),
+                },
+                Case {
+                    scenario: "succeeded, metadata with no labels",
+                    input: rpc::forge::RemediationApplicationStatus {
+                        succeeded: true,
+                        metadata: Some(metadata("n", "d", vec![])),
+                    },
+                    expect: Yields((true, Some(("n".to_string(), vec![])))),
+                },
+                Case {
+                    scenario: "absent label value defaults to empty string",
+                    input: rpc::forge::RemediationApplicationStatus {
+                        succeeded: true,
+                        metadata: Some(metadata("n", "d", vec![label("k", None)])),
+                    },
+                    expect: Yields((
+                        true,
+                        Some(("n".to_string(), vec![("k".to_string(), String::new())])),
+                    )),
+                },
+                Case {
+                    scenario: "duplicate label key fails",
+                    input: rpc::forge::RemediationApplicationStatus {
+                        succeeded: true,
+                        metadata: Some(metadata(
+                            "n",
+                            "d",
+                            vec![label("k", Some("a")), label("k", Some("b"))],
+                        )),
+                    },
+                    expect: Fails,
+                },
+            ],
+            |status| -> Result<Projected, ()> {
+                let domain = RemediationApplicationStatus::try_from(status).map_err(drop)?;
+                let metadata = domain.metadata.map(|m| {
+                    let mut labels: Vec<(String, String)> = m.labels.into_iter().collect();
+                    labels.sort();
+                    (m.name, labels)
+                });
+                Ok((domain.succeeded, metadata))
+            },
+        );
+    }
+
+    // `(CreateRemediationRequest, author) -> NewRemediation` is fallible: a negative
+    // retry count, an empty script, and an oversized script are the three explicit
+    // error arms; an inner duplicate-label `Metadata` conversion is a fourth. Project
+    // the Ok result to (script, retries, author, has-metadata) — the fields the
+    // conversion sets.
+    #[test]
+    fn new_remediation_rpc_try_from() {
+        type Projected = (String, i32, String, bool);
+
+        let oversized = "x".repeat(MAXIMUM_SCRIPT_LENGTH + 1);
+
+        check_cases(
+            [
+                Case {
+                    scenario: "minimal script, no metadata, zero retries",
+                    input: (
+                        CreateRemediationRequest {
+                            script: "echo hi".to_string(),
+                            metadata: None,
+                            retries: 0,
+                        },
+                        "alice".to_string(),
+                    ),
+                    expect: Yields(("echo hi".to_string(), 0, "alice".to_string(), false)),
+                },
+                Case {
+                    scenario: "positive retries pass through",
+                    input: (
+                        CreateRemediationRequest {
+                            script: "echo hi".to_string(),
+                            metadata: None,
+                            retries: 5,
+                        },
+                        "bob".to_string(),
+                    ),
+                    expect: Yields(("echo hi".to_string(), 5, "bob".to_string(), false)),
+                },
+                Case {
+                    scenario: "metadata present is carried",
+                    input: (
+                        CreateRemediationRequest {
+                            script: "echo hi".to_string(),
+                            metadata: Some(metadata("n", "d", vec![label("k", Some("v"))])),
+                            retries: 1,
+                        },
+                        "carol".to_string(),
+                    ),
+                    expect: Yields(("echo hi".to_string(), 1, "carol".to_string(), true)),
+                },
+                Case {
+                    scenario: "script at maximum length is accepted",
+                    input: (
+                        CreateRemediationRequest {
+                            script: "y".repeat(MAXIMUM_SCRIPT_LENGTH),
+                            metadata: None,
+                            retries: 0,
+                        },
+                        "dave".to_string(),
+                    ),
+                    expect: Yields((
+                        "y".repeat(MAXIMUM_SCRIPT_LENGTH),
+                        0,
+                        "dave".to_string(),
+                        false,
+                    )),
+                },
+                Case {
+                    scenario: "negative retries fail",
+                    input: (
+                        CreateRemediationRequest {
+                            script: "echo hi".to_string(),
+                            metadata: None,
+                            retries: -1,
+                        },
+                        "alice".to_string(),
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty script fails",
+                    input: (
+                        CreateRemediationRequest {
+                            script: String::new(),
+                            metadata: None,
+                            retries: 0,
+                        },
+                        "alice".to_string(),
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "oversized script fails",
+                    input: (
+                        CreateRemediationRequest {
+                            script: oversized,
+                            metadata: None,
+                            retries: 0,
+                        },
+                        "alice".to_string(),
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "duplicate metadata label fails",
+                    input: (
+                        CreateRemediationRequest {
+                            script: "echo hi".to_string(),
+                            metadata: Some(metadata(
+                                "n",
+                                "d",
+                                vec![label("k", Some("a")), label("k", Some("b"))],
+                            )),
+                            retries: 0,
+                        },
+                        "alice".to_string(),
+                    ),
+                    expect: Fails,
+                },
+            ],
+            |(request, author)| -> Result<Projected, ()> {
+                let new = NewRemediation::rpc_try_from((request, author)).map_err(drop)?;
+                Ok((
+                    new.script,
+                    new.retries,
+                    new.author.to_string(),
+                    new.metadata.is_some(),
+                ))
+            },
+        );
+    }
+
+    // `Remediation -> rpc::forge::Remediation` is a total conversion. Project the
+    // result to its scalar fields plus (reviewer, has-metadata) so each row pins the
+    // present/absent optional arms and the bool/int pass-throughs.
+    #[test]
+    fn remediation_into_rpc() {
+        type Projected = (String, String, Option<String>, bool, i32, bool);
+
+        fn remediation(
+            reviewer: Option<&str>,
+            metadata: Option<Metadata>,
+            enabled: bool,
+            retries: i32,
+        ) -> Remediation {
+            Remediation {
+                id: RemediationId::default(),
+                script: "echo".to_string(),
+                metadata,
+                reviewer: reviewer.map(|r| r.to_string().into()),
+                author: "alice".to_string().into(),
+                retries,
+                enabled,
+                creation_time: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            }
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "no reviewer, no metadata, disabled",
+                    input: remediation(None, None, false, 0),
+                    expect: (
+                        "echo".to_string(),
+                        "alice".to_string(),
+                        None,
+                        false,
+                        0,
+                        false,
+                    ),
+                },
+                Check {
+                    scenario: "reviewer present, enabled, retries",
+                    input: remediation(Some("bob"), None, true, 3),
+                    expect: (
+                        "echo".to_string(),
+                        "alice".to_string(),
+                        Some("bob".to_string()),
+                        true,
+                        3,
+                        false,
+                    ),
+                },
+                Check {
+                    scenario: "metadata present",
+                    input: remediation(None, Some(Metadata::default()), false, 0),
+                    expect: (
+                        "echo".to_string(),
+                        "alice".to_string(),
+                        None,
+                        false,
+                        0,
+                        true,
+                    ),
+                },
+            ],
+            |remediation| -> Projected {
+                let proto = rpc::forge::Remediation::from(remediation);
+                (
+                    proto.script,
+                    proto.script_author,
+                    proto.script_reviewed_by,
+                    proto.enabled,
+                    proto.retries,
+                    proto.metadata.is_some(),
+                )
+            },
+        );
+    }
+
+    // `Remediation -> rpc::forge::CreateRemediationResponse` projects to just the id.
+    #[test]
+    fn remediation_into_create_response() {
+        let id = RemediationId::default();
+
+        Check {
+            scenario: "id passes through",
+            input: Remediation {
+                id,
+                script: "echo".to_string(),
+                metadata: None,
+                reviewer: None,
+                author: "alice".to_string().into(),
+                retries: 0,
+                enabled: false,
+                creation_time: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            },
+            expect: id.into(),
+        }
+        .check(|remediation| rpc::forge::CreateRemediationResponse::from(remediation).remediation_id);
+    }
+
+    // `AppliedRemediation -> rpc::forge::AppliedRemediation` is total. Project to
+    // (dpu_machine_id, remediation_id, attempt, succeeded, sorted status labels) —
+    // the `status` map travels through `metadata.labels`.
+    #[test]
+    fn applied_remediation_into_rpc() {
+        type Projected = (
+            Option<MachineId>,
+            Option<RemediationId>,
+            i32,
+            bool,
+            Vec<(String, String)>,
+        );
+
+        let machine =
+            MachineId::from_str("fm100htjsaledfasinabqqer70e2ua5ksqj4kfjii0v0a90vulps48c1h7g")
+                .unwrap();
+        let remediation = RemediationId::default();
+
+        fn applied(
+            machine: MachineId,
+            remediation: RemediationId,
+            attempt: i32,
+            succeeded: bool,
+            status: HashMap<String, String>,
+        ) -> AppliedRemediation {
+            AppliedRemediation {
+                id: remediation,
+                dpu_machine_id: machine,
+                attempt,
+                succeeded,
+                status,
+                applied_time: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            }
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "succeeded, empty status",
+                    input: applied(machine, remediation, 1, true, HashMap::new()),
+                    expect: (Some(machine), Some(remediation), 1, true, vec![]),
+                },
+                Check {
+                    scenario: "failed, status labels carried",
+                    input: applied(
+                        machine,
+                        remediation,
+                        2,
+                        false,
+                        HashMap::from([("err".to_string(), "boom".to_string())]),
+                    ),
+                    expect: (
+                        Some(machine),
+                        Some(remediation),
+                        2,
+                        false,
+                        vec![("err".to_string(), "boom".to_string())],
+                    ),
+                },
+            ],
+            |applied| -> Projected {
+                let proto = rpc::forge::AppliedRemediation::from(applied);
+                let mut labels: Vec<(String, String)> = proto
+                    .metadata
+                    .map(|m| {
+                        m.labels
+                            .into_iter()
+                            .map(|l| (l.key, l.value.unwrap_or_default()))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                labels.sort();
+                (
+                    proto.dpu_machine_id,
+                    proto.remediation_id,
+                    proto.attempt,
+                    proto.succeeded,
+                    labels,
+                )
+            },
+        );
+    }
+
+    // `(ApproveRemediationRequest, reviewer) -> ApproveRemediation` is fallible: a
+    // missing remediation id is the one error arm. The error type is not `PartialEq`,
+    // so it uses `Fails`. Project the Ok result to (id, reviewer).
+    #[test]
+    fn approve_remediation_rpc_try_from() {
+        let id = RemediationId::default();
+
+        check_cases(
+            [
+                Case {
+                    scenario: "id present",
+                    input: (
+                        ApproveRemediationRequest {
+                            remediation_id: Some(id),
+                        },
+                        "bob".to_string(),
+                    ),
+                    expect: Yields((id, "bob".to_string())),
+                },
+                Case {
+                    scenario: "missing id fails",
+                    input: (
+                        ApproveRemediationRequest {
+                            remediation_id: None,
+                        },
+                        "bob".to_string(),
+                    ),
+                    expect: Fails,
+                },
+            ],
+            |(request, reviewer)| -> Result<(RemediationId, String), ()> {
+                let approve = ApproveRemediation::rpc_try_from((request, reviewer)).map_err(drop)?;
+                Ok((approve.id, approve.reviewer.to_string()))
+            },
+        );
+    }
+
+    // `(RevokeRemediationRequest, actor) -> RevokeRemediation` is fallible: a missing
+    // id is the one error arm; the actor is logged, not stored. Project to the id.
+    #[test]
+    fn revoke_remediation_rpc_try_from() {
+        let id = RemediationId::default();
+
+        check_cases(
+            [
+                Case {
+                    scenario: "id present",
+                    input: (
+                        RevokeRemediationRequest {
+                            remediation_id: Some(id),
+                        },
+                        "bob".to_string(),
+                    ),
+                    expect: Yields(id),
+                },
+                Case {
+                    scenario: "missing id fails",
+                    input: (
+                        RevokeRemediationRequest {
+                            remediation_id: None,
+                        },
+                        "bob".to_string(),
+                    ),
+                    expect: Fails,
+                },
+            ],
+            |(request, actor)| -> Result<RemediationId, ()> {
+                Ok(RevokeRemediation::rpc_try_from((request, actor))
+                    .map_err(drop)?
+                    .id)
+            },
+        );
+    }
+
+    // `(EnableRemediationRequest, actor) -> EnableRemediation` is fallible on a
+    // missing id; the actor is logged, not stored. Project to the id.
+    #[test]
+    fn enable_remediation_rpc_try_from() {
+        let id = RemediationId::default();
+
+        check_cases(
+            [
+                Case {
+                    scenario: "id present",
+                    input: (
+                        EnableRemediationRequest {
+                            remediation_id: Some(id),
+                        },
+                        "bob".to_string(),
+                    ),
+                    expect: Yields(id),
+                },
+                Case {
+                    scenario: "missing id fails",
+                    input: (
+                        EnableRemediationRequest {
+                            remediation_id: None,
+                        },
+                        "bob".to_string(),
+                    ),
+                    expect: Fails,
+                },
+            ],
+            |(request, actor)| -> Result<RemediationId, ()> {
+                Ok(EnableRemediation::rpc_try_from((request, actor))
+                    .map_err(drop)?
+                    .id)
+            },
+        );
+    }
+
+    // `(DisableRemediationRequest, actor) -> DisableRemediation` is fallible on a
+    // missing id; the actor is logged, not stored. Project to the id.
+    #[test]
+    fn disable_remediation_rpc_try_from() {
+        let id = RemediationId::default();
+
+        check_cases(
+            [
+                Case {
+                    scenario: "id present",
+                    input: (
+                        DisableRemediationRequest {
+                            remediation_id: Some(id),
+                        },
+                        "bob".to_string(),
+                    ),
+                    expect: Yields(id),
+                },
+                Case {
+                    scenario: "missing id fails",
+                    input: (
+                        DisableRemediationRequest {
+                            remediation_id: None,
+                        },
+                        "bob".to_string(),
+                    ),
+                    expect: Fails,
+                },
+            ],
+            |(request, actor)| -> Result<RemediationId, ()> {
+                Ok(DisableRemediation::rpc_try_from((request, actor))
+                    .map_err(drop)?
+                    .id)
+            },
+        );
     }
 }

--- a/crates/rpc/src/model/expected_machine.rs
+++ b/crates/rpc/src/model/expected_machine.rs
@@ -268,25 +268,52 @@ fn metadata_from_request(
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+    use std::str::FromStr;
+
     use super::*;
 
-    /// Unspecified (0) on the wire means "use the default." Old clients
-    /// sending no value land here, and we want to preserve the DpuMode
-    /// default so existing deployments keep their behavior.
+    /// `DpuMode::from(rpc::forge::DpuMode)` maps each named variant onto its
+    /// model twin, and Unspecified (what old clients send) onto the default —
+    /// which keeps existing deployments behaving as before. The named rows also
+    /// stand in for the model -> rpc -> model round trip, since the rpc input is
+    /// exactly what `rpc::forge::DpuMode::from(model)` produces.
     #[test]
-    fn from_rpc_unspecified_maps_to_default() {
-        assert_eq!(
-            DpuMode::from(rpc::forge::DpuMode::Unspecified),
-            DpuMode::default()
+    fn rpc_dpu_mode_maps_to_model() {
+        check_values(
+            [
+                Check {
+                    scenario: "unspecified maps to default",
+                    input: rpc::forge::DpuMode::Unspecified,
+                    expect: DpuMode::default(),
+                },
+                Check {
+                    scenario: "dpu mode round trips",
+                    input: rpc::forge::DpuMode::DpuMode,
+                    expect: DpuMode::DpuMode,
+                },
+                Check {
+                    scenario: "nic mode round trips",
+                    input: rpc::forge::DpuMode::NicMode,
+                    expect: DpuMode::NicMode,
+                },
+                Check {
+                    scenario: "no dpu round trips",
+                    input: rpc::forge::DpuMode::NoDpu,
+                    expect: DpuMode::NoDpu,
+                },
+            ],
+            DpuMode::from,
         );
-        assert_eq!(DpuMode::default(), DpuMode::DpuMode);
     }
 
+    /// The DpuMode default is DpuMode, which is what the Unspecified mapping above
+    /// relies on.
     #[test]
-    fn rpc_enum_round_trips_all_named_variants() {
-        for mode in [DpuMode::DpuMode, DpuMode::NicMode, DpuMode::NoDpu] {
-            assert_eq!(DpuMode::from(rpc::forge::DpuMode::from(mode)), mode);
-        }
+    fn dpu_mode_default_is_dpu_mode() {
+        assert_eq!(DpuMode::default(), DpuMode::DpuMode);
     }
 
     #[test]
@@ -332,54 +359,632 @@ mod tests {
         }
     }
 
+    /// `rpc::forge::DpuMode::from(model)` -- the model -> rpc direction. Each
+    /// named model variant maps onto its rpc twin; the model has no
+    /// Unspecified arm so every variant is named.
     #[test]
-    fn disable_lockdown_true_round_trips_through_proto() {
-        let rpc_em = make_rpc_expected_machine(Some(true));
-        let data = ExpectedMachineData::try_from(rpc_em).unwrap();
-        assert_eq!(data.host_lifecycle_profile.disable_lockdown, Some(true));
-
-        let em = ExpectedMachine {
-            id: None,
-            bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
-            data,
-        };
-        let back: rpc::forge::ExpectedMachine = em.into();
-        assert_eq!(
-            back.host_lifecycle_profile.unwrap().disable_lockdown,
-            Some(true)
+    fn model_dpu_mode_maps_to_rpc() {
+        check_values(
+            [
+                Check {
+                    scenario: "dpu mode",
+                    input: DpuMode::DpuMode,
+                    expect: rpc::forge::DpuMode::DpuMode,
+                },
+                Check {
+                    scenario: "nic mode",
+                    input: DpuMode::NicMode,
+                    expect: rpc::forge::DpuMode::NicMode,
+                },
+                Check {
+                    scenario: "no dpu",
+                    input: DpuMode::NoDpu,
+                    expect: rpc::forge::DpuMode::NoDpu,
+                },
+            ],
+            rpc::forge::DpuMode::from,
         );
     }
 
+    /// `ExpectedMachineRequest::try_from` parses the optional UUID id and the
+    /// (possibly empty) BMC MAC string. Empty MAC and absent id both become
+    /// `None`; a malformed UUID or MAC fails. The run closure projects the
+    /// parsed request to `(id.is_some(), bmc_mac_address.is_some())` so the
+    /// table is a single `bool`-pair shape.
     #[test]
-    fn disable_lockdown_false_round_trips_through_proto() {
-        let rpc_em = make_rpc_expected_machine(Some(false));
-        let data = ExpectedMachineData::try_from(rpc_em).unwrap();
-        assert_eq!(data.host_lifecycle_profile.disable_lockdown, Some(false));
-
-        let em = ExpectedMachine {
-            id: None,
-            bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
-            data,
-        };
-        let back: rpc::forge::ExpectedMachine = em.into();
-        assert_eq!(
-            back.host_lifecycle_profile.unwrap().disable_lockdown,
-            Some(false)
+    fn expected_machine_request_try_from_parses_id_and_mac() {
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        check_cases(
+            [
+                Case {
+                    scenario: "id and mac both present",
+                    input: rpc::forge::ExpectedMachineRequest {
+                        bmc_mac_address: "AA:BB:CC:DD:EE:FF".into(),
+                        id: Some(crate::common::Uuid {
+                            value: uuid.into(),
+                        }),
+                    },
+                    expect: Yields((true, true)),
+                },
+                Case {
+                    scenario: "id absent, mac empty",
+                    input: rpc::forge::ExpectedMachineRequest {
+                        bmc_mac_address: "".into(),
+                        id: None,
+                    },
+                    expect: Yields((false, false)),
+                },
+                Case {
+                    scenario: "invalid uuid fails",
+                    input: rpc::forge::ExpectedMachineRequest {
+                        bmc_mac_address: "".into(),
+                        id: Some(crate::common::Uuid {
+                            value: "not-a-uuid".into(),
+                        }),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "invalid mac fails",
+                    input: rpc::forge::ExpectedMachineRequest {
+                        bmc_mac_address: "not-a-mac".into(),
+                        id: None,
+                    },
+                    expect: Fails,
+                },
+            ],
+            |req| {
+                let parsed = ExpectedMachineRequest::try_from(req).map_err(drop)?;
+                Ok::<_, ()>((parsed.id.is_some(), parsed.bmc_mac_address.is_some()))
+            },
         );
     }
 
+    /// `rpc::forge::ExpectedHostNic::from(model)` -- the infallible model -> rpc
+    /// direction. Each row projects the produced proto to
+    /// `(mac_address, fixed_ip, fixed_gateway, primary)` so present vs absent
+    /// optionals and the MAC/IP stringification are all visible.
     #[test]
-    fn disable_lockdown_none_round_trips_through_proto() {
-        let rpc_em = make_rpc_expected_machine(None);
-        let data = ExpectedMachineData::try_from(rpc_em).unwrap();
-        assert_eq!(data.host_lifecycle_profile.disable_lockdown, None);
+    fn expected_host_nic_to_rpc_maps_fields() {
+        check_values(
+            [
+                Check {
+                    scenario: "all optionals present",
+                    input: ExpectedHostNic {
+                        mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
+                        nic_type: Some("bf3".into()),
+                        fixed_ip: Some("10.0.0.5".parse().unwrap()),
+                        fixed_mask: Some("255.255.255.0".into()),
+                        fixed_gateway: Some("10.0.0.1".parse().unwrap()),
+                        primary: Some(true),
+                    },
+                    expect: (
+                        "AA:BB:CC:DD:EE:FF".to_string(),
+                        Some("10.0.0.5".to_string()),
+                        Some("10.0.0.1".to_string()),
+                        Some(true),
+                    ),
+                },
+                Check {
+                    scenario: "optionals absent",
+                    input: ExpectedHostNic {
+                        mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
+                        nic_type: None,
+                        fixed_ip: None,
+                        fixed_mask: None,
+                        fixed_gateway: None,
+                        primary: None,
+                    },
+                    expect: ("AA:BB:CC:DD:EE:FF".to_string(), None, None, None),
+                },
+            ],
+            |nic| {
+                let rpc: rpc::forge::ExpectedHostNic = nic.into();
+                (rpc.mac_address, rpc.fixed_ip, rpc.fixed_gateway, rpc.primary)
+            },
+        );
+    }
 
-        let em = ExpectedMachine {
-            id: None,
-            bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
-            data,
+    /// `ExpectedHostNic::try_from(rpc)` -- the fallible rpc -> model direction.
+    /// Empty-string `fixed_ip` / `fixed_gateway` collapse to `None` (same as
+    /// absent); malformed MAC, IP, or gateway each fail. The run closure
+    /// projects success to `(fixed_ip.is_some(), fixed_gateway.is_some())`.
+    #[test]
+    fn expected_host_nic_try_from_handles_optionals_and_errors() {
+        let base = || rpc::forge::ExpectedHostNic {
+            mac_address: "AA:BB:CC:DD:EE:FF".into(),
+            ..Default::default()
         };
-        let back: rpc::forge::ExpectedMachine = em.into();
-        assert!(back.host_lifecycle_profile.is_none());
+        check_cases(
+            [
+                Case {
+                    scenario: "valid ip and gateway",
+                    input: rpc::forge::ExpectedHostNic {
+                        fixed_ip: Some("10.0.0.5".into()),
+                        fixed_gateway: Some("10.0.0.1".into()),
+                        ..base()
+                    },
+                    expect: Yields((true, true)),
+                },
+                Case {
+                    scenario: "empty-string ip and gateway become none",
+                    input: rpc::forge::ExpectedHostNic {
+                        fixed_ip: Some("".into()),
+                        fixed_gateway: Some("".into()),
+                        ..base()
+                    },
+                    expect: Yields((false, false)),
+                },
+                Case {
+                    scenario: "absent ip and gateway are none",
+                    input: base(),
+                    expect: Yields((false, false)),
+                },
+                Case {
+                    scenario: "invalid mac fails",
+                    input: rpc::forge::ExpectedHostNic {
+                        mac_address: "not-a-mac".into(),
+                        ..Default::default()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "invalid fixed ip fails",
+                    input: rpc::forge::ExpectedHostNic {
+                        fixed_ip: Some("not-an-ip".into()),
+                        ..base()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "invalid fixed gateway fails",
+                    input: rpc::forge::ExpectedHostNic {
+                        fixed_gateway: Some("not-an-ip".into()),
+                        ..base()
+                    },
+                    expect: Fails,
+                },
+            ],
+            |rpc_nic| {
+                let nic = ExpectedHostNic::try_from(rpc_nic).map_err(drop)?;
+                Ok::<_, ()>((nic.fixed_ip.is_some(), nic.fixed_gateway.is_some()))
+            },
+        );
+    }
+
+    /// `rpc::forge::LinkedExpectedMachine::from(model)` -- the infallible
+    /// projection. Each row checks `(interface_id, explored_endpoint_address,
+    /// machine_id.is_some(), expected_machine_id.is_some())` so present vs
+    /// absent optionals are all covered.
+    #[test]
+    fn linked_expected_machine_to_rpc_maps_fields() {
+        let uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        check_values(
+            [
+                Check {
+                    scenario: "optionals present",
+                    input: LinkedExpectedMachine {
+                        serial_number: "SN-1".into(),
+                        bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
+                        interface_id: Some(MachineInterfaceId::nil()),
+                        address: Some("10.0.0.5".parse().unwrap()),
+                        machine_id: Some(
+                            MachineId::from_str(
+                                "fm100htjsaledfasinabqqer70e2ua5ksqj4kfjii0v0a90vulps48c1h7g",
+                            )
+                            .unwrap(),
+                        ),
+                        expected_machine_id: Some(uuid),
+                    },
+                    expect: (
+                        Some(MachineInterfaceId::nil().to_string()),
+                        Some("10.0.0.5".to_string()),
+                        true,
+                        true,
+                    ),
+                },
+                Check {
+                    scenario: "optionals absent",
+                    input: LinkedExpectedMachine {
+                        serial_number: "SN-1".into(),
+                        bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
+                        interface_id: None,
+                        address: None,
+                        machine_id: None,
+                        expected_machine_id: None,
+                    },
+                    expect: (None, None, false, false),
+                },
+            ],
+            |m| {
+                let rpc: rpc::forge::LinkedExpectedMachine = m.into();
+                (
+                    rpc.interface_id,
+                    rpc.explored_endpoint_address,
+                    rpc.machine_id.is_some(),
+                    rpc.expected_machine_id.is_some(),
+                )
+            },
+        );
+    }
+
+    /// `rpc::forge::UnexpectedMachine::from(model)` -- the infallible
+    /// projection, including the optional `machine_id`. Each row checks
+    /// `(address, bmc_mac_address, machine_id.is_some())`.
+    #[test]
+    fn unexpected_machine_to_rpc_maps_fields() {
+        check_values(
+            [
+                Check {
+                    scenario: "machine id present",
+                    input: UnexpectedMachine {
+                        address: "10.0.0.5".parse().unwrap(),
+                        bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
+                        machine_id: Some(
+                            MachineId::from_str(
+                                "fm100htjsaledfasinabqqer70e2ua5ksqj4kfjii0v0a90vulps48c1h7g",
+                            )
+                            .unwrap(),
+                        ),
+                    },
+                    expect: (
+                        "10.0.0.5".to_string(),
+                        "AA:BB:CC:DD:EE:FF".to_string(),
+                        true,
+                    ),
+                },
+                Check {
+                    scenario: "machine id absent",
+                    input: UnexpectedMachine {
+                        address: "10.0.0.5".parse().unwrap(),
+                        bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
+                        machine_id: None,
+                    },
+                    expect: (
+                        "10.0.0.5".to_string(),
+                        "AA:BB:CC:DD:EE:FF".to_string(),
+                        false,
+                    ),
+                },
+            ],
+            |m| {
+                let rpc: rpc::forge::UnexpectedMachine = m.into();
+                (rpc.address, rpc.bmc_mac_address, rpc.machine_id.is_some())
+            },
+        );
+    }
+
+    /// `ExpectedMachineData::try_from(rpc)` resolves the optional `dpu_mode`
+    /// field: each named wire value maps to its model twin, while a missing
+    /// field and an Unspecified (0) value both fall back to the default
+    /// (`DpuMode::DpuMode`), preserving old-client behavior.
+    #[test]
+    fn expected_machine_data_resolves_dpu_mode() {
+        check_cases(
+            [
+                Case {
+                    scenario: "missing field falls back to default",
+                    input: None,
+                    expect: Yields(DpuMode::DpuMode),
+                },
+                Case {
+                    scenario: "unspecified falls back to default",
+                    input: Some(rpc::forge::DpuMode::Unspecified as i32),
+                    expect: Yields(DpuMode::DpuMode),
+                },
+                Case {
+                    scenario: "dpu mode",
+                    input: Some(rpc::forge::DpuMode::DpuMode as i32),
+                    expect: Yields(DpuMode::DpuMode),
+                },
+                Case {
+                    scenario: "nic mode",
+                    input: Some(rpc::forge::DpuMode::NicMode as i32),
+                    expect: Yields(DpuMode::NicMode),
+                },
+                Case {
+                    scenario: "no dpu",
+                    input: Some(rpc::forge::DpuMode::NoDpu as i32),
+                    expect: Yields(DpuMode::NoDpu),
+                },
+                Case {
+                    scenario: "unknown enum value falls back to default",
+                    input: Some(999),
+                    expect: Yields(DpuMode::DpuMode),
+                },
+            ],
+            |dpu_mode| {
+                let mut rpc = make_rpc_expected_machine(None);
+                rpc.dpu_mode = dpu_mode;
+                ExpectedMachineData::try_from(rpc)
+                    .map(|d| d.dpu_mode)
+                    .map_err(drop)
+            },
+        );
+    }
+
+    /// `ExpectedMachineData::try_from(rpc)` parses the optional `bmc_ip_address`
+    /// wire string: empty and absent both become `None`, a valid v4/v6 string
+    /// parses, and a malformed string fails the whole conversion. The run
+    /// closure projects success to `bmc_ip_address.is_some()`.
+    #[test]
+    fn expected_machine_data_parses_bmc_ip_address() {
+        check_cases(
+            [
+                Case {
+                    scenario: "absent is none",
+                    input: None,
+                    expect: Yields(false),
+                },
+                Case {
+                    scenario: "empty string is none",
+                    input: Some("".to_string()),
+                    expect: Yields(false),
+                },
+                Case {
+                    scenario: "valid v4 parses",
+                    input: Some("10.0.0.5".to_string()),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "valid v6 parses",
+                    input: Some("2001:db8::1".to_string()),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "invalid string fails",
+                    input: Some("not-an-ip".to_string()),
+                    expect: Fails,
+                },
+            ],
+            |bmc_ip_address| {
+                let mut rpc = make_rpc_expected_machine(None);
+                rpc.bmc_ip_address = bmc_ip_address;
+                ExpectedMachineData::try_from(rpc)
+                    .map(|d| d.bmc_ip_address.is_some())
+                    .map_err(drop)
+            },
+        );
+    }
+
+    /// `metadata_from_request` (via `ExpectedMachineData::try_from`): an absent
+    /// proto Metadata yields empty model metadata, a present-and-valid one is
+    /// carried through, and a present-but-invalid one (here an empty label key)
+    /// fails validation. The run closure projects success to the parsed
+    /// metadata name.
+    #[test]
+    fn expected_machine_data_validates_metadata() {
+        check_cases(
+            [
+                Case {
+                    scenario: "absent metadata yields empty name",
+                    input: None,
+                    expect: Yields(String::new()),
+                },
+                Case {
+                    scenario: "valid metadata is carried through",
+                    input: Some(rpc::forge::Metadata {
+                        name: "my-host".into(),
+                        description: "desc".into(),
+                        labels: vec![],
+                    }),
+                    expect: Yields("my-host".to_string()),
+                },
+                Case {
+                    scenario: "invalid metadata (empty label key) fails",
+                    input: Some(rpc::forge::Metadata {
+                        name: "my-host".into(),
+                        description: "desc".into(),
+                        labels: vec![rpc::forge::Label {
+                            key: "".into(),
+                            value: Some("v".into()),
+                        }],
+                    }),
+                    expect: Fails,
+                },
+            ],
+            |metadata| {
+                let mut rpc = make_rpc_expected_machine(None);
+                rpc.metadata = metadata;
+                ExpectedMachineData::try_from(rpc)
+                    .map(|d| d.metadata.name)
+                    .map_err(drop)
+            },
+        );
+    }
+
+    /// `rpc::forge::ExpectedMachine::from(model)` only emits `dpu_mode` on the
+    /// wire when it's non-default -- the default `DpuMode` collapses to `None`
+    /// (matching the bmc_retain_credentials filter pattern), while `NicMode`
+    /// and `NoDpu` are emitted as their i32 wire values.
+    #[test]
+    fn expected_machine_to_rpc_emits_non_default_dpu_mode() {
+        check_values(
+            [
+                Check {
+                    scenario: "default dpu mode is omitted",
+                    input: DpuMode::DpuMode,
+                    expect: None,
+                },
+                Check {
+                    scenario: "nic mode is emitted",
+                    input: DpuMode::NicMode,
+                    expect: Some(rpc::forge::DpuMode::NicMode as i32),
+                },
+                Check {
+                    scenario: "no dpu is emitted",
+                    input: DpuMode::NoDpu,
+                    expect: Some(rpc::forge::DpuMode::NoDpu as i32),
+                },
+            ],
+            |dpu_mode| {
+                let em = ExpectedMachine {
+                    id: None,
+                    bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
+                    data: ExpectedMachineData {
+                        dpu_mode,
+                        ..Default::default()
+                    },
+                };
+                let rpc: rpc::forge::ExpectedMachine = em.into();
+                rpc.dpu_mode
+            },
+        );
+    }
+
+    /// `rpc::forge::ExpectedMachine::from(model)` only emits
+    /// `bmc_retain_credentials` when it's `Some(true)`; `Some(false)` and
+    /// `None` both collapse to `None` on the wire (the filter pattern).
+    #[test]
+    fn expected_machine_to_rpc_filters_bmc_retain_credentials() {
+        check_values(
+            [
+                Check {
+                    scenario: "some true is emitted",
+                    input: Some(true),
+                    expect: Some(true),
+                },
+                Check {
+                    scenario: "some false is filtered out",
+                    input: Some(false),
+                    expect: None,
+                },
+                Check {
+                    scenario: "none stays none",
+                    input: None,
+                    expect: None,
+                },
+            ],
+            |bmc_retain_credentials| {
+                let em = ExpectedMachine {
+                    id: None,
+                    bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
+                    data: ExpectedMachineData {
+                        bmc_retain_credentials,
+                        ..Default::default()
+                    },
+                };
+                let rpc: rpc::forge::ExpectedMachine = em.into();
+                rpc.bmc_retain_credentials
+            },
+        );
+    }
+
+    /// `rpc::forge::ExpectedMachine::from(model)` mirrors the optional
+    /// `dpf_enabled` onto both the deprecated `dpf_enabled` bool (defaulting to
+    /// `false` when unset) and the optional `is_dpf_enabled`. Each row checks
+    /// `(dpf_enabled, is_dpf_enabled)`.
+    #[test]
+    fn expected_machine_to_rpc_mirrors_dpf_enabled() {
+        #[allow(deprecated)]
+        check_values(
+            [
+                Check {
+                    scenario: "some true",
+                    input: Some(true),
+                    expect: (true, Some(true)),
+                },
+                Check {
+                    scenario: "some false",
+                    input: Some(false),
+                    expect: (false, Some(false)),
+                },
+                Check {
+                    scenario: "none defaults bool to false",
+                    input: None,
+                    expect: (false, None),
+                },
+            ],
+            |dpf_enabled| {
+                let em = ExpectedMachine {
+                    id: None,
+                    bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
+                    data: ExpectedMachineData {
+                        dpf_enabled,
+                        ..Default::default()
+                    },
+                };
+                let rpc: rpc::forge::ExpectedMachine = em.into();
+                (rpc.dpf_enabled, rpc.is_dpf_enabled)
+            },
+        );
+    }
+
+    /// `rpc::forge::ExpectedMachine::from(model)` only emits the
+    /// `host_lifecycle_profile` message when the model profile is non-empty
+    /// (any field set); an empty profile collapses to `None` on the wire.
+    #[test]
+    fn expected_machine_to_rpc_omits_empty_host_lifecycle_profile() {
+        check_values(
+            [
+                Check {
+                    scenario: "empty profile is omitted",
+                    input: HostLifecycleProfile::default(),
+                    expect: None,
+                },
+                Check {
+                    scenario: "disable_lockdown set is emitted",
+                    input: HostLifecycleProfile {
+                        disable_lockdown: Some(true),
+                    },
+                    expect: Some(Some(true)),
+                },
+            ],
+            |host_lifecycle_profile| {
+                let em = ExpectedMachine {
+                    id: None,
+                    bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
+                    data: ExpectedMachineData {
+                        host_lifecycle_profile,
+                        ..Default::default()
+                    },
+                };
+                let rpc: rpc::forge::ExpectedMachine = em.into();
+                rpc.host_lifecycle_profile.map(|p| p.disable_lockdown)
+            },
+        );
+    }
+
+    /// `disable_lockdown` survives the rpc -> data -> rpc round trip: each input
+    /// is projected to (data-side disable_lockdown, back-side host_lifecycle_profile
+    /// mapped to its disable_lockdown). A `None` input yields no profile on the way
+    /// back, so the back-side projection is `None` rather than `Some(None)`.
+    #[test]
+    fn disable_lockdown_round_trips_through_proto() {
+        check_cases(
+            [
+                Case {
+                    scenario: "true",
+                    input: Some(true),
+                    expect: Yields((Some(true), Some(Some(true)))),
+                },
+                Case {
+                    scenario: "false",
+                    input: Some(false),
+                    expect: Yields((Some(false), Some(Some(false)))),
+                },
+                Case {
+                    scenario: "none",
+                    input: None,
+                    expect: Yields((None, None)),
+                },
+            ],
+            |disable_lockdown| {
+                let data =
+                    ExpectedMachineData::try_from(make_rpc_expected_machine(disable_lockdown))
+                        .map_err(drop)?;
+                let data_side = data.host_lifecycle_profile.disable_lockdown;
+
+                let em = ExpectedMachine {
+                    id: None,
+                    bmc_mac_address: "AA:BB:CC:DD:EE:FF".parse().map_err(drop)?,
+                    data,
+                };
+                let back: rpc::forge::ExpectedMachine = em.into();
+                let back_side = back.host_lifecycle_profile.map(|p| p.disable_lockdown);
+
+                Ok::<_, ()>((data_side, back_side))
+            },
+        );
     }
 }

--- a/crates/rpc/src/model/extension_service.rs
+++ b/crates/rpc/src/model/extension_service.rs
@@ -203,134 +203,349 @@ impl TryFrom<rpc::DpuExtensionServiceObservabilityConfig> for ExtensionServiceOb
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::{Case, Check, Outcome::*, check_cases, check_values};
+    use carbide_uuid::extension_service::ExtensionServiceId;
+    use chrono::{TimeZone, Utc};
+    use config_version::ConfigVersion;
+    use uuid::Uuid;
+
     use super::*;
     use crate::forge::dpu_extension_service_observability_config::Config;
     use crate::forge::{self as rpc};
 
+    /// Build a domain observability config carrying a prometheus variant.
+    fn prom_config(
+        name: Option<&str>,
+        endpoint: &str,
+        scrape: u32,
+    ) -> ExtensionServiceObservabilityConfig {
+        ExtensionServiceObservabilityConfig {
+            name: name.map(str::to_string),
+            config: ExtensionServiceObservabilityConfigType::Prometheus(
+                ExtensionServiceObservabilityConfigTypePrometheus {
+                    scrape_interval_seconds: scrape,
+                    endpoint: endpoint.to_string(),
+                },
+            ),
+        }
+    }
+
+    /// Build a domain observability config carrying a logging variant.
+    fn log_config(name: Option<&str>, path: &str) -> ExtensionServiceObservabilityConfig {
+        ExtensionServiceObservabilityConfig {
+            name: name.map(str::to_string),
+            config: ExtensionServiceObservabilityConfigType::Logging(
+                ExtensionServiceObservabilityConfigTypeLogging {
+                    path: path.to_string(),
+                },
+            ),
+        }
+    }
+
+    /// Build an rpc observability config wrapping a prometheus oneof variant.
+    fn rpc_prom(
+        name: Option<&str>,
+        endpoint: &str,
+        scrape: u32,
+    ) -> rpc::DpuExtensionServiceObservabilityConfig {
+        rpc::DpuExtensionServiceObservabilityConfig {
+            name: name.map(str::to_string),
+            config: Some(Config::Prometheus(
+                rpc::DpuExtensionServiceObservabilityConfigPrometheus {
+                    endpoint: endpoint.to_string(),
+                    scrape_interval_seconds: scrape,
+                },
+            )),
+        }
+    }
+
+    /// Build an rpc observability config wrapping a logging oneof variant.
+    fn rpc_log(name: Option<&str>, path: &str) -> rpc::DpuExtensionServiceObservabilityConfig {
+        rpc::DpuExtensionServiceObservabilityConfig {
+            name: name.map(str::to_string),
+            config: Some(Config::Logging(
+                rpc::DpuExtensionServiceObservabilityConfigLogging {
+                    path: path.to_string(),
+                },
+            )),
+        }
+    }
+
     #[test]
-    fn test_observability_config_from_rpc() {
-        // Try a bad name
-        ExtensionServiceObservabilityConfig::try_from(
-            rpc::DpuExtensionServiceObservabilityConfig {
-                name: Some("a".repeat(1024)),
-                config: Some(Config::Logging(
-                    rpc::DpuExtensionServiceObservabilityConfigLogging {
-                        path: "/dev/null".to_string(),
-                    },
-                )),
-            },
-        )
-        .unwrap_err();
-
-        // Try a missing config
-        ExtensionServiceObservabilityConfig::try_from(
-            rpc::DpuExtensionServiceObservabilityConfig {
-                name: Some("a".repeat(10)),
-                config: None,
-            },
-        )
-        .unwrap_err();
-
-        // Try a bad log path size
-        ExtensionServiceObservabilityConfig::try_from(
-            rpc::DpuExtensionServiceObservabilityConfig {
-                name: Some("a".repeat(10)),
-                config: Some(Config::Logging(
-                    rpc::DpuExtensionServiceObservabilityConfigLogging {
-                        path: "/dev/null".repeat(1024),
-                    },
-                )),
-            },
-        )
-        .unwrap_err();
-
-        // Try a bad log path
-        ExtensionServiceObservabilityConfig::try_from(
-            rpc::DpuExtensionServiceObservabilityConfig {
-                name: Some("a".repeat(10)),
-                config: Some(Config::Logging(
-                    rpc::DpuExtensionServiceObservabilityConfigLogging {
-                        path: "/dev/null$$$$$$".repeat(1024),
-                    },
-                )),
-            },
-        )
-        .unwrap_err();
-
-        // Try a bad endpoint
-        ExtensionServiceObservabilityConfig::try_from(
-            rpc::DpuExtensionServiceObservabilityConfig {
-                name: Some("a".repeat(10)),
-                config: Some(Config::Prometheus(
-                    rpc::DpuExtensionServiceObservabilityConfigPrometheus {
-                        endpoint: "localhost".repeat(1024),
-                        scrape_interval_seconds: 30,
-                    },
-                )),
-            },
-        )
-        .unwrap_err();
-
-        // Try another bad endpoint using bad characters
-        ExtensionServiceObservabilityConfig::try_from(
-            rpc::DpuExtensionServiceObservabilityConfig {
-                name: Some("a".repeat(10)),
-                config: Some(Config::Prometheus(
-                    rpc::DpuExtensionServiceObservabilityConfigPrometheus {
-                        endpoint: "/this/is/not/valid".repeat(1024),
-                        scrape_interval_seconds: 30,
-                    },
-                )),
-            },
-        )
-        .unwrap_err();
-
-        // Try a good prom config
-        assert_eq!(
-            ExtensionServiceObservabilityConfig::try_from(
-                rpc::DpuExtensionServiceObservabilityConfig {
-                    name: Some("a".repeat(10)),
-                    config: Some(Config::Prometheus(
-                        rpc::DpuExtensionServiceObservabilityConfigPrometheus {
-                            endpoint: "localhost:8080".to_string(),
-                            scrape_interval_seconds: 30,
-                        },
-                    )),
-                }
-            )
-            .unwrap(),
-            ExtensionServiceObservabilityConfig {
-                name: Some("a".repeat(10)),
-                config: ExtensionServiceObservabilityConfigType::Prometheus(
-                    ExtensionServiceObservabilityConfigTypePrometheus {
-                        endpoint: "localhost:8080".to_string(),
-                        scrape_interval_seconds: 30
-                    }
-                )
-            }
+    fn service_type_to_rpc_round_trips_each_arm() {
+        check_values(
+            [Check {
+                scenario: "kubernetes pod maps to rpc kubernetes pod",
+                input: ExtensionServiceType::KubernetesPod,
+                expect: rpc::DpuExtensionServiceType::KubernetesPod,
+            }],
+            rpc::DpuExtensionServiceType::from,
         );
+    }
 
-        // Try a good logging config
-        assert_eq!(
-            ExtensionServiceObservabilityConfig::try_from(
-                rpc::DpuExtensionServiceObservabilityConfig {
-                    name: Some("a".repeat(10)),
-                    config: Some(Config::Logging(
-                        rpc::DpuExtensionServiceObservabilityConfigLogging {
-                            path: "/dev/null@home".to_string(),
-                        },
+    #[test]
+    fn service_type_from_rpc_round_trips_each_arm() {
+        check_values(
+            [Check {
+                scenario: "rpc kubernetes pod maps to domain kubernetes pod",
+                input: rpc::DpuExtensionServiceType::KubernetesPod,
+                expect: ExtensionServiceType::KubernetesPod,
+            }],
+            ExtensionServiceType::from,
+        );
+    }
+
+    #[test]
+    fn observability_config_to_rpc_maps_each_variant() {
+        check_values(
+            [
+                Check {
+                    scenario: "prometheus variant with a name",
+                    input: prom_config(Some("scrape"), "localhost:8080", 30),
+                    expect: rpc_prom(Some("scrape"), "localhost:8080", 30),
+                },
+                Check {
+                    scenario: "prometheus variant without a name",
+                    input: prom_config(None, "localhost:9090", 15),
+                    expect: rpc_prom(None, "localhost:9090", 15),
+                },
+                Check {
+                    scenario: "logging variant with a name",
+                    input: log_config(Some("logs"), "/dev/null"),
+                    expect: rpc_log(Some("logs"), "/dev/null"),
+                },
+                Check {
+                    scenario: "logging variant without a name",
+                    input: log_config(None, "/var/log/app.log"),
+                    expect: rpc_log(None, "/var/log/app.log"),
+                },
+            ],
+            rpc::DpuExtensionServiceObservabilityConfig::from,
+        );
+    }
+
+    #[test]
+    fn observability_to_rpc_maps_every_config() {
+        check_values(
+            [
+                Check {
+                    scenario: "empty config list",
+                    input: ExtensionServiceObservability { configs: vec![] },
+                    expect: rpc::DpuExtensionServiceObservability { configs: vec![] },
+                },
+                Check {
+                    scenario: "mixed prometheus and logging configs",
+                    input: ExtensionServiceObservability {
+                        configs: vec![
+                            prom_config(Some("a"), "host:80", 5),
+                            log_config(None, "/tmp/x"),
+                        ],
+                    },
+                    expect: rpc::DpuExtensionServiceObservability {
+                        configs: vec![rpc_prom(Some("a"), "host:80", 5), rpc_log(None, "/tmp/x")],
+                    },
+                },
+            ],
+            rpc::DpuExtensionServiceObservability::from,
+        );
+    }
+
+    #[test]
+    fn observability_config_from_rpc_covers_ok_and_error_arms() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid prometheus config",
+                    input: rpc_prom(Some("a"), "localhost:8080", 30),
+                    expect: Yields(prom_config(Some("a"), "localhost:8080", 30)),
+                },
+                Case {
+                    scenario: "valid prometheus config without a name",
+                    input: rpc_prom(None, "localhost:8080", 30),
+                    expect: Yields(prom_config(None, "localhost:8080", 30)),
+                },
+                Case {
+                    scenario: "valid logging config with @ and . characters",
+                    input: rpc_log(Some("a"), "/dev/null@home"),
+                    expect: Yields(log_config(Some("a"), "/dev/null@home")),
+                },
+                Case {
+                    scenario: "valid logging config without a name",
+                    input: rpc_log(None, "/dev/null"),
+                    expect: Yields(log_config(None, "/dev/null")),
+                },
+                Case {
+                    scenario: "missing config oneof",
+                    input: rpc::DpuExtensionServiceObservabilityConfig {
+                        name: Some("a".repeat(10)),
+                        config: None,
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "name exceeds the max length",
+                    input: rpc_log(Some(&"a".repeat(MAX_OBSERVABILITY_CONFIG_NAME + 1)), "/dev/null"),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "name exactly at the max length is allowed",
+                    input: rpc_log(Some(&"a".repeat(MAX_OBSERVABILITY_CONFIG_NAME)), "/dev/null"),
+                    expect: Yields(log_config(
+                        Some(&"a".repeat(MAX_OBSERVABILITY_CONFIG_NAME)),
+                        "/dev/null",
                     )),
-                }
-            )
-            .unwrap(),
-            ExtensionServiceObservabilityConfig {
-                name: Some("a".repeat(10)),
-                config: ExtensionServiceObservabilityConfigType::Logging(
-                    ExtensionServiceObservabilityConfigTypeLogging {
-                        path: "/dev/null@home".to_string(),
-                    }
+                },
+                Case {
+                    scenario: "prometheus endpoint exceeds the max length",
+                    input: rpc_prom(Some("a"), &"localhost".repeat(1024), 30),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "prometheus endpoint has invalid characters",
+                    input: rpc_prom(Some("a"), "/this/is/not/valid", 30),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "logging path exceeds the max length",
+                    input: rpc_log(Some("a"), &"/dev/null".repeat(1024)),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "logging path has invalid characters",
+                    input: rpc_log(Some("a"), "/dev/null$$$"),
+                    expect: Fails,
+                },
+            ],
+            |c| ExtensionServiceObservabilityConfig::try_from(c).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn observability_from_rpc_propagates_inner_errors() {
+        check_cases(
+            [
+                Case {
+                    scenario: "all inner configs valid",
+                    input: rpc::DpuExtensionServiceObservability {
+                        configs: vec![rpc_prom(None, "host:80", 5), rpc_log(None, "/tmp/x")],
+                    },
+                    expect: Yields(ExtensionServiceObservability {
+                        configs: vec![prom_config(None, "host:80", 5), log_config(None, "/tmp/x")],
+                    }),
+                },
+                Case {
+                    scenario: "empty config list yields empty observability",
+                    input: rpc::DpuExtensionServiceObservability { configs: vec![] },
+                    expect: Yields(ExtensionServiceObservability { configs: vec![] }),
+                },
+                Case {
+                    scenario: "one invalid inner config fails the whole conversion",
+                    input: rpc::DpuExtensionServiceObservability {
+                        configs: vec![rpc_prom(None, "host:80", 5), rpc_log(None, "/dev/null$$$")],
+                    },
+                    expect: Fails,
+                },
+            ],
+            |o| ExtensionServiceObservability::try_from(o).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn version_info_to_rpc_maps_fields_and_optional_observability() {
+        let created = Utc.with_ymd_and_hms(2026, 1, 2, 3, 4, 5).unwrap();
+        let version = ConfigVersion::new(7);
+        let with_obs = ExtensionServiceVersionInfo {
+            service_id: ExtensionServiceId::from(Uuid::nil()),
+            version,
+            created,
+            data: "yaml".to_string(),
+            observability: Some(ExtensionServiceObservability {
+                configs: vec![log_config(None, "/tmp/x")],
+            }),
+            has_credential: true,
+            deleted: None,
+        };
+        let without_obs = ExtensionServiceVersionInfo {
+            observability: None,
+            has_credential: false,
+            ..with_obs.clone()
+        };
+
+        check_values(
+            [
+                Check {
+                    scenario: "observability present is carried through",
+                    input: with_obs,
+                    expect: (true, true, "yaml".to_string()),
+                },
+                Check {
+                    scenario: "observability absent yields none",
+                    input: without_obs,
+                    expect: (false, false, "yaml".to_string()),
+                },
+            ],
+            |v| {
+                let rpc = rpc::DpuExtensionServiceVersionInfo::from(v);
+                (rpc.observability.is_some(), rpc.has_credential, rpc.data)
+            },
+        );
+    }
+
+    #[test]
+    fn snapshot_to_rpc_maps_fields_and_optional_latest_version() {
+        let created = Utc.with_ymd_and_hms(2026, 1, 2, 3, 4, 5).unwrap();
+        let updated = Utc.with_ymd_and_hms(2026, 2, 3, 4, 5, 6).unwrap();
+        let service_id = ExtensionServiceId::from(Uuid::nil());
+        let tenant = "org".parse().unwrap();
+        let latest = ExtensionServiceVersionInfo {
+            service_id,
+            version: ConfigVersion::new(2),
+            created,
+            data: "data".to_string(),
+            observability: None,
+            has_credential: false,
+            deleted: None,
+        };
+        let with_latest = ExtensionServiceSnapshot {
+            service_id,
+            service_type: ExtensionServiceType::KubernetesPod,
+            service_name: "svc".to_string(),
+            tenant_organization_id: tenant,
+            version_ctr: 3,
+            latest_version: Some(latest),
+            active_versions: vec![ConfigVersion::new(1), ConfigVersion::new(2)],
+            description: "desc".to_string(),
+            created,
+            updated,
+            deleted: None,
+        };
+        let without_latest = ExtensionServiceSnapshot {
+            latest_version: None,
+            active_versions: vec![],
+            ..with_latest.clone()
+        };
+
+        check_values(
+            [
+                Check {
+                    scenario: "latest version present, two active versions",
+                    input: with_latest,
+                    expect: (true, 2usize, "svc".to_string()),
+                },
+                Check {
+                    scenario: "latest version absent, no active versions",
+                    input: without_latest,
+                    expect: (false, 0usize, "svc".to_string()),
+                },
+            ],
+            |s| {
+                let rpc = rpc::DpuExtensionService::from(s);
+                (
+                    rpc.latest_version_info.is_some(),
+                    rpc.active_versions.len(),
+                    rpc.service_name,
                 )
-            }
+            },
         );
     }
 }

--- a/crates/rpc/src/model/instance/config/network.rs
+++ b/crates/rpc/src/model/instance/config/network.rs
@@ -419,6 +419,8 @@ impl TryFrom<rpc::forge::instance_interface_config::NetworkDetails> for NetworkD
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
     use carbide_uuid::network::NetworkSegmentId;
     use carbide_uuid::vpc::VpcPrefixId;
     use model::instance::config::network::{INTERFACE_VFID_MAX, INTERFACE_VFID_MIN};
@@ -603,111 +605,73 @@ mod tests {
         ]
     }
 
+    // Converting an rpc config validates virtual-function ids and assigns them.
+    // Each row starts from `get_rpc_instance_network_config()`, optionally mutated,
+    // and the op converts then projects the sorted VF ids out of the model (or
+    // fails when the VF ids are invalid). The error type isn't pinned here -- a
+    // duplicate or a mix of None/valid just `Fails`.
     #[test]
     fn test_validate_virtual_function_ids() {
-        let interfaces = get_rpc_instance_network_config();
+        let all = get_rpc_instance_network_config();
 
-        let network_config = rpc::InstanceNetworkConfig {
-            interfaces,
-            auto: false,
-        };
-        let network_config: InstanceNetworkConfig = network_config.try_into().unwrap();
+        let only_physical = vec![all[0].clone()];
 
-        let vf_ids = network_config.interfaces.iter().filter_map(|x| {
-            if let InterfaceFunctionId::Virtual { id } = x.function_id {
-                Some(id)
-            } else {
-                None
-            }
-        });
+        let mut missing_1 = get_rpc_instance_network_config();
+        missing_1.remove(2);
 
-        let vf_ids = vf_ids.sorted().collect_vec();
+        let mut duplicate = get_rpc_instance_network_config();
+        duplicate[2].virtual_function_id = Some(0);
 
-        // All VF ids should be present after converting.
-        let expected = vec![0, 1, 2];
-        assert_eq!(expected, vf_ids);
-    }
+        let mut mix = get_rpc_instance_network_config();
+        mix[2].virtual_function_id = None;
 
-    #[test]
-    fn test_validate_virtual_function_ids_missing_1() {
-        let mut interfaces = get_rpc_instance_network_config();
-        interfaces.remove(2);
-
-        let network_config = rpc::InstanceNetworkConfig {
-            interfaces,
-            auto: false,
-        };
-        let network_config: InstanceNetworkConfig = network_config.try_into().unwrap();
-
-        let vf_ids = network_config.interfaces.iter().filter_map(|x| {
-            if let InterfaceFunctionId::Virtual { id } = x.function_id {
-                Some(id)
-            } else {
-                None
-            }
-        });
-
-        let vf_ids = vf_ids.sorted().collect_vec();
-
-        // Since vf_id: 1 is removed, it should not be present in the parsed config.
-        let expected = vec![0, 2];
-        assert_eq!(expected, vf_ids);
-    }
-
-    #[test]
-    fn test_validate_virtual_function_ids_only_physical() {
-        let mut interfaces = get_rpc_instance_network_config();
-        interfaces = vec![interfaces[0].clone()];
-
-        let network_config = rpc::InstanceNetworkConfig {
-            interfaces,
-            auto: false,
-        };
-        let network_config: InstanceNetworkConfig = network_config.try_into().unwrap();
-
-        let vf_ids = network_config
-            .interfaces
-            .iter()
-            .filter_map(|x| {
-                if let InterfaceFunctionId::Virtual { id } = x.function_id {
-                    Some(id)
-                } else {
-                    None
-                }
-            })
-            .collect_vec();
-
-        assert!(vf_ids.is_empty());
-    }
-
-    #[test]
-    fn test_validate_virtual_function_ids_duplicate() {
-        let mut interfaces = get_rpc_instance_network_config();
-        interfaces[2].virtual_function_id = Some(0);
-
-        let network_config = rpc::InstanceNetworkConfig {
-            interfaces,
-            auto: false,
-        };
-        let network_config: Result<InstanceNetworkConfig, RpcDataConversionError> =
-            network_config.try_into();
-
-        assert!(network_config.is_err());
-    }
-
-    #[test]
-    fn test_validate_virtual_function_ids_mix() {
-        let mut interfaces = get_rpc_instance_network_config();
-        interfaces[2].virtual_function_id = None;
-
-        let network_config = rpc::InstanceNetworkConfig {
-            interfaces,
-            auto: false,
-        };
-        let network_config: Result<InstanceNetworkConfig, RpcDataConversionError> =
-            network_config.try_into();
-
-        assert!(network_config.is_err());
+        check_cases(
+            [
+                Case {
+                    scenario: "all VF ids present after converting",
+                    input: all,
+                    expect: Yields(vec![0, 1, 2]),
+                },
+                Case {
+                    scenario: "removed vf_id 1 is absent from the parsed config",
+                    input: missing_1,
+                    expect: Yields(vec![0, 2]),
+                },
+                Case {
+                    scenario: "only a physical interface yields no VF ids",
+                    input: only_physical,
+                    expect: Yields(vec![]),
+                },
+                Case {
+                    scenario: "duplicate VF id is rejected",
+                    input: duplicate,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "mix of None and valid VF ids is rejected",
+                    input: mix,
+                    expect: Fails,
+                },
+            ],
+            |interfaces| {
+                let network_config = rpc::InstanceNetworkConfig {
+                    interfaces,
+                    auto: false,
+                };
+                let network_config =
+                    InstanceNetworkConfig::try_from(network_config).map_err(drop)?;
+                let vf_ids = network_config
+                    .interfaces
+                    .iter()
+                    .filter_map(|x| match x.function_id {
+                        InterfaceFunctionId::Virtual { id } => Some(id),
+                        InterfaceFunctionId::Physical {} => None,
+                    })
+                    .sorted()
+                    .collect_vec();
+                Ok::<_, ()>(vf_ids)
+            },
+        );
     }
 
     #[test]
@@ -883,33 +847,96 @@ mod tests {
         ));
     }
 
+    // ipv6_interface_config alongside ip_address / network_details is gated at the
+    // RPC boundary: each row builds one interface config and the op asserts only
+    // whether the conversion succeeds (`true`) or is rejected (`false`).
     #[test]
-    fn test_ipv6_requires_vpc_prefix_id() {
-        // ipv6 without vpc_prefix_id should be rejected.
+    fn test_ipv6_interface_config_acceptance() {
         let v6_id = VpcPrefixId::new();
-        let rpc_config = rpc::InstanceNetworkConfig {
-            interfaces: vec![rpc::InstanceInterfaceConfig {
-                function_type: rpc::InterfaceFunctionType::Physical as i32,
-                network_segment_id: Some(NetworkSegmentId::new()),
-                network_details: Some(
-                    rpc::forge::instance_interface_config::NetworkDetails::SegmentId(
-                        NetworkSegmentId::new(),
-                    ),
+        let v4_id = VpcPrefixId::new();
+
+        // ipv6 without vpc_prefix_id (network_details is a segment) should be rejected.
+        let ipv6_without_vpc_prefix = rpc::InstanceInterfaceConfig {
+            function_type: rpc::InterfaceFunctionType::Physical as i32,
+            network_segment_id: Some(NetworkSegmentId::new()),
+            network_details: Some(
+                rpc::forge::instance_interface_config::NetworkDetails::SegmentId(
+                    NetworkSegmentId::new(),
                 ),
-                device: None,
-                device_instance: 0,
-                virtual_function_id: None,
+            ),
+            device: None,
+            device_instance: 0,
+            virtual_function_id: None,
+            ip_address: None,
+            ipv6_interface_config: Some(rpc::forge::InstanceInterfaceIpv6Config {
+                vpc_prefix_id: Some(v6_id),
                 ip_address: None,
-                ipv6_interface_config: Some(rpc::forge::InstanceInterfaceIpv6Config {
-                    vpc_prefix_id: Some(v6_id),
-                    ip_address: None,
-                }),
-                routing_profile: None,
-            }],
-            auto: false,
+            }),
+            routing_profile: None,
         };
-        let result: Result<InstanceNetworkConfig, _> = rpc_config.try_into();
-        assert!(result.is_err());
+
+        // An IPv6 ip_address AND ipv6_interface_config together should be rejected.
+        let v6_ip_with_ipv6_config = rpc::InstanceInterfaceConfig {
+            function_type: rpc::InterfaceFunctionType::Physical as i32,
+            network_segment_id: None,
+            network_details: Some(
+                rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(v4_id),
+            ),
+            device: None,
+            device_instance: 0,
+            virtual_function_id: None,
+            ip_address: Some("2001:db8::1".to_string()),
+            ipv6_interface_config: Some(rpc::forge::InstanceInterfaceIpv6Config {
+                vpc_prefix_id: Some(v6_id),
+                ip_address: None,
+            }),
+            routing_profile: None,
+        };
+
+        // An IPv4 ip_address AND ipv6_interface_config is fine (dual-stack).
+        let v4_ip_with_ipv6_config = rpc::InstanceInterfaceConfig {
+            function_type: rpc::InterfaceFunctionType::Physical as i32,
+            network_segment_id: None,
+            network_details: Some(
+                rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(v4_id),
+            ),
+            device: None,
+            device_instance: 0,
+            virtual_function_id: None,
+            ip_address: Some("10.0.0.1".to_string()),
+            ipv6_interface_config: Some(rpc::forge::InstanceInterfaceIpv6Config {
+                vpc_prefix_id: Some(v6_id),
+                ip_address: None,
+            }),
+            routing_profile: None,
+        };
+
+        check_values(
+            [
+                Check {
+                    scenario: "ipv6 without vpc_prefix_id is rejected",
+                    input: ipv6_without_vpc_prefix,
+                    expect: false,
+                },
+                Check {
+                    scenario: "ipv6 ip_address with ipv6_interface_config is rejected",
+                    input: v6_ip_with_ipv6_config,
+                    expect: false,
+                },
+                Check {
+                    scenario: "ipv4 ip_address with ipv6_interface_config is allowed",
+                    input: v4_ip_with_ipv6_config,
+                    expect: true,
+                },
+            ],
+            |iface| {
+                let rpc_config = rpc::InstanceNetworkConfig {
+                    interfaces: vec![iface],
+                    auto: false,
+                };
+                InstanceNetworkConfig::try_from(rpc_config).is_ok()
+            },
+        );
     }
 
     #[test]
@@ -938,62 +965,6 @@ mod tests {
             Some(NetworkDetails::VpcPrefixId(v6_id))
         );
         assert_eq!(model.interfaces[0].ipv6_interface_config, None);
-    }
-
-    #[test]
-    fn test_reject_v6_ip_address_with_ipv6_interface_config() {
-        // Setting an IPv6 ip_address AND ipv6_interface_config should be rejected.
-        let v4_id = VpcPrefixId::new();
-        let v6_id = VpcPrefixId::new();
-        let rpc_config = rpc::InstanceNetworkConfig {
-            interfaces: vec![rpc::InstanceInterfaceConfig {
-                function_type: rpc::InterfaceFunctionType::Physical as i32,
-                network_segment_id: None,
-                network_details: Some(
-                    rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(v4_id),
-                ),
-                device: None,
-                device_instance: 0,
-                virtual_function_id: None,
-                ip_address: Some("2001:db8::1".to_string()),
-                ipv6_interface_config: Some(rpc::forge::InstanceInterfaceIpv6Config {
-                    vpc_prefix_id: Some(v6_id),
-                    ip_address: None,
-                }),
-                routing_profile: None,
-            }],
-            auto: false,
-        };
-        let result: Result<InstanceNetworkConfig, _> = rpc_config.try_into();
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_allow_v4_ip_address_with_ipv6_interface_config() {
-        // Setting an IPv4 ip_address AND ipv6_interface_config is fine (dual-stack).
-        let v4_id = VpcPrefixId::new();
-        let v6_id = VpcPrefixId::new();
-        let rpc_config = rpc::InstanceNetworkConfig {
-            interfaces: vec![rpc::InstanceInterfaceConfig {
-                function_type: rpc::InterfaceFunctionType::Physical as i32,
-                network_segment_id: None,
-                network_details: Some(
-                    rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(v4_id),
-                ),
-                device: None,
-                device_instance: 0,
-                virtual_function_id: None,
-                ip_address: Some("10.0.0.1".to_string()),
-                ipv6_interface_config: Some(rpc::forge::InstanceInterfaceIpv6Config {
-                    vpc_prefix_id: Some(v6_id),
-                    ip_address: None,
-                }),
-                routing_profile: None,
-            }],
-            auto: false,
-        };
-        let result: Result<InstanceNetworkConfig, _> = rpc_config.try_into();
-        assert!(result.is_ok());
     }
 
     #[test]
@@ -1035,5 +1006,398 @@ mod tests {
             .expect("auto + empty should round-trip");
         assert!(model.auto);
         assert!(model.interfaces.is_empty());
+    }
+
+    // `TryFrom<rpc::InterfaceFunctionType>` maps each wire enum arm to its model
+    // arm. The conversion is fallible in signature but total in practice -- every
+    // arm yields a value.
+    #[test]
+    fn test_rpc_function_type_into_model() {
+        check_cases(
+            [
+                Case {
+                    scenario: "physical maps to physical",
+                    input: rpc::InterfaceFunctionType::Physical,
+                    expect: Yields(InterfaceFunctionType::Physical),
+                },
+                Case {
+                    scenario: "virtual maps to virtual",
+                    input: rpc::InterfaceFunctionType::Virtual,
+                    expect: Yields(InterfaceFunctionType::Virtual),
+                },
+            ],
+            |ft| InterfaceFunctionType::try_from(ft).map_err(drop),
+        );
+    }
+
+    // `From<InterfaceFunctionType>` for the wire enum maps each model arm back to
+    // its wire arm. Total conversion, compared on the wire enum.
+    #[test]
+    fn test_model_function_type_into_rpc() {
+        check_values(
+            [
+                Check {
+                    scenario: "physical maps to physical",
+                    input: InterfaceFunctionType::Physical,
+                    expect: rpc::InterfaceFunctionType::Physical,
+                },
+                Check {
+                    scenario: "virtual maps to virtual",
+                    input: InterfaceFunctionType::Virtual,
+                    expect: rpc::InterfaceFunctionType::Virtual,
+                },
+            ],
+            rpc::InterfaceFunctionType::from,
+        );
+    }
+
+    // Function type survives a model -> wire -> model round-trip for every arm.
+    #[test]
+    fn test_function_type_roundtrip() {
+        check_cases(
+            [
+                Case {
+                    scenario: "physical round-trips",
+                    input: InterfaceFunctionType::Physical,
+                    expect: Yields(InterfaceFunctionType::Physical),
+                },
+                Case {
+                    scenario: "virtual round-trips",
+                    input: InterfaceFunctionType::Virtual,
+                    expect: Yields(InterfaceFunctionType::Virtual),
+                },
+            ],
+            |ft| InterfaceFunctionType::try_from(rpc::InterfaceFunctionType::from(ft)).map_err(drop),
+        );
+    }
+
+    // `From<NetworkDetails>` for the wire oneof maps each model arm to the matching
+    // wire arm. The op projects which wire arm was produced so the table can pin a
+    // plain `&str` per row.
+    #[test]
+    fn test_network_details_model_into_rpc() {
+        let segment_id = NetworkSegmentId::new();
+        let prefix_id = VpcPrefixId::new();
+        check_values(
+            [
+                Check {
+                    scenario: "network segment maps to SegmentId arm",
+                    input: NetworkDetails::NetworkSegment(segment_id),
+                    expect: "segment",
+                },
+                Check {
+                    scenario: "vpc prefix maps to VpcPrefixId arm",
+                    input: NetworkDetails::VpcPrefixId(prefix_id),
+                    expect: "vpc_prefix",
+                },
+            ],
+            |nd| {
+                let rpc_nd: rpc::forge::instance_interface_config::NetworkDetails = nd.into();
+                match rpc_nd {
+                    rpc::forge::instance_interface_config::NetworkDetails::SegmentId(_) => "segment",
+                    rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(_) => {
+                        "vpc_prefix"
+                    }
+                }
+            },
+        );
+    }
+
+    // `TryFrom<rpc::...NetworkDetails>` maps each wire arm back to the model arm,
+    // preserving the embedded id. Fallible in signature, total in practice.
+    #[test]
+    fn test_network_details_rpc_into_model() {
+        let segment_id = NetworkSegmentId::new();
+        let prefix_id = VpcPrefixId::new();
+        check_cases(
+            [
+                Case {
+                    scenario: "SegmentId arm yields NetworkSegment with same id",
+                    input: rpc::forge::instance_interface_config::NetworkDetails::SegmentId(
+                        segment_id,
+                    ),
+                    expect: Yields(NetworkDetails::NetworkSegment(segment_id)),
+                },
+                Case {
+                    scenario: "VpcPrefixId arm yields VpcPrefixId with same id",
+                    input: rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(
+                        prefix_id,
+                    ),
+                    expect: Yields(NetworkDetails::VpcPrefixId(prefix_id)),
+                },
+            ],
+            |rpc_nd| NetworkDetails::try_from(rpc_nd).map_err(drop),
+        );
+    }
+
+    // NetworkDetails survives a model -> wire -> model round-trip for both arms.
+    #[test]
+    fn test_network_details_roundtrip_both_arms() {
+        let segment_id = NetworkSegmentId::new();
+        let prefix_id = VpcPrefixId::new();
+        check_cases(
+            [
+                Case {
+                    scenario: "network segment round-trips",
+                    input: NetworkDetails::NetworkSegment(segment_id),
+                    expect: Yields(NetworkDetails::NetworkSegment(segment_id)),
+                },
+                Case {
+                    scenario: "vpc prefix round-trips",
+                    input: NetworkDetails::VpcPrefixId(prefix_id),
+                    expect: Yields(NetworkDetails::VpcPrefixId(prefix_id)),
+                },
+            ],
+            |nd| {
+                let rpc_nd: rpc::forge::instance_interface_config::NetworkDetails = nd.into();
+                NetworkDetails::try_from(rpc_nd).map_err(drop)
+            },
+        );
+    }
+
+    // `From<&InstanceInterfaceRoutingProfile>` for the flat wire profile copies each
+    // allowed anycast prefix across as its string form. The op projects the produced
+    // wire prefixes so the table can pin an exact `Vec<String>`.
+    #[test]
+    fn test_flat_routing_profile_from_model() {
+        check_values(
+            [
+                Check {
+                    scenario: "empty profile produces no prefixes",
+                    input: InstanceInterfaceRoutingProfile {
+                        allowed_anycast_prefixes: vec![],
+                    },
+                    expect: Vec::<String>::new(),
+                },
+                Check {
+                    scenario: "single prefix is stringified",
+                    input: InstanceInterfaceRoutingProfile {
+                        allowed_anycast_prefixes: vec!["192.0.2.0/24".parse().unwrap()],
+                    },
+                    expect: vec!["192.0.2.0/24".to_string()],
+                },
+                Check {
+                    scenario: "multiple prefixes preserve order",
+                    input: InstanceInterfaceRoutingProfile {
+                        allowed_anycast_prefixes: vec![
+                            "192.0.2.0/24".parse().unwrap(),
+                            "2001:db8::/32".parse().unwrap(),
+                        ],
+                    },
+                    expect: vec!["192.0.2.0/24".to_string(), "2001:db8::/32".to_string()],
+                },
+            ],
+            |profile| {
+                let flat = rpc::forge::FlatInterfaceRoutingProfile::from(&profile);
+                flat.allowed_anycast_prefixes
+                    .into_iter()
+                    .map(|entry| entry.prefix)
+                    .collect::<Vec<String>>()
+            },
+        );
+    }
+
+    // The full `TryFrom<rpc::InstanceNetworkConfig>` gates several edge cases. Each
+    // row builds one interface config and the op reports only whether the whole
+    // conversion is accepted (`true`) or rejected (`false`).
+    #[test]
+    fn test_instance_network_config_acceptance() {
+        let segment_id = NetworkSegmentId::new();
+        let prefix_id = VpcPrefixId::new();
+
+        // network_details absent AND network_segment_id absent: nothing to attach.
+        let no_details_no_segment = rpc::InstanceInterfaceConfig {
+            function_type: rpc::InterfaceFunctionType::Physical as i32,
+            network_segment_id: None,
+            network_details: None,
+            device: None,
+            device_instance: 0,
+            virtual_function_id: None,
+            ip_address: None,
+            ipv6_interface_config: None,
+            routing_profile: None,
+        };
+
+        // Explicit IP against a network segment is not allowed.
+        let explicit_ip_on_segment = rpc::InstanceInterfaceConfig {
+            function_type: rpc::InterfaceFunctionType::Physical as i32,
+            network_segment_id: Some(segment_id),
+            network_details: Some(
+                rpc::forge::instance_interface_config::NetworkDetails::SegmentId(segment_id),
+            ),
+            device: None,
+            device_instance: 0,
+            virtual_function_id: None,
+            ip_address: Some("10.0.0.5".to_string()),
+            ipv6_interface_config: None,
+            routing_profile: None,
+        };
+
+        // Explicit IP against a VPC prefix is allowed.
+        let explicit_ip_on_vpc_prefix = rpc::InstanceInterfaceConfig {
+            function_type: rpc::InterfaceFunctionType::Physical as i32,
+            network_segment_id: None,
+            network_details: Some(
+                rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(prefix_id),
+            ),
+            device: None,
+            device_instance: 0,
+            virtual_function_id: None,
+            ip_address: Some("10.0.0.5".to_string()),
+            ipv6_interface_config: None,
+            routing_profile: None,
+        };
+
+        // A malformed ip_address string is rejected.
+        let malformed_ip = rpc::InstanceInterfaceConfig {
+            function_type: rpc::InterfaceFunctionType::Physical as i32,
+            network_segment_id: None,
+            network_details: Some(
+                rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(prefix_id),
+            ),
+            device: None,
+            device_instance: 0,
+            virtual_function_id: None,
+            ip_address: Some("not-an-ip".to_string()),
+            ipv6_interface_config: None,
+            routing_profile: None,
+        };
+
+        // ipv6_interface_config with a missing vpc_prefix_id is rejected.
+        let ipv6_missing_prefix = rpc::InstanceInterfaceConfig {
+            function_type: rpc::InterfaceFunctionType::Physical as i32,
+            network_segment_id: None,
+            network_details: Some(
+                rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(prefix_id),
+            ),
+            device: None,
+            device_instance: 0,
+            virtual_function_id: None,
+            ip_address: None,
+            ipv6_interface_config: Some(rpc::forge::InstanceInterfaceIpv6Config {
+                vpc_prefix_id: None,
+                ip_address: None,
+            }),
+            routing_profile: None,
+        };
+
+        // ipv6_interface_config with a malformed ip_address is rejected.
+        let ipv6_malformed_ip = rpc::InstanceInterfaceConfig {
+            function_type: rpc::InterfaceFunctionType::Physical as i32,
+            network_segment_id: None,
+            network_details: Some(
+                rpc::forge::instance_interface_config::NetworkDetails::VpcPrefixId(prefix_id),
+            ),
+            device: None,
+            device_instance: 0,
+            virtual_function_id: None,
+            ip_address: None,
+            ipv6_interface_config: Some(rpc::forge::InstanceInterfaceIpv6Config {
+                vpc_prefix_id: Some(VpcPrefixId::new()),
+                ip_address: Some("not-a-v6".to_string()),
+            }),
+            routing_profile: None,
+        };
+
+        // A device locator (device + device_instance) is accepted and attached.
+        let with_device_locator = rpc::InstanceInterfaceConfig {
+            function_type: rpc::InterfaceFunctionType::Physical as i32,
+            network_segment_id: Some(segment_id),
+            network_details: Some(
+                rpc::forge::instance_interface_config::NetworkDetails::SegmentId(segment_id),
+            ),
+            device: Some("eth0".to_string()),
+            device_instance: 2,
+            virtual_function_id: None,
+            ip_address: None,
+            ipv6_interface_config: None,
+            routing_profile: None,
+        };
+
+        check_values(
+            [
+                Check {
+                    scenario: "missing both network_details and segment id is rejected",
+                    input: no_details_no_segment,
+                    expect: false,
+                },
+                Check {
+                    scenario: "explicit ip on a network segment is rejected",
+                    input: explicit_ip_on_segment,
+                    expect: false,
+                },
+                Check {
+                    scenario: "explicit ip on a vpc prefix is allowed",
+                    input: explicit_ip_on_vpc_prefix,
+                    expect: true,
+                },
+                Check {
+                    scenario: "malformed ip_address is rejected",
+                    input: malformed_ip,
+                    expect: false,
+                },
+                Check {
+                    scenario: "ipv6 config without vpc_prefix_id is rejected",
+                    input: ipv6_missing_prefix,
+                    expect: false,
+                },
+                Check {
+                    scenario: "ipv6 config with malformed ip_address is rejected",
+                    input: ipv6_malformed_ip,
+                    expect: false,
+                },
+                Check {
+                    scenario: "interface with a device locator is accepted",
+                    input: with_device_locator,
+                    expect: true,
+                },
+            ],
+            |iface| {
+                let rpc_config = rpc::InstanceNetworkConfig {
+                    interfaces: vec![iface],
+                    auto: false,
+                };
+                InstanceNetworkConfig::try_from(rpc_config).is_ok()
+            },
+        );
+    }
+
+    // The device locator survives the rpc -> model conversion: device name and
+    // instance index are preserved. The op projects them as a `(String, usize)`.
+    #[test]
+    fn test_device_locator_preserved() {
+        let segment_id = NetworkSegmentId::new();
+        let iface = rpc::InstanceInterfaceConfig {
+            function_type: rpc::InterfaceFunctionType::Physical as i32,
+            network_segment_id: Some(segment_id),
+            network_details: Some(
+                rpc::forge::instance_interface_config::NetworkDetails::SegmentId(segment_id),
+            ),
+            device: Some("eth3".to_string()),
+            device_instance: 7,
+            virtual_function_id: None,
+            ip_address: None,
+            ipv6_interface_config: None,
+            routing_profile: None,
+        };
+        check_cases(
+            [Case {
+                scenario: "device name and instance carry through",
+                input: iface,
+                expect: Yields(("eth3".to_string(), 7usize)),
+            }],
+            |iface| {
+                let rpc_config = rpc::InstanceNetworkConfig {
+                    interfaces: vec![iface],
+                    auto: false,
+                };
+                let model = InstanceNetworkConfig::try_from(rpc_config).map_err(drop)?;
+                let dl = model.interfaces[0]
+                    .device_locator
+                    .clone()
+                    .ok_or(())?;
+                Ok::<_, ()>((dl.device, dl.device_instance))
+            },
+        );
     }
 }

--- a/crates/rpc/src/model/instance/status.rs
+++ b/crates/rpc/src/model/instance/status.rs
@@ -300,6 +300,133 @@ mod tests {
         );
     }
 
+    /// Runs `instance_status_from_config_and_observation` with a minimal config and
+    /// the given `machine_state` / `delete_requested`, returning the resulting
+    /// tenant-visible state. Lets the table below enumerate the machine-state arms
+    /// the status pipeline projects onto a `TenantState`.
+    fn tenant_state_for(machine_state: ManagedHostState, delete_requested: bool) -> TenantState {
+        let config = minimal_instance_config();
+        let version = ConfigVersion::initial();
+        let health = HealthReportSources::default();
+
+        let status = instance_status_from_config_and_observation(
+            HashMap::new(),
+            None,
+            Versioned::new(&config, version),
+            Versioned::new(&config.network, version),
+            Versioned::new(&config.infiniband, version),
+            Versioned::new(&config.extension_services, version),
+            Versioned::new(&config.nvlink, version),
+            Versioned::new(&config.spxconfig, version),
+            &InstanceStatusObservations {
+                network: HashMap::new(),
+                extension_services: HashMap::new(),
+                phone_home_last_contact: None,
+            },
+            machine_state,
+            delete_requested,
+            None,
+            None,
+            None,
+            None,
+            false,
+            &health,
+        )
+        .unwrap();
+
+        status.tenant.unwrap().state
+    }
+
+    #[test]
+    fn sync_state_maps_each_arm_to_proto() {
+        use carbide_test_support::Outcome::*;
+        use carbide_test_support::{Case, check_cases};
+
+        check_cases(
+            [
+                Case {
+                    scenario: "synced -> proto synced",
+                    input: SyncState::Synced,
+                    expect: Yields(rpc::SyncState::Synced),
+                },
+                Case {
+                    scenario: "pending -> proto pending",
+                    input: SyncState::Pending,
+                    expect: Yields(rpc::SyncState::Pending),
+                },
+            ],
+            |state| rpc::SyncState::try_from(state).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn pipeline_projects_machine_state_to_tenant_state() {
+        use carbide_test_support::{Check, check_values};
+
+        check_values(
+            [
+                // delete_requested short-circuits every machine state to Terminating.
+                Check {
+                    scenario: "delete requested while ready -> terminating",
+                    input: (
+                        ManagedHostState::Assigned {
+                            instance_state: InstanceState::Ready,
+                        },
+                        true,
+                    ),
+                    expect: TenantState::Terminating,
+                },
+                Check {
+                    scenario: "delete requested while provisioning -> terminating",
+                    input: (
+                        ManagedHostState::Assigned {
+                            instance_state: InstanceState::Init,
+                        },
+                        true,
+                    ),
+                    expect: TenantState::Terminating,
+                },
+                // Without delete, the machine state drives the tenant state.
+                Check {
+                    scenario: "assigned + ready + synced -> ready",
+                    input: (
+                        ManagedHostState::Assigned {
+                            instance_state: InstanceState::Ready,
+                        },
+                        false,
+                    ),
+                    expect: TenantState::Ready,
+                },
+                Check {
+                    scenario: "assigned + init -> provisioning",
+                    input: (
+                        ManagedHostState::Assigned {
+                            instance_state: InstanceState::Init,
+                        },
+                        false,
+                    ),
+                    expect: TenantState::Provisioning,
+                },
+                Check {
+                    scenario: "host ready (unassigned) -> provisioning",
+                    input: (ManagedHostState::Ready, false),
+                    expect: TenantState::Provisioning,
+                },
+                Check {
+                    scenario: "force deletion -> terminating",
+                    input: (ManagedHostState::ForceDeletion, false),
+                    expect: TenantState::Terminating,
+                },
+                Check {
+                    scenario: "unmodelled state (created) -> invalid",
+                    input: (ManagedHostState::Created, false),
+                    expect: TenantState::Invalid,
+                },
+            ],
+            |(machine_state, delete_requested)| tenant_state_for(machine_state, delete_requested),
+        );
+    }
+
     #[test]
     fn test_tenant_state() {
         let machine_id: MachineId =

--- a/crates/rpc/src/model/instance/status/tenant.rs
+++ b/crates/rpc/src/model/instance/status/tenant.rs
@@ -174,17 +174,34 @@ mod tests {
     use std::collections::HashMap;
     use std::str::FromStr;
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
     use carbide_uuid::machine::MachineId;
     use chrono::Utc;
     use health_report::{HealthReport, REPAIR_REQUEST_MERGE_SOURCE};
     use model::health::HealthReportSources;
     use model::instance::status::SyncState;
     use model::machine::{
-        DpuReprovisionStates, FailureCause, FailureDetails, FailureSource, InstanceState,
-        ManagedHostState,
+        DpuReprovisionStates, FailureCause, FailureDetails, FailureSource, HostPlatformConfigurationState,
+        HostReprovisionState, InstanceState, ManagedHostState, NetworkConfigUpdateState, RetryInfo,
     };
 
     use super::*;
+
+    /// Build a representative `InstanceState::Failed` for table inputs.
+    fn failed_state() -> InstanceState {
+        let machine_id =
+            MachineId::from_str("fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0")
+                .unwrap();
+        InstanceState::Failed {
+            details: FailureDetails {
+                cause: FailureCause::NoError,
+                failed_at: Utc::now(),
+                source: FailureSource::StateMachine,
+            },
+            machine_id,
+        }
+    }
 
     #[test]
     fn repair_merge_active_detects_merge_sources() {
@@ -214,135 +231,507 @@ mod tests {
             machine_id,
         };
 
-        struct Case {
-            name: &'static str,
-            machine_state: ManagedHostState,
-            configs_synced: SyncState,
-            repair_active: bool,
-            expected: TenantState,
-        }
-
-        let cases = [
-            Case {
-                name: "tenant-ready with repair merge",
-                machine_state: ManagedHostState::Assigned {
-                    instance_state: InstanceState::Ready,
-                },
-                configs_synced: SyncState::Synced,
-                repair_active: true,
-                expected: TenantState::Repairing,
-            },
-            Case {
-                name: "terminating with repair merge",
-                machine_state: ManagedHostState::Assigned {
-                    instance_state: InstanceState::SwitchToAdminNetwork,
-                },
-                configs_synced: SyncState::Synced,
-                repair_active: true,
-                expected: TenantState::Terminating,
-            },
-            Case {
-                name: "reprovision with repair merge",
-                machine_state: ManagedHostState::Assigned {
-                    instance_state: InstanceState::DPUReprovision {
-                        dpu_states: DpuReprovisionStates {
-                            states: HashMap::new(),
+        // Each row: a (machine_state, configs_synced) pair under repair_active=true,
+        // exercising which states repair-merge does or does not override.
+        check_cases(
+            [
+                Case {
+                    scenario: "tenant-ready with repair merge",
+                    input: (
+                        ManagedHostState::Assigned {
+                            instance_state: InstanceState::Ready,
                         },
-                    },
+                        SyncState::Synced,
+                    ),
+                    expect: Yields(TenantState::Repairing),
                 },
-                configs_synced: SyncState::Synced,
-                repair_active: true,
-                expected: TenantState::Updating,
-            },
-            Case {
-                name: "configuring with repair merge",
-                machine_state: ManagedHostState::Assigned {
-                    instance_state: InstanceState::Ready,
+                Case {
+                    scenario: "terminating with repair merge",
+                    input: (
+                        ManagedHostState::Assigned {
+                            instance_state: InstanceState::SwitchToAdminNetwork,
+                        },
+                        SyncState::Synced,
+                    ),
+                    expect: Yields(TenantState::Terminating),
                 },
-                configs_synced: SyncState::Pending,
-                repair_active: true,
-                expected: TenantState::Configuring,
-            },
-            Case {
-                name: "failed with repair merge",
-                machine_state: ManagedHostState::Assigned {
-                    instance_state: failed,
+                Case {
+                    scenario: "reprovision with repair merge",
+                    input: (
+                        ManagedHostState::Assigned {
+                            instance_state: InstanceState::DPUReprovision {
+                                dpu_states: DpuReprovisionStates {
+                                    states: HashMap::new(),
+                                },
+                            },
+                        },
+                        SyncState::Synced,
+                    ),
+                    expect: Yields(TenantState::Updating),
                 },
-                configs_synced: SyncState::Synced,
-                repair_active: true,
-                expected: TenantState::Failed,
+                Case {
+                    scenario: "configuring with repair merge",
+                    input: (
+                        ManagedHostState::Assigned {
+                            instance_state: InstanceState::Ready,
+                        },
+                        SyncState::Pending,
+                    ),
+                    expect: Yields(TenantState::Configuring),
+                },
+                Case {
+                    scenario: "failed with repair merge",
+                    input: (
+                        ManagedHostState::Assigned {
+                            instance_state: failed,
+                        },
+                        SyncState::Synced,
+                    ),
+                    expect: Yields(TenantState::Failed),
+                },
+            ],
+            |(machine_state, configs_synced)| {
+                instance_status_tenant_state(
+                    machine_state,
+                    configs_synced,
+                    false,
+                    None,
+                    true,
+                    false,
+                    true,
+                )
+                .map_err(drop)
             },
-        ];
-
-        for case in cases {
-            let state = instance_status_tenant_state(
-                case.machine_state,
-                case.configs_synced,
-                false,
-                None,
-                true,
-                false,
-                case.repair_active,
-            )
-            .unwrap_or_else(|_| panic!("case {:?} failed conversion", case.name));
-            assert_eq!(state, case.expected, "case: {}", case.name);
-        }
+        );
     }
 
     #[test]
     fn operator_managed_allocations_project_as_tenant_ready() {
-        struct Case {
-            name: &'static str,
-            machine_state: ManagedHostState,
-            expected: TenantState,
+        // Allocated/network-wait states where Flat has no NICo readiness signal:
+        // operator-managed networking should not wait on network observations.
+        check_cases(
+            [
+                Case {
+                    scenario: "allocated before state controller pickup",
+                    input: ManagedHostState::Ready,
+                    expect: Yields(TenantState::Ready),
+                },
+                Case {
+                    scenario: "assigned init",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::Init,
+                    },
+                    expect: Yields(TenantState::Ready),
+                },
+                Case {
+                    scenario: "waiting for network config",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::WaitingForNetworkConfig,
+                    },
+                    expect: Yields(TenantState::Ready),
+                },
+                Case {
+                    scenario: "network config update",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::NetworkConfigUpdate {
+                            network_config_update_state:
+                                model::machine::NetworkConfigUpdateState::WaitingForNetworkSegmentToBeReady,
+                        },
+                    },
+                    expect: Yields(TenantState::Ready),
+                },
+            ],
+            |machine_state| {
+                instance_status_tenant_state(
+                    machine_state,
+                    SyncState::Pending,
+                    true,
+                    None,
+                    false,
+                    true,
+                    false,
+                )
+                .map_err(drop)
+            },
+        );
+    }
+
+    /// Every `TenantState` arm maps to its `rpc::TenantState` counterpart. The
+    /// conversion is fallible in signature only; each arm is expected to yield.
+    #[test]
+    fn tenant_state_to_rpc_maps_every_variant() {
+        check_cases(
+            [
+                Case {
+                    scenario: "provisioning",
+                    input: TenantState::Provisioning,
+                    expect: Yields(rpc::TenantState::Provisioning),
+                },
+                Case {
+                    scenario: "dpu reprovisioning",
+                    input: TenantState::DpuReprovisioning,
+                    expect: Yields(rpc::TenantState::DpuReprovisioning),
+                },
+                Case {
+                    scenario: "ready",
+                    input: TenantState::Ready,
+                    expect: Yields(rpc::TenantState::Ready),
+                },
+                Case {
+                    scenario: "configuring",
+                    input: TenantState::Configuring,
+                    expect: Yields(rpc::TenantState::Configuring),
+                },
+                Case {
+                    scenario: "terminating",
+                    input: TenantState::Terminating,
+                    expect: Yields(rpc::TenantState::Terminating),
+                },
+                Case {
+                    scenario: "terminated",
+                    input: TenantState::Terminated,
+                    expect: Yields(rpc::TenantState::Terminated),
+                },
+                Case {
+                    scenario: "failed",
+                    input: TenantState::Failed,
+                    expect: Yields(rpc::TenantState::Failed),
+                },
+                Case {
+                    scenario: "host reprovisioning",
+                    input: TenantState::HostReprovisioning,
+                    expect: Yields(rpc::TenantState::HostReprovisioning),
+                },
+                Case {
+                    scenario: "updating",
+                    input: TenantState::Updating,
+                    expect: Yields(rpc::TenantState::Updating),
+                },
+                Case {
+                    scenario: "invalid",
+                    input: TenantState::Invalid,
+                    expect: Yields(rpc::TenantState::Invalid),
+                },
+                Case {
+                    scenario: "repairing",
+                    input: TenantState::Repairing,
+                    expect: Yields(rpc::TenantState::Repairing),
+                },
+            ],
+            |state| rpc::TenantState::try_from(state).map_err(drop),
+        );
+    }
+
+    /// `InstanceTenantStatus` converts into its rpc message: the state arm is
+    /// projected to its `i32` tag and `state_details` carries through verbatim,
+    /// including when empty.
+    #[test]
+    fn instance_tenant_status_to_rpc_round_trips() {
+        check_cases(
+            [
+                Case {
+                    scenario: "ready with details",
+                    input: InstanceTenantStatus {
+                        state: TenantState::Ready,
+                        state_details: "all good".to_string(),
+                    },
+                    expect: Yields(rpc::InstanceTenantStatus {
+                        state: rpc::TenantState::Ready as i32,
+                        state_details: "all good".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "failed with empty details",
+                    input: InstanceTenantStatus {
+                        state: TenantState::Failed,
+                        state_details: String::new(),
+                    },
+                    expect: Yields(rpc::InstanceTenantStatus {
+                        state: rpc::TenantState::Failed as i32,
+                        state_details: String::new(),
+                    }),
+                },
+                Case {
+                    scenario: "repairing preserves details",
+                    input: InstanceTenantStatus {
+                        state: TenantState::Repairing,
+                        state_details: "online repair".to_string(),
+                    },
+                    expect: Yields(rpc::InstanceTenantStatus {
+                        state: rpc::TenantState::Repairing as i32,
+                        state_details: "online repair".to_string(),
+                    }),
+                },
+            ],
+            |status| rpc::InstanceTenantStatus::try_from(status).map_err(drop),
+        );
+    }
+
+    /// Default projection (no operator-managed networking, no active repair): every
+    /// `InstanceState` arm plus the `ManagedHostState` arms resolve to their
+    /// tenant-visible state.
+    #[test]
+    fn instance_status_tenant_state_default_projection() {
+        check_cases(
+            [
+                Case {
+                    scenario: "host ready -> provisioning",
+                    input: ManagedHostState::Ready,
+                    expect: Yields(TenantState::Provisioning),
+                },
+                Case {
+                    scenario: "assigned init -> provisioning",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::Init,
+                    },
+                    expect: Yields(TenantState::Provisioning),
+                },
+                Case {
+                    scenario: "waiting for network segment -> provisioning",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::WaitingForNetworkSegmentToBeReady,
+                    },
+                    expect: Yields(TenantState::Provisioning),
+                },
+                Case {
+                    scenario: "waiting for network config -> provisioning",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::WaitingForNetworkConfig,
+                    },
+                    expect: Yields(TenantState::Provisioning),
+                },
+                Case {
+                    scenario: "waiting for storage config -> provisioning",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::WaitingForStorageConfig,
+                    },
+                    expect: Yields(TenantState::Provisioning),
+                },
+                Case {
+                    scenario: "waiting for extension services config -> provisioning",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::WaitingForExtensionServicesConfig,
+                    },
+                    expect: Yields(TenantState::Provisioning),
+                },
+                Case {
+                    scenario: "waiting for reboot to ready -> provisioning",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::WaitingForRebootToReady,
+                    },
+                    expect: Yields(TenantState::Provisioning),
+                },
+                Case {
+                    scenario: "network config update -> configuring",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::NetworkConfigUpdate {
+                            network_config_update_state:
+                                NetworkConfigUpdateState::WaitingForConfigSynced,
+                        },
+                    },
+                    expect: Yields(TenantState::Configuring),
+                },
+                Case {
+                    scenario: "switch to admin network -> terminating",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::SwitchToAdminNetwork,
+                    },
+                    expect: Yields(TenantState::Terminating),
+                },
+                Case {
+                    scenario: "waiting for network reconfig -> terminating",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::WaitingForNetworkReconfig,
+                    },
+                    expect: Yields(TenantState::Terminating),
+                },
+                Case {
+                    scenario: "waiting for dpus to up -> configuring",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::WaitingForDpusToUp,
+                    },
+                    expect: Yields(TenantState::Configuring),
+                },
+                Case {
+                    scenario: "host platform configuration -> configuring",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::HostPlatformConfiguration {
+                            platform_config_state:
+                                HostPlatformConfigurationState::CheckHostConfig,
+                        },
+                    },
+                    expect: Yields(TenantState::Configuring),
+                },
+                Case {
+                    scenario: "booting with discovery image -> updating",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::BootingWithDiscoveryImage {
+                            retry: RetryInfo::default(),
+                        },
+                    },
+                    expect: Yields(TenantState::Updating),
+                },
+                Case {
+                    scenario: "dpu reprovision -> updating",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::DPUReprovision {
+                            dpu_states: DpuReprovisionStates {
+                                states: HashMap::new(),
+                            },
+                        },
+                    },
+                    expect: Yields(TenantState::Updating),
+                },
+                Case {
+                    scenario: "host reprovision -> updating",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::HostReprovision {
+                            reprovision_state: HostReprovisionState::WaitingForScript {},
+                        },
+                    },
+                    expect: Yields(TenantState::Updating),
+                },
+                Case {
+                    scenario: "dpa provisioning -> updating",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::DpaProvisioning,
+                    },
+                    expect: Yields(TenantState::Updating),
+                },
+                Case {
+                    scenario: "waiting for dpa to be ready -> updating",
+                    input: ManagedHostState::Assigned {
+                        instance_state: InstanceState::WaitingForDpaToBeReady,
+                    },
+                    expect: Yields(TenantState::Updating),
+                },
+                Case {
+                    scenario: "failed -> failed",
+                    input: ManagedHostState::Assigned {
+                        instance_state: failed_state(),
+                    },
+                    expect: Yields(TenantState::Failed),
+                },
+                Case {
+                    scenario: "force deletion -> terminating",
+                    input: ManagedHostState::ForceDeletion,
+                    expect: Yields(TenantState::Terminating),
+                },
+                Case {
+                    scenario: "unhandled host state -> invalid",
+                    input: ManagedHostState::Created,
+                    expect: Yields(TenantState::Invalid),
+                },
+            ],
+            |machine_state| {
+                instance_status_tenant_state(
+                    machine_state,
+                    SyncState::Synced,
+                    false,
+                    None,
+                    true,
+                    false,
+                    false,
+                )
+                .map_err(drop)
+            },
+        );
+    }
+
+    /// The `InstanceState::Ready` arm fans out on phone-home, config sync, and
+    /// extension-service readiness; cover each combination under default
+    /// (non-operator) networking.
+    #[test]
+    fn instance_status_tenant_state_ready_fanout() {
+        struct Row {
+            scenario: &'static str,
+            phone_home_enrolled: bool,
+            phone_home_last_contact: Option<chrono::DateTime<Utc>>,
+            configs_synced: SyncState,
+            extension_services_ready: bool,
+            repair_active: bool,
+            expect: TenantState,
         }
 
-        // Cover allocated/network-wait states where Flat has no NICo readiness signal.
-        let cases = [
-            Case {
-                name: "allocated before state controller pickup",
-                machine_state: ManagedHostState::Ready,
-                expected: TenantState::Ready,
+        let rows = [
+            Row {
+                scenario: "synced and ready -> ready",
+                phone_home_enrolled: false,
+                phone_home_last_contact: None,
+                configs_synced: SyncState::Synced,
+                extension_services_ready: true,
+                repair_active: false,
+                expect: TenantState::Ready,
             },
-            Case {
-                name: "assigned init",
-                machine_state: ManagedHostState::Assigned {
-                    instance_state: InstanceState::Init,
-                },
-                expected: TenantState::Ready,
+            Row {
+                scenario: "synced and ready with repair -> repairing",
+                phone_home_enrolled: false,
+                phone_home_last_contact: None,
+                configs_synced: SyncState::Synced,
+                extension_services_ready: true,
+                repair_active: true,
+                expect: TenantState::Repairing,
             },
-            Case {
-                name: "waiting for network config",
-                machine_state: ManagedHostState::Assigned {
-                    instance_state: InstanceState::WaitingForNetworkConfig,
-                },
-                expected: TenantState::Ready,
+            Row {
+                scenario: "configs pending -> configuring",
+                phone_home_enrolled: false,
+                phone_home_last_contact: None,
+                configs_synced: SyncState::Pending,
+                extension_services_ready: true,
+                repair_active: false,
+                expect: TenantState::Configuring,
             },
-            Case {
-                name: "network config update",
-                machine_state: ManagedHostState::Assigned {
-                    instance_state: InstanceState::NetworkConfigUpdate {
-                        network_config_update_state:
-                            model::machine::NetworkConfigUpdateState::WaitingForNetworkSegmentToBeReady,
-                    },
-                },
-                expected: TenantState::Ready,
+            Row {
+                scenario: "extension services not ready -> configuring",
+                phone_home_enrolled: false,
+                phone_home_last_contact: None,
+                configs_synced: SyncState::Synced,
+                extension_services_ready: false,
+                repair_active: false,
+                expect: TenantState::Configuring,
+            },
+            Row {
+                scenario: "phone-home enrolled but not contacted -> provisioning",
+                phone_home_enrolled: true,
+                phone_home_last_contact: None,
+                configs_synced: SyncState::Synced,
+                extension_services_ready: true,
+                repair_active: false,
+                expect: TenantState::Provisioning,
+            },
+            Row {
+                scenario: "phone-home enrolled and contacted -> ready",
+                phone_home_enrolled: true,
+                phone_home_last_contact: Some(Utc::now()),
+                configs_synced: SyncState::Synced,
+                extension_services_ready: true,
+                repair_active: false,
+                expect: TenantState::Ready,
             },
         ];
 
-        // Flat/operator-managed states should not wait on network observations.
-        for case in cases {
-            let state = instance_status_tenant_state(
-                case.machine_state,
-                SyncState::Pending,
-                true,
-                None,
-                false,
-                true,
-                false,
-            )
-            .unwrap_or_else(|_| panic!("case {:?} failed conversion", case.name));
-            assert_eq!(state, case.expected, "case: {}", case.name);
-        }
+        check_cases(
+            rows.map(|row| Case {
+                scenario: row.scenario,
+                input: row,
+                expect: Yields(()),
+            }),
+            |row| {
+                let expected = row.expect;
+                instance_status_tenant_state(
+                    ManagedHostState::Assigned {
+                        instance_state: InstanceState::Ready,
+                    },
+                    row.configs_synced,
+                    row.phone_home_enrolled,
+                    row.phone_home_last_contact,
+                    row.extension_services_ready,
+                    false,
+                    row.repair_active,
+                )
+                .map_err(drop)
+                .map(|got| assert_eq!(got, expected))
+            },
+        );
     }
 }

--- a/crates/rpc/src/model/instance_type.rs
+++ b/crates/rpc/src/model/instance_type.rs
@@ -132,6 +132,8 @@ impl TryFrom<InstanceType> for rpc::InstanceType {
 mod tests {
     use std::collections::HashMap;
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
     use config_version::ConfigVersion;
     use model::machine::capabilities;
     use model::metadata::Metadata;
@@ -139,90 +141,9 @@ mod tests {
     use super::*;
     use crate::forge as rpc;
 
-    #[test]
-    fn test_model_instance_type_to_rpc_conversion() {
-        let version = ConfigVersion::initial();
-
-        let req_type = rpc::InstanceType {
-            id: "test_id".to_string(),
-            version: version.to_string(),
-            metadata: Some(rpc::Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: vec![],
-            }),
-            allocation_stats: None,
-            attributes: Some(rpc::InstanceTypeAttributes {
-                desired_capabilities: vec![rpc::InstanceTypeMachineCapabilityFilterAttributes {
-                    capability_type: rpc::MachineCapabilityType::CapTypeCpu.into(),
-                    name: Some("pentium 4 HT".to_string()),
-                    frequency: Some("1.3 GHz".to_string()),
-                    capacity: Some("9001 GB".to_string()),
-                    vendor: Some("intel".to_string()),
-                    count: Some(1),
-                    hardware_revision: Some("rev 9001".to_string()),
-                    cores: Some(1),
-                    threads: Some(2),
-                    inactive_devices: Some(rpc_common::Uint32List { items: vec![2, 4] }),
-                    device_type: Some(rpc::MachineCapabilityDeviceType::Unknown as i32),
-                }],
-            }),
-            created_at: Some("2023-01-01 00:00:00 UTC".to_string()),
-        };
-
-        let inst_type = InstanceType {
-            id: "test_id".parse().unwrap(),
-            deleted: None,
-            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
-            version,
-            metadata: Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: HashMap::new(),
-            },
-            desired_capabilities: vec![InstanceTypeMachineCapabilityFilter {
-                capability_type: rpc::MachineCapabilityType::CapTypeCpu.try_into().unwrap(),
-                name: Some("pentium 4 HT".to_string()),
-                frequency: Some("1.3 GHz".to_string()),
-                capacity: Some("9001 GB".to_string()),
-                vendor: Some("intel".to_string()),
-                count: Some(1),
-                hardware_revision: Some("rev 9001".to_string()),
-                cores: Some(1),
-                threads: Some(2),
-                inactive_devices: Some(vec![2, 4]),
-                device_type: Some(capabilities::MachineCapabilityDeviceType::Unknown),
-            }],
-        };
-
-        // Verify that we can go from an internal instance type to the
-        // protobuf InstanceType message
-        assert_eq!(req_type, rpc::InstanceType::try_from(inst_type).unwrap());
-    }
-
-    #[test]
-    fn test_model_instance_type_match_fails_on_empty_machine() {
-        //
-        // Verify that an empty capability set fails to match.
-        //
-
-        let inst_type = InstanceType {
-            id: "test_id".parse().unwrap(),
-            deleted: None,
-            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
-            version: ConfigVersion::initial(),
-            metadata: Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: HashMap::new(),
-            },
-            desired_capabilities: vec![InstanceTypeMachineCapabilityFilter {
-                capability_type: rpc::MachineCapabilityType::CapTypeCpu.try_into().unwrap(),
-                ..Default::default()
-            }],
-        };
-
-        let machine_cap_set = capabilities::MachineCapabilitiesSet {
+    // A capability set with every category empty -- nothing for a filter to match.
+    fn empty_cap_set() -> capabilities::MachineCapabilitiesSet {
+        capabilities::MachineCapabilitiesSet {
             cpu: vec![],
             gpu: vec![],
             memory: vec![],
@@ -230,34 +151,12 @@ mod tests {
             network: vec![],
             infiniband: vec![],
             dpu: vec![],
-        };
-
-        assert!(!inst_type.matches_capability_set(&machine_cap_set));
+        }
     }
 
-    #[test]
-    fn test_model_instance_type_loose_type_match() {
-        //
-        // Verify that a general match works on just type
-        //
-
-        let inst_type = InstanceType {
-            id: "test_id".parse().unwrap(),
-            deleted: None,
-            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
-            version: ConfigVersion::initial(),
-            metadata: Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: HashMap::new(),
-            },
-            desired_capabilities: vec![InstanceTypeMachineCapabilityFilter {
-                capability_type: rpc::MachineCapabilityType::CapTypeCpu.try_into().unwrap(),
-                ..Default::default()
-            }],
-        };
-
-        let machine_cap_set = capabilities::MachineCapabilitiesSet {
+    // A capability set holding a single CPU.
+    fn cpu_only_cap_set() -> capabilities::MachineCapabilitiesSet {
+        capabilities::MachineCapabilitiesSet {
             cpu: vec![capabilities::MachineCapabilityCpu {
                 name: "pentium 4 HT".to_string(),
                 vendor: Some("intel".to_string()),
@@ -265,73 +164,13 @@ mod tests {
                 cores: Some(1),
                 threads: Some(2),
             }],
-            gpu: vec![],
-            memory: vec![],
-            storage: vec![],
-            network: vec![],
-            infiniband: vec![],
-            dpu: vec![],
-        };
-
-        assert!(inst_type.matches_capability_set(&machine_cap_set));
+            ..empty_cap_set()
+        }
     }
 
-    #[test]
-    fn test_model_instance_type_zero_count_match() {
-        //
-        // Verify that a general match works on just type
-        // with a zero-count InstanceType filter
-        //
-
-        let inst_type = InstanceType {
-            id: "test_id".parse().unwrap(),
-            deleted: None,
-            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
-            version: ConfigVersion::initial(),
-            metadata: Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: HashMap::new(),
-            },
-            desired_capabilities: vec![
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeCpu.try_into().unwrap(),
-                    ..Default::default()
-                },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeDpu.try_into().unwrap(),
-                    count: Some(0),
-                    ..Default::default()
-                },
-            ],
-        };
-
-        let machine_cap_set = capabilities::MachineCapabilitiesSet {
-            cpu: vec![capabilities::MachineCapabilityCpu {
-                name: "pentium 4 HT".to_string(),
-                vendor: Some("intel".to_string()),
-                count: 1,
-                cores: Some(1),
-                threads: Some(2),
-            }],
-            gpu: vec![],
-            memory: vec![],
-            storage: vec![],
-            network: vec![],
-            infiniband: vec![],
-            dpu: vec![],
-        };
-
-        assert!(inst_type.matches_capability_set(&machine_cap_set));
-    }
-
-    #[test]
-    fn test_model_instance_type_specific_match() {
-        //
-        // Verify that a more specific capability set matches
-        //
-
-        let machine_cap_set = capabilities::MachineCapabilitiesSet {
+    // A fully-populated capability set spanning every category.
+    fn full_cap_set() -> capabilities::MachineCapabilitiesSet {
+        capabilities::MachineCapabilitiesSet {
             cpu: vec![capabilities::MachineCapabilityCpu {
                 name: "pentium 4 HT".to_string(),
                 vendor: Some("intel".to_string()),
@@ -386,15 +225,66 @@ mod tests {
                 hardware_revision: Some("abc123".to_string()),
                 count: 1,
             }],
-        };
+        }
+    }
 
-        // First test with a simple InstanceType
+    // Wraps a list of desired-capability filters in an otherwise-fixed InstanceType.
+    fn inst_type_with(
+        desired_capabilities: Vec<InstanceTypeMachineCapabilityFilter>,
+    ) -> InstanceType {
+        InstanceType {
+            id: "test_id".parse().unwrap(),
+            deleted: None,
+            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
+            version: ConfigVersion::initial(),
+            metadata: Metadata {
+                name: "fancy name".to_string(),
+                description: "".to_string(),
+                labels: HashMap::new(),
+            },
+            desired_capabilities,
+        }
+    }
+
+    // Verify that an internal InstanceType converts into the protobuf
+    // InstanceType message. The error (RpcDataConversionError) is not the
+    // contract here, so the row only asserts the converted value.
+    #[test]
+    fn model_instance_type_converts_to_rpc() {
+        let version = ConfigVersion::initial();
+
+        let req_type = rpc::InstanceType {
+            id: "test_id".to_string(),
+            version: version.to_string(),
+            metadata: Some(rpc::Metadata {
+                name: "fancy name".to_string(),
+                description: "".to_string(),
+                labels: vec![],
+            }),
+            allocation_stats: None,
+            attributes: Some(rpc::InstanceTypeAttributes {
+                desired_capabilities: vec![rpc::InstanceTypeMachineCapabilityFilterAttributes {
+                    capability_type: rpc::MachineCapabilityType::CapTypeCpu.into(),
+                    name: Some("pentium 4 HT".to_string()),
+                    frequency: Some("1.3 GHz".to_string()),
+                    capacity: Some("9001 GB".to_string()),
+                    vendor: Some("intel".to_string()),
+                    count: Some(1),
+                    hardware_revision: Some("rev 9001".to_string()),
+                    cores: Some(1),
+                    threads: Some(2),
+                    inactive_devices: Some(rpc_common::Uint32List { items: vec![2, 4] }),
+                    device_type: Some(rpc::MachineCapabilityDeviceType::Unknown as i32),
+                }],
+            }),
+            created_at: Some("2023-01-01 00:00:00 UTC".to_string()),
+        };
 
         let inst_type = InstanceType {
             id: "test_id".parse().unwrap(),
             deleted: None,
             created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
-            version: ConfigVersion::initial(),
+            version,
             metadata: Metadata {
                 name: "fancy name".to_string(),
                 description: "".to_string(),
@@ -404,186 +294,647 @@ mod tests {
                 capability_type: rpc::MachineCapabilityType::CapTypeCpu.try_into().unwrap(),
                 name: Some("pentium 4 HT".to_string()),
                 frequency: Some("1.3 GHz".to_string()),
-                capacity: None,
+                capacity: Some("9001 GB".to_string()),
                 vendor: Some("intel".to_string()),
                 count: Some(1),
-                hardware_revision: None,
+                hardware_revision: Some("rev 9001".to_string()),
                 cores: Some(1),
                 threads: Some(2),
-                inactive_devices: None,
+                inactive_devices: Some(vec![2, 4]),
                 device_type: Some(capabilities::MachineCapabilityDeviceType::Unknown),
             }],
         };
 
-        assert!(inst_type.matches_capability_set(&machine_cap_set));
+        Case {
+            scenario: "internal instance type to protobuf message",
+            input: inst_type,
+            expect: Yields(req_type),
+        }
+        .check(|it| rpc::InstanceType::try_from(it).map_err(drop));
+    }
 
-        // Then a fuller instance type
-
-        let inst_type = InstanceType {
-            id: "test_id".parse().unwrap(),
-            deleted: None,
-            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
-            version: ConfigVersion::initial(),
-            metadata: Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: HashMap::new(),
-            },
-            desired_capabilities: vec![
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeCpu.try_into().unwrap(),
-                    name: Some("pentium 4 HT".to_string()),
-                    frequency: Some("1.3 GHz".to_string()),
-                    capacity: None,
-                    vendor: Some("intel".to_string()),
-                    count: Some(1),
-                    hardware_revision: None,
-                    cores: Some(1),
-                    threads: Some(2),
-                    ..Default::default()
+    // `matches_capability_set` is a total bool predicate: does an InstanceType's
+    // desired-capability filter set match a machine's capabilities? Folds the
+    // empty/loose/zero-count/specific cases (the specific test ran three filter
+    // sets against the full set) into one table over (InstanceType, set).
+    #[test]
+    fn instance_type_matches_capability_set() {
+        check_values(
+            [
+                Check {
+                    scenario: "empty machine fails to match a typed filter",
+                    input: (
+                        inst_type_with(vec![InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                                .try_into()
+                                .unwrap(),
+                            ..Default::default()
+                        }]),
+                        empty_cap_set(),
+                    ),
+                    expect: false,
                 },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeGpu.try_into().unwrap(),
-                    name: Some("rtx6000".to_string()),
-                    frequency: None,
-                    vendor: Some("nvidia".to_string()),
-                    count: Some(1),
-                    cores: Some(1),
-                    threads: Some(2),
-                    capacity: Some("12 GB".to_string()),
-                    ..Default::default()
+                Check {
+                    scenario: "loose match on just the type",
+                    input: (
+                        inst_type_with(vec![InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                                .try_into()
+                                .unwrap(),
+                            ..Default::default()
+                        }]),
+                        cpu_only_cap_set(),
+                    ),
+                    expect: true,
                 },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeMemory
-                        .try_into()
-                        .unwrap(),
-                    name: Some("ddr4".to_string()),
-                    vendor: Some("micron".to_string()),
-                    count: Some(1),
-                    capacity: Some("16 GB".to_string()),
-                    ..Default::default()
+                Check {
+                    scenario: "zero-count filter for an absent type still matches",
+                    input: (
+                        inst_type_with(vec![
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                                    .try_into()
+                                    .unwrap(),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeDpu
+                                    .try_into()
+                                    .unwrap(),
+                                count: Some(0),
+                                ..Default::default()
+                            },
+                        ]),
+                        cpu_only_cap_set(),
+                    ),
+                    expect: true,
                 },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeStorage
-                        .try_into()
-                        .unwrap(),
-                    name: Some("HDD".to_string()),
-                    vendor: Some("western digital".to_string()),
-                    count: Some(1),
-                    capacity: Some("2 TB".to_string()),
-                    ..Default::default()
+                Check {
+                    scenario: "specific single CPU filter matches the full set",
+                    input: (
+                        inst_type_with(vec![InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                                .try_into()
+                                .unwrap(),
+                            name: Some("pentium 4 HT".to_string()),
+                            frequency: Some("1.3 GHz".to_string()),
+                            capacity: None,
+                            vendor: Some("intel".to_string()),
+                            count: Some(1),
+                            hardware_revision: None,
+                            cores: Some(1),
+                            threads: Some(2),
+                            inactive_devices: None,
+                            device_type: Some(capabilities::MachineCapabilityDeviceType::Unknown),
+                        }]),
+                        full_cap_set(),
+                    ),
+                    expect: true,
                 },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeNetwork
-                        .try_into()
-                        .unwrap(),
-                    name: Some("e10000".to_string()),
-                    vendor: Some("intel".to_string()),
-                    count: Some(1),
-                    ..Default::default()
+                Check {
+                    scenario: "full multi-category filter set with names matches",
+                    input: (
+                        inst_type_with(vec![
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                                    .try_into()
+                                    .unwrap(),
+                                name: Some("pentium 4 HT".to_string()),
+                                frequency: Some("1.3 GHz".to_string()),
+                                capacity: None,
+                                vendor: Some("intel".to_string()),
+                                count: Some(1),
+                                hardware_revision: None,
+                                cores: Some(1),
+                                threads: Some(2),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeGpu
+                                    .try_into()
+                                    .unwrap(),
+                                name: Some("rtx6000".to_string()),
+                                frequency: None,
+                                vendor: Some("nvidia".to_string()),
+                                count: Some(1),
+                                cores: Some(1),
+                                threads: Some(2),
+                                capacity: Some("12 GB".to_string()),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeMemory
+                                    .try_into()
+                                    .unwrap(),
+                                name: Some("ddr4".to_string()),
+                                vendor: Some("micron".to_string()),
+                                count: Some(1),
+                                capacity: Some("16 GB".to_string()),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeStorage
+                                    .try_into()
+                                    .unwrap(),
+                                name: Some("HDD".to_string()),
+                                vendor: Some("western digital".to_string()),
+                                count: Some(1),
+                                capacity: Some("2 TB".to_string()),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeNetwork
+                                    .try_into()
+                                    .unwrap(),
+                                name: Some("e10000".to_string()),
+                                vendor: Some("intel".to_string()),
+                                count: Some(1),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeInfiniband
+                                    .try_into()
+                                    .unwrap(),
+                                name: Some("connectx7".to_string()),
+                                vendor: Some("nvidia".to_string()),
+                                count: Some(1),
+                                inactive_devices: Some(vec![2, 4]),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeDpu
+                                    .try_into()
+                                    .unwrap(),
+                                name: Some("bluefield3".to_string()),
+                                hardware_revision: Some("abc123".to_string()),
+                                count: Some(1),
+                                ..Default::default()
+                            },
+                        ]),
+                        full_cap_set(),
+                    ),
+                    expect: true,
                 },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeInfiniband
-                        .try_into()
-                        .unwrap(),
-                    name: Some("connectx7".to_string()),
-                    vendor: Some("nvidia".to_string()),
-                    count: Some(1),
-                    inactive_devices: Some(vec![2, 4]),
-                    ..Default::default()
-                },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeDpu.try_into().unwrap(),
-                    name: Some("bluefield3".to_string()),
-                    hardware_revision: Some("abc123".to_string()),
-                    count: Some(1),
-                    ..Default::default()
+                Check {
+                    scenario: "full filter set without names/models matches by type/vendor",
+                    input: (
+                        inst_type_with(vec![
+                            InstanceTypeMachineCapabilityFilter {
+                                name: None,
+                                capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                                    .try_into()
+                                    .unwrap(),
+                                frequency: Some("1.3 GHz".to_string()),
+                                capacity: None,
+                                vendor: Some("intel".to_string()),
+                                count: Some(1),
+                                hardware_revision: None,
+                                cores: Some(1),
+                                threads: Some(2),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeGpu
+                                    .try_into()
+                                    .unwrap(),
+                                frequency: None,
+                                vendor: Some("nvidia".to_string()),
+                                count: Some(1),
+                                cores: Some(1),
+                                threads: Some(2),
+                                capacity: Some("12 GB".to_string()),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeMemory
+                                    .try_into()
+                                    .unwrap(),
+                                vendor: Some("micron".to_string()),
+                                count: Some(1),
+                                capacity: Some("16 GB".to_string()),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeStorage
+                                    .try_into()
+                                    .unwrap(),
+                                vendor: Some("western digital".to_string()),
+                                count: Some(1),
+                                capacity: Some("2 TB".to_string()),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeNetwork
+                                    .try_into()
+                                    .unwrap(),
+                                vendor: Some("intel".to_string()),
+                                count: Some(3), // Two intel nics of different speeds: 2x one and 1x the other.
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeInfiniband
+                                    .try_into()
+                                    .unwrap(),
+                                vendor: Some("nvidia".to_string()),
+                                count: Some(1),
+                                inactive_devices: Some(vec![2, 4]),
+                                ..Default::default()
+                            },
+                            InstanceTypeMachineCapabilityFilter {
+                                capability_type: rpc::MachineCapabilityType::CapTypeDpu
+                                    .try_into()
+                                    .unwrap(),
+                                hardware_revision: Some("abc123".to_string()),
+                                count: Some(1),
+                                ..Default::default()
+                            },
+                        ]),
+                        full_cap_set(),
+                    ),
+                    expect: true,
                 },
             ],
-        };
+            |(inst_type, machine_cap_set)| inst_type.matches_capability_set(&machine_cap_set),
+        );
+    }
 
-        assert!(inst_type.matches_capability_set(&machine_cap_set));
+    // A bare proto filter carrying only a capability_type discriminant; every
+    // optional field is absent. The base for the proto -> domain rows below.
+    fn proto_filter_of_type(
+        capability_type: i32,
+    ) -> rpc::InstanceTypeMachineCapabilityFilterAttributes {
+        rpc::InstanceTypeMachineCapabilityFilterAttributes {
+            capability_type,
+            name: None,
+            frequency: None,
+            capacity: None,
+            vendor: None,
+            count: None,
+            hardware_revision: None,
+            cores: None,
+            threads: None,
+            inactive_devices: None,
+            device_type: None,
+        }
+    }
 
-        // Then a fuller instance type but without caring about name/model
+    // A bare domain filter carrying only a capability_type; the base for the
+    // domain -> proto rows.
+    fn domain_filter_of_type(
+        capability_type: capabilities::MachineCapabilityType,
+    ) -> InstanceTypeMachineCapabilityFilter {
+        InstanceTypeMachineCapabilityFilter {
+            capability_type,
+            ..Default::default()
+        }
+    }
 
-        let inst_type = InstanceType {
-            id: "test_id".parse().unwrap(),
-            deleted: None,
-            created: "2023-01-01 00:00:00 UTC".parse().unwrap(),
-            version: ConfigVersion::initial(),
-            metadata: Metadata {
-                name: "fancy name".to_string(),
-                description: "".to_string(),
-                labels: HashMap::new(),
-            },
-            desired_capabilities: vec![
-                InstanceTypeMachineCapabilityFilter {
-                    name: None,
-                    capability_type: rpc::MachineCapabilityType::CapTypeCpu.try_into().unwrap(),
-                    frequency: Some("1.3 GHz".to_string()),
-                    capacity: None,
-                    vendor: Some("intel".to_string()),
-                    count: Some(1),
-                    hardware_revision: None,
-                    cores: Some(1),
-                    threads: Some(2),
-                    ..Default::default()
+    // proto -> domain: every capability_type discriminant maps to its domain
+    // counterpart, while the reserved CapTypeInvalid (and any unknown i32, which
+    // prost's getter coerces to CapTypeInvalid) is rejected. Error type isn't the
+    // contract -- it carries no PartialEq -- so failing rows assert only that it
+    // fails.
+    #[test]
+    fn proto_filter_capability_type_converts_to_domain() {
+        check_cases(
+            [
+                Case {
+                    scenario: "CapTypeCpu -> Cpu",
+                    input: rpc::MachineCapabilityType::CapTypeCpu as i32,
+                    expect: Yields(capabilities::MachineCapabilityType::Cpu),
                 },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeGpu.try_into().unwrap(),
-                    frequency: None,
-                    vendor: Some("nvidia".to_string()),
-                    count: Some(1),
-                    cores: Some(1),
-                    threads: Some(2),
-                    capacity: Some("12 GB".to_string()),
-                    ..Default::default()
+                Case {
+                    scenario: "CapTypeGpu -> Gpu",
+                    input: rpc::MachineCapabilityType::CapTypeGpu as i32,
+                    expect: Yields(capabilities::MachineCapabilityType::Gpu),
                 },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeMemory
-                        .try_into()
-                        .unwrap(),
-                    vendor: Some("micron".to_string()),
-                    count: Some(1),
-                    capacity: Some("16 GB".to_string()),
-                    ..Default::default()
+                Case {
+                    scenario: "CapTypeMemory -> Memory",
+                    input: rpc::MachineCapabilityType::CapTypeMemory as i32,
+                    expect: Yields(capabilities::MachineCapabilityType::Memory),
                 },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeStorage
-                        .try_into()
-                        .unwrap(),
-                    vendor: Some("western digital".to_string()),
-                    count: Some(1),
-                    capacity: Some("2 TB".to_string()),
-                    ..Default::default()
+                Case {
+                    scenario: "CapTypeStorage -> Storage",
+                    input: rpc::MachineCapabilityType::CapTypeStorage as i32,
+                    expect: Yields(capabilities::MachineCapabilityType::Storage),
                 },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeNetwork
-                        .try_into()
-                        .unwrap(),
-                    vendor: Some("intel".to_string()),
-                    count: Some(3), // There are two intel nics of different speeds.  2x of one and 1x of the other.
-
-                    ..Default::default()
+                Case {
+                    scenario: "CapTypeNetwork -> Network",
+                    input: rpc::MachineCapabilityType::CapTypeNetwork as i32,
+                    expect: Yields(capabilities::MachineCapabilityType::Network),
                 },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeInfiniband
-                        .try_into()
-                        .unwrap(),
-                    vendor: Some("nvidia".to_string()),
-                    count: Some(1),
-                    inactive_devices: Some(vec![2, 4]),
-                    ..Default::default()
+                Case {
+                    scenario: "CapTypeInfiniband -> Infiniband",
+                    input: rpc::MachineCapabilityType::CapTypeInfiniband as i32,
+                    expect: Yields(capabilities::MachineCapabilityType::Infiniband),
                 },
-                InstanceTypeMachineCapabilityFilter {
-                    capability_type: rpc::MachineCapabilityType::CapTypeDpu.try_into().unwrap(),
-                    hardware_revision: Some("abc123".to_string()),
-                    count: Some(1),
-                    ..Default::default()
+                Case {
+                    scenario: "CapTypeDpu -> Dpu",
+                    input: rpc::MachineCapabilityType::CapTypeDpu as i32,
+                    expect: Yields(capabilities::MachineCapabilityType::Dpu),
+                },
+                Case {
+                    scenario: "CapTypeInvalid is rejected",
+                    input: rpc::MachineCapabilityType::CapTypeInvalid as i32,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unset capability_type (0) is rejected",
+                    input: 0,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown discriminant coerces to invalid and is rejected",
+                    input: 9001,
+                    expect: Fails,
                 },
             ],
+            |capability_type| {
+                InstanceTypeMachineCapabilityFilter::try_from(proto_filter_of_type(capability_type))
+                    .map(|f| f.capability_type)
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // proto -> domain: the optional device_type i32 round-trips each known
+    // discriminant, treats absence as None, and rejects an out-of-range value.
+    #[test]
+    fn proto_filter_device_type_converts_to_domain() {
+        check_cases(
+            [
+                Case {
+                    scenario: "absent device_type -> None",
+                    input: None,
+                    expect: Yields(None),
+                },
+                Case {
+                    scenario: "Unknown -> Some(Unknown)",
+                    input: Some(rpc::MachineCapabilityDeviceType::Unknown as i32),
+                    expect: Yields(Some(capabilities::MachineCapabilityDeviceType::Unknown)),
+                },
+                Case {
+                    scenario: "Dpu -> Some(Dpu)",
+                    input: Some(rpc::MachineCapabilityDeviceType::Dpu as i32),
+                    expect: Yields(Some(capabilities::MachineCapabilityDeviceType::Dpu)),
+                },
+                Case {
+                    scenario: "Nvlink -> Some(NvLink)",
+                    input: Some(rpc::MachineCapabilityDeviceType::Nvlink as i32),
+                    expect: Yields(Some(capabilities::MachineCapabilityDeviceType::NvLink)),
+                },
+                Case {
+                    scenario: "out-of-range device_type is rejected",
+                    input: Some(9001),
+                    expect: Fails,
+                },
+            ],
+            |device_type| {
+                let proto = rpc::InstanceTypeMachineCapabilityFilterAttributes {
+                    device_type,
+                    ..proto_filter_of_type(rpc::MachineCapabilityType::CapTypeNetwork as i32)
+                };
+                InstanceTypeMachineCapabilityFilter::try_from(proto)
+                    .map(|f| f.device_type)
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // proto -> domain: optional scalar fields carry through verbatim, and the
+    // inactive_devices list unwraps to its items.
+    #[test]
+    fn proto_filter_optional_fields_carry_through() {
+        let proto = rpc::InstanceTypeMachineCapabilityFilterAttributes {
+            name: Some("xeon".to_string()),
+            frequency: Some("2.4 GHz".to_string()),
+            capacity: Some("256 GB".to_string()),
+            vendor: Some("intel".to_string()),
+            count: Some(4),
+            hardware_revision: Some("rev2".to_string()),
+            cores: Some(8),
+            threads: Some(16),
+            inactive_devices: Some(rpc_common::Uint32List { items: vec![1, 3, 5] }),
+            ..proto_filter_of_type(rpc::MachineCapabilityType::CapTypeCpu as i32)
         };
 
-        assert!(inst_type.matches_capability_set(&machine_cap_set));
+        Case {
+            scenario: "populated proto filter -> domain filter",
+            input: proto,
+            expect: Yields(InstanceTypeMachineCapabilityFilter {
+                capability_type: capabilities::MachineCapabilityType::Cpu,
+                name: Some("xeon".to_string()),
+                frequency: Some("2.4 GHz".to_string()),
+                capacity: Some("256 GB".to_string()),
+                vendor: Some("intel".to_string()),
+                count: Some(4),
+                hardware_revision: Some("rev2".to_string()),
+                cores: Some(8),
+                threads: Some(16),
+                inactive_devices: Some(vec![1, 3, 5]),
+                device_type: None,
+            }),
+        }
+        .check(|p| InstanceTypeMachineCapabilityFilter::try_from(p).map_err(drop));
+    }
+
+    // domain -> proto: each capability_type maps to the proto discriminant as an
+    // i32. The conversion is fallible in signature but total over these inputs.
+    #[test]
+    fn domain_filter_capability_type_converts_to_proto() {
+        check_cases(
+            [
+                Case {
+                    scenario: "Cpu -> CapTypeCpu",
+                    input: capabilities::MachineCapabilityType::Cpu,
+                    expect: Yields(rpc::MachineCapabilityType::CapTypeCpu as i32),
+                },
+                Case {
+                    scenario: "Gpu -> CapTypeGpu",
+                    input: capabilities::MachineCapabilityType::Gpu,
+                    expect: Yields(rpc::MachineCapabilityType::CapTypeGpu as i32),
+                },
+                Case {
+                    scenario: "Memory -> CapTypeMemory",
+                    input: capabilities::MachineCapabilityType::Memory,
+                    expect: Yields(rpc::MachineCapabilityType::CapTypeMemory as i32),
+                },
+                Case {
+                    scenario: "Storage -> CapTypeStorage",
+                    input: capabilities::MachineCapabilityType::Storage,
+                    expect: Yields(rpc::MachineCapabilityType::CapTypeStorage as i32),
+                },
+                Case {
+                    scenario: "Network -> CapTypeNetwork",
+                    input: capabilities::MachineCapabilityType::Network,
+                    expect: Yields(rpc::MachineCapabilityType::CapTypeNetwork as i32),
+                },
+                Case {
+                    scenario: "Infiniband -> CapTypeInfiniband",
+                    input: capabilities::MachineCapabilityType::Infiniband,
+                    expect: Yields(rpc::MachineCapabilityType::CapTypeInfiniband as i32),
+                },
+                Case {
+                    scenario: "Dpu -> CapTypeDpu",
+                    input: capabilities::MachineCapabilityType::Dpu,
+                    expect: Yields(rpc::MachineCapabilityType::CapTypeDpu as i32),
+                },
+            ],
+            |capability_type| {
+                rpc::InstanceTypeMachineCapabilityFilterAttributes::try_from(domain_filter_of_type(
+                    capability_type,
+                ))
+                .map(|p| p.capability_type)
+                .map_err(drop)
+            },
+        );
+    }
+
+    // domain -> proto: device_type maps each known arm to its proto i32, and an
+    // absent device_type stays None.
+    #[test]
+    fn domain_filter_device_type_converts_to_proto() {
+        check_cases(
+            [
+                Case {
+                    scenario: "None -> None",
+                    input: None,
+                    expect: Yields(None),
+                },
+                Case {
+                    scenario: "Unknown -> Some(Unknown i32)",
+                    input: Some(capabilities::MachineCapabilityDeviceType::Unknown),
+                    expect: Yields(Some(rpc::MachineCapabilityDeviceType::Unknown as i32)),
+                },
+                Case {
+                    scenario: "Dpu -> Some(Dpu i32)",
+                    input: Some(capabilities::MachineCapabilityDeviceType::Dpu),
+                    expect: Yields(Some(rpc::MachineCapabilityDeviceType::Dpu as i32)),
+                },
+                Case {
+                    scenario: "NvLink -> Some(Nvlink i32)",
+                    input: Some(capabilities::MachineCapabilityDeviceType::NvLink),
+                    expect: Yields(Some(rpc::MachineCapabilityDeviceType::Nvlink as i32)),
+                },
+            ],
+            |device_type| {
+                let filter = InstanceTypeMachineCapabilityFilter {
+                    device_type,
+                    ..domain_filter_of_type(capabilities::MachineCapabilityType::Network)
+                };
+                rpc::InstanceTypeMachineCapabilityFilterAttributes::try_from(filter)
+                    .map(|p| p.device_type)
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // domain -> proto: optional scalar fields carry through and inactive_devices
+    // re-wraps into a Uint32List.
+    #[test]
+    fn domain_filter_optional_fields_carry_through() {
+        let filter = InstanceTypeMachineCapabilityFilter {
+            capability_type: capabilities::MachineCapabilityType::Cpu,
+            name: Some("xeon".to_string()),
+            frequency: Some("2.4 GHz".to_string()),
+            capacity: Some("256 GB".to_string()),
+            vendor: Some("intel".to_string()),
+            count: Some(4),
+            hardware_revision: Some("rev2".to_string()),
+            cores: Some(8),
+            threads: Some(16),
+            inactive_devices: Some(vec![1, 3, 5]),
+            device_type: None,
+        };
+
+        Case {
+            scenario: "populated domain filter -> proto filter",
+            input: filter,
+            expect: Yields(rpc::InstanceTypeMachineCapabilityFilterAttributes {
+                capability_type: rpc::MachineCapabilityType::CapTypeCpu as i32,
+                name: Some("xeon".to_string()),
+                frequency: Some("2.4 GHz".to_string()),
+                capacity: Some("256 GB".to_string()),
+                vendor: Some("intel".to_string()),
+                count: Some(4),
+                hardware_revision: Some("rev2".to_string()),
+                cores: Some(8),
+                threads: Some(16),
+                inactive_devices: Some(rpc_common::Uint32List { items: vec![1, 3, 5] }),
+                device_type: None,
+            }),
+        }
+        .check(|f| {
+            rpc::InstanceTypeMachineCapabilityFilterAttributes::try_from(f).map_err(drop)
+        });
+    }
+
+    // InstanceType -> proto: the desired_capabilities count is preserved across the
+    // conversion, whether the list is empty or holds several filters. Asserting on
+    // the count keeps the row a single bool predicate while still exercising the
+    // per-filter loop.
+    #[test]
+    fn model_instance_type_preserves_capability_count() {
+        check_cases(
+            [
+                Case {
+                    scenario: "no desired capabilities -> empty attributes",
+                    input: inst_type_with(vec![]),
+                    expect: Yields(0),
+                },
+                Case {
+                    scenario: "two desired capabilities -> two attributes",
+                    input: inst_type_with(vec![
+                        domain_filter_of_type(capabilities::MachineCapabilityType::Cpu),
+                        domain_filter_of_type(capabilities::MachineCapabilityType::Gpu),
+                    ]),
+                    expect: Yields(2),
+                },
+            ],
+            |it| {
+                rpc::InstanceType::try_from(it)
+                    .map(|p| {
+                        p.attributes
+                            .map(|a| a.desired_capabilities.len())
+                            .unwrap_or(0)
+                    })
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // InstanceType -> proto: an empty label value becomes None in the proto Label,
+    // while a non-empty value carries through as Some. Folded to a bool over the
+    // produced label's value, keyed by the one label we inject.
+    #[test]
+    fn model_instance_type_empty_label_value_becomes_none() {
+        check_cases(
+            [
+                Case {
+                    scenario: "empty label value -> None",
+                    input: "".to_string(),
+                    expect: Yields(None),
+                },
+                Case {
+                    scenario: "non-empty label value -> Some",
+                    input: "prod".to_string(),
+                    expect: Yields(Some("prod".to_string())),
+                },
+            ],
+            |value| {
+                let mut inst_type = inst_type_with(vec![]);
+                inst_type
+                    .metadata
+                    .labels
+                    .insert("env".to_string(), value);
+                rpc::InstanceType::try_from(inst_type)
+                    .map(|p| {
+                        p.metadata
+                            .and_then(|m| m.labels.into_iter().find(|l| l.key == "env"))
+                            .and_then(|l| l.value)
+                    })
+                    .map_err(drop)
+            },
+        );
     }
 }

--- a/crates/rpc/src/model/machine/capabilities.rs
+++ b/crates/rpc/src/model/machine/capabilities.rs
@@ -190,174 +190,317 @@ impl TryFrom<rpc::MachineCapabilityDeviceType> for MachineCapabilityDeviceType {
 #[cfg(test)]
 mod tests {
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
     use crate::forge as rpc;
 
+    // The capability-type enum maps one model arm to one rpc arm; every arm is a
+    // `check_values` row over the infallible `From`.
+    #[test]
+    fn test_model_capability_type_to_rpc_conversion() {
+        check_values(
+            [
+                Check {
+                    scenario: "cpu",
+                    input: MachineCapabilityType::Cpu,
+                    expect: rpc::MachineCapabilityType::CapTypeCpu,
+                },
+                Check {
+                    scenario: "gpu",
+                    input: MachineCapabilityType::Gpu,
+                    expect: rpc::MachineCapabilityType::CapTypeGpu,
+                },
+                Check {
+                    scenario: "memory",
+                    input: MachineCapabilityType::Memory,
+                    expect: rpc::MachineCapabilityType::CapTypeMemory,
+                },
+                Check {
+                    scenario: "storage",
+                    input: MachineCapabilityType::Storage,
+                    expect: rpc::MachineCapabilityType::CapTypeStorage,
+                },
+                Check {
+                    scenario: "network",
+                    input: MachineCapabilityType::Network,
+                    expect: rpc::MachineCapabilityType::CapTypeNetwork,
+                },
+                Check {
+                    scenario: "infiniband",
+                    input: MachineCapabilityType::Infiniband,
+                    expect: rpc::MachineCapabilityType::CapTypeInfiniband,
+                },
+                Check {
+                    scenario: "dpu",
+                    input: MachineCapabilityType::Dpu,
+                    expect: rpc::MachineCapabilityType::CapTypeDpu,
+                },
+            ],
+            rpc::MachineCapabilityType::from,
+        );
+    }
+
+    // The reverse `TryFrom` accepts every named arm and rejects the invalid
+    // sentinel; the error type isn't `PartialEq`, so the Err arm is `Fails`.
+    #[test]
+    fn test_rpc_capability_type_to_model_conversion() {
+        check_cases(
+            [
+                Case {
+                    scenario: "invalid sentinel rejected",
+                    input: rpc::MachineCapabilityType::CapTypeInvalid,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "cpu",
+                    input: rpc::MachineCapabilityType::CapTypeCpu,
+                    expect: Yields(MachineCapabilityType::Cpu),
+                },
+                Case {
+                    scenario: "gpu",
+                    input: rpc::MachineCapabilityType::CapTypeGpu,
+                    expect: Yields(MachineCapabilityType::Gpu),
+                },
+                Case {
+                    scenario: "memory",
+                    input: rpc::MachineCapabilityType::CapTypeMemory,
+                    expect: Yields(MachineCapabilityType::Memory),
+                },
+                Case {
+                    scenario: "storage",
+                    input: rpc::MachineCapabilityType::CapTypeStorage,
+                    expect: Yields(MachineCapabilityType::Storage),
+                },
+                Case {
+                    scenario: "network",
+                    input: rpc::MachineCapabilityType::CapTypeNetwork,
+                    expect: Yields(MachineCapabilityType::Network),
+                },
+                Case {
+                    scenario: "infiniband",
+                    input: rpc::MachineCapabilityType::CapTypeInfiniband,
+                    expect: Yields(MachineCapabilityType::Infiniband),
+                },
+                Case {
+                    scenario: "dpu",
+                    input: rpc::MachineCapabilityType::CapTypeDpu,
+                    expect: Yields(MachineCapabilityType::Dpu),
+                },
+            ],
+            |t| MachineCapabilityType::try_from(t).map_err(drop),
+        );
+    }
+
+    // The device-type enum maps one model arm to one rpc arm; every arm is a
+    // `check_values` row over the infallible `From`.
+    #[test]
+    fn test_model_device_type_to_rpc_conversion() {
+        check_values(
+            [
+                Check {
+                    scenario: "unknown",
+                    input: MachineCapabilityDeviceType::Unknown,
+                    expect: rpc::MachineCapabilityDeviceType::Unknown,
+                },
+                Check {
+                    scenario: "dpu",
+                    input: MachineCapabilityDeviceType::Dpu,
+                    expect: rpc::MachineCapabilityDeviceType::Dpu,
+                },
+                Check {
+                    scenario: "nvlink (NvLink -> Nvlink)",
+                    input: MachineCapabilityDeviceType::NvLink,
+                    expect: rpc::MachineCapabilityDeviceType::Nvlink,
+                },
+            ],
+            rpc::MachineCapabilityDeviceType::from,
+        );
+    }
+
+    // The reverse device-type `TryFrom` accepts every rpc arm; it has no failing
+    // arm today, so every row is a `Yields`. Error type isn't `PartialEq`.
+    #[test]
+    fn test_rpc_device_type_to_model_conversion() {
+        check_cases(
+            [
+                Case {
+                    scenario: "unknown",
+                    input: rpc::MachineCapabilityDeviceType::Unknown,
+                    expect: Yields(MachineCapabilityDeviceType::Unknown),
+                },
+                Case {
+                    scenario: "dpu",
+                    input: rpc::MachineCapabilityDeviceType::Dpu,
+                    expect: Yields(MachineCapabilityDeviceType::Dpu),
+                },
+                Case {
+                    scenario: "nvlink (Nvlink -> NvLink)",
+                    input: rpc::MachineCapabilityDeviceType::Nvlink,
+                    expect: Yields(MachineCapabilityDeviceType::NvLink),
+                },
+            ],
+            |t| MachineCapabilityDeviceType::try_from(t).map_err(drop),
+        );
+    }
+
+    // Each per-attribute model -> rpc conversion is a distinct total `From` over a
+    // distinct pair of types, so each is one `Check` row exercising that `.into()`.
+
     #[test]
     fn test_model_cpu_capability_to_rpc_conversion() {
-        let req_type = rpc::MachineCapabilityAttributesCpu {
-            name: "pentium 4 HT".to_string(),
-            count: 1,
-            vendor: Some("intel".to_string()),
-            cores: Some(1),
-            threads: Some(2),
-        };
-
-        let machine_cap = MachineCapabilityCpu {
-            name: "pentium 4 HT".to_string(),
-            count: 1,
-            vendor: Some("intel".to_string()),
-            cores: Some(1),
-            threads: Some(2),
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::MachineCapabilityAttributesCpu::from(machine_cap)
-        );
+        Check {
+            scenario: "cpu capability converts field-for-field",
+            input: MachineCapabilityCpu {
+                name: "pentium 4 HT".to_string(),
+                count: 1,
+                vendor: Some("intel".to_string()),
+                cores: Some(1),
+                threads: Some(2),
+            },
+            expect: rpc::MachineCapabilityAttributesCpu {
+                name: "pentium 4 HT".to_string(),
+                count: 1,
+                vendor: Some("intel".to_string()),
+                cores: Some(1),
+                threads: Some(2),
+            },
+        }
+        .check(rpc::MachineCapabilityAttributesCpu::from);
     }
 
     #[test]
     fn test_model_gpu_capability_to_rpc_conversion() {
-        let req_type = rpc::MachineCapabilityAttributesGpu {
-            name: "RTX 6000".to_string(),
-            count: 1,
-            frequency: Some("1.2 giggawattz".to_string()),
-            vendor: Some("nvidia".to_string()),
-            cores: Some(1),
-            threads: Some(2),
-            capacity: Some("24 GB".to_string()),
-            device_type: Some(MachineCapabilityDeviceType::Unknown as i32),
-        };
-
-        let machine_cap = MachineCapabilityGpu {
-            name: "RTX 6000".to_string(),
-            count: 1,
-            frequency: Some("1.2 giggawattz".to_string()),
-            vendor: Some("nvidia".to_string()),
-            cores: Some(1),
-            threads: Some(2),
-            memory_capacity: Some("24 GB".to_string()),
-            device_type: Some(MachineCapabilityDeviceType::Unknown),
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::MachineCapabilityAttributesGpu::from(machine_cap)
-        );
+        Check {
+            scenario: "gpu capability converts (memory_capacity -> capacity, device_type mapped)",
+            input: MachineCapabilityGpu {
+                name: "RTX 6000".to_string(),
+                count: 1,
+                frequency: Some("1.2 giggawattz".to_string()),
+                vendor: Some("nvidia".to_string()),
+                cores: Some(1),
+                threads: Some(2),
+                memory_capacity: Some("24 GB".to_string()),
+                device_type: Some(MachineCapabilityDeviceType::Unknown),
+            },
+            expect: rpc::MachineCapabilityAttributesGpu {
+                name: "RTX 6000".to_string(),
+                count: 1,
+                frequency: Some("1.2 giggawattz".to_string()),
+                vendor: Some("nvidia".to_string()),
+                cores: Some(1),
+                threads: Some(2),
+                capacity: Some("24 GB".to_string()),
+                device_type: Some(MachineCapabilityDeviceType::Unknown as i32),
+            },
+        }
+        .check(rpc::MachineCapabilityAttributesGpu::from);
     }
 
     #[test]
     fn test_model_memory_capability_to_rpc_conversion() {
-        let req_type = rpc::MachineCapabilityAttributesMemory {
-            name: "DDR4".to_string(),
-            count: 1,
-            vendor: Some("crucial".to_string()),
-            capacity: Some("32 GB".to_string()),
-        };
-
-        let machine_cap = MachineCapabilityMemory {
-            name: "DDR4".to_string(),
-            count: 1,
-            vendor: Some("crucial".to_string()),
-            capacity: Some("32 GB".to_string()),
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::MachineCapabilityAttributesMemory::from(machine_cap)
-        );
+        Check {
+            scenario: "memory capability converts field-for-field",
+            input: MachineCapabilityMemory {
+                name: "DDR4".to_string(),
+                count: 1,
+                vendor: Some("crucial".to_string()),
+                capacity: Some("32 GB".to_string()),
+            },
+            expect: rpc::MachineCapabilityAttributesMemory {
+                name: "DDR4".to_string(),
+                count: 1,
+                vendor: Some("crucial".to_string()),
+                capacity: Some("32 GB".to_string()),
+            },
+        }
+        .check(rpc::MachineCapabilityAttributesMemory::from);
     }
 
     #[test]
     fn test_model_storage_capability_to_rpc_conversion() {
-        let req_type = rpc::MachineCapabilityAttributesStorage {
-            name: "Spinning Disk".to_string(),
-            count: 1,
-            vendor: Some("western digital".to_string()),
-            capacity: Some("1 TB".to_string()),
-        };
-
-        let machine_cap = MachineCapabilityStorage {
-            name: "Spinning Disk".to_string(),
-            count: 1,
-            vendor: Some("western digital".to_string()),
-            capacity: Some("1 TB".to_string()),
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::MachineCapabilityAttributesStorage::from(machine_cap)
-        );
+        Check {
+            scenario: "storage capability converts field-for-field",
+            input: MachineCapabilityStorage {
+                name: "Spinning Disk".to_string(),
+                count: 1,
+                vendor: Some("western digital".to_string()),
+                capacity: Some("1 TB".to_string()),
+            },
+            expect: rpc::MachineCapabilityAttributesStorage {
+                name: "Spinning Disk".to_string(),
+                count: 1,
+                vendor: Some("western digital".to_string()),
+                capacity: Some("1 TB".to_string()),
+            },
+        }
+        .check(rpc::MachineCapabilityAttributesStorage::from);
     }
 
     #[test]
     fn test_model_network_capability_to_rpc_conversion() {
-        let req_type = rpc::MachineCapabilityAttributesNetwork {
-            name: "BCM57414 NetXtreme-E 10Gb/25Gb RDMA Ethernet Controller".to_string(),
-            count: 1,
-            vendor: Some("0x14e4".to_string()),
-            device_type: Some(MachineCapabilityDeviceType::Unknown as i32),
-        };
-
-        let machine_cap = MachineCapabilityNetwork {
-            name: "BCM57414 NetXtreme-E 10Gb/25Gb RDMA Ethernet Controller".to_string(),
-            count: 1,
-            vendor: Some("0x14e4".to_string()),
-            device_type: Some(MachineCapabilityDeviceType::Unknown),
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::MachineCapabilityAttributesNetwork::from(machine_cap)
-        );
+        Check {
+            scenario: "network capability converts (device_type mapped)",
+            input: MachineCapabilityNetwork {
+                name: "BCM57414 NetXtreme-E 10Gb/25Gb RDMA Ethernet Controller".to_string(),
+                count: 1,
+                vendor: Some("0x14e4".to_string()),
+                device_type: Some(MachineCapabilityDeviceType::Unknown),
+            },
+            expect: rpc::MachineCapabilityAttributesNetwork {
+                name: "BCM57414 NetXtreme-E 10Gb/25Gb RDMA Ethernet Controller".to_string(),
+                count: 1,
+                vendor: Some("0x14e4".to_string()),
+                device_type: Some(MachineCapabilityDeviceType::Unknown as i32),
+            },
+        }
+        .check(rpc::MachineCapabilityAttributesNetwork::from);
     }
 
     #[test]
     fn test_model_infiniband_capability_to_rpc_conversion() {
-        let req_type = rpc::MachineCapabilityAttributesInfiniband {
-            name: "IB NIC".to_string(),
-            count: 4,
-            vendor: Some("IB NIC Vendor".to_string()),
-            inactive_devices: vec![0, 2],
-        };
-
-        let machine_cap = MachineCapabilityInfiniband {
-            name: "IB NIC".to_string(),
-            count: 4,
-            vendor: "IB NIC Vendor".to_string(),
-            inactive_devices: vec![0, 2],
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::MachineCapabilityAttributesInfiniband::from(machine_cap)
-        );
+        Check {
+            scenario: "infiniband capability converts (vendor wrapped in Some)",
+            input: MachineCapabilityInfiniband {
+                name: "IB NIC".to_string(),
+                count: 4,
+                vendor: "IB NIC Vendor".to_string(),
+                inactive_devices: vec![0, 2],
+            },
+            expect: rpc::MachineCapabilityAttributesInfiniband {
+                name: "IB NIC".to_string(),
+                count: 4,
+                vendor: Some("IB NIC Vendor".to_string()),
+                inactive_devices: vec![0, 2],
+            },
+        }
+        .check(rpc::MachineCapabilityAttributesInfiniband::from);
     }
 
     #[test]
     fn test_model_dpu_capability_to_rpc_conversion() {
-        let req_type = rpc::MachineCapabilityAttributesDpu {
-            name: "bf3".to_string(),
-            count: 1,
-            hardware_revision: Some("uh, 3?".to_string()),
-        };
-
-        let machine_cap = MachineCapabilityDpu {
-            name: "bf3".to_string(),
-            count: 1,
-            hardware_revision: Some("uh, 3?".to_string()),
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::MachineCapabilityAttributesDpu::from(machine_cap)
-        );
+        Check {
+            scenario: "dpu capability converts field-for-field",
+            input: MachineCapabilityDpu {
+                name: "bf3".to_string(),
+                count: 1,
+                hardware_revision: Some("uh, 3?".to_string()),
+            },
+            expect: rpc::MachineCapabilityAttributesDpu {
+                name: "bf3".to_string(),
+                count: 1,
+                hardware_revision: Some("uh, 3?".to_string()),
+            },
+        }
+        .check(rpc::MachineCapabilityAttributesDpu::from);
     }
 
+    // The whole-set conversion delegates to the per-attribute `From` impls above;
+    // one `Check` row exercises the aggregate `.into()` over a populated set.
     #[test]
     fn test_model_capability_set_to_rpc_conversion() {
-        let req_type = rpc::MachineCapabilitiesSet {
+        let expect = rpc::MachineCapabilitiesSet {
             cpu: vec![rpc::MachineCapabilityAttributesCpu {
                 name: "xeon".to_string(),
                 count: 2,
@@ -414,7 +557,7 @@ mod tests {
             }],
         };
 
-        let machine_cap = MachineCapabilitiesSet {
+        let input = MachineCapabilitiesSet {
             cpu: vec![MachineCapabilityCpu {
                 name: "xeon".to_string(),
                 count: 2,
@@ -471,6 +614,11 @@ mod tests {
             }],
         };
 
-        assert_eq!(req_type, rpc::MachineCapabilitiesSet::from(machine_cap));
+        Check {
+            scenario: "populated set converts each attribute vec",
+            input,
+            expect,
+        }
+        .check(rpc::MachineCapabilitiesSet::from);
     }
 }

--- a/crates/rpc/src/model/machine/mod.rs
+++ b/crates/rpc/src/model/machine/mod.rs
@@ -559,10 +559,247 @@ fn machine_instance_network_restrictions(
 
 #[cfg(test)]
 mod test {
+    use carbide_test_support::{Check, check_values};
+    use carbide_uuid::machine::MachineType;
+
     use crate as rpc;
+    use crate::forge_agent_control_response as fac;
     use crate::model::machine::{
         DpuInfo, DpuInfoStatusObservation, DpuOsOperationalState, DpuRepresentorStatus,
+        MachineValidationFilter, RpcMachineTypeWrapper,
     };
+
+    #[test]
+    fn dpu_os_operational_state_to_rpc_maps_state_detail() {
+        check_values(
+            [
+                Check {
+                    scenario: "ready",
+                    input: "Ready".to_string(),
+                    expect: "Ready".to_string(),
+                },
+                Check {
+                    scenario: "empty detail",
+                    input: String::new(),
+                    expect: String::new(),
+                },
+            ],
+            |state_detail| {
+                let rpc: rpc::forge::DpuOsOperationalState =
+                    DpuOsOperationalState { state_detail }.into();
+                rpc.state_detail
+            },
+        );
+    }
+
+    #[test]
+    fn dpu_representor_status_to_rpc_maps_every_field() {
+        // (carrier_up, state) -> round-tripped tuple, exercising present/absent optionals.
+        check_values(
+            [
+                Check {
+                    scenario: "both present, up",
+                    input: (Some(true), Some("up".to_string())),
+                    expect: (Some(true), Some("up".to_string())),
+                },
+                Check {
+                    scenario: "both present, down",
+                    input: (Some(false), Some("down".to_string())),
+                    expect: (Some(false), Some("down".to_string())),
+                },
+                Check {
+                    scenario: "both absent",
+                    input: (None, None),
+                    expect: (None, None),
+                },
+                Check {
+                    scenario: "carrier present, state absent",
+                    input: (Some(true), None),
+                    expect: (Some(true), None),
+                },
+            ],
+            |(carrier_up, state)| {
+                let rpc: rpc::forge::DpuRepresentorStatus = DpuRepresentorStatus {
+                    name: "pf0hpf".to_string(),
+                    carrier_up,
+                    state,
+                }
+                .into();
+                assert_eq!(rpc.name, "pf0hpf");
+                (rpc.carrier_up, rpc.state)
+            },
+        );
+    }
+
+    #[test]
+    fn dpu_info_status_observation_to_rpc_handles_optionals() {
+        // (os_operational_state present?, firmware_version, representor count, heartbeat present?)
+        // -> a bool predicate folding the resulting rpc shape.
+        check_values(
+            [
+                Check {
+                    scenario: "fully populated",
+                    input: (true, Some("24.42.1000".to_string()), 2usize, true),
+                    expect: true,
+                },
+                Check {
+                    scenario: "all optionals absent, no representors",
+                    input: (false, None, 0usize, false),
+                    expect: true,
+                },
+                Check {
+                    scenario: "only firmware present",
+                    input: (false, Some("1.0".to_string()), 0usize, false),
+                    expect: true,
+                },
+            ],
+            |(has_os, firmware_version, representor_count, has_heartbeat)| {
+                let observation = DpuInfoStatusObservation {
+                    os_operational_state: has_os.then(|| DpuOsOperationalState {
+                        state_detail: "Ready".to_string(),
+                    }),
+                    firmware_version: firmware_version.clone(),
+                    representors: (0..representor_count)
+                        .map(|i| DpuRepresentorStatus {
+                            name: format!("rep{i}"),
+                            carrier_up: Some(true),
+                            state: Some("up".to_string()),
+                        })
+                        .collect(),
+                    last_heartbeat: has_heartbeat.then(chrono::Utc::now),
+                };
+                let rpc: rpc::forge::DpuInfoStatusObservation = observation.into();
+                rpc.os_operational_state.is_some() == has_os
+                    && rpc.firmware_version == firmware_version
+                    && rpc.representors.len() == representor_count
+                    && rpc.last_heartbeat.is_some() == has_heartbeat
+            },
+        );
+    }
+
+    #[test]
+    fn dpu_info_to_rpc_with_and_without_observed_status() {
+        // (id, loopback_ip, observed_status present?) -> (id, loopback_ip, observed present?)
+        check_values(
+            [
+                Check {
+                    scenario: "with observed status",
+                    input: ("dpu-1".to_string(), "10.0.0.1".to_string(), true),
+                    expect: ("dpu-1".to_string(), "10.0.0.1".to_string(), true),
+                },
+                Check {
+                    scenario: "without observed status",
+                    input: ("dpu-2".to_string(), "10.0.0.2".to_string(), false),
+                    expect: ("dpu-2".to_string(), "10.0.0.2".to_string(), false),
+                },
+            ],
+            |(id, loopback_ip, has_status)| {
+                let info = DpuInfo {
+                    id,
+                    loopback_ip,
+                    observed_status: has_status.then(|| DpuInfoStatusObservation {
+                        os_operational_state: None,
+                        firmware_version: None,
+                        representors: vec![],
+                        last_heartbeat: None,
+                    }),
+                };
+                let rpc: rpc::forge::DpuInfo = info.into();
+                (rpc.id, rpc.loopback_ip, rpc.observed_status.is_some())
+            },
+        );
+    }
+
+    #[test]
+    fn machine_type_to_rpc_wrapper_covers_every_arm() {
+        check_values(
+            [
+                Check {
+                    scenario: "host stays host",
+                    input: MachineType::Host,
+                    expect: rpc::forge::MachineType::Host,
+                },
+                Check {
+                    scenario: "predicted host folds to host",
+                    input: MachineType::PredictedHost,
+                    expect: rpc::forge::MachineType::Host,
+                },
+                Check {
+                    scenario: "dpu stays dpu",
+                    input: MachineType::Dpu,
+                    expect: rpc::forge::MachineType::Dpu,
+                },
+            ],
+            |machine_type| *RpcMachineTypeWrapper::from(machine_type),
+        );
+    }
+
+    #[test]
+    fn rpc_filter_to_domain_filter_maps_contexts() {
+        // contexts present/absent is the only optional in the filter.
+        check_values(
+            [
+                Check {
+                    scenario: "contexts present",
+                    input: Some(vec!["ctx-a".to_string(), "ctx-b".to_string()]),
+                    expect: MachineValidationFilter {
+                        tags: vec!["tag".to_string()],
+                        allowed_tests: vec!["test".to_string()],
+                        run_unverfied_tests: Some(true),
+                        contexts: Some(vec!["ctx-a".to_string(), "ctx-b".to_string()]),
+                    },
+                },
+                Check {
+                    scenario: "contexts absent",
+                    input: None,
+                    expect: MachineValidationFilter {
+                        tags: vec!["tag".to_string()],
+                        allowed_tests: vec!["test".to_string()],
+                        run_unverfied_tests: Some(true),
+                        contexts: None,
+                    },
+                },
+            ],
+            |items| {
+                let rpc_filter = fac::MachineValidationFilter {
+                    tags: vec!["tag".to_string()],
+                    allowed_tests: vec!["test".to_string()],
+                    run_unverfied_tests: Some(true),
+                    contexts: items.map(|items| rpc::common::StringList { items }),
+                };
+                MachineValidationFilter::from(rpc_filter)
+            },
+        );
+    }
+
+    #[test]
+    fn domain_filter_to_rpc_filter_maps_contexts() {
+        // contexts present (wrapped in StringList) vs absent -> the inner Vec is what we assert.
+        check_values(
+            [
+                Check {
+                    scenario: "contexts present",
+                    input: Some(vec!["ctx-a".to_string()]),
+                    expect: Some(vec!["ctx-a".to_string()]),
+                },
+                Check {
+                    scenario: "contexts absent",
+                    input: None,
+                    expect: None,
+                },
+            ],
+            |contexts| {
+                let filter = MachineValidationFilter {
+                    tags: vec![],
+                    allowed_tests: vec![],
+                    run_unverfied_tests: None,
+                    contexts,
+                };
+                let rpc_filter: fac::MachineValidationFilter = filter.into();
+                rpc_filter.contexts.map(|list| list.items)
+            },
+        );
+    }
 
     #[test]
     fn dpu_info_to_rpc() {

--- a/crates/rpc/src/model/machine_validation.rs
+++ b/crates/rpc/src/model/machine_validation.rs
@@ -312,7 +312,524 @@ impl TryFrom<rpc::forge::MachineValidationResult> for MachineValidationResult {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
+
+    // ---- machine_validation_from_state: every domain state arm maps to the
+    // matching proto oneof variant. The function is total, so check_values.
+    #[test]
+    fn validation_state_maps_each_arm() {
+        use rpc::forge::machine_validation_status::{
+            MachineValidationCompleted, MachineValidationInProgress, MachineValidationStarted,
+            MachineValidationState as ProtoState,
+        };
+        check_values(
+            [
+                Check {
+                    scenario: "started",
+                    input: MachineValidationState::Started,
+                    expect: ProtoState::Started(MachineValidationStarted::Started.into()),
+                },
+                Check {
+                    scenario: "in progress",
+                    input: MachineValidationState::InProgress,
+                    expect: ProtoState::InProgress(MachineValidationInProgress::InProgress.into()),
+                },
+                Check {
+                    scenario: "success -> completed/success",
+                    input: MachineValidationState::Success,
+                    expect: ProtoState::Completed(MachineValidationCompleted::Success.into()),
+                },
+                Check {
+                    scenario: "skipped -> completed/skipped",
+                    input: MachineValidationState::Skipped,
+                    expect: ProtoState::Completed(MachineValidationCompleted::Skipped.into()),
+                },
+                Check {
+                    scenario: "failed -> completed/failed",
+                    input: MachineValidationState::Failed,
+                    expect: ProtoState::Completed(MachineValidationCompleted::Failed.into()),
+                },
+            ],
+            machine_validation_from_state,
+        );
+    }
+
+    // ---- MachineValidationTestAddRequest::from: a direct field-for-field map.
+    // Confirm each scalar/optional/repeated field is carried straight through.
+    #[test]
+    fn add_request_carries_every_field() {
+        check_values(
+            [
+                Check {
+                    scenario: "name carried",
+                    input: rpc::forge::MachineValidationTestAddRequest {
+                        name: "t".to_string(),
+                        ..Default::default()
+                    },
+                    expect: "t".to_string(),
+                },
+                Check {
+                    scenario: "empty name default",
+                    input: rpc::forge::MachineValidationTestAddRequest::default(),
+                    expect: String::new(),
+                },
+            ],
+            |r| MachineValidationTestAddRequest::from(r).name,
+        );
+        check_values(
+            [
+                Check {
+                    scenario: "is_enabled present true",
+                    input: rpc::forge::MachineValidationTestAddRequest {
+                        is_enabled: Some(true),
+                        ..Default::default()
+                    },
+                    expect: Some(true),
+                },
+                Check {
+                    scenario: "is_enabled present false",
+                    input: rpc::forge::MachineValidationTestAddRequest {
+                        is_enabled: Some(false),
+                        ..Default::default()
+                    },
+                    expect: Some(false),
+                },
+                Check {
+                    scenario: "is_enabled absent",
+                    input: rpc::forge::MachineValidationTestAddRequest::default(),
+                    expect: None,
+                },
+            ],
+            |r| MachineValidationTestAddRequest::from(r).is_enabled,
+        );
+        check_values(
+            [
+                Check {
+                    scenario: "repeated contexts + read_only + execute_in_host carried",
+                    input: rpc::forge::MachineValidationTestAddRequest {
+                        contexts: vec!["a".to_string(), "b".to_string()],
+                        read_only: Some(true),
+                        execute_in_host: Some(false),
+                        supported_platforms: vec!["x86_64".to_string()],
+                        ..Default::default()
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "empty repeated + absent optionals",
+                    input: rpc::forge::MachineValidationTestAddRequest::default(),
+                    expect: true,
+                },
+            ],
+            |r| {
+                let want_contexts = r.contexts.clone();
+                let want_platforms = r.supported_platforms.clone();
+                let want_read_only = r.read_only;
+                let want_execute = r.execute_in_host;
+                let d = MachineValidationTestAddRequest::from(r);
+                d.contexts == want_contexts
+                    && d.supported_platforms == want_platforms
+                    && d.read_only == want_read_only
+                    && d.execute_in_host == want_execute
+            },
+        );
+    }
+
+    // ---- Payload -> MachineValidationTestUpdatePayload: same field-for-field map,
+    // exercising the verified flag (present true/false/absent) and a scalar.
+    #[test]
+    fn update_payload_carries_verified_and_fields() {
+        check_values(
+            [
+                Check {
+                    scenario: "verified true",
+                    input: rpc::forge::machine_validation_test_update_request::Payload {
+                        verified: Some(true),
+                        ..Default::default()
+                    },
+                    expect: Some(true),
+                },
+                Check {
+                    scenario: "verified false",
+                    input: rpc::forge::machine_validation_test_update_request::Payload {
+                        verified: Some(false),
+                        ..Default::default()
+                    },
+                    expect: Some(false),
+                },
+                Check {
+                    scenario: "verified absent",
+                    input: rpc::forge::machine_validation_test_update_request::Payload::default(),
+                    expect: None,
+                },
+            ],
+            |p| MachineValidationTestUpdatePayload::from(p).verified,
+        );
+        check_values(
+            [
+                Check {
+                    scenario: "name present",
+                    input: rpc::forge::machine_validation_test_update_request::Payload {
+                        name: Some("n".to_string()),
+                        ..Default::default()
+                    },
+                    expect: Some("n".to_string()),
+                },
+                Check {
+                    scenario: "name absent",
+                    input: rpc::forge::machine_validation_test_update_request::Payload::default(),
+                    expect: None,
+                },
+            ],
+            |p| MachineValidationTestUpdatePayload::from(p).name,
+        );
+    }
+
+    // ---- MachineValidationTestUpdateRequest::from: payload present vs absent, and
+    // the scalar test_id / version carried straight through.
+    #[test]
+    fn update_request_maps_payload_presence() {
+        check_values(
+            [
+                Check {
+                    scenario: "payload present",
+                    input: rpc::forge::MachineValidationTestUpdateRequest {
+                        test_id: "id".to_string(),
+                        version: "1".to_string(),
+                        payload: Some(
+                            rpc::forge::machine_validation_test_update_request::Payload::default(),
+                        ),
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "payload absent",
+                    input: rpc::forge::MachineValidationTestUpdateRequest {
+                        test_id: "id".to_string(),
+                        version: "1".to_string(),
+                        payload: None,
+                    },
+                    expect: false,
+                },
+            ],
+            |r| MachineValidationTestUpdateRequest::from(r).payload.is_some(),
+        );
+        check_values(
+            [Check {
+                scenario: "test_id + version carried",
+                input: rpc::forge::MachineValidationTestUpdateRequest {
+                    test_id: "forge_x".to_string(),
+                    version: "7".to_string(),
+                    payload: None,
+                },
+                expect: true,
+            }],
+            |r| {
+                let d = MachineValidationTestUpdateRequest::from(r);
+                d.test_id == "forge_x" && d.version == "7"
+            },
+        );
+    }
+
+    // ---- MachineValidationTestsGetRequest::from: optional filters present/absent.
+    #[test]
+    fn tests_get_request_maps_optionals() {
+        check_values(
+            [
+                Check {
+                    scenario: "all key optionals present",
+                    input: rpc::forge::MachineValidationTestsGetRequest {
+                        test_id: Some("t".to_string()),
+                        read_only: Some(true),
+                        version: Some("1".to_string()),
+                        is_enabled: Some(false),
+                        verified: Some(true),
+                        contexts: vec!["c".to_string()],
+                        custom_tags: vec!["k".to_string()],
+                        supported_platforms: vec!["x86_64".to_string()],
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "all optionals absent (default)",
+                    input: rpc::forge::MachineValidationTestsGetRequest::default(),
+                    expect: false,
+                },
+            ],
+            |r| {
+                let d = MachineValidationTestsGetRequest::from(r);
+                d.test_id.is_some()
+                    && d.read_only.is_some()
+                    && d.version.is_some()
+                    && d.is_enabled.is_some()
+                    && d.verified.is_some()
+            },
+        );
+        check_values(
+            [
+                Check {
+                    scenario: "repeated contexts/custom_tags/platforms carried",
+                    input: rpc::forge::MachineValidationTestsGetRequest {
+                        contexts: vec!["c".to_string()],
+                        custom_tags: vec!["k".to_string(), "j".to_string()],
+                        supported_platforms: vec!["x86_64".to_string()],
+                        ..Default::default()
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "empty repeated default",
+                    input: rpc::forge::MachineValidationTestsGetRequest::default(),
+                    expect: true,
+                },
+            ],
+            |r| {
+                let want = (
+                    r.contexts.clone(),
+                    r.custom_tags.clone(),
+                    r.supported_platforms.clone(),
+                );
+                let d = MachineValidationTestsGetRequest::from(r);
+                (d.contexts, d.custom_tags, d.supported_platforms) == want
+            },
+        );
+    }
+
+    // ---- MachineValidationExternalConfig::try_from (proto -> domain): fallible on
+    // the version string. RpcDataConversionError has no PartialEq, so use Fails.
+    #[test]
+    fn external_config_try_from_parses_version() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid V-T version parses",
+                    input: rpc::forge::MachineValidationExternalConfig {
+                        name: "cfg".to_string(),
+                        description: Some("d".to_string()),
+                        config: vec![1, 2, 3],
+                        version: "V1-T0".to_string(),
+                        timestamp: None,
+                    },
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "absent description defaults to empty",
+                    input: rpc::forge::MachineValidationExternalConfig {
+                        name: "cfg".to_string(),
+                        description: None,
+                        config: vec![],
+                        version: "V2-T0".to_string(),
+                        timestamp: None,
+                    },
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "bare number is not a valid version",
+                    input: rpc::forge::MachineValidationExternalConfig {
+                        name: "cfg".to_string(),
+                        description: None,
+                        config: vec![],
+                        version: "1".to_string(),
+                        timestamp: None,
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty version string fails",
+                    input: rpc::forge::MachineValidationExternalConfig {
+                        name: "cfg".to_string(),
+                        description: None,
+                        config: vec![],
+                        version: String::new(),
+                        timestamp: None,
+                    },
+                    expect: Fails,
+                },
+            ],
+            |proto| {
+                let want_desc = proto.description.clone().unwrap_or_default();
+                let want_name = proto.name.clone();
+                let want_config = proto.config.clone();
+                MachineValidationExternalConfig::try_from(proto)
+                    .map(|d| {
+                        d.description == want_desc
+                            && d.name == want_name
+                            && d.config == want_config
+                    })
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // ---- MachineValidationExternalConfig::from (domain -> proto): total. version
+    // becomes the bare number string; description is wrapped Some.
+    #[test]
+    fn external_config_to_proto_serializes_version_number() {
+        check_values(
+            [
+                Check {
+                    scenario: "version number rendered, description wrapped",
+                    input: MachineValidationExternalConfig {
+                        name: "cfg".to_string(),
+                        description: "d".to_string(),
+                        config: vec![9],
+                        version: ConfigVersion::new(5),
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "empty description still wrapped Some",
+                    input: MachineValidationExternalConfig {
+                        name: "cfg".to_string(),
+                        description: String::new(),
+                        config: vec![],
+                        version: ConfigVersion::new(1),
+                    },
+                    expect: true,
+                },
+            ],
+            |d| {
+                let want_version = d.version.version_nr().to_string();
+                let want_desc = d.description.clone();
+                let p = rpc::forge::MachineValidationExternalConfig::from(d);
+                p.version == want_version
+                    && p.description == Some(want_desc)
+                    && p.timestamp.is_some()
+            },
+        );
+    }
+
+    // ---- MachineValidationTest::try_from (proto -> domain): version parse Ok/Err,
+    // and the empty-custom_tags -> None / non-empty -> Some mapping.
+    #[test]
+    fn test_try_from_parses_version_and_folds_custom_tags() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid version, empty custom_tags -> None",
+                    input: rpc::forge::MachineValidationTest {
+                        version: "V1-T0".to_string(),
+                        custom_tags: vec![],
+                        ..Default::default()
+                    },
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "valid version, populated custom_tags -> Some",
+                    input: rpc::forge::MachineValidationTest {
+                        version: "V3-T0".to_string(),
+                        custom_tags: vec!["k".to_string()],
+                        ..Default::default()
+                    },
+                    expect: Yields(false),
+                },
+                Case {
+                    scenario: "invalid version fails",
+                    input: rpc::forge::MachineValidationTest {
+                        version: "nope".to_string(),
+                        ..Default::default()
+                    },
+                    expect: Fails,
+                },
+            ],
+            |proto| {
+                MachineValidationTest::try_from(proto)
+                    .map(|d| d.custom_tags.is_none())
+                    .map_err(drop)
+            },
+        );
+        // Scalar/optional fields carried straight through on the Ok path.
+        check_cases(
+            [Case {
+                scenario: "fields carried through",
+                input: rpc::forge::MachineValidationTest {
+                    test_id: "id".to_string(),
+                    name: "n".to_string(),
+                    command: "cmd".to_string(),
+                    args: "a".to_string(),
+                    timeout: Some(30),
+                    verified: true,
+                    read_only: true,
+                    is_enabled: true,
+                    contexts: vec!["c".to_string()],
+                    version: "V1-T0".to_string(),
+                    ..Default::default()
+                },
+                expect: Yields(true),
+            }],
+            |proto| {
+                MachineValidationTest::try_from(proto)
+                    .map(|d| {
+                        d.test_id == "id"
+                            && d.name == "n"
+                            && d.command == "cmd"
+                            && d.timeout == Some(30)
+                            && d.verified
+                            && d.read_only
+                            && d.is_enabled
+                            && d.contexts == vec!["c".to_string()]
+                    })
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // ---- MachineValidationTest::from (domain -> proto): total. version becomes the
+    // V-T string; absent custom_tags become an empty vec.
+    #[test]
+    fn test_to_proto_renders_version_and_unwraps_custom_tags() {
+        check_values(
+            [
+                Check {
+                    scenario: "None custom_tags -> empty vec, version string rendered",
+                    input: sample_test(None),
+                    expect: true,
+                },
+                Check {
+                    scenario: "Some custom_tags carried",
+                    input: sample_test(Some(vec!["k".to_string()])),
+                    expect: true,
+                },
+            ],
+            |d| {
+                let want_version = d.version.version_string();
+                let want_tags = d.custom_tags.clone().unwrap_or_default();
+                let p = rpc::forge::MachineValidationTest::from(d);
+                p.version == want_version && p.custom_tags == want_tags
+            },
+        );
+    }
+
+    fn sample_test(custom_tags: Option<Vec<String>>) -> MachineValidationTest {
+        MachineValidationTest {
+            test_id: "id".to_string(),
+            name: "n".to_string(),
+            description: None,
+            contexts: vec![],
+            img_name: None,
+            execute_in_host: None,
+            container_arg: None,
+            command: "cmd".to_string(),
+            args: "a".to_string(),
+            extra_output_file: None,
+            extra_err_file: None,
+            external_config_file: None,
+            pre_condition: None,
+            timeout: None,
+            version: ConfigVersion::new(2),
+            supported_platforms: vec![],
+            modified_by: "me".to_string(),
+            verified: false,
+            read_only: false,
+            custom_tags,
+            components: vec![],
+            last_modified_at: Utc::now(),
+            is_enabled: true,
+        }
+    }
 
     #[test]
     fn tests_get_request_from_rpc() {

--- a/crates/rpc/src/model/metadata.rs
+++ b/crates/rpc/src/model/metadata.rs
@@ -79,38 +79,236 @@ impl From<rpc::forge::Label> for LabelFilter {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
+    // `LabelFilter::from` is a total conversion: project to (key, value) — the two
+    // fields the originals asserted.
     #[test]
-    fn label_filter_from_rpc_with_value() {
-        let rpc_label = rpc::forge::Label {
-            key: "env".to_string(),
-            value: Some("prod".to_string()),
-        };
-        let filter = LabelFilter::from(rpc_label);
-        assert_eq!(filter.key, "env");
-        assert_eq!(filter.value, Some("prod".to_string()));
+    fn label_filter_from_rpc() {
+        check_values(
+            [
+                Check {
+                    scenario: "with value",
+                    input: rpc::forge::Label {
+                        key: "env".to_string(),
+                        value: Some("prod".to_string()),
+                    },
+                    expect: ("env".to_string(), Some("prod".to_string())),
+                },
+                Check {
+                    scenario: "without value",
+                    input: rpc::forge::Label {
+                        key: "env".to_string(),
+                        value: None,
+                    },
+                    expect: ("env".to_string(), None),
+                },
+                Check {
+                    scenario: "empty key",
+                    input: rpc::forge::Label {
+                        key: String::new(),
+                        value: Some("prod".to_string()),
+                    },
+                    expect: (String::new(), Some("prod".to_string())),
+                },
+            ],
+            |label| {
+                let filter = LabelFilter::from(label);
+                (filter.key, filter.value)
+            },
+        );
     }
 
+    // `Metadata -> rpc::Metadata` is a total conversion. Project the result to
+    // (name, description, sorted labels) so the row-by-row expects are
+    // order-independent (labels come out of a `HashMap`). An empty label value
+    // collapses to `None`; a non-empty one is wrapped in `Some`.
     #[test]
-    fn label_filter_from_rpc_without_value() {
-        let rpc_label = rpc::forge::Label {
-            key: "env".to_string(),
-            value: None,
-        };
-        let filter = LabelFilter::from(rpc_label);
-        assert_eq!(filter.key, "env");
-        assert_eq!(filter.value, None);
+    fn metadata_into_rpc() {
+        type Projected = (String, String, Vec<(String, Option<String>)>);
+
+        check_values(
+            [
+                Check {
+                    scenario: "name and description pass through, no labels",
+                    input: Metadata {
+                        name: "web".to_string(),
+                        description: "front end".to_string(),
+                        labels: HashMap::new(),
+                    },
+                    expect: ("web".to_string(), "front end".to_string(), vec![]),
+                },
+                Check {
+                    scenario: "empty fields pass through",
+                    input: Metadata::default(),
+                    expect: (String::new(), String::new(), vec![]),
+                },
+                Check {
+                    scenario: "non-empty label value becomes Some",
+                    input: Metadata {
+                        name: "n".to_string(),
+                        description: "d".to_string(),
+                        labels: HashMap::from([("env".to_string(), "prod".to_string())]),
+                    },
+                    expect: (
+                        "n".to_string(),
+                        "d".to_string(),
+                        vec![("env".to_string(), Some("prod".to_string()))],
+                    ),
+                },
+                Check {
+                    scenario: "empty label value collapses to None",
+                    input: Metadata {
+                        name: "n".to_string(),
+                        description: "d".to_string(),
+                        labels: HashMap::from([("env".to_string(), String::new())]),
+                    },
+                    expect: (
+                        "n".to_string(),
+                        "d".to_string(),
+                        vec![("env".to_string(), None)],
+                    ),
+                },
+                Check {
+                    scenario: "mixed empty and non-empty label values",
+                    input: Metadata {
+                        name: "n".to_string(),
+                        description: "d".to_string(),
+                        labels: HashMap::from([
+                            ("a".to_string(), "1".to_string()),
+                            ("b".to_string(), String::new()),
+                        ]),
+                    },
+                    expect: (
+                        "n".to_string(),
+                        "d".to_string(),
+                        vec![
+                            ("a".to_string(), Some("1".to_string())),
+                            ("b".to_string(), None),
+                        ],
+                    ),
+                },
+            ],
+            |metadata| -> Projected {
+                let proto = rpc::Metadata::from(metadata);
+                let mut labels: Vec<(String, Option<String>)> = proto
+                    .labels
+                    .into_iter()
+                    .map(|label| (label.key, label.value))
+                    .collect();
+                labels.sort();
+                (proto.name, proto.description, labels)
+            },
+        );
     }
 
+    // `rpc::Metadata -> Metadata` is fallible: a duplicate label key is the one
+    // error arm. The error type carries non-PartialEq `#[from]` variants, so the
+    // failing rows use `Fails`. Project the Ok result to (name, description,
+    // sorted labels) for order-independent comparison.
     #[test]
-    fn label_filter_from_rpc_empty_key() {
-        let rpc_label = rpc::forge::Label {
-            key: String::new(),
-            value: Some("prod".to_string()),
-        };
-        let filter = LabelFilter::from(rpc_label);
-        assert!(filter.key.is_empty());
-        assert_eq!(filter.value, Some("prod".to_string()));
+    fn metadata_try_from_rpc() {
+        type Projected = (String, String, Vec<(String, String)>);
+
+        fn label(key: &str, value: Option<&str>) -> rpc::forge::Label {
+            rpc::forge::Label {
+                key: key.to_string(),
+                value: value.map(str::to_string),
+            }
+        }
+
+        check_cases(
+            [
+                Case {
+                    scenario: "no labels",
+                    input: rpc::Metadata {
+                        name: "web".to_string(),
+                        description: "front end".to_string(),
+                        labels: vec![],
+                    },
+                    expect: Yields(("web".to_string(), "front end".to_string(), vec![])),
+                },
+                Case {
+                    scenario: "empty fields",
+                    input: rpc::Metadata {
+                        name: String::new(),
+                        description: String::new(),
+                        labels: vec![],
+                    },
+                    expect: Yields((String::new(), String::new(), vec![])),
+                },
+                Case {
+                    scenario: "label with value",
+                    input: rpc::Metadata {
+                        name: "n".to_string(),
+                        description: "d".to_string(),
+                        labels: vec![label("env", Some("prod"))],
+                    },
+                    expect: Yields((
+                        "n".to_string(),
+                        "d".to_string(),
+                        vec![("env".to_string(), "prod".to_string())],
+                    )),
+                },
+                Case {
+                    scenario: "absent label value defaults to empty string",
+                    input: rpc::Metadata {
+                        name: "n".to_string(),
+                        description: "d".to_string(),
+                        labels: vec![label("env", None)],
+                    },
+                    expect: Yields((
+                        "n".to_string(),
+                        "d".to_string(),
+                        vec![("env".to_string(), String::new())],
+                    )),
+                },
+                Case {
+                    scenario: "multiple distinct keys",
+                    input: rpc::Metadata {
+                        name: "n".to_string(),
+                        description: "d".to_string(),
+                        labels: vec![label("a", Some("1")), label("b", Some("2"))],
+                    },
+                    expect: Yields((
+                        "n".to_string(),
+                        "d".to_string(),
+                        vec![
+                            ("a".to_string(), "1".to_string()),
+                            ("b".to_string(), "2".to_string()),
+                        ],
+                    )),
+                },
+                Case {
+                    scenario: "duplicate key fails",
+                    input: rpc::Metadata {
+                        name: "n".to_string(),
+                        description: "d".to_string(),
+                        labels: vec![label("env", Some("a")), label("env", Some("b"))],
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "duplicate key with differing present/absent values fails",
+                    input: rpc::Metadata {
+                        name: "n".to_string(),
+                        description: "d".to_string(),
+                        labels: vec![label("env", Some("a")), label("env", None)],
+                    },
+                    expect: Fails,
+                },
+            ],
+            |proto| -> Result<Projected, ()> {
+                let metadata = Metadata::try_from(proto).map_err(drop)?;
+                let mut labels: Vec<(String, String)> = metadata.labels.into_iter().collect();
+                labels.sort();
+                Ok((metadata.name, metadata.description, labels))
+            },
+        );
     }
 }

--- a/crates/rpc/src/model/network_security_group.rs
+++ b/crates/rpc/src/model/network_security_group.rs
@@ -629,147 +629,144 @@ impl TryFrom<rpc::NetworkSecurityGroupStatus> for NetworkSecurityGroupStatusObse
 mod tests {
     use std::collections::HashMap;
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
     use config_version::ConfigVersion;
     use model::metadata::Metadata;
 
     use super::*;
     use crate::forge as rpc;
 
+    // `From<NetworkSecurityGroupPropagationObjectStatus>` derives the propagation
+    // status (and any details) from the applied-vs-expected interface counts.
     #[test]
     fn test_model_nsg_prop_obj_status_to_rpc_conversion() {
-        // Full
-        let req_type = rpc::NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusFull.into(),
-            details: None,
-            unpropagated_instance_ids: vec![],
-            related_instance_ids: vec![],
-        };
-
-        let status = NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            interfaces_expected: 0,
-            interfaces_applied: 0,
-            unpropagated_instance_ids: vec![],
-            related_instance_ids: vec![],
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::NetworkSecurityGroupPropagationObjectStatus::from(status)
-        );
-
-        let req_type = rpc::NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusFull.into(),
-            details: None,
-            related_instance_ids: vec![
-                "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+        check_values(
+            [
+                Check {
+                    scenario: "full, no interfaces",
+                    input: NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        interfaces_expected: 0,
+                        interfaces_applied: 0,
+                        unpropagated_instance_ids: vec![],
+                        related_instance_ids: vec![],
+                    },
+                    expect: rpc::NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusFull
+                            .into(),
+                        details: None,
+                        unpropagated_instance_ids: vec![],
+                        related_instance_ids: vec![],
+                    },
+                },
+                Check {
+                    scenario: "full, all interfaces applied",
+                    input: NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        interfaces_expected: 2,
+                        interfaces_applied: 2,
+                        related_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
+                        ],
+                        unpropagated_instance_ids: vec![],
+                    },
+                    expect: rpc::NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusFull
+                            .into(),
+                        details: None,
+                        related_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+                        ],
+                        unpropagated_instance_ids: vec![],
+                    },
+                },
+                Check {
+                    scenario: "partial, some interfaces applied",
+                    input: NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        interfaces_expected: 2,
+                        interfaces_applied: 1,
+                        related_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
+                        ],
+                        unpropagated_instance_ids: vec![
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
+                        ],
+                    },
+                    expect: rpc::NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusPartial
+                            .into(),
+                        details: None,
+                        related_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+                        ],
+                        unpropagated_instance_ids: vec![
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+                        ],
+                    },
+                },
+                Check {
+                    scenario: "none, no interfaces applied",
+                    input: NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        interfaces_expected: 2,
+                        interfaces_applied: 0,
+                        related_instance_ids: vec![],
+                        unpropagated_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
+                        ],
+                    },
+                    expect: rpc::NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusNone
+                            .into(),
+                        details: None,
+                        related_instance_ids: vec![],
+                        unpropagated_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+                        ],
+                    },
+                },
+                Check {
+                    scenario: "unknown, applied exceeds expected",
+                    input: NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        interfaces_expected: 1,
+                        interfaces_applied: 2,
+                        related_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
+                        ],
+                        unpropagated_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
+                        ],
+                    },
+                    expect: rpc::NetworkSecurityGroupPropagationObjectStatus {
+                        id: "any_id".to_string(),
+                        status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusUnknown
+                            .into(),
+                        details: Some("propagated objects exceeds expected objects".to_string()),
+                        related_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
+                        ],
+                        unpropagated_instance_ids: vec![
+                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
+                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+                        ],
+                    },
+                },
             ],
-            unpropagated_instance_ids: vec![],
-        };
-
-        let status = NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            interfaces_expected: 2,
-            interfaces_applied: 2,
-            related_instance_ids: vec![
-                "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
-            ],
-            unpropagated_instance_ids: vec![],
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::NetworkSecurityGroupPropagationObjectStatus::from(status)
-        );
-
-        // Partial
-        let req_type = rpc::NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusPartial.into(),
-            details: None,
-            related_instance_ids: vec![
-                "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
-            ],
-            unpropagated_instance_ids: vec!["fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string()],
-        };
-
-        let status = NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            interfaces_expected: 2,
-            interfaces_applied: 1,
-            related_instance_ids: vec![
-                "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
-            ],
-            unpropagated_instance_ids: vec![
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
-            ],
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::NetworkSecurityGroupPropagationObjectStatus::from(status)
-        );
-
-        // None
-        let req_type = rpc::NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusNone.into(),
-            details: None,
-            related_instance_ids: vec![],
-            unpropagated_instance_ids: vec![
-                "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
-            ],
-        };
-
-        let status = NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            interfaces_expected: 2,
-            interfaces_applied: 0,
-            related_instance_ids: vec![],
-            unpropagated_instance_ids: vec![
-                "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
-            ],
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::NetworkSecurityGroupPropagationObjectStatus::from(status)
-        );
-
-        // Unknown
-        let req_type = rpc::NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusUnknown.into(),
-            details: Some("propagated objects exceeds expected objects".to_string()),
-            related_instance_ids: vec!["200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap()],
-            unpropagated_instance_ids: vec![
-                "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
-            ],
-        };
-
-        let status = NetworkSecurityGroupPropagationObjectStatus {
-            id: "any_id".to_string(),
-            interfaces_expected: 1,
-            interfaces_applied: 2,
-            related_instance_ids: vec!["200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap()],
-            unpropagated_instance_ids: vec![
-                "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
-                "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
-            ],
-        };
-
-        assert_eq!(
-            req_type,
-            rpc::NetworkSecurityGroupPropagationObjectStatus::from(status)
+            rpc::NetworkSecurityGroupPropagationObjectStatus::from,
         );
     }
 
@@ -854,182 +851,204 @@ mod tests {
         assert_eq!(req_type, rpc::NetworkSecurityGroup::try_from(nsg).unwrap());
     }
 
+    // `TryFrom<rpc::NetworkSecurityGroupRuleAttributes>` rejects ill-formed rules:
+    // ports on port-less protocols, and prefix/protocol IP-version mismatches.
     #[test]
     fn test_rpc_rule_to_nsg_model_rule_conversion_failures() {
-        // ICMP with ports should fail
-        let req = rpc::NetworkSecurityGroupRuleAttributes {
-            id: Some("anything".to_string()),
-            direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
-            ipv6: false,
-            src_port_start: Some(80),
-            src_port_end: Some(32768),
-            dst_port_start: Some(80),
-            dst_port_end: Some(32768),
-            protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
-            action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-            priority: 9001,
-            source_net: Some(
-                rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                    "0.0.0.0/0".to_string(),
-                ),
-            ),
-            destination_net: Some(
-                rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                    "0.0.0.0/0".to_string(),
-                ),
-            ),
-        };
-        NetworkSecurityGroupRule::try_from(req).unwrap_err();
-
-        // ICMP6 with ports should fail
-        let req = rpc::NetworkSecurityGroupRuleAttributes {
-            id: Some("anything".to_string()),
-            direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
-            ipv6: true,
-            src_port_start: Some(80),
-            src_port_end: Some(32768),
-            dst_port_start: Some(80),
-            dst_port_end: Some(32768),
-            protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
-            action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-            priority: 9001,
-            source_net: Some(
-                rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                    "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                ),
-            ),
-            destination_net: Some(
-                rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                    "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                ),
-            ),
-        };
-        NetworkSecurityGroupRule::try_from(req).unwrap_err();
-
-        // ANY with ports should fail
-        let req = rpc::NetworkSecurityGroupRuleAttributes {
-            id: Some("anything".to_string()),
-            direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
-            ipv6: true,
-            src_port_start: Some(80),
-            src_port_end: Some(32768),
-            dst_port_start: Some(80),
-            dst_port_end: Some(32768),
-            protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoAny.into(),
-            action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-            priority: 9001,
-            source_net: Some(
-                rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                    "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                ),
-            ),
-            destination_net: Some(
-                rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                    "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                ),
-            ),
-        };
-        NetworkSecurityGroupRule::try_from(req).unwrap_err();
-
-        // v4 prefixes with v6 rule should fail
-        let req = rpc::NetworkSecurityGroupRuleAttributes {
-            id: Some("anything".to_string()),
-            direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
-            ipv6: true,
-            src_port_start: Some(80),
-            src_port_end: Some(32768),
-            dst_port_start: Some(80),
-            dst_port_end: Some(32768),
-            protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoTcp.into(),
-            action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-            priority: 9001,
-            source_net: Some(
-                rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                    "0.0.0.0/0".to_string(),
-                ),
-            ),
-            destination_net: Some(
-                rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                    "0.0.0.0/0".to_string(),
-                ),
-            ),
-        };
-        NetworkSecurityGroupRule::try_from(req).unwrap_err();
-
-        // v6 prefixes with v4 rule should fail
-        let req = rpc::NetworkSecurityGroupRuleAttributes {
-            id: Some("anything".to_string()),
-            direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
-            ipv6: false,
-            src_port_start: Some(80),
-            src_port_end: Some(32768),
-            dst_port_start: Some(80),
-            dst_port_end: Some(32768),
-            protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoTcp.into(),
-            action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-            priority: 9001,
-            source_net: Some(
-                rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                    "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                ),
-            ),
-            destination_net: Some(
-                rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                    "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                ),
-            ),
-        };
-        NetworkSecurityGroupRule::try_from(req).unwrap_err();
-
-        // ICMP6 with v4 rule should fail
-        let req = rpc::NetworkSecurityGroupRuleAttributes {
-            id: Some("anything".to_string()),
-            direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
-            ipv6: false,
-            src_port_start: None,
-            src_port_end: None,
-            dst_port_start: None,
-            dst_port_end: None,
-            protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp6.into(),
-            action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-            priority: 9001,
-            source_net: Some(
-                rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                    "1.1.1.1/24".to_string(),
-                ),
-            ),
-            destination_net: Some(
-                rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                    "1.1.1.1/24".to_string(),
-                ),
-            ),
-        };
-        NetworkSecurityGroupRule::try_from(req).unwrap_err();
-
-        // ICMP6 with v4 rule should fail
-        let req = rpc::NetworkSecurityGroupRuleAttributes {
-            id: Some("anything".to_string()),
-            direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
-            ipv6: true,
-            src_port_start: None,
-            src_port_end: None,
-            dst_port_start: None,
-            dst_port_end: None,
-            protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
-            action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-            priority: 9001,
-            source_net: Some(
-                rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                    "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                ),
-            ),
-            destination_net: Some(
-                rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                    "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                ),
-            ),
-        };
-        NetworkSecurityGroupRule::try_from(req).unwrap_err();
+        check_cases(
+            [
+                Case {
+                    scenario: "ICMP with ports",
+                    input: rpc::NetworkSecurityGroupRuleAttributes {
+                        id: Some("anything".to_string()),
+                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                            .into(),
+                        ipv6: false,
+                        src_port_start: Some(80),
+                        src_port_end: Some(32768),
+                        dst_port_start: Some(80),
+                        dst_port_end: Some(32768),
+                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
+                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                        priority: 9001,
+                        source_net: Some(
+                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                                "0.0.0.0/0".to_string(),
+                            ),
+                        ),
+                        destination_net: Some(
+                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                                "0.0.0.0/0".to_string(),
+                            ),
+                        ),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ICMP6 with ports",
+                    input: rpc::NetworkSecurityGroupRuleAttributes {
+                        id: Some("anything".to_string()),
+                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                            .into(),
+                        ipv6: true,
+                        src_port_start: Some(80),
+                        src_port_end: Some(32768),
+                        dst_port_start: Some(80),
+                        dst_port_end: Some(32768),
+                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
+                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                        priority: 9001,
+                        source_net: Some(
+                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
+                            ),
+                        ),
+                        destination_net: Some(
+                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
+                            ),
+                        ),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ANY with ports",
+                    input: rpc::NetworkSecurityGroupRuleAttributes {
+                        id: Some("anything".to_string()),
+                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                            .into(),
+                        ipv6: true,
+                        src_port_start: Some(80),
+                        src_port_end: Some(32768),
+                        dst_port_start: Some(80),
+                        dst_port_end: Some(32768),
+                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoAny.into(),
+                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                        priority: 9001,
+                        source_net: Some(
+                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
+                            ),
+                        ),
+                        destination_net: Some(
+                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
+                            ),
+                        ),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "v4 prefixes with v6 rule",
+                    input: rpc::NetworkSecurityGroupRuleAttributes {
+                        id: Some("anything".to_string()),
+                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                            .into(),
+                        ipv6: true,
+                        src_port_start: Some(80),
+                        src_port_end: Some(32768),
+                        dst_port_start: Some(80),
+                        dst_port_end: Some(32768),
+                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoTcp.into(),
+                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                        priority: 9001,
+                        source_net: Some(
+                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                                "0.0.0.0/0".to_string(),
+                            ),
+                        ),
+                        destination_net: Some(
+                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                                "0.0.0.0/0".to_string(),
+                            ),
+                        ),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "v6 prefixes with v4 rule",
+                    input: rpc::NetworkSecurityGroupRuleAttributes {
+                        id: Some("anything".to_string()),
+                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                            .into(),
+                        ipv6: false,
+                        src_port_start: Some(80),
+                        src_port_end: Some(32768),
+                        dst_port_start: Some(80),
+                        dst_port_end: Some(32768),
+                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoTcp.into(),
+                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                        priority: 9001,
+                        source_net: Some(
+                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
+                            ),
+                        ),
+                        destination_net: Some(
+                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
+                            ),
+                        ),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ICMP6 with v4 prefixes on v4 rule",
+                    input: rpc::NetworkSecurityGroupRuleAttributes {
+                        id: Some("anything".to_string()),
+                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                            .into(),
+                        ipv6: false,
+                        src_port_start: None,
+                        src_port_end: None,
+                        dst_port_start: None,
+                        dst_port_end: None,
+                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp6.into(),
+                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                        priority: 9001,
+                        source_net: Some(
+                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                                "1.1.1.1/24".to_string(),
+                            ),
+                        ),
+                        destination_net: Some(
+                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                                "1.1.1.1/24".to_string(),
+                            ),
+                        ),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ICMP on v6 rule",
+                    input: rpc::NetworkSecurityGroupRuleAttributes {
+                        id: Some("anything".to_string()),
+                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                            .into(),
+                        ipv6: true,
+                        src_port_start: None,
+                        src_port_end: None,
+                        dst_port_start: None,
+                        dst_port_end: None,
+                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
+                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                        priority: 9001,
+                        source_net: Some(
+                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
+                            ),
+                        ),
+                        destination_net: Some(
+                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
+                            ),
+                        ),
+                    },
+                    expect: Fails,
+                },
+            ],
+            |req| NetworkSecurityGroupRule::try_from(req).map_err(drop),
+        );
     }
 
     #[test]
@@ -1060,5 +1079,685 @@ mod tests {
         };
 
         assert_eq!(req_type, rpc::NetworkSecurityGroupAttachments::from(status));
+    }
+
+    // `From<NetworkSecurityGroupSource>` maps each domain source onto its rpc enum.
+    #[test]
+    fn test_model_source_to_rpc() {
+        check_values(
+            [
+                Check {
+                    scenario: "none",
+                    input: NetworkSecurityGroupSource::None,
+                    expect: rpc::NetworkSecurityGroupSource::NsgSourceNone,
+                },
+                Check {
+                    scenario: "vpc",
+                    input: NetworkSecurityGroupSource::Vpc,
+                    expect: rpc::NetworkSecurityGroupSource::NsgSourceVpc,
+                },
+                Check {
+                    scenario: "instance",
+                    input: NetworkSecurityGroupSource::Instance,
+                    expect: rpc::NetworkSecurityGroupSource::NsgSourceInstance,
+                },
+            ],
+            rpc::NetworkSecurityGroupSource::from,
+        );
+    }
+
+    // `TryFrom<rpc::NetworkSecurityGroupSource>`: each valid arm maps back, and the
+    // `Invalid` sentinel is rejected.
+    #[test]
+    fn test_rpc_source_to_model() {
+        check_cases(
+            [
+                Case {
+                    scenario: "none",
+                    input: rpc::NetworkSecurityGroupSource::NsgSourceNone,
+                    expect: Yields(NetworkSecurityGroupSource::None),
+                },
+                Case {
+                    scenario: "vpc",
+                    input: rpc::NetworkSecurityGroupSource::NsgSourceVpc,
+                    expect: Yields(NetworkSecurityGroupSource::Vpc),
+                },
+                Case {
+                    scenario: "instance",
+                    input: rpc::NetworkSecurityGroupSource::NsgSourceInstance,
+                    expect: Yields(NetworkSecurityGroupSource::Instance),
+                },
+                Case {
+                    scenario: "invalid is rejected",
+                    input: rpc::NetworkSecurityGroupSource::NsgSourceInvalid,
+                    expect: Fails,
+                },
+            ],
+            |s| NetworkSecurityGroupSource::try_from(s).map_err(drop),
+        );
+    }
+
+    // `From<NetworkSecurityGroupPropagationStatus>` maps each domain status onto its
+    // rpc enum.
+    #[test]
+    fn test_model_prop_status_to_rpc() {
+        check_values(
+            [
+                Check {
+                    scenario: "unknown",
+                    input: NetworkSecurityGroupPropagationStatus::Unknown,
+                    expect: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusUnknown,
+                },
+                Check {
+                    scenario: "full",
+                    input: NetworkSecurityGroupPropagationStatus::Full,
+                    expect: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusFull,
+                },
+                Check {
+                    scenario: "partial",
+                    input: NetworkSecurityGroupPropagationStatus::Partial,
+                    expect: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusPartial,
+                },
+                Check {
+                    scenario: "none",
+                    input: NetworkSecurityGroupPropagationStatus::None,
+                    expect: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusNone,
+                },
+                Check {
+                    scenario: "error",
+                    input: NetworkSecurityGroupPropagationStatus::Error,
+                    expect: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusError,
+                },
+            ],
+            rpc::NetworkSecurityGroupPropagationStatus::from,
+        );
+    }
+
+    // `TryFrom<rpc::NetworkSecurityGroupPropagationStatus>` maps every arm back; this
+    // conversion is total over the rpc enum (no `Invalid` rejection path).
+    #[test]
+    fn test_rpc_prop_status_to_model() {
+        check_cases(
+            [
+                Case {
+                    scenario: "unknown",
+                    input: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusUnknown,
+                    expect: Yields(NetworkSecurityGroupPropagationStatus::Unknown),
+                },
+                Case {
+                    scenario: "full",
+                    input: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusFull,
+                    expect: Yields(NetworkSecurityGroupPropagationStatus::Full),
+                },
+                Case {
+                    scenario: "partial",
+                    input: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusPartial,
+                    expect: Yields(NetworkSecurityGroupPropagationStatus::Partial),
+                },
+                Case {
+                    scenario: "none",
+                    input: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusNone,
+                    expect: Yields(NetworkSecurityGroupPropagationStatus::None),
+                },
+                Case {
+                    scenario: "error",
+                    input: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusError,
+                    expect: Yields(NetworkSecurityGroupPropagationStatus::Error),
+                },
+            ],
+            |s| NetworkSecurityGroupPropagationStatus::try_from(s).map_err(drop),
+        );
+    }
+
+    // `From<NetworkSecurityGroupRuleDirection>` maps both directions onto the rpc enum.
+    #[test]
+    fn test_model_direction_to_rpc() {
+        check_values(
+            [
+                Check {
+                    scenario: "ingress",
+                    input: NetworkSecurityGroupRuleDirection::Ingress,
+                    expect: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress,
+                },
+                Check {
+                    scenario: "egress",
+                    input: NetworkSecurityGroupRuleDirection::Egress,
+                    expect: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionEgress,
+                },
+            ],
+            rpc::NetworkSecurityGroupRuleDirection::from,
+        );
+    }
+
+    // `TryFrom<rpc::NetworkSecurityGroupRuleDirection>`: both directions map back, the
+    // `Invalid` sentinel is rejected.
+    #[test]
+    fn test_rpc_direction_to_model() {
+        check_cases(
+            [
+                Case {
+                    scenario: "ingress",
+                    input: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress,
+                    expect: Yields(NetworkSecurityGroupRuleDirection::Ingress),
+                },
+                Case {
+                    scenario: "egress",
+                    input: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionEgress,
+                    expect: Yields(NetworkSecurityGroupRuleDirection::Egress),
+                },
+                Case {
+                    scenario: "invalid is rejected",
+                    input: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionInvalid,
+                    expect: Fails,
+                },
+            ],
+            |d| NetworkSecurityGroupRuleDirection::try_from(d).map_err(drop),
+        );
+    }
+
+    // `From<NetworkSecurityGroupRuleProtocol>` maps each protocol onto the rpc enum.
+    #[test]
+    fn test_model_protocol_to_rpc() {
+        check_values(
+            [
+                Check {
+                    scenario: "any",
+                    input: NetworkSecurityGroupRuleProtocol::Any,
+                    expect: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoAny,
+                },
+                Check {
+                    scenario: "icmp",
+                    input: NetworkSecurityGroupRuleProtocol::Icmp,
+                    expect: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp,
+                },
+                Check {
+                    scenario: "icmp6",
+                    input: NetworkSecurityGroupRuleProtocol::Icmp6,
+                    expect: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp6,
+                },
+                Check {
+                    scenario: "udp",
+                    input: NetworkSecurityGroupRuleProtocol::Udp,
+                    expect: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoUdp,
+                },
+                Check {
+                    scenario: "tcp",
+                    input: NetworkSecurityGroupRuleProtocol::Tcp,
+                    expect: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoTcp,
+                },
+            ],
+            rpc::NetworkSecurityGroupRuleProtocol::from,
+        );
+    }
+
+    // `TryFrom<rpc::NetworkSecurityGroupRuleProtocol>`: each protocol maps back, the
+    // `Invalid` sentinel is rejected.
+    #[test]
+    fn test_rpc_protocol_to_model() {
+        check_cases(
+            [
+                Case {
+                    scenario: "any",
+                    input: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoAny,
+                    expect: Yields(NetworkSecurityGroupRuleProtocol::Any),
+                },
+                Case {
+                    scenario: "icmp",
+                    input: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp,
+                    expect: Yields(NetworkSecurityGroupRuleProtocol::Icmp),
+                },
+                Case {
+                    scenario: "icmp6",
+                    input: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp6,
+                    expect: Yields(NetworkSecurityGroupRuleProtocol::Icmp6),
+                },
+                Case {
+                    scenario: "udp",
+                    input: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoUdp,
+                    expect: Yields(NetworkSecurityGroupRuleProtocol::Udp),
+                },
+                Case {
+                    scenario: "tcp",
+                    input: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoTcp,
+                    expect: Yields(NetworkSecurityGroupRuleProtocol::Tcp),
+                },
+                Case {
+                    scenario: "invalid is rejected",
+                    input: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoInvalid,
+                    expect: Fails,
+                },
+            ],
+            |p| NetworkSecurityGroupRuleProtocol::try_from(p).map_err(drop),
+        );
+    }
+
+    // `From<NetworkSecurityGroupRuleAction>` maps both actions onto the rpc enum.
+    #[test]
+    fn test_model_action_to_rpc() {
+        check_values(
+            [
+                Check {
+                    scenario: "deny",
+                    input: NetworkSecurityGroupRuleAction::Deny,
+                    expect: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny,
+                },
+                Check {
+                    scenario: "permit",
+                    input: NetworkSecurityGroupRuleAction::Permit,
+                    expect: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionPermit,
+                },
+            ],
+            rpc::NetworkSecurityGroupRuleAction::from,
+        );
+    }
+
+    // `TryFrom<rpc::NetworkSecurityGroupRuleAction>`: both actions map back, the
+    // `Invalid` sentinel is rejected.
+    #[test]
+    fn test_rpc_action_to_model() {
+        check_cases(
+            [
+                Case {
+                    scenario: "deny",
+                    input: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny,
+                    expect: Yields(NetworkSecurityGroupRuleAction::Deny),
+                },
+                Case {
+                    scenario: "permit",
+                    input: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionPermit,
+                    expect: Yields(NetworkSecurityGroupRuleAction::Permit),
+                },
+                Case {
+                    scenario: "invalid is rejected",
+                    input: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionInvalid,
+                    expect: Fails,
+                },
+            ],
+            |a| NetworkSecurityGroupRuleAction::try_from(a).map_err(drop),
+        );
+    }
+
+    // `TryFrom<rpc::...::SourceNet>` parses the prefix string into a `Prefix`, and a
+    // malformed prefix is rejected.
+    #[test]
+    fn test_rpc_source_net_to_model() {
+        check_cases(
+            [
+                Case {
+                    scenario: "v4 prefix parses",
+                    input: rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                        "10.0.0.0/8".to_string(),
+                    ),
+                    expect: Yields(NetworkSecurityGroupRuleNet::Prefix(
+                        "10.0.0.0/8".parse().unwrap(),
+                    )),
+                },
+                Case {
+                    scenario: "v6 prefix parses",
+                    input: rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                        "2001:db8::/32".to_string(),
+                    ),
+                    expect: Yields(NetworkSecurityGroupRuleNet::Prefix(
+                        "2001:db8::/32".parse().unwrap(),
+                    )),
+                },
+                Case {
+                    scenario: "garbage prefix is rejected",
+                    input: rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                        "not-an-ip".to_string(),
+                    ),
+                    expect: Fails,
+                },
+            ],
+            |n| NetworkSecurityGroupRuleNet::try_from(n).map_err(drop),
+        );
+    }
+
+    // `TryFrom<rpc::...::DestinationNet>` parses the prefix string into a `Prefix`,
+    // and a malformed prefix is rejected.
+    #[test]
+    fn test_rpc_destination_net_to_model() {
+        check_cases(
+            [
+                Case {
+                    scenario: "v4 prefix parses",
+                    input: rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                        "192.168.0.0/16".to_string(),
+                    ),
+                    expect: Yields(NetworkSecurityGroupRuleNet::Prefix(
+                        "192.168.0.0/16".parse().unwrap(),
+                    )),
+                },
+                Case {
+                    scenario: "v6 prefix parses",
+                    input: rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                        "fd00::/8".to_string(),
+                    ),
+                    expect: Yields(NetworkSecurityGroupRuleNet::Prefix(
+                        "fd00::/8".parse().unwrap(),
+                    )),
+                },
+                Case {
+                    scenario: "garbage prefix is rejected",
+                    input: rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                        "999.0.0.0/8".to_string(),
+                    ),
+                    expect: Fails,
+                },
+            ],
+            |n| NetworkSecurityGroupRuleNet::try_from(n).map_err(drop),
+        );
+    }
+
+    // `TryFrom<NetworkSecurityGroupRuleNet>` for the rpc `SourceNet` / `DestinationNet`
+    // renders the prefix back to its string form.
+    #[test]
+    fn test_model_net_to_rpc() {
+        check_cases(
+            [
+                Case {
+                    scenario: "source net renders v4 prefix",
+                    input: NetworkSecurityGroupRuleNet::Prefix("10.0.0.0/8".parse().unwrap()),
+                    expect: Yields(
+                        rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                            "10.0.0.0/8".to_string(),
+                        ),
+                    ),
+                },
+                Case {
+                    scenario: "source net renders v6 prefix",
+                    input: NetworkSecurityGroupRuleNet::Prefix("2001:db8::/32".parse().unwrap()),
+                    expect: Yields(
+                        rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                            "2001:db8::/32".to_string(),
+                        ),
+                    ),
+                },
+            ],
+            |n| {
+                rpc::network_security_group_rule_attributes::SourceNet::try_from(n).map_err(drop)
+            },
+        );
+
+        check_cases(
+            [Case {
+                scenario: "destination net renders v4 prefix",
+                input: NetworkSecurityGroupRuleNet::Prefix("192.168.0.0/16".parse().unwrap()),
+                expect: Yields(
+                    rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                        "192.168.0.0/16".to_string(),
+                    ),
+                ),
+            }],
+            |n| {
+                rpc::network_security_group_rule_attributes::DestinationNet::try_from(n)
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // A well-formed rule that carries a fixed id round-trips through
+    // `TryFrom<rpc::NetworkSecurityGroupRuleAttributes>`.
+    #[test]
+    fn test_rpc_rule_to_model_succeeds() {
+        let attrs = rpc::NetworkSecurityGroupRuleAttributes {
+            id: Some("anything".to_string()),
+            direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
+            ipv6: false,
+            src_port_start: Some(80),
+            src_port_end: Some(32768),
+            dst_port_start: Some(80),
+            dst_port_end: Some(32768),
+            protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoTcp.into(),
+            action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+            priority: 9001,
+            source_net: Some(
+                rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                    "0.0.0.0/0".to_string(),
+                ),
+            ),
+            destination_net: Some(
+                rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                    "0.0.0.0/0".to_string(),
+                ),
+            ),
+        };
+
+        Case {
+            scenario: "well-formed tcp rule converts",
+            input: attrs,
+            expect: Yields(NetworkSecurityGroupRule {
+                id: Some("anything".to_string()),
+                direction: NetworkSecurityGroupRuleDirection::Ingress,
+                ipv6: false,
+                src_port_start: Some(80),
+                src_port_end: Some(32768),
+                dst_port_start: Some(80),
+                dst_port_end: Some(32768),
+                protocol: NetworkSecurityGroupRuleProtocol::Tcp,
+                action: NetworkSecurityGroupRuleAction::Deny,
+                priority: 9001,
+                src_net: NetworkSecurityGroupRuleNet::Prefix("0.0.0.0/0".parse().unwrap()),
+                dst_net: NetworkSecurityGroupRuleNet::Prefix("0.0.0.0/0".parse().unwrap()),
+            }),
+        }
+        .check(|req| NetworkSecurityGroupRule::try_from(req).map_err(drop));
+    }
+
+    // More `TryFrom<rpc::NetworkSecurityGroupRuleAttributes>` rejection paths: a
+    // priority over the cap, half-specified port ranges, an inverted range, and
+    // missing source/destination nets.
+    #[test]
+    fn test_rpc_rule_to_model_more_failures() {
+        // A v4 tcp rule template; rows below mutate just the field under test.
+        let base = || rpc::NetworkSecurityGroupRuleAttributes {
+            id: Some("anything".to_string()),
+            direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress.into(),
+            ipv6: false,
+            src_port_start: None,
+            src_port_end: None,
+            dst_port_start: None,
+            dst_port_end: None,
+            protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoTcp.into(),
+            action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+            priority: 100,
+            source_net: Some(
+                rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                    "0.0.0.0/0".to_string(),
+                ),
+            ),
+            destination_net: Some(
+                rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                    "0.0.0.0/0".to_string(),
+                ),
+            ),
+        };
+
+        let priority_too_high = rpc::NetworkSecurityGroupRuleAttributes {
+            priority: MAX_RULE_PRIORITY + 1,
+            ..base()
+        };
+        let src_port_half = rpc::NetworkSecurityGroupRuleAttributes {
+            src_port_start: Some(80),
+            src_port_end: None,
+            ..base()
+        };
+        let dst_port_half = rpc::NetworkSecurityGroupRuleAttributes {
+            dst_port_start: None,
+            dst_port_end: Some(80),
+            ..base()
+        };
+        let src_range_inverted = rpc::NetworkSecurityGroupRuleAttributes {
+            src_port_start: Some(200),
+            src_port_end: Some(100),
+            ..base()
+        };
+        let dst_range_inverted = rpc::NetworkSecurityGroupRuleAttributes {
+            dst_port_start: Some(200),
+            dst_port_end: Some(100),
+            ..base()
+        };
+        let missing_src_net = rpc::NetworkSecurityGroupRuleAttributes {
+            source_net: None,
+            ..base()
+        };
+        let missing_dst_net = rpc::NetworkSecurityGroupRuleAttributes {
+            destination_net: None,
+            ..base()
+        };
+
+        check_cases(
+            [
+                Case {
+                    scenario: "priority over the cap",
+                    input: priority_too_high,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "src port range half-specified",
+                    input: src_port_half,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "dst port range half-specified",
+                    input: dst_port_half,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "src port range inverted",
+                    input: src_range_inverted,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "dst port range inverted",
+                    input: dst_range_inverted,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing source net",
+                    input: missing_src_net,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing destination net",
+                    input: missing_dst_net,
+                    expect: Fails,
+                },
+            ],
+            |req| NetworkSecurityGroupRule::try_from(req).map_err(drop),
+        );
+    }
+
+    // `TryFrom<NetworkSecurityGroupRule>` for rpc renders the rule's nets, ports, and
+    // enums back into proto attribute form.
+    #[test]
+    fn test_model_rule_to_rpc_succeeds() {
+        let rule = NetworkSecurityGroupRule {
+            id: Some("anything".to_string()),
+            direction: NetworkSecurityGroupRuleDirection::Egress,
+            ipv6: false,
+            src_port_start: Some(80),
+            src_port_end: Some(32768),
+            dst_port_start: Some(81),
+            dst_port_end: Some(32769),
+            protocol: NetworkSecurityGroupRuleProtocol::Udp,
+            action: NetworkSecurityGroupRuleAction::Permit,
+            priority: 9001,
+            src_net: NetworkSecurityGroupRuleNet::Prefix("10.0.0.0/8".parse().unwrap()),
+            dst_net: NetworkSecurityGroupRuleNet::Prefix("192.168.0.0/16".parse().unwrap()),
+        };
+
+        Case {
+            scenario: "well-formed udp rule renders",
+            input: rule,
+            expect: Yields(rpc::NetworkSecurityGroupRuleAttributes {
+                id: Some("anything".to_string()),
+                direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionEgress.into(),
+                ipv6: false,
+                src_port_start: Some(80),
+                src_port_end: Some(32768),
+                dst_port_start: Some(81),
+                dst_port_end: Some(32769),
+                protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoUdp.into(),
+                action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionPermit.into(),
+                priority: 9001,
+                source_net: Some(
+                    rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                        "10.0.0.0/8".to_string(),
+                    ),
+                ),
+                destination_net: Some(
+                    rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                        "192.168.0.0/16".to_string(),
+                    ),
+                ),
+            }),
+        }
+        .check(|r| rpc::NetworkSecurityGroupRuleAttributes::try_from(r).map_err(drop));
+    }
+
+    // `TryFrom<rpc::NetworkSecurityGroupStatus>`: a well-formed status parses, while a
+    // bad id, a bad version, and an invalid source each fail.
+    #[test]
+    fn test_rpc_status_to_observation() {
+        // Fixed, deterministic version so the parsed-back value equals the expected
+        // one; the real `initial()` constructor stamps the current time.
+        fn fixed_version() -> ConfigVersion {
+            use std::str::FromStr;
+            ConfigVersion::from_str("V1-T1700000000000000").unwrap()
+        }
+        let good = rpc::NetworkSecurityGroupStatus {
+            id: "60d92a18-e56b-11ef-8ecd-ef90f290abf4".to_string(),
+            version: fixed_version().to_string(),
+            source: rpc::NetworkSecurityGroupSource::NsgSourceVpc.into(),
+        };
+        let bad_id = rpc::NetworkSecurityGroupStatus {
+            id: "not-a-uuid".to_string(),
+            ..good.clone()
+        };
+        let bad_version = rpc::NetworkSecurityGroupStatus {
+            version: "not-a-version".to_string(),
+            ..good.clone()
+        };
+        let invalid_source = rpc::NetworkSecurityGroupStatus {
+            source: rpc::NetworkSecurityGroupSource::NsgSourceInvalid.into(),
+            ..good.clone()
+        };
+
+        check_cases(
+            [
+                Case {
+                    scenario: "well-formed status parses",
+                    input: good,
+                    expect: Yields(NetworkSecurityGroupStatusObservation {
+                        id: "60d92a18-e56b-11ef-8ecd-ef90f290abf4".parse().unwrap(),
+                        version: fixed_version(),
+                        source: NetworkSecurityGroupSource::Vpc,
+                    }),
+                },
+                Case {
+                    // The id is a free-form string id, not UUID-validated, so a
+                    // non-uuid value passes through rather than being rejected.
+                    scenario: "non-uuid id passes through unvalidated",
+                    input: bad_id,
+                    expect: Yields(NetworkSecurityGroupStatusObservation {
+                        id: "not-a-uuid".parse().unwrap(),
+                        version: fixed_version(),
+                        source: NetworkSecurityGroupSource::Vpc,
+                    }),
+                },
+                Case {
+                    scenario: "bad version is rejected",
+                    input: bad_version,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "invalid source is rejected",
+                    input: invalid_source,
+                    expect: Fails,
+                },
+            ],
+            |s| NetworkSecurityGroupStatusObservation::try_from(s).map_err(drop),
+        );
     }
 }

--- a/crates/rpc/src/model/network_segment.rs
+++ b/crates/rpc/src/model/network_segment.rs
@@ -253,6 +253,9 @@ impl TryFrom<NetworkSegment> for rpc::NetworkSegment {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
     fn make_test_creation_request(
@@ -297,88 +300,410 @@ mod tests {
         }
     }
 
+    // Every row drives the same conversion (NewNetworkSegment::try_from): IPv6 and
+    // dual-stack prefixes are accepted (and the resulting prefix count / IPv6-ness
+    // preserved), while tenant segments reject too-small IPv4 (/31, /32) and IPv6
+    // (/127, /128) prefixes. Accepting rows project to (prefix count, first prefix
+    // is IPv6); rejecting rows assert only that the conversion fails.
     #[test]
-    fn test_ipv6_prefix_accepted() {
-        let request = make_test_creation_request(
-            vec![ipv6_prefix("2001:db8::/64")],
-            NetworkSegmentType::Admin,
-        );
-        let result = NewNetworkSegment::try_from(request);
-        assert!(result.is_ok(), "IPv6 prefix should be accepted: {result:?}");
-        let segment = result.unwrap();
-        assert_eq!(segment.prefixes.len(), 1);
-        assert!(segment.prefixes[0].prefix.is_ipv6());
-    }
-
-    #[test]
-    fn test_dual_stack_prefixes_accepted() {
-        let request = make_test_creation_request(
-            vec![
-                ipv4_prefix("192.0.2.0/24", Some("192.0.2.1")),
-                ipv6_prefix("2001:db8::/64"),
+    fn try_from_creation_request_validates_prefixes() {
+        check_cases(
+            [
+                Case {
+                    scenario: "ipv6 prefix accepted (admin)",
+                    input: make_test_creation_request(
+                        vec![ipv6_prefix("2001:db8::/64")],
+                        NetworkSegmentType::Admin,
+                    ),
+                    expect: Yields((1, true)),
+                },
+                Case {
+                    scenario: "dual-stack prefixes accepted (admin)",
+                    input: make_test_creation_request(
+                        vec![
+                            ipv4_prefix("192.0.2.0/24", Some("192.0.2.1")),
+                            ipv6_prefix("2001:db8::/64"),
+                        ],
+                        NetworkSegmentType::Admin,
+                    ),
+                    expect: Yields((2, false)),
+                },
+                Case {
+                    scenario: "tenant /64 IPv6 allowed",
+                    input: make_test_creation_request(
+                        vec![ipv6_prefix("2001:db8::/64")],
+                        NetworkSegmentType::Tenant,
+                    ),
+                    expect: Yields((1, true)),
+                },
+                Case {
+                    scenario: "tenant /127 IPv6 rejected",
+                    input: make_test_creation_request(
+                        vec![ipv6_prefix("2001:db8::1/127")],
+                        NetworkSegmentType::Tenant,
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "tenant /128 IPv6 rejected",
+                    input: make_test_creation_request(
+                        vec![ipv6_prefix("2001:db8::1/128")],
+                        NetworkSegmentType::Tenant,
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "tenant /24 IPv4 allowed",
+                    input: make_test_creation_request(
+                        vec![ipv4_prefix("192.0.2.0/24", Some("192.0.2.1"))],
+                        NetworkSegmentType::Tenant,
+                    ),
+                    expect: Yields((1, false)),
+                },
+                Case {
+                    scenario: "tenant /31 IPv4 rejected",
+                    input: make_test_creation_request(
+                        vec![ipv4_prefix("192.0.2.0/31", Some("192.0.2.1"))],
+                        NetworkSegmentType::Tenant,
+                    ),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "tenant /32 IPv4 rejected",
+                    input: make_test_creation_request(
+                        vec![ipv4_prefix("192.0.2.0/32", None)],
+                        NetworkSegmentType::Tenant,
+                    ),
+                    expect: Fails,
+                },
             ],
+            // The error type (RpcDataConversionError) is not asserted by these rows,
+            // so failing rows discard it; accepting rows project to the prefix count
+            // and whether the first prefix is IPv6.
+            |request| {
+                NewNetworkSegment::try_from(request)
+                    .map(|segment| (segment.prefixes.len(), segment.prefixes[0].prefix.is_ipv6()))
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // Empty prefixes are rejected outright, regardless of segment type.
+    #[test]
+    fn try_from_creation_request_rejects_empty_prefixes() {
+        check_cases(
+            [
+                Case {
+                    scenario: "admin with no prefixes",
+                    input: make_test_creation_request(vec![], NetworkSegmentType::Admin),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "tenant with no prefixes",
+                    input: make_test_creation_request(vec![], NetworkSegmentType::Tenant),
+                    expect: Fails,
+                },
+            ],
+            |request| NewNetworkSegment::try_from(request).map(drop).map_err(drop),
+        );
+    }
+
+    // When `mtu` is absent the conversion supplies a type-dependent default:
+    // 9000 for tenant segments, 1500 otherwise. An explicit `mtu` overrides both.
+    // Each row projects to the resulting segment's mtu.
+    #[test]
+    fn try_from_creation_request_defaults_mtu_by_type() {
+        fn request_with_mtu(
+            mtu: Option<i32>,
+            segment_type: NetworkSegmentType,
+        ) -> rpc::forge::NetworkSegmentCreationRequest {
+            let mut request = make_test_creation_request(
+                vec![ipv4_prefix("192.0.2.0/24", Some("192.0.2.1"))],
+                segment_type,
+            );
+            request.mtu = mtu;
+            request
+        }
+
+        check_cases(
+            [
+                Case {
+                    scenario: "tenant default mtu is 9000",
+                    input: request_with_mtu(None, NetworkSegmentType::Tenant),
+                    expect: Yields(DEFAULT_MTU_TENANT),
+                },
+                Case {
+                    scenario: "admin default mtu is 1500",
+                    input: request_with_mtu(None, NetworkSegmentType::Admin),
+                    expect: Yields(DEFAULT_MTU_OTHER),
+                },
+                Case {
+                    scenario: "underlay default mtu is 1500",
+                    input: request_with_mtu(None, NetworkSegmentType::Underlay),
+                    expect: Yields(DEFAULT_MTU_OTHER),
+                },
+                Case {
+                    scenario: "host-inband default mtu is 1500",
+                    input: request_with_mtu(None, NetworkSegmentType::HostInband),
+                    expect: Yields(DEFAULT_MTU_OTHER),
+                },
+                Case {
+                    scenario: "explicit mtu overrides tenant default",
+                    input: request_with_mtu(Some(1400), NetworkSegmentType::Tenant),
+                    expect: Yields(1400),
+                },
+                Case {
+                    scenario: "explicit mtu overrides admin default",
+                    input: request_with_mtu(Some(1400), NetworkSegmentType::Admin),
+                    expect: Yields(1400),
+                },
+            ],
+            |request| NewNetworkSegment::try_from(request).map(|s| s.mtu).map_err(drop),
+        );
+    }
+
+    // `can_stretch` is set to Some(true) for tenant segments and left None for
+    // every other type. Each row projects to the resulting `can_stretch`.
+    #[test]
+    fn try_from_creation_request_sets_can_stretch_for_tenant() {
+        check_cases(
+            [
+                Case {
+                    scenario: "tenant is stretchable",
+                    input: make_test_creation_request(
+                        vec![ipv4_prefix("192.0.2.0/24", Some("192.0.2.1"))],
+                        NetworkSegmentType::Tenant,
+                    ),
+                    expect: Yields(Some(true)),
+                },
+                Case {
+                    scenario: "admin is not stretchable",
+                    input: make_test_creation_request(
+                        vec![ipv4_prefix("192.0.2.0/24", Some("192.0.2.1"))],
+                        NetworkSegmentType::Admin,
+                    ),
+                    expect: Yields(None),
+                },
+                Case {
+                    scenario: "underlay is not stretchable",
+                    input: make_test_creation_request(
+                        vec![ipv4_prefix("192.0.2.0/24", Some("192.0.2.1"))],
+                        NetworkSegmentType::Underlay,
+                    ),
+                    expect: Yields(None),
+                },
+                Case {
+                    scenario: "host-inband is not stretchable",
+                    input: make_test_creation_request(
+                        vec![ipv4_prefix("192.0.2.0/24", Some("192.0.2.1"))],
+                        NetworkSegmentType::HostInband,
+                    ),
+                    expect: Yields(None),
+                },
+            ],
+            |request| {
+                NewNetworkSegment::try_from(request)
+                    .map(|s| s.can_stretch)
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // The conversion carries the segment type through and defaults the allocation
+    // strategy to Dynamic. Each row projects to (segment_type, allocation_strategy).
+    #[test]
+    fn try_from_creation_request_carries_segment_type() {
+        check_cases(
+            [
+                Case {
+                    scenario: "tenant type preserved",
+                    input: make_test_creation_request(
+                        vec![ipv4_prefix("192.0.2.0/24", Some("192.0.2.1"))],
+                        NetworkSegmentType::Tenant,
+                    ),
+                    expect: Yields((NetworkSegmentType::Tenant, AllocationStrategy::Dynamic)),
+                },
+                Case {
+                    scenario: "admin type preserved",
+                    input: make_test_creation_request(
+                        vec![ipv4_prefix("192.0.2.0/24", Some("192.0.2.1"))],
+                        NetworkSegmentType::Admin,
+                    ),
+                    expect: Yields((NetworkSegmentType::Admin, AllocationStrategy::Dynamic)),
+                },
+                Case {
+                    scenario: "underlay type preserved",
+                    input: make_test_creation_request(
+                        vec![ipv4_prefix("192.0.2.0/24", Some("192.0.2.1"))],
+                        NetworkSegmentType::Underlay,
+                    ),
+                    expect: Yields((NetworkSegmentType::Underlay, AllocationStrategy::Dynamic)),
+                },
+                Case {
+                    scenario: "host-inband type preserved",
+                    input: make_test_creation_request(
+                        vec![ipv4_prefix("192.0.2.0/24", Some("192.0.2.1"))],
+                        NetworkSegmentType::HostInband,
+                    ),
+                    expect: Yields((NetworkSegmentType::HostInband, AllocationStrategy::Dynamic)),
+                },
+            ],
+            |request| {
+                NewNetworkSegment::try_from(request)
+                    .map(|s| (s.segment_type, s.allocation_strategy))
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // An unrecognized `segment_type` discriminant fails the whole conversion.
+    #[test]
+    fn try_from_creation_request_rejects_unknown_segment_type() {
+        let mut request = make_test_creation_request(
+            vec![ipv4_prefix("192.0.2.0/24", Some("192.0.2.1"))],
             NetworkSegmentType::Admin,
         );
-        let result = NewNetworkSegment::try_from(request);
-        assert!(result.is_ok(), "Dual-stack should be accepted: {result:?}");
-        let segment = result.unwrap();
-        assert_eq!(segment.prefixes.len(), 2);
+        request.segment_type = 999;
+
+        Case {
+            scenario: "unknown segment type discriminant",
+            input: request,
+            expect: Fails,
+        }
+        .check(|request| NewNetworkSegment::try_from(request).map(drop).map_err(drop));
     }
 
+    // i32 -> NetworkSegmentType: each valid discriminant maps to its arm, and any
+    // out-of-range value fails. The error type is not asserted, so failing rows
+    // discard it.
     #[test]
-    fn test_ipv6_tenant_prefix_size_validation() {
-        // /64 should be allowed for tenant segments
-        let request = make_test_creation_request(
-            vec![ipv6_prefix("2001:db8::/64")],
-            NetworkSegmentType::Tenant,
-        );
-        assert!(
-            NewNetworkSegment::try_from(request).is_ok(),
-            "/64 IPv6 prefix should be allowed for tenant segments"
-        );
-
-        // /127 should be rejected for tenant segments
-        let request = make_test_creation_request(
-            vec![ipv6_prefix("2001:db8::1/127")],
-            NetworkSegmentType::Tenant,
-        );
-        assert!(
-            NewNetworkSegment::try_from(request).is_err(),
-            "/127 IPv6 prefix should be rejected for tenant segments"
-        );
-
-        // /128 should be rejected for tenant segments
-        let request = make_test_creation_request(
-            vec![ipv6_prefix("2001:db8::1/128")],
-            NetworkSegmentType::Tenant,
-        );
-        assert!(
-            NewNetworkSegment::try_from(request).is_err(),
-            "/128 IPv6 prefix should be rejected for tenant segments"
+    fn network_segment_type_from_i32() {
+        check_cases(
+            [
+                Case {
+                    scenario: "0 -> Tenant",
+                    input: rpc::forge::NetworkSegmentType::Tenant as i32,
+                    expect: Yields(NetworkSegmentType::Tenant),
+                },
+                Case {
+                    scenario: "1 -> Admin",
+                    input: rpc::forge::NetworkSegmentType::Admin as i32,
+                    expect: Yields(NetworkSegmentType::Admin),
+                },
+                Case {
+                    scenario: "2 -> Underlay",
+                    input: rpc::forge::NetworkSegmentType::Underlay as i32,
+                    expect: Yields(NetworkSegmentType::Underlay),
+                },
+                Case {
+                    scenario: "3 -> HostInband",
+                    input: rpc::forge::NetworkSegmentType::HostInband as i32,
+                    expect: Yields(NetworkSegmentType::HostInband),
+                },
+                Case {
+                    scenario: "unknown discriminant rejected",
+                    input: 999,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "negative discriminant rejected",
+                    input: -1,
+                    expect: Fails,
+                },
+            ],
+            |value| NetworkSegmentType::rpc_try_from(value).map_err(drop),
         );
     }
 
+    // NetworkSegmentSearchFilter::from is a direct field copy; each row projects
+    // to (name, tenant_org_id) so present vs absent optionals are both exercised.
     #[test]
-    fn test_ipv4_tenant_prefix_size_validation_unchanged() {
-        // /24 should be allowed
-        let request = make_test_creation_request(
-            vec![ipv4_prefix("192.0.2.0/24", Some("192.0.2.1"))],
-            NetworkSegmentType::Tenant,
+    fn search_filter_from_proto() {
+        check_values(
+            [
+                Check {
+                    scenario: "both fields present",
+                    input: rpc::forge::NetworkSegmentSearchFilter {
+                        name: Some("seg".to_string()),
+                        tenant_org_id: Some("org".to_string()),
+                    },
+                    expect: (Some("seg".to_string()), Some("org".to_string())),
+                },
+                Check {
+                    scenario: "name only",
+                    input: rpc::forge::NetworkSegmentSearchFilter {
+                        name: Some("seg".to_string()),
+                        tenant_org_id: None,
+                    },
+                    expect: (Some("seg".to_string()), None),
+                },
+                Check {
+                    scenario: "tenant_org_id only",
+                    input: rpc::forge::NetworkSegmentSearchFilter {
+                        name: None,
+                        tenant_org_id: Some("org".to_string()),
+                    },
+                    expect: (None, Some("org".to_string())),
+                },
+                Check {
+                    scenario: "both absent",
+                    input: rpc::forge::NetworkSegmentSearchFilter {
+                        name: None,
+                        tenant_org_id: None,
+                    },
+                    expect: (None, None),
+                },
+            ],
+            |proto| {
+                let filter = NetworkSegmentSearchFilter::from(proto);
+                (filter.name, filter.tenant_org_id)
+            },
         );
-        assert!(NewNetworkSegment::try_from(request).is_ok());
+    }
 
-        // /31 should be rejected
-        let request = make_test_creation_request(
-            vec![ipv4_prefix("192.0.2.0/31", Some("192.0.2.1"))],
-            NetworkSegmentType::Tenant,
+    // NetworkSegmentSearchConfig::from is a direct bool copy; each row projects to
+    // (include_history, include_num_free_ips) across all four combinations.
+    #[test]
+    fn search_config_from_proto() {
+        check_values(
+            [
+                Check {
+                    scenario: "both false",
+                    input: rpc::forge::NetworkSegmentSearchConfig {
+                        include_history: false,
+                        include_num_free_ips: false,
+                    },
+                    expect: (false, false),
+                },
+                Check {
+                    scenario: "history only",
+                    input: rpc::forge::NetworkSegmentSearchConfig {
+                        include_history: true,
+                        include_num_free_ips: false,
+                    },
+                    expect: (true, false),
+                },
+                Check {
+                    scenario: "free ips only",
+                    input: rpc::forge::NetworkSegmentSearchConfig {
+                        include_history: false,
+                        include_num_free_ips: true,
+                    },
+                    expect: (false, true),
+                },
+                Check {
+                    scenario: "both true",
+                    input: rpc::forge::NetworkSegmentSearchConfig {
+                        include_history: true,
+                        include_num_free_ips: true,
+                    },
+                    expect: (true, true),
+                },
+            ],
+            |proto| {
+                let config = NetworkSegmentSearchConfig::from(proto);
+                (config.include_history, config.include_num_free_ips)
+            },
         );
-        assert!(NewNetworkSegment::try_from(request).is_err());
-
-        // /32 should be rejected
-        let request = make_test_creation_request(
-            vec![ipv4_prefix("192.0.2.0/32", None)],
-            NetworkSegmentType::Tenant,
-        );
-        assert!(NewNetworkSegment::try_from(request).is_err());
     }
 }

--- a/crates/rpc/src/model/rack.rs
+++ b/crates/rpc/src/model/rack.rs
@@ -71,42 +71,235 @@ impl From<rpc::forge::RackSearchFilter> for RackSearchFilter {
 
 #[cfg(test)]
 mod tests {
-    use model::rack::{LABEL_CHASSIS_MANUFACTURER, LABEL_LOCATION_DATACENTER};
+    use carbide_test_support::{Check, check_values};
+    use carbide_uuid::rack::RackId;
+    use chrono::{DateTime, TimeZone, Utc};
+    use config_version::{ConfigVersion, Versioned};
+    use model::metadata::{LabelFilter, Metadata};
+    use model::rack::{
+        LABEL_CHASSIS_MANUFACTURER, LABEL_LOCATION_DATACENTER, RackConfig, RackMaintenanceState,
+        RackState, RackValidationState,
+    };
 
     use super::*;
 
-    #[test]
-    fn rack_search_filter_from_rpc_with_label_key_and_value() {
-        let rpc_filter = rpc::forge::RackSearchFilter {
-            label: Some(rpc::forge::Label {
-                key: LABEL_LOCATION_DATACENTER.to_string(),
-                value: Some("az01".to_string()),
-            }),
-        };
-        let filter = RackSearchFilter::from(rpc_filter);
-        let label = filter.label.unwrap();
-        assert_eq!(label.key, LABEL_LOCATION_DATACENTER);
-        assert_eq!(label.value, Some("az01".to_string()));
+    // Build a model `Rack` whose only interesting fields are the controller
+    // state (which drives `rack_state` and `lifecycle.state`) and `deleted`.
+    // Everything else is held at a fixed, conversion-neutral value so each row
+    // isolates the one projection it exercises.
+    fn rack_with(state: RackState, deleted: Option<DateTime<Utc>>) -> Rack {
+        Rack {
+            id: RackId::default(),
+            rack_profile_id: None,
+            config: RackConfig::default(),
+            controller_state: Versioned::new(state, ConfigVersion::new(7)),
+            controller_state_outcome: None,
+            firmware_upgrade_job: None,
+            nvos_update_job: None,
+            health_reports: Default::default(),
+            created: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            updated: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
+            deleted,
+            metadata: Metadata::default(),
+            version: ConfigVersion::new(7),
+        }
     }
 
+    // `RackSearchFilter::from` maps the optional proto label onto the model's
+    // optional `LabelFilter`; project to that `label` field for each input.
     #[test]
-    fn rack_search_filter_from_rpc_with_label_key_only() {
-        let rpc_filter = rpc::forge::RackSearchFilter {
-            label: Some(rpc::forge::Label {
-                key: LABEL_CHASSIS_MANUFACTURER.to_string(),
-                value: None,
-            }),
-        };
-        let filter = RackSearchFilter::from(rpc_filter);
-        let label = filter.label.unwrap();
-        assert_eq!(label.key, LABEL_CHASSIS_MANUFACTURER);
-        assert!(label.value.is_none());
+    fn rack_search_filter_from_rpc() {
+        check_values(
+            [
+                Check {
+                    scenario: "label with key and value",
+                    input: rpc::forge::RackSearchFilter {
+                        label: Some(rpc::forge::Label {
+                            key: LABEL_LOCATION_DATACENTER.to_string(),
+                            value: Some("az01".to_string()),
+                        }),
+                    },
+                    expect: Some(LabelFilter {
+                        key: LABEL_LOCATION_DATACENTER.to_string(),
+                        value: Some("az01".to_string()),
+                    }),
+                },
+                Check {
+                    scenario: "label with key only",
+                    input: rpc::forge::RackSearchFilter {
+                        label: Some(rpc::forge::Label {
+                            key: LABEL_CHASSIS_MANUFACTURER.to_string(),
+                            value: None,
+                        }),
+                    },
+                    expect: Some(LabelFilter {
+                        key: LABEL_CHASSIS_MANUFACTURER.to_string(),
+                        value: None,
+                    }),
+                },
+                Check {
+                    scenario: "no label",
+                    input: rpc::forge::RackSearchFilter { label: None },
+                    expect: None,
+                },
+            ],
+            |rpc_filter| RackSearchFilter::from(rpc_filter).label,
+        );
     }
 
+    // `From<Rack>` copies the controller state through `RackState`'s `Display`
+    // into the (deprecated) flat `rack_state` field. One row per enum arm,
+    // including the nested `Validating`/`Maintenance`/`Error` payloads.
     #[test]
-    fn rack_search_filter_from_rpc_no_label() {
-        let rpc_filter = rpc::forge::RackSearchFilter { label: None };
-        let filter = RackSearchFilter::from(rpc_filter);
-        assert!(filter.label.is_none());
+    fn rack_state_field_from_display() {
+        check_values(
+            [
+                Check {
+                    scenario: "created",
+                    input: RackState::Created,
+                    expect: "Created".to_string(),
+                },
+                Check {
+                    scenario: "discovering",
+                    input: RackState::Discovering,
+                    expect: "Discovering".to_string(),
+                },
+                Check {
+                    scenario: "ready",
+                    input: RackState::Ready,
+                    expect: "Ready".to_string(),
+                },
+                Check {
+                    scenario: "deleting",
+                    input: RackState::Deleting,
+                    expect: "Deleting".to_string(),
+                },
+                Check {
+                    scenario: "validating pending",
+                    input: RackState::Validating {
+                        validating_state: RackValidationState::Pending,
+                    },
+                    expect: "Validating(Pending)".to_string(),
+                },
+                Check {
+                    scenario: "validating in progress",
+                    input: RackState::Validating {
+                        validating_state: RackValidationState::InProgress {
+                            run_id: "r1".to_string(),
+                        },
+                    },
+                    expect: "Validating(InProgress)".to_string(),
+                },
+                Check {
+                    scenario: "maintenance completed",
+                    input: RackState::Maintenance {
+                        maintenance_state: RackMaintenanceState::Completed,
+                    },
+                    expect: "Maintenance(Completed)".to_string(),
+                },
+                Check {
+                    scenario: "error carries cause",
+                    input: RackState::Error {
+                        cause: "boom".to_string(),
+                    },
+                    expect: "Error(boom)".to_string(),
+                },
+            ],
+            |state| rpc::forge::Rack::from(rack_with(state, None)).rack_state,
+        );
+    }
+
+    // The `lifecycle.state` field carries the same controller state, but as the
+    // serde-JSON of `RackState` (internally tagged on `state`, snake_case). Each
+    // row pins the exact JSON for one arm so the serde contract is covered
+    // alongside the `Display` projection above.
+    #[test]
+    fn lifecycle_state_field_from_serde_json() {
+        check_values(
+            [
+                Check {
+                    scenario: "created",
+                    input: RackState::Created,
+                    expect: r#"{"state":"created"}"#.to_string(),
+                },
+                Check {
+                    scenario: "discovering",
+                    input: RackState::Discovering,
+                    expect: r#"{"state":"discovering"}"#.to_string(),
+                },
+                Check {
+                    scenario: "ready",
+                    input: RackState::Ready,
+                    expect: r#"{"state":"ready"}"#.to_string(),
+                },
+                Check {
+                    scenario: "deleting",
+                    input: RackState::Deleting,
+                    expect: r#"{"state":"deleting"}"#.to_string(),
+                },
+                Check {
+                    scenario: "error carries cause",
+                    input: RackState::Error {
+                        cause: "boom".to_string(),
+                    },
+                    expect: r#"{"state":"error","cause":"boom"}"#.to_string(),
+                },
+            ],
+            |state| {
+                rpc::forge::Rack::from(rack_with(state, None))
+                    .status
+                    .and_then(|s| s.lifecycle)
+                    .map(|l| l.state)
+                    .unwrap_or_default()
+            },
+        );
+    }
+
+    // The optional `deleted` timestamp maps through only when present: `Some`
+    // becomes a populated proto `Timestamp`, `None` stays `None`.
+    #[test]
+    fn deleted_timestamp_present_or_absent() {
+        check_values(
+            [
+                Check {
+                    scenario: "not deleted",
+                    input: None,
+                    expect: false,
+                },
+                Check {
+                    scenario: "deleted",
+                    input: Some(Utc.timestamp_opt(1_700_000_500, 0).unwrap()),
+                    expect: true,
+                },
+            ],
+            |deleted| {
+                rpc::forge::Rack::from(rack_with(RackState::Ready, deleted))
+                    .deleted
+                    .is_some()
+            },
+        );
+    }
+
+    // `version` is serialized through `ConfigVersion::version_string`, and `id`
+    // is wrapped verbatim into the optional proto field. Both are direct,
+    // lossless mappings; fold each into a `bool` so one table can assert both.
+    #[test]
+    fn version_and_id_map_through() {
+        check_values(
+            [
+                Check {
+                    scenario: "version string matches ConfigVersion",
+                    input: RackState::Ready,
+                    expect: true,
+                },
+            ],
+            |state| {
+                let rack = rack_with(state, None);
+                let want_version = rack.version.version_string();
+                let want_id = rack.id.clone();
+                let proto = rpc::forge::Rack::from(rack);
+                proto.version == want_version && proto.id == Some(want_id)
+            },
+        );
     }
 }

--- a/crates/rpc/src/model/rack_type.rs
+++ b/crates/rpc/src/model/rack_type.rs
@@ -182,69 +182,361 @@ impl From<&RackProfile> for rpc::forge::RackProfile {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
     // Proto conversion tests.
 
+    // RackHardwareType is a transparent string newtype, so both directions of the
+    // proto conversion just move the inner string across. Each row carries a string
+    // and asserts it survives model -> proto -> model unchanged, including the
+    // wildcard "any" and the empty string.
+    #[test]
+    fn test_rack_hardware_type_proto_round_trip() {
+        check_values(
+            [
+                Check {
+                    scenario: "named type",
+                    input: "dsx_gb200nvl_72x1",
+                    expect: "dsx_gb200nvl_72x1".to_string(),
+                },
+                Check {
+                    scenario: "wildcard any",
+                    input: "any",
+                    expect: "any".to_string(),
+                },
+                Check {
+                    scenario: "empty string",
+                    input: "",
+                    expect: "".to_string(),
+                },
+            ],
+            |s| {
+                let model = RackHardwareType::from(s);
+                let proto: rpc::common::RackHardwareType = model.into();
+                // The proto carries the raw string verbatim.
+                assert_eq!(proto.value, s);
+                // ...and the reverse From recovers the original newtype.
+                RackHardwareType::from(proto).0
+            },
+        );
+    }
+
+    // Each capability struct maps name/count/vendor straight across, and an absent
+    // (None) slot_ids becomes an empty Vec while a present one is carried verbatim.
+    // The op encodes that mapping as a single boolean predicate per row.
+    #[test]
+    fn test_rack_capability_compute_proto_conversion() {
+        check_values(
+            [
+                Check {
+                    scenario: "all fields present, slots set",
+                    input: RackCapabilityCompute {
+                        name: Some("GB200".to_string()),
+                        count: 18,
+                        vendor: Some("NVIDIA".to_string()),
+                        slot_ids: Some(vec![1, 2, 3]),
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "optionals absent, slots none -> empty vec",
+                    input: RackCapabilityCompute {
+                        name: None,
+                        count: 0,
+                        vendor: None,
+                        slot_ids: None,
+                    },
+                    expect: true,
+                },
+            ],
+            |compute| {
+                let proto: rpc::forge::RackCapabilityCompute = (&compute).into();
+                proto.name == compute.name
+                    && proto.count == compute.count
+                    && proto.vendor == compute.vendor
+                    && proto.slot_ids == compute.slot_ids.unwrap_or_default()
+            },
+        );
+    }
+
+    #[test]
+    fn test_rack_capability_switch_proto_conversion() {
+        check_values(
+            [
+                Check {
+                    scenario: "all fields present, slots set",
+                    input: RackCapabilitySwitch {
+                        name: Some("Quantum".to_string()),
+                        count: 9,
+                        vendor: Some("NVIDIA".to_string()),
+                        slot_ids: Some(vec![4, 5]),
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "optionals absent, slots none -> empty vec",
+                    input: RackCapabilitySwitch {
+                        name: None,
+                        count: 0,
+                        vendor: None,
+                        slot_ids: None,
+                    },
+                    expect: true,
+                },
+            ],
+            |switch| {
+                let proto: rpc::forge::RackCapabilitySwitch = (&switch).into();
+                proto.name == switch.name
+                    && proto.count == switch.count
+                    && proto.vendor == switch.vendor
+                    && proto.slot_ids == switch.slot_ids.unwrap_or_default()
+            },
+        );
+    }
+
+    #[test]
+    fn test_rack_capability_power_shelf_proto_conversion() {
+        check_values(
+            [
+                Check {
+                    scenario: "all fields present, slots set",
+                    input: RackCapabilityPowerShelf {
+                        name: Some("PSU".to_string()),
+                        count: 8,
+                        vendor: Some("Delta".to_string()),
+                        slot_ids: Some(vec![6]),
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "optionals absent, slots none -> empty vec",
+                    input: RackCapabilityPowerShelf {
+                        name: None,
+                        count: 0,
+                        vendor: None,
+                        slot_ids: None,
+                    },
+                    expect: true,
+                },
+            ],
+            |power_shelf| {
+                let proto: rpc::forge::RackCapabilityPowerShelf = (&power_shelf).into();
+                proto.name == power_shelf.name
+                    && proto.count == power_shelf.count
+                    && proto.vendor == power_shelf.vendor
+                    && proto.slot_ids == power_shelf.slot_ids.unwrap_or_default()
+            },
+        );
+    }
+
+    // RackCapabilitiesSet wraps each of its three members in Some(..). A single row
+    // (default set) is enough to pin that all three become present and carry the
+    // members' counts.
+    #[test]
+    fn test_rack_capabilities_set_proto_conversion() {
+        check_values(
+            [Check {
+                scenario: "default set wraps all three members",
+                input: RackCapabilitiesSet {
+                    compute: RackCapabilityCompute {
+                        count: 18,
+                        ..Default::default()
+                    },
+                    switch: RackCapabilitySwitch {
+                        count: 9,
+                        ..Default::default()
+                    },
+                    power_shelf: RackCapabilityPowerShelf {
+                        count: 8,
+                        ..Default::default()
+                    },
+                },
+                expect: true,
+            }],
+            |set| {
+                let proto: rpc::forge::RackCapabilitiesSet = (&set).into();
+                proto.compute.map(|c| c.count) == Some(18)
+                    && proto.switch.map(|s| s.count) == Some(9)
+                    && proto.power_shelf.map(|p| p.count) == Some(8)
+            },
+        );
+    }
+
+    // RackProfile maps its three optional hardware fields: a present type becomes a
+    // Some proto type, an absent one None; present topology/class become their proto
+    // discriminants, absent ones the Unspecified discriminant. capabilities is always
+    // Some. Each row pins one present-vs-absent combination via a boolean predicate.
+    #[test]
+    fn test_rack_profile_proto_field_mapping() {
+        check_values(
+            [
+                Check {
+                    scenario: "all hardware fields present",
+                    input: RackProfile {
+                        rack_hardware_type: Some(RackHardwareType::from("dsx_gb200nvl_72x1")),
+                        rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
+                        rack_hardware_class: Some(RackHardwareClass::Prod),
+                        rack_capabilities: RackCapabilitiesSet::default(),
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "all hardware fields absent -> none/unspecified",
+                    input: RackProfile::default(),
+                    expect: true,
+                },
+                Check {
+                    scenario: "dev class and gb300 topology",
+                    input: RackProfile {
+                        rack_hardware_type: Some(RackHardwareType::from("dev_rack")),
+                        rack_hardware_topology: Some(RackHardwareTopology::Gb300Nvl36r1C2g4Topology),
+                        rack_hardware_class: Some(RackHardwareClass::Dev),
+                        rack_capabilities: RackCapabilitiesSet::default(),
+                    },
+                    expect: true,
+                },
+            ],
+            |profile| {
+                let proto: rpc::forge::RackProfile = (&profile).into();
+
+                let want_type = profile
+                    .rack_hardware_type
+                    .as_ref()
+                    .map(|t| t.0.clone());
+                let type_ok = proto.rack_hardware_type.map(|t| t.value) == want_type;
+
+                let want_topology = profile
+                    .rack_hardware_topology
+                    .map(|t| rpc::forge::RackHardwareTopology::from(t) as i32)
+                    .unwrap_or(rpc::forge::RackHardwareTopology::Unspecified as i32);
+                let topology_ok = proto.rack_hardware_topology == want_topology;
+
+                let want_class = profile
+                    .rack_hardware_class
+                    .map(|c| rpc::forge::RackHardwareClass::from(c) as i32)
+                    .unwrap_or(rpc::forge::RackHardwareClass::Unspecified as i32);
+                let class_ok = proto.rack_hardware_class == want_class;
+
+                type_ok && topology_ok && class_ok && proto.capabilities.is_some()
+            },
+        );
+    }
+
+    // Each topology round-trips: model -> proto matches the expected proto, and the
+    // proto -> model TryFrom yields the original model. The op asserts the forward
+    // direction, then yields the recovered model so the row pins both directions.
     #[test]
     fn test_rack_hardware_topology_proto_round_trip() {
-        let cases = [
-            (
-                RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
-                rpc::forge::RackHardwareTopology::Gb200Nvl36r1C2g4,
-            ),
-            (
-                RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
-                rpc::forge::RackHardwareTopology::Gb300Nvl36r1C2g4,
-            ),
-            (
-                RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
-                rpc::forge::RackHardwareTopology::Gb200Nvl72r1C2g4,
-            ),
-            (
-                RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
-                rpc::forge::RackHardwareTopology::Gb300Nvl72r1C2g4,
-            ),
-            (
-                RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
-                rpc::forge::RackHardwareTopology::VrNvl8r1C2g4Rtf,
-            ),
-            (
-                RackHardwareTopology::VrNvl72r1C2g4Topology,
-                rpc::forge::RackHardwareTopology::VrNvl72r1C2g4,
-            ),
-        ];
-        for (model, proto) in cases {
-            let converted: rpc::forge::RackHardwareTopology = model.into();
-            assert_eq!(converted, proto);
-            let back: RackHardwareTopology = proto.try_into().unwrap();
-            assert_eq!(back, model);
+        struct Row {
+            scenario: &'static str,
+            model: RackHardwareTopology,
+            proto: rpc::forge::RackHardwareTopology,
         }
+
+        check_cases(
+            [
+                Row {
+                    scenario: "gb200 nvl36",
+                    model: RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
+                    proto: rpc::forge::RackHardwareTopology::Gb200Nvl36r1C2g4,
+                },
+                Row {
+                    scenario: "gb300 nvl36",
+                    model: RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
+                    proto: rpc::forge::RackHardwareTopology::Gb300Nvl36r1C2g4,
+                },
+                Row {
+                    scenario: "gb200 nvl72",
+                    model: RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
+                    proto: rpc::forge::RackHardwareTopology::Gb200Nvl72r1C2g4,
+                },
+                Row {
+                    scenario: "gb300 nvl72",
+                    model: RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
+                    proto: rpc::forge::RackHardwareTopology::Gb300Nvl72r1C2g4,
+                },
+                Row {
+                    scenario: "vr nvl8 rtf",
+                    model: RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
+                    proto: rpc::forge::RackHardwareTopology::VrNvl8r1C2g4Rtf,
+                },
+                Row {
+                    scenario: "vr nvl72",
+                    model: RackHardwareTopology::VrNvl72r1C2g4Topology,
+                    proto: rpc::forge::RackHardwareTopology::VrNvl72r1C2g4,
+                },
+            ]
+            .map(|row| Case {
+                scenario: row.scenario,
+                input: (row.model, row.proto),
+                expect: Yields(row.model),
+            }),
+            |(model, proto)| {
+                let converted: rpc::forge::RackHardwareTopology = model.into();
+                assert_eq!(converted, proto);
+                RackHardwareTopology::try_from(proto).map_err(drop)
+            },
+        );
     }
 
+    // The Unspecified proto value has no model counterpart, so TryFrom rejects it.
     #[test]
     fn test_rack_hardware_topology_proto_unspecified_errors() {
-        let result = RackHardwareTopology::try_from(rpc::forge::RackHardwareTopology::Unspecified);
-        assert!(result.is_err());
+        Case {
+            scenario: "unspecified topology rejected",
+            input: rpc::forge::RackHardwareTopology::Unspecified,
+            expect: Fails,
+        }
+        .check(|proto| RackHardwareTopology::try_from(proto).map_err(drop));
     }
 
+    // Each class round-trips: model -> proto matches, and proto -> model recovers the
+    // original. The op asserts the forward direction, then yields the model.
     #[test]
     fn test_rack_hardware_class_proto_round_trip() {
-        let cases = [
-            (RackHardwareClass::Dev, rpc::forge::RackHardwareClass::Dev),
-            (RackHardwareClass::Prod, rpc::forge::RackHardwareClass::Prod),
-        ];
-        for (model, proto) in cases {
-            let converted: rpc::forge::RackHardwareClass = model.into();
-            assert_eq!(converted, proto);
-            let back: RackHardwareClass = proto.try_into().unwrap();
-            assert_eq!(back, model);
+        struct Row {
+            scenario: &'static str,
+            model: RackHardwareClass,
+            proto: rpc::forge::RackHardwareClass,
         }
+
+        check_cases(
+            [
+                Row {
+                    scenario: "dev",
+                    model: RackHardwareClass::Dev,
+                    proto: rpc::forge::RackHardwareClass::Dev,
+                },
+                Row {
+                    scenario: "prod",
+                    model: RackHardwareClass::Prod,
+                    proto: rpc::forge::RackHardwareClass::Prod,
+                },
+            ]
+            .map(|row| Case {
+                scenario: row.scenario,
+                input: (row.model, row.proto),
+                expect: Yields(row.model),
+            }),
+            |(model, proto)| {
+                let converted: rpc::forge::RackHardwareClass = model.into();
+                assert_eq!(converted, proto);
+                RackHardwareClass::try_from(proto).map_err(drop)
+            },
+        );
     }
 
+    // The Unspecified proto value has no model counterpart, so TryFrom rejects it.
     #[test]
     fn test_rack_hardware_class_proto_unspecified_errors() {
-        let result = RackHardwareClass::try_from(rpc::forge::RackHardwareClass::Unspecified);
-        assert!(result.is_err());
+        Case {
+            scenario: "unspecified class rejected",
+            input: rpc::forge::RackHardwareClass::Unspecified,
+            expect: Fails,
+        }
+        .check(|proto| RackHardwareClass::try_from(proto).map_err(drop));
     }
 
     #[test]

--- a/crates/rpc/src/model/redfish.rs
+++ b/crates/rpc/src/model/redfish.rs
@@ -79,35 +79,323 @@ impl From<ActionRequest> for rpc::forge::RedfishAction {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use chrono::{DateTime, TimeZone, Utc};
+    use model::redfish::BMCResponse;
+    use rpc::Timestamp;
+
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
 
+    // A fixed instant used throughout, so timestamp conversions are deterministic.
+    fn instant() -> DateTime<Utc> {
+        Utc.timestamp_opt(1_700_000_000, 0).single().unwrap()
+    }
+
+    // The proto timestamp the conversions produce for `instant()`.
+    fn proto_instant() -> Timestamp {
+        Timestamp::from(instant())
+    }
+
+    // A minimal `ActionRequest` with all collections empty and optionals absent;
+    // rows below override only the field under test.
+    fn empty_action_request() -> ActionRequest {
+        ActionRequest {
+            request_id: 0,
+            requester: String::new(),
+            approvers: vec![],
+            approver_dates: vec![],
+            machine_ips: vec![],
+            board_serials: vec![],
+            target: String::new(),
+            action: String::new(),
+            parameters: String::new(),
+            applied_at: None,
+            applier: None,
+            results: vec![],
+        }
+    }
+
+    // `From<rpc::forge::RedfishActionId>` carries the request id through, across sign.
     #[test]
     fn redfish_action_id_from_rpc() {
-        let rpc_id = rpc::forge::RedfishActionId { request_id: 42 };
-        let id = RedfishActionId::from(rpc_id);
-        assert_eq!(id.request_id, 42);
+        check_values(
+            [
+                Check {
+                    scenario: "positive request id passes through",
+                    input: rpc::forge::RedfishActionId { request_id: 42 },
+                    expect: 42i64,
+                },
+                Check {
+                    scenario: "zero request id passes through",
+                    input: rpc::forge::RedfishActionId { request_id: 0 },
+                    expect: 0i64,
+                },
+                Check {
+                    scenario: "negative request id passes through",
+                    input: rpc::forge::RedfishActionId { request_id: -7 },
+                    expect: -7i64,
+                },
+            ],
+            |id| RedfishActionId::from(id).request_id,
+        );
     }
 
+    // `From<rpc::forge::RedfishListActionsRequest>` carries the machine ip filter,
+    // present and absent.
     #[test]
     fn redfish_list_actions_filter_from_rpc() {
-        let rpc_req = rpc::forge::RedfishListActionsRequest {
-            machine_ip: Some("10.0.0.1".to_string()),
-        };
-        let filter = RedfishListActionsFilter::from(rpc_req);
-        assert_eq!(filter.machine_ip, Some("10.0.0.1".to_string()));
+        check_values(
+            [
+                Check {
+                    scenario: "machine ip present passes through",
+                    input: rpc::forge::RedfishListActionsRequest {
+                        machine_ip: Some("10.0.0.1".to_string()),
+                    },
+                    expect: Some("10.0.0.1".to_string()),
+                },
+                Check {
+                    scenario: "machine ip absent stays absent",
+                    input: rpc::forge::RedfishListActionsRequest { machine_ip: None },
+                    expect: None,
+                },
+            ],
+            |req| RedfishListActionsFilter::from(req).machine_ip,
+        );
     }
 
+    // `From<rpc::forge::RedfishCreateActionRequest>` maps action/target/parameters
+    // across and drops the `ips` field, which the domain type does not hold.
     #[test]
     fn redfish_create_action_from_rpc() {
-        let rpc_req = rpc::forge::RedfishCreateActionRequest {
-            ips: vec!["10.0.0.1".to_string()],
-            action: "Reset".to_string(),
-            target: "/redfish/v1/Systems/1/Actions".to_string(),
-            parameters: r#"{"ResetType":"ForceRestart"}"#.to_string(),
+        check_values(
+            [
+                Check {
+                    scenario: "action, target, and parameters map across",
+                    input: rpc::forge::RedfishCreateActionRequest {
+                        ips: vec!["10.0.0.1".to_string()],
+                        action: "Reset".to_string(),
+                        target: "/redfish/v1/Systems/1/Actions".to_string(),
+                        parameters: r#"{"ResetType":"ForceRestart"}"#.to_string(),
+                    },
+                    expect: (
+                        "Reset".to_string(),
+                        "/redfish/v1/Systems/1/Actions".to_string(),
+                        r#"{"ResetType":"ForceRestart"}"#.to_string(),
+                    ),
+                },
+                Check {
+                    scenario: "empty strings map across unchanged",
+                    input: rpc::forge::RedfishCreateActionRequest {
+                        ips: vec![],
+                        action: String::new(),
+                        target: String::new(),
+                        parameters: String::new(),
+                    },
+                    expect: (String::new(), String::new(), String::new()),
+                },
+            ],
+            |req| {
+                let action = RedfishCreateAction::from(req);
+                (action.action, action.target, action.parameters)
+            },
+        );
+    }
+
+    // `From<ActionRequest> for rpc::forge::RedfishAction` carries the scalar and
+    // repeated string fields through unchanged.
+    #[test]
+    fn redfish_action_from_request_scalar_fields() {
+        check_values(
+            [
+                Check {
+                    scenario: "request id passes through",
+                    input: ActionRequest {
+                        request_id: -5,
+                        ..empty_action_request()
+                    },
+                    expect: rpc::forge::RedfishAction {
+                        request_id: -5,
+                        ..Default::default()
+                    },
+                },
+                Check {
+                    scenario: "requester, target, action, parameters pass through",
+                    input: ActionRequest {
+                        requester: "alice".to_string(),
+                        target: "/redfish/v1/Systems/1".to_string(),
+                        action: "Reset".to_string(),
+                        parameters: r#"{"ResetType":"On"}"#.to_string(),
+                        ..empty_action_request()
+                    },
+                    expect: rpc::forge::RedfishAction {
+                        requester: "alice".to_string(),
+                        target: "/redfish/v1/Systems/1".to_string(),
+                        action: "Reset".to_string(),
+                        parameters: r#"{"ResetType":"On"}"#.to_string(),
+                        ..Default::default()
+                    },
+                },
+                Check {
+                    scenario: "approvers, machine ips, board serials pass through",
+                    input: ActionRequest {
+                        approvers: vec!["bob".to_string(), "carol".to_string()],
+                        machine_ips: vec!["10.0.0.1".to_string()],
+                        board_serials: vec!["SN-1".to_string(), "SN-2".to_string()],
+                        ..empty_action_request()
+                    },
+                    expect: rpc::forge::RedfishAction {
+                        approvers: vec!["bob".to_string(), "carol".to_string()],
+                        machine_ips: vec!["10.0.0.1".to_string()],
+                        board_serials: vec!["SN-1".to_string(), "SN-2".to_string()],
+                        ..Default::default()
+                    },
+                },
+            ],
+            rpc::forge::RedfishAction::from,
+        );
+    }
+
+    // `From<ActionRequest> for rpc::forge::RedfishAction` maps the timestamp-bearing
+    // fields: the repeated `approver_dates` and the optional `applied_at`/`applier`.
+    #[test]
+    fn redfish_action_from_request_timestamps() {
+        check_values(
+            [
+                Check {
+                    scenario: "empty approver dates stay empty",
+                    input: empty_action_request(),
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "approver dates convert to proto timestamps",
+                    input: ActionRequest {
+                        approver_dates: vec![instant()],
+                        ..empty_action_request()
+                    },
+                    expect: vec![proto_instant()],
+                },
+            ],
+            |req| rpc::forge::RedfishAction::from(req).approver_dates,
+        );
+    }
+
+    // The optional `applied_at` timestamp: present becomes `Some(ts)`, absent stays `None`.
+    #[test]
+    fn redfish_action_from_request_applied_at() {
+        check_values(
+            [
+                Check {
+                    scenario: "applied_at absent stays None",
+                    input: empty_action_request(),
+                    expect: None,
+                },
+                Check {
+                    scenario: "applied_at present becomes Some timestamp",
+                    input: ActionRequest {
+                        applied_at: Some(instant()),
+                        ..empty_action_request()
+                    },
+                    expect: Some(proto_instant()),
+                },
+            ],
+            |req| rpc::forge::RedfishAction::from(req).applied_at,
+        );
+    }
+
+    // The optional `applier` string: present and absent.
+    #[test]
+    fn redfish_action_from_request_applier() {
+        check_values(
+            [
+                Check {
+                    scenario: "applier absent stays None",
+                    input: empty_action_request(),
+                    expect: None,
+                },
+                Check {
+                    scenario: "applier present passes through",
+                    input: ActionRequest {
+                        applier: Some("operator".to_string()),
+                        ..empty_action_request()
+                    },
+                    expect: Some("operator".to_string()),
+                },
+            ],
+            |req| rpc::forge::RedfishAction::from(req).applier,
+        );
+    }
+
+    // `results` is a vec of `Option<BMCResponse>`: each `None` arm becomes an
+    // `OptionalRedfishActionResult { result: None }`, each `Some` becomes a populated
+    // `RedfishActionResult` with `completed_at` always present.
+    #[test]
+    fn redfish_action_from_request_results() {
+        let response = || BMCResponse {
+            headers: HashMap::from([("Location".to_string(), "/task/1".to_string())]),
+            status: "200 OK".to_string(),
+            body: r#"{"ok":true}"#.to_string(),
+            completed_at: instant(),
         };
-        let action = RedfishCreateAction::from(rpc_req);
-        assert_eq!(action.action, "Reset");
-        assert_eq!(action.target, "/redfish/v1/Systems/1/Actions");
-        assert_eq!(action.parameters, r#"{"ResetType":"ForceRestart"}"#);
+
+        check_values(
+            [
+                Check {
+                    scenario: "empty results stay empty",
+                    input: empty_action_request(),
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "a None result becomes an empty optional result",
+                    input: ActionRequest {
+                        results: vec![None],
+                        ..empty_action_request()
+                    },
+                    expect: vec![rpc::forge::OptionalRedfishActionResult { result: None }],
+                },
+                Check {
+                    scenario: "a Some result populates the inner action result",
+                    input: ActionRequest {
+                        results: vec![Some(response())],
+                        ..empty_action_request()
+                    },
+                    expect: vec![rpc::forge::OptionalRedfishActionResult {
+                        result: Some(rpc::forge::RedfishActionResult {
+                            headers: HashMap::from([(
+                                "Location".to_string(),
+                                "/task/1".to_string(),
+                            )]),
+                            status: "200 OK".to_string(),
+                            body: r#"{"ok":true}"#.to_string(),
+                            completed_at: Some(proto_instant()),
+                        }),
+                    }],
+                },
+                Check {
+                    scenario: "mixed Some/None results preserve order and arms",
+                    input: ActionRequest {
+                        results: vec![None, Some(response())],
+                        ..empty_action_request()
+                    },
+                    expect: vec![
+                        rpc::forge::OptionalRedfishActionResult { result: None },
+                        rpc::forge::OptionalRedfishActionResult {
+                            result: Some(rpc::forge::RedfishActionResult {
+                                headers: HashMap::from([(
+                                    "Location".to_string(),
+                                    "/task/1".to_string(),
+                                )]),
+                                status: "200 OK".to_string(),
+                                body: r#"{"ok":true}"#.to_string(),
+                                completed_at: Some(proto_instant()),
+                            }),
+                        },
+                    ],
+                },
+            ],
+            |req| rpc::forge::RedfishAction::from(req).results,
+        );
     }
 }

--- a/crates/rpc/src/model/switch.rs
+++ b/crates/rpc/src/model/switch.rs
@@ -213,12 +213,388 @@ impl From<rpc::SwitchSearchFilter> for SwitchSearchFilter {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_uuid::rack::RackId;
     use config_version::{ConfigVersion, Versioned};
     use model::controller_outcome::PersistentStateHandlerOutcome;
     use model::metadata::Metadata;
     use model::switch::{FabricManagerStatus, SwitchControllerState, SwitchStatus};
 
     use super::*;
+
+    fn rpc_uuid(value: &str) -> crate::common::Uuid {
+        crate::common::Uuid {
+            value: value.to_string(),
+        }
+    }
+
+    fn base_rpc_config() -> rpc::SwitchConfig {
+        rpc::SwitchConfig {
+            name: "leaf-1".to_string(),
+            enable_nmxc: false,
+            fabric_manager_config: None,
+        }
+    }
+
+    fn base_rpc_filter() -> rpc::SwitchSearchFilter {
+        rpc::SwitchSearchFilter {
+            rack_id: None,
+            deleted: 0,
+            controller_state: None,
+            bmc_mac: None,
+            nvos_mac: None,
+            only_with_health_alert: None,
+        }
+    }
+
+    // to_rpc_fabric_manager_state: every enum arm maps to its proto discriminant.
+    #[test]
+    fn to_rpc_fabric_manager_state_maps_each_arm() {
+        check_values(
+            [
+                Check {
+                    scenario: "ok",
+                    input: FabricManagerState::Ok,
+                    expect: rpc::FabricManagerState::Ok as i32,
+                },
+                Check {
+                    scenario: "not ok",
+                    input: FabricManagerState::NotOk,
+                    expect: rpc::FabricManagerState::NotOk as i32,
+                },
+                Check {
+                    scenario: "unknown",
+                    input: FabricManagerState::Unknown,
+                    expect: rpc::FabricManagerState::Unknown as i32,
+                },
+            ],
+            to_rpc_fabric_manager_state,
+        );
+    }
+
+    // rpc::SwitchConfig -> SwitchConfig: name and enable_nmxc pass through; the
+    // fabric_manager_config is always materialized (default empty when absent).
+    #[test]
+    fn switch_config_from_rpc_passes_fields_through() {
+        check_cases(
+            [
+                Case {
+                    scenario: "name preserved",
+                    input: rpc::SwitchConfig {
+                        name: "spine-7".to_string(),
+                        ..base_rpc_config()
+                    },
+                    expect: Yields("spine-7".to_string()),
+                },
+                Case {
+                    scenario: "empty name preserved",
+                    input: rpc::SwitchConfig {
+                        name: String::new(),
+                        ..base_rpc_config()
+                    },
+                    expect: Yields(String::new()),
+                },
+            ],
+            |conf| SwitchConfig::try_from(conf).map(|c| c.name).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn switch_config_from_rpc_carries_enable_nmxc() {
+        check_cases(
+            [
+                Case {
+                    scenario: "nmxc enabled",
+                    input: rpc::SwitchConfig {
+                        enable_nmxc: true,
+                        ..base_rpc_config()
+                    },
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "nmxc disabled",
+                    input: rpc::SwitchConfig {
+                        enable_nmxc: false,
+                        ..base_rpc_config()
+                    },
+                    expect: Yields(false),
+                },
+            ],
+            |conf| {
+                SwitchConfig::try_from(conf)
+                    .map(|c| c.enable_nmxc)
+                    .map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn switch_config_from_rpc_materializes_fabric_manager_config() {
+        check_cases(
+            [
+                Case {
+                    scenario: "absent config becomes default empty map",
+                    input: rpc::SwitchConfig {
+                        fabric_manager_config: None,
+                        ..base_rpc_config()
+                    },
+                    expect: Yields(0),
+                },
+                Case {
+                    scenario: "present config map preserved",
+                    input: rpc::SwitchConfig {
+                        fabric_manager_config: Some(rpc::FabricManagerConfig {
+                            config_map: std::collections::HashMap::from([(
+                                "a".to_string(),
+                                "b".to_string(),
+                            )]),
+                        }),
+                        ..base_rpc_config()
+                    },
+                    expect: Yields(1),
+                },
+            ],
+            |conf| {
+                SwitchConfig::try_from(conf)
+                    .map(|c| c.fabric_manager_config.unwrap().config_map.len())
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // rpc::SwitchCreationRequest -> NewSwitch: the config is required, an explicit
+    // id must parse, and placement fields flow through when present.
+    #[test]
+    fn new_switch_from_creation_request_requires_config() {
+        Case {
+            scenario: "missing config fails",
+            input: rpc::SwitchCreationRequest {
+                config: None,
+                id: None,
+                placement_in_rack: None,
+            },
+            expect: Fails,
+        }
+        .check(|req| NewSwitch::try_from(req).map(|_| ()).map_err(drop));
+    }
+
+    #[test]
+    fn new_switch_from_creation_request_validates_id() {
+        check_cases(
+            [
+                Case {
+                    scenario: "absent id generates one",
+                    input: rpc::SwitchCreationRequest {
+                        config: Some(base_rpc_config()),
+                        id: None,
+                        placement_in_rack: None,
+                    },
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "valid uuid accepted",
+                    input: rpc::SwitchCreationRequest {
+                        config: Some(base_rpc_config()),
+                        id: Some(rpc_uuid("3a8c0f1e-2b4d-4c6e-8f10-1234567890ab")),
+                        placement_in_rack: None,
+                    },
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "malformed uuid rejected",
+                    input: rpc::SwitchCreationRequest {
+                        config: Some(base_rpc_config()),
+                        id: Some(rpc_uuid("not-a-uuid")),
+                        placement_in_rack: None,
+                    },
+                    expect: Fails,
+                },
+            ],
+            |req| {
+                NewSwitch::try_from(req)
+                    .map(|_| true)
+                    .map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn new_switch_from_creation_request_carries_placement() {
+        check_cases(
+            [
+                Case {
+                    scenario: "no placement leaves both None",
+                    input: rpc::SwitchCreationRequest {
+                        config: Some(base_rpc_config()),
+                        id: None,
+                        placement_in_rack: None,
+                    },
+                    expect: Yields((None, None)),
+                },
+                Case {
+                    scenario: "placement slot and tray flow through",
+                    input: rpc::SwitchCreationRequest {
+                        config: Some(base_rpc_config()),
+                        id: None,
+                        placement_in_rack: Some(rpc::PlacementInRack {
+                            slot_number: Some(4),
+                            tray_index: Some(9),
+                        }),
+                    },
+                    expect: Yields((Some(4), Some(9))),
+                },
+                Case {
+                    scenario: "placement present with empty fields",
+                    input: rpc::SwitchCreationRequest {
+                        config: Some(base_rpc_config()),
+                        id: None,
+                        placement_in_rack: Some(rpc::PlacementInRack {
+                            slot_number: None,
+                            tray_index: None,
+                        }),
+                    },
+                    expect: Yields((None, None)),
+                },
+            ],
+            |req| {
+                NewSwitch::try_from(req)
+                    .map(|n| (n.slot_number, n.tray_index))
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // rpc::SwitchSearchFilter -> SwitchSearchFilter: the DeletedFilter discriminant
+    // maps by value (unknown -> Exclude default).
+    #[test]
+    fn search_filter_maps_deleted_discriminant() {
+        check_values(
+            [
+                Check {
+                    scenario: "0 -> Exclude",
+                    input: 0,
+                    expect: model::DeletedFilter::Exclude,
+                },
+                Check {
+                    scenario: "1 -> Only",
+                    input: 1,
+                    expect: model::DeletedFilter::Only,
+                },
+                Check {
+                    scenario: "2 -> Include",
+                    input: 2,
+                    expect: model::DeletedFilter::Include,
+                },
+                Check {
+                    scenario: "unknown -> Exclude default",
+                    input: 99,
+                    expect: model::DeletedFilter::Exclude,
+                },
+            ],
+            |deleted| {
+                SwitchSearchFilter::from(rpc::SwitchSearchFilter {
+                    deleted,
+                    ..base_rpc_filter()
+                })
+                .deleted
+            },
+        );
+    }
+
+    #[test]
+    fn search_filter_carries_rack_and_state() {
+        check_values(
+            [
+                Check {
+                    scenario: "rack absent",
+                    input: base_rpc_filter(),
+                    expect: (None, None),
+                },
+                Check {
+                    scenario: "rack and controller_state present",
+                    input: rpc::SwitchSearchFilter {
+                        rack_id: Some(RackId::new("rack-9")),
+                        controller_state: Some("ready".to_string()),
+                        ..base_rpc_filter()
+                    },
+                    expect: (Some(RackId::new("rack-9")), Some("ready".to_string())),
+                },
+            ],
+            |filter| {
+                let f = SwitchSearchFilter::from(filter);
+                (f.rack_id, f.controller_state)
+            },
+        );
+    }
+
+    #[test]
+    fn search_filter_parses_mac_fields() {
+        // Returns (bmc_mac.is_some(), nvos_mac.is_some()) — a valid MAC parses to
+        // Some, a malformed one is silently dropped to None.
+        check_values(
+            [
+                Check {
+                    scenario: "both absent",
+                    input: base_rpc_filter(),
+                    expect: (false, false),
+                },
+                Check {
+                    scenario: "valid bmc mac parses",
+                    input: rpc::SwitchSearchFilter {
+                        bmc_mac: Some("00:11:22:33:44:55".to_string()),
+                        ..base_rpc_filter()
+                    },
+                    expect: (true, false),
+                },
+                Check {
+                    scenario: "valid nvos mac parses",
+                    input: rpc::SwitchSearchFilter {
+                        nvos_mac: Some("aa:bb:cc:dd:ee:ff".to_string()),
+                        ..base_rpc_filter()
+                    },
+                    expect: (false, true),
+                },
+                Check {
+                    scenario: "malformed macs drop to None",
+                    input: rpc::SwitchSearchFilter {
+                        bmc_mac: Some("nope".to_string()),
+                        nvos_mac: Some("also-nope".to_string()),
+                        ..base_rpc_filter()
+                    },
+                    expect: (false, false),
+                },
+            ],
+            |filter| {
+                let f = SwitchSearchFilter::from(filter);
+                (f.bmc_mac.is_some(), f.nvos_mac.is_some())
+            },
+        );
+    }
+
+    #[test]
+    fn search_filter_carries_health_alert() {
+        check_values(
+            [
+                Check {
+                    scenario: "absent",
+                    input: base_rpc_filter(),
+                    expect: None,
+                },
+                Check {
+                    scenario: "present",
+                    input: rpc::SwitchSearchFilter {
+                        only_with_health_alert: Some(
+                            "hardware-health.tray-leak-detection".to_string(),
+                        ),
+                        ..base_rpc_filter()
+                    },
+                    expect: Some("hardware-health.tray-leak-detection".to_string()),
+                },
+            ],
+            |filter| SwitchSearchFilter::from(filter).only_with_health_alert,
+        );
+    }
 
     #[test]
     fn try_from_switch_populates_state_reason() {

--- a/crates/rpc/src/model/tenant.rs
+++ b/crates/rpc/src/model/tenant.rs
@@ -523,62 +523,99 @@ pub fn validate_identity_overlap_for_rotation(
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
     use model::tenant::{identity_config, validate_trust_domain_allowlist_patterns};
 
     use super::*;
     use crate::forge as rpc_forge;
     use crate::forge::token_delegation_response::AuthMethodConfig;
 
-    #[test]
-    fn test_stored_to_response_auth_config_none() {
-        assert!(stored_to_response_auth_config(TokenDelegationAuthMethod::None, None).is_none());
+    /// Builds identity-config validation bounds, varying only the two fields the
+    /// per-case tables exercise (trust-domain allowlist and master key id).
+    fn identity_bounds(
+        trust_domain_allowlist: Vec<String>,
+        encryption_key_id: &str,
+    ) -> IdentityConfigValidationBounds {
+        IdentityConfigValidationBounds {
+            token_ttl_min_sec: 60,
+            token_ttl_max_sec: 86400,
+            algorithm: identity_config::SigningAlgorithm::Es256,
+            encryption_key_id: encryption_key_id.parse().unwrap(),
+            trust_domain_allowlist,
+            signing_key_overlap_max_sec: 604_800,
+        }
     }
 
-    #[test]
-    fn test_stored_to_response_auth_config_client_secret_basic() {
-        let stored = ClientSecretBasic {
-            client_id: "my-client".to_string(),
-            client_secret: "secret".to_string(),
-        };
-        let out = stored_to_response_auth_config(
-            TokenDelegationAuthMethod::ClientSecretBasic,
-            Some(stored),
-        )
-        .unwrap();
-        let AuthMethodConfig::ClientSecretBasic(c) = &out;
-        assert_eq!(c.client_id, "my-client");
-        assert!(c.client_secret_hash.starts_with("sha256:"));
-        assert!(c.client_secret_hash.ends_with(".."));
-    }
-
-    #[test]
-    fn test_stored_to_response_auth_config_omits_cleartext() {
-        let stored = ClientSecretBasic {
-            client_id: "my-client".to_string(),
-            client_secret: "secret".to_string(),
-        };
-        let out = stored_to_response_auth_config(
-            TokenDelegationAuthMethod::ClientSecretBasic,
-            Some(stored),
-        )
-        .unwrap();
-        let AuthMethodConfig::ClientSecretBasic(c) = &out;
-        assert_eq!(c.client_id, "my-client");
-        assert!(!c.client_secret_hash.is_empty());
-    }
-
-    #[test]
-    fn test_stored_to_response_auth_config_client_secret_empty_returns_none() {
-        let stored = ClientSecretBasic {
-            client_id: "x".to_string(),
-            client_secret: String::new(),
-        };
-        assert!(
-            stored_to_response_auth_config(
-                TokenDelegationAuthMethod::ClientSecretBasic,
-                Some(stored),
+    /// Projects a stored auth config to the fields the originals asserted:
+    /// the client id and three display-hash properties.
+    fn project_auth_config(out: Option<AuthMethodConfig>) -> Option<(String, bool, bool, bool)> {
+        out.map(|AuthMethodConfig::ClientSecretBasic(c)| {
+            (
+                c.client_id,
+                c.client_secret_hash.starts_with("sha256:"),
+                c.client_secret_hash.ends_with(".."),
+                !c.client_secret_hash.is_empty(),
             )
-            .is_none()
+        })
+    }
+
+    // stored_to_response_auth_config: maps stored config to the response oneof,
+    // hashing/truncating the client secret and dropping empty/None secrets.
+    #[test]
+    fn stored_to_response_auth_config_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "auth method None yields no config",
+                    input: (TokenDelegationAuthMethod::None, None),
+                    expect: None,
+                },
+                Check {
+                    scenario: "client secret basic yields truncated hash",
+                    input: (
+                        TokenDelegationAuthMethod::ClientSecretBasic,
+                        Some(ClientSecretBasic {
+                            client_id: "my-client".to_string(),
+                            client_secret: "secret".to_string(),
+                        }),
+                    ),
+                    expect: Some(("my-client".to_string(), true, true, true)),
+                },
+                Check {
+                    scenario: "empty client secret yields no config",
+                    input: (
+                        TokenDelegationAuthMethod::ClientSecretBasic,
+                        Some(ClientSecretBasic {
+                            client_id: "x".to_string(),
+                            client_secret: String::new(),
+                        }),
+                    ),
+                    expect: None,
+                },
+            ],
+            |(auth_method, stored)| {
+                project_auth_config(stored_to_response_auth_config(auth_method, stored))
+            },
+        );
+    }
+
+    // The hashed client secret in the response never exposes the cleartext.
+    #[test]
+    fn stored_to_response_auth_config_hash_omits_cleartext() {
+        let out = stored_to_response_auth_config(
+            TokenDelegationAuthMethod::ClientSecretBasic,
+            Some(ClientSecretBasic {
+                client_id: "my-client".to_string(),
+                client_secret: "secret".to_string(),
+            }),
+        )
+        .expect("client secret basic yields a config");
+        let AuthMethodConfig::ClientSecretBasic(c) = out;
+        assert!(
+            !c.client_secret_hash.contains("secret"),
+            "hash must not expose the cleartext secret: {}",
+            c.client_secret_hash
         );
     }
 
@@ -635,297 +672,196 @@ mod tests {
         assert_eq!(config.encryption_key_id.as_str(), "test-master");
     }
 
+    // identity_config_try_from_proto success: each row asserts the normalized
+    // issuer and resolved SPIFFE subject_prefix produced from the proto + bounds.
     #[test]
-    fn identity_config_try_from_proto_stores_normalized_issuer() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "HTTPS://Issuer.EXAMPLE.COM/wl".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: None,
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test-master".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let config = identity_config_try_from_proto(proto, &bounds).unwrap();
-        assert_eq!(config.issuer.as_str(), "https://issuer.example.com/wl");
-        assert_eq!(config.subject_prefix, "spiffe://issuer.example.com");
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_empty_issuer() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: String::new(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: None,
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
-        assert!(err.0.contains("issuer is required"));
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_empty_default_audience() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://issuer.example.com".to_string(),
-            default_audience: String::new(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: None,
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
-        assert!(err.0.contains("default_audience is required"));
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_accepts_custom_subject_prefix_in_proto() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://issuer.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: Some("spiffe://issuer.example.com/workloads".to_string()),
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let config = identity_config_try_from_proto(proto, &bounds).unwrap();
-        assert_eq!(
-            config.subject_prefix,
-            "spiffe://issuer.example.com/workloads"
+    fn identity_config_try_from_proto_success_cases() {
+        struct Row {
+            scenario: &'static str,
+            issuer: &'static str,
+            subject_prefix: Option<&'static str>,
+            allowlist: Vec<String>,
+            expect_issuer: &'static str,
+            expect_subject_prefix: &'static str,
+        }
+        let rows = [
+            Row {
+                scenario: "issuer is lowercased and normalized",
+                issuer: "HTTPS://Issuer.EXAMPLE.COM/wl",
+                subject_prefix: None,
+                allowlist: vec![],
+                expect_issuer: "https://issuer.example.com/wl",
+                expect_subject_prefix: "spiffe://issuer.example.com",
+            },
+            Row {
+                scenario: "custom subject_prefix in proto is honored",
+                issuer: "https://issuer.example.com",
+                subject_prefix: Some("spiffe://issuer.example.com/workloads"),
+                allowlist: vec![],
+                expect_issuer: "https://issuer.example.com",
+                expect_subject_prefix: "spiffe://issuer.example.com/workloads",
+            },
+            Row {
+                scenario: "empty optional subject_prefix defaults",
+                issuer: "https://issuer.example.com",
+                subject_prefix: Some(""),
+                allowlist: vec![],
+                expect_issuer: "https://issuer.example.com",
+                expect_subject_prefix: "spiffe://issuer.example.com",
+            },
+            Row {
+                scenario: "trust domain matching wildcard allowlist",
+                issuer: "https://auth.login.example.com",
+                subject_prefix: None,
+                allowlist: vec!["**.login.example.com".to_string()],
+                expect_issuer: "https://auth.login.example.com",
+                expect_subject_prefix: "spiffe://auth.login.example.com",
+            },
+        ];
+        check_cases(
+            rows.map(|r| Case {
+                scenario: r.scenario,
+                input: (r.issuer, r.subject_prefix, r.allowlist),
+                expect: Yields((
+                    r.expect_issuer.to_string(),
+                    r.expect_subject_prefix.to_string(),
+                )),
+            }),
+            |(issuer, subject_prefix, allowlist)| {
+                let proto = rpc_forge::TenantIdentityConfig {
+                    enabled: true,
+                    issuer: issuer.to_string(),
+                    default_audience: "api".to_string(),
+                    allowed_audiences: vec![],
+                    token_ttl_sec: 3600,
+                    subject_prefix: subject_prefix.map(|s| s.to_string()),
+                    rotate_key: false,
+                    signing_key_overlap_sec: None,
+                };
+                let bounds = identity_bounds(allowlist, "test-master");
+                let config = identity_config_try_from_proto(proto, &bounds).map_err(drop)?;
+                Ok::<_, ()>((config.issuer.as_str().to_string(), config.subject_prefix))
+            },
         );
     }
 
+    // identity_config_try_from_proto rejections: each row's error message must
+    // contain every listed substring (the user-facing validation contract).
     #[test]
-    fn identity_config_try_from_proto_empty_optional_subject_prefix_defaults() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://issuer.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: Some(String::new()),
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let config = identity_config_try_from_proto(proto, &bounds).unwrap();
-        assert_eq!(config.subject_prefix, "spiffe://issuer.example.com");
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_rejects_non_spiffe_subject_prefix() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://issuer.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: Some("https://issuer.example.com/p".to_string()),
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
-        assert!(err.0.contains("spiffe://"));
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_rejects_subject_prefix_trust_domain_mismatch() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://issuer.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: Some("spiffe://other.example/wl".to_string()),
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
-        assert!(err.0.contains("does not match"));
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_token_ttl_zero() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://issuer.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 0,
-            subject_prefix: None,
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
-        assert!(err.0.contains("token_ttl_sec"));
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_token_ttl_below_min() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://issuer.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 30,
-            subject_prefix: None,
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
-        assert!(err.0.contains("token_ttl_sec must be between"));
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_token_ttl_above_max() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://issuer.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 100000,
-            subject_prefix: None,
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec![],
-            signing_key_overlap_max_sec: 604800,
-        };
-        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
-        assert!(err.0.contains("token_ttl_sec must be between"));
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_rejects_trust_domain_not_on_allowlist() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://evil.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: None,
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec!["login.example.com".to_string()],
-            signing_key_overlap_max_sec: 604_800,
-        };
-        let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
-        assert!(err.0.contains("trust domain"));
-        assert!(err.0.contains("allowlist"));
-    }
-
-    #[test]
-    fn identity_config_try_from_proto_accepts_trust_domain_matching_allowlist() {
-        let proto = rpc_forge::TenantIdentityConfig {
-            enabled: true,
-            issuer: "https://auth.login.example.com".to_string(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: None,
-            rotate_key: false,
-            signing_key_overlap_sec: None,
-        };
-        let bounds = IdentityConfigValidationBounds {
-            token_ttl_min_sec: 60,
-            token_ttl_max_sec: 86400,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            trust_domain_allowlist: vec!["**.login.example.com".to_string()],
-            signing_key_overlap_max_sec: 604_800,
-        };
-        let config = identity_config_try_from_proto(proto, &bounds).unwrap();
-        assert_eq!(config.subject_prefix, "spiffe://auth.login.example.com");
+    fn identity_config_try_from_proto_error_cases() {
+        struct Row {
+            scenario: &'static str,
+            proto: rpc_forge::TenantIdentityConfig,
+            allowlist: Vec<String>,
+            wants: Vec<&'static str>,
+        }
+        fn proto(
+            issuer: &str,
+            default_audience: &str,
+            token_ttl_sec: u32,
+            subject_prefix: Option<&str>,
+            signing_key_overlap_sec: Option<u32>,
+        ) -> rpc_forge::TenantIdentityConfig {
+            rpc_forge::TenantIdentityConfig {
+                enabled: true,
+                issuer: issuer.to_string(),
+                default_audience: default_audience.to_string(),
+                allowed_audiences: vec![],
+                token_ttl_sec,
+                subject_prefix: subject_prefix.map(|s| s.to_string()),
+                rotate_key: false,
+                signing_key_overlap_sec,
+            }
+        }
+        let rows = [
+            Row {
+                scenario: "empty issuer",
+                proto: proto("", "api", 3600, None, None),
+                allowlist: vec![],
+                wants: vec!["issuer is required"],
+            },
+            Row {
+                scenario: "empty default_audience",
+                proto: proto("https://issuer.example.com", "", 3600, None, None),
+                allowlist: vec![],
+                wants: vec!["default_audience is required"],
+            },
+            Row {
+                scenario: "non-spiffe subject_prefix",
+                proto: proto(
+                    "https://issuer.example.com",
+                    "api",
+                    3600,
+                    Some("https://issuer.example.com/p"),
+                    None,
+                ),
+                allowlist: vec![],
+                wants: vec!["spiffe://"],
+            },
+            Row {
+                scenario: "subject_prefix trust-domain mismatch",
+                proto: proto(
+                    "https://issuer.example.com",
+                    "api",
+                    3600,
+                    Some("spiffe://other.example/wl"),
+                    None,
+                ),
+                allowlist: vec![],
+                wants: vec!["does not match"],
+            },
+            Row {
+                scenario: "token_ttl_sec zero",
+                proto: proto("https://issuer.example.com", "api", 0, None, None),
+                allowlist: vec![],
+                wants: vec!["token_ttl_sec"],
+            },
+            Row {
+                scenario: "token_ttl_sec below min",
+                proto: proto("https://issuer.example.com", "api", 30, None, None),
+                allowlist: vec![],
+                wants: vec!["token_ttl_sec must be between"],
+            },
+            Row {
+                scenario: "token_ttl_sec above max",
+                proto: proto("https://issuer.example.com", "api", 100000, None, None),
+                allowlist: vec![],
+                wants: vec!["token_ttl_sec must be between"],
+            },
+            Row {
+                scenario: "trust domain not on allowlist",
+                proto: proto("https://evil.example.com", "api", 3600, None, None),
+                allowlist: vec!["login.example.com".to_string()],
+                wants: vec!["trust domain", "allowlist"],
+            },
+            Row {
+                scenario: "no allowlist entry matches",
+                proto: proto("https://idp.other.example/", "api", 3600, None, None),
+                allowlist: vec![
+                    "login.example.com".to_string(),
+                    "*.tenant.example.net".to_string(),
+                ],
+                wants: vec!["allowlist"],
+            },
+            Row {
+                scenario: "overlap set when not rotating",
+                proto: proto("https://issuer.example.com", "api", 3600, None, Some(120)),
+                allowlist: vec![],
+                wants: vec!["signing_key_overlap_sec may only be set"],
+            },
+        ];
+        check_values(
+            rows.map(|r| Check {
+                scenario: r.scenario,
+                input: (r.proto, r.allowlist, r.wants),
+                expect: true,
+            }),
+            |(proto, allowlist, wants)| {
+                let bounds = identity_bounds(allowlist, "test");
+                let err = identity_config_try_from_proto(proto, &bounds).unwrap_err();
+                wants.iter().all(|w| err.0.contains(w))
+            },
+        );
     }
 
     #[test]
@@ -1014,163 +950,820 @@ mod tests {
         assert!(err.0.contains("signing_key_overlap_sec may only be set"));
     }
 
+    // validate_identity_overlap_for_rotation: a missing overlap and an
+    // overlap shorter than token_ttl_sec are rejected (with the listed
+    // substring); a sufficient overlap is accepted (`None` want = Ok).
     #[test]
-    fn validate_identity_overlap_requires_value_when_rotating() {
-        let config = IdentityConfig {
-            issuer: "https://issuer.example.com".parse().unwrap(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: "spiffe://issuer.example.com".to_string(),
-            enabled: true,
-            rotate_key: true,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            signing_key_overlap_sec: None,
-        };
-        let err = validate_identity_overlap_for_rotation(&config).unwrap_err();
-        assert!(err.0.contains("signing_key_overlap_sec is required"));
-    }
-
-    #[test]
-    fn validate_identity_overlap_rejects_less_than_token_ttl() {
-        let config = IdentityConfig {
-            issuer: "https://issuer.example.com".parse().unwrap(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: "spiffe://issuer.example.com".to_string(),
-            enabled: true,
-            rotate_key: true,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            signing_key_overlap_sec: Some(120),
-        };
-        let err = validate_identity_overlap_for_rotation(&config).unwrap_err();
-        assert!(
-            err.0.contains("must be at least token_ttl_sec"),
-            "unexpected: {}",
-            err.0
+    fn validate_identity_overlap_cases() {
+        fn rotating_config(signing_key_overlap_sec: Option<i32>) -> IdentityConfig {
+            IdentityConfig {
+                issuer: "https://issuer.example.com".parse().unwrap(),
+                default_audience: "api".to_string(),
+                allowed_audiences: vec![],
+                token_ttl_sec: 3600,
+                subject_prefix: "spiffe://issuer.example.com".to_string(),
+                enabled: true,
+                rotate_key: true,
+                algorithm: identity_config::SigningAlgorithm::Es256,
+                encryption_key_id: "test".parse().unwrap(),
+                signing_key_overlap_sec,
+            }
+        }
+        check_values(
+            [
+                Check {
+                    scenario: "missing overlap is rejected",
+                    input: (None, Some("signing_key_overlap_sec is required")),
+                    expect: true,
+                },
+                Check {
+                    scenario: "overlap shorter than token_ttl_sec is rejected",
+                    input: (Some(120), Some("must be at least token_ttl_sec")),
+                    expect: true,
+                },
+                Check {
+                    scenario: "overlap at least token_ttl_sec is accepted",
+                    input: (Some(3600), None),
+                    expect: true,
+                },
+            ],
+            |(overlap, want): (Option<i32>, Option<&str>)| {
+                let result = validate_identity_overlap_for_rotation(&rotating_config(overlap));
+                match want {
+                    Some(substr) => result.unwrap_err().0.contains(substr),
+                    None => result.is_ok(),
+                }
+            },
         );
     }
 
-    #[test]
-    fn validate_identity_overlap_ok_when_rotating() {
-        let config = IdentityConfig {
-            issuer: "https://issuer.example.com".parse().unwrap(),
-            default_audience: "api".to_string(),
-            allowed_audiences: vec![],
-            token_ttl_sec: 3600,
-            subject_prefix: "spiffe://issuer.example.com".to_string(),
-            enabled: true,
-            rotate_key: true,
-            algorithm: identity_config::SigningAlgorithm::Es256,
-            encryption_key_id: "test".parse().unwrap(),
-            signing_key_overlap_sec: Some(3600),
-        };
-        validate_identity_overlap_for_rotation(&config).unwrap();
-    }
-
-    #[test]
-    fn token_delegation_try_from_success_none() {
-        let proto = rpc_forge::TokenDelegation {
-            token_endpoint: "https://auth.example.com/token".to_string(),
-            subject_token_audience: "https://api.example.com".to_string(),
-            auth_method_config: None,
-        };
-        let config = TokenDelegation::try_from(proto).unwrap();
-        assert_eq!(config.token_endpoint, "https://auth.example.com/token");
-        assert_eq!(config.subject_token_audience, "https://api.example.com");
-        matches!(
-            config.auth_method_config,
-            TokenDelegationAuthMethodConfig::None
-        );
-    }
-
-    #[test]
-    fn token_delegation_try_from_success_client_secret_basic() {
-        let proto = rpc_forge::TokenDelegation {
-            token_endpoint: "https://auth.example.com/token".to_string(),
-            subject_token_audience: "https://api.example.com".to_string(),
-            auth_method_config: Some(
-                rpc_forge::token_delegation::AuthMethodConfig::ClientSecretBasic(
-                    rpc_forge::ClientSecretBasic {
-                        client_id: "my-client".to_string(),
-                        client_secret: "my-secret".to_string(),
-                    },
-                ),
-            ),
-        };
-        let config = TokenDelegation::try_from(proto).unwrap();
-        assert_eq!(config.token_endpoint, "https://auth.example.com/token");
-        assert_eq!(config.subject_token_audience, "https://api.example.com");
-        match &config.auth_method_config {
+    /// Projects a converted `TokenDelegation` to the endpoint, audience, and the
+    /// auth-method-config fields the originals asserted.
+    fn project_token_delegation(
+        config: TokenDelegation,
+    ) -> (String, String, Option<(String, String)>) {
+        let auth = match config.auth_method_config {
+            TokenDelegationAuthMethodConfig::None => None,
             TokenDelegationAuthMethodConfig::ClientSecretBasic {
                 client_id,
                 client_secret,
-            } => {
-                assert_eq!(client_id, "my-client");
-                assert_eq!(client_secret, "my-secret");
-            }
-            _ => panic!("expected ClientSecretBasic"),
+            } => Some((client_id, client_secret)),
+        };
+        (config.token_endpoint, config.subject_token_audience, auth)
+    }
+
+    // TokenDelegation::try_from success: the endpoint and audience pass through,
+    // and the auth method config maps to None or the client-secret-basic pair.
+    #[test]
+    fn token_delegation_try_from_success_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "no auth method config",
+                    input: rpc_forge::TokenDelegation {
+                        token_endpoint: "https://auth.example.com/token".to_string(),
+                        subject_token_audience: "https://api.example.com".to_string(),
+                        auth_method_config: None,
+                    },
+                    expect: Yields((
+                        "https://auth.example.com/token".to_string(),
+                        "https://api.example.com".to_string(),
+                        None,
+                    )),
+                },
+                Case {
+                    scenario: "client secret basic",
+                    input: rpc_forge::TokenDelegation {
+                        token_endpoint: "https://auth.example.com/token".to_string(),
+                        subject_token_audience: "https://api.example.com".to_string(),
+                        auth_method_config: Some(
+                            rpc_forge::token_delegation::AuthMethodConfig::ClientSecretBasic(
+                                rpc_forge::ClientSecretBasic {
+                                    client_id: "my-client".to_string(),
+                                    client_secret: "my-secret".to_string(),
+                                },
+                            ),
+                        ),
+                    },
+                    expect: Yields((
+                        "https://auth.example.com/token".to_string(),
+                        "https://api.example.com".to_string(),
+                        Some(("my-client".to_string(), "my-secret".to_string())),
+                    )),
+                },
+            ],
+            |proto| {
+                let config = TokenDelegation::try_from(proto).map_err(drop)?;
+                Ok::<_, ()>(project_token_delegation(config))
+            },
+        );
+    }
+
+    // TokenDelegation::try_from rejections: each row's error message must contain
+    // the listed substring (the user-facing validation contract).
+    #[test]
+    fn token_delegation_try_from_error_cases() {
+        fn client_secret_basic(
+            client_id: &str,
+            client_secret: &str,
+        ) -> Option<rpc_forge::token_delegation::AuthMethodConfig> {
+            Some(
+                rpc_forge::token_delegation::AuthMethodConfig::ClientSecretBasic(
+                    rpc_forge::ClientSecretBasic {
+                        client_id: client_id.to_string(),
+                        client_secret: client_secret.to_string(),
+                    },
+                ),
+            )
+        }
+        check_values(
+            [
+                Check {
+                    scenario: "empty token_endpoint",
+                    input: (
+                        rpc_forge::TokenDelegation {
+                            token_endpoint: String::new(),
+                            subject_token_audience: "https://api.example.com".to_string(),
+                            auth_method_config: None,
+                        },
+                        "token_endpoint is required",
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "empty subject_token_audience",
+                    input: (
+                        rpc_forge::TokenDelegation {
+                            token_endpoint: "https://auth.example.com/token".to_string(),
+                            subject_token_audience: String::new(),
+                            auth_method_config: None,
+                        },
+                        "subject_token_audience is required",
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "empty client_id",
+                    input: (
+                        rpc_forge::TokenDelegation {
+                            token_endpoint: "https://auth.example.com/token".to_string(),
+                            subject_token_audience: "https://api.example.com".to_string(),
+                            auth_method_config: client_secret_basic("", "secret"),
+                        },
+                        "client_id is required",
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "empty client_secret",
+                    input: (
+                        rpc_forge::TokenDelegation {
+                            token_endpoint: "https://auth.example.com/token".to_string(),
+                            subject_token_audience: "https://api.example.com".to_string(),
+                            auth_method_config: client_secret_basic("client", ""),
+                        },
+                        "client_secret is required",
+                    ),
+                    expect: true,
+                },
+            ],
+            |(proto, want): (rpc_forge::TokenDelegation, &str)| {
+                TokenDelegation::try_from(proto)
+                    .unwrap_err()
+                    .0
+                    .contains(want)
+            },
+        );
+    }
+
+    /// A version string the domain `ConfigVersion` parser accepts, round-tripping
+    /// to itself through `version_string()`.
+    const VALID_VERSION: &str = "V1-T1700000000000000";
+
+    /// A proto tenant keyset identifier with the given org and keyset id.
+    fn proto_keyset_identifier(
+        organization_id: &str,
+        keyset_id: &str,
+    ) -> rpc_forge::TenantKeysetIdentifier {
+        rpc_forge::TenantKeysetIdentifier {
+            organization_id: organization_id.to_string(),
+            keyset_id: keyset_id.to_string(),
         }
     }
 
+    // TenantSearchFilter::from copies the optional organization-name filter through
+    // unchanged for both present and absent.
     #[test]
-    fn token_delegation_try_from_empty_token_endpoint() {
-        let proto = rpc_forge::TokenDelegation {
-            token_endpoint: String::new(),
-            subject_token_audience: "https://api.example.com".to_string(),
-            auth_method_config: None,
-        };
-        let err = TokenDelegation::try_from(proto).unwrap_err();
-        assert!(err.0.contains("token_endpoint is required"));
+    fn tenant_search_filter_from_rpc() {
+        check_values(
+            [
+                Check {
+                    scenario: "present organization name",
+                    input: Some("acme".to_string()),
+                    expect: Some("acme".to_string()),
+                },
+                Check {
+                    scenario: "absent organization name",
+                    input: None,
+                    expect: None,
+                },
+            ],
+            |tenant_organization_name| {
+                TenantSearchFilter::from(rpc::forge::TenantSearchFilter {
+                    tenant_organization_name,
+                })
+                .tenant_organization_name
+            },
+        );
     }
 
+    // TenantKeysetSearchFilter::from copies the optional org-id filter through
+    // unchanged for both present and absent.
     #[test]
-    fn token_delegation_try_from_empty_subject_token_audience() {
-        let proto = rpc_forge::TokenDelegation {
-            token_endpoint: "https://auth.example.com/token".to_string(),
-            subject_token_audience: String::new(),
-            auth_method_config: None,
-        };
-        let err = TokenDelegation::try_from(proto).unwrap_err();
-        assert!(err.0.contains("subject_token_audience is required"));
+    fn tenant_keyset_search_filter_from_rpc() {
+        check_values(
+            [
+                Check {
+                    scenario: "present org id",
+                    input: Some("org-1".to_string()),
+                    expect: Some("org-1".to_string()),
+                },
+                Check {
+                    scenario: "absent org id",
+                    input: None,
+                    expect: None,
+                },
+            ],
+            |tenant_org_id| {
+                TenantKeysetSearchFilter::from(rpc::forge::TenantKeysetSearchFilter { tenant_org_id })
+                    .tenant_org_id
+            },
+        );
     }
 
+    // TenantPublicKey proto -> domain: the public_key string is parsed into algo/key/
+    // comment parts and the proto comment passes through. Projects to
+    // (algo, key, key-comment, tenant-comment).
     #[test]
-    fn token_delegation_try_from_empty_client_id() {
-        let proto = rpc_forge::TokenDelegation {
-            token_endpoint: "https://auth.example.com/token".to_string(),
-            subject_token_audience: "https://api.example.com".to_string(),
-            auth_method_config: Some(
-                rpc_forge::token_delegation::AuthMethodConfig::ClientSecretBasic(
-                    rpc_forge::ClientSecretBasic {
-                        client_id: String::new(),
-                        client_secret: "secret".to_string(),
+    fn tenant_public_key_from_rpc() {
+        check_values(
+            [
+                Check {
+                    scenario: "algo and key and embedded comment",
+                    input: ("ssh-ed25519 AAAA user@host".to_string(), Some("c".to_string())),
+                    expect: (
+                        Some("ssh-ed25519".to_string()),
+                        "AAAA".to_string(),
+                        Some("user@host".to_string()),
+                        Some("c".to_string()),
+                    ),
+                },
+                Check {
+                    scenario: "bare key has no algo or comment",
+                    input: ("AAAA".to_string(), None),
+                    expect: (None, "AAAA".to_string(), None, None),
+                },
+            ],
+            |(public_key, comment)| {
+                let domain =
+                    TenantPublicKey::from(rpc::forge::TenantPublicKey { public_key, comment });
+                (
+                    domain.public_key.algo,
+                    domain.public_key.key,
+                    domain.public_key.comment,
+                    domain.comment,
+                )
+            },
+        );
+    }
+
+    // TenantPublicKey domain -> proto: the public key renders via Display and the
+    // tenant comment passes through. Projects to (public_key, comment).
+    #[test]
+    fn tenant_public_key_to_rpc() {
+        check_values(
+            [
+                Check {
+                    scenario: "algo and key and key-comment render together",
+                    input: (
+                        PublicKey {
+                            algo: Some("ssh-ed25519".to_string()),
+                            key: "AAAA".to_string(),
+                            comment: Some("user@host".to_string()),
+                        },
+                        Some("tenant-comment".to_string()),
+                    ),
+                    expect: (
+                        "ssh-ed25519 AAAA user@host".to_string(),
+                        Some("tenant-comment".to_string()),
+                    ),
+                },
+                Check {
+                    scenario: "bare key renders alone with no comment",
+                    input: (
+                        PublicKey {
+                            algo: None,
+                            key: "AAAA".to_string(),
+                            comment: None,
+                        },
+                        None,
+                    ),
+                    expect: ("AAAA".to_string(), None),
+                },
+            ],
+            |(public_key, comment)| {
+                let proto = rpc::forge::TenantPublicKey::from(TenantPublicKey {
+                    public_key,
+                    comment,
+                });
+                (proto.public_key, proto.comment)
+            },
+        );
+    }
+
+    // TenantKeysetContent converts both directions; each row counts the keys that
+    // survive the round trip out and back, covering empty and populated sets.
+    #[test]
+    fn tenant_keyset_content_round_trips() {
+        fn proto_key(key: &str) -> rpc::forge::TenantPublicKey {
+            rpc::forge::TenantPublicKey {
+                public_key: key.to_string(),
+                comment: None,
+            }
+        }
+        check_values(
+            [
+                Check {
+                    scenario: "empty key set",
+                    input: vec![],
+                    expect: 0usize,
+                },
+                Check {
+                    scenario: "two keys",
+                    input: vec![proto_key("AAAA"), proto_key("BBBB")],
+                    expect: 2usize,
+                },
+            ],
+            |public_keys| {
+                let domain = TenantKeysetContent::from(rpc::forge::TenantKeysetContent {
+                    public_keys,
+                });
+                let proto = rpc::forge::TenantKeysetContent::from(domain);
+                proto.public_keys.len()
+            },
+        );
+    }
+
+    // TenantKeysetIdentifier::try_from: a valid org id yields the (org, keyset_id)
+    // pair; an empty/invalid org id is rejected.
+    #[test]
+    fn tenant_keyset_identifier_try_from_rpc() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid org and keyset id",
+                    input: proto_keyset_identifier("acme-1", "k1"),
+                    expect: Yields(("acme-1".to_string(), "k1".to_string())),
+                },
+                Case {
+                    scenario: "empty org id is rejected",
+                    input: proto_keyset_identifier("", "k1"),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "org id with illegal char is rejected",
+                    input: proto_keyset_identifier("a b", "k1"),
+                    expect: Fails,
+                },
+            ],
+            |proto| {
+                let domain = TenantKeysetIdentifier::try_from(proto).map_err(drop)?;
+                Ok::<_, ()>((domain.organization_id.to_string(), domain.keyset_id))
+            },
+        );
+    }
+
+    // TenantKeysetIdentifier::from (domain -> proto) copies org id and keyset id.
+    #[test]
+    fn tenant_keyset_identifier_to_rpc() {
+        let proto = rpc::forge::TenantKeysetIdentifier::from(TenantKeysetIdentifier {
+            organization_id: "acme-1".to_string().try_into().unwrap(),
+            keyset_id: "k1".to_string(),
+        });
+        Check {
+            scenario: "org and keyset id pass through",
+            input: proto,
+            expect: ("acme-1".to_string(), "k1".to_string()),
+        }
+        .check(|p| (p.organization_id, p.keyset_id));
+    }
+
+    // TenantKeysetId::from (the string-typed find-by-ids shape) -> proto identifier
+    // copies both fields verbatim.
+    #[test]
+    fn tenant_keyset_id_to_rpc_identifier() {
+        let proto = rpc::forge::TenantKeysetIdentifier::from(TenantKeysetId {
+            organization_id: "acme-1".to_string(),
+            keyset_id: "k1".to_string(),
+        });
+        Check {
+            scenario: "org and keyset id pass through",
+            input: proto,
+            expect: ("acme-1".to_string(), "k1".to_string()),
+        }
+        .check(|p| (p.organization_id, p.keyset_id));
+    }
+
+    // TenantKeyset::try_from: a complete proto yields the keyset (projected to
+    // org id, keyset id, key count, version); a missing identifier or missing
+    // content is rejected.
+    #[test]
+    fn tenant_keyset_try_from_rpc() {
+        let content = rpc::forge::TenantKeysetContent {
+            public_keys: vec![rpc::forge::TenantPublicKey {
+                public_key: "AAAA".to_string(),
+                comment: None,
+            }],
+        };
+        check_cases(
+            [
+                Case {
+                    scenario: "complete keyset",
+                    input: rpc::forge::TenantKeyset {
+                        keyset_identifier: Some(proto_keyset_identifier("acme-1", "k1")),
+                        keyset_content: Some(content.clone()),
+                        version: "v1".to_string(),
                     },
-                ),
-            ),
-        };
-        let err = TokenDelegation::try_from(proto).unwrap_err();
-        assert!(err.0.contains("client_id is required"));
+                    expect: Yields(("acme-1".to_string(), "k1".to_string(), 1usize, "v1".to_string())),
+                },
+                Case {
+                    scenario: "missing keyset identifier is rejected",
+                    input: rpc::forge::TenantKeyset {
+                        keyset_identifier: None,
+                        keyset_content: Some(content.clone()),
+                        version: "v1".to_string(),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing keyset content is rejected",
+                    input: rpc::forge::TenantKeyset {
+                        keyset_identifier: Some(proto_keyset_identifier("acme-1", "k1")),
+                        keyset_content: None,
+                        version: "v1".to_string(),
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "invalid org in identifier is rejected",
+                    input: rpc::forge::TenantKeyset {
+                        keyset_identifier: Some(proto_keyset_identifier("", "k1")),
+                        keyset_content: Some(content),
+                        version: "v1".to_string(),
+                    },
+                    expect: Fails,
+                },
+            ],
+            |proto| {
+                let domain = TenantKeyset::try_from(proto).map_err(drop)?;
+                Ok::<_, ()>((
+                    domain.keyset_identifier.organization_id.to_string(),
+                    domain.keyset_identifier.keyset_id,
+                    domain.keyset_content.public_keys.len(),
+                    domain.version,
+                ))
+            },
+        );
     }
 
+    // TenantKeyset::from (domain -> proto) wraps identifier and content in Some and
+    // copies the version; projects to (has_identifier, has_content, version).
     #[test]
-    fn token_delegation_try_from_empty_client_secret() {
-        let proto = rpc_forge::TokenDelegation {
-            token_endpoint: "https://auth.example.com/token".to_string(),
-            subject_token_audience: "https://api.example.com".to_string(),
-            auth_method_config: Some(
-                rpc_forge::token_delegation::AuthMethodConfig::ClientSecretBasic(
-                    rpc_forge::ClientSecretBasic {
-                        client_id: "client".to_string(),
-                        client_secret: String::new(),
-                    },
-                ),
-            ),
+    fn tenant_keyset_to_rpc() {
+        let domain = TenantKeyset {
+            keyset_identifier: TenantKeysetIdentifier {
+                organization_id: "acme-1".to_string().try_into().unwrap(),
+                keyset_id: "k1".to_string(),
+            },
+            keyset_content: TenantKeysetContent {
+                public_keys: vec![],
+            },
+            version: "v1".to_string(),
         };
-        let err = TokenDelegation::try_from(proto).unwrap_err();
-        assert!(err.0.contains("client_secret is required"));
+        Check {
+            scenario: "identifier and content are present, version copied",
+            input: domain,
+            expect: (true, true, "v1".to_string()),
+        }
+        .check(|d| {
+            let proto = rpc::forge::TenantKeyset::from(d);
+            (
+                proto.keyset_identifier.is_some(),
+                proto.keyset_content.is_some(),
+                proto.version,
+            )
+        });
+    }
+
+    // CreateTenantKeysetRequest::try_from: a complete request yields the keyset;
+    // absent content defaults to an empty key set; a missing/invalid identifier
+    // is rejected.
+    #[test]
+    fn create_tenant_keyset_request_try_from_rpc() {
+        check_cases(
+            [
+                Case {
+                    scenario: "complete request",
+                    input: rpc::forge::CreateTenantKeysetRequest {
+                        keyset_identifier: Some(proto_keyset_identifier("acme-1", "k1")),
+                        keyset_content: Some(rpc::forge::TenantKeysetContent {
+                            public_keys: vec![rpc::forge::TenantPublicKey {
+                                public_key: "AAAA".to_string(),
+                                comment: None,
+                            }],
+                        }),
+                        version: "v1".to_string(),
+                    },
+                    expect: Yields(("k1".to_string(), 1usize, "v1".to_string())),
+                },
+                Case {
+                    scenario: "absent content defaults to empty key set",
+                    input: rpc::forge::CreateTenantKeysetRequest {
+                        keyset_identifier: Some(proto_keyset_identifier("acme-1", "k2")),
+                        keyset_content: None,
+                        version: "v2".to_string(),
+                    },
+                    expect: Yields(("k2".to_string(), 0usize, "v2".to_string())),
+                },
+                Case {
+                    scenario: "missing identifier is rejected",
+                    input: rpc::forge::CreateTenantKeysetRequest {
+                        keyset_identifier: None,
+                        keyset_content: None,
+                        version: "v1".to_string(),
+                    },
+                    expect: Fails,
+                },
+            ],
+            |proto| {
+                let domain = TenantKeyset::try_from(proto).map_err(drop)?;
+                Ok::<_, ()>((
+                    domain.keyset_identifier.keyset_id,
+                    domain.keyset_content.public_keys.len(),
+                    domain.version,
+                ))
+            },
+        );
+    }
+
+    // UpdateTenantKeysetRequest::try_from: a complete request yields the update
+    // (projected to keyset id, key count, version, if_version_match); absent
+    // content defaults to empty; a missing identifier is rejected.
+    #[test]
+    fn update_tenant_keyset_request_try_from_rpc() {
+        check_cases(
+            [
+                Case {
+                    scenario: "complete request with version guard",
+                    input: rpc::forge::UpdateTenantKeysetRequest {
+                        keyset_identifier: Some(proto_keyset_identifier("acme-1", "k1")),
+                        keyset_content: Some(rpc::forge::TenantKeysetContent {
+                            public_keys: vec![rpc::forge::TenantPublicKey {
+                                public_key: "AAAA".to_string(),
+                                comment: None,
+                            }],
+                        }),
+                        version: "v2".to_string(),
+                        if_version_match: Some("v1".to_string()),
+                    },
+                    expect: Yields((
+                        "k1".to_string(),
+                        1usize,
+                        "v2".to_string(),
+                        Some("v1".to_string()),
+                    )),
+                },
+                Case {
+                    scenario: "absent content defaults to empty, no version guard",
+                    input: rpc::forge::UpdateTenantKeysetRequest {
+                        keyset_identifier: Some(proto_keyset_identifier("acme-1", "k1")),
+                        keyset_content: None,
+                        version: "v2".to_string(),
+                        if_version_match: None,
+                    },
+                    expect: Yields(("k1".to_string(), 0usize, "v2".to_string(), None)),
+                },
+                Case {
+                    scenario: "missing identifier is rejected",
+                    input: rpc::forge::UpdateTenantKeysetRequest {
+                        keyset_identifier: None,
+                        keyset_content: None,
+                        version: "v2".to_string(),
+                        if_version_match: None,
+                    },
+                    expect: Fails,
+                },
+            ],
+            |proto| {
+                let domain = UpdateTenantKeyset::try_from(proto).map_err(drop)?;
+                Ok::<_, ()>((
+                    domain.keyset_identifier.keyset_id,
+                    domain.keyset_content.public_keys.len(),
+                    domain.version,
+                    domain.if_version_match,
+                ))
+            },
+        );
+    }
+
+    /// A proto tenant with the given org id, version string, and routing profile.
+    /// Metadata is always present (the conversion requires it).
+    fn proto_tenant(
+        organization_id: &str,
+        version: &str,
+        routing_profile_type: Option<&str>,
+    ) -> rpc::forge::Tenant {
+        rpc::forge::Tenant {
+            organization_id: organization_id.to_string(),
+            metadata: Some(rpc::Metadata {
+                name: "acme".to_string(),
+                description: String::new(),
+                labels: vec![],
+            }),
+            version: version.to_string(),
+            routing_profile_type: routing_profile_type.map(|s| s.to_string()),
+        }
+    }
+
+    // Tenant::try_from(proto): a well-formed proto yields the domain tenant
+    // (projected to org id, metadata name, routing profile); missing metadata,
+    // an unparseable version, and an invalid org id are each rejected.
+    #[test]
+    fn tenant_try_from_rpc() {
+        check_cases(
+            [
+                Case {
+                    scenario: "well-formed tenant with routing profile",
+                    input: proto_tenant("acme-1", VALID_VERSION, Some("default")),
+                    expect: Yields((
+                        "acme-1".to_string(),
+                        "acme".to_string(),
+                        Some("default".to_string()),
+                    )),
+                },
+                Case {
+                    scenario: "well-formed tenant without routing profile",
+                    input: proto_tenant("acme-1", VALID_VERSION, None),
+                    expect: Yields(("acme-1".to_string(), "acme".to_string(), None)),
+                },
+                Case {
+                    scenario: "missing metadata is rejected",
+                    input: rpc::forge::Tenant {
+                        organization_id: "acme-1".to_string(),
+                        metadata: None,
+                        version: VALID_VERSION.to_string(),
+                        routing_profile_type: None,
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unparseable version is rejected",
+                    input: proto_tenant("acme-1", "not-a-version", None),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "invalid org id is rejected",
+                    input: proto_tenant("a b", VALID_VERSION, None),
+                    expect: Fails,
+                },
+            ],
+            |proto| {
+                let domain = Tenant::try_from(proto).map_err(drop)?;
+                Ok::<_, ()>((
+                    domain.organization_id.to_string(),
+                    domain.metadata.name,
+                    domain.routing_profile_type,
+                ))
+            },
+        );
+    }
+
+    /// A domain tenant whose org id, version, and routing profile vary per case.
+    fn domain_tenant(
+        organization_id: &str,
+        routing_profile_type: Option<&str>,
+    ) -> Tenant {
+        Tenant {
+            organization_id: organization_id.to_string().try_into().unwrap(),
+            routing_profile_type: routing_profile_type.map(|s| s.to_string()),
+            metadata: model::metadata::Metadata {
+                name: "acme".to_string(),
+                description: String::new(),
+                labels: std::collections::HashMap::new(),
+            },
+            version: VALID_VERSION.parse().unwrap(),
+        }
+    }
+
+    // Tenant -> proto Tenant: org id renders, version serializes back to the
+    // canonical string, and the routing profile passes through. Projects to
+    // (org id, version, routing profile).
+    #[test]
+    fn tenant_to_rpc() {
+        check_cases(
+            [
+                Case {
+                    scenario: "with routing profile",
+                    input: domain_tenant("acme-1", Some("default")),
+                    expect: Yields((
+                        "acme-1".to_string(),
+                        VALID_VERSION.to_string(),
+                        Some("default".to_string()),
+                    )),
+                },
+                Case {
+                    scenario: "without routing profile",
+                    input: domain_tenant("acme-1", None),
+                    expect: Yields(("acme-1".to_string(), VALID_VERSION.to_string(), None)),
+                },
+            ],
+            |tenant| {
+                let proto = rpc::forge::Tenant::try_from(tenant).map_err(drop)?;
+                Ok::<_, ()>((proto.organization_id, proto.version, proto.routing_profile_type))
+            },
+        );
+    }
+
+    // The three Tenant response wrappers each embed the converted tenant under
+    // their `tenant` field; every wrapper carries the same org id through.
+    #[test]
+    fn tenant_response_wrappers_embed_tenant() {
+        check_cases(
+            [
+                Case {
+                    scenario: "create response",
+                    input: 0u8,
+                    expect: Yields("acme-1".to_string()),
+                },
+                Case {
+                    scenario: "find response",
+                    input: 1u8,
+                    expect: Yields("acme-1".to_string()),
+                },
+                Case {
+                    scenario: "update response",
+                    input: 2u8,
+                    expect: Yields("acme-1".to_string()),
+                },
+            ],
+            |which| {
+                let tenant = domain_tenant("acme-1", None);
+                let org_id = match which {
+                    0 => rpc::forge::CreateTenantResponse::try_from(tenant)
+                        .map_err(drop)?
+                        .tenant
+                        .map(|t| t.organization_id),
+                    1 => rpc::forge::FindTenantResponse::try_from(tenant)
+                        .map_err(drop)?
+                        .tenant
+                        .map(|t| t.organization_id),
+                    _ => rpc::forge::UpdateTenantResponse::try_from(tenant)
+                        .map_err(drop)?
+                        .tenant
+                        .map(|t| t.organization_id),
+                };
+                org_id.ok_or(())
+            },
+        );
+    }
+
+    // ValidateTenantPublicKeyRequest::try_from: a valid instance UUID yields the
+    // request (projected to the public-key string); a non-UUID instance id fails.
+    #[test]
+    fn validate_tenant_public_key_request_try_from_rpc() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid instance uuid",
+                    input: rpc::forge::ValidateTenantPublicKeyRequest {
+                        instance_id: "00000000-0000-0000-0000-000000000001".to_string(),
+                        tenant_public_key: "ssh-ed25519 AAAA".to_string(),
+                    },
+                    expect: Yields("ssh-ed25519 AAAA".to_string()),
+                },
+                Case {
+                    scenario: "non-uuid instance id is rejected",
+                    input: rpc::forge::ValidateTenantPublicKeyRequest {
+                        instance_id: "not-a-uuid".to_string(),
+                        tenant_public_key: "ssh-ed25519 AAAA".to_string(),
+                    },
+                    expect: Fails,
+                },
+            ],
+            |proto| {
+                let domain = TenantPublicKeyValidationRequest::try_from(proto).map_err(drop)?;
+                Ok::<_, ()>(domain.public_key)
+            },
+        );
     }
 }

--- a/crates/rpc/src/model/vpc.rs
+++ b/crates/rpc/src/model/vpc.rs
@@ -233,52 +233,719 @@ impl From<VpcPeering> for rpc::forge::VpcPeering {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_uuid::vpc::VpcId;
+    use carbide_uuid::vpc_peering::VpcPeeringId;
+    use chrono::{DateTime, Utc};
+
     use super::*;
 
+    // A nil VpcId, handy for rows where the id's exact value is irrelevant.
+    fn nil_vpc_id() -> VpcId {
+        VpcId::from(uuid::Uuid::nil())
+    }
+
+    fn nil_peering_id() -> VpcPeeringId {
+        VpcPeeringId::from(uuid::Uuid::nil())
+    }
+
+    fn epoch() -> DateTime<Utc> {
+        DateTime::<Utc>::from_timestamp(0, 0).unwrap()
+    }
+
+    // A valid proto Metadata whose domain projection passes `validate(true)`:
+    // its name is long enough and ASCII.
+    fn valid_proto_metadata() -> rpc::Metadata {
+        rpc::Metadata {
+            name: "my-vpc".to_string(),
+            description: String::new(),
+            labels: vec![],
+        }
+    }
+
+    // `VpcSearchFilter::from` is a total conversion, so we project its output to
+    // the fields the originals asserted: name, tenant_org_id, and the label as its
+    // (key, value) pair (None when no label is present).
     #[test]
-    fn vpc_search_filter_from_rpc_all_fields() {
-        let rpc_filter = rpc::forge::VpcSearchFilter {
-            name: Some("my-vpc".to_string()),
-            tenant_org_id: Some("org-123".to_string()),
-            label: Some(rpc::forge::Label {
-                key: "env".to_string(),
-                value: Some("prod".to_string()),
-            }),
-        };
-        let filter = VpcSearchFilter::from(rpc_filter);
-        assert_eq!(filter.name, Some("my-vpc".to_string()));
-        assert_eq!(filter.tenant_org_id, Some("org-123".to_string()));
-        let label = filter.label.unwrap();
-        assert_eq!(label.key, "env");
-        assert_eq!(label.value, Some("prod".to_string()));
+    fn vpc_search_filter_from_rpc() {
+        type Projected = (
+            Option<String>,
+            Option<String>,
+            Option<(String, Option<String>)>,
+        );
+
+        check_values(
+            [
+                Check {
+                    scenario: "all fields populated",
+                    input: rpc::forge::VpcSearchFilter {
+                        name: Some("my-vpc".to_string()),
+                        tenant_org_id: Some("org-123".to_string()),
+                        label: Some(rpc::forge::Label {
+                            key: "env".to_string(),
+                            value: Some("prod".to_string()),
+                        }),
+                    },
+                    expect: (
+                        Some("my-vpc".to_string()),
+                        Some("org-123".to_string()),
+                        Some(("env".to_string(), Some("prod".to_string()))),
+                    ),
+                },
+                Check {
+                    scenario: "no fields",
+                    input: rpc::forge::VpcSearchFilter {
+                        name: None,
+                        tenant_org_id: None,
+                        label: None,
+                    },
+                    expect: (None, None, None),
+                },
+                Check {
+                    scenario: "label key only",
+                    input: rpc::forge::VpcSearchFilter {
+                        name: None,
+                        tenant_org_id: None,
+                        label: Some(rpc::forge::Label {
+                            key: "team".to_string(),
+                            value: None,
+                        }),
+                    },
+                    expect: (None, None, Some(("team".to_string(), None))),
+                },
+            ],
+            |rpc_filter| {
+                let filter = VpcSearchFilter::from(rpc_filter);
+                let projected: Projected = (
+                    filter.name,
+                    filter.tenant_org_id,
+                    filter.label.map(|l| (l.key, l.value)),
+                );
+                projected
+            },
+        );
+    }
+
+    // `VpcStatus::from` is total: the model's `Option<i32>` VNI becomes the proto's
+    // `Option<u32>`, present-or-absent.
+    #[test]
+    fn vpc_status_into_rpc() {
+        check_values(
+            [
+                Check {
+                    scenario: "vni present",
+                    input: VpcStatus { vni: Some(4242) },
+                    expect: Some(4242u32),
+                },
+                Check {
+                    scenario: "vni absent",
+                    input: VpcStatus { vni: None },
+                    expect: None,
+                },
+            ],
+            |status| rpc::forge::VpcStatus::from(status).vni,
+        );
+    }
+
+    // `From<Vpc> for rpc::forge::Vpc` is total. Project the fields the conversion
+    // actually computes so each row can pin one variant of every optional/derived
+    // field.
+    #[derive(Debug, PartialEq)]
+    struct ProjectedVpc {
+        version: String,
+        nsg: Option<String>,
+        deleted_present: bool,
+        deprecated_vni: Option<u32>,
+        vni: Option<u32>,
+        virt_type: Option<i32>,
+        status_vni: Option<u32>,
+        routing_profile_type: Option<String>,
+        metadata_name: String,
+        labels: Vec<(String, Option<String>)>,
+    }
+
+    // A fixed, deterministic version so a row's expected `version_string()` matches
+    // the converted value byte-for-byte; the real `initial()` constructor stamps `now()`.
+    fn fixed_version() -> ConfigVersion {
+        use std::str::FromStr;
+        ConfigVersion::from_str("V1-T1700000000000000").unwrap()
+    }
+
+    fn base_vpc() -> Vpc {
+        Vpc {
+            id: nil_vpc_id(),
+            tenant_organization_id: "org".to_string(),
+            network_security_group_id: None,
+            version: fixed_version(),
+            created: epoch(),
+            updated: epoch(),
+            deleted: None,
+            tenant_keyset_id: None,
+            network_virtualization_type:
+                carbide_network::virtualization::VpcVirtualizationType::EthernetVirtualizer,
+            routing_profile_type: None,
+            vni: None,
+            metadata: Metadata::new_with_default_name(),
+            status: None,
+        }
     }
 
     #[test]
-    fn vpc_search_filter_from_rpc_no_fields() {
-        let rpc_filter = rpc::forge::VpcSearchFilter {
-            name: None,
-            tenant_org_id: None,
-            label: None,
-        };
-        let filter = VpcSearchFilter::from(rpc_filter);
-        assert_eq!(filter.name, None);
-        assert_eq!(filter.tenant_org_id, None);
-        assert!(filter.label.is_none());
+    fn vpc_into_rpc() {
+        let ethernet = rpc::forge::VpcVirtualizationType::EthernetVirtualizer as i32;
+        let flat = rpc::forge::VpcVirtualizationType::Flat as i32;
+        let fnn = rpc::forge::VpcVirtualizationType::Fnn as i32;
+
+        check_values(
+            [
+                Check {
+                    scenario: "minimal vpc, all optionals absent",
+                    input: base_vpc(),
+                    expect: ProjectedVpc {
+                        version: fixed_version().version_string(),
+                        nsg: None,
+                        deleted_present: false,
+                        deprecated_vni: None,
+                        vni: None,
+                        virt_type: Some(ethernet),
+                        status_vni: None,
+                        routing_profile_type: None,
+                        metadata_name: "default_name".to_string(),
+                        labels: vec![],
+                    },
+                },
+                Check {
+                    scenario: "nsg present, deleted present",
+                    input: Vpc {
+                        network_security_group_id: Some("nsg-1".parse().unwrap()),
+                        deleted: Some(epoch()),
+                        ..base_vpc()
+                    },
+                    expect: ProjectedVpc {
+                        version: fixed_version().version_string(),
+                        nsg: Some("nsg-1".to_string()),
+                        deleted_present: true,
+                        deprecated_vni: None,
+                        vni: None,
+                        virt_type: Some(ethernet),
+                        status_vni: None,
+                        routing_profile_type: None,
+                        metadata_name: "default_name".to_string(),
+                        labels: vec![],
+                    },
+                },
+                Check {
+                    scenario: "explicit vni and status vni populate both fields",
+                    input: Vpc {
+                        vni: Some(7),
+                        status: Some(VpcStatus { vni: Some(7) }),
+                        ..base_vpc()
+                    },
+                    expect: ProjectedVpc {
+                        version: fixed_version().version_string(),
+                        nsg: None,
+                        deleted_present: false,
+                        // deprecated_vni is sourced from status.vni.
+                        deprecated_vni: Some(7),
+                        vni: Some(7),
+                        virt_type: Some(ethernet),
+                        status_vni: Some(7),
+                        routing_profile_type: None,
+                        metadata_name: "default_name".to_string(),
+                        labels: vec![],
+                    },
+                },
+                Check {
+                    scenario: "status present but vni unset leaves deprecated_vni None",
+                    input: Vpc {
+                        status: Some(VpcStatus { vni: None }),
+                        ..base_vpc()
+                    },
+                    expect: ProjectedVpc {
+                        version: fixed_version().version_string(),
+                        nsg: None,
+                        deleted_present: false,
+                        deprecated_vni: None,
+                        vni: None,
+                        virt_type: Some(ethernet),
+                        status_vni: None,
+                        routing_profile_type: None,
+                        metadata_name: "default_name".to_string(),
+                        labels: vec![],
+                    },
+                },
+                Check {
+                    scenario: "flat virtualization type",
+                    input: Vpc {
+                        network_virtualization_type:
+                            carbide_network::virtualization::VpcVirtualizationType::Flat,
+                        ..base_vpc()
+                    },
+                    expect: ProjectedVpc {
+                        version: fixed_version().version_string(),
+                        nsg: None,
+                        deleted_present: false,
+                        deprecated_vni: None,
+                        vni: None,
+                        virt_type: Some(flat),
+                        status_vni: None,
+                        routing_profile_type: None,
+                        metadata_name: "default_name".to_string(),
+                        labels: vec![],
+                    },
+                },
+                Check {
+                    scenario: "fnn virtualization type",
+                    input: Vpc {
+                        network_virtualization_type:
+                            carbide_network::virtualization::VpcVirtualizationType::Fnn,
+                        ..base_vpc()
+                    },
+                    expect: ProjectedVpc {
+                        version: fixed_version().version_string(),
+                        nsg: None,
+                        deleted_present: false,
+                        deprecated_vni: None,
+                        vni: None,
+                        virt_type: Some(fnn),
+                        status_vni: None,
+                        routing_profile_type: None,
+                        metadata_name: "default_name".to_string(),
+                        labels: vec![],
+                    },
+                },
+                Check {
+                    scenario: "deprecated nvue virtualization type collapses to ethernet",
+                    input: Vpc {
+                        #[allow(deprecated)]
+                        network_virtualization_type:
+                            carbide_network::virtualization::VpcVirtualizationType::EthernetVirtualizerWithNvue,
+                        ..base_vpc()
+                    },
+                    expect: ProjectedVpc {
+                        version: fixed_version().version_string(),
+                        nsg: None,
+                        deleted_present: false,
+                        deprecated_vni: None,
+                        vni: None,
+                        virt_type: Some(ethernet),
+                        status_vni: None,
+                        routing_profile_type: None,
+                        metadata_name: "default_name".to_string(),
+                        labels: vec![],
+                    },
+                },
+                Check {
+                    scenario: "routing profile type carried through",
+                    input: Vpc {
+                        routing_profile_type: Some("internal".to_string()),
+                        ..base_vpc()
+                    },
+                    expect: ProjectedVpc {
+                        version: fixed_version().version_string(),
+                        nsg: None,
+                        deleted_present: false,
+                        deprecated_vni: None,
+                        vni: None,
+                        virt_type: Some(ethernet),
+                        status_vni: None,
+                        routing_profile_type: Some("internal".to_string()),
+                        metadata_name: "default_name".to_string(),
+                        labels: vec![],
+                    },
+                },
+                Check {
+                    scenario: "labels: empty value becomes None, non-empty stays Some",
+                    input: Vpc {
+                        metadata: Metadata {
+                            name: "named".to_string(),
+                            description: String::new(),
+                            labels: std::collections::HashMap::from([
+                                ("env".to_string(), "prod".to_string()),
+                                ("blank".to_string(), String::new()),
+                            ]),
+                        },
+                        ..base_vpc()
+                    },
+                    expect: ProjectedVpc {
+                        version: fixed_version().version_string(),
+                        nsg: None,
+                        deleted_present: false,
+                        deprecated_vni: None,
+                        vni: None,
+                        virt_type: Some(ethernet),
+                        status_vni: None,
+                        routing_profile_type: None,
+                        metadata_name: "named".to_string(),
+                        labels: vec![
+                            ("blank".to_string(), None),
+                            ("env".to_string(), Some("prod".to_string())),
+                        ],
+                    },
+                },
+            ],
+            |vpc| {
+                let proto = rpc::forge::Vpc::from(vpc);
+                let metadata = proto.metadata.unwrap();
+                let mut labels: Vec<(String, Option<String>)> = metadata
+                    .labels
+                    .into_iter()
+                    .map(|l| (l.key, l.value))
+                    .collect();
+                labels.sort_by(|a, b| a.0.cmp(&b.0));
+                ProjectedVpc {
+                    version: proto.version,
+                    nsg: proto.network_security_group_id,
+                    deleted_present: proto.deleted.is_some(),
+                    deprecated_vni: proto.deprecated_vni,
+                    vni: proto.vni,
+                    virt_type: proto.network_virtualization_type,
+                    status_vni: proto.status.and_then(|s| s.vni),
+                    routing_profile_type: proto.routing_profile_type,
+                    metadata_name: metadata.name,
+                    labels,
+                }
+            },
+        );
     }
 
+    // `From<Vpc> for rpc::forge::VpcDeletionResult` is total and discards its input,
+    // always yielding the empty result. Project to `true` to assert it ran.
     #[test]
-    fn vpc_search_filter_from_rpc_label_key_only() {
-        let rpc_filter = rpc::forge::VpcSearchFilter {
-            name: None,
-            tenant_org_id: None,
-            label: Some(rpc::forge::Label {
-                key: "team".to_string(),
-                value: None,
-            }),
-        };
-        let filter = VpcSearchFilter::from(rpc_filter);
-        let label = filter.label.unwrap();
-        assert_eq!(label.key, "team");
-        assert_eq!(label.value, None);
+    fn vpc_into_deletion_result() {
+        check_values(
+            [Check {
+                scenario: "any vpc yields the empty deletion result",
+                input: base_vpc(),
+                expect: true,
+            }],
+            |vpc| {
+                let _: rpc::forge::VpcDeletionResult = vpc.into();
+                true
+            },
+        );
+    }
+
+    // `From<VpcPeering> for rpc::forge::VpcPeering` is total: each id field is wrapped
+    // in `Some`. Project to the presence of all three.
+    #[test]
+    fn vpc_peering_into_rpc() {
+        check_values(
+            [Check {
+                scenario: "all three ids wrapped in Some",
+                input: VpcPeering {
+                    id: nil_peering_id(),
+                    vpc_id: nil_vpc_id(),
+                    peer_vpc_id: nil_vpc_id(),
+                },
+                expect: (true, true, true),
+            }],
+            |peering| {
+                let proto = rpc::forge::VpcPeering::from(peering);
+                (
+                    proto.id.is_some(),
+                    proto.vpc_id.is_some(),
+                    proto.peer_vpc_id.is_some(),
+                )
+            },
+        );
+    }
+
+    fn base_creation_request() -> rpc::forge::VpcCreationRequest {
+        rpc::forge::VpcCreationRequest {
+            tenant_organization_id: "org".to_string(),
+            tenant_keyset_id: None,
+            network_virtualization_type: None,
+            id: None,
+            metadata: Some(valid_proto_metadata()),
+            network_security_group_id: None,
+            default_nvlink_logical_partition_id: None,
+            vni: None,
+            routing_profile_type: None,
+        }
+    }
+
+    // `TryFrom<VpcCreationRequest> for NewVpc` is fallible; its error type isn't
+    // PartialEq, so error rows use `Fails` and the run closure drops the error.
+    // Each Ok row projects the field it exercises.
+    #[test]
+    fn new_vpc_try_from_creation_request() {
+        let ethernet =
+            carbide_network::virtualization::VpcVirtualizationType::EthernetVirtualizer;
+        let flat = carbide_network::virtualization::VpcVirtualizationType::Flat;
+
+        check_cases(
+            [
+                Case {
+                    scenario: "absent virt type defaults to ethernet",
+                    input: base_creation_request(),
+                    expect: Yields(ethernet),
+                },
+                Case {
+                    scenario: "explicit flat virt type",
+                    input: rpc::forge::VpcCreationRequest {
+                        network_virtualization_type: Some(
+                            rpc::forge::VpcVirtualizationType::Flat as i32,
+                        ),
+                        ..base_creation_request()
+                    },
+                    expect: Yields(flat),
+                },
+                Case {
+                    scenario: "absent metadata defaults to a valid name",
+                    input: rpc::forge::VpcCreationRequest {
+                        metadata: None,
+                        ..base_creation_request()
+                    },
+                    expect: Yields(ethernet),
+                },
+                Case {
+                    scenario: "unknown virt enum value is rejected",
+                    input: rpc::forge::VpcCreationRequest {
+                        network_virtualization_type: Some(99999),
+                        ..base_creation_request()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty nsg id is rejected",
+                    input: rpc::forge::VpcCreationRequest {
+                        network_security_group_id: Some(String::new()),
+                        ..base_creation_request()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "metadata that fails validation is rejected",
+                    input: rpc::forge::VpcCreationRequest {
+                        metadata: Some(rpc::Metadata {
+                            name: String::new(),
+                            description: String::new(),
+                            labels: vec![],
+                        }),
+                        ..base_creation_request()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "duplicate label keys in metadata are rejected",
+                    input: rpc::forge::VpcCreationRequest {
+                        metadata: Some(rpc::Metadata {
+                            name: "named".to_string(),
+                            description: String::new(),
+                            labels: vec![
+                                rpc::forge::Label {
+                                    key: "dup".to_string(),
+                                    value: Some("a".to_string()),
+                                },
+                                rpc::forge::Label {
+                                    key: "dup".to_string(),
+                                    value: Some("b".to_string()),
+                                },
+                            ],
+                        }),
+                        ..base_creation_request()
+                    },
+                    expect: Fails,
+                },
+            ],
+            |req| {
+                NewVpc::try_from(req)
+                    .map(|new| new.network_virtualization_type)
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // Projects an Ok NewVpc to the fields the optional inputs drive: nsg presence and
+    // the VNI. Separate from the virt-type table to keep one Ok projection per table.
+    #[test]
+    fn new_vpc_carries_optional_fields() {
+        check_cases(
+            [
+                Case {
+                    scenario: "nsg and vni present",
+                    input: rpc::forge::VpcCreationRequest {
+                        network_security_group_id: Some("nsg-7".to_string()),
+                        vni: Some(42),
+                        ..base_creation_request()
+                    },
+                    expect: Yields((true, Some(42i32))),
+                },
+                Case {
+                    scenario: "nsg and vni absent",
+                    input: base_creation_request(),
+                    expect: Yields((false, None)),
+                },
+            ],
+            |req| {
+                NewVpc::try_from(req)
+                    .map(|new| (new.network_security_group_id.is_some(), new.vni))
+                    .map_err(drop)
+            },
+        );
+    }
+
+    fn base_update_request() -> rpc::forge::VpcUpdateRequest {
+        rpc::forge::VpcUpdateRequest {
+            id: Some(nil_vpc_id()),
+            if_version_match: None,
+            metadata: Some(valid_proto_metadata()),
+            network_security_group_id: None,
+            default_nvlink_logical_partition_id: None,
+        }
+    }
+
+    // `TryFrom<VpcUpdateRequest> for UpdateVpc` is fallible; error type isn't
+    // PartialEq, so errors use `Fails`. Project Ok rows to (nsg present, if-version
+    // present).
+    #[test]
+    fn update_vpc_try_from_request() {
+        check_cases(
+            [
+                Case {
+                    scenario: "minimal valid request",
+                    input: base_update_request(),
+                    expect: Yields((false, false)),
+                },
+                Case {
+                    scenario: "nsg and matching version present",
+                    input: rpc::forge::VpcUpdateRequest {
+                        network_security_group_id: Some("nsg-1".to_string()),
+                        if_version_match: Some(fixed_version().version_string()),
+                        ..base_update_request()
+                    },
+                    expect: Yields((true, true)),
+                },
+                Case {
+                    scenario: "absent metadata defaults to a valid name",
+                    input: rpc::forge::VpcUpdateRequest {
+                        metadata: None,
+                        ..base_update_request()
+                    },
+                    expect: Yields((false, false)),
+                },
+                Case {
+                    scenario: "missing id is rejected",
+                    input: rpc::forge::VpcUpdateRequest {
+                        id: None,
+                        ..base_update_request()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unparseable if_version_match is rejected",
+                    input: rpc::forge::VpcUpdateRequest {
+                        if_version_match: Some("not-a-version".to_string()),
+                        ..base_update_request()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty nsg id is rejected",
+                    input: rpc::forge::VpcUpdateRequest {
+                        network_security_group_id: Some(String::new()),
+                        ..base_update_request()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "metadata that fails validation is rejected",
+                    input: rpc::forge::VpcUpdateRequest {
+                        metadata: Some(rpc::Metadata {
+                            name: String::new(),
+                            description: String::new(),
+                            labels: vec![],
+                        }),
+                        ..base_update_request()
+                    },
+                    expect: Fails,
+                },
+            ],
+            |req| {
+                UpdateVpc::try_from(req)
+                    .map(|u| (u.network_security_group_id.is_some(), u.if_version_match.is_some()))
+                    .map_err(drop)
+            },
+        );
+    }
+
+    fn base_virt_request() -> rpc::forge::VpcUpdateVirtualizationRequest {
+        rpc::forge::VpcUpdateVirtualizationRequest {
+            id: Some(nil_vpc_id()),
+            if_version_match: None,
+            network_virtualization_type: Some(
+                rpc::forge::VpcVirtualizationType::EthernetVirtualizer as i32,
+            ),
+        }
+    }
+
+    // `TryFrom<VpcUpdateVirtualizationRequest> for UpdateVpcVirtualization` is
+    // fallible; error type isn't PartialEq, so errors use `Fails`. Ok rows project
+    // the resolved virtualization type.
+    #[test]
+    fn update_vpc_virtualization_try_from_request() {
+        let ethernet =
+            carbide_network::virtualization::VpcVirtualizationType::EthernetVirtualizer;
+        let flat = carbide_network::virtualization::VpcVirtualizationType::Flat;
+
+        check_cases(
+            [
+                Case {
+                    scenario: "ethernet virt type",
+                    input: base_virt_request(),
+                    expect: Yields(ethernet),
+                },
+                Case {
+                    scenario: "flat virt type with matching version",
+                    input: rpc::forge::VpcUpdateVirtualizationRequest {
+                        if_version_match: Some(fixed_version().version_string()),
+                        network_virtualization_type: Some(
+                            rpc::forge::VpcVirtualizationType::Flat as i32,
+                        ),
+                        ..base_virt_request()
+                    },
+                    expect: Yields(flat),
+                },
+                Case {
+                    scenario: "missing id is rejected",
+                    input: rpc::forge::VpcUpdateVirtualizationRequest {
+                        id: None,
+                        ..base_virt_request()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing virt type is rejected",
+                    input: rpc::forge::VpcUpdateVirtualizationRequest {
+                        network_virtualization_type: None,
+                        ..base_virt_request()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown virt enum value is rejected",
+                    input: rpc::forge::VpcUpdateVirtualizationRequest {
+                        network_virtualization_type: Some(99999),
+                        ..base_virt_request()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unparseable if_version_match is rejected",
+                    input: rpc::forge::VpcUpdateVirtualizationRequest {
+                        if_version_match: Some("not-a-version".to_string()),
+                        ..base_virt_request()
+                    },
+                    expect: Fails,
+                },
+            ],
+            |req| {
+                UpdateVpcVirtualization::try_from(req)
+                    .map(|u| u.network_virtualization_type)
+                    .map_err(drop)
+            },
+        );
     }
 }

--- a/crates/rpc/src/model/vpc_prefix.rs
+++ b/crates/rpc/src/model/vpc_prefix.rs
@@ -199,12 +199,35 @@ impl From<VpcPrefix> for rpc::forge::VpcPrefix {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
     use carbide_uuid::vpc::VpcId;
     use chrono::{DateTime, Utc};
     use config_version::{ConfigVersion, Versioned};
     use model::vpc_prefix::{VpcPrefixDeletionState, VpcPrefixStatus};
 
     use super::*;
+
+    /// A proto Metadata whose name is long enough to pass `validate(true)`.
+    fn valid_metadata(name: &str) -> rpc::forge::Metadata {
+        rpc::forge::Metadata {
+            name: name.to_owned(),
+            description: String::new(),
+            labels: Vec::new(),
+        }
+    }
+
+    /// A bare creation request: only the fields a row cares about are filled in
+    /// by mutating the returned value.
+    fn creation_request() -> rpc::forge::VpcPrefixCreationRequest {
+        rpc::forge::VpcPrefixCreationRequest {
+            id: None,
+            prefix: "10.0.0.0/24".to_owned(),
+            vpc_id: Some(VpcId::new()),
+            config: None,
+            metadata: None,
+        }
+    }
 
     /// Builds a minimal VPC prefix for status conversion tests.
     fn test_vpc_prefix(
@@ -274,5 +297,311 @@ mod tests {
             .expect("VPC prefix lifecycle should be populated");
         assert_eq!(lifecycle.state, r#"{"state":"ready"}"#);
         assert_eq!(status.tenant_state, TenantState::Terminating as i32);
+    }
+
+    #[test]
+    fn new_vpc_prefix_from_creation_request() {
+        check_cases(
+            [
+                Case {
+                    scenario: "deprecated prefix string used when config absent",
+                    input: creation_request(),
+                    expect: Yields("10.0.0.0/24".to_owned()),
+                },
+                Case {
+                    scenario: "config prefix wins over deprecated prefix string",
+                    input: rpc::forge::VpcPrefixCreationRequest {
+                        prefix: "10.0.0.0/24".to_owned(),
+                        config: Some(rpc::forge::VpcPrefixConfig {
+                            prefix: "192.168.0.0/16".to_owned(),
+                        }),
+                        ..creation_request()
+                    },
+                    expect: Yields("192.168.0.0/16".to_owned()),
+                },
+                Case {
+                    scenario: "explicit valid metadata accepted",
+                    input: rpc::forge::VpcPrefixCreationRequest {
+                        metadata: Some(valid_metadata("my-prefix")),
+                        ..creation_request()
+                    },
+                    expect: Yields("10.0.0.0/24".to_owned()),
+                },
+                Case {
+                    scenario: "ipv6 prefix accepted",
+                    input: rpc::forge::VpcPrefixCreationRequest {
+                        prefix: "2001:db8::/32".to_owned(),
+                        ..creation_request()
+                    },
+                    expect: Yields("2001:db8::/32".to_owned()),
+                },
+                Case {
+                    scenario: "missing vpc_id rejected",
+                    input: rpc::forge::VpcPrefixCreationRequest {
+                        vpc_id: None,
+                        ..creation_request()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "invalid deprecated prefix string rejected",
+                    input: rpc::forge::VpcPrefixCreationRequest {
+                        prefix: "not-a-cidr".to_owned(),
+                        ..creation_request()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "invalid config prefix rejected",
+                    input: rpc::forge::VpcPrefixCreationRequest {
+                        config: Some(rpc::forge::VpcPrefixConfig {
+                            prefix: "bogus".to_owned(),
+                        }),
+                        ..creation_request()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty-name metadata fails validation",
+                    input: rpc::forge::VpcPrefixCreationRequest {
+                        metadata: Some(valid_metadata("")),
+                        ..creation_request()
+                    },
+                    expect: Fails,
+                },
+            ],
+            |req| {
+                NewVpcPrefix::try_from(req)
+                    .map(|new| new.config.prefix.to_string())
+                    .map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn vpc_prefix_config_from_proto() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid ipv4 cidr",
+                    input: "10.0.0.0/24",
+                    expect: Yields("10.0.0.0/24".to_owned()),
+                },
+                Case {
+                    scenario: "valid ipv6 cidr",
+                    input: "2001:db8::/32",
+                    expect: Yields("2001:db8::/32".to_owned()),
+                },
+                Case {
+                    scenario: "empty prefix rejected",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-cidr text rejected",
+                    input: "nonsense",
+                    expect: Fails,
+                },
+            ],
+            |prefix| {
+                VpcPrefixConfig::try_from(rpc::forge::VpcPrefixConfig {
+                    prefix: prefix.to_owned(),
+                })
+                .map(|config| config.prefix.to_string())
+                .map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn update_vpc_prefix_from_request() {
+        let id = VpcPrefixId::new();
+        check_cases(
+            [
+                Case {
+                    scenario: "id present, default metadata accepted",
+                    input: rpc::forge::VpcPrefixUpdateRequest {
+                        id: Some(id),
+                        prefix: None,
+                        config: None,
+                        metadata: None,
+                    },
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "id present, explicit valid metadata accepted",
+                    input: rpc::forge::VpcPrefixUpdateRequest {
+                        id: Some(id),
+                        prefix: None,
+                        config: None,
+                        metadata: Some(valid_metadata("renamed")),
+                    },
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "empty config prefix is not a resize",
+                    input: rpc::forge::VpcPrefixUpdateRequest {
+                        id: Some(id),
+                        prefix: None,
+                        config: Some(rpc::forge::VpcPrefixConfig {
+                            prefix: String::new(),
+                        }),
+                        metadata: None,
+                    },
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "deprecated prefix resize rejected",
+                    input: rpc::forge::VpcPrefixUpdateRequest {
+                        id: Some(id),
+                        prefix: Some("10.0.0.0/24".to_owned()),
+                        config: None,
+                        metadata: None,
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "config prefix resize rejected",
+                    input: rpc::forge::VpcPrefixUpdateRequest {
+                        id: Some(id),
+                        prefix: None,
+                        config: Some(rpc::forge::VpcPrefixConfig {
+                            prefix: "10.0.0.0/24".to_owned(),
+                        }),
+                        metadata: None,
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing id rejected",
+                    input: rpc::forge::VpcPrefixUpdateRequest {
+                        id: None,
+                        prefix: None,
+                        config: None,
+                        metadata: None,
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty-name metadata fails validation",
+                    input: rpc::forge::VpcPrefixUpdateRequest {
+                        id: Some(id),
+                        prefix: None,
+                        config: None,
+                        metadata: Some(valid_metadata("")),
+                    },
+                    expect: Fails,
+                },
+            ],
+            |req| {
+                UpdateVpcPrefix::try_from(req)
+                    .map(|update| update.id == id)
+                    .map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn delete_vpc_prefix_from_request() {
+        let id = VpcPrefixId::new();
+        check_cases(
+            [
+                Case {
+                    scenario: "id present accepted",
+                    input: rpc::forge::VpcPrefixDeletionRequest { id: Some(id) },
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "missing id rejected",
+                    input: rpc::forge::VpcPrefixDeletionRequest { id: None },
+                    expect: Fails,
+                },
+            ],
+            |req| {
+                DeleteVpcPrefix::try_from(req)
+                    .map(|delete| delete.id == id)
+                    .map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn vpc_prefix_to_proto_lifecycle_state_json() {
+        check_values(
+            [
+                Check {
+                    scenario: "provisioning serializes to controller json",
+                    input: VpcPrefixControllerState::Provisioning,
+                    expect: r#"{"state":"provisioning"}"#.to_owned(),
+                },
+                Check {
+                    scenario: "ready serializes to controller json",
+                    input: VpcPrefixControllerState::Ready,
+                    expect: r#"{"state":"ready"}"#.to_owned(),
+                },
+                Check {
+                    scenario: "deleting serializes with deletion_state",
+                    input: VpcPrefixControllerState::Deleting {
+                        deletion_state: VpcPrefixDeletionState::DBDelete,
+                    },
+                    expect: r#"{"state":"deleting","deletion_state":{"state":"dbdelete"}}"#
+                        .to_owned(),
+                },
+            ],
+            |controller_state| {
+                rpc::forge::VpcPrefix::from(test_vpc_prefix(controller_state, None))
+                    .status
+                    .and_then(|s| s.lifecycle)
+                    .map(|l| l.state)
+                    .unwrap_or_default()
+            },
+        );
+    }
+
+    #[test]
+    fn vpc_prefix_to_proto_carries_fields() {
+        check_values(
+            [
+                Check {
+                    scenario: "deprecated prefix string populated",
+                    input: "deprecated_prefix",
+                    expect: true,
+                },
+                Check {
+                    scenario: "config prefix matches deprecated prefix",
+                    input: "config_matches",
+                    expect: true,
+                },
+                Check {
+                    scenario: "id is surfaced",
+                    input: "id_present",
+                    expect: true,
+                },
+                Check {
+                    scenario: "vpc_id is surfaced",
+                    input: "vpc_id_present",
+                    expect: true,
+                },
+                Check {
+                    scenario: "metadata is surfaced",
+                    input: "metadata_present",
+                    expect: true,
+                },
+            ],
+            |which| {
+                let proto = rpc::forge::VpcPrefix::from(test_vpc_prefix(
+                    VpcPrefixControllerState::Ready,
+                    None,
+                ));
+                match which {
+                    "deprecated_prefix" => proto.prefix == "10.0.0.0/24",
+                    "config_matches" => proto.config.map(|c| c.prefix) == Some(proto.prefix),
+                    "id_present" => proto.id.is_some(),
+                    "vpc_id_present" => proto.vpc_id.is_some(),
+                    "metadata_present" => proto.metadata.is_some(),
+                    _ => false,
+                }
+            },
+        );
     }
 }

--- a/crates/rpc/src/network.rs
+++ b/crates/rpc/src/network.rs
@@ -72,48 +72,144 @@ pub fn vpc_virtualization_type_try_from_rpc(
 #[cfg(test)]
 mod test {
     use carbide_network::virtualization::VpcVirtualizationType;
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
 
     use super::*;
 
+    // proto -> model: `From<rpc::VpcVirtualizationType>` (infallible). Every proto
+    // arm, including the deprecated etv-with-nvue / fnn-classic / fnn-l3 aliases
+    // that collapse onto a live model variant.
     #[test]
-    fn from_rpc_etv_with_nvue_maps_to_etv() {
+    fn from_rpc_maps_to_model() {
         #[allow(deprecated)]
-        let vtype: VpcVirtualizationType =
-            rpc::VpcVirtualizationType::EthernetVirtualizerWithNvue.into();
-        assert_eq!(vtype, VpcVirtualizationType::EthernetVirtualizer);
+        check_values(
+            [
+                Check {
+                    scenario: "etv maps to etv",
+                    input: rpc::VpcVirtualizationType::EthernetVirtualizer,
+                    expect: VpcVirtualizationType::EthernetVirtualizer,
+                },
+                Check {
+                    scenario: "etv-with-nvue maps to etv",
+                    input: rpc::VpcVirtualizationType::EthernetVirtualizerWithNvue,
+                    expect: VpcVirtualizationType::EthernetVirtualizer,
+                },
+                Check {
+                    scenario: "fnn maps to fnn",
+                    input: rpc::VpcVirtualizationType::Fnn,
+                    expect: VpcVirtualizationType::Fnn,
+                },
+                Check {
+                    scenario: "deprecated fnn-classic maps to fnn",
+                    input: rpc::VpcVirtualizationType::FnnClassic,
+                    expect: VpcVirtualizationType::Fnn,
+                },
+                Check {
+                    scenario: "deprecated fnn-l3 maps to fnn",
+                    input: rpc::VpcVirtualizationType::FnnL3,
+                    expect: VpcVirtualizationType::Fnn,
+                },
+                Check {
+                    scenario: "flat round-trips to flat",
+                    input: rpc::VpcVirtualizationType::Flat,
+                    expect: VpcVirtualizationType::Flat,
+                },
+            ],
+            |v| v.into(),
+        );
     }
 
+    // model -> proto: `From<VpcVirtualizationType>` (infallible). Every model arm,
+    // including the deprecated etv-with-nvue alias that folds onto proto etv.
     #[test]
-    fn to_rpc_etv_maps_to_proto_etv() {
-        let rpc_vtype: rpc::VpcVirtualizationType =
-            VpcVirtualizationType::EthernetVirtualizer.into();
-        assert_eq!(rpc_vtype, rpc::VpcVirtualizationType::EthernetVirtualizer);
+    fn to_rpc_maps_to_proto() {
+        check_values(
+            [
+                Check {
+                    scenario: "etv maps to proto etv",
+                    input: VpcVirtualizationType::EthernetVirtualizer,
+                    expect: rpc::VpcVirtualizationType::EthernetVirtualizer,
+                },
+                Check {
+                    scenario: "etv-with-nvue folds onto proto etv",
+                    input: VpcVirtualizationType::EthernetVirtualizerWithNvue,
+                    expect: rpc::VpcVirtualizationType::EthernetVirtualizer,
+                },
+                Check {
+                    scenario: "fnn maps to proto fnn",
+                    input: VpcVirtualizationType::Fnn,
+                    expect: rpc::VpcVirtualizationType::Fnn,
+                },
+                Check {
+                    scenario: "flat round-trips to proto flat",
+                    input: VpcVirtualizationType::Flat,
+                    expect: rpc::VpcVirtualizationType::Flat,
+                },
+            ],
+            |v| v.into(),
+        );
     }
 
+    // proto i32 -> model: `vpc_virtualization_type_try_from_rpc` (fallible). Each
+    // known proto discriminant on the Ok arm, plus the Err arm for an i32 that
+    // names no proto variant (negative, the retired gap value 1, out-of-range).
+    // `RpcDataConversionError` is not `PartialEq`, so use `Fails` with `map_err`.
     #[test]
-    fn proto_value_2_maps_to_etv() {
-        // Make sure our proto From implementation turns
-        // ETHERNET_VIRTUALIZER_WITH_NVUE into EthernetVirtualizer.
-        let vtype = vpc_virtualization_type_try_from_rpc(2).unwrap();
-        assert_eq!(vtype, VpcVirtualizationType::EthernetVirtualizer);
-    }
-
-    #[test]
-    fn proto_value_0_maps_to_etv() {
-        let vtype = vpc_virtualization_type_try_from_rpc(0).unwrap();
-        assert_eq!(vtype, VpcVirtualizationType::EthernetVirtualizer);
-    }
-
-    #[test]
-    fn flat_round_trips() {
-        let rpc_vtype: rpc::VpcVirtualizationType = VpcVirtualizationType::Flat.into();
-        assert_eq!(rpc_vtype, rpc::VpcVirtualizationType::Flat);
-
-        let vtype: VpcVirtualizationType = rpc::VpcVirtualizationType::Flat.into();
-        assert_eq!(vtype, VpcVirtualizationType::Flat);
-
-        let vtype =
-            vpc_virtualization_type_try_from_rpc(rpc::VpcVirtualizationType::Flat as i32).unwrap();
-        assert_eq!(vtype, VpcVirtualizationType::Flat);
+    fn try_from_rpc_i32_maps_to_model() {
+        check_cases(
+            [
+                Case {
+                    scenario: "value 0 (etv) maps to etv",
+                    input: 0,
+                    expect: Yields(VpcVirtualizationType::EthernetVirtualizer),
+                },
+                Case {
+                    // proto field 2, ETHERNET_VIRTUALIZER_WITH_NVUE, maps to etv.
+                    scenario: "value 2 (etv-with-nvue) maps to etv",
+                    input: 2,
+                    expect: Yields(VpcVirtualizationType::EthernetVirtualizer),
+                },
+                Case {
+                    // The typed `From<rpc::VpcVirtualizationType>` collapses the
+                    // deprecated fnn-classic alias onto Fnn, but the i32 path does
+                    // not list it and rejects the raw discriminant.
+                    scenario: "fnn-classic (3) is rejected by the i32 path",
+                    input: rpc::VpcVirtualizationType::FnnClassic as i32,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "fnn-l3 (4) is rejected by the i32 path",
+                    input: rpc::VpcVirtualizationType::FnnL3 as i32,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "fnn (5) maps to fnn",
+                    input: rpc::VpcVirtualizationType::Fnn as i32,
+                    expect: Yields(VpcVirtualizationType::Fnn),
+                },
+                Case {
+                    scenario: "flat (6) round-trips from i32",
+                    input: rpc::VpcVirtualizationType::Flat as i32,
+                    expect: Yields(VpcVirtualizationType::Flat),
+                },
+                Case {
+                    scenario: "retired gap value 1 is invalid",
+                    input: 1,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "out-of-range high value is invalid",
+                    input: 7,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "negative value is invalid",
+                    input: -1,
+                    expect: Fails,
+                },
+            ],
+            |value| vpc_virtualization_type_try_from_rpc(value).map_err(drop),
+        );
     }
 }


### PR DESCRIPTION
The `rpc` crate is almost entirely proto<->domain conversions, and most of them
had no test at all.

This folds the existing conversion tests onto `carbide-test-support` based
`Case`/`Check` tables and then enumerates the conversion variants each `From` /
`TryFrom` handles: every enum arm, present vs absent optional fields, and, for
the fallible paths, both the `Ok` arm and each rejection (missing required field,
unknown discriminant, unparseable value). The dense per-row enumeration is what
moves the numbers; the conversion modules sit behind the `model` feature, so the
coverage below is measured with `--features model`.

- `model`: enumerated the `vpc`, `network-security-group`, `tenant`, `switch`,
  `rack`, `instance`, and `machine` conversions over their variant and error arms.
- `network`: documented a real divergence the enumeration surfaced — the typed
  `From<rpc::VpcVirtualizationType>` collapses the deprecated `fnn-classic` /
  `fnn-l3` aliases onto `Fnn`, but the i32 path
  (`vpc_virtualization_type_try_from_rpc`) does not list them and rejects the raw
  discriminants.
- determinism: rows that round-trip a version pin a fixed `ConfigVersion` so the
  expected string matches the converted value byte-for-byte instead of racing
  `Utc::now()`.

┌──────────┬─────────┬─────────┐
│ Metric   │ Before  │  After  │
├──────────┼─────────┼─────────┤
│ Region   │ 42.90%  │ 63.96%  │
│ Function │ 28.03%  │ 56.60%  │
│ Line     │ 44.90%  │ 72.44%  │
└──────────┴─────────┴─────────┘

The remaining uncovered surface is the id-and-timestamp-heavy conversions that
call `Utc::now()` on absent fields (non-deterministic without injection) and the
gRPC client/TLS plumbing, which need mocks rather than additional table rows.

All tests pass and clippy is clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>
