### PR TITLE
docs: add AGENTS.md and style guide notes around carbide-test-support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,10 @@ cargo test
 cargo make correctly-execute-tests
 ```
 
+When writing tests, prefer the **table-driven** style — see the [Testing section in `STYLE_GUIDE.md`](STYLE_GUIDE.md#testing).
+Enumerating a function's input variants as `carbide-test-support` cases (`check_cases` / `check_values`) is the easiest
+way to reach thorough coverage of parsers, validators, conversions, and the like.
+
 ### Linting and Formatting
 
 ```bash

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -49,6 +49,65 @@ Other common places where we've seen `#[allow(dead_code)]` that are not necessar
   unused database column, or unused JSON field), comment it out.
 - Otherwise, strongly consider deleting the code.
 
+## Testing
+
+Prefer **table-driven tests** for any function that maps inputs to outputs, errors, or other observable results —
+parsers, validators, conversions, serde round-trips, formatters, and the like. The `carbide-test-support` crate
+provides tiny, zero-dependency helpers for exactly this. Add it as a dev-dependency:
+
+```toml
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+```
+
+Write the test as a list of labeled cases — each a `scenario`, an `input`, and an `expect`ed result — and run them all
+through one operation, written once:
+
+```rust
+use carbide_test_support::Outcome::*;
+use carbide_test_support::{Case, check_cases};
+
+#[test]
+fn parse_port() {
+    check_cases(
+        [
+            Case { scenario: "valid", input: "443", expect: Yields(443) },
+            Case { scenario: "zero is allowed", input: "0", expect: Yields(0) },
+            Case { scenario: "non-numeric", input: "https", expect: Fails },
+            Case { scenario: "out of range", input: "99999", expect: FailsWith(PortError::TooLarge) },
+        ],
+        |s| parse_port(s),
+    );
+}
+```
+
+- Use **`check_cases`** with `Outcome` (`Yields` / `Fails` / `FailsWith`) for **fallible** operations (those returning
+  `Result`).
+- Use **`check_values`** with `Check` for **total** operations (those returning a plain value, `Option`, or `bool`).
+- Reach for `FailsWith(err)` only when the error type is `PartialEq` and its exact value is the contract. Otherwise use
+  `Fails` (with `.map_err(drop)` in the operation) when only "it failed" matters.
+
+Why we prefer this:
+
+- **It is the cheapest path to thorough coverage.** Each branch of the function under test — every `match` arm, each
+  `Option`/`Result` path, every boundary and error case — becomes one more row. To comprehensively test (and cover) a
+  function, simply *enumerate its input variants as cases*: the operation is written once, and every row exercises it.
+  This is by far the easiest way to take a function from partially-tested to nearly fully-covered, and it applies equally
+  whether a human or an agent is writing the tests.
+- **Failures are precise.** Each row carries its `scenario` label, so a failure names the exact case instead of leaving
+  you to bisect a wall of `assert!`s.
+- **Adding a case is one line**, so there is no friction to covering the edge case you would otherwise skip.
+
+Reach for a table whenever two or more tests call the same operation with different inputs. Do **not** force
+genuinely-distinct tests (different setup, a different operation, or several unrelated assertions) into a table — a table
+that obscures intent is worse than a few honest standalone `#[test]`s.
+
+When an exact expected value is awkward to write by hand, assert a robust property instead of guessing: a round-trip
+(`Yields(input)` after serialize-then-deserialize), `Fails` vs `Yields(())` for plain success/failure, or a
+substring/`contains` check. The case still exercises — and covers — the path.
+
+See [`crates/test-support/src/lib.rs`](crates/test-support/src/lib.rs) for the full API and more examples.
+
 ## gRPC API definitions
 
 - APIs to list resources and retrieve resource state should be paginated in order to scale to a high amount of managed


### PR DESCRIPTION
This supports #3914.

Add a `Testing` section to `STYLE_GUIDE.md` describing the `carbide-test-support` table-driven testing framework/helpers, and the convention of enumerating a function's input variants as cases. The emphasis is that this  allows for thorough coverage of inputs for a function, such that we can ensure less test duplication. The test wraps the function, and if the function goes away or changes, we just remove that function-specific test (which encapsulates various enumerated inputs and expected outputs/errors/etc).

Add a pointer to it from `AGENTS.md`, which was written by an agent, since it probably does a better job following its own guidelines.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>