### PR TITLE
forge 7451: Restart OVS when use_admin_network state changes

### DIFF
--- a/crates/admin-cli/src/version/cmd.rs
+++ b/crates/admin-cli/src/version/cmd.rs
@@ -143,6 +143,7 @@ pub async fn handle_show_version(
         r!(table, config, dpf_enabled);
         r!(table, config, compile_time_helm_version);
         r!(table, config, compile_time_docker_version);
+        r!(table, config, restart_ovs_on_use_admin_network_change);
 
         _ = table.print_tty(true);
     }

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -3081,6 +3081,7 @@ mod tests {
             instance: None,
             dpu_extension_services: vec![],
             astra_config: None,
+            use_admin_network_changed: None,
         }
     }
 
@@ -3574,6 +3575,7 @@ mod tests {
             instance: None,
             dpu_extension_services: vec![],
             astra_config: None,
+            use_admin_network_changed: None,
         };
 
         let f = tempfile::NamedTempFile::new()?;
@@ -3762,6 +3764,7 @@ mod tests {
             instance: None,
             dpu_extension_services: vec![],
             astra_config: None,
+            use_admin_network_changed: None,
         };
 
         let f = tempfile::NamedTempFile::new()?;

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -382,6 +382,7 @@ pub async fn setup_and_run(
         dhcp_interface_translation_mode,
         current_network_version: CurrentNetworkVersion::default(),
         last_ovs_restart_version: None,
+        ovs_restart_retry_backoff: None,
     };
 
     main_loop.run().await
@@ -417,6 +418,12 @@ struct MainLoop {
     dhcp_interface_translation_mode: Option<InterfaceTranslationMode>,
     current_network_version: CurrentNetworkVersion,
     last_ovs_restart_version: Option<String>,
+    ovs_restart_retry_backoff: Option<OvsRestartRetryBackoff>,
+}
+
+struct OvsRestartRetryBackoff {
+    managed_host_config_version: String,
+    retry_after: Instant,
 }
 
 struct IterationResult {
@@ -614,6 +621,75 @@ impl MainLoop {
                 _ = tokio::time::sleep(result.loop_period) => {}
             }
         }
+    }
+
+    async fn restart_ovs_after_admin_network_change_if_needed(
+        &mut self,
+        conf: &ManagedHostNetworkConfigResponse,
+        status_out: &mut rpc::DpuNetworkStatus,
+    ) -> bool {
+        if !conf.use_admin_network_changed.unwrap_or_default() {
+            return true;
+        }
+
+        let now = Instant::now();
+        let mut can_ack_network_config = true;
+        if !self.options.agent_platform_type.is_dpu_os() {
+            tracing::info!(
+                agent_platform_type = ?self.options.agent_platform_type,
+                managed_host_config_version =
+                    conf.managed_host_config_version.as_str(),
+                "Skip OVS restart because agent is not running on DPU OS"
+            );
+        } else if self.last_ovs_restart_version.as_deref()
+            == Some(conf.managed_host_config_version.as_str())
+        {
+            tracing::info!(
+                managed_host_config_version = conf.managed_host_config_version.as_str(),
+                "Skip OVS restart because this network config version already restarted OVS"
+            );
+        } else if self
+            .ovs_restart_retry_backoff
+            .as_ref()
+            .is_some_and(|backoff| {
+                backoff.managed_host_config_version == conf.managed_host_config_version
+                    && now < backoff.retry_after
+            })
+        {
+            tracing::warn!(
+                managed_host_config_version = conf.managed_host_config_version.as_str(),
+                "Skip OVS restart retry because backoff is still active"
+            );
+            status_out.network_config_error =
+                Some("waiting to retry OVS restart after prior failure".to_string());
+            can_ack_network_config = false;
+        } else {
+            tracing::info!(
+                managed_host_config_version = conf.managed_host_config_version.as_str(),
+                "Restart OVS because use_admin_network_changed is set to true"
+            );
+            if let Err(err) = crate::ovs::restart_ovs()
+                .await
+                .wrap_err("restarting OVS after admin network change")
+            {
+                tracing::error!(
+                    error = format!("{err:#}"),
+                    "Restarting OVS after admin network change"
+                );
+                status_out.network_config_error = Some(err.to_string());
+                self.ovs_restart_retry_backoff = Some(OvsRestartRetryBackoff {
+                    managed_host_config_version: conf.managed_host_config_version.clone(),
+                    retry_after: Instant::now() + OVS_RESTART_RETRY_BACKOFF,
+                });
+                can_ack_network_config = false;
+            } else {
+                self.last_ovs_restart_version = Some(conf.managed_host_config_version.clone());
+                self.ovs_restart_retry_backoff = None;
+            }
+        }
+        tracing::info!("Done with Restart OVS can_ack_network_config is {can_ack_network_config}");
+
+        can_ack_network_config
     }
 
     /// Runs a single iteration of the main loop
@@ -850,41 +926,12 @@ impl MainLoop {
                                 tracing::error!(error = %err, "Error reading/setting MTU for p0 or p1");
                             }
 
