### PR TITLE
fix: Drop firmware_version from expected-inventory metadata

### DIFF
--- a/rest-api/db/pkg/db/model/common.go
+++ b/rest-api/db/pkg/db/model/common.go
@@ -75,12 +75,11 @@ func (l *Labels) FromProto(protoLabels []*cwssaws.Label) {
 // type (device + rack-position fields) carried explicitly, rather than packing
 // the values into stringly-typed labels. Follow-up PR.
 const (
-	ExpectedComponentLabelManufacturer    = "manufacturer"
-	ExpectedComponentLabelModel           = "model"
-	ExpectedComponentLabelFirmwareVersion = "firmware_version"
-	ExpectedComponentLabelSlotID          = "slot_id"
-	ExpectedComponentLabelTrayIdx         = "tray_idx"
-	ExpectedComponentLabelHostID          = "host_id"
+	ExpectedComponentLabelManufacturer = "manufacturer"
+	ExpectedComponentLabelModel        = "model"
+	ExpectedComponentLabelSlotID       = "slot_id"
+	ExpectedComponentLabelTrayIdx      = "tray_idx"
+	ExpectedComponentLabelHostID       = "host_id"
 )
 
 // expectedComponentLabelsInput carries the flat device/rack columns that its
@@ -88,13 +87,12 @@ const (
 // them into a struct keeps the call sites self-documenting and avoids a long,
 // transposition-prone arg list.
 type expectedComponentLabelsInput struct {
-	Manufacturer    *string
-	Model           *string
-	FirmwareVersion *string
-	SlotID          *int32
-	TrayIdx         *int32
-	HostID          *int32
-	Labels          Labels
+	Manufacturer *string
+	Model        *string
+	SlotID       *int32
+	TrayIdx      *int32
+	HostID       *int32
+	Labels       Labels
 }
 
 // ToProto merges the input's labels with the flat device/rack columns, each
@@ -105,7 +103,7 @@ type expectedComponentLabelsInput struct {
 // not labels -- callers set those on Metadata directly.
 func (in expectedComponentLabelsInput) ToProto() []*cwssaws.Label {
 	// Merge through a map so a system field overrides a colliding user label.
-	merged := make(map[string]string, len(in.Labels)+6)
+	merged := make(map[string]string, len(in.Labels)+5)
 	for k, v := range in.Labels {
 		merged[k] = v
 	}
@@ -114,9 +112,6 @@ func (in expectedComponentLabelsInput) ToProto() []*cwssaws.Label {
 	}
 	if in.Model != nil {
 		merged[ExpectedComponentLabelModel] = *in.Model
-	}
-	if in.FirmwareVersion != nil {
-		merged[ExpectedComponentLabelFirmwareVersion] = *in.FirmwareVersion
 	}
 	if in.SlotID != nil {
 		merged[ExpectedComponentLabelSlotID] = strconv.FormatInt(int64(*in.SlotID), 10)

--- a/rest-api/db/pkg/db/model/common_test.go
+++ b/rest-api/db/pkg/db/model/common_test.go
@@ -119,23 +119,21 @@ func labelsAsMap(protoLabels []*cwssaws.Label) Labels {
 func TestExpectedComponentLabelsInput_ToProto(t *testing.T) {
 	t.Run("merges user labels with the flat device fields", func(t *testing.T) {
 		got := labelsAsMap(expectedComponentLabelsInput{
-			Manufacturer:    cutil.GetPtr("NVIDIA"),
-			Model:           cutil.GetPtr("MGX"),
-			FirmwareVersion: cutil.GetPtr("25.06-2"),
-			SlotID:          cutil.GetPtr(int32(3)),
-			TrayIdx:         cutil.GetPtr(int32(0)), // zero is a valid position
-			HostID:          cutil.GetPtr(int32(1)),
-			Labels:          Labels{"environment": "prod", "team": "infra"},
+			Manufacturer: cutil.GetPtr("NVIDIA"),
+			Model:        cutil.GetPtr("MGX"),
+			SlotID:       cutil.GetPtr(int32(3)),
+			TrayIdx:      cutil.GetPtr(int32(0)), // zero is a valid position
+			HostID:       cutil.GetPtr(int32(1)),
+			Labels:       Labels{"environment": "prod", "team": "infra"},
 		}.ToProto())
 		assert.Equal(t, Labels{
-			"environment":      "prod",
-			"team":             "infra",
-			"manufacturer":     "NVIDIA",
-			"model":            "MGX",
-			"firmware_version": "25.06-2",
-			"slot_id":          "3",
-			"tray_idx":         "0",
-			"host_id":          "1",
+			"environment":  "prod",
+			"team":         "infra",
+			"manufacturer": "NVIDIA",
+			"model":        "MGX",
+			"slot_id":      "3",
+			"tray_idx":     "0",
+			"host_id":      "1",
 		}, got)
 	})
 

--- a/rest-api/db/pkg/db/model/expectedmachine.go
+++ b/rest-api/db/pkg/db/model/expectedmachine.go
@@ -133,13 +133,12 @@ func (em *ExpectedMachine) ToProto(creds ExpectedMachineCredentials) *cwssaws.Ex
 
 	metadata := &cwssaws.Metadata{
 		Labels: expectedComponentLabelsInput{
-			Manufacturer:    em.Manufacturer,
-			Model:           em.Model,
-			FirmwareVersion: em.FirmwareVersion,
-			SlotID:          em.SlotID,
-			TrayIdx:         em.TrayIdx,
-			HostID:          em.HostID,
-			Labels:          em.Labels,
+			Manufacturer: em.Manufacturer,
+			Model:        em.Model,
+			SlotID:       em.SlotID,
+			TrayIdx:      em.TrayIdx,
+			HostID:       em.HostID,
+			Labels:       em.Labels,
 		}.ToProto(),
 	}
 	if em.Name != nil {

--- a/rest-api/db/pkg/db/model/expectedpowershelf.go
+++ b/rest-api/db/pkg/db/model/expectedpowershelf.go
@@ -124,13 +124,12 @@ func (eps *ExpectedPowerShelf) ToProto(creds ExpectedPowerShelfCredentials) *cws
 
 	metadata := &cwssaws.Metadata{
 		Labels: expectedComponentLabelsInput{
-			Manufacturer:    eps.Manufacturer,
-			Model:           eps.Model,
-			FirmwareVersion: eps.FirmwareVersion,
-			SlotID:          eps.SlotID,
-			TrayIdx:         eps.TrayIdx,
-			HostID:          eps.HostID,
-			Labels:          eps.Labels,
+			Manufacturer: eps.Manufacturer,
+			Model:        eps.Model,
+			SlotID:       eps.SlotID,
+			TrayIdx:      eps.TrayIdx,
+			HostID:       eps.HostID,
+			Labels:       eps.Labels,
 		}.ToProto(),
 	}
 	if eps.Name != nil {

--- a/rest-api/db/pkg/db/model/expectedswitch.go
+++ b/rest-api/db/pkg/db/model/expectedswitch.go
@@ -131,13 +131,12 @@ func (es *ExpectedSwitch) ToProto(creds ExpectedSwitchCredentials) *cwssaws.Expe
 
 	metadata := &cwssaws.Metadata{
 		Labels: expectedComponentLabelsInput{
-			Manufacturer:    es.Manufacturer,
-			Model:           es.Model,
-			FirmwareVersion: es.FirmwareVersion,
-			SlotID:          es.SlotID,
-			TrayIdx:         es.TrayIdx,
-			HostID:          es.HostID,
-			Labels:          es.Labels,
+			Manufacturer: es.Manufacturer,
+			Model:        es.Model,
+			SlotID:       es.SlotID,
+			TrayIdx:      es.TrayIdx,
+			HostID:       es.HostID,
+			Labels:       es.Labels,
 		}.ToProto(),
 	}
 	if es.Name != nil {


### PR DESCRIPTION

## Description
Firmware version is a runtime/observed property, not part of an expected component's declared inventory, so it shouldn't be written as a Core metadata label on the expected write path. Removes the firmware_version label key, the expectedComponentLabelsInput field, and the three ExpectedMachine/Switch/PowerShelf ToProto call sites that fed it.

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [x] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
https://github.com/NVIDIA/infra-controller/pull/2310