-                            let mut can_ack_network_config = true;
-                            if conf.use_admin_network_changed.unwrap_or_default() {
-                                if self.last_ovs_restart_version.as_deref()
-                                    == Some(conf.managed_host_config_version.as_str())
-                                {
-                                    tracing::info!(
-                                        managed_host_config_version =
-                                            conf.managed_host_config_version.as_str(),
-                                        "Skip OVS restart because this network config version already restarted OVS"
-                                    );
-                                } else {
-                                    tracing::info!(
-                                        managed_host_config_version =
-                                            conf.managed_host_config_version.as_str(),
-                                        "Restart OVS because use_admin_network_changed is set to true"
-                                    );
-                                    if let Err(err) = crate::ovs::restart_ovs()
-                                        .await
-                                        .wrap_err("restarting OVS after admin network change")
-                                    {
-                                        tracing::error!(
-                                            error = format!("{err:#}"),
-                                            "Restarting OVS after admin network change"
-                                        );
-                                        status_out.network_config_error = Some(err.to_string());
-                                        can_ack_network_config = false;
-                                    } else {
-                                        self.last_ovs_restart_version =
-                                            Some(conf.managed_host_config_version.clone());
-                                    }
-                                }
-                                tracing::info!(
-                                    "Done with Restart OVS can_ack_network_config is {can_ack_network_config}"
-                                );
-                            }
+                            let can_ack_network_config = self
+                                .restart_ovs_after_admin_network_change_if_needed(
+                                    &conf,
+                                    &mut status_out,
+                                )
+                                .await;
 
                             if can_ack_network_config {
                                 (
@@ -1390,6 +1437,7 @@ async fn get_fabric_interfaces_data()
 }
 
 const ONE_SECOND: Duration = Duration::from_secs(1);
+const OVS_RESTART_RETRY_BACKOFF: Duration = Duration::from_secs(60);
 
 // Format a Duration for display
 fn dt(d: Duration) -> humantime::FormattedDuration {

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -381,6 +381,7 @@ pub async fn setup_and_run(
         nvue_context,
         dhcp_interface_translation_mode,
         current_network_version: CurrentNetworkVersion::default(),
+        last_ovs_restart_version: None,
     };
 
     main_loop.run().await
@@ -415,6 +416,7 @@ struct MainLoop {
     nvue_context: Option<NvueClientContext>,
     dhcp_interface_translation_mode: Option<InterfaceTranslationMode>,
     current_network_version: CurrentNetworkVersion,
+    last_ovs_restart_version: Option<String>,
 }
 
 struct IterationResult {
@@ -848,69 +850,52 @@ impl MainLoop {
                                 tracing::error!(error = %err, "Error reading/setting MTU for p0 or p1");
                             }
 
-                            // Updating network config succeeded.
-                            // Tell the server about the applied version.
-                            status_out.network_config_version =
-                                Some(conf.managed_host_config_version.clone());
-                            status_out.instance_id = conf.instance_id;
-                            // On the admin network we don't have to report the instance network config version
-                            if !conf.instance_network_config_version.is_empty() {
-                                status_out.instance_network_config_version = Some(
-                                    match conf
-                                        .instance_network_config_version
-                                        .parse::<config_version::ConfigVersion>()
+                            let mut can_ack_network_config = true;
+                            if conf.use_admin_network_changed.unwrap_or_default() {
+                                if self.last_ovs_restart_version.as_deref()
+                                    == Some(conf.managed_host_config_version.as_str())
+                                {
+                                    tracing::info!(
+                                        managed_host_config_version =
+                                            conf.managed_host_config_version.as_str(),
+                                        "Skip OVS restart because this network config version already restarted OVS"
+                                    );
+                                } else {
+                                    tracing::info!(
+                                        managed_host_config_version =
+                                            conf.managed_host_config_version.as_str(),
+                                        "Restart OVS because use_admin_network_changed is set to true"
+                                    );
+                                    if let Err(err) = crate::ovs::restart_ovs()
+                                        .await
+                                        .wrap_err("restarting OVS after admin network change")
                                     {
-                                        Ok(managed_host_instance_network_config_version) => {
-                                            match instance_data
-                                                .as_ref()
-                                                .map(|instance| instance.network_config_version)
-                                            {
-                                                Some(instance_metadata_network_config_version) => {
-                                                    // Report the older version of the versions received via 2 path
-                                                    // That makes sure we don't report progress if we haven't received the newest version
-                                                    // via both path.
-                                                    let reported_instance_network_config_version =
-                                                    managed_host_instance_network_config_version
-                                                        .min_by_timestamp(
-                                                        &instance_metadata_network_config_version,
-                                                    );
-                                                    if instance_metadata_network_config_version
-                                                    != managed_host_instance_network_config_version
-                                                {
-                                                    tracing::warn!("Different instance network config version received. GetManagedHostNetworkConfig: {}, FindInstanceByMachineId: {}, Reporting: {}",
-                                                        managed_host_instance_network_config_version,
-                                                    instance_metadata_network_config_version,
-                                                    reported_instance_network_config_version,
-                                                );
-                                                }
-                                                    reported_instance_network_config_version
-                                                        .version_string()
-                                                }
-                                                None => {
-                                                    // TODO: Maybe we want to wait until both receive path provide the same data?
-                                                    tracing::warn!(
-                                                        "Received instance_network_config_version via GetManagedHostNetworkConfig, but not via FindInstanceByMachineId. Acknowledging received version"
-                                                    );
-                                                    conf.instance_network_config_version.clone()
-                                                }
-                                            }
-                                        }
-                                        Err(err) => {
-                                            // We can't compare the 2 received versions since the first is not parseable
-                                            // This isn't really supposed to happen.
-                                            // However to avoid breaking the system in that case,
-                                            // we still report the version received via GetManagedHostNetworkConfig,
-                                            // because that is also what we did in the past.
-                                            tracing::error!(error = %err, "Failed to parse instance_network_config_version received via GetManagedHostNetworkConfig");
-                                            conf.instance_network_config_version.clone()
-                                        }
-                                    },
+                                        tracing::error!(
+                                            error = format!("{err:#}"),
+                                            "Restarting OVS after admin network change"
+                                        );
+                                        status_out.network_config_error = Some(err.to_string());
+                                        can_ack_network_config = false;
+                                    } else {
+                                        self.last_ovs_restart_version =
+                                            Some(conf.managed_host_config_version.clone());
+                                    }
+                                }
+                                tracing::info!(
+                                    "Done with Restart OVS can_ack_network_config is {can_ack_network_config}"
                                 );
                             }
-                            current_host_network_config_version =
-                                status_out.network_config_version.clone();
-                            current_instance_network_config_version =
-                                status_out.instance_network_config_version.clone();
+
+                            if can_ack_network_config {
+                                (
+                                    current_host_network_config_version,
+                                    current_instance_network_config_version,
+                                ) = ack_network_config_update(
+                                    &conf,
+                                    instance_data.as_deref(),
+                                    &mut status_out,
+                                );
+                            }
 
                             match ethernet_virtualization::interfaces(
                                 &conf,
@@ -1209,6 +1194,71 @@ fn effective_virtualization_type(
         });
 
     Ok(virtualization_type)
+}
+
+fn ack_network_config_update(
+    conf: &ManagedHostNetworkConfigResponse,
+    instance_data: Option<&periodic_config_fetcher::InstanceMetadata>,
+    status_out: &mut rpc::DpuNetworkStatus,
+) -> (Option<String>, Option<String>) {
+    // Updating network config succeeded.
+    // Tell the server about the applied version.
+    status_out.network_config_version = Some(conf.managed_host_config_version.clone());
+    status_out.instance_id = conf.instance_id;
+    // On the admin network we don't have to report the instance network config version
+    if !conf.instance_network_config_version.is_empty() {
+        status_out.instance_network_config_version = Some(
+            match conf
+                .instance_network_config_version
+                .parse::<config_version::ConfigVersion>()
+            {
+                Ok(managed_host_instance_network_config_version) => {
+                    match instance_data.map(|instance| instance.network_config_version) {
+                        Some(instance_metadata_network_config_version) => {
+                            // Report the older version of the versions received via 2 path
+                            // That makes sure we don't report progress if we haven't received the newest version
+                            // via both path.
+                            let reported_instance_network_config_version =
+                                managed_host_instance_network_config_version
+                                    .min_by_timestamp(&instance_metadata_network_config_version);
+                            if instance_metadata_network_config_version
+                                != managed_host_instance_network_config_version
+                            {
+                                tracing::warn!(
+                                    "Different instance network config version received. GetManagedHostNetworkConfig: {}, FindInstanceByMachineId: {}, Reporting: {}",
+                                    managed_host_instance_network_config_version,
+                                    instance_metadata_network_config_version,
+                                    reported_instance_network_config_version,
+                                );
+                            }
+                            reported_instance_network_config_version.version_string()
+                        }
+                        None => {
+                            // TODO: Maybe we want to wait until both receive path provide the same data?
+                            tracing::warn!(
+                                "Received instance_network_config_version via GetManagedHostNetworkConfig, but not via FindInstanceByMachineId. Acknowledging received version"
+                            );
+                            conf.instance_network_config_version.clone()
+                        }
+                    }
+                }
+                Err(err) => {
+                    // We can't compare the 2 received versions since the first is not parseable
+                    // This isn't really supposed to happen.
+                    // However to avoid breaking the system in that case,
+                    // we still report the version received via GetManagedHostNetworkConfig,
+                    // because that is also what we did in the past.
+                    tracing::error!(error = %err, "Failed to parse instance_network_config_version received via GetManagedHostNetworkConfig");
+                    conf.instance_network_config_version.clone()
+                }
+            },
+        );
+    }
+
+    (
+        status_out.network_config_version.clone(),
+        status_out.instance_network_config_version.clone(),
+    )
 }
 
 // TODO(chet): We'll eventually want a documented IPv6 address we can

--- a/crates/agent/src/ovs.rs
+++ b/crates/agent/src/ovs.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use std::time::Duration;
+
 use eyre::WrapErr;
 
 /// ovs-vswitchd is part of HBN. It handles network packets in user-space using DPDK
@@ -53,5 +55,32 @@ pub async fn set_vswitchd_yield() -> eyre::Result<()> {
         eyre::bail!("Failed running ovs-vsctl command. Check logs for stdout/stderr.");
     }
 
+    Ok(())
+}
+
+/// Restart the OVS service (ovs-vswitchd) via systemctl.
+pub async fn restart_ovs() -> eyre::Result<()> {
+    let restart = tokio::time::timeout(
+        Duration::from_secs(180),
+        tokio::process::Command::new("systemctl")
+            .args(["restart", "ovs-vswitchd.service"])
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await;
+    let restart = match restart {
+        Ok(Ok(output)) => output,
+        Ok(Err(e)) => eyre::bail!("Failed to execute systemctl restart: {}", e),
+        Err(_) => eyre::bail!("Timeout (180s) waiting for ovs-vswitchd.service restart"),
+    };
+
+    if !restart.status.success() {
+        eyre::bail!(
+            "systemctl restart ovs-vswitchd.service failed (status: {})",
+            restart.status
+        );
+    }
+
+    tracing::info!("Successfully restarted ovs-vswitchd.service");
     Ok(())
 }

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -922,6 +922,7 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
         instance: Some(instance),
         dpu_extension_services: vec![],
         astra_config: None,
+        use_admin_network_changed: None,
     };
     common::respond(netconf)
 }

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -423,6 +423,7 @@ Extends `StateControllerConfig` with:
 | `dpu_nic_firmware_update_versions` | `Vec<String>` | *(BF2+BF3 NIC versions)* | DPU NIC firmware version strings. |
 | `dpu_enable_secure_boot` | `bool` | `false` | Enable secure boot flow for DPU provisioning via Redfish. |
 | `num_of_vfs` | `u32` | `16` | Number of VFs configured per DPU PF during BlueField provisioning. Max `126`. |
+| `restart_ovs_on_use_admin_network_change` | `bool` | `false` | Restart OVS on DPU-OS agents when host `use_admin_network` changes. Containerized agents skip the local service restart and still ACK the network config. |
 
 ### `NetworkSecurityGroupConfig`
 

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -785,9 +785,8 @@ impl CarbideConfig {
 
             dpu_enable_secure_boot: self.dpu_config.dpu_enable_secure_boot,
             restart_ovs_on_use_admin_network_change: self
-                .site_explorer
-                .restart_ovs_on_use_admin_network_change
-                .clone(),
+                .dpu_config
+                .restart_ovs_on_use_admin_network_change,
         }
     }
 }
@@ -1938,6 +1937,12 @@ pub struct DpuConfig {
     /// Defaults to 16 and must not exceed 126.
     #[serde(default)]
     pub num_of_vfs: u32,
+
+    /// Restart OVS on DPU agents whenever the host switches between
+    /// admin and tenant networking. Required in some environments to
+    /// ensure OVS picks up the changed network configuration.
+    #[serde(default)]
+    pub restart_ovs_on_use_admin_network_change: bool,
 }
 
 impl DpuConfig {
@@ -1977,6 +1982,8 @@ impl<'de> Deserialize<'de> for DpuConfig {
             dpu_enable_secure_boot: Option<bool>,
             #[serde(default)]
             num_of_vfs: Option<u32>,
+            #[serde(default)]
+            restart_ovs_on_use_admin_network_change: Option<bool>,
         }
 
         let partial = PartialDpuConfig::deserialize(deserializer)?;
@@ -2003,6 +2010,9 @@ impl<'de> Deserialize<'de> for DpuConfig {
                 .dpu_enable_secure_boot
                 .unwrap_or(default.dpu_enable_secure_boot),
             num_of_vfs,
+            restart_ovs_on_use_admin_network_change: partial
+                .restart_ovs_on_use_admin_network_change
+                .unwrap_or(default.restart_ovs_on_use_admin_network_change),
         })
     }
 }
@@ -2129,6 +2139,7 @@ impl Default for DpuConfig {
             ],
             dpu_enable_secure_boot: false,
             num_of_vfs: DEFAULT_DPU_NUM_OF_VFS,
+            restart_ovs_on_use_admin_network_change: false,
         }
     }
 }
@@ -2402,9 +2413,8 @@ impl From<CarbideConfig> for rpc::forge::RuntimeConfig {
             compile_time_helm_version: crate::dpf_services::COMPILE_TIME_HELM_VERSION.to_string(),
             compile_time_docker_version: crate::dpf_services::COMPILE_TIME_IMAGE_TAG.to_string(),
             restart_ovs_on_use_admin_network_change: value
-                .site_explorer
-                .restart_ovs_on_use_admin_network_change
-                .load(std::sync::atomic::Ordering::Relaxed),
+                .dpu_config
+                .restart_ovs_on_use_admin_network_change,
         }
     }
 }
@@ -3009,7 +3019,6 @@ mod tests {
                 switches_created_per_run: 9,
                 rotate_switch_nvos_credentials: Arc::new(false.into()),
                 dpu_mode: None,
-                restart_ovs_on_use_admin_network_change: Arc::new(false.into()),
                 explore_mode: SiteExplorerExploreMode::LibRedfish,
             }
         );
@@ -3207,7 +3216,6 @@ mod tests {
                 switches_created_per_run: 9,
                 rotate_switch_nvos_credentials: Arc::new(false.into()),
                 dpu_mode: None,
-                restart_ovs_on_use_admin_network_change: Arc::new(false.into()),
                 explore_mode: SiteExplorerExploreMode::LibRedfish,
             }
         );
@@ -3552,7 +3560,6 @@ mod tests {
                 switches_created_per_run: 9,
                 rotate_switch_nvos_credentials: Arc::new(false.into()),
                 dpu_mode: None,
-                restart_ovs_on_use_admin_network_change: Arc::new(false.into()),
                 explore_mode: SiteExplorerExploreMode::LibRedfish,
             }
         );
@@ -3761,21 +3768,16 @@ mod tests {
     }
 
     #[test]
-    fn site_explorer_restart_ovs_on_use_admin_network_change_parses_and_displays() {
+    fn dpu_config_restart_ovs_on_use_admin_network_change_parses_and_displays() {
         let config: CarbideConfig = Figment::new()
             .merge(Toml::file(format!("{TEST_DATA_DIR}/min_config.toml")))
             .merge(Toml::string(
-                "[site_explorer]\nrestart_ovs_on_use_admin_network_change = true\n",
+                "[dpu_config]\nrestart_ovs_on_use_admin_network_change = true\n",
             ))
             .extract()
             .unwrap();
 
-        assert!(
-            config
-                .site_explorer
-                .restart_ovs_on_use_admin_network_change
-                .load(AtomicOrdering::Relaxed)
-        );
+        assert!(config.dpu_config.restart_ovs_on_use_admin_network_change);
 
         let runtime_config: rpc::forge::RuntimeConfig = config.into();
         assert!(runtime_config.restart_ovs_on_use_admin_network_change);

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -784,6 +784,10 @@ impl CarbideConfig {
             spdm_enabled: self.spdm.enabled,
 
             dpu_enable_secure_boot: self.dpu_config.dpu_enable_secure_boot,
+            restart_ovs_on_use_admin_network_change: self
+                .site_explorer
+                .restart_ovs_on_use_admin_network_change
+                .clone(),
         }
     }
 }
@@ -2397,6 +2401,10 @@ impl From<CarbideConfig> for rpc::forge::RuntimeConfig {
             dpf_enabled: value.dpf.enabled,
             compile_time_helm_version: crate::dpf_services::COMPILE_TIME_HELM_VERSION.to_string(),
             compile_time_docker_version: crate::dpf_services::COMPILE_TIME_IMAGE_TAG.to_string(),
+            restart_ovs_on_use_admin_network_change: value
+                .site_explorer
+                .restart_ovs_on_use_admin_network_change
+                .load(std::sync::atomic::Ordering::Relaxed),
         }
     }
 }
@@ -3001,6 +3009,7 @@ mod tests {
                 switches_created_per_run: 9,
                 rotate_switch_nvos_credentials: Arc::new(false.into()),
                 dpu_mode: None,
+                restart_ovs_on_use_admin_network_change: Arc::new(false.into()),
                 explore_mode: SiteExplorerExploreMode::LibRedfish,
             }
         );
@@ -3198,6 +3207,7 @@ mod tests {
                 switches_created_per_run: 9,
                 rotate_switch_nvos_credentials: Arc::new(false.into()),
                 dpu_mode: None,
+                restart_ovs_on_use_admin_network_change: Arc::new(false.into()),
                 explore_mode: SiteExplorerExploreMode::LibRedfish,
             }
         );
@@ -3542,6 +3552,7 @@ mod tests {
                 switches_created_per_run: 9,
                 rotate_switch_nvos_credentials: Arc::new(false.into()),
                 dpu_mode: None,
+                restart_ovs_on_use_admin_network_change: Arc::new(false.into()),
                 explore_mode: SiteExplorerExploreMode::LibRedfish,
             }
         );
@@ -3747,6 +3758,27 @@ mod tests {
                 "[site_explorer] dpu_mode = {toml_value:?} should parse to {expected:?}",
             );
         }
+    }
+
+    #[test]
+    fn site_explorer_restart_ovs_on_use_admin_network_change_parses_and_displays() {
+        let config: CarbideConfig = Figment::new()
+            .merge(Toml::file(format!("{TEST_DATA_DIR}/min_config.toml")))
+            .merge(Toml::string(
+                "[site_explorer]\nrestart_ovs_on_use_admin_network_change = true\n",
+            ))
+            .extract()
+            .unwrap();
+
+        assert!(
+            config
+                .site_explorer
+                .restart_ovs_on_use_admin_network_change
+                .load(AtomicOrdering::Relaxed)
+        );
+
+        let runtime_config: rpc::forge::RuntimeConfig = config.into();
+        assert!(runtime_config.restart_ovs_on_use_admin_network_change);
     }
 
     /// Real-world site TOMLs may still carry the now-removed

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -865,9 +865,10 @@ pub(crate) async fn record_dpu_network_status(
         && machine_obs.network_config_version.as_ref() == Some(&dpu_machine.network_config.version)
     {
         tracing::info!(
-            "DPU {} reported network config version {}; reset use_admin_network_changed in the database.",
-            &dpu_machine_id,
-            dpu_machine.network_config.version,
+            dpu_id = %dpu_machine_id,
+            network_config_version = %dpu_machine.network_config.version,
+            agent_version = ?machine_obs.agent_version,
+            "Clearing use_admin_network_changed after matching-version ACK; OVS restart may have been skipped by agents that do not support the flag"
         );
         db::machine::clear_use_admin_network_changed_if_version_matches(
             &mut txn,

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -171,6 +171,8 @@ pub(crate) async fn get_managed_host_network_config_inner(
     // and keep it on admin. This prevents the host from using the DPU at all.
     let use_admin_network = snapshot.use_admin_network() || !dpu_has_tenant_interface_config;
 
+    let use_admin_network_changed = dpu_snapshot.network_config.use_admin_network_changed;
+
     let mut network_virtualization_type = VpcVirtualizationType::EthernetVirtualizer;
 
     let mut use_fnn_over_admin_nw = false;
@@ -751,6 +753,7 @@ pub(crate) async fn get_managed_host_network_config_inner(
             None => None,
         },
         astra_config,
+        use_admin_network_changed,
     };
 
     // If this all worked, we shouldn't emit a log line
@@ -858,6 +861,21 @@ pub(crate) async fn record_dpu_network_status(
 
     // Instance network observation is the part of network observation now.
     db::machine::update_network_status_observation(&mut txn, &dpu_machine_id, &machine_obs).await?;
+    if dpu_machine.network_config.value.use_admin_network_changed == Some(true)
+        && machine_obs.network_config_version.as_ref() == Some(&dpu_machine.network_config.version)
+    {
+        tracing::info!(
+            "DPU {} reported network config version {}; reset use_admin_network_changed in the database.",
+            &dpu_machine_id,
+            dpu_machine.network_config.version,
+        );
+        db::machine::clear_use_admin_network_changed_if_version_matches(
+            &mut txn,
+            &dpu_machine_id,
+            &dpu_machine.network_config.version,
+        )
+        .await?;
+    }
     tracing::trace!(
         machine_id = %dpu_machine_id,
         machine_network_config = ?request.network_config_version,
@@ -1385,6 +1403,7 @@ mod consolidated_network_config_tests {
             // top-level response field, not in this consolidated struct.
             use_admin_network: Some(false),
             quarantine_state: None,
+            use_admin_network_changed: None,
         };
         let consolidated = build_consolidated_network_config(&host, dpu_ip());
         assert_eq!(

--- a/crates/api-core/src/test_support/default_config.rs
+++ b/crates/api-core/src/test_support/default_config.rs
@@ -158,6 +158,7 @@ pub fn get() -> CarbideConfig {
             dpu_nic_firmware_update_versions: vec!["24.42.1000".to_string()],
             dpu_enable_secure_boot: true,
             num_of_vfs: crate::cfg::file::DEFAULT_DPU_NUM_OF_VFS,
+            restart_ovs_on_use_admin_network_change: false,
         },
         host_models: host_firmware_example(),
         firmware_global: FirmwareGlobal::test_default(),

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -1726,6 +1726,7 @@ pub async fn create_test_env_with_overrides(
             switches_created_per_run: 1,
             rotate_switch_nvos_credentials: Arc::new(false.into()),
             dpu_mode: None,
+            restart_ovs_on_use_admin_network_change: Arc::new(false.into()),
             // Tests use MockEndpointExplorer. So this doesn't affect anything.
             explore_mode: SiteExplorerExploreMode::NvRedfish,
         },

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -1726,7 +1726,6 @@ pub async fn create_test_env_with_overrides(
             switches_created_per_run: 1,
             rotate_switch_nvos_credentials: Arc::new(false.into()),
             dpu_mode: None,
-            restart_ovs_on_use_admin_network_change: Arc::new(false.into()),
             // Tests use MockEndpointExplorer. So this doesn't affect anything.
             explore_mode: SiteExplorerExploreMode::NvRedfish,
         },

--- a/crates/api-core/src/tests/machine_network.rs
+++ b/crates/api-core/src/tests/machine_network.rs
@@ -24,6 +24,7 @@ use ::rpc::forge::{
     ManagedHostNetworkConfigRequest, ManagedHostNetworkStatusRequest,
 };
 use carbide_secrets::credentials::{BgpCredentialType, CredentialKey, Credentials};
+use carbide_uuid::machine::MachineId;
 use common::api_fixtures::network_segment::{
     FIXTURE_TENANT_NETWORK_SEGMENT_GATEWAYS, create_network_segment, create_tenant_network_segment,
 };
@@ -45,6 +46,113 @@ use crate::tests::common::api_fixtures::TestEnvOverrides;
 use crate::tests::common::api_fixtures::site_explorer::MockExploredHost;
 use crate::tests::common::rpc_builder::VpcCreationRequest;
 
+async fn set_use_admin_network_changed(
+    env: &api_fixtures::TestEnv,
+    dpu_machine_id: MachineId,
+    value: bool,
+) {
+    let mut txn = env.db_txn().await;
+    db::machine::set_use_admin_network_changed(txn.deref_mut(), &dpu_machine_id, value)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+}
+
+async fn use_admin_network_changed(
+    env: &api_fixtures::TestEnv,
+    dpu_machine_id: MachineId,
+) -> Option<bool> {
+    let mut txn = env.db_txn().await;
+    let dpu = db::machine::find_one(txn.deref_mut(), &dpu_machine_id, Default::default())
+        .await
+        .unwrap()
+        .unwrap();
+    txn.commit().await.unwrap();
+    dpu.network_config.value.use_admin_network_changed
+}
+
+async fn bump_dpu_network_config_version(env: &api_fixtures::TestEnv, dpu_machine_id: MachineId) {
+    let mut txn = env.db_txn().await;
+    let dpu = db::machine::find_one(txn.deref_mut(), &dpu_machine_id, Default::default())
+        .await
+        .unwrap()
+        .unwrap();
+    let version = dpu.network_config.version;
+    let value = dpu.network_config.value;
+    db::machine::try_update_network_config(txn.deref_mut(), &dpu_machine_id, version, &value)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+}
+
+async fn record_dpu_network_status(
+    env: &api_fixtures::TestEnv,
+    dpu_machine_id: MachineId,
+    network_config_version: Option<String>,
+) {
+    env.api
+        .record_dpu_network_status(tonic::Request::new(DpuNetworkStatus {
+            dpu_machine_id: Some(dpu_machine_id),
+            dpu_agent_version: Some(dpu::TEST_DPU_AGENT_VERSION.to_string()),
+            observed_at: Some(SystemTime::now().into()),
+            dpu_health: Some(rpc::health::HealthReport {
+                source: "forge-dpu-agent".to_string(),
+                triggered_by: None,
+                observed_at: None,
+                successes: vec![],
+                alerts: vec![],
+            }),
+            network_config_version,
+            instance_id: None,
+            instance_config_version: None,
+            instance_network_config_version: None,
+            interfaces: vec![],
+            network_config_error: None,
+            client_certificate_expiry_unix_epoch_secs: None,
+            fabric_interfaces: vec![],
+            last_dhcp_requests: vec![],
+            dpu_extension_service_version: None,
+            dpu_extension_services: vec![],
+        }))
+        .await
+        .unwrap();
+}
+
+#[crate::sqlx_test]
+async fn test_clear_use_admin_network_changed_keeps_newer_version_flag(pool: sqlx::PgPool) {
+    let env = api_fixtures::create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+    let dpu_machine_id = mh.dpu().id;
+
+    set_use_admin_network_changed(&env, dpu_machine_id, true).await;
+    let mut txn = env.db_txn().await;
+    let stale_version = db::machine::find_one(txn.deref_mut(), &dpu_machine_id, Default::default())
+        .await
+        .unwrap()
+        .unwrap()
+        .network_config
+        .version;
+    txn.commit().await.unwrap();
+
+    bump_dpu_network_config_version(&env, dpu_machine_id).await;
+
+    let mut txn = env.db_txn().await;
+    let cleared = db::machine::clear_use_admin_network_changed_if_version_matches(
+        txn.deref_mut(),
+        &dpu_machine_id,
+        &stale_version,
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    assert!(!cleared);
+    assert_eq!(
+        use_admin_network_changed(&env, dpu_machine_id).await,
+        Some(true)
+    );
+}
+
 #[crate::sqlx_test]
 async fn test_managed_host_network_config(pool: sqlx::PgPool) {
     let env = api_fixtures::create_test_env(pool).await;
@@ -61,6 +169,80 @@ async fn test_managed_host_network_config(pool: sqlx::PgPool) {
         .await;
 
     assert!(response.is_ok());
+}
+
+#[crate::sqlx_test]
+async fn test_managed_host_network_config_does_not_clear_use_admin_network_changed(
+    pool: sqlx::PgPool,
+) {
+    let env = api_fixtures::create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+    let dpu_machine_id = mh.dpu().id;
+
+    set_use_admin_network_changed(&env, dpu_machine_id, true).await;
+
+    let response = env
+        .api
+        .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
+            dpu_machine_id: Some(dpu_machine_id),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(response.use_admin_network_changed, Some(true));
+    assert_eq!(
+        use_admin_network_changed(&env, dpu_machine_id).await,
+        Some(true)
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_record_dpu_network_status_clears_use_admin_network_changed_for_matching_version(
+    pool: sqlx::PgPool,
+) {
+    let env = api_fixtures::create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+    let dpu_machine_id = mh.dpu().id;
+
+    set_use_admin_network_changed(&env, dpu_machine_id, true).await;
+    let response = env
+        .api
+        .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
+            dpu_machine_id: Some(dpu_machine_id),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+
+    record_dpu_network_status(
+        &env,
+        dpu_machine_id,
+        Some(response.managed_host_config_version),
+    )
+    .await;
+
+    assert_eq!(
+        use_admin_network_changed(&env, dpu_machine_id).await,
+        Some(false)
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_record_dpu_network_status_keeps_use_admin_network_changed_without_matching_version(
+    pool: sqlx::PgPool,
+) {
+    let env = api_fixtures::create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+    let dpu_machine_id = mh.dpu().id;
+
+    set_use_admin_network_changed(&env, dpu_machine_id, true).await;
+    record_dpu_network_status(&env, dpu_machine_id, None).await;
+
+    assert_eq!(
+        use_admin_network_changed(&env, dpu_machine_id).await,
+        Some(true)
+    );
 }
 
 #[crate::sqlx_test]

--- a/crates/api-core/src/tests/machine_network.rs
+++ b/crates/api-core/src/tests/machine_network.rs
@@ -113,6 +113,7 @@ async fn record_dpu_network_status(
             last_dhcp_requests: vec![],
             dpu_extension_service_version: None,
             dpu_extension_services: vec![],
+            astra_config_status: None,
         }))
         .await
         .unwrap();

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -1334,6 +1334,57 @@ pub async fn try_update_network_config(
     }
 }
 
+/// Sets or clears the `use_admin_network_changed` flag on a single machine
+/// row without bumping `network_config_version` or fanning out to the group.
+pub async fn set_use_admin_network_changed(
+    txn: &mut PgConnection,
+    machine_id: &MachineId,
+    value: bool,
+) -> Result<(), DatabaseError> {
+    let query = r#"
+        UPDATE machines
+        SET network_config = jsonb_set(COALESCE(network_config, '{}'::jsonb), '{use_admin_network_changed}', $1::jsonb)
+        WHERE id = $2
+    "#;
+    let result = sqlx::query(query)
+        .bind(sqlx::types::Json(value))
+        .bind(machine_id)
+        .execute(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+    if result.rows_affected() == 0 {
+        return Err(DatabaseError::NotFoundError {
+            kind: "machine",
+            id: machine_id.to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Clears the `use_admin_network_changed` flag only if the machine is still at
+/// the expected network config version.
+pub async fn clear_use_admin_network_changed_if_version_matches(
+    txn: &mut PgConnection,
+    machine_id: &MachineId,
+    expected_version: &ConfigVersion,
+) -> Result<bool, DatabaseError> {
+    let query = r#"
+        UPDATE machines
+        SET network_config = jsonb_set(COALESCE(network_config, '{}'::jsonb), '{use_admin_network_changed}', 'false'::jsonb)
+        WHERE id = $1
+          AND network_config_version = $2
+          AND network_config -> 'use_admin_network_changed' = 'true'::jsonb
+    "#;
+    let result = sqlx::query(query)
+        .bind(machine_id)
+        .bind(expected_version)
+        .execute(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(result.rows_affected() > 0)
+}
+
 /// Replaces predicted host id with stable host id.
 /// Once forge receives DiscoveryData from Host, forge can create StableMachineId.
 /// This StableMachineId must replace existing PredictedHostId in db.

--- a/crates/api-model/src/machine/network.rs
+++ b/crates/api-model/src/machine/network.rs
@@ -154,6 +154,7 @@ pub struct ManagedHostNetworkConfig {
     /// merging in DPU-specific configs.
     pub use_admin_network: Option<bool>,
     pub quarantine_state: Option<ManagedHostQuarantineState>,
+    pub use_admin_network_changed: Option<bool>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -192,6 +193,7 @@ impl Default for ManagedHostNetworkConfig {
             secondary_overlay_vtep_ip: None,
             use_admin_network: Some(true),
             quarantine_state: None,
+            use_admin_network_changed: None,
         }
     }
 }
@@ -287,11 +289,13 @@ mod tests {
                     secondary_overlay_vtep_ip: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
                     use_admin_network: Some(true),
                     quarantine_state: None,
+                    use_admin_network_changed: None,
                 } => Yields(ManagedHostNetworkConfig {
                     loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
                     secondary_overlay_vtep_ip: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
                     use_admin_network: Some(true),
                     quarantine_state: None,
+                    use_admin_network_changed: None,
                 }),
             }
 
@@ -305,6 +309,7 @@ mod tests {
                     ))),
                     use_admin_network: Some(false),
                     quarantine_state: None,
+                    use_admin_network_changed: None,
                 } => Yields(ManagedHostNetworkConfig {
                     loopback_ip: Some(IpAddr::V6(Ipv6Addr::new(
                         0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
@@ -314,6 +319,7 @@ mod tests {
                     ))),
                     use_admin_network: Some(false),
                     quarantine_state: None,
+                    use_admin_network_changed: None,
                 }),
             }
         );
@@ -367,6 +373,7 @@ mod tests {
             secondary_overlay_vtep_ip: None,
             use_admin_network: Some(true),
             quarantine_state: None,
+            use_admin_network_changed: None,
         };
         let json = serde_json::to_string(&config).unwrap();
         // Ensure IpAddr serializes IPv4 same as Ipv4Addr.
@@ -395,6 +402,10 @@ mod tests {
             run = |flag| flag;
             "use_admin_network defaults to Some(true)" {
                 default.use_admin_network => Some(true),
+            }
+
+            "use_admin_network_changed defaults to None" {
+                default.use_admin_network_changed => None,
             }
         );
         Check {
@@ -594,6 +605,7 @@ mod tests {
                         reason: Some("noisy".to_string()),
                         mode: ManagedHostQuarantineMode::BlockAllTraffic,
                     }),
+                    use_admin_network_changed: None,
                 }),
             }
 
@@ -603,6 +615,7 @@ mod tests {
                     secondary_overlay_vtep_ip: None,
                     use_admin_network: None,
                     quarantine_state: None,
+                    use_admin_network_changed: None,
                 }),
             }
 
@@ -653,6 +666,7 @@ mod tests {
                         reason: Some("flooded".to_string()),
                         mode: ManagedHostQuarantineMode::BlockAllTraffic,
                     }),
+                    use_admin_network_changed: None,
                 } => Yields(ManagedHostNetworkConfig {
                     loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
                     secondary_overlay_vtep_ip: None,
@@ -661,6 +675,7 @@ mod tests {
                         reason: Some("flooded".to_string()),
                         mode: ManagedHostQuarantineMode::BlockAllTraffic,
                     }),
+                    use_admin_network_changed: None,
                 }),
             }
         );

--- a/crates/machine-controller/src/config/mod.rs
+++ b/crates/machine-controller/src/config/mod.rs
@@ -17,6 +17,8 @@
 
 #[cfg(any(test, feature = "test-support"))]
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use model::machine::HostHealthConfig;
 use serde::{Deserialize, Serialize};
@@ -48,6 +50,7 @@ pub struct MachineStateHandlerSiteConfig {
     pub spdm_enabled: bool,
 
     pub dpu_enable_secure_boot: bool,
+    pub restart_ovs_on_use_admin_network_change: Arc<AtomicBool>,
 }
 
 impl MachineStateHandlerSiteConfig {
@@ -65,6 +68,7 @@ impl MachineStateHandlerSiteConfig {
             dpf_enabled: false,
             spdm_enabled: false,
             dpu_enable_secure_boot: true,
+            restart_ovs_on_use_admin_network_change: Arc::new(false.into()),
         }
     }
 }

--- a/crates/machine-controller/src/config/mod.rs
+++ b/crates/machine-controller/src/config/mod.rs
@@ -17,8 +17,6 @@
 
 #[cfg(any(test, feature = "test-support"))]
 use std::collections::HashMap;
-use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 
 use model::machine::HostHealthConfig;
 use serde::{Deserialize, Serialize};
@@ -50,7 +48,7 @@ pub struct MachineStateHandlerSiteConfig {
     pub spdm_enabled: bool,
 
     pub dpu_enable_secure_boot: bool,
-    pub restart_ovs_on_use_admin_network_change: Arc<AtomicBool>,
+    pub restart_ovs_on_use_admin_network_change: bool,
 }
 
 impl MachineStateHandlerSiteConfig {
@@ -68,7 +66,7 @@ impl MachineStateHandlerSiteConfig {
             dpf_enabled: false,
             spdm_enabled: false,
             dpu_enable_secure_boot: true,
-            restart_ovs_on_use_admin_network_change: Arc::new(false.into()),
+            restart_ovs_on_use_admin_network_change: false,
         }
     }
 }

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -6896,14 +6896,28 @@ impl StateHandler for InstanceStateHandler {
                     let mut txn = ctx.services.db_pool.begin().await?;
                     let host_version = mh_snapshot.host_snapshot.network_config.version;
                     let mut host_netconf = mh_snapshot.host_snapshot.network_config.value.clone();
+                    let old_use_admin_network = host_netconf.use_admin_network;
                     host_netconf.use_admin_network = Some(true);
-                    db::machine::try_update_network_config(
+                    let updated = db::machine::try_update_network_config(
                         &mut txn,
                         &mh_snapshot.host_snapshot.id,
                         host_version,
                         &host_netconf,
                     )
                     .await?;
+
+                    // Set use_admin_network_changed if we want to reboot
+                    // ovs on admin network change.
+                    if updated
+                        && old_use_admin_network != host_netconf.use_admin_network
+                        && ctx
+                            .services
+                            .site_config
+                            .restart_ovs_on_use_admin_network_change
+                            .load(std::sync::atomic::Ordering::Relaxed)
+                    {
+                        process_dpu_use_admin_network_state_change(&mut txn, mh_snapshot).await?;
+                    }
 
                     // Bump each DPA interface's config version so the DPA State Controller
                     // re-evaluates and sends SetVNI commands with VNI zero.
@@ -7241,14 +7255,28 @@ impl StateHandler for InstanceStateHandler {
                     let mut txn = ctx.services.db_pool.begin().await?;
                     let host_version = mh_snapshot.host_snapshot.network_config.version;
                     let mut host_netconf = mh_snapshot.host_snapshot.network_config.value.clone();
+                    let old_use_admin_network = host_netconf.use_admin_network;
                     host_netconf.use_admin_network = Some(false);
-                    db::machine::try_update_network_config(
+                    let updated = db::machine::try_update_network_config(
                         &mut txn,
                         &mh_snapshot.host_snapshot.id,
                         host_version,
                         &host_netconf,
                     )
                     .await?;
+
+                    // Set use_admin_network_changed if we want to reboot
+                    // ovs on admin network change.
+                    if updated
+                        && old_use_admin_network != host_netconf.use_admin_network
+                        && ctx
+                            .services
+                            .site_config
+                            .restart_ovs_on_use_admin_network_change
+                            .load(std::sync::atomic::Ordering::Relaxed)
+                    {
+                        process_dpu_use_admin_network_state_change(&mut txn, mh_snapshot).await?;
+                    }
 
                     // The host was already flipped to tenant network in the
                     // Ready -> Assigned transition; that write fanned out via
@@ -7265,6 +7293,66 @@ impl StateHandler for InstanceStateHandler {
             Ok(StateHandlerOutcome::do_nothing())
         }
     }
+}
+
+// Process the host's use_admin_network flag change and selectively flag
+// DPUs that undergo an actual network mode change with the
+// use_admin_network_changed flag if restart_ovs_on_use_admin_network_change
+// is true.
+// Not every DPU participates in tenant networking — only those with instance
+// interface configs assigned to them. DPUs without tenant interfaces remain on
+// the admin network regardless of the host-level toggle.
+async fn process_dpu_use_admin_network_state_change(
+    txn: &mut PgConnection,
+    mh_snapshot: &ManagedHostStateSnapshot,
+) -> Result<(), StateHandlerError> {
+    tracing::info!(
+        "Set use_admin_network_changed flag as host {} has changed use_admin_network state and site-restart-ovs is set",
+        &mh_snapshot.host_snapshot.id
+    );
+
+    // Determine which DPUs have tenant interface configs. A DPU matches if:
+    //  - the interface config has no device_locator and the DPU is the
+    // primary, OR
+    //  - the interface config's device_locator matches this DPU's PCI device
+    //
+    // Only these DPUs actually transition between admin and tenant network.
+    // On allocate: they switch from admin → tenant.
+    // On release: they switch from tenant → admin.
+    // DPUs without tenant interfaces never change mode — skip them.
+    let interface_configs = mh_snapshot
+        .instance
+        .as_ref()
+        .map(|i| i.config.network.interfaces.clone())
+        .unwrap_or_default();
+
+    let primary_dpu_id = mh_snapshot
+        .host_snapshot
+        .interfaces
+        .iter()
+        .find(|i| i.primary_interface)
+        .and_then(|i| i.attached_dpu_machine_id);
+
+    for dpu in &mh_snapshot.dpu_snapshots {
+        let dpu_has_tenant_interface_config = interface_configs.iter().any(|cfg| {
+            let is_primary = primary_dpu_id == Some(dpu.id);
+            (cfg.device_locator.is_none() && is_primary)
+                || (cfg.device_locator.is_some()
+                    && mh_snapshot
+                        .host_snapshot
+                        .get_device_locator_for_dpu_id(&dpu.id)
+                        .ok()
+                        .as_ref()
+                        == cfg.device_locator.as_ref())
+        });
+
+        if dpu_has_tenant_interface_config {
+            tracing::info!("Set DPU use_admin_network_changed flag for dpu {}", &dpu.id);
+            db::machine::set_use_admin_network_changed(txn, &dpu.id, true).await?;
+        }
+    }
+
+    Ok(())
 }
 
 // Gets extension services status from DB, checks if any removed services are fully terminated

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -6914,7 +6914,6 @@ impl StateHandler for InstanceStateHandler {
                             .services
                             .site_config
                             .restart_ovs_on_use_admin_network_change
-                            .load(std::sync::atomic::Ordering::Relaxed)
                     {
                         process_dpu_use_admin_network_state_change(&mut txn, mh_snapshot).await?;
                     }
@@ -7273,7 +7272,6 @@ impl StateHandler for InstanceStateHandler {
                             .services
                             .site_config
                             .restart_ovs_on_use_admin_network_change
-                            .load(std::sync::atomic::Ordering::Relaxed)
                     {
                         process_dpu_use_admin_network_state_change(&mut txn, mh_snapshot).await?;
                     }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1524,6 +1524,7 @@ message RuntimeConfig {
 
   string compile_time_helm_version = 51;
   string compile_time_docker_version = 52;
+  bool restart_ovs_on_use_admin_network_change = 53;
 }
 
 message EchoRequest {
@@ -4387,6 +4388,11 @@ message ManagedHostNetworkConfigResponse {
   optional string bgp_leaf_session_password = 118;
 
   optional AstraConfig astra_config = 119;
+
+  // Tracks admin->tenant and tenant->admin change. The DPU agent will
+  // restart openvswitch-switch if this is set. Other actions could also
+  // be added based on this tracking variable.
+  optional bool use_admin_network_changed = 120;
 }
 
 message TrafficInterceptConfig {

--- a/crates/site-explorer/src/config.rs
+++ b/crates/site-explorer/src/config.rs
@@ -188,6 +188,17 @@ pub struct SiteExplorerConfig {
     /// `DpuMode::DpuMode`.
     #[serde(default)]
     pub dpu_mode: Option<DpuMode>,
+
+    /// Restart OVS on DPU agents whenever the host switches between
+    /// admin and tenant networking. Required in some environments to
+    /// ensure OVS picks up the changed network configuration.
+    #[serde(
+        default = "SiteExplorerConfig::default_restart_ovs_on_use_admin_network_change",
+        deserialize_with = "deserialize_arc_atomic_bool",
+        serialize_with = "serialize_arc_atomic_bool"
+    )]
+    pub restart_ovs_on_use_admin_network_change: Arc<AtomicBool>,
+
     /// Controls which Redfish client implementation is used
     /// for hardware discovery (LibRedfish, NvRedfish, or
     /// CompareResult for side-by-side validation).
@@ -219,6 +230,7 @@ impl Default for SiteExplorerConfig {
             switches_created_per_run: Self::default_switches_created_per_run(),
             rotate_switch_nvos_credentials: Self::default_rotate_switch_nvos_credentials(),
             dpu_mode: None,
+            restart_ovs_on_use_admin_network_change: Arc::new(false.into()),
             explore_mode: Self::default_explore_mode(),
         }
     }
@@ -292,6 +304,10 @@ impl SiteExplorerConfig {
 
     pub const fn default_switches_created_per_run() -> u64 {
         9
+    }
+
+    pub fn default_restart_ovs_on_use_admin_network_change() -> Arc<AtomicBool> {
+        Arc::new(false.into())
     }
 
     pub const fn default_explore_mode() -> SiteExplorerExploreMode {

--- a/crates/site-explorer/src/config.rs
+++ b/crates/site-explorer/src/config.rs
@@ -189,16 +189,6 @@ pub struct SiteExplorerConfig {
     #[serde(default)]
     pub dpu_mode: Option<DpuMode>,
 
-    /// Restart OVS on DPU agents whenever the host switches between
-    /// admin and tenant networking. Required in some environments to
-    /// ensure OVS picks up the changed network configuration.
-    #[serde(
-        default = "SiteExplorerConfig::default_restart_ovs_on_use_admin_network_change",
-        deserialize_with = "deserialize_arc_atomic_bool",
-        serialize_with = "serialize_arc_atomic_bool"
-    )]
-    pub restart_ovs_on_use_admin_network_change: Arc<AtomicBool>,
-
     /// Controls which Redfish client implementation is used
     /// for hardware discovery (LibRedfish, NvRedfish, or
     /// CompareResult for side-by-side validation).
@@ -230,7 +220,6 @@ impl Default for SiteExplorerConfig {
             switches_created_per_run: Self::default_switches_created_per_run(),
             rotate_switch_nvos_credentials: Self::default_rotate_switch_nvos_credentials(),
             dpu_mode: None,
-            restart_ovs_on_use_admin_network_change: Arc::new(false.into()),
             explore_mode: Self::default_explore_mode(),
         }
     }
@@ -304,10 +293,6 @@ impl SiteExplorerConfig {
 
     pub const fn default_switches_created_per_run() -> u64 {
         9
-    }
-
-    pub fn default_restart_ovs_on_use_admin_network_change() -> Arc<AtomicBool> {
-        Arc::new(false.into())
     }
 
     pub const fn default_explore_mode() -> SiteExplorerExploreMode {

--- a/crates/site-explorer/tests/integration/site_explorer.rs
+++ b/crates/site-explorer/tests/integration/site_explorer.rs
@@ -1642,6 +1642,7 @@ async fn test_site_explorer_audit_exploration_results(
         switches_created_per_run: 1,
         rotate_switch_nvos_credentials: Arc::new(false.into()),
         dpu_mode: None,
+        restart_ovs_on_use_admin_network_change: Arc::new(false.into()),
         // Tests use MockEndpointExplorer. So this doesn't affect anything.
         explore_mode: SiteExplorerExploreMode::NvRedfish,
     };

--- a/crates/site-explorer/tests/integration/site_explorer.rs
+++ b/crates/site-explorer/tests/integration/site_explorer.rs
@@ -1642,7 +1642,6 @@ async fn test_site_explorer_audit_exploration_results(
         switches_created_per_run: 1,
         rotate_switch_nvos_credentials: Arc::new(false.into()),
         dpu_mode: None,
-        restart_ovs_on_use_admin_network_change: Arc::new(false.into()),
         // Tests use MockEndpointExplorer. So this doesn't affect anything.
         explore_mode: SiteExplorerExploreMode::NvRedfish,
     };

--- a/rest-api/flow/internal/nicoapi/gen/nico.pb.go
+++ b/rest-api/flow/internal/nicoapi/gen/nico.pb.go
@@ -8081,6 +8081,7 @@ type RuntimeConfig struct {
 	RackValidationEnabled                           bool     `protobuf:"varint,50,opt,name=rack_validation_enabled,json=rackValidationEnabled,proto3" json:"rack_validation_enabled,omitempty"`
 	CompileTimeHelmVersion                          string   `protobuf:"bytes,51,opt,name=compile_time_helm_version,json=compileTimeHelmVersion,proto3" json:"compile_time_helm_version,omitempty"`
 	CompileTimeDockerVersion                        string   `protobuf:"bytes,52,opt,name=compile_time_docker_version,json=compileTimeDockerVersion,proto3" json:"compile_time_docker_version,omitempty"`
+	RestartOvsOnUseAdminNetworkChange               bool     `protobuf:"varint,53,opt,name=restart_ovs_on_use_admin_network_change,json=restartOvsOnUseAdminNetworkChange,proto3" json:"restart_ovs_on_use_admin_network_change,omitempty"`
 	unknownFields                                   protoimpl.UnknownFields
 	sizeCache                                       protoimpl.SizeCache
 }
@@ -8450,6 +8451,13 @@ func (x *RuntimeConfig) GetCompileTimeDockerVersion() string {
 		return x.CompileTimeDockerVersion
 	}
 	return ""
+}
+
+func (x *RuntimeConfig) GetRestartOvsOnUseAdminNetworkChange() bool {
+	if x != nil {
+		return x.RestartOvsOnUseAdminNetworkChange
+	}
+	return false
 }
 
 type EchoRequest struct {
@@ -24105,6 +24113,10 @@ type ManagedHostNetworkConfigResponse struct {
 	// BGP session with the its TOR
 	BgpLeafSessionPassword *string      `protobuf:"bytes,118,opt,name=bgp_leaf_session_password,json=bgpLeafSessionPassword,proto3,oneof" json:"bgp_leaf_session_password,omitempty"`
 	AstraConfig            *AstraConfig `protobuf:"bytes,119,opt,name=astra_config,json=astraConfig,proto3,oneof" json:"astra_config,omitempty"`
+	// Tracks admin->tenant and tenant->admin change. The DPU agent will
+	// restart openvswitch-switch if this is set. Other actions could also
+	// be added based on this tracking variable.
+	UseAdminNetworkChanged *bool `protobuf:"varint,120,opt,name=use_admin_network_changed,json=useAdminNetworkChanged,proto3,oneof" json:"use_admin_network_changed,omitempty"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -24410,6 +24422,13 @@ func (x *ManagedHostNetworkConfigResponse) GetAstraConfig() *AstraConfig {
 		return x.AstraConfig
 	}
 	return nil
+}
+
+func (x *ManagedHostNetworkConfigResponse) GetUseAdminNetworkChanged() bool {
+	if x != nil && x.UseAdminNetworkChanged != nil {
+		return *x.UseAdminNetworkChanged
+	}
+	return false
 }
 
 type TrafficInterceptConfig struct {
@@ -60342,7 +60361,7 @@ const file_nico_proto_rawDesc = "" +
 	"build_user\x18\x05 \x01(\tR\tbuildUser\x12%\n" +
 	"\x0ebuild_hostname\x18\x06 \x01(\tR\rbuildHostname\x12@\n" +
 	"\x0eruntime_config\x182 \x01(\v2\x14.forge.RuntimeConfigH\x00R\rruntimeConfig\x88\x01\x01B\x11\n" +
-	"\x0f_runtime_config\"\x8d\x16\n" +
+	"\x0f_runtime_config\"\xe1\x16\n" +
 	"\rRuntimeConfig\x12\x16\n" +
 	"\x06listen\x18\x01 \x01(\tR\x06listen\x12)\n" +
 	"\x10metrics_endpoint\x18\x02 \x01(\tR\x0fmetricsEndpoint\x12!\n" +
@@ -60394,7 +60413,8 @@ const file_nico_proto_rawDesc = "" +
 	"dpfEnabled\x126\n" +
 	"\x17rack_validation_enabled\x182 \x01(\bR\x15rackValidationEnabled\x129\n" +
 	"\x19compile_time_helm_version\x183 \x01(\tR\x16compileTimeHelmVersion\x12=\n" +
-	"\x1bcompile_time_docker_version\x184 \x01(\tR\x18compileTimeDockerVersion\x1aN\n" +
+	"\x1bcompile_time_docker_version\x184 \x01(\tR\x18compileTimeDockerVersion\x12R\n" +
+	"'restart_ovs_on_use_admin_network_change\x185 \x01(\bR!restartOvsOnUseAdminNetworkChange\x1aN\n" +
 	" DpuNicFirmwareUpdateVersionEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x16\n" +
@@ -61825,7 +61845,7 @@ const file_nico_proto_rawDesc = "" +
 	"\x13MachineHardwareInfo\x12*\n" +
 	"\x04gpus\x18\x01 \x03(\v2\x16.machine_discovery.GpuR\x04gpus\"Z\n" +
 	"\x1fManagedHostNetworkConfigRequest\x127\n" +
-	"\x0edpu_machine_id\x18\x01 \x01(\v2\x11.common.MachineIdR\fdpuMachineId\"\xe3\x14\n" +
+	"\x0edpu_machine_id\x18\x01 \x01(\v2\x11.common.MachineIdR\fdpuMachineId\"\xc1\x15\n" +
 	" ManagedHostNetworkConfigResponse\x12\x10\n" +
 	"\x03asn\x18\x02 \x01(\rR\x03asn\x12!\n" +
 	"\fdhcp_servers\x18\x03 \x03(\tR\vdhcpServers\x12\x1d\n" +
@@ -61871,7 +61891,8 @@ const file_nico_proto_rawDesc = "" +
 	"\x0ftenant_host_asn\x18t \x01(\rH\vR\rtenantHostAsn\x88\x01\x01\x122\n" +
 	"\x13site_global_vpc_vni\x18u \x01(\rH\fR\x10siteGlobalVpcVni\x88\x01\x01\x12>\n" +
 	"\x19bgp_leaf_session_password\x18v \x01(\tH\rR\x16bgpLeafSessionPassword\x88\x01\x01\x12:\n" +
-	"\fastra_config\x18w \x01(\v2\x12.forge.AstraConfigH\x0eR\vastraConfig\x88\x01\x01B\x0e\n" +
+	"\fastra_config\x18w \x01(\v2\x12.forge.AstraConfigH\x0eR\vastraConfig\x88\x01\x01\x12>\n" +
+	"\x19use_admin_network_changed\x18x \x01(\bH\x0fR\x16useAdminNetworkChanged\x88\x01\x01B\x0e\n" +
 	"\f_instance_idB\x1e\n" +
 	"\x1c_network_virtualization_typeB\n" +
 	"\n" +
@@ -61887,7 +61908,8 @@ const file_nico_proto_rawDesc = "" +
 	"\x10_tenant_host_asnB\x16\n" +
 	"\x14_site_global_vpc_vniB\x1c\n" +
 	"\x1a_bgp_leaf_session_passwordB\x0f\n" +
-	"\r_astra_configJ\x04\b\x01\x10\x02J\x04\bi\x10j\"\xbc\x02\n" +
+	"\r_astra_configB\x1c\n" +
+	"\x1a_use_admin_network_changedJ\x04\b\x01\x10\x02J\x04\bi\x10j\"\xbc\x02\n" +
 	"\x16TrafficInterceptConfig\x12@\n" +
 	"\x1aadditional_overlay_vtep_ip\x18\x01 \x01(\tH\x00R\x17additionalOverlayVtepIp\x88\x01\x01\x12@\n" +
 	"\bbridging\x18\x02 \x01(\v2\x1f.forge.TrafficInterceptBridgingH\x01R\bbridging\x88\x01\x01\x12'\n" +

--- a/rest-api/flow/internal/nicoapi/nicoproto/nico.proto
+++ b/rest-api/flow/internal/nicoapi/nicoproto/nico.proto
@@ -1516,6 +1516,7 @@ message RuntimeConfig {
 
   string compile_time_helm_version = 51;
   string compile_time_docker_version = 52;
+  bool restart_ovs_on_use_admin_network_change = 53;
 }
 
 message EchoRequest {
@@ -4379,6 +4380,11 @@ message ManagedHostNetworkConfigResponse {
   optional string bgp_leaf_session_password = 118;
 
   optional AstraConfig astra_config = 119;
+
+  // Tracks admin->tenant and tenant->admin change. The DPU agent will
+  // restart openvswitch-switch if this is set. Other actions could also
+  // be added based on this tracking variable.
+  optional bool use_admin_network_changed = 120;
 }
 
 message TrafficInterceptConfig {

--- a/rest-api/workflow-schema/schema/site-agent/workflows/v1/nico_nico.pb.go
+++ b/rest-api/workflow-schema/schema/site-agent/workflows/v1/nico_nico.pb.go
@@ -8085,6 +8085,7 @@ type RuntimeConfig struct {
 	RackValidationEnabled                           bool     `protobuf:"varint,50,opt,name=rack_validation_enabled,json=rackValidationEnabled,proto3" json:"rack_validation_enabled,omitempty"`
 	CompileTimeHelmVersion                          string   `protobuf:"bytes,51,opt,name=compile_time_helm_version,json=compileTimeHelmVersion,proto3" json:"compile_time_helm_version,omitempty"`
 	CompileTimeDockerVersion                        string   `protobuf:"bytes,52,opt,name=compile_time_docker_version,json=compileTimeDockerVersion,proto3" json:"compile_time_docker_version,omitempty"`
+	RestartOvsOnUseAdminNetworkChange               bool     `protobuf:"varint,53,opt,name=restart_ovs_on_use_admin_network_change,json=restartOvsOnUseAdminNetworkChange,proto3" json:"restart_ovs_on_use_admin_network_change,omitempty"`
 	unknownFields                                   protoimpl.UnknownFields
 	sizeCache                                       protoimpl.SizeCache
 }
@@ -8454,6 +8455,13 @@ func (x *RuntimeConfig) GetCompileTimeDockerVersion() string {
 		return x.CompileTimeDockerVersion
 	}
 	return ""
+}
+
+func (x *RuntimeConfig) GetRestartOvsOnUseAdminNetworkChange() bool {
+	if x != nil {
+		return x.RestartOvsOnUseAdminNetworkChange
+	}
+	return false
 }
 
 type EchoRequest struct {
@@ -24036,6 +24044,10 @@ type ManagedHostNetworkConfigResponse struct {
 	// BGP session with the its TOR
 	BgpLeafSessionPassword *string      `protobuf:"bytes,118,opt,name=bgp_leaf_session_password,json=bgpLeafSessionPassword,proto3,oneof" json:"bgp_leaf_session_password,omitempty"`
 	AstraConfig            *AstraConfig `protobuf:"bytes,119,opt,name=astra_config,json=astraConfig,proto3,oneof" json:"astra_config,omitempty"`
+	// Tracks admin->tenant and tenant->admin change. The DPU agent will
+	// restart openvswitch-switch if this is set. Other actions could also
+	// be added based on this tracking variable.
+	UseAdminNetworkChanged *bool `protobuf:"varint,120,opt,name=use_admin_network_changed,json=useAdminNetworkChanged,proto3,oneof" json:"use_admin_network_changed,omitempty"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -24341,6 +24353,13 @@ func (x *ManagedHostNetworkConfigResponse) GetAstraConfig() *AstraConfig {
 		return x.AstraConfig
 	}
 	return nil
+}
+
+func (x *ManagedHostNetworkConfigResponse) GetUseAdminNetworkChanged() bool {
+	if x != nil && x.UseAdminNetworkChanged != nil {
+		return *x.UseAdminNetworkChanged
+	}
+	return false
 }
 
 type TrafficInterceptConfig struct {
@@ -60367,7 +60386,7 @@ const file_nico_nico_proto_rawDesc = "" +
 	"build_user\x18\x05 \x01(\tR\tbuildUser\x12%\n" +
 	"\x0ebuild_hostname\x18\x06 \x01(\tR\rbuildHostname\x12@\n" +
 	"\x0eruntime_config\x182 \x01(\v2\x14.forge.RuntimeConfigH\x00R\rruntimeConfig\x88\x01\x01B\x11\n" +
-	"\x0f_runtime_config\"\x8d\x16\n" +
+	"\x0f_runtime_config\"\xe1\x16\n" +
 	"\rRuntimeConfig\x12\x16\n" +
 	"\x06listen\x18\x01 \x01(\tR\x06listen\x12)\n" +
 	"\x10metrics_endpoint\x18\x02 \x01(\tR\x0fmetricsEndpoint\x12!\n" +
@@ -60419,7 +60438,8 @@ const file_nico_nico_proto_rawDesc = "" +
 	"dpfEnabled\x126\n" +
 	"\x17rack_validation_enabled\x182 \x01(\bR\x15rackValidationEnabled\x129\n" +
 	"\x19compile_time_helm_version\x183 \x01(\tR\x16compileTimeHelmVersion\x12=\n" +
-	"\x1bcompile_time_docker_version\x184 \x01(\tR\x18compileTimeDockerVersion\x1aN\n" +
+	"\x1bcompile_time_docker_version\x184 \x01(\tR\x18compileTimeDockerVersion\x12R\n" +
+	"'restart_ovs_on_use_admin_network_change\x185 \x01(\bR!restartOvsOnUseAdminNetworkChange\x1aN\n" +
 	" DpuNicFirmwareUpdateVersionEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x16\n" +
@@ -61878,7 +61898,7 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x13MachineHardwareInfo\x12*\n" +
 	"\x04gpus\x18\x01 \x03(\v2\x16.machine_discovery.GpuR\x04gpus\"Z\n" +
 	"\x1fManagedHostNetworkConfigRequest\x127\n" +
-	"\x0edpu_machine_id\x18\x01 \x01(\v2\x11.common.MachineIdR\fdpuMachineId\"\xe3\x14\n" +
+	"\x0edpu_machine_id\x18\x01 \x01(\v2\x11.common.MachineIdR\fdpuMachineId\"\xc1\x15\n" +
 	" ManagedHostNetworkConfigResponse\x12\x10\n" +
 	"\x03asn\x18\x02 \x01(\rR\x03asn\x12!\n" +
 	"\fdhcp_servers\x18\x03 \x03(\tR\vdhcpServers\x12\x1d\n" +
@@ -61924,7 +61944,8 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x0ftenant_host_asn\x18t \x01(\rH\vR\rtenantHostAsn\x88\x01\x01\x122\n" +
 	"\x13site_global_vpc_vni\x18u \x01(\rH\fR\x10siteGlobalVpcVni\x88\x01\x01\x12>\n" +
 	"\x19bgp_leaf_session_password\x18v \x01(\tH\rR\x16bgpLeafSessionPassword\x88\x01\x01\x12:\n" +
-	"\fastra_config\x18w \x01(\v2\x12.forge.AstraConfigH\x0eR\vastraConfig\x88\x01\x01B\x0e\n" +
+	"\fastra_config\x18w \x01(\v2\x12.forge.AstraConfigH\x0eR\vastraConfig\x88\x01\x01\x12>\n" +
+	"\x19use_admin_network_changed\x18x \x01(\bH\x0fR\x16useAdminNetworkChanged\x88\x01\x01B\x0e\n" +
 	"\f_instance_idB\x1e\n" +
 	"\x1c_network_virtualization_typeB\n" +
 	"\n" +
@@ -61940,7 +61961,8 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x10_tenant_host_asnB\x16\n" +
 	"\x14_site_global_vpc_vniB\x1c\n" +
 	"\x1a_bgp_leaf_session_passwordB\x0f\n" +
-	"\r_astra_configJ\x04\b\x01\x10\x02J\x04\bi\x10j\"\xbc\x02\n" +
+	"\r_astra_configB\x1c\n" +
+	"\x1a_use_admin_network_changedJ\x04\b\x01\x10\x02J\x04\bi\x10j\"\xbc\x02\n" +
 	"\x16TrafficInterceptConfig\x12@\n" +
 	"\x1aadditional_overlay_vtep_ip\x18\x01 \x01(\tH\x00R\x17additionalOverlayVtepIp\x88\x01\x01\x12@\n" +
 	"\bbridging\x18\x02 \x01(\v2\x1f.forge.TrafficInterceptBridgingH\x01R\bbridging\x88\x01\x01\x12'\n" +

--- a/rest-api/workflow-schema/site-agent/workflows/v1/nico_nico.proto
+++ b/rest-api/workflow-schema/site-agent/workflows/v1/nico_nico.proto
@@ -1529,6 +1529,7 @@ message RuntimeConfig {
 
   string compile_time_helm_version = 51;
   string compile_time_docker_version = 52;
+  bool restart_ovs_on_use_admin_network_change = 53;
 }
 
 message EchoRequest {
@@ -4387,6 +4388,11 @@ message ManagedHostNetworkConfigResponse {
   optional string bgp_leaf_session_password = 118;
 
   optional AstraConfig astra_config = 119;
+
+  // Tracks admin->tenant and tenant->admin change. The DPU agent will
+  // restart openvswitch-switch if this is set. Other actions could also
+  // be added based on this tracking variable.
+  optional bool use_admin_network_changed = 120;
 }
 
 message TrafficInterceptConfig {


### PR DESCRIPTION
… from admin-network

This PR adds an opt-in site config to restart OVS on DPU agents when a host switches between admin and tenant networking. The goal is to force ovs-vswitchd to pick up network mode changes in environments where
  it otherwise keeps stale behavior.

  Main changes:

  - Adds restart_ovs_on_use_admin_network_change under [dpu_config], defaulting to false.
  - Adds RPC/proto fields:
      - RuntimeConfig.restart_ovs_on_use_admin_network_change = 53
      - ManagedHostNetworkConfigResponse.use_admin_network_changed = 120

  - Machine controller detects host use_admin_network transitions and flags affected DPUs with use_admin_network_changed.
  - DPU API serves that flag in GetManagedHostNetworkConfig.
  - DPU agent checks the flag and restarts ovs-vswitchd.service on DPU OS agents.
  - Agent withholds the network config ACK if the OVS restart fails, then retries with a 60s backoff.
  - API clears the flag after a matching-version network config ACK, including for old agents that do not understand the new flag.
  - Rest-api proto copies and generated Go files were updated to keep builds working.


## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->
JIRA 7451

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->
[Uploading forge_7451_tests_3.txt…]()



