### PR TITLE
test(api-model): enumerate cases to raise coverage

### DIFF
--- a/crates/api-model/Cargo.toml
+++ b/crates/api-model/Cargo.toml
@@ -89,6 +89,7 @@ test-support = []
 carbide-version = { path = "../version" }
 
 [dev-dependencies]
+carbide-macros = { path = "../macros" }
 carbide-sqlx-testing = { path = "../sqlx-testing", default-features = false }
 carbide-secrets = { path = "../secrets" }
 carbide-test-support = { path = "../test-support" }

--- a/crates/api-model/src/allocation_type.rs
+++ b/crates/api-model/src/allocation_type.rs
@@ -88,49 +88,115 @@ pub enum AssignStaticResult {
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, Ipv6Addr};
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::{Case, Check, check_cases, check_values};
 
     use super::*;
     use crate::address_selection_strategy::AddressSelectionStrategy;
 
     // Total `From<AddressSelectionStrategy>` conversions: every strategy maps to an
-    // allocation type. These are infallible, so they stay standalone rather than
-    // being wrapped in a fake Result.
-
+    // allocation type. The conversion is infallible, so each row is a plain value
+    // checked with `check_values`. Strategies that carry data are exercised across
+    // boundary payloads (prefix length extremes, IPv4 vs IPv6 static addresses) to
+    // confirm the discriminant alone — not the payload — drives the result.
     #[test]
-    fn next_available_ip_is_dhcp() {
-        assert_eq!(
-            AllocationType::from(AddressSelectionStrategy::NextAvailableIp),
-            AllocationType::Dhcp,
+    fn strategy_maps_to_allocation_type() {
+        check_values(
+            [
+                Check {
+                    scenario: "next available ip -> dhcp",
+                    input: AddressSelectionStrategy::NextAvailableIp,
+                    expect: AllocationType::Dhcp,
+                },
+                Check {
+                    scenario: "automatic alias -> dhcp",
+                    input: AddressSelectionStrategy::Automatic,
+                    expect: AllocationType::Dhcp,
+                },
+                Check {
+                    scenario: "next available prefix /30 -> dhcp",
+                    input: AddressSelectionStrategy::NextAvailablePrefix(30),
+                    expect: AllocationType::Dhcp,
+                },
+                Check {
+                    scenario: "next available prefix /0 (boundary low) -> dhcp",
+                    input: AddressSelectionStrategy::NextAvailablePrefix(0),
+                    expect: AllocationType::Dhcp,
+                },
+                Check {
+                    scenario: "next available prefix /32 -> dhcp",
+                    input: AddressSelectionStrategy::NextAvailablePrefix(32),
+                    expect: AllocationType::Dhcp,
+                },
+                Check {
+                    scenario: "next available prefix /128 -> dhcp",
+                    input: AddressSelectionStrategy::NextAvailablePrefix(128),
+                    expect: AllocationType::Dhcp,
+                },
+                Check {
+                    scenario: "next available prefix /255 (boundary high) -> dhcp",
+                    input: AddressSelectionStrategy::NextAvailablePrefix(u8::MAX),
+                    expect: AllocationType::Dhcp,
+                },
+                Check {
+                    scenario: "static ipv4 -> static",
+                    input: AddressSelectionStrategy::StaticAddress(
+                        Ipv4Addr::new(10, 0, 0, 1).into(),
+                    ),
+                    expect: AllocationType::Static,
+                },
+                Check {
+                    scenario: "static ipv4 unspecified (0.0.0.0) -> static",
+                    input: AddressSelectionStrategy::StaticAddress(Ipv4Addr::UNSPECIFIED.into()),
+                    expect: AllocationType::Static,
+                },
+                Check {
+                    scenario: "static ipv4 broadcast (255.255.255.255) -> static",
+                    input: AddressSelectionStrategy::StaticAddress(Ipv4Addr::BROADCAST.into()),
+                    expect: AllocationType::Static,
+                },
+                Check {
+                    scenario: "static ipv6 -> static",
+                    input: AddressSelectionStrategy::StaticAddress(
+                        Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1).into(),
+                    ),
+                    expect: AllocationType::Static,
+                },
+                Check {
+                    scenario: "static ipv6 unspecified (::) -> static",
+                    input: AddressSelectionStrategy::StaticAddress(Ipv6Addr::UNSPECIFIED.into()),
+                    expect: AllocationType::Static,
+                },
+                Check {
+                    scenario: "static ipv6 localhost (::1) -> static",
+                    input: AddressSelectionStrategy::StaticAddress(Ipv6Addr::LOCALHOST.into()),
+                    expect: AllocationType::Static,
+                },
+            ],
+            AllocationType::from,
         );
     }
 
+    // Serialization: each `AllocationType` variant renders to its snake_case wire
+    // form. Total operation, so the produced string is checked directly.
     #[test]
-    fn automatic_is_dhcp() {
-        assert_eq!(
-            AllocationType::from(AddressSelectionStrategy::Automatic),
-            AllocationType::Dhcp,
-        );
-    }
-
-    #[test]
-    fn next_available_prefix_is_dhcp() {
-        assert_eq!(
-            AllocationType::from(AddressSelectionStrategy::NextAvailablePrefix(30)),
-            AllocationType::Dhcp,
-        );
-    }
-
-    #[test]
-    fn static_address_is_static() {
-        assert_eq!(
-            AllocationType::from(AddressSelectionStrategy::StaticAddress(
-                Ipv4Addr::new(10, 0, 0, 1).into()
-            )),
-            AllocationType::Static,
+    fn serializes_to_snake_case() {
+        check_values(
+            [
+                Check {
+                    scenario: "dhcp",
+                    input: AllocationType::Dhcp,
+                    expect: r#""dhcp""#.to_string(),
+                },
+                Check {
+                    scenario: "static",
+                    input: AllocationType::Static,
+                    expect: r#""static""#.to_string(),
+                },
+            ],
+            |value| serde_json::to_string(&value).expect("serialization is infallible"),
         );
     }
 
@@ -158,6 +224,152 @@ mod tests {
                 let recovered: AllocationType = serde_json::from_str(&wire).map_err(drop)?;
                 Ok::<_, ()>((wire, recovered))
             },
+        );
+    }
+
+    // Deserialization from the wire: accepted snake_case forms recover their
+    // variant; anything else (wrong case, unknown tag, wrong JSON type, malformed)
+    // is rejected. `serde_json::Error` is not `PartialEq`, so failures use `Fails`
+    // with `.map_err(drop)`.
+    #[test]
+    fn deserializes_known_forms_and_rejects_the_rest() {
+        check_cases(
+            [
+                Case {
+                    scenario: "dhcp",
+                    input: r#""dhcp""#,
+                    expect: Yields(AllocationType::Dhcp),
+                },
+                Case {
+                    scenario: "static",
+                    input: r#""static""#,
+                    expect: Yields(AllocationType::Static),
+                },
+                Case {
+                    scenario: "wrong case rejected",
+                    input: r#""Dhcp""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "uppercase rejected",
+                    input: r#""STATIC""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown variant rejected",
+                    input: r#""bootp""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string rejected",
+                    input: r#""""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "leading whitespace in tag rejected",
+                    input: r#"" dhcp""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "number rejected",
+                    input: "0",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "null rejected",
+                    input: "null",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "object rejected",
+                    input: r#"{"dhcp":true}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "malformed json rejected",
+                    input: r#""dhcp"#,
+                    expect: Fails,
+                },
+            ],
+            |wire| serde_json::from_str::<AllocationType>(wire).map_err(drop),
+        );
+    }
+
+    // Derived `PartialEq`/`Eq` over both `AllocationType` and `AssignStaticResult`:
+    // a variant equals only itself. `AssignStaticResult` has no other pure logic, so
+    // equality across its full variant set is its coverage.
+    #[test]
+    fn variants_compare_by_identity() {
+        check_values(
+            [
+                Check {
+                    scenario: "dhcp == dhcp",
+                    input: (AllocationType::Dhcp, AllocationType::Dhcp),
+                    expect: true,
+                },
+                Check {
+                    scenario: "static == static",
+                    input: (AllocationType::Static, AllocationType::Static),
+                    expect: true,
+                },
+                Check {
+                    scenario: "dhcp != static",
+                    input: (AllocationType::Dhcp, AllocationType::Static),
+                    expect: false,
+                },
+            ],
+            |(left, right)| left == right,
+        );
+
+        check_values(
+            [
+                Check {
+                    scenario: "assigned == assigned",
+                    input: (AssignStaticResult::Assigned, AssignStaticResult::Assigned),
+                    expect: true,
+                },
+                Check {
+                    scenario: "replaced static == replaced static",
+                    input: (
+                        AssignStaticResult::ReplacedStatic,
+                        AssignStaticResult::ReplacedStatic,
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "replaced dhcp == replaced dhcp",
+                    input: (
+                        AssignStaticResult::ReplacedDhcp,
+                        AssignStaticResult::ReplacedDhcp,
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "assigned != replaced static",
+                    input: (
+                        AssignStaticResult::Assigned,
+                        AssignStaticResult::ReplacedStatic,
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "replaced static != replaced dhcp",
+                    input: (
+                        AssignStaticResult::ReplacedStatic,
+                        AssignStaticResult::ReplacedDhcp,
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "assigned != replaced dhcp",
+                    input: (
+                        AssignStaticResult::Assigned,
+                        AssignStaticResult::ReplacedDhcp,
+                    ),
+                    expect: false,
+                },
+            ],
+            |(left, right)| left == right,
         );
     }
 }

--- a/crates/api-model/src/attestation.rs
+++ b/crates/api-model/src/attestation.rs
@@ -356,22 +356,248 @@ pub mod spdm {
 
 #[cfg(test)]
 mod test {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
-    use crate::attestation::spdm::SpdmObjectId;
+    use crate::attestation::spdm::{
+        DeviceType, SpdmAttestationState, SpdmDeviceAttestationDetails, SpdmObjectId,
+    };
+
+    // A valid serialized MachineId, reused across rows.
+    const VALID_MACHINE_ID: &str = "fm100htv4fu8fpktl0e0qrg4dl58g2bc2g7naq0l6c15ruc22po1i5rfsq0";
+
+    fn machine_id() -> MachineId {
+        VALID_MACHINE_ID.parse().expect("valid machine id")
+    }
 
     #[test]
-    fn test_spdmobject_id_from_str() {
-        let machine_id: MachineId = "fm100htv4fu8fpktl0e0qrg4dl58g2bc2g7naq0l6c15ruc22po1i5rfsq0"
-            .parse()
-            .unwrap();
-        let device_id = "Device-1".to_string();
-        let spdm_object_id = SpdmObjectId(machine_id, device_id.clone());
+    fn spdm_object_id_round_trips() {
+        let spdm_object_id = SpdmObjectId(machine_id(), "Device-1".to_string());
 
-        let expected_str = format!("{},{}", machine_id, device_id);
+        let expected_str = format!("{VALID_MACHINE_ID},Device-1");
         assert_eq!(expected_str, spdm_object_id.to_string());
 
         let parsed_object_id: SpdmObjectId = spdm_object_id.to_string().parse().unwrap();
-
         assert_eq!(parsed_object_id, spdm_object_id);
+    }
+
+    #[test]
+    fn spdm_object_id_display() {
+        check_values(
+            [
+                Check {
+                    scenario: "simple device id",
+                    input: SpdmObjectId(machine_id(), "Device-1".to_string()),
+                    expect: format!("{VALID_MACHINE_ID},Device-1"),
+                },
+                Check {
+                    scenario: "empty device id",
+                    input: SpdmObjectId(machine_id(), String::new()),
+                    expect: format!("{VALID_MACHINE_ID},"),
+                },
+                Check {
+                    scenario: "device id with internal comma",
+                    input: SpdmObjectId(machine_id(), "a,b".to_string()),
+                    expect: format!("{VALID_MACHINE_ID},a,b"),
+                },
+                Check {
+                    scenario: "device id with spaces",
+                    input: SpdmObjectId(machine_id(), "HGX IRoT GPU 0".to_string()),
+                    expect: format!("{VALID_MACHINE_ID},HGX IRoT GPU 0"),
+                },
+            ],
+            |id| id.to_string(),
+        );
+    }
+
+    #[test]
+    fn spdm_object_id_from_str() {
+        // SpdmObjectIdParseError has no PartialEq, so use Fails (+ map_err(drop)).
+        check_cases(
+            [
+                Case {
+                    scenario: "valid two parts",
+                    input: format!("{VALID_MACHINE_ID},Device-1"),
+                    expect: Yields(SpdmObjectId(machine_id(), "Device-1".to_string())),
+                },
+                Case {
+                    scenario: "valid with empty device id",
+                    input: format!("{VALID_MACHINE_ID},"),
+                    expect: Yields(SpdmObjectId(machine_id(), String::new())),
+                },
+                Case {
+                    scenario: "no comma is wrong format",
+                    input: VALID_MACHINE_ID.to_string(),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string is wrong format",
+                    input: String::new(),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "three parts is wrong format",
+                    input: format!("{VALID_MACHINE_ID},Device-1,extra"),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "only a comma is wrong format",
+                    input: ",".to_string(),
+                    // two parts ("" and ""), but the first fails to parse as MachineId
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "bad machine id",
+                    input: "not-a-machine-id,Device-1".to_string(),
+                    expect: Fails,
+                },
+            ],
+            |s| s.parse::<SpdmObjectId>().map_err(drop),
+        );
+    }
+
+    #[test]
+    fn device_type_from_str() {
+        // SpdmHandlerError is PartialEq, but from_str never errors — it always
+        // classifies. Use the Display name as the observable, pure result.
+        check_cases(
+            [
+                Case {
+                    scenario: "gpu token present",
+                    input: "HGX_IRoT_GPU_0",
+                    expect: Yields("Gpu".to_string()),
+                },
+                Case {
+                    scenario: "gpu token bare",
+                    input: "GPU",
+                    expect: Yields("Gpu".to_string()),
+                },
+                Case {
+                    scenario: "cx7 token present",
+                    input: "HGX_ERoT_CX7_1",
+                    expect: Yields("Cx7".to_string()),
+                },
+                Case {
+                    scenario: "cx7 token bare",
+                    input: "CX7",
+                    expect: Yields("Cx7".to_string()),
+                },
+                Case {
+                    scenario: "gpu wins when both present (checked first)",
+                    input: "GPU_CX7",
+                    expect: Yields("Gpu".to_string()),
+                },
+                Case {
+                    scenario: "cpu is unknown",
+                    input: "HGX_ERoT_CPU_0",
+                    expect: Yields("Unknown".to_string()),
+                },
+                Case {
+                    scenario: "bmc is unknown",
+                    input: "BMC",
+                    expect: Yields("Unknown".to_string()),
+                },
+                Case {
+                    scenario: "empty is unknown",
+                    input: "",
+                    expect: Yields("Unknown".to_string()),
+                },
+                Case {
+                    scenario: "lowercase gpu does not match (case sensitive)",
+                    input: "gpu",
+                    expect: Yields("Unknown".to_string()),
+                },
+                Case {
+                    scenario: "lowercase cx7 does not match (case sensitive)",
+                    input: "cx7",
+                    expect: Yields("Unknown".to_string()),
+                },
+            ],
+            |s| {
+                Ok::<_, ()>(format!(
+                    "{:?}",
+                    s.parse::<DeviceType>().expect("never errors")
+                ))
+            },
+        );
+    }
+
+    fn details_with_state(state: SpdmAttestationState) -> SpdmDeviceAttestationDetails {
+        let now = Utc::now();
+        SpdmDeviceAttestationDetails {
+            machine_id: machine_id(),
+            device_id: "GPU_0".to_string(),
+            state,
+            started_at: now,
+            cancelled_at: None,
+            completed_at: None,
+        }
+    }
+
+    #[test]
+    fn get_failure_cause() {
+        check_values(
+            [
+                Check {
+                    scenario: "failed state yields a cause naming device and reason",
+                    input: details_with_state(SpdmAttestationState::Failed(
+                        "signature mismatch".to_string(),
+                    )),
+                    expect: Some("Device: GPU_0, failed reason: signature mismatch".to_string()),
+                },
+                Check {
+                    scenario: "failed with empty reason",
+                    input: details_with_state(SpdmAttestationState::Failed(String::new())),
+                    expect: Some("Device: GPU_0, failed reason: ".to_string()),
+                },
+                Check {
+                    scenario: "passed state has no cause",
+                    input: details_with_state(SpdmAttestationState::Passed),
+                    expect: None,
+                },
+                Check {
+                    scenario: "cancelled state has no cause",
+                    input: details_with_state(SpdmAttestationState::Cancelled),
+                    expect: None,
+                },
+                Check {
+                    scenario: "fetch metadata state has no cause",
+                    input: details_with_state(SpdmAttestationState::FetchMetadata),
+                    expect: None,
+                },
+                Check {
+                    scenario: "fetch certificate state has no cause",
+                    input: details_with_state(SpdmAttestationState::FetchCertificate),
+                    expect: None,
+                },
+                Check {
+                    scenario: "trigger evidence collection state has no cause",
+                    input: details_with_state(SpdmAttestationState::TriggerEvidenceCollection {
+                        retry_count: 0,
+                    }),
+                    expect: None,
+                },
+                Check {
+                    scenario: "poll evidence collection state has no cause",
+                    input: details_with_state(SpdmAttestationState::PollEvidenceCollection {
+                        task_id: "t1".to_string(),
+                        retry_count: 2,
+                    }),
+                    expect: None,
+                },
+                Check {
+                    scenario: "nras verification state has no cause",
+                    input: details_with_state(SpdmAttestationState::NrasVerification),
+                    expect: None,
+                },
+                Check {
+                    scenario: "apply appraisal policy state has no cause",
+                    input: details_with_state(SpdmAttestationState::ApplyAppraisalPolicy),
+                    expect: None,
+                },
+            ],
+            |details| details.get_failure_cause(),
+        );
     }
 }

--- a/crates/api-model/src/controller_outcome.rs
+++ b/crates/api-model/src/controller_outcome.rs
@@ -79,19 +79,28 @@ impl From<&&'static Location<'static>> for PersistentSourceReference {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::{Case, Check, check_cases, check_values};
 
     use super::*;
+
+    fn source_ref() -> PersistentSourceReference {
+        PersistentSourceReference {
+            file: "a.rs".to_string(),
+            line: 100,
+        }
+    }
 
     // Serialize each outcome variant to JSON. The serialized String is the
     // contract, so we yield it directly. serde_json::Error is not PartialEq, so
     // the (unreachable here) failing path would use Fails; every row succeeds.
+    // The tag is "outcome" and variants are lowercased, with source_ref omitted
+    // when None.
     #[test]
     fn test_state_outcome_serialize() {
         check_cases(
             [
                 Case {
-                    scenario: "wait with reason",
+                    scenario: "wait with reason, no source ref",
                     input: PersistentStateHandlerOutcome::Wait {
                         reason: "Reason goes here".to_string(),
                         source_ref: None,
@@ -99,22 +108,77 @@ mod tests {
                     expect: Yields(r#"{"outcome":"wait","reason":"Reason goes here"}"#.to_string()),
                 },
                 Case {
+                    scenario: "wait with empty reason",
+                    input: PersistentStateHandlerOutcome::Wait {
+                        reason: String::new(),
+                        source_ref: None,
+                    },
+                    expect: Yields(r#"{"outcome":"wait","reason":""}"#.to_string()),
+                },
+                Case {
+                    scenario: "wait with reason and source ref",
+                    input: PersistentStateHandlerOutcome::Wait {
+                        reason: "waiting".to_string(),
+                        source_ref: Some(source_ref()),
+                    },
+                    expect: Yields(
+                        r#"{"outcome":"wait","reason":"waiting","source_ref":{"file":"a.rs","line":100}}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "error variant, no source ref",
+                    input: PersistentStateHandlerOutcome::Error {
+                        err: "boom".to_string(),
+                        source_ref: None,
+                    },
+                    expect: Yields(r#"{"outcome":"error","err":"boom"}"#.to_string()),
+                },
+                Case {
+                    scenario: "error variant with source ref",
+                    input: PersistentStateHandlerOutcome::Error {
+                        err: "boom".to_string(),
+                        source_ref: Some(source_ref()),
+                    },
+                    expect: Yields(
+                        r#"{"outcome":"error","err":"boom","source_ref":{"file":"a.rs","line":100}}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
                     scenario: "transition, no source ref",
                     input: PersistentStateHandlerOutcome::Transition { source_ref: None },
                     expect: Yields(r#"{"outcome":"transition"}"#.to_string()),
                 },
                 Case {
+                    scenario: "transition with source ref",
+                    input: PersistentStateHandlerOutcome::Transition {
+                        source_ref: Some(source_ref()),
+                    },
+                    expect: Yields(
+                        r#"{"outcome":"transition","source_ref":{"file":"a.rs","line":100}}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "donothing, no source ref",
+                    input: PersistentStateHandlerOutcome::DoNothing { source_ref: None },
+                    expect: Yields(r#"{"outcome":"donothing"}"#.to_string()),
+                },
+                Case {
                     scenario: "donothing with source ref details",
                     input: PersistentStateHandlerOutcome::DoNothing {
-                        source_ref: Some(PersistentSourceReference {
-                            file: "a.rs".to_string(),
-                            line: 100,
-                        }),
+                        source_ref: Some(source_ref()),
                     },
                     expect: Yields(
                         r#"{"outcome":"donothing","source_ref":{"file":"a.rs","line":100}}"#
                             .to_string(),
                     ),
+                },
+                Case {
+                    scenario: "donothingwithdetails legacy variant",
+                    input: PersistentStateHandlerOutcome::DoNothingWithDetails,
+                    expect: Yields(r#"{"outcome":"donothingwithdetails"}"#.to_string()),
                 },
             ],
             |outcome| serde_json::to_string(&outcome).map_err(drop),
@@ -129,6 +193,22 @@ mod tests {
         check_cases(
             [
                 Case {
+                    scenario: "wait round-trip, no source ref",
+                    input: r#"{"outcome":"wait","reason":"r"}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::Wait {
+                        reason: "r".to_string(),
+                        source_ref: None,
+                    }),
+                },
+                Case {
+                    scenario: "wait with source ref round-trip",
+                    input: r#"{"outcome":"wait","reason":"r","source_ref":{"file":"a.rs","line":100}}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::Wait {
+                        reason: "r".to_string(),
+                        source_ref: Some(source_ref()),
+                    }),
+                },
+                Case {
                     scenario: "error variant",
                     input: r#"{"outcome":"error","err":"Error message here"}"#,
                     expect: Yields(PersistentStateHandlerOutcome::Error {
@@ -137,22 +217,163 @@ mod tests {
                     }),
                 },
                 Case {
+                    scenario: "error with source ref round-trip",
+                    input: r#"{"outcome":"error","err":"e","source_ref":{"file":"a.rs","line":100}}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::Error {
+                        err: "e".to_string(),
+                        source_ref: Some(source_ref()),
+                    }),
+                },
+                Case {
                     scenario: "transition round-trip",
                     input: r#"{"outcome":"transition"}"#,
                     expect: Yields(PersistentStateHandlerOutcome::Transition { source_ref: None }),
                 },
                 Case {
+                    scenario: "transition with explicit null source ref (serde default)",
+                    input: r#"{"outcome":"transition","source_ref":null}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::Transition { source_ref: None }),
+                },
+                Case {
+                    scenario: "donothing, no source ref",
+                    input: r#"{"outcome":"donothing"}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::DoNothing { source_ref: None }),
+                },
+                Case {
                     scenario: "donothing with source ref round-trip",
                     input: r#"{"outcome":"donothing","source_ref":{"file":"a.rs","line":100}}"#,
                     expect: Yields(PersistentStateHandlerOutcome::DoNothing {
-                        source_ref: Some(PersistentSourceReference {
-                            file: "a.rs".to_string(),
-                            line: 100,
-                        }),
+                        source_ref: Some(source_ref()),
                     }),
+                },
+                Case {
+                    scenario: "donothingwithdetails legacy variant",
+                    input: r#"{"outcome":"donothingwithdetails"}"#,
+                    expect: Yields(PersistentStateHandlerOutcome::DoNothingWithDetails),
+                },
+                // Rejected inputs: the error type is not PartialEq, so use Fails.
+                Case {
+                    scenario: "unknown outcome tag is rejected",
+                    input: r#"{"outcome":"bogus"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing required reason on wait is rejected",
+                    input: r#"{"outcome":"wait"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing required err on error is rejected",
+                    input: r#"{"outcome":"error"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing outcome tag is rejected",
+                    input: r#"{"reason":"r"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "uppercase tag is rejected (variants are lowercased)",
+                    input: r#"{"outcome":"Transition"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "malformed json is rejected",
+                    input: r#"{"outcome":"transition""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string is rejected",
+                    input: "",
+                    expect: Fails,
                 },
             ],
             |json| serde_json::from_str::<PersistentStateHandlerOutcome>(json).map_err(drop),
+        );
+    }
+
+    // Display for both types delegates to Debug. The rendered String is the
+    // contract; comparing against the Debug rendering keeps the rows honest
+    // without hard-coding the exact derived layout.
+    #[test]
+    fn test_display_matches_debug() {
+        check_values(
+            [
+                Check {
+                    scenario: "source reference display equals debug",
+                    input: format!("{}", source_ref()),
+                    expect: format!("{:?}", source_ref()),
+                },
+                Check {
+                    scenario: "transition outcome display equals debug",
+                    input: format!(
+                        "{}",
+                        PersistentStateHandlerOutcome::Transition { source_ref: None }
+                    ),
+                    expect: format!(
+                        "{:?}",
+                        PersistentStateHandlerOutcome::Transition { source_ref: None }
+                    ),
+                },
+                Check {
+                    scenario: "wait outcome display equals debug",
+                    input: format!(
+                        "{}",
+                        PersistentStateHandlerOutcome::Wait {
+                            reason: "r".to_string(),
+                            source_ref: Some(source_ref()),
+                        }
+                    ),
+                    expect: format!(
+                        "{:?}",
+                        PersistentStateHandlerOutcome::Wait {
+                            reason: "r".to_string(),
+                            source_ref: Some(source_ref()),
+                        }
+                    ),
+                },
+            ],
+            |rendered| rendered,
+        );
+    }
+
+    // Display for the source reference contains both the file and the line.
+    #[test]
+    fn test_source_reference_display_tokens() {
+        check_cases(
+            [Case {
+                scenario: "display carries file and line",
+                input: (source_ref(), &["a.rs", "100"][..]),
+                expect: Yields(true),
+            }],
+            |(reference, tokens): (PersistentSourceReference, &[&str])| {
+                let produced = format!("{reference}");
+                Ok::<_, ()>(tokens.iter().all(|t| produced.contains(t)))
+            },
+        );
+    }
+
+    // From<&&'static Location> copies the panic location's file and line into a
+    // PersistentSourceReference. Location::caller() gives a real location to
+    // convert; we assert the line is carried through and the file is non-empty.
+    #[test]
+    fn test_source_reference_from_location() {
+        let location = Location::caller();
+        let reference = PersistentSourceReference::from(&location);
+        check_values(
+            [
+                Check {
+                    scenario: "line carried from location",
+                    input: reference.line == location.line(),
+                    expect: true,
+                },
+                Check {
+                    scenario: "file carried from location",
+                    input: reference.file.as_str() == location.file(),
+                    expect: true,
+                },
+            ],
+            |value| value,
         );
     }
 }

--- a/crates/api-model/src/dpa_interface/mod.rs
+++ b/crates/api-model/src/dpa_interface/mod.rs
@@ -439,7 +439,7 @@ mod tests {
     use std::str::FromStr;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::{Case, Check, check_cases, check_values};
 
     use super::*;
 
@@ -482,6 +482,38 @@ mod tests {
                     )),
                 },
                 Case {
+                    scenario: "extracts fields for astra interface type",
+                    input: DeviceInfoInput {
+                        base_mac: Some(MacAddress::from_str("aa:bb:cc:dd:ee:ff").unwrap()),
+                        device_type: "ConnectX7".to_string(),
+                        pci_name: "02:00.1".to_string(),
+                        device_description: None,
+                        interface_type: DpaInterfaceType::Astra,
+                    },
+                    expect: Yields((
+                        machine_id,
+                        MacAddress::from_str("aa:bb:cc:dd:ee:ff").unwrap(),
+                        "ConnectX7".to_string(),
+                        "02:00.1".to_string(),
+                    )),
+                },
+                Case {
+                    scenario: "extracts fields with empty device type and pci name",
+                    input: DeviceInfoInput {
+                        base_mac: Some(MacAddress::from_str("00:00:00:00:00:00").unwrap()),
+                        device_type: String::new(),
+                        pci_name: String::new(),
+                        device_description: Some(String::new()),
+                        interface_type: DpaInterfaceType::Svpc,
+                    },
+                    expect: Yields((
+                        machine_id,
+                        MacAddress::from_str("00:00:00:00:00:00").unwrap(),
+                        String::new(),
+                        String::new(),
+                    )),
+                },
+                Case {
                     scenario: "returns none without base mac",
                     input: DeviceInfoInput {
                         base_mac: None,
@@ -489,6 +521,17 @@ mod tests {
                         pci_name: "01:00.0".to_string(),
                         device_description: None,
                         interface_type: DpaInterfaceType::Svpc,
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "returns none without base mac for astra",
+                    input: DeviceInfoInput {
+                        base_mac: None,
+                        device_type: "ConnectX7".to_string(),
+                        pci_name: "02:00.1".to_string(),
+                        device_description: Some("desc".to_string()),
+                        interface_type: DpaInterfaceType::Astra,
                     },
                     expect: Fails,
                 },
@@ -526,9 +569,29 @@ mod tests {
                     expect: Yields("{\"state\":\"ready\"}".to_string()),
                 },
                 Case {
+                    scenario: "unlocking",
+                    input: DpaInterfaceControllerState::Unlocking,
+                    expect: Yields("{\"state\":\"unlocking\"}".to_string()),
+                },
+                Case {
                     scenario: "applyfirmware",
                     input: DpaInterfaceControllerState::ApplyFirmware,
                     expect: Yields("{\"state\":\"applyfirmware\"}".to_string()),
+                },
+                Case {
+                    scenario: "applyprofile",
+                    input: DpaInterfaceControllerState::ApplyProfile,
+                    expect: Yields("{\"state\":\"applyprofile\"}".to_string()),
+                },
+                Case {
+                    scenario: "locking",
+                    input: DpaInterfaceControllerState::Locking,
+                    expect: Yields("{\"state\":\"locking\"}".to_string()),
+                },
+                Case {
+                    scenario: "assigned",
+                    input: DpaInterfaceControllerState::Assigned,
+                    expect: Yields("{\"state\":\"assigned\"}".to_string()),
                 },
             ],
             |state| -> Result<String, ()> {
@@ -537,6 +600,201 @@ mod tests {
                     serde_json::from_str::<DpaInterfaceControllerState>(&serialized)
                         .map_err(|_| ())?;
                 assert_eq!(round_tripped, state);
+                Ok(serialized)
+            },
+        );
+    }
+
+    #[test]
+    fn lock_mode_try_from_i32() {
+        // `DpaLockMode::try_from(i32)` accepts only 1 (Locked) and 2 (Unlocked);
+        // every other value — including the zero and the values just outside the
+        // accepted pair — is rejected with the same static error.
+        check_cases(
+            [
+                Case {
+                    scenario: "one is locked",
+                    input: 1,
+                    expect: Yields(DpaLockMode::Locked),
+                },
+                Case {
+                    scenario: "two is unlocked",
+                    input: 2,
+                    expect: Yields(DpaLockMode::Unlocked),
+                },
+                Case {
+                    scenario: "zero is invalid",
+                    input: 0,
+                    expect: FailsWith("Invalid value for DpaLockMode"),
+                },
+                Case {
+                    scenario: "three is invalid",
+                    input: 3,
+                    expect: FailsWith("Invalid value for DpaLockMode"),
+                },
+                Case {
+                    scenario: "negative is invalid",
+                    input: -1,
+                    expect: FailsWith("Invalid value for DpaLockMode"),
+                },
+                Case {
+                    scenario: "max is invalid",
+                    input: i32::MAX,
+                    expect: FailsWith("Invalid value for DpaLockMode"),
+                },
+                Case {
+                    scenario: "min is invalid",
+                    input: i32::MIN,
+                    expect: FailsWith("Invalid value for DpaLockMode"),
+                },
+            ],
+            DpaLockMode::try_from,
+        );
+    }
+
+    #[test]
+    fn controller_state_display() {
+        // The `Display` impl defers to `Debug`, so each variant renders as its
+        // bare Rust identifier — distinct from the lowercase serde tag.
+        check_values(
+            [
+                Check {
+                    scenario: "provisioning",
+                    input: DpaInterfaceControllerState::Provisioning,
+                    expect: "Provisioning".to_string(),
+                },
+                Check {
+                    scenario: "ready",
+                    input: DpaInterfaceControllerState::Ready,
+                    expect: "Ready".to_string(),
+                },
+                Check {
+                    scenario: "unlocking",
+                    input: DpaInterfaceControllerState::Unlocking,
+                    expect: "Unlocking".to_string(),
+                },
+                Check {
+                    scenario: "applyfirmware",
+                    input: DpaInterfaceControllerState::ApplyFirmware,
+                    expect: "ApplyFirmware".to_string(),
+                },
+                Check {
+                    scenario: "applyprofile",
+                    input: DpaInterfaceControllerState::ApplyProfile,
+                    expect: "ApplyProfile".to_string(),
+                },
+                Check {
+                    scenario: "locking",
+                    input: DpaInterfaceControllerState::Locking,
+                    expect: "Locking".to_string(),
+                },
+                Check {
+                    scenario: "assigned",
+                    input: DpaInterfaceControllerState::Assigned,
+                    expect: "Assigned".to_string(),
+                },
+            ],
+            |state| state.to_string(),
+        );
+    }
+
+    #[test]
+    fn controller_state_deserialize_rejects_unknown_tag() {
+        // The accepted tags are exactly the lowercase variant names; an unknown
+        // tag and a missing tag are both rejected.
+        check_cases(
+            [
+                Case {
+                    scenario: "known tag deserializes",
+                    input: "{\"state\":\"ready\"}",
+                    expect: Yields(DpaInterfaceControllerState::Ready),
+                },
+                Case {
+                    scenario: "capitalized tag is rejected",
+                    input: "{\"state\":\"Ready\"}",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown tag is rejected",
+                    input: "{\"state\":\"bogus\"}",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing tag is rejected",
+                    input: "{}",
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<DpaInterfaceControllerState>(json).map_err(|_| ()),
+        );
+    }
+
+    #[test]
+    fn network_config_default_uses_admin_network() {
+        // The default network config opts into the admin network and carries no
+        // quarantine state.
+        check_values(
+            [Check {
+                scenario: "defaults to admin network",
+                input: (),
+                expect: (Some(true), None),
+            }],
+            |()| {
+                let cfg = DpaInterfaceNetworkConfig::default();
+                (cfg.use_admin_network, cfg.quarantine_state)
+            },
+        );
+    }
+
+    #[test]
+    fn lock_mode_serde_round_trips() {
+        // Both lock modes survive a JSON round-trip, serializing to their bare
+        // variant names.
+        check_cases(
+            [
+                Case {
+                    scenario: "locked",
+                    input: DpaLockMode::Locked,
+                    expect: Yields("\"Locked\"".to_string()),
+                },
+                Case {
+                    scenario: "unlocked",
+                    input: DpaLockMode::Unlocked,
+                    expect: Yields("\"Unlocked\"".to_string()),
+                },
+            ],
+            |mode| -> Result<String, ()> {
+                let serialized = serde_json::to_string(&mode).map_err(|_| ())?;
+                let round_tripped =
+                    serde_json::from_str::<DpaLockMode>(&serialized).map_err(|_| ())?;
+                assert_eq!(round_tripped, mode);
+                Ok(serialized)
+            },
+        );
+    }
+
+    #[test]
+    fn interface_type_serde_round_trips() {
+        // Each `DpaInterfaceType` variant serializes to its bare name and parses
+        // back to itself.
+        check_cases(
+            [
+                Case {
+                    scenario: "svpc",
+                    input: DpaInterfaceType::Svpc,
+                    expect: Yields("\"Svpc\"".to_string()),
+                },
+                Case {
+                    scenario: "astra",
+                    input: DpaInterfaceType::Astra,
+                    expect: Yields("\"Astra\"".to_string()),
+                },
+            ],
+            |ty| -> Result<String, ()> {
+                let serialized = serde_json::to_string(&ty).map_err(|_| ())?;
+                let round_tripped =
+                    serde_json::from_str::<DpaInterfaceType>(&serialized).map_err(|_| ())?;
+                assert_eq!(round_tripped, ty);
                 Ok(serialized)
             },
         );

--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -397,9 +397,19 @@ impl From<libnmxm::nmxm_model::Gpu> for NvLinkGpu {
 mod tests {
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::{Case, Check, check_cases, check_values};
 
     use super::*;
+
+    // Build a `HardwareInfo` carrying only the architecture and `DmiData` fields
+    // the classification predicates look at, leaving everything else defaulted.
+    fn info_with_dmi(machine_type: CpuArchitecture, dmi: DmiData) -> HardwareInfo {
+        HardwareInfo {
+            machine_type,
+            dmi_data: Some(dmi),
+            ..Default::default()
+        }
+    }
 
     const DPU_INFO_JSON: &[u8] = include_bytes!("hardware_info/test_data/dpu_info.json");
     const DPU_BF3_INFO_JSON: &[u8] = include_bytes!("hardware_info/test_data/dpu_bf3_info.json");
@@ -652,6 +662,516 @@ mod tests {
         assert_eq!(
             deserialized.cert.as_ref().map(|cert| cert.as_bytes()),
             Some(cert_data.as_slice())
+        );
+    }
+
+    // `is_dpu()` is true only when the architecture is Aarch64 *and* the DMI board
+    // name contains "bluefield" (case-insensitively). Both conditions must hold.
+    #[test]
+    fn hardware_info_is_dpu() {
+        check_values(
+            [
+                Check {
+                    scenario: "aarch64 with bluefield board is a DPU",
+                    input: info_with_dmi(
+                        CpuArchitecture::Aarch64,
+                        DmiData {
+                            board_name: "BlueField-3".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "board name match is case-insensitive",
+                    input: info_with_dmi(
+                        CpuArchitecture::Aarch64,
+                        DmiData {
+                            board_name: "MY-BLUEFIELD-CARD".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "bluefield as a lowercase substring still matches",
+                    input: info_with_dmi(
+                        CpuArchitecture::Aarch64,
+                        DmiData {
+                            board_name: "prefix-bluefield-suffix".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "aarch64 without bluefield board is not a DPU",
+                    input: info_with_dmi(
+                        CpuArchitecture::Aarch64,
+                        DmiData {
+                            board_name: "GenericBoard".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "aarch64 with empty board name is not a DPU",
+                    input: info_with_dmi(CpuArchitecture::Aarch64, DmiData::default()),
+                    expect: false,
+                },
+                Check {
+                    scenario: "x86_64 with bluefield board is not a DPU",
+                    input: info_with_dmi(
+                        CpuArchitecture::X86_64,
+                        DmiData {
+                            board_name: "BlueField-3".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "unknown arch with bluefield board is not a DPU",
+                    input: info_with_dmi(
+                        CpuArchitecture::Unknown,
+                        DmiData {
+                            board_name: "BlueField-3".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "aarch64 with no dmi data at all is not a DPU",
+                    input: HardwareInfo {
+                        machine_type: CpuArchitecture::Aarch64,
+                        dmi_data: None,
+                        ..Default::default()
+                    },
+                    expect: false,
+                },
+            ],
+            |info| info.is_dpu(),
+        );
+    }
+
+    // `factory_mac_address()` requires `dpu_info` and a parseable MAC string within
+    // it; its error type is not PartialEq, so failures are asserted as `Fails`.
+    #[test]
+    fn hardware_info_factory_mac_address() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid mac in dpu info yields the address",
+                    input: HardwareInfo {
+                        dpu_info: Some(DpuData {
+                            factory_mac_address: "00:11:22:33:44:55".to_string(),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                    expect: Yields(MacAddress::from_str("00:11:22:33:44:55").unwrap()),
+                },
+                Case {
+                    scenario: "missing dpu info fails",
+                    input: HardwareInfo::default(),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty mac string fails to parse",
+                    input: HardwareInfo {
+                        dpu_info: Some(DpuData {
+                            factory_mac_address: String::new(),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "malformed mac string fails to parse",
+                    input: HardwareInfo {
+                        dpu_info: Some(DpuData {
+                            factory_mac_address: "not-a-mac".to_string(),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "too-short mac string fails to parse",
+                    input: HardwareInfo {
+                        dpu_info: Some(DpuData {
+                            factory_mac_address: "00:11:22".to_string(),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    },
+                    expect: Fails,
+                },
+            ],
+            // HardwareInfoError is not PartialEq, so drop the error to make the run
+            // closure's error type `()`.
+            |info| info.factory_mac_address().map_err(drop),
+        );
+    }
+
+    // `bmc_vendor()` maps the DMI `sys_vendor` string through `from_udev_dmi`, and
+    // falls back to `Unknown` when there is no DMI data at all.
+    #[test]
+    fn hardware_info_bmc_vendor() {
+        check_values(
+            [
+                Check {
+                    scenario: "lenovo sys vendor",
+                    input: info_with_dmi(
+                        CpuArchitecture::X86_64,
+                        DmiData {
+                            sys_vendor: "Lenovo".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: bmc_vendor::BMCVendor::Lenovo,
+                },
+                Check {
+                    scenario: "dell sys vendor",
+                    input: info_with_dmi(
+                        CpuArchitecture::X86_64,
+                        DmiData {
+                            sys_vendor: "Dell Inc.".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: bmc_vendor::BMCVendor::Dell,
+                },
+                Check {
+                    scenario: "nvidia sys vendor",
+                    input: info_with_dmi(
+                        CpuArchitecture::Aarch64,
+                        DmiData {
+                            sys_vendor: "NVIDIA".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: bmc_vendor::BMCVendor::Nvidia,
+                },
+                Check {
+                    scenario: "mellanox url maps to nvidia",
+                    input: info_with_dmi(
+                        CpuArchitecture::Aarch64,
+                        DmiData {
+                            sys_vendor: "https://www.mellanox.com".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: bmc_vendor::BMCVendor::Nvidia,
+                },
+                Check {
+                    scenario: "supermicro sys vendor",
+                    input: info_with_dmi(
+                        CpuArchitecture::X86_64,
+                        DmiData {
+                            sys_vendor: "Supermicro".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: bmc_vendor::BMCVendor::Supermicro,
+                },
+                Check {
+                    scenario: "hpe sys vendor",
+                    input: info_with_dmi(
+                        CpuArchitecture::X86_64,
+                        DmiData {
+                            sys_vendor: "HPE".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: bmc_vendor::BMCVendor::Hpe,
+                },
+                Check {
+                    scenario: "unrecognized sys vendor is unknown",
+                    input: info_with_dmi(
+                        CpuArchitecture::X86_64,
+                        DmiData {
+                            sys_vendor: "Acme Corp".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: bmc_vendor::BMCVendor::Unknown,
+                },
+                Check {
+                    scenario: "case-sensitive: lowercase dell is unknown",
+                    input: info_with_dmi(
+                        CpuArchitecture::X86_64,
+                        DmiData {
+                            sys_vendor: "dell inc.".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    expect: bmc_vendor::BMCVendor::Unknown,
+                },
+                Check {
+                    scenario: "no dmi data is unknown",
+                    input: HardwareInfo::default(),
+                    expect: bmc_vendor::BMCVendor::Unknown,
+                },
+            ],
+            |info| info.bmc_vendor(),
+        );
+    }
+
+    // `is_gbx00()` checks for a "GB200" substring in the product name; `is_dgx_h100()`
+    // wants an exact NVIDIA / DGXH100 pairing.
+    #[test]
+    fn hardware_info_product_predicates() {
+        check_values(
+            [
+                Check {
+                    scenario: "exact GB200 product name",
+                    input: ("GB200", false),
+                    expect: true,
+                },
+                Check {
+                    scenario: "GB200 as a substring",
+                    input: ("NVIDIA GB200 NVL72", false),
+                    expect: true,
+                },
+                Check {
+                    scenario: "different product is not gbx00",
+                    input: ("GB300", false),
+                    expect: false,
+                },
+                Check {
+                    scenario: "empty product name is not gbx00",
+                    input: ("", false),
+                    expect: false,
+                },
+                Check {
+                    scenario: "case-sensitive: lowercase gb200 is not gbx00",
+                    input: ("gb200", false),
+                    expect: false,
+                },
+            ],
+            |(product_name, _)| {
+                info_with_dmi(
+                    CpuArchitecture::Aarch64,
+                    DmiData {
+                        product_name: product_name.to_string(),
+                        ..Default::default()
+                    },
+                )
+                .is_gbx00()
+            },
+        );
+    }
+
+    // `is_dgx_h100()` requires both sys_vendor == "NVIDIA" and product_name == "DGXH100".
+    #[test]
+    fn hardware_info_is_dgx_h100() {
+        check_values(
+            [
+                Check {
+                    scenario: "nvidia vendor and dgxh100 product",
+                    input: ("NVIDIA", "DGXH100"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "wrong product is not a dgx h100",
+                    input: ("NVIDIA", "DGXH200"),
+                    expect: false,
+                },
+                Check {
+                    scenario: "wrong vendor is not a dgx h100",
+                    input: ("Supermicro", "DGXH100"),
+                    expect: false,
+                },
+                Check {
+                    scenario: "both empty is not a dgx h100",
+                    input: ("", ""),
+                    expect: false,
+                },
+                Check {
+                    scenario: "product as substring is rejected (exact match required)",
+                    input: ("NVIDIA", "DGXH100-rev2"),
+                    expect: false,
+                },
+            ],
+            |(sys_vendor, product_name)| {
+                info_with_dmi(
+                    CpuArchitecture::X86_64,
+                    DmiData {
+                        sys_vendor: sys_vendor.to_string(),
+                        product_name: product_name.to_string(),
+                        ..Default::default()
+                    },
+                )
+                .is_dgx_h100()
+            },
+        );
+    }
+
+    // `all_mac_addresses()` projects each network interface's MAC, in order.
+    #[test]
+    fn hardware_info_all_mac_addresses() {
+        let iface = |mac: &str| NetworkInterface {
+            mac_address: MacAddress::from_str(mac).unwrap(),
+            pci_properties: None,
+        };
+        check_values(
+            [
+                Check {
+                    scenario: "no interfaces yields an empty list",
+                    input: vec![],
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "one interface yields its mac",
+                    input: vec![iface("00:11:22:33:44:55")],
+                    expect: vec![MacAddress::from_str("00:11:22:33:44:55").unwrap()],
+                },
+                Check {
+                    scenario: "several interfaces preserve order",
+                    input: vec![iface("00:11:22:33:44:55"), iface("aa:bb:cc:dd:ee:ff")],
+                    expect: vec![
+                        MacAddress::from_str("00:11:22:33:44:55").unwrap(),
+                        MacAddress::from_str("aa:bb:cc:dd:ee:ff").unwrap(),
+                    ],
+                },
+            ],
+            |network_interfaces| {
+                HardwareInfo {
+                    network_interfaces,
+                    ..Default::default()
+                }
+                .all_mac_addresses()
+            },
+        );
+    }
+
+    // `Display` for a software component renders as `url/name:version`, including
+    // the empty-url case.
+    #[test]
+    fn machine_inventory_component_display() {
+        check_values(
+            [
+                Check {
+                    scenario: "all fields populated",
+                    input: ("nvidia.com", "bar", "2.0"),
+                    expect: "nvidia.com/bar:2.0".to_string(),
+                },
+                Check {
+                    scenario: "empty url keeps the leading slash",
+                    input: ("", "foo", "1.0"),
+                    expect: "/foo:1.0".to_string(),
+                },
+                Check {
+                    scenario: "all fields empty",
+                    input: ("", "", ""),
+                    expect: "/:".to_string(),
+                },
+            ],
+            |(url, name, version)| {
+                MachineInventorySoftwareComponent {
+                    name: name.to_string(),
+                    version: version.to_string(),
+                    url: url.to_string(),
+                }
+                .to_string()
+            },
+        );
+    }
+
+    // `TpmEkCertificate` round-trips its bytes through `From`, `as_bytes`, and
+    // `into_bytes`, including the empty-certificate case.
+    #[test]
+    fn tpm_ek_certificate_byte_accessors() {
+        check_values(
+            [
+                Check {
+                    scenario: "non-empty certificate round-trips",
+                    input: vec![1u8, 2, 3, 4],
+                    expect: vec![1u8, 2, 3, 4],
+                },
+                Check {
+                    scenario: "empty certificate round-trips",
+                    input: vec![],
+                    expect: vec![],
+                },
+            ],
+            |bytes: Vec<u8>| {
+                let cert = TpmEkCertificate::from(bytes.clone());
+                assert_eq!(cert.as_bytes(), bytes.as_slice());
+                cert.into_bytes()
+            },
+        );
+    }
+
+    // `NvLinkGpu::from` pulls tray/slot from `location_info` (defaulting to 0 when
+    // absent or unset) and copies device_id / device_uid straight across.
+    #[test]
+    fn nvlink_gpu_from_nmxm_gpu() {
+        check_values(
+            [
+                Check {
+                    scenario: "full location info is carried through",
+                    input: r#"{
+                        "LocationInfo": {"TrayIndex": 3, "SlotID": 7},
+                        "DeviceUID": 42,
+                        "DeviceID": 5,
+                        "DevicePcieID": 0,
+                        "SystemUID": 0,
+                        "VendorID": 0,
+                        "ALIDList": []
+                    }"#,
+                    expect: NvLinkGpu {
+                        tray_index: 3,
+                        slot_id: 7,
+                        device_id: 5,
+                        guid: 42,
+                    },
+                },
+                Check {
+                    scenario: "absent location info defaults tray and slot to zero",
+                    input: r#"{
+                        "DeviceUID": 99,
+                        "DeviceID": 1,
+                        "DevicePcieID": 0,
+                        "SystemUID": 0,
+                        "VendorID": 0,
+                        "ALIDList": []
+                    }"#,
+                    expect: NvLinkGpu {
+                        tray_index: 0,
+                        slot_id: 0,
+                        device_id: 1,
+                        guid: 99,
+                    },
+                },
+                Check {
+                    scenario: "partial location info defaults the missing field",
+                    input: r#"{
+                        "LocationInfo": {"TrayIndex": 2},
+                        "DeviceUID": 0,
+                        "DeviceID": 0,
+                        "DevicePcieID": 0,
+                        "SystemUID": 0,
+                        "VendorID": 0,
+                        "ALIDList": []
+                    }"#,
+                    expect: NvLinkGpu {
+                        tray_index: 2,
+                        slot_id: 0,
+                        device_id: 0,
+                        guid: 0,
+                    },
+                },
+            ],
+            |json| {
+                let gpu = serde_json::from_str::<libnmxm::nmxm_model::Gpu>(json).unwrap();
+                NvLinkGpu::from(gpu)
+            },
         );
     }
 }

--- a/crates/api-model/src/health.rs
+++ b/crates/api-model/src/health.rs
@@ -113,8 +113,88 @@ mod tests {
         check_cases(
             [
                 Case {
+                    scenario: "empty yields nothing",
+                    input: sources(None, &[]),
+                    expect: Yields(vec![]),
+                },
+                Case {
+                    scenario: "single merge",
+                    input: sources(None, &["only"]),
+                    expect: Yields(vec![("only".to_string(), HealthReportApplyMode::Merge)]),
+                },
+                Case {
                     scenario: "merges only",
                     input: sources(None, &["source-a", "source-b"]),
+                    expect: Yields(vec![
+                        ("source-a".to_string(), HealthReportApplyMode::Merge),
+                        ("source-b".to_string(), HealthReportApplyMode::Merge),
+                    ]),
+                },
+                Case {
+                    // The map is keyed by source name, so iteration follows the
+                    // BTreeMap's sorted key order regardless of insertion order.
+                    scenario: "merges sorted by source key, not insertion order",
+                    input: sources(None, &["zebra", "alpha", "mike"]),
+                    expect: Yields(vec![
+                        ("alpha".to_string(), HealthReportApplyMode::Merge),
+                        ("mike".to_string(), HealthReportApplyMode::Merge),
+                        ("zebra".to_string(), HealthReportApplyMode::Merge),
+                    ]),
+                },
+                Case {
+                    scenario: "replace only",
+                    input: sources(Some("admin-replace"), &[]),
+                    expect: Yields(vec![(
+                        "admin-replace".to_string(),
+                        HealthReportApplyMode::Replace,
+                    )]),
+                },
+                Case {
+                    scenario: "mixed merge and replace",
+                    input: sources(Some("sre-override"), &["external-monitor"]),
+                    expect: Yields(vec![
+                        ("external-monitor".to_string(), HealthReportApplyMode::Merge),
+                        ("sre-override".to_string(), HealthReportApplyMode::Replace),
+                    ]),
+                },
+                Case {
+                    // The replace source always trails the merges, even when its name
+                    // would sort before them.
+                    scenario: "replace trails merges regardless of its name",
+                    input: sources(Some("aaa-replace"), &["mmm", "zzz"]),
+                    expect: Yields(vec![
+                        ("mmm".to_string(), HealthReportApplyMode::Merge),
+                        ("zzz".to_string(), HealthReportApplyMode::Merge),
+                        ("aaa-replace".to_string(), HealthReportApplyMode::Replace),
+                    ]),
+                },
+            ],
+            |sources: HealthReportSources| {
+                Ok::<_, ()>(
+                    sources
+                        .into_iter()
+                        .map(|(report, mode)| (report.source, mode))
+                        .collect::<Vec<_>>(),
+                )
+            },
+        );
+    }
+
+    #[test]
+    fn health_reports_iter() {
+        // `iter` borrows rather than consuming, but yields the same (source, mode)
+        // sequence as `into_iter`: merges first in sorted key order, then the
+        // replace source. Infallible, so every row `Yields`.
+        check_cases(
+            [
+                Case {
+                    scenario: "empty borrows nothing",
+                    input: sources(None, &[]),
+                    expect: Yields(vec![]),
+                },
+                Case {
+                    scenario: "merges only",
+                    input: sources(None, &["source-b", "source-a"]),
                     expect: Yields(vec![
                         ("source-a".to_string(), HealthReportApplyMode::Merge),
                         ("source-b".to_string(), HealthReportApplyMode::Merge),
@@ -140,11 +220,81 @@ mod tests {
             |sources: HealthReportSources| {
                 Ok::<_, ()>(
                     sources
-                        .into_iter()
-                        .map(|(report, mode)| (report.source, mode))
+                        .iter()
+                        .map(|(report, mode)| (report.source.clone(), mode))
                         .collect::<Vec<_>>(),
                 )
             },
+        );
+    }
+
+    #[test]
+    fn health_reports_repair_merge_active() {
+        // `repair_merge_active` is true exactly when a merge source named
+        // `repair-request` or `request-online-repair` is present. The replace slot
+        // is irrelevant, as are unrelated merge sources. Infallible predicate, so
+        // every row `Yields` a bool.
+        check_cases(
+            [
+                Case {
+                    scenario: "no sources at all",
+                    input: sources(None, &[]),
+                    expect: Yields(false),
+                },
+                Case {
+                    scenario: "only unrelated merges",
+                    input: sources(None, &["external-monitor", "sre"]),
+                    expect: Yields(false),
+                },
+                Case {
+                    scenario: "repair-request merge present",
+                    input: sources(None, &[health_report::REPAIR_REQUEST_MERGE_SOURCE]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "request-online-repair merge present",
+                    input: sources(None, &[health_report::REQUEST_ONLINE_REPAIR_MERGE_SOURCE]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "both repair merges present",
+                    input: sources(
+                        None,
+                        &[
+                            health_report::REPAIR_REQUEST_MERGE_SOURCE,
+                            health_report::REQUEST_ONLINE_REPAIR_MERGE_SOURCE,
+                        ],
+                    ),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "repair merge alongside unrelated merges",
+                    input: sources(
+                        None,
+                        &[
+                            "external-monitor",
+                            health_report::REPAIR_REQUEST_MERGE_SOURCE,
+                        ],
+                    ),
+                    expect: Yields(true),
+                },
+                Case {
+                    // The repair signal lives in the merges map; a replace source by
+                    // the same name does not count.
+                    scenario: "repair name in replace slot does not count",
+                    input: sources(Some(health_report::REPAIR_REQUEST_MERGE_SOURCE), &[]),
+                    expect: Yields(false),
+                },
+                Case {
+                    scenario: "repair merge present with an unrelated replace",
+                    input: sources(
+                        Some("admin-replace"),
+                        &[health_report::REQUEST_ONLINE_REPAIR_MERGE_SOURCE],
+                    ),
+                    expect: Yields(true),
+                },
+            ],
+            |sources: HealthReportSources| Ok::<_, ()>(sources.repair_merge_active()),
         );
     }
 

--- a/crates/api-model/src/ib.rs
+++ b/crates/api-model/src/ib.rs
@@ -219,11 +219,404 @@ impl From<IBServiceLevel> for i32 {
 
 #[cfg(test)]
 mod tests {
-    use crate::ib::IBPortMembership;
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
+    use crate::ib::{IBMtu, IBPortMembership, IBPortState, IBRateLimit, IBServiceLevel};
 
     #[test]
     fn port_membership_to_string() {
-        assert_eq!(IBPortMembership::Full.to_string(), "full");
-        assert_eq!(IBPortMembership::Limited.to_string(), "limited");
+        check_values(
+            [
+                Check {
+                    scenario: "full",
+                    input: IBPortMembership::Full,
+                    expect: "full".to_string(),
+                },
+                Check {
+                    scenario: "limited",
+                    input: IBPortMembership::Limited,
+                    expect: "limited".to_string(),
+                },
+            ],
+            |membership| membership.to_string(),
+        );
+    }
+
+    #[test]
+    fn port_state_try_from_str() {
+        check_cases(
+            [
+                Case {
+                    scenario: "active",
+                    input: "active",
+                    expect: Yields(IBPortState::Active),
+                },
+                Case {
+                    scenario: "down",
+                    input: "down",
+                    expect: Yields(IBPortState::Down),
+                },
+                Case {
+                    scenario: "initialize",
+                    input: "initialize",
+                    expect: Yields(IBPortState::Initialize),
+                },
+                Case {
+                    scenario: "armed",
+                    input: "armed",
+                    expect: Yields(IBPortState::Armed),
+                },
+                Case {
+                    scenario: "uppercase is lowercased",
+                    input: "ACTIVE",
+                    expect: Yields(IBPortState::Active),
+                },
+                Case {
+                    scenario: "mixed case",
+                    input: "ArMeD",
+                    expect: Yields(IBPortState::Armed),
+                },
+                Case {
+                    scenario: "surrounding whitespace is trimmed",
+                    input: "  down  ",
+                    expect: Yields(IBPortState::Down),
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "whitespace only",
+                    input: "   ",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown word",
+                    input: "sleeping",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "near miss",
+                    input: "actives",
+                    expect: Fails,
+                },
+            ],
+            |state| IBPortState::try_from(state).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn port_state_try_from_string() {
+        check_cases(
+            [
+                Case {
+                    scenario: "active",
+                    input: "active".to_string(),
+                    expect: Yields(IBPortState::Active),
+                },
+                Case {
+                    scenario: "trimmed and lowercased",
+                    input: " Initialize ".to_string(),
+                    expect: Yields(IBPortState::Initialize),
+                },
+                Case {
+                    scenario: "invalid",
+                    input: "bogus".to_string(),
+                    expect: Fails,
+                },
+            ],
+            |state| IBPortState::try_from(state).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn mtu_default_is_4() {
+        Check {
+            scenario: "default mtu",
+            input: (),
+            expect: IBMtu(4),
+        }
+        .check(|()| IBMtu::default());
+    }
+
+    #[test]
+    fn mtu_try_from_i32() {
+        check_cases(
+            [
+                Case {
+                    scenario: "2k",
+                    input: 2,
+                    expect: Yields(IBMtu(2)),
+                },
+                Case {
+                    scenario: "4k",
+                    input: 4,
+                    expect: Yields(IBMtu(4)),
+                },
+                Case {
+                    scenario: "zero",
+                    input: 0,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "one",
+                    input: 1,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "three between valid values",
+                    input: 3,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "negative",
+                    input: -2,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "large",
+                    input: 4096,
+                    expect: Fails,
+                },
+            ],
+            |mtu| IBMtu::try_from(mtu).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn mtu_into_i32() {
+        check_values(
+            [
+                Check {
+                    scenario: "2k",
+                    input: IBMtu(2),
+                    expect: 2,
+                },
+                Check {
+                    scenario: "4k",
+                    input: IBMtu(4),
+                    expect: 4,
+                },
+            ],
+            i32::from,
+        );
+    }
+
+    #[test]
+    fn rate_limit_default_is_200() {
+        Check {
+            scenario: "default rate limit",
+            input: (),
+            expect: IBRateLimit(200),
+        }
+        .check(|()| IBRateLimit::default());
+    }
+
+    #[test]
+    fn rate_limit_try_from_i32() {
+        check_cases(
+            [
+                Case {
+                    scenario: "legacy sdr 2.5 sentinel",
+                    input: 2,
+                    expect: Yields(IBRateLimit(2)),
+                },
+                Case {
+                    scenario: "5",
+                    input: 5,
+                    expect: Yields(IBRateLimit(5)),
+                },
+                Case {
+                    scenario: "10",
+                    input: 10,
+                    expect: Yields(IBRateLimit(10)),
+                },
+                Case {
+                    scenario: "14",
+                    input: 14,
+                    expect: Yields(IBRateLimit(14)),
+                },
+                Case {
+                    scenario: "20",
+                    input: 20,
+                    expect: Yields(IBRateLimit(20)),
+                },
+                Case {
+                    scenario: "25",
+                    input: 25,
+                    expect: Yields(IBRateLimit(25)),
+                },
+                Case {
+                    scenario: "30",
+                    input: 30,
+                    expect: Yields(IBRateLimit(30)),
+                },
+                Case {
+                    scenario: "40",
+                    input: 40,
+                    expect: Yields(IBRateLimit(40)),
+                },
+                Case {
+                    scenario: "56",
+                    input: 56,
+                    expect: Yields(IBRateLimit(56)),
+                },
+                Case {
+                    scenario: "60",
+                    input: 60,
+                    expect: Yields(IBRateLimit(60)),
+                },
+                Case {
+                    scenario: "80",
+                    input: 80,
+                    expect: Yields(IBRateLimit(80)),
+                },
+                Case {
+                    scenario: "100",
+                    input: 100,
+                    expect: Yields(IBRateLimit(100)),
+                },
+                Case {
+                    scenario: "112",
+                    input: 112,
+                    expect: Yields(IBRateLimit(112)),
+                },
+                Case {
+                    scenario: "120",
+                    input: 120,
+                    expect: Yields(IBRateLimit(120)),
+                },
+                Case {
+                    scenario: "168",
+                    input: 168,
+                    expect: Yields(IBRateLimit(168)),
+                },
+                Case {
+                    scenario: "200",
+                    input: 200,
+                    expect: Yields(IBRateLimit(200)),
+                },
+                Case {
+                    scenario: "300",
+                    input: 300,
+                    expect: Yields(IBRateLimit(300)),
+                },
+                Case {
+                    scenario: "zero",
+                    input: 0,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "one",
+                    input: 1,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "three is not a valid rate",
+                    input: 3,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "negative",
+                    input: -200,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unsupported large",
+                    input: 400,
+                    expect: Fails,
+                },
+            ],
+            |rate| IBRateLimit::try_from(rate).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn rate_limit_into_i32() {
+        check_values(
+            [
+                Check {
+                    scenario: "200",
+                    input: IBRateLimit(200),
+                    expect: 200,
+                },
+                Check {
+                    scenario: "sdr sentinel",
+                    input: IBRateLimit(2),
+                    expect: 2,
+                },
+            ],
+            i32::from,
+        );
+    }
+
+    #[test]
+    fn service_level_default_is_0() {
+        Check {
+            scenario: "default service level",
+            input: (),
+            expect: IBServiceLevel(0),
+        }
+        .check(|()| IBServiceLevel::default());
+    }
+
+    #[test]
+    fn service_level_try_from_i32() {
+        check_cases(
+            [
+                Case {
+                    scenario: "lower bound 0",
+                    input: 0,
+                    expect: Yields(IBServiceLevel(0)),
+                },
+                Case {
+                    scenario: "mid 7",
+                    input: 7,
+                    expect: Yields(IBServiceLevel(7)),
+                },
+                Case {
+                    scenario: "upper bound 15",
+                    input: 15,
+                    expect: Yields(IBServiceLevel(15)),
+                },
+                Case {
+                    scenario: "just past upper bound",
+                    input: 16,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "negative below lower bound",
+                    input: -1,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "large",
+                    input: 1000,
+                    expect: Fails,
+                },
+            ],
+            |level| IBServiceLevel::try_from(level).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn service_level_into_i32() {
+        check_values(
+            [
+                Check {
+                    scenario: "0",
+                    input: IBServiceLevel(0),
+                    expect: 0,
+                },
+                Check {
+                    scenario: "15",
+                    input: IBServiceLevel(15),
+                    expect: 15,
+                },
+            ],
+            i32::from,
+        );
     }
 }

--- a/crates/api-model/src/ib_partition/mod.rs
+++ b/crates/api-model/src/ib_partition/mod.rs
@@ -103,10 +103,10 @@ impl FromStr for PartitionKey {
         let pkey = pkey.to_lowercase();
         let base = if pkey.starts_with("0x") { 16 } else { 10 };
         let p = pkey.trim_start_matches("0x");
-        let k = u16::from_str_radix(p, base);
-
-        match k {
-            Ok(v) => Ok(PartitionKey(v)),
+        // Apply the same 0x7fff range check as `TryFrom<u16>` so every
+        // construction path agrees on what a valid pkey is.
+        match u16::from_str_radix(p, base) {
+            Ok(v) => PartitionKey::try_from(v),
             Err(_e) => Err(InvalidPartitionKeyError(pkey.to_string())),
         }
     }
@@ -313,53 +313,436 @@ pub fn state_sla(state: &IBPartitionControllerState, state_version: &ConfigVersi
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
+    // ---- PartitionKey::from_str --------------------------------------------
+
     #[test]
-    fn serialize_and_format_pkey() {
-        let pkey = PartitionKey::from_str("0xf").unwrap();
-        let serialized = serde_json::to_string(&pkey).unwrap();
-        assert_eq!(serialized, "\"0xf\"");
-        assert_eq!(pkey.to_string(), "0xf");
-        let deserialized = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(pkey, deserialized);
-        let deserialized = serde_json::from_str("\"15\"").unwrap();
-        assert_eq!(pkey, deserialized);
-        let deserialized = serde_json::from_str("\"0xf\"").unwrap();
-        assert_eq!(pkey, deserialized);
+    fn from_str_parses_each_input() {
+        check_cases(
+            [
+                Case {
+                    scenario: "hex with 0x prefix",
+                    input: "0xf",
+                    expect: Yields(0x000f),
+                },
+                Case {
+                    scenario: "decimal of the same value",
+                    input: "15",
+                    expect: Yields(0x000f),
+                },
+                Case {
+                    scenario: "zero hex",
+                    input: "0x0",
+                    expect: Yields(0),
+                },
+                Case {
+                    scenario: "zero decimal",
+                    input: "0",
+                    expect: Yields(0),
+                },
+                Case {
+                    scenario: "max default-partition hex",
+                    input: "0x7fff",
+                    expect: Yields(0x7fff),
+                },
+                Case {
+                    scenario: "uppercase hex digits",
+                    input: "0x7ABC",
+                    expect: Yields(0x7abc),
+                },
+                Case {
+                    scenario: "uppercase 0X prefix is lowercased first",
+                    input: "0XF",
+                    expect: Yields(0x000f),
+                },
+                Case {
+                    // from_str enforces the same 0x7fff mask as TryFrom<u16>.
+                    scenario: "hex above the valid pkey mask is rejected",
+                    input: "0xffff",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "decimal above the mask is rejected",
+                    input: "65535",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-numeric text",
+                    input: "nope",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "decimal overflowing u16",
+                    input: "65536",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "hex overflowing u16",
+                    input: "0x10000",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "bare 0x prefix with no digits",
+                    input: "0x",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "decimal value carrying hex letters",
+                    input: "1f",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "negative sign rejected",
+                    input: "-1",
+                    expect: Fails,
+                },
+            ],
+            |s| PartitionKey::from_str(s).map(u16::from).map_err(drop),
+        );
+    }
+
+    // ---- PartitionKey: TryFrom<&str> / String / &String --------------------
+
+    #[test]
+    fn try_from_str_like_inputs_match_from_str() {
+        check_cases(
+            [
+                Case {
+                    scenario: "&str hex",
+                    input: "0x20",
+                    expect: Yields(0x20),
+                },
+                Case {
+                    scenario: "&str decimal",
+                    input: "32",
+                    expect: Yields(0x20),
+                },
+                Case {
+                    scenario: "&str malformed",
+                    input: "zz",
+                    expect: Fails,
+                },
+            ],
+            |s| PartitionKey::try_from(s).map(u16::from).map_err(drop),
+        );
     }
 
     #[test]
-    fn serialize_controller_state() {
-        let state = IBPartitionControllerState::Provisioning {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"provisioning\"}");
-        assert_eq!(
-            serde_json::from_str::<IBPartitionControllerState>(&serialized).unwrap(),
-            state
+    fn try_from_owned_and_borrowed_string() {
+        // TryFrom<String>
+        check_cases(
+            [
+                Case {
+                    scenario: "owned String hex",
+                    input: "0xab".to_string(),
+                    expect: Yields(0xab),
+                },
+                Case {
+                    scenario: "owned String malformed",
+                    input: "bad".to_string(),
+                    expect: Fails,
+                },
+            ],
+            |s| PartitionKey::try_from(s).map(u16::from).map_err(drop),
         );
-        let state = IBPartitionControllerState::Ready {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"ready\"}");
-        assert_eq!(
-            serde_json::from_str::<IBPartitionControllerState>(&serialized).unwrap(),
-            state
+        // TryFrom<&String>
+        check_cases(
+            [
+                Case {
+                    scenario: "&String decimal",
+                    input: "171".to_string(),
+                    expect: Yields(0xab),
+                },
+                Case {
+                    scenario: "&String malformed",
+                    input: "bad".to_string(),
+                    expect: Fails,
+                },
+            ],
+            |s| PartitionKey::try_from(&s).map(u16::from).map_err(drop),
         );
-        let state = IBPartitionControllerState::Error {
-            cause: "cause goes here".to_string(),
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, r#"{"state":"error","cause":"cause goes here"}"#);
-        assert_eq!(
-            serde_json::from_str::<IBPartitionControllerState>(&serialized).unwrap(),
-            state
+    }
+
+    // ---- PartitionKey: TryFrom<u16> (the 0x7fff mask) ----------------------
+
+    #[test]
+    fn try_from_u16_enforces_the_mask() {
+        check_cases(
+            [
+                Case {
+                    scenario: "zero",
+                    input: 0u16,
+                    expect: Yields(0),
+                },
+                Case {
+                    scenario: "small in-range value",
+                    input: 0x000f,
+                    expect: Yields(0x000f),
+                },
+                Case {
+                    scenario: "max valid (default partition)",
+                    input: 0x7fff,
+                    expect: Yields(0x7fff),
+                },
+                Case {
+                    scenario: "first value past the mask",
+                    input: 0x8000,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "u16 max has the high bit set",
+                    input: 0xffff,
+                    expect: Fails,
+                },
+            ],
+            |n| PartitionKey::try_from(n).map(u16::from).map_err(drop),
         );
-        let state = IBPartitionControllerState::Deleting {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"deleting\"}");
-        assert_eq!(
-            serde_json::from_str::<IBPartitionControllerState>(&serialized).unwrap(),
-            state
+    }
+
+    // ---- PartitionKey: Display ---------------------------------------------
+
+    #[test]
+    fn display_renders_lowercase_hex_with_prefix() {
+        check_values(
+            [
+                Check {
+                    scenario: "zero",
+                    input: 0u16,
+                    expect: "0x0".to_string(),
+                },
+                Check {
+                    scenario: "single hex digit",
+                    input: 0x000f,
+                    expect: "0xf".to_string(),
+                },
+                Check {
+                    scenario: "multi-digit lowercased",
+                    input: 0x00ab,
+                    expect: "0xab".to_string(),
+                },
+                Check {
+                    scenario: "default partition key",
+                    input: 0x7fff,
+                    expect: "0x7fff".to_string(),
+                },
+            ],
+            |n| PartitionKey::try_from(n).unwrap().to_string(),
         );
+    }
+
+    // ---- PartitionKey: default-partition helpers ---------------------------
+
+    #[test]
+    fn for_default_partition_is_0x7fff() {
+        assert_eq!(u16::from(PartitionKey::for_default_partition()), 0x7fff);
+    }
+
+    #[test]
+    fn is_default_partition_predicate() {
+        check_values(
+            [
+                Check {
+                    scenario: "the default key",
+                    input: 0x7fff,
+                    expect: true,
+                },
+                Check {
+                    scenario: "zero is not default",
+                    input: 0,
+                    expect: false,
+                },
+                Check {
+                    scenario: "an ordinary key is not default",
+                    input: 0x000f,
+                    expect: false,
+                },
+                Check {
+                    scenario: "one below default",
+                    input: 0x7ffe,
+                    expect: false,
+                },
+            ],
+            |n| PartitionKey::try_from(n).unwrap().is_default_partition(),
+        );
+    }
+
+    // ---- PartitionKey: round-trip parse -> render --------------------------
+
+    #[test]
+    fn parse_then_display_round_trips_to_canonical_hex() {
+        check_cases(
+            [
+                Case {
+                    scenario: "decimal normalizes to hex",
+                    input: "15",
+                    expect: Yields("0xf".to_string()),
+                },
+                Case {
+                    scenario: "hex stays hex",
+                    input: "0xf",
+                    expect: Yields("0xf".to_string()),
+                },
+                Case {
+                    scenario: "uppercase folds to lowercase",
+                    input: "0x7ABC",
+                    expect: Yields("0x7abc".to_string()),
+                },
+            ],
+            |s| {
+                PartitionKey::from_str(s)
+                    .map(|p| p.to_string())
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // ---- PartitionKey: serde (string is the canonical form) ----------------
+
+    #[test]
+    fn serializes_as_canonical_hex_string() {
+        check_cases(
+            [
+                Case {
+                    scenario: "single digit",
+                    input: 0x000f,
+                    expect: Yields("\"0xf\"".to_string()),
+                },
+                Case {
+                    scenario: "zero",
+                    input: 0,
+                    expect: Yields("\"0x0\"".to_string()),
+                },
+                Case {
+                    scenario: "default partition",
+                    input: 0x7fff,
+                    expect: Yields("\"0x7fff\"".to_string()),
+                },
+            ],
+            |n| {
+                let pkey = PartitionKey::try_from(n).unwrap();
+                serde_json::to_string(&pkey).map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn deserializes_from_hex_or_decimal_strings() {
+        check_cases(
+            [
+                Case {
+                    scenario: "hex string",
+                    input: "\"0xf\"",
+                    expect: Yields(0x000f),
+                },
+                Case {
+                    scenario: "decimal string of the same value",
+                    input: "\"15\"",
+                    expect: Yields(0x000f),
+                },
+                Case {
+                    scenario: "malformed string",
+                    input: "\"nope\"",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-string JSON is rejected",
+                    input: "15",
+                    expect: Fails,
+                },
+            ],
+            |s| {
+                serde_json::from_str::<PartitionKey>(s)
+                    .map(u16::from)
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // ---- IBPartitionControllerState: serde (tagged, lowercase) -------------
+
+    #[test]
+    fn controller_state_serializes_with_lowercase_tag() {
+        check_cases(
+            [
+                Case {
+                    scenario: "provisioning",
+                    input: IBPartitionControllerState::Provisioning,
+                    expect: Yields(r#"{"state":"provisioning"}"#.to_string()),
+                },
+                Case {
+                    scenario: "ready",
+                    input: IBPartitionControllerState::Ready,
+                    expect: Yields(r#"{"state":"ready"}"#.to_string()),
+                },
+                Case {
+                    scenario: "deleting",
+                    input: IBPartitionControllerState::Deleting,
+                    expect: Yields(r#"{"state":"deleting"}"#.to_string()),
+                },
+                Case {
+                    scenario: "error carries its cause",
+                    input: IBPartitionControllerState::Error {
+                        cause: "cause goes here".to_string(),
+                    },
+                    expect: Yields(r#"{"state":"error","cause":"cause goes here"}"#.to_string()),
+                },
+            ],
+            |state| serde_json::to_string(&state).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn controller_state_round_trips_through_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "provisioning",
+                    input: IBPartitionControllerState::Provisioning,
+                    expect: Yields(IBPartitionControllerState::Provisioning),
+                },
+                Case {
+                    scenario: "ready",
+                    input: IBPartitionControllerState::Ready,
+                    expect: Yields(IBPartitionControllerState::Ready),
+                },
+                Case {
+                    scenario: "deleting",
+                    input: IBPartitionControllerState::Deleting,
+                    expect: Yields(IBPartitionControllerState::Deleting),
+                },
+                Case {
+                    scenario: "error preserves its cause",
+                    input: IBPartitionControllerState::Error {
+                        cause: "boom".to_string(),
+                    },
+                    expect: Yields(IBPartitionControllerState::Error {
+                        cause: "boom".to_string(),
+                    }),
+                },
+            ],
+            |state| {
+                let json = serde_json::to_string(&state).map_err(drop)?;
+                serde_json::from_str::<IBPartitionControllerState>(&json).map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn controller_state_deserialize_rejects_unknown_tag() {
+        Case {
+            scenario: "unknown state tag",
+            input: r#"{"state":"bogus"}"#,
+            expect: Fails,
+        }
+        .check(|s| serde_json::from_str::<IBPartitionControllerState>(s).map_err(drop));
     }
 }

--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -100,6 +100,11 @@ pub mod trim_table;
 pub mod vpc;
 pub mod vpc_prefix;
 
+// Lets the database round-trip tests use `#[crate::sqlx_test]` to get a per-test
+// Postgres pool from the shared harness (DATABASE_URL via .envrc).
+#[cfg(test)]
+pub(crate) use carbide_macros::sqlx_test;
+
 /// Error that is returned when we validate various configurations that are obtained
 /// from Forge users.
 #[derive(Debug, thiserror::Error, Clone)]

--- a/crates/api-model/src/machine/capabilities.rs
+++ b/crates/api-model/src/machine/capabilities.rs
@@ -510,6 +510,8 @@ impl MachineCapabilitiesSet {
 mod tests {
     use std::str::FromStr;
 
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
     use crate::hardware_info::*;
     use crate::ib::DEFAULT_IB_FABRIC_NAME;
@@ -848,5 +850,250 @@ mod tests {
         compare_cap.sort();
 
         assert_eq!(expected_ib_caps, compare_cap.infiniband);
+    }
+
+    #[test]
+    fn capability_type_display_covers_every_variant() {
+        check_values(
+            [
+                Check {
+                    scenario: "cpu",
+                    input: MachineCapabilityType::Cpu,
+                    expect: "CPU".to_string(),
+                },
+                Check {
+                    scenario: "gpu",
+                    input: MachineCapabilityType::Gpu,
+                    expect: "GPU".to_string(),
+                },
+                Check {
+                    scenario: "memory",
+                    input: MachineCapabilityType::Memory,
+                    expect: "MEMORY".to_string(),
+                },
+                Check {
+                    scenario: "storage",
+                    input: MachineCapabilityType::Storage,
+                    expect: "STORAGE".to_string(),
+                },
+                Check {
+                    scenario: "network",
+                    input: MachineCapabilityType::Network,
+                    expect: "NETWORK".to_string(),
+                },
+                Check {
+                    scenario: "infiniband",
+                    input: MachineCapabilityType::Infiniband,
+                    expect: "INFINIBAND".to_string(),
+                },
+                Check {
+                    scenario: "dpu",
+                    input: MachineCapabilityType::Dpu,
+                    expect: "DPU".to_string(),
+                },
+            ],
+            |variant| variant.to_string(),
+        );
+    }
+
+    #[test]
+    fn capability_type_default_is_cpu() {
+        Check {
+            scenario: "default capability type",
+            input: (),
+            expect: MachineCapabilityType::Cpu,
+        }
+        .check(|()| MachineCapabilityType::default());
+    }
+
+    #[test]
+    fn device_type_display_covers_every_variant() {
+        check_values(
+            [
+                Check {
+                    scenario: "unknown",
+                    input: MachineCapabilityDeviceType::Unknown,
+                    expect: "UNKNOWN".to_string(),
+                },
+                Check {
+                    scenario: "dpu",
+                    input: MachineCapabilityDeviceType::Dpu,
+                    expect: "DPU".to_string(),
+                },
+                Check {
+                    scenario: "nvlink",
+                    input: MachineCapabilityDeviceType::NvLink,
+                    expect: "NVLINK".to_string(),
+                },
+            ],
+            |variant| variant.to_string(),
+        );
+    }
+
+    #[test]
+    fn cpu_capability_from_cpu_info_maps_every_field() {
+        fn cpu_info(model: &str, vendor: &str, sockets: u32, cores: u32, threads: u32) -> CpuInfo {
+            CpuInfo {
+                model: model.to_string(),
+                vendor: vendor.to_string(),
+                sockets,
+                cores,
+                threads,
+            }
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "typical dual-socket",
+                    input: cpu_info("Xeon Gold 6354", "GenuineIntel", 2, 18, 36),
+                    expect: MachineCapabilityCpu {
+                        name: "Xeon Gold 6354".to_string(),
+                        count: 2,
+                        vendor: Some("GenuineIntel".to_string()),
+                        cores: Some(18),
+                        threads: Some(36),
+                    },
+                },
+                Check {
+                    scenario: "single socket",
+                    input: cpu_info("EPYC 7763", "AuthenticAMD", 1, 64, 128),
+                    expect: MachineCapabilityCpu {
+                        name: "EPYC 7763".to_string(),
+                        count: 1,
+                        vendor: Some("AuthenticAMD".to_string()),
+                        cores: Some(64),
+                        threads: Some(128),
+                    },
+                },
+                Check {
+                    scenario: "all-zero / empty defaults",
+                    input: cpu_info("", "", 0, 0, 0),
+                    expect: MachineCapabilityCpu {
+                        name: String::new(),
+                        count: 0,
+                        // From always wraps the source fields in Some, even when empty/zero.
+                        vendor: Some(String::new()),
+                        cores: Some(0),
+                        threads: Some(0),
+                    },
+                },
+            ],
+            |info| MachineCapabilityCpu::from(&info),
+        );
+    }
+
+    #[test]
+    fn infiniband_caps_from_interfaces_and_status() {
+        fn iface(guid: &str, pci: Option<PciDeviceProperties>) -> InfinibandInterface {
+            InfinibandInterface {
+                guid: guid.to_string(),
+                pci_properties: pci,
+            }
+        }
+
+        fn pci(vendor: &str, description: Option<&str>, slot: Option<&str>) -> PciDeviceProperties {
+            PciDeviceProperties {
+                vendor: vendor.to_string(),
+                device: String::new(),
+                path: String::new(),
+                numa_node: 0,
+                description: description.map(str::to_string),
+                slot: slot.map(str::to_string),
+            }
+        }
+
+        // No status observation: every device defaults to inactive.
+        check_values(
+            [
+                Check {
+                    scenario: "empty interface list -> no capabilities",
+                    input: Vec::<InfinibandInterface>::new(),
+                    expect: 0,
+                },
+                Check {
+                    scenario: "interface without pci_properties is skipped",
+                    input: vec![iface("g0", None)],
+                    expect: 0,
+                },
+                Check {
+                    scenario: "pci_properties without description is skipped",
+                    input: vec![iface("g0", Some(pci("0x15b3", None, Some("0"))))],
+                    expect: 0,
+                },
+                Check {
+                    scenario: "two devices of the same model roll into one capability",
+                    input: vec![
+                        iface("g0", Some(pci("0x15b3", Some("ConnectX-7"), Some("1")))),
+                        iface("g1", Some(pci("0x15b3", Some("ConnectX-7"), Some("0")))),
+                    ],
+                    expect: 1,
+                },
+                Check {
+                    scenario: "two distinct models produce two capabilities",
+                    input: vec![
+                        iface("g0", Some(pci("0x15b3", Some("ConnectX-5"), Some("0")))),
+                        iface("g1", Some(pci("0x15b3", Some("ConnectX-7"), Some("1")))),
+                    ],
+                    expect: 2,
+                },
+            ],
+            |interfaces| {
+                MachineCapabilityInfiniband::from_ib_interfaces_and_status(&interfaces, None).len()
+            },
+        );
+    }
+
+    #[test]
+    fn infiniband_caps_count_and_inactive_without_status() {
+        // Without a status observation, lid lookups never succeed, so every
+        // device is treated as inactive and recorded in inactive_devices.
+        let interfaces = vec![
+            InfinibandInterface {
+                guid: "g0".to_string(),
+                pci_properties: Some(PciDeviceProperties {
+                    vendor: "0x15b3".to_string(),
+                    device: String::new(),
+                    path: String::new(),
+                    numa_node: 0,
+                    description: Some("ConnectX-7".to_string()),
+                    slot: Some("0".to_string()),
+                }),
+            },
+            InfinibandInterface {
+                guid: "g1".to_string(),
+                pci_properties: Some(PciDeviceProperties {
+                    vendor: "0x15b3".to_string(),
+                    device: String::new(),
+                    path: String::new(),
+                    numa_node: 0,
+                    description: Some("ConnectX-7".to_string()),
+                    slot: Some("1".to_string()),
+                }),
+            },
+        ];
+
+        let caps = MachineCapabilityInfiniband::from_ib_interfaces_and_status(&interfaces, None);
+        assert_eq!(caps.len(), 1);
+
+        check_values(
+            [
+                Check {
+                    scenario: "rolled-up count",
+                    input: "count",
+                    expect: 2u32,
+                },
+                Check {
+                    scenario: "all inactive without status",
+                    input: "inactive_len",
+                    expect: 2u32,
+                },
+            ],
+            |field| match field {
+                "count" => caps[0].count,
+                "inactive_len" => caps[0].inactive_devices.len() as u32,
+                other => panic!("unknown field {other}"),
+            },
+        );
     }
 }

--- a/crates/api-model/src/machine/infiniband.rs
+++ b/crates/api-model/src/machine/infiniband.rs
@@ -323,6 +323,22 @@ mod tests {
             observed_at: chrono::Utc::now(),
         };
 
+        // Observation where the interface is observable but sits on a different
+        // partition than the config requests, so the config is not synced.
+        let other_partition_id: IBPartitionId =
+            uuid::uuid!("00000000-0000-0000-0000-0000deadbeef").into();
+        let other_pkey: PartitionKey = 0x42.try_into().unwrap();
+        let mismatched = MachineInfinibandStatusObservation {
+            ib_interfaces: vec![MachineIbInterfaceStatusObservation {
+                guid: "946dae03006104f8".to_string(),
+                lid: 0x10,
+                fabric_id: "default".to_string(),
+                associated_pkeys: Some([other_pkey].into_iter().collect()),
+                associated_partition_ids: Some([other_partition_id].into_iter().collect()),
+            }],
+            observed_at: chrono::Utc::now(),
+        };
+
         // ib_config_synced over (observation, config, use_tenant_network). The
         // error variant's `details` are built dynamically, so rather than assert
         // the exact reason we project the result to a comparable summary:
@@ -353,6 +369,11 @@ mod tests {
                     scenario: "ok when synced",
                     input: (Some(&synced), Some(&cfg), true),
                     expect: Yields(("ok", Vec::new(), false, false)),
+                },
+                Case {
+                    scenario: "configuration mismatch (interface on a different partition)",
+                    input: (Some(&mismatched), Some(&cfg), true),
+                    expect: Yields(("ConfigurationMismatch", Vec::new(), false, false)),
                 },
             ],
             |(observation, config, use_tenant_network)| -> Result<Summary, ()> {

--- a/crates/api-model/src/machine/machine_id.rs
+++ b/crates/api-model/src/machine/machine_id.rs
@@ -106,11 +106,28 @@ pub enum MissingHardwareInfo {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::{Case, Check, check_cases, check_values};
     use carbide_uuid::machine::MACHINE_ID_LENGTH;
 
     use super::*;
-    use crate::hardware_info::TpmEkCertificate;
+    use crate::hardware_info::{DmiData, TpmEkCertificate};
+
+    // Build a `HardwareInfo` carrying only the two fields the ID derivation looks
+    // at — an optional TPM certificate and optional DMI serials — leaving every
+    // other field defaulted. `tpm` is the certificate bytes (when present) and
+    // `serials` is the (product, board, chassis) triple folded into `DmiData`.
+    fn info_for_id(tpm: Option<Vec<u8>>, serials: Option<(&str, &str, &str)>) -> HardwareInfo {
+        HardwareInfo {
+            tpm_ek_certificate: tpm.map(TpmEkCertificate::from),
+            dmi_data: serials.map(|(product, board, chassis)| DmiData {
+                product_serial: product.to_string(),
+                board_serial: board.to_string(),
+                chassis_serial: chassis.to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
 
     const TEST_DATA_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src/hardware_info/test_data");
 
@@ -235,6 +252,289 @@ mod tests {
 
                 test_derive_machine_id(&mut fingerprint, expected_type, constructor);
                 Ok(())
+            },
+        );
+    }
+
+    // The error paths of `from_hardware_info_with_type`: a present-but-empty TPM
+    // certificate, DMI data with every serial blank, and neither TPM nor DMI
+    // present each map to a distinct `MissingHardwareInfo`. A non-empty TPM cert,
+    // or DMI data with at least one serial, derives an ID and so `Yields`.
+    #[test]
+    fn from_hardware_info_with_type_error_paths() {
+        check_cases(
+            [
+                Case {
+                    scenario: "present but empty TPM cert is rejected",
+                    input: info_for_id(Some(vec![]), None),
+                    expect: FailsWith(MissingHardwareInfo::TPMCertEmpty),
+                },
+                Case {
+                    scenario: "empty TPM cert is rejected even with valid serials present",
+                    input: info_for_id(Some(vec![]), Some(("p1", "b1", "c1"))),
+                    expect: FailsWith(MissingHardwareInfo::TPMCertEmpty),
+                },
+                Case {
+                    scenario: "DMI data with all serials blank is rejected",
+                    input: info_for_id(None, Some(("", "", ""))),
+                    expect: FailsWith(MissingHardwareInfo::Serial),
+                },
+                Case {
+                    scenario: "neither TPM nor DMI present",
+                    input: info_for_id(None, None),
+                    expect: FailsWith(MissingHardwareInfo::All),
+                },
+                Case {
+                    scenario: "non-empty TPM cert derives an ID",
+                    input: info_for_id(Some(vec![1, 2, 3, 4]), None),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "product serial alone derives an ID",
+                    input: info_for_id(None, Some(("p1", "", ""))),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "board serial alone derives an ID",
+                    input: info_for_id(None, Some(("", "b1", ""))),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "chassis serial alone derives an ID",
+                    input: info_for_id(None, Some(("", "", "c1"))),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "all three serials present derives an ID",
+                    input: info_for_id(None, Some(("p1", "b1", "c1"))),
+                    expect: Yields(()),
+                },
+            ],
+            // Drop the derived ID so a success is `Ok(())`: the `Yields(())` rows
+            // assert an ID was derived, while the error rows keep their exact
+            // `MissingHardwareInfo` for the `FailsWith` checks.
+            |info| from_hardware_info_with_type(&info, MachineType::Host).map(drop),
+        );
+    }
+
+    // Which `MachineIdSource` the derivation selects: a present TPM certificate
+    // wins outright, and falls through to the product/board/chassis serial source
+    // only when no TPM certificate is present.
+    #[test]
+    fn from_hardware_info_with_type_selects_source() {
+        check_cases(
+            [
+                Case {
+                    scenario: "TPM certificate selects the Tpm source",
+                    input: info_for_id(Some(vec![9]), None),
+                    expect: Yields(MachineIdSource::Tpm),
+                },
+                Case {
+                    scenario: "TPM certificate wins even when serials are present",
+                    input: info_for_id(Some(vec![9]), Some(("p1", "b1", "c1"))),
+                    expect: Yields(MachineIdSource::Tpm),
+                },
+                Case {
+                    scenario: "serials select the ProductBoardChassisSerial source",
+                    input: info_for_id(None, Some(("p1", "", ""))),
+                    expect: Yields(MachineIdSource::ProductBoardChassisSerial),
+                },
+            ],
+            |info| {
+                from_hardware_info_with_type(&info, MachineType::Host)
+                    .map(|id| id.source())
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // The requested `MachineType` is carried onto the derived ID unchanged,
+    // independent of which hardware source produced the fingerprint.
+    #[test]
+    fn from_hardware_info_with_type_carries_machine_type() {
+        check_cases(
+            [
+                Case {
+                    scenario: "Host onto a TPM-derived ID",
+                    input: (info_for_id(Some(vec![7]), None), MachineType::Host),
+                    expect: Yields(MachineType::Host),
+                },
+                Case {
+                    scenario: "Dpu onto a TPM-derived ID",
+                    input: (info_for_id(Some(vec![7]), None), MachineType::Dpu),
+                    expect: Yields(MachineType::Dpu),
+                },
+                Case {
+                    scenario: "PredictedHost onto a TPM-derived ID",
+                    input: (info_for_id(Some(vec![7]), None), MachineType::PredictedHost),
+                    expect: Yields(MachineType::PredictedHost),
+                },
+                Case {
+                    scenario: "Host onto a serial-derived ID",
+                    input: (
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                        MachineType::Host,
+                    ),
+                    expect: Yields(MachineType::Host),
+                },
+                Case {
+                    scenario: "Dpu onto a serial-derived ID",
+                    input: (
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                        MachineType::Dpu,
+                    ),
+                    expect: Yields(MachineType::Dpu),
+                },
+                Case {
+                    scenario: "PredictedHost onto a serial-derived ID",
+                    input: (
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                        MachineType::PredictedHost,
+                    ),
+                    expect: Yields(MachineType::PredictedHost),
+                },
+            ],
+            |(info, ty)| {
+                from_hardware_info_with_type(&info, ty)
+                    .map(|id| id.machine_type())
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // The derivation is a deterministic hash: the same fingerprint and type
+    // produce the same ID string, and the string fields differing on type/source
+    // change the rendered prefix.
+    #[test]
+    fn from_hardware_info_with_type_is_deterministic() {
+        check_values(
+            [
+                Check {
+                    scenario: "same TPM cert and type yields the same id string",
+                    input: (
+                        info_for_id(Some(vec![1, 2, 3]), None),
+                        info_for_id(Some(vec![1, 2, 3]), None),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "different TPM certs yield different id strings",
+                    input: (
+                        info_for_id(Some(vec![1, 2, 3]), None),
+                        info_for_id(Some(vec![4, 5, 6]), None),
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "different serials yield different id strings",
+                    input: (
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                        info_for_id(None, Some(("p2", "b1", "c1"))),
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "same serials yield the same id string",
+                    input: (
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                    ),
+                    expect: true,
+                },
+            ],
+            |(left, right)| {
+                let left = from_hardware_info_with_type(&left, MachineType::Host).unwrap();
+                let right = from_hardware_info_with_type(&right, MachineType::Host).unwrap();
+                left.to_string() == right.to_string()
+            },
+        );
+    }
+
+    // The rendered ID string opens with the type+source prefix the constructed
+    // fingerprint and requested type imply (see `MachineType::id_prefix` and
+    // `MachineIdSource::id_char`).
+    #[test]
+    fn from_hardware_info_with_type_renders_expected_prefix() {
+        check_cases(
+            [
+                Case {
+                    scenario: "host + TPM renders fm100ht",
+                    input: (
+                        info_for_id(Some(vec![1]), None),
+                        MachineType::Host,
+                        "fm100ht",
+                    ),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "dpu + TPM renders fm100dt",
+                    input: (
+                        info_for_id(Some(vec![1]), None),
+                        MachineType::Dpu,
+                        "fm100dt",
+                    ),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "predicted host + serial renders fm100ps",
+                    input: (
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                        MachineType::PredictedHost,
+                        "fm100ps",
+                    ),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "host + serial renders fm100hs",
+                    input: (
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                        MachineType::Host,
+                        "fm100hs",
+                    ),
+                    expect: Yields(true),
+                },
+            ],
+            |(info, ty, prefix)| {
+                from_hardware_info_with_type(&info, ty)
+                    .map(|id| id.to_string().starts_with(prefix))
+                    .map_err(drop)
+            },
+        );
+    }
+
+    // The rendered ID string is exactly `MACHINE_ID_LENGTH` characters regardless
+    // of which source or type produced it.
+    #[test]
+    fn from_hardware_info_with_type_renders_fixed_length() {
+        check_values(
+            [
+                Check {
+                    scenario: "TPM-derived host id length",
+                    input: (info_for_id(Some(vec![1, 2]), None), MachineType::Host),
+                    expect: MACHINE_ID_LENGTH,
+                },
+                Check {
+                    scenario: "serial-derived dpu id length",
+                    input: (
+                        info_for_id(None, Some(("p1", "b1", "c1"))),
+                        MachineType::Dpu,
+                    ),
+                    expect: MACHINE_ID_LENGTH,
+                },
+                Check {
+                    scenario: "serial-derived predicted-host id length",
+                    input: (
+                        info_for_id(None, Some(("", "b1", ""))),
+                        MachineType::PredictedHost,
+                    ),
+                    expect: MACHINE_ID_LENGTH,
+                },
+            ],
+            |(info, ty)| {
+                from_hardware_info_with_type(&info, ty)
+                    .unwrap()
+                    .to_string()
+                    .len()
             },
         );
     }

--- a/crates/api-model/src/machine/network.rs
+++ b/crates/api-model/src/machine/network.rs
@@ -199,11 +199,75 @@ impl Default for ManagedHostNetworkConfig {
 #[cfg(test)]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use std::str::FromStr;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use chrono::TimeZone;
+    use config_version::ConfigVersion;
 
     use super::*;
+
+    // A stable MachineId for status observations; `any_observed_version_changed`
+    // never inspects it, so any valid id does.
+    fn machine_id() -> MachineId {
+        MachineId::from_str("fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg").unwrap()
+    }
+
+    // A fixed timestamp so observations built in tests compare deterministically.
+    fn observed_at() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()
+    }
+
+    // ConfigVersion built from its string form so the timestamp is deterministic
+    // (ConfigVersion::new() stamps `now()`, which makes two calls unequal).
+    fn config_version(version_nr: u64) -> ConfigVersion {
+        ConfigVersion::from_str(&format!("V{version_nr}-T1000000")).unwrap()
+    }
+
+    // A MachineNetworkStatusObservation carrying only the fields
+    // `any_observed_version_changed` reads; everything else is a fixed default.
+    fn network_status(
+        network_config_version: Option<ConfigVersion>,
+        instance_network_observation: Option<InstanceNetworkStatusObservation>,
+        extension_service_observation: Option<InstanceExtensionServiceStatusObservation>,
+    ) -> MachineNetworkStatusObservation {
+        MachineNetworkStatusObservation {
+            machine_id: machine_id(),
+            agent_version: None,
+            observed_at: observed_at(),
+            network_config_version,
+            client_certificate_expiry: None,
+            agent_version_superseded_at: None,
+            instance_network_observation,
+            extension_service_observation,
+            fabric_interfaces: Vec::new(),
+        }
+    }
+
+    fn network_observation(
+        config_version: ConfigVersion,
+        instance_config_version: Option<ConfigVersion>,
+    ) -> InstanceNetworkStatusObservation {
+        InstanceNetworkStatusObservation {
+            config_version,
+            instance_config_version,
+            interfaces: Vec::new(),
+            observed_at: observed_at(),
+        }
+    }
+
+    fn extension_observation(
+        config_version: ConfigVersion,
+        instance_config_version: Option<ConfigVersion>,
+    ) -> InstanceExtensionServiceStatusObservation {
+        InstanceExtensionServiceStatusObservation {
+            config_version,
+            instance_config_version,
+            extension_service_statuses: Vec::new(),
+            observed_at: observed_at(),
+        }
+    }
 
     // JSON round-trips: serialize a config to JSON and deserialize it back; the
     // config must survive intact. Covers the IPv4 case (existing Postgres JSON
@@ -321,25 +385,286 @@ mod tests {
 
     // Ensure default ManagedHostNetworkConfig is still all-None/Some(true),
     // etc etc, and unaffected by the type change to IpAddr for v6 support.
+    // Folded from four hand-written asserts into a table that projects each
+    // default field; equality of the whole default config is exercised by the
+    // round-trip test.
     #[test]
     fn test_managed_host_network_config_default() {
-        let config = ManagedHostNetworkConfig::default();
-        assert_eq!(config.loopback_ip, None);
-        assert_eq!(config.secondary_overlay_vtep_ip, None);
-        assert_eq!(config.use_admin_network, Some(true));
-        assert_eq!(config.quarantine_state, None);
+        let default = ManagedHostNetworkConfig::default();
+        check_values(
+            [
+                Check {
+                    scenario: "loopback_ip defaults to None",
+                    input: default.loopback_ip,
+                    expect: None,
+                },
+                Check {
+                    scenario: "secondary_overlay_vtep_ip defaults to None",
+                    input: default.secondary_overlay_vtep_ip,
+                    expect: None,
+                },
+            ],
+            |ip| ip,
+        );
+        check_values(
+            [Check {
+                scenario: "use_admin_network defaults to Some(true)",
+                input: default.use_admin_network,
+                expect: Some(true),
+            }],
+            |flag| flag,
+        );
+        Check {
+            scenario: "quarantine_state defaults to None",
+            input: default.quarantine_state,
+            expect: None,
+        }
+        .check(|qs| qs);
     }
 
     // Verify that IpAddr::to_string() produces the expected format for both
     // address families, since several call sites throughout the codebase
-    // use .to_string() on the loopback_ip value.
+    // use .to_string() on the loopback_ip value. Folded from a pair of
+    // hand-written asserts into a table covering both families plus the
+    // boundary/canonicalization cases (zero, broadcast, all-ones,
+    // loopback, embedded-IPv4) where formatting can surprise.
     #[test]
     fn test_ip_addr_to_string_format() {
-        let v4 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
-        assert_eq!(v4.to_string(), "10.0.0.1");
+        check_values(
+            [
+                Check {
+                    scenario: "ipv4",
+                    input: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
+                    expect: "10.0.0.1".to_string(),
+                },
+                Check {
+                    scenario: "ipv4 unspecified",
+                    input: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+                    expect: "0.0.0.0".to_string(),
+                },
+                Check {
+                    scenario: "ipv4 broadcast",
+                    input: IpAddr::V4(Ipv4Addr::new(255, 255, 255, 255)),
+                    expect: "255.255.255.255".to_string(),
+                },
+                Check {
+                    scenario: "ipv4 loopback",
+                    input: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                    expect: "127.0.0.1".to_string(),
+                },
+                Check {
+                    scenario: "ipv6 compressed",
+                    input: IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
+                    expect: "2001:db8::1".to_string(),
+                },
+                Check {
+                    scenario: "ipv6 unspecified collapses to ::",
+                    input: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
+                    expect: "::".to_string(),
+                },
+                Check {
+                    scenario: "ipv6 loopback collapses to ::1",
+                    input: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+                    expect: "::1".to_string(),
+                },
+                Check {
+                    scenario: "ipv6 full (no run to compress)",
+                    input: IpAddr::V6(Ipv6Addr::new(0xfd00, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x42)),
+                    expect: "fd00:1:2:3:4:5:6:42".to_string(),
+                },
+            ],
+            |ip| ip.to_string(),
+        );
+    }
 
-        let v6 = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
-        assert_eq!(v6.to_string(), "2001:db8::1");
+    // ManagedHostQuarantineState::reason_str() returns the reason or an empty
+    // string when None. ManagedHostQuarantineMode has a single variant today;
+    // its as_str()/mode_str() must render it exactly so the persisted form is
+    // stable.
+    #[test]
+    fn test_quarantine_reason_str() {
+        check_values(
+            [
+                Check {
+                    scenario: "present reason passes through",
+                    input: ManagedHostQuarantineState {
+                        reason: Some("flooding the fabric".to_string()),
+                        mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                    },
+                    expect: "flooding the fabric".to_string(),
+                },
+                Check {
+                    scenario: "empty reason stays empty",
+                    input: ManagedHostQuarantineState {
+                        reason: Some(String::new()),
+                        mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                    },
+                    expect: String::new(),
+                },
+                Check {
+                    scenario: "missing reason yields empty string",
+                    input: ManagedHostQuarantineState {
+                        reason: None,
+                        mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                    },
+                    expect: String::new(),
+                },
+            ],
+            |state| state.reason_str().to_string(),
+        );
+    }
+
+    #[test]
+    fn test_quarantine_mode_str() {
+        check_values(
+            [Check {
+                scenario: "block-all-traffic renders its name",
+                input: ManagedHostQuarantineMode::BlockAllTraffic,
+                expect: "BlockAllTraffic".to_string(),
+            }],
+            |mode| {
+                ManagedHostQuarantineState { reason: None, mode }
+                    .mode_str()
+                    .to_string()
+            },
+        );
+    }
+
+    // any_observed_version_changed compares the network config version and then
+    // the two nested observations (instance-network and extension-service),
+    // each via a None/Some pairing that delegates to the sub-observation's own
+    // comparison. Enumerate every arm: matching versions, differing versions,
+    // each None/Some transition, and a deeper change inside each Some/Some pair.
+    #[test]
+    fn test_any_observed_version_changed() {
+        let v1 = config_version(1);
+        let v2 = config_version(2);
+
+        check_values(
+            [
+                Check {
+                    scenario: "identical observations -> unchanged",
+                    input: (
+                        network_status(Some(v1), None, None),
+                        network_status(Some(v1), None, None),
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "both network config versions None -> unchanged",
+                    input: (
+                        network_status(None, None, None),
+                        network_status(None, None, None),
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "network config version differs -> changed",
+                    input: (
+                        network_status(Some(v1), None, None),
+                        network_status(Some(v2), None, None),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "network config version None vs Some -> changed",
+                    input: (
+                        network_status(None, None, None),
+                        network_status(Some(v1), None, None),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "network config version Some vs None -> changed",
+                    input: (
+                        network_status(Some(v1), None, None),
+                        network_status(None, None, None),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "instance observation None vs Some -> changed",
+                    input: (
+                        network_status(Some(v1), None, None),
+                        network_status(Some(v1), Some(network_observation(v1, None)), None),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "instance observation Some vs None -> changed",
+                    input: (
+                        network_status(Some(v1), Some(network_observation(v1, None)), None),
+                        network_status(Some(v1), None, None),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "instance observation Some/Some identical -> unchanged",
+                    input: (
+                        network_status(Some(v1), Some(network_observation(v1, Some(v1))), None),
+                        network_status(Some(v1), Some(network_observation(v1, Some(v1))), None),
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "instance observation inner config version differs -> changed",
+                    input: (
+                        network_status(Some(v1), Some(network_observation(v1, None)), None),
+                        network_status(Some(v1), Some(network_observation(v2, None)), None),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "instance observation inner instance-config version differs -> changed",
+                    input: (
+                        network_status(Some(v1), Some(network_observation(v1, Some(v1))), None),
+                        network_status(Some(v1), Some(network_observation(v1, Some(v2))), None),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "extension observation None vs Some -> changed",
+                    input: (
+                        network_status(Some(v1), None, None),
+                        network_status(Some(v1), None, Some(extension_observation(v1, None))),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "extension observation Some vs None -> changed",
+                    input: (
+                        network_status(Some(v1), None, Some(extension_observation(v1, None))),
+                        network_status(Some(v1), None, None),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "extension observation Some/Some identical -> unchanged",
+                    input: (
+                        network_status(Some(v1), None, Some(extension_observation(v1, Some(v1)))),
+                        network_status(Some(v1), None, Some(extension_observation(v1, Some(v1)))),
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "extension observation inner config version differs -> changed",
+                    input: (
+                        network_status(Some(v1), None, Some(extension_observation(v1, None))),
+                        network_status(Some(v1), None, Some(extension_observation(v2, None))),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "extension observation inner instance-config version differs -> changed",
+                    input: (
+                        network_status(Some(v1), None, Some(extension_observation(v1, Some(v1)))),
+                        network_status(Some(v1), None, Some(extension_observation(v1, Some(v2)))),
+                    ),
+                    expect: true,
+                },
+            ],
+            |(a, b)| a.any_observed_version_changed(&b),
+        );
     }
 
     // Parse pool strings as IpAddr (resource pools store values as strings and
@@ -360,8 +685,175 @@ mod tests {
                     input: "2001:db8::1",
                     expect: Yields(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))),
                 },
+                Case {
+                    scenario: "ipv4 unspecified",
+                    input: "0.0.0.0",
+                    expect: Yields(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))),
+                },
+                Case {
+                    scenario: "ipv4 broadcast",
+                    input: "255.255.255.255",
+                    expect: Yields(IpAddr::V4(Ipv4Addr::new(255, 255, 255, 255))),
+                },
+                Case {
+                    scenario: "ipv6 unspecified",
+                    input: "::",
+                    expect: Yields(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0))),
+                },
+                Case {
+                    scenario: "ipv6 loopback",
+                    input: "::1",
+                    expect: Yields(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))),
+                },
+                Case {
+                    scenario: "empty string is rejected",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-address text is rejected",
+                    input: "not-an-ip",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ipv4 octet out of range is rejected",
+                    input: "256.0.0.1",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ipv4 with too few octets is rejected",
+                    input: "10.0.0",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ipv4 with trailing whitespace is rejected",
+                    input: "10.0.0.1 ",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "ipv6 with double :: is rejected",
+                    input: "2001::db8::1",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "cidr suffix is not an address",
+                    input: "10.0.0.0/24",
+                    expect: Fails,
+                },
             ],
-            |s| s.parse::<IpAddr>(),
+            |s| s.parse::<IpAddr>().map_err(drop),
+        );
+    }
+
+    // Deserialize raw JSON whose shape is malformed or whose IP strings are
+    // invalid; serde_json::Error is not PartialEq, so rejected rows use `Fails`.
+    // Also covers a populated quarantine_state, which the earlier deserialize
+    // table left null.
+    #[test]
+    fn test_managed_host_network_config_deserialize_errors() {
+        check_cases(
+            [
+                Case {
+                    scenario: "well-formed with quarantine state",
+                    input: r#"{
+                        "loopback_ip": "10.0.0.1",
+                        "secondary_overlay_vtep_ip": null,
+                        "use_admin_network": false,
+                        "quarantine_state": {
+                            "reason": "noisy",
+                            "mode": "BlockAllTraffic"
+                        }
+                    }"#,
+                    expect: Yields(ManagedHostNetworkConfig {
+                        loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                        secondary_overlay_vtep_ip: None,
+                        use_admin_network: Some(false),
+                        quarantine_state: Some(ManagedHostQuarantineState {
+                            reason: Some("noisy".to_string()),
+                            mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                        }),
+                    }),
+                },
+                Case {
+                    scenario: "empty object defaults all optional fields",
+                    input: "{}",
+                    expect: Yields(ManagedHostNetworkConfig {
+                        loopback_ip: None,
+                        secondary_overlay_vtep_ip: None,
+                        use_admin_network: None,
+                        quarantine_state: None,
+                    }),
+                },
+                Case {
+                    scenario: "invalid loopback ip string is rejected",
+                    input: r#"{"loopback_ip": "not-an-ip"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown quarantine mode is rejected",
+                    input: r#"{"quarantine_state": {"mode": "Nope"}}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wrong type for use_admin_network is rejected",
+                    input: r#"{"use_admin_network": "true"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "truncated json is rejected",
+                    input: r#"{"loopback_ip": "10.0.0.1""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-object json is rejected",
+                    input: "[]",
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<ManagedHostNetworkConfig>(json).map_err(drop),
+        );
+    }
+
+    // The default config round-trips through JSON unchanged, and the
+    // quarantine-state variant survives a round-trip too. Folds the prior
+    // single-default assertion into the round-trip table that already exists
+    // for the IP cases. serde_json::Error is not PartialEq, so failing rows
+    // would use `Fails`.
+    #[test]
+    fn test_managed_host_network_config_default_and_quarantine_roundtrip() {
+        check_cases(
+            [
+                Case {
+                    scenario: "default round-trips",
+                    input: ManagedHostNetworkConfig::default(),
+                    expect: Yields(ManagedHostNetworkConfig::default()),
+                },
+                Case {
+                    scenario: "quarantine state round-trips",
+                    input: ManagedHostNetworkConfig {
+                        loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                        secondary_overlay_vtep_ip: None,
+                        use_admin_network: Some(true),
+                        quarantine_state: Some(ManagedHostQuarantineState {
+                            reason: Some("flooded".to_string()),
+                            mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                        }),
+                    },
+                    expect: Yields(ManagedHostNetworkConfig {
+                        loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                        secondary_overlay_vtep_ip: None,
+                        use_admin_network: Some(true),
+                        quarantine_state: Some(ManagedHostQuarantineState {
+                            reason: Some("flooded".to_string()),
+                            mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                        }),
+                    }),
+                },
+            ],
+            |config| {
+                let json = serde_json::to_string(&config).map_err(drop)?;
+                serde_json::from_str::<ManagedHostNetworkConfig>(&json).map_err(drop)
+            },
         );
     }
 }

--- a/crates/api-model/src/machine/upgrade_policy.rs
+++ b/crates/api-model/src/machine/upgrade_policy.rs
@@ -361,6 +361,61 @@ fn test_parse_version() {
                 }),
             },
             Case {
+                scenario: "date tag with rc and hotfix (3 parts, non-numeric second)",
+                input: "v2024.05.02-rc3-0",
+                expect: Yields(BuildVersion {
+                    version: "2024.05.02",
+                    rc: "rc3",
+                    hotfix: 0,
+                    commits: 0,
+                    git_hash: "",
+                }),
+            },
+            Case {
+                scenario: "date tag with rc, hotfix, commits and hash (5 parts)",
+                input: "v2024.05.02-rc4-0-27-gc3ce4d5d",
+                expect: Yields(BuildVersion {
+                    version: "2024.05.02",
+                    rc: "rc4",
+                    hotfix: 0,
+                    commits: 27,
+                    git_hash: "gc3ce4d5d",
+                }),
+            },
+            Case {
+                scenario: "bare semver, two parts only is treated as rc",
+                input: "v2023.09-rc1",
+                expect: Yields(BuildVersion {
+                    version: "2023.09",
+                    rc: "rc1",
+                    hotfix: 0,
+                    commits: 0,
+                    git_hash: "",
+                }),
+            },
+            Case {
+                scenario: "semver with rc, hotfix, commits and hash (5 parts)",
+                input: "v0.0.4-rc4-0-27-gc3ce4d5d",
+                expect: Yields(BuildVersion {
+                    version: "0.0.4",
+                    rc: "rc4",
+                    hotfix: 0,
+                    commits: 27,
+                    git_hash: "gc3ce4d5d",
+                }),
+            },
+            Case {
+                scenario: "nonzero hotfix parses",
+                input: "v2024.05.02-rc3-2",
+                expect: Yields(BuildVersion {
+                    version: "2024.05.02",
+                    rc: "rc3",
+                    hotfix: 2,
+                    commits: 0,
+                    git_hash: "",
+                }),
+            },
+            Case {
                 scenario: "too many dash-separated parts",
                 input: "v2023.08-rc1-0-3-g123eff-x",
                 expect: Fails,
@@ -368,6 +423,31 @@ fn test_parse_version() {
             Case {
                 scenario: "no version number after the 'v'",
                 input: "v-rc1",
+                expect: Fails,
+            },
+            Case {
+                scenario: "empty string",
+                input: "",
+                expect: Fails,
+            },
+            Case {
+                scenario: "missing the leading 'v'",
+                input: "2023.08",
+                expect: Fails,
+            },
+            Case {
+                scenario: "just the leading 'v'",
+                input: "v",
+                expect: Fails,
+            },
+            Case {
+                scenario: "first part does not start with a digit",
+                input: "vfoo.bar",
+                expect: Fails,
+            },
+            Case {
+                scenario: "leading 'v' followed by a dash",
+                input: "v-",
                 expect: Fails,
             },
         ],
@@ -380,7 +460,449 @@ fn test_parse_version() {
 
 #[cfg(test)]
 mod tests {
-    use super::BuildVersion;
+    use std::cmp::Ordering;
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
+    use super::{AgentUpgradePolicy, BuildVersion};
+    use crate::firmware::AgentUpgradePolicyChoice;
+
+    #[test]
+    fn agent_upgrade_policy_display() {
+        check_values(
+            [
+                Check {
+                    scenario: "off",
+                    input: AgentUpgradePolicy::Off,
+                    expect: "Off".to_string(),
+                },
+                Check {
+                    scenario: "up-only",
+                    input: AgentUpgradePolicy::UpOnly,
+                    expect: "UpOnly".to_string(),
+                },
+                Check {
+                    scenario: "up-down",
+                    input: AgentUpgradePolicy::UpDown,
+                    expect: "UpDown".to_string(),
+                },
+            ],
+            |p| p.to_string(),
+        );
+    }
+
+    #[test]
+    fn agent_upgrade_policy_from_str() {
+        check_values(
+            [
+                Check {
+                    scenario: "canonical Off",
+                    input: "Off",
+                    expect: AgentUpgradePolicy::Off,
+                },
+                Check {
+                    scenario: "lowercase off",
+                    input: "off",
+                    expect: AgentUpgradePolicy::Off,
+                },
+                Check {
+                    scenario: "canonical UpOnly",
+                    input: "UpOnly",
+                    expect: AgentUpgradePolicy::UpOnly,
+                },
+                Check {
+                    scenario: "lowercase uponly",
+                    input: "uponly",
+                    expect: AgentUpgradePolicy::UpOnly,
+                },
+                Check {
+                    scenario: "snake_case up_only",
+                    input: "up_only",
+                    expect: AgentUpgradePolicy::UpOnly,
+                },
+                Check {
+                    scenario: "canonical UpDown",
+                    input: "UpDown",
+                    expect: AgentUpgradePolicy::UpDown,
+                },
+                Check {
+                    scenario: "lowercase updown",
+                    input: "updown",
+                    expect: AgentUpgradePolicy::UpDown,
+                },
+                Check {
+                    scenario: "snake_case up_down",
+                    input: "up_down",
+                    expect: AgentUpgradePolicy::UpDown,
+                },
+                Check {
+                    scenario: "unknown string falls back to Off",
+                    input: "nonsense",
+                    expect: AgentUpgradePolicy::Off,
+                },
+                Check {
+                    scenario: "empty string falls back to Off",
+                    input: "",
+                    expect: AgentUpgradePolicy::Off,
+                },
+                Check {
+                    scenario: "wrong casing falls back to Off",
+                    input: "OFF",
+                    expect: AgentUpgradePolicy::Off,
+                },
+            ],
+            AgentUpgradePolicy::from,
+        );
+    }
+
+    #[test]
+    fn agent_upgrade_policy_from_choice() {
+        check_values(
+            [
+                Check {
+                    scenario: "off",
+                    input: AgentUpgradePolicyChoice::Off,
+                    expect: AgentUpgradePolicy::Off,
+                },
+                Check {
+                    scenario: "up-only",
+                    input: AgentUpgradePolicyChoice::UpOnly,
+                    expect: AgentUpgradePolicy::UpOnly,
+                },
+                Check {
+                    scenario: "up-down",
+                    input: AgentUpgradePolicyChoice::UpDown,
+                    expect: AgentUpgradePolicy::UpDown,
+                },
+            ],
+            AgentUpgradePolicy::from,
+        );
+    }
+
+    #[test]
+    fn should_upgrade_decides_per_policy() {
+        struct Inputs {
+            policy: AgentUpgradePolicy,
+            agent: &'static str,
+            carbide: &'static str,
+        }
+        check_values(
+            [
+                // Off never upgrades, regardless of versions.
+                Check {
+                    scenario: "off, agent older",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::Off,
+                        agent: "v2023.08",
+                        carbide: "v2023.09",
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "off, agent newer",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::Off,
+                        agent: "v2023.09",
+                        carbide: "v2023.08",
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "off, invalid agent version",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::Off,
+                        agent: "garbage",
+                        carbide: "v2023.08",
+                    },
+                    expect: false,
+                },
+                // UpOnly upgrades only when the agent is strictly older.
+                Check {
+                    scenario: "up-only, agent older",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpOnly,
+                        agent: "v2023.08",
+                        carbide: "v2023.09",
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "up-only, agent equal",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpOnly,
+                        agent: "v2023.09",
+                        carbide: "v2023.09",
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "up-only, agent newer (no downgrade)",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpOnly,
+                        agent: "v2023.09",
+                        carbide: "v2023.08",
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "up-only, agent older by commit count",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpOnly,
+                        agent: "v2023.08-14-gbc549a66",
+                        carbide: "v2023.08-92-g1b48e8b6",
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "up-only, semver agent newer than date carbide (no upgrade)",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpOnly,
+                        agent: "v0.0.1",
+                        carbide: "v2024.05.10-rc1-3",
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "up-only, date agent older than semver carbide",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpOnly,
+                        agent: "v2024.05.10-rc1-3",
+                        carbide: "v0.0.1",
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "up-only, invalid agent version forces upgrade",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpOnly,
+                        agent: "not-a-version",
+                        carbide: "v2023.09",
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "up-only, invalid carbide version waits (no upgrade)",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpOnly,
+                        agent: "v2023.08",
+                        carbide: "not-a-version",
+                    },
+                    expect: false,
+                },
+                // UpDown upgrades on any string difference.
+                Check {
+                    scenario: "up-down, identical versions",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpDown,
+                        agent: "v2023.09",
+                        carbide: "v2023.09",
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "up-down, agent older",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpDown,
+                        agent: "v2023.08",
+                        carbide: "v2023.09",
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "up-down, agent newer (downgrade)",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpDown,
+                        agent: "v2023.09",
+                        carbide: "v2023.08",
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "up-down, differing only by hash",
+                    input: Inputs {
+                        policy: AgentUpgradePolicy::UpDown,
+                        agent: "v2023.08-92-g1b48e8b6",
+                        carbide: "v2023.08-92-gdeadbeef",
+                    },
+                    expect: true,
+                },
+            ],
+            |Inputs {
+                 policy,
+                 agent,
+                 carbide,
+             }| policy.should_upgrade(agent, carbide),
+        );
+    }
+
+    #[test]
+    fn build_version_display_round_trips() {
+        check_cases(
+            [
+                Case {
+                    scenario: "bare date tag",
+                    input: "v2023.08",
+                    expect: Yields("v2023.08".to_string()),
+                },
+                Case {
+                    scenario: "bare semver tag",
+                    input: "v1.2.3",
+                    expect: Yields("v1.2.3".to_string()),
+                },
+                Case {
+                    scenario: "date tag with commits and hash",
+                    input: "v2023.08-92-g1b48e8b6",
+                    expect: Yields("v2023.08-92-g1b48e8b6".to_string()),
+                },
+                Case {
+                    scenario: "rc and hotfix both render",
+                    input: "v2024.05.02-rc3-0",
+                    expect: Yields("v2024.05.02-rc3-0".to_string()),
+                },
+                Case {
+                    scenario: "full version with rc, hotfix, commits and hash",
+                    input: "v2024.05.02-rc4-0-27-gc3ce4d5d",
+                    expect: Yields("v2024.05.02-rc4-0-27-gc3ce4d5d".to_string()),
+                },
+                Case {
+                    scenario: "two-part input normalizes hotfix to 0",
+                    input: "v2023.09-rc1",
+                    expect: Yields("v2023.09-rc1-0".to_string()),
+                },
+            ],
+            |s| {
+                BuildVersion::try_from(s)
+                    .map(|bv| bv.to_string())
+                    .map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn build_version_ordering() {
+        struct Pair {
+            left: &'static str,
+            right: &'static str,
+        }
+        check_values(
+            [
+                Check {
+                    scenario: "older date less than newer date",
+                    input: Pair {
+                        left: "v2023.08",
+                        right: "v2023.09",
+                    },
+                    expect: Ordering::Less,
+                },
+                Check {
+                    scenario: "equal date tags",
+                    input: Pair {
+                        left: "v2023.08",
+                        right: "v2023.08",
+                    },
+                    expect: Ordering::Equal,
+                },
+                Check {
+                    scenario: "newer date greater than older date",
+                    input: Pair {
+                        left: "v2023.09",
+                        right: "v2023.08",
+                    },
+                    expect: Ordering::Greater,
+                },
+                Check {
+                    scenario: "more commits is greater",
+                    input: Pair {
+                        left: "v2023.08-92-g1b48e8b6",
+                        right: "v2023.08-14-gbc549a66",
+                    },
+                    expect: Ordering::Greater,
+                },
+                Check {
+                    scenario: "date is always less than semver",
+                    input: Pair {
+                        left: "v2024.05.10-rc1-3",
+                        right: "v0.0.1",
+                    },
+                    expect: Ordering::Less,
+                },
+                Check {
+                    scenario: "semver is always greater than date",
+                    input: Pair {
+                        left: "v0.0.1",
+                        right: "v2024.05.10-rc1-3",
+                    },
+                    expect: Ordering::Greater,
+                },
+                Check {
+                    scenario: "lower semver less than higher semver",
+                    input: Pair {
+                        left: "v0.0.1",
+                        right: "v0.0.4-rc4-0-g2a3c98cac",
+                    },
+                    expect: Ordering::Less,
+                },
+                Check {
+                    scenario: "semver major dominates",
+                    input: Pair {
+                        left: "v0.0.4-rc4-0-g2a3c98cac",
+                        right: "v1.0.0",
+                    },
+                    expect: Ordering::Less,
+                },
+                Check {
+                    scenario: "equal semver tags",
+                    input: Pair {
+                        left: "v1.2.3",
+                        right: "v1.2.3",
+                    },
+                    expect: Ordering::Equal,
+                },
+                Check {
+                    scenario: "semver patch difference",
+                    input: Pair {
+                        left: "v0.0.4",
+                        right: "v0.0.5",
+                    },
+                    expect: Ordering::Less,
+                },
+            ],
+            |Pair { left, right }| {
+                let l = BuildVersion::try_from(left).unwrap();
+                let r = BuildVersion::try_from(right).unwrap();
+                l.cmp(&r)
+            },
+        );
+    }
+
+    #[test]
+    fn build_version_partial_cmp_matches_cmp() {
+        check_values(
+            [
+                Check {
+                    scenario: "less",
+                    input: ("v0.0.1", "v1.0.0"),
+                    expect: Some(Ordering::Less),
+                },
+                Check {
+                    scenario: "greater",
+                    input: ("v1.0.0", "v0.0.1"),
+                    expect: Some(Ordering::Greater),
+                },
+                Check {
+                    scenario: "equal",
+                    input: ("v1.0.0", "v1.0.0"),
+                    expect: Some(Ordering::Equal),
+                },
+            ],
+            |(l, r)| {
+                BuildVersion::try_from(l)
+                    .unwrap()
+                    .partial_cmp(&BuildVersion::try_from(r).unwrap())
+            },
+        );
+    }
 
     #[test]
     fn test_compare_versions() -> eyre::Result<()> {
@@ -442,23 +964,6 @@ mod tests {
                 panic!("Pos {i} does not match. Got {got} expected {expect}.");
             }
         }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_semver_comparison() -> eyre::Result<()> {
-        let v0_0_1 = BuildVersion::try_from("v0.0.1")?;
-        let v0_0_4 = BuildVersion::try_from("v0.0.4-rc4-0-g2a3c98cac")?;
-        let v1_0_0 = BuildVersion::try_from("v1.0.0")?;
-        let v_date = BuildVersion::try_from("v2024.05.10-rc1-3")?;
-
-        // Semver ordering
-        assert!(v0_0_1 < v0_0_4);
-        assert!(v0_0_4 < v1_0_0);
-
-        // Semver is always newer than date-based
-        assert!(v_date < v0_0_1);
 
         Ok(())
     }

--- a/crates/api-model/src/machine_validation.rs
+++ b/crates/api-model/src/machine_validation.rs
@@ -269,6 +269,9 @@ impl<'r> FromRow<'r, PgRow> for MachineValidationResult {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
     #[test]
@@ -280,5 +283,229 @@ mod tests {
         assert!(obj["test_id"].is_null());
         assert!(obj["is_enabled"].is_null());
         assert_eq!(obj["supported_platforms"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn state_from_str_parses_every_variant_and_rejects_the_rest() {
+        check_cases(
+            [
+                Case {
+                    scenario: "Started",
+                    input: "Started",
+                    expect: Yields(MachineValidationState::Started),
+                },
+                Case {
+                    scenario: "InProgress",
+                    input: "InProgress",
+                    expect: Yields(MachineValidationState::InProgress),
+                },
+                Case {
+                    scenario: "Success",
+                    input: "Success",
+                    expect: Yields(MachineValidationState::Success),
+                },
+                Case {
+                    scenario: "Skipped",
+                    input: "Skipped",
+                    expect: Yields(MachineValidationState::Skipped),
+                },
+                Case {
+                    scenario: "Failed",
+                    input: "Failed",
+                    expect: Yields(MachineValidationState::Failed),
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown variant",
+                    input: "Pending",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "lowercase is not accepted",
+                    input: "started",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "uppercase is not accepted",
+                    input: "SUCCESS",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "leading whitespace is not trimmed",
+                    input: " Started",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "trailing whitespace is not trimmed",
+                    input: "Failed ",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "numeric input",
+                    input: "0",
+                    expect: Fails,
+                },
+            ],
+            |s| MachineValidationState::from_str(s).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn state_display_renders_the_variant_name() {
+        check_values(
+            [
+                Check {
+                    scenario: "Started",
+                    input: MachineValidationState::Started,
+                    expect: "Started".to_string(),
+                },
+                Check {
+                    scenario: "InProgress",
+                    input: MachineValidationState::InProgress,
+                    expect: "InProgress".to_string(),
+                },
+                Check {
+                    scenario: "Success",
+                    input: MachineValidationState::Success,
+                    expect: "Success".to_string(),
+                },
+                Check {
+                    scenario: "Skipped",
+                    input: MachineValidationState::Skipped,
+                    expect: "Skipped".to_string(),
+                },
+                Check {
+                    scenario: "Failed",
+                    input: MachineValidationState::Failed,
+                    expect: "Failed".to_string(),
+                },
+            ],
+            |state| state.to_string(),
+        );
+    }
+
+    #[test]
+    fn state_display_round_trips_through_from_str() {
+        check_cases(
+            [
+                Case {
+                    scenario: "Started",
+                    input: MachineValidationState::Started,
+                    expect: Yields(MachineValidationState::Started),
+                },
+                Case {
+                    scenario: "InProgress",
+                    input: MachineValidationState::InProgress,
+                    expect: Yields(MachineValidationState::InProgress),
+                },
+                Case {
+                    scenario: "Success",
+                    input: MachineValidationState::Success,
+                    expect: Yields(MachineValidationState::Success),
+                },
+                Case {
+                    scenario: "Skipped",
+                    input: MachineValidationState::Skipped,
+                    expect: Yields(MachineValidationState::Skipped),
+                },
+                Case {
+                    scenario: "Failed",
+                    input: MachineValidationState::Failed,
+                    expect: Yields(MachineValidationState::Failed),
+                },
+            ],
+            |state| MachineValidationState::from_str(&state.to_string()).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn state_default_is_started() {
+        Check {
+            scenario: "default state",
+            input: (),
+            expect: MachineValidationState::Started,
+        }
+        .check(|()| MachineValidationState::default());
+    }
+
+    #[test]
+    fn status_default_is_started_with_zero_counts() {
+        check_values(
+            [
+                Check {
+                    scenario: "default state is Started",
+                    input: MachineValidationStatus::default(),
+                    expect: MachineValidationStatus {
+                        state: MachineValidationState::Started,
+                        total: 0,
+                        completed: 0,
+                    },
+                },
+                Check {
+                    scenario: "matches an explicitly built default",
+                    input: MachineValidationStatus {
+                        state: MachineValidationState::Started,
+                        total: 0,
+                        completed: 0,
+                    },
+                    expect: MachineValidationStatus::default(),
+                },
+            ],
+            |status| status,
+        );
+    }
+
+    #[test]
+    fn status_equality_distinguishes_each_field() {
+        let base = MachineValidationStatus {
+            state: MachineValidationState::InProgress,
+            total: 10,
+            completed: 4,
+        };
+        check_values(
+            [
+                Check {
+                    scenario: "identical is equal",
+                    input: MachineValidationStatus {
+                        state: MachineValidationState::InProgress,
+                        total: 10,
+                        completed: 4,
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "differing state is unequal",
+                    input: MachineValidationStatus {
+                        state: MachineValidationState::Success,
+                        total: 10,
+                        completed: 4,
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "differing total is unequal",
+                    input: MachineValidationStatus {
+                        state: MachineValidationState::InProgress,
+                        total: 11,
+                        completed: 4,
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "differing completed is unequal",
+                    input: MachineValidationStatus {
+                        state: MachineValidationState::InProgress,
+                        total: 10,
+                        completed: 5,
+                    },
+                    expect: false,
+                },
+            ],
+            |status| status == base,
+        );
     }
 }

--- a/crates/api-model/src/metadata.rs
+++ b/crates/api-model/src/metadata.rs
@@ -120,133 +120,297 @@ pub struct LabelFilter {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
-    #[test]
-    fn fail_invalid_metadata() {
-        // Good metadata
-        let metadata = Metadata {
-            name: "nice_name".to_string(),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([("key1".to_string(), "val1".to_string())]),
-        };
-
-        assert!(metadata.validate(true).is_ok());
-
-        // And now lots of bad metadata
-
-        // name too short
-        let metadata = Metadata {
-            name: "x".to_string(),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([("key1".to_string(), "val1".to_string())]),
-        };
-
-        assert!(matches!(
-            metadata.validate(true),
-            Err(ConfigValidationError::InvalidValue(_))
-        ));
-
-        // name too short without requiring min length is ok
-        let metadata = Metadata {
-            name: "".to_string(),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([("key1".to_string(), "val1".to_string())]),
-        };
-
-        assert!(metadata.validate(false).is_ok());
-
-        // name too long
-        let metadata = Metadata {
-            name: [0; 257].iter().fold(String::new(), |name, _| name + "a"),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([("key1".to_string(), "val1".to_string())]),
-        };
-
-        assert!(matches!(
-            metadata.validate(true),
-            Err(ConfigValidationError::InvalidValue(_))
-        ));
-
-        // non-ascii name
-        let metadata = Metadata {
-            name: "것봐".to_string(),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([("key1".to_string(), "val1".to_string())]),
-        };
-
-        assert!(matches!(
-            metadata.validate(true),
-            Err(ConfigValidationError::InvalidValue(_))
-        ));
-
-        // Empty key
-        let metadata = Metadata {
-            name: "nice name".to_string(),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([("".to_string(), "val1".to_string())]),
-        };
-
-        assert!(matches!(
-            metadata.validate(true),
-            Err(ConfigValidationError::InvalidValue(_))
-        ));
-
-        // Non-ascii key
-        let metadata = Metadata {
-            name: "nice name".to_string(),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([("것봐".to_string(), "val1".to_string())]),
-        };
-
-        assert!(matches!(
-            metadata.validate(true),
-            Err(ConfigValidationError::InvalidValue(_))
-        ));
-
-        // Key too big
-        let metadata = Metadata {
-            name: "nice name".to_string(),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([(
-                [0; 256].iter().fold(String::new(), |name, _| name + "a"),
-                "val1".to_string(),
-            )]),
-        };
-
-        assert!(matches!(
-            metadata.validate(true),
-            Err(ConfigValidationError::InvalidValue(_))
-        ));
-
-        // Value too big
-        let metadata = Metadata {
-            name: "nice name".to_string(),
-            description: "anything is fine".to_string(),
-            labels: HashMap::from([(
-                "key1".to_string(),
-                [0; 256].iter().fold(String::new(), |name, _| name + "a"),
-            )]),
-        };
-
-        assert!(matches!(
-            metadata.validate(true),
-            Err(ConfigValidationError::InvalidValue(_))
-        ));
-
-        // Too many labels (17 > 16)
-        let metadata = Metadata {
-            name: "nice name".to_string(),
-            description: "anything is fine".to_string(),
-            labels: "abcdefghijklmnopq"
-                .chars()
-                .map(|c| (c.to_string(), "x".to_string()))
+    /// Build a `Metadata` from parts, with sensible defaults so each row only
+    /// names the field it is exercising.
+    fn meta(name: &str, description: &str, labels: &[(&str, &str)]) -> Metadata {
+        Metadata {
+            name: name.to_string(),
+            description: description.to_string(),
+            labels: labels
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
-        };
+        }
+    }
 
-        assert!(matches!(
-            metadata.validate(true),
-            Err(ConfigValidationError::InvalidValue(_))
-        ));
+    /// A string of `n` repeated `'a'` characters.
+    fn long(n: usize) -> String {
+        "a".repeat(n)
+    }
+
+    #[test]
+    fn validate_with_min_length_required() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid name, description, and label",
+                    input: meta("nice_name", "anything is fine", &[("key1", "val1")]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "no labels is fine",
+                    input: meta("nice_name", "", &[]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "name at min length (2)",
+                    input: meta("ab", "", &[]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "name one below min length (1)",
+                    input: meta("x", "", &[]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty name rejected when min length required",
+                    input: meta("", "", &[]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "name at max length (256)",
+                    input: Metadata {
+                        name: long(256),
+                        ..Metadata::default()
+                    },
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "name one over max length (257)",
+                    input: Metadata {
+                        name: long(257),
+                        ..Metadata::default()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-ascii name rejected",
+                    input: meta("것봐", "", &[]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "description at max length (1024)",
+                    input: Metadata {
+                        name: "nice name".to_string(),
+                        description: long(1024),
+                        ..Metadata::default()
+                    },
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "description one over max length (1025)",
+                    input: Metadata {
+                        name: "nice name".to_string(),
+                        description: long(1025),
+                        ..Metadata::default()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty label key rejected",
+                    input: meta("nice name", "", &[("", "val1")]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-ascii label key rejected",
+                    input: meta("nice name", "", &[("것봐", "val1")]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "label key at max length (255)",
+                    input: Metadata {
+                        name: "nice name".to_string(),
+                        labels: HashMap::from([(long(255), "val1".to_string())]),
+                        ..Metadata::default()
+                    },
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "label key one over max length (256)",
+                    input: Metadata {
+                        name: "nice name".to_string(),
+                        labels: HashMap::from([(long(256), "val1".to_string())]),
+                        ..Metadata::default()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "label value at max length (255)",
+                    input: Metadata {
+                        name: "nice name".to_string(),
+                        labels: HashMap::from([("key1".to_string(), long(255))]),
+                        ..Metadata::default()
+                    },
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "label value one over max length (256)",
+                    input: Metadata {
+                        name: "nice name".to_string(),
+                        labels: HashMap::from([("key1".to_string(), long(256))]),
+                        ..Metadata::default()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty label value is fine",
+                    input: meta("nice name", "", &[("key1", "")]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "labels at max count (16)",
+                    input: Metadata {
+                        name: "nice name".to_string(),
+                        labels: "abcdefghijklmnop"
+                            .chars()
+                            .map(|c| (c.to_string(), "x".to_string()))
+                            .collect(),
+                        ..Metadata::default()
+                    },
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "labels one over max count (17)",
+                    input: Metadata {
+                        name: "nice name".to_string(),
+                        labels: "abcdefghijklmnopq"
+                            .chars()
+                            .map(|c| (c.to_string(), "x".to_string()))
+                            .collect(),
+                        ..Metadata::default()
+                    },
+                    expect: Fails,
+                },
+            ],
+            |m| m.validate(true).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn validate_without_min_length_required() {
+        check_cases(
+            [
+                Case {
+                    scenario: "empty name allowed when min length not required",
+                    input: meta("", "anything is fine", &[("key1", "val1")]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "single-char name allowed when min length not required",
+                    input: meta("x", "", &[]),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "name still capped at max length (257 rejected)",
+                    input: Metadata {
+                        name: long(257),
+                        ..Metadata::default()
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-ascii name still rejected",
+                    input: meta("것봐", "", &[]),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "label checks still apply (empty key rejected)",
+                    input: meta("", "", &[("", "val1")]),
+                    expect: Fails,
+                },
+            ],
+            |m| m.validate(false).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn validate_error_message_names_the_offending_field() {
+        check_cases(
+            [
+                Case {
+                    scenario: "short-name error mentions length bounds",
+                    input: (meta("x", "", &[]), &["between", "256"][..]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "non-ascii name error mentions ASCII",
+                    input: (meta("것봐", "", &[]), &["ASCII"][..]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "long-description error mentions Description",
+                    input: (
+                        Metadata {
+                            name: "nice name".to_string(),
+                            description: long(1025),
+                            ..Metadata::default()
+                        },
+                        &["Description", "1024"][..],
+                    ),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "empty-key error mentions empty",
+                    input: (meta("nice name", "", &[("", "v")]), &["empty"][..]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "too-many-labels error mentions the count",
+                    input: (
+                        Metadata {
+                            name: "nice name".to_string(),
+                            labels: "abcdefghijklmnopq"
+                                .chars()
+                                .map(|c| (c.to_string(), "x".to_string()))
+                                .collect(),
+                            ..Metadata::default()
+                        },
+                        &["more than 16", "17"][..],
+                    ),
+                    expect: Yields(true),
+                },
+            ],
+            |(m, tokens)| {
+                let message = m.validate(true).unwrap_err().to_string();
+                Ok::<_, ()>(tokens.iter().all(|t| message.contains(t)))
+            },
+        );
+    }
+
+    #[test]
+    fn constructors_produce_expected_metadata() {
+        check_values(
+            [
+                Check {
+                    scenario: "new_with_default_name sets the default name",
+                    input: Metadata::new_with_default_name(),
+                    expect: Metadata {
+                        name: "default_name".to_string(),
+                        description: String::new(),
+                        labels: HashMap::new(),
+                    },
+                },
+                Check {
+                    scenario: "default is fully empty",
+                    input: Metadata::default(),
+                    expect: Metadata {
+                        name: String::new(),
+                        description: String::new(),
+                        labels: HashMap::new(),
+                    },
+                },
+                Check {
+                    scenario: "deserializer default matches Metadata::default",
+                    input: default_metadata_for_deserializer(),
+                    expect: Metadata::default(),
+                },
+            ],
+            |m| m,
+        );
     }
 }

--- a/crates/api-model/src/network_segment/mod.rs
+++ b/crates/api-model/src/network_segment/mod.rs
@@ -364,40 +364,327 @@ impl NewNetworkSegment {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
+    fn drain_state() -> NetworkSegmentControllerState {
+        let delete_at: DateTime<Utc> = "2022-12-13T04:41:38Z".parse().unwrap();
+        NetworkSegmentControllerState::Deleting {
+            deletion_state: NetworkSegmentDeletionState::DrainAllocatedIps { delete_at },
+        }
+    }
+
+    fn dbdelete_state() -> NetworkSegmentControllerState {
+        NetworkSegmentControllerState::Deleting {
+            deletion_state: NetworkSegmentDeletionState::DBDelete,
+        }
+    }
+
     #[test]
-    fn serialize_controller_state() {
-        let state = NetworkSegmentControllerState::Provisioning {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"provisioning\"}");
-        assert_eq!(
-            serde_json::from_str::<NetworkSegmentControllerState>(&serialized).unwrap(),
-            state
+    fn controller_state_serializes_to_tagged_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "provisioning",
+                    input: NetworkSegmentControllerState::Provisioning,
+                    expect: Yields(r#"{"state":"provisioning"}"#.to_string()),
+                },
+                Case {
+                    scenario: "ready",
+                    input: NetworkSegmentControllerState::Ready,
+                    expect: Yields(r#"{"state":"ready"}"#.to_string()),
+                },
+                Case {
+                    scenario: "deleting / drain allocated ips",
+                    input: drain_state(),
+                    expect: Yields(
+                        r#"{"state":"deleting","deletion_state":{"state":"drainallocatedips","delete_at":"2022-12-13T04:41:38Z"}}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "deleting / db delete",
+                    input: dbdelete_state(),
+                    expect: Yields(
+                        r#"{"state":"deleting","deletion_state":{"state":"dbdelete"}}"#.to_string(),
+                    ),
+                },
+            ],
+            |state| serde_json::to_string(&state).map_err(drop),
         );
+    }
 
-        let state = NetworkSegmentControllerState::Ready {};
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"ready\"}");
-        assert_eq!(
-            serde_json::from_str::<NetworkSegmentControllerState>(&serialized).unwrap(),
-            state
-        );
-
-        let deletion_time: DateTime<Utc> = "2022-12-13T04:41:38Z".parse().unwrap();
-        let state = NetworkSegmentControllerState::Deleting {
-            deletion_state: NetworkSegmentDeletionState::DrainAllocatedIps {
-                delete_at: deletion_time,
+    #[test]
+    fn controller_state_round_trips_through_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "provisioning",
+                    input: NetworkSegmentControllerState::Provisioning,
+                    expect: Yields(NetworkSegmentControllerState::Provisioning),
+                },
+                Case {
+                    scenario: "ready",
+                    input: NetworkSegmentControllerState::Ready,
+                    expect: Yields(NetworkSegmentControllerState::Ready),
+                },
+                Case {
+                    scenario: "deleting / drain allocated ips",
+                    input: drain_state(),
+                    expect: Yields(drain_state()),
+                },
+                Case {
+                    scenario: "deleting / db delete",
+                    input: dbdelete_state(),
+                    expect: Yields(dbdelete_state()),
+                },
+            ],
+            |state| {
+                let json = serde_json::to_string(&state).map_err(drop)?;
+                serde_json::from_str::<NetworkSegmentControllerState>(&json).map_err(drop)
             },
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(
-            serialized,
-            "{\"state\":\"deleting\",\"deletion_state\":{\"state\":\"drainallocatedips\",\"delete_at\":\"2022-12-13T04:41:38Z\"}}"
         );
-        assert_eq!(
-            serde_json::from_str::<NetworkSegmentControllerState>(&serialized).unwrap(),
-            state
+    }
+
+    #[test]
+    fn segment_type_parses_from_db_string() {
+        check_cases(
+            [
+                Case {
+                    scenario: "tenant",
+                    input: "tenant",
+                    expect: Yields(NetworkSegmentType::Tenant),
+                },
+                Case {
+                    scenario: "admin",
+                    input: "admin",
+                    expect: Yields(NetworkSegmentType::Admin),
+                },
+                Case {
+                    scenario: "tor maps to underlay",
+                    input: "tor",
+                    expect: Yields(NetworkSegmentType::Underlay),
+                },
+                Case {
+                    scenario: "host_inband",
+                    input: "host_inband",
+                    expect: Yields(NetworkSegmentType::HostInband),
+                },
+                Case {
+                    scenario: "unknown token",
+                    input: "bogus",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wrong-case admin",
+                    input: "Admin",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "display name underlay, not parse name",
+                    input: "underlay",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "whitespace padded",
+                    input: " tenant ",
+                    expect: Fails,
+                },
+            ],
+            |s| NetworkSegmentType::from_str(s).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn segment_type_parse_error_names_the_input() {
+        check_cases(
+            [
+                Case {
+                    scenario: "error mentions the offending token",
+                    input: ("bogus", &["Invalid segment type", "bogus"][..]),
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "error mentions an empty token",
+                    input: ("", &["Invalid segment type"][..]),
+                    expect: Yields(true),
+                },
+            ],
+            |(s, tokens)| {
+                let msg = NetworkSegmentType::from_str(s)
+                    .map(|_| String::new())
+                    .unwrap_or_else(|e| e.to_string());
+                Ok::<_, ()>(tokens.iter().all(|t| msg.contains(t)))
+            },
+        );
+    }
+
+    #[test]
+    fn segment_type_round_trips_through_display_and_parse() {
+        check_cases(
+            [
+                Case {
+                    scenario: "tenant",
+                    input: NetworkSegmentType::Tenant,
+                    expect: Yields(NetworkSegmentType::Tenant),
+                },
+                Case {
+                    scenario: "admin",
+                    input: NetworkSegmentType::Admin,
+                    expect: Yields(NetworkSegmentType::Admin),
+                },
+                Case {
+                    scenario: "underlay",
+                    input: NetworkSegmentType::Underlay,
+                    expect: Yields(NetworkSegmentType::Underlay),
+                },
+                Case {
+                    scenario: "host_inband",
+                    input: NetworkSegmentType::HostInband,
+                    expect: Yields(NetworkSegmentType::HostInband),
+                },
+            ],
+            |ty| NetworkSegmentType::from_str(&ty.to_string()).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn segment_type_displays_its_db_token() {
+        check_values(
+            [
+                Check {
+                    scenario: "tenant",
+                    input: NetworkSegmentType::Tenant,
+                    expect: "tenant".to_string(),
+                },
+                Check {
+                    scenario: "admin",
+                    input: NetworkSegmentType::Admin,
+                    expect: "admin".to_string(),
+                },
+                Check {
+                    scenario: "underlay renders as tor",
+                    input: NetworkSegmentType::Underlay,
+                    expect: "tor".to_string(),
+                },
+                Check {
+                    scenario: "host_inband",
+                    input: NetworkSegmentType::HostInband,
+                    expect: "host_inband".to_string(),
+                },
+            ],
+            |ty| ty.to_string(),
+        );
+    }
+
+    #[test]
+    fn is_tenant_is_true_for_tenant_facing_segments() {
+        check_values(
+            [
+                Check {
+                    scenario: "tenant is tenant-facing",
+                    input: NetworkSegmentType::Tenant,
+                    expect: true,
+                },
+                Check {
+                    scenario: "host_inband is tenant-facing",
+                    input: NetworkSegmentType::HostInband,
+                    expect: true,
+                },
+                Check {
+                    scenario: "admin is not tenant-facing",
+                    input: NetworkSegmentType::Admin,
+                    expect: false,
+                },
+                Check {
+                    scenario: "underlay is not tenant-facing",
+                    input: NetworkSegmentType::Underlay,
+                    expect: false,
+                },
+            ],
+            |ty| ty.is_tenant(),
+        );
+    }
+
+    #[test]
+    fn segment_type_converts_from_definition_type() {
+        check_values(
+            [
+                Check {
+                    scenario: "admin",
+                    input: NetworkDefinitionSegmentType::Admin,
+                    expect: NetworkSegmentType::Admin,
+                },
+                Check {
+                    scenario: "underlay",
+                    input: NetworkDefinitionSegmentType::Underlay,
+                    expect: NetworkSegmentType::Underlay,
+                },
+                Check {
+                    scenario: "host_inband",
+                    input: NetworkDefinitionSegmentType::HostInband,
+                    expect: NetworkSegmentType::HostInband,
+                },
+            ],
+            NetworkSegmentType::from,
+        );
+    }
+
+    #[test]
+    fn allocation_strategy_round_trips_through_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "dynamic serializes to its snake-case token",
+                    input: AllocationStrategy::Dynamic,
+                    expect: Yields(r#""dynamic""#.to_string()),
+                },
+                Case {
+                    scenario: "reserved serializes to its snake-case token",
+                    input: AllocationStrategy::Reserved,
+                    expect: Yields(r#""reserved""#.to_string()),
+                },
+            ],
+            |s| serde_json::to_string(&s).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn allocation_strategy_defaults_to_dynamic() {
+        check_values(
+            [Check {
+                scenario: "default",
+                input: (),
+                expect: AllocationStrategy::Dynamic,
+            }],
+            |()| AllocationStrategy::default(),
+        );
+    }
+
+    #[test]
+    fn is_marked_as_deleted_follows_the_deleted_timestamp() {
+        let stamp: DateTime<Utc> = "2022-12-13T04:41:38Z".parse().unwrap();
+        check_values(
+            [
+                Check {
+                    scenario: "no timestamp means live",
+                    input: None,
+                    expect: false,
+                },
+                Check {
+                    scenario: "timestamp means deleted",
+                    input: Some(stamp),
+                    expect: true,
+                },
+            ],
+            |deleted| deleted.is_some(),
         );
     }
 }

--- a/crates/api-model/src/power_shelf/mod.rs
+++ b/crates/api-model/src/power_shelf/mod.rs
@@ -231,7 +231,7 @@ pub struct PowerShelfSearchFilter {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::{Case, Check, check_cases, check_values};
 
     use super::*;
 
@@ -405,5 +405,366 @@ mod tests {
             operation: PowerShelfMaintenanceOperation::PowerOff,
         };
         assert_ne!(on, off);
+    }
+
+    #[test]
+    fn controller_state_deserializes_from_tagged_json() {
+        // Each tagged-JSON form parses back to its variant; malformed or unknown
+        // tags are rejected. The op yields the parsed variant so both the accepted
+        // shapes and the rejected ones are pinned in one table.
+        check_cases(
+            [
+                Case {
+                    scenario: "initializing tag",
+                    input: r#"{"state":"initializing"}"#,
+                    expect: Yields(PowerShelfControllerState::Initializing),
+                },
+                Case {
+                    scenario: "fetchingdata tag",
+                    input: r#"{"state":"fetchingdata"}"#,
+                    expect: Yields(PowerShelfControllerState::FetchingData),
+                },
+                Case {
+                    scenario: "configuring tag",
+                    input: r#"{"state":"configuring"}"#,
+                    expect: Yields(PowerShelfControllerState::Configuring),
+                },
+                Case {
+                    scenario: "ready tag",
+                    input: r#"{"state":"ready"}"#,
+                    expect: Yields(PowerShelfControllerState::Ready),
+                },
+                Case {
+                    scenario: "deleting tag",
+                    input: r#"{"state":"deleting"}"#,
+                    expect: Yields(PowerShelfControllerState::Deleting),
+                },
+                Case {
+                    scenario: "error with cause",
+                    input: r#"{"state":"error","cause":"boom"}"#,
+                    expect: Yields(PowerShelfControllerState::Error {
+                        cause: "boom".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "error with empty cause",
+                    input: r#"{"state":"error","cause":""}"#,
+                    expect: Yields(PowerShelfControllerState::Error {
+                        cause: String::new(),
+                    }),
+                },
+                Case {
+                    scenario: "maintenance power-on",
+                    input: r#"{"state":"maintenance","operation":{"operation":"poweron"}}"#,
+                    expect: Yields(PowerShelfControllerState::Maintenance {
+                        operation: PowerShelfMaintenanceOperation::PowerOn,
+                    }),
+                },
+                Case {
+                    scenario: "maintenance power-off",
+                    input: r#"{"state":"maintenance","operation":{"operation":"poweroff"}}"#,
+                    expect: Yields(PowerShelfControllerState::Maintenance {
+                        operation: PowerShelfMaintenanceOperation::PowerOff,
+                    }),
+                },
+                Case {
+                    scenario: "unknown tag is rejected",
+                    input: r#"{"state":"running"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wrong-case tag is rejected",
+                    input: r#"{"state":"Initializing"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "error without cause is rejected",
+                    input: r#"{"state":"error"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "maintenance without operation is rejected",
+                    input: r#"{"state":"maintenance"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing state tag is rejected",
+                    input: r#"{}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "not an object is rejected",
+                    input: r#""initializing""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "malformed json is rejected",
+                    input: r#"{"state":"#,
+                    expect: Fails,
+                },
+            ],
+            |json: &str| serde_json::from_str::<PowerShelfControllerState>(json).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn maintenance_operation_deserializes_from_tagged_json() {
+        // The lowercase operation tags parse back to their variants; unknown or
+        // wrong-case tags are rejected.
+        check_cases(
+            [
+                Case {
+                    scenario: "poweron tag",
+                    input: r#"{"operation":"poweron"}"#,
+                    expect: Yields(PowerShelfMaintenanceOperation::PowerOn),
+                },
+                Case {
+                    scenario: "poweroff tag",
+                    input: r#"{"operation":"poweroff"}"#,
+                    expect: Yields(PowerShelfMaintenanceOperation::PowerOff),
+                },
+                Case {
+                    scenario: "unknown operation is rejected",
+                    input: r#"{"operation":"reset"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wrong-case operation is rejected",
+                    input: r#"{"operation":"PowerOn"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing operation tag is rejected",
+                    input: r#"{}"#,
+                    expect: Fails,
+                },
+            ],
+            |json: &str| serde_json::from_str::<PowerShelfMaintenanceOperation>(json).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn config_round_trips_through_json() {
+        // PowerShelfConfig round-trips for present/absent optionals, empty names, and
+        // numeric boundaries. The op yields the value parsed back from its own JSON.
+        check_cases(
+            [
+                Case {
+                    scenario: "all fields present",
+                    input: PowerShelfConfig {
+                        name: "shelf-1".to_string(),
+                        capacity: Some(5000),
+                        voltage: Some(48),
+                    },
+                    expect: Yields(PowerShelfConfig {
+                        name: "shelf-1".to_string(),
+                        capacity: Some(5000),
+                        voltage: Some(48),
+                    }),
+                },
+                Case {
+                    scenario: "optionals absent",
+                    input: PowerShelfConfig {
+                        name: "shelf-2".to_string(),
+                        capacity: None,
+                        voltage: None,
+                    },
+                    expect: Yields(PowerShelfConfig {
+                        name: "shelf-2".to_string(),
+                        capacity: None,
+                        voltage: None,
+                    }),
+                },
+                Case {
+                    scenario: "empty name and zero values",
+                    input: PowerShelfConfig {
+                        name: String::new(),
+                        capacity: Some(0),
+                        voltage: Some(0),
+                    },
+                    expect: Yields(PowerShelfConfig {
+                        name: String::new(),
+                        capacity: Some(0),
+                        voltage: Some(0),
+                    }),
+                },
+                Case {
+                    scenario: "u32 maxima",
+                    input: PowerShelfConfig {
+                        name: "max".to_string(),
+                        capacity: Some(u32::MAX),
+                        voltage: Some(u32::MAX),
+                    },
+                    expect: Yields(PowerShelfConfig {
+                        name: "max".to_string(),
+                        capacity: Some(u32::MAX),
+                        voltage: Some(u32::MAX),
+                    }),
+                },
+            ],
+            |config: PowerShelfConfig| {
+                let serialized = serde_json::to_string(&config).map_err(drop)?;
+                serde_json::from_str::<PowerShelfConfig>(&serialized).map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn status_round_trips_through_json() {
+        // PowerShelfStatus round-trips across each power/health string the field is
+        // documented to hold, plus empty strings.
+        check_cases(
+            [
+                Case {
+                    scenario: "on / ok",
+                    input: PowerShelfStatus {
+                        shelf_name: "psu-a".to_string(),
+                        power_state: "on".to_string(),
+                        health_status: "ok".to_string(),
+                    },
+                    expect: Yields(PowerShelfStatus {
+                        shelf_name: "psu-a".to_string(),
+                        power_state: "on".to_string(),
+                        health_status: "ok".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "off / warning",
+                    input: PowerShelfStatus {
+                        shelf_name: "psu-b".to_string(),
+                        power_state: "off".to_string(),
+                        health_status: "warning".to_string(),
+                    },
+                    expect: Yields(PowerShelfStatus {
+                        shelf_name: "psu-b".to_string(),
+                        power_state: "off".to_string(),
+                        health_status: "warning".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "standby / critical",
+                    input: PowerShelfStatus {
+                        shelf_name: "psu-c".to_string(),
+                        power_state: "standby".to_string(),
+                        health_status: "critical".to_string(),
+                    },
+                    expect: Yields(PowerShelfStatus {
+                        shelf_name: "psu-c".to_string(),
+                        power_state: "standby".to_string(),
+                        health_status: "critical".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "empty strings",
+                    input: PowerShelfStatus {
+                        shelf_name: String::new(),
+                        power_state: String::new(),
+                        health_status: String::new(),
+                    },
+                    expect: Yields(PowerShelfStatus {
+                        shelf_name: String::new(),
+                        power_state: String::new(),
+                        health_status: String::new(),
+                    }),
+                },
+            ],
+            |status: PowerShelfStatus| {
+                let serialized = serde_json::to_string(&status).map_err(drop)?;
+                serde_json::from_str::<PowerShelfStatus>(&serialized).map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn state_sla_reports_whether_an_sla_applies() {
+        // `state_sla` selects an SLA bucket per controller state. Driven from an
+        // epoch-old `ConfigVersion` (via `invalid()`), the time-in-state is far past
+        // any finite SLA, so each SLA-bearing state reports its exact SLA duration and
+        // an `above_sla` of true, while the no-SLA states report `None`/false. The op
+        // yields `(sla, time_in_state_above_sla)`.
+        let stale = ConfigVersion::invalid();
+        let secs = |s: u64| Some(std::time::Duration::from_secs(s));
+        check_values(
+            [
+                Check {
+                    scenario: "initializing has an SLA and is overdue",
+                    input: PowerShelfControllerState::Initializing,
+                    expect: (secs(slas::INITIALIZING), true),
+                },
+                Check {
+                    scenario: "fetching-data has an SLA and is overdue",
+                    input: PowerShelfControllerState::FetchingData,
+                    expect: (secs(slas::FETCHING_DATA), true),
+                },
+                Check {
+                    scenario: "configuring has an SLA and is overdue",
+                    input: PowerShelfControllerState::Configuring,
+                    expect: (secs(slas::CONFIGURING), true),
+                },
+                Check {
+                    scenario: "deleting has an SLA and is overdue",
+                    input: PowerShelfControllerState::Deleting,
+                    expect: (secs(slas::DELETING), true),
+                },
+                Check {
+                    scenario: "maintenance power-on has the maintenance SLA",
+                    input: PowerShelfControllerState::Maintenance {
+                        operation: PowerShelfMaintenanceOperation::PowerOn,
+                    },
+                    expect: (secs(slas::MAINTENANCE), true),
+                },
+                Check {
+                    scenario: "maintenance power-off has the maintenance SLA",
+                    input: PowerShelfControllerState::Maintenance {
+                        operation: PowerShelfMaintenanceOperation::PowerOff,
+                    },
+                    expect: (secs(slas::MAINTENANCE), true),
+                },
+                Check {
+                    scenario: "ready carries no SLA",
+                    input: PowerShelfControllerState::Ready,
+                    expect: (None, false),
+                },
+                Check {
+                    scenario: "error carries no SLA",
+                    input: PowerShelfControllerState::Error {
+                        cause: "boom".to_string(),
+                    },
+                    expect: (None, false),
+                },
+            ],
+            |state: PowerShelfControllerState| {
+                let result = state_sla(&state, &stale);
+                (result.sla, result.time_in_state_above_sla)
+            },
+        );
+    }
+
+    #[test]
+    fn aggregate_health_prefers_the_replace_source() {
+        // When a `replace` source is set, `derive_power_shelf_aggregate_health` returns
+        // it verbatim (its `observed_at` untouched), short-circuiting the merge path.
+        // The op yields the derived report's source name.
+        let with_replace = |source: &str| HealthReportSources {
+            replace: Some(health_report::HealthReport::empty(source.to_string())),
+            ..Default::default()
+        };
+        check_cases(
+            [
+                Case {
+                    scenario: "replace source wins",
+                    input: with_replace("override.sre"),
+                    expect: Yields("override.sre".to_string()),
+                },
+                Case {
+                    scenario: "no replace falls back to the aggregate name",
+                    input: HealthReportSources::default(),
+                    expect: Yields("power-shelf-aggregate-health".to_string()),
+                },
+            ],
+            |sources: HealthReportSources| {
+                Ok::<_, ()>(derive_power_shelf_aggregate_health(&sources).source)
+            },
+        );
     }
 }

--- a/crates/api-model/src/rack_type.rs
+++ b/crates/api-model/src/rack_type.rs
@@ -280,7 +280,7 @@ impl RackProfileConfig {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::{Case, Check, check_cases, check_values};
 
     use super::*;
 
@@ -437,24 +437,130 @@ count = 2
         );
     }
 
+    // Display forwards the inner string verbatim, including for the wildcard
+    // and for empty/odd inputs.
     #[test]
     fn test_rack_hardware_type_display() {
-        assert_eq!(RackHardwareType::any().to_string(), "any");
-        assert_eq!(
-            RackHardwareType::from("dsx_gb200nvl_72x1").to_string(),
-            "dsx_gb200nvl_72x1"
+        check_values(
+            [
+                Check {
+                    scenario: "wildcard any",
+                    input: RackHardwareType::any(),
+                    expect: "any".to_string(),
+                },
+                Check {
+                    scenario: "dsx hardware type",
+                    input: RackHardwareType::from("dsx_gb200nvl_72x1"),
+                    expect: "dsx_gb200nvl_72x1".to_string(),
+                },
+                Check {
+                    scenario: "empty string",
+                    input: RackHardwareType::from(""),
+                    expect: String::new(),
+                },
+                Check {
+                    scenario: "uppercase verbatim",
+                    input: RackHardwareType::from("ANY"),
+                    expect: "ANY".to_string(),
+                },
+                Check {
+                    scenario: "whitespace preserved",
+                    input: RackHardwareType::from("  spaced  "),
+                    expect: "  spaced  ".to_string(),
+                },
+                Check {
+                    scenario: "default renders as any",
+                    input: RackHardwareType::default(),
+                    expect: "any".to_string(),
+                },
+            ],
+            |hw_type| hw_type.to_string(),
         );
     }
 
+    // is_any is an exact, case-sensitive match against the literal "any".
     #[test]
     fn test_rack_hardware_type_is_any() {
-        assert!(RackHardwareType::any().is_any());
-        assert!(!RackHardwareType::from("dsx_gb200nvl_72x1").is_any());
+        check_values(
+            [
+                Check {
+                    scenario: "constructed via any()",
+                    input: RackHardwareType::any(),
+                    expect: true,
+                },
+                Check {
+                    scenario: "default is any",
+                    input: RackHardwareType::default(),
+                    expect: true,
+                },
+                Check {
+                    scenario: "literal any from str",
+                    input: RackHardwareType::from("any"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "concrete hardware type",
+                    input: RackHardwareType::from("dsx_gb200nvl_72x1"),
+                    expect: false,
+                },
+                Check {
+                    scenario: "empty is not any",
+                    input: RackHardwareType::from(""),
+                    expect: false,
+                },
+                Check {
+                    scenario: "uppercase is not any",
+                    input: RackHardwareType::from("ANY"),
+                    expect: false,
+                },
+                Check {
+                    scenario: "any with trailing space is not any",
+                    input: RackHardwareType::from("any "),
+                    expect: false,
+                },
+                Check {
+                    scenario: "substring is not any",
+                    input: RackHardwareType::from("anything"),
+                    expect: false,
+                },
+            ],
+            |hw_type| hw_type.is_any(),
+        );
     }
 
     #[test]
     fn test_rack_hardware_type_default_is_any() {
         assert_eq!(RackHardwareType::default(), RackHardwareType::any());
+    }
+
+    // Both From conversions wrap the input verbatim and agree with each other.
+    #[test]
+    fn test_rack_hardware_type_from_conversions() {
+        check_values(
+            [
+                Check {
+                    scenario: "from owned string",
+                    input: RackHardwareType::from("dsx".to_string()),
+                    expect: RackHardwareType("dsx".to_string()),
+                },
+                Check {
+                    scenario: "from str slice",
+                    input: RackHardwareType::from("dsx"),
+                    expect: RackHardwareType("dsx".to_string()),
+                },
+                Check {
+                    scenario: "from empty str",
+                    input: RackHardwareType::from(""),
+                    expect: RackHardwareType(String::new()),
+                },
+                Check {
+                    scenario: "owned and borrowed agree",
+                    input: RackHardwareType::from("any".to_string()),
+                    expect: RackHardwareType::from("any"),
+                },
+            ],
+            |hw_type| hw_type,
+        );
     }
 
     // RackHardwareTopology serde.
@@ -523,19 +629,81 @@ count = 2
         );
     }
 
+    // Display covers every topology variant; the rendered string matches the
+    // snake_case serde form.
     #[test]
     fn test_rack_hardware_topology_display() {
-        assert_eq!(
-            RackHardwareTopology::Gb200Nvl36r1C2g4Topology.to_string(),
-            "gb200_nvl36r1_c2g4_topology"
+        check_values(
+            [
+                Check {
+                    scenario: "gb200 nvl36",
+                    input: RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
+                    expect: "gb200_nvl36r1_c2g4_topology".to_string(),
+                },
+                Check {
+                    scenario: "gb300 nvl36",
+                    input: RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
+                    expect: "gb300_nvl36r1_c2g4_topology".to_string(),
+                },
+                Check {
+                    scenario: "gb200 nvl72",
+                    input: RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
+                    expect: "gb200_nvl72r1_c2g4_topology".to_string(),
+                },
+                Check {
+                    scenario: "gb300 nvl72",
+                    input: RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
+                    expect: "gb300_nvl72r1_c2g4_topology".to_string(),
+                },
+                Check {
+                    scenario: "vr nvl8 rtf",
+                    input: RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
+                    expect: "vr_nvl8r1_c2g4_rtf_topology".to_string(),
+                },
+                Check {
+                    scenario: "vr nvl72",
+                    input: RackHardwareTopology::VrNvl72r1C2g4Topology,
+                    expect: "vr_nvl72r1_c2g4_topology".to_string(),
+                },
+            ],
+            |variant| variant.to_string(),
         );
-        assert_eq!(
-            RackHardwareTopology::VrNvl8r1C2g4RtfTopology.to_string(),
-            "vr_nvl8r1_c2g4_rtf_topology"
-        );
-        assert_eq!(
-            RackHardwareTopology::VrNvl72r1C2g4Topology.to_string(),
-            "vr_nvl72r1_c2g4_topology"
+    }
+
+    // Deserialization accepts exactly the snake_case names and rejects anything
+    // else (unknown names, the Display-only variant casing, empty). The
+    // (non-PartialEq) serde error is discarded with map_err(drop).
+    #[test]
+    fn test_rack_hardware_topology_deserialize() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid gb200 nvl36",
+                    input: "\"gb200_nvl36r1_c2g4_topology\"",
+                    expect: Yields(RackHardwareTopology::Gb200Nvl36r1C2g4Topology),
+                },
+                Case {
+                    scenario: "valid vr nvl72",
+                    input: "\"vr_nvl72r1_c2g4_topology\"",
+                    expect: Yields(RackHardwareTopology::VrNvl72r1C2g4Topology),
+                },
+                Case {
+                    scenario: "unknown topology name",
+                    input: "\"gb500_nvl99_topology\"",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "\"\"",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wrong json type",
+                    input: "42",
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<RackHardwareTopology>(json).map_err(drop),
         );
     }
 
@@ -569,7 +737,82 @@ count = 2
 
     #[test]
     fn test_rack_hardware_class_display() {
-        assert_eq!(RackHardwareClass::Dev.to_string(), "dev");
-        assert_eq!(RackHardwareClass::Prod.to_string(), "prod");
+        check_values(
+            [
+                Check {
+                    scenario: "dev",
+                    input: RackHardwareClass::Dev,
+                    expect: "dev".to_string(),
+                },
+                Check {
+                    scenario: "prod",
+                    input: RackHardwareClass::Prod,
+                    expect: "prod".to_string(),
+                },
+            ],
+            |variant| variant.to_string(),
+        );
+    }
+
+    // Deserialization accepts the two snake_case names and rejects others.
+    // The (non-PartialEq) serde error is discarded with map_err(drop).
+    #[test]
+    fn test_rack_hardware_class_deserialize() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid dev",
+                    input: "\"dev\"",
+                    expect: Yields(RackHardwareClass::Dev),
+                },
+                Case {
+                    scenario: "valid prod",
+                    input: "\"prod\"",
+                    expect: Yields(RackHardwareClass::Prod),
+                },
+                Case {
+                    scenario: "uppercase rejected",
+                    input: "\"Dev\"",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown class",
+                    input: "\"staging\"",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "\"\"",
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<RackHardwareClass>(json).map_err(drop),
+        );
+    }
+
+    // RackCapabilityType Display renders each variant with its canonical
+    // PascalCase label.
+    #[test]
+    fn test_rack_capability_type_display() {
+        check_values(
+            [
+                Check {
+                    scenario: "compute",
+                    input: RackCapabilityType::Compute,
+                    expect: "Compute".to_string(),
+                },
+                Check {
+                    scenario: "switch",
+                    input: RackCapabilityType::Switch,
+                    expect: "Switch".to_string(),
+                },
+                Check {
+                    scenario: "power shelf",
+                    input: RackCapabilityType::PowerShelf,
+                    expect: "PowerShelf".to_string(),
+                },
+            ],
+            |variant| variant.to_string(),
+        );
     }
 }

--- a/crates/api-model/src/redfish.rs
+++ b/crates/api-model/src/redfish.rs
@@ -105,12 +105,50 @@ pub struct RedfishCreateAction {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
+    /// `From<i64>` is a plain field move; enumerate the integer boundaries it must
+    /// carry through unchanged.
     #[test]
-    fn redfish_action_id_from_i64() {
-        let id = RedfishActionId::from(99i64);
-        assert_eq!(id.request_id, 99);
+    fn redfish_action_id_from_i64_carries_the_value() {
+        check_values(
+            [
+                Check {
+                    scenario: "positive",
+                    input: 99i64,
+                    expect: 99i64,
+                },
+                Check {
+                    scenario: "zero",
+                    input: 0,
+                    expect: 0,
+                },
+                Check {
+                    scenario: "one",
+                    input: 1,
+                    expect: 1,
+                },
+                Check {
+                    scenario: "negative",
+                    input: -1,
+                    expect: -1,
+                },
+                Check {
+                    scenario: "i64::MAX",
+                    input: i64::MAX,
+                    expect: i64::MAX,
+                },
+                Check {
+                    scenario: "i64::MIN",
+                    input: i64::MIN,
+                    expect: i64::MIN,
+                },
+            ],
+            |n| RedfishActionId::from(n).request_id,
+        );
     }
 
     #[test]
@@ -118,5 +156,100 @@ mod tests {
         let id = RedfishActionId { request_id: 1 };
         let id2 = id;
         assert_eq!(id.request_id, id2.request_id);
+    }
+
+    #[test]
+    fn redfish_list_actions_filter_default_is_empty() {
+        check_values(
+            [Check {
+                scenario: "default leaves machine_ip unset",
+                input: RedfishListActionsFilter::default(),
+                expect: None,
+            }],
+            |filter| filter.machine_ip,
+        );
+    }
+
+    fn bmc_response(status: &str, body: &str) -> BMCResponse {
+        BMCResponse {
+            headers: HashMap::new(),
+            status: status.to_string(),
+            body: body.to_string(),
+            completed_at: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+        }
+    }
+
+    /// `BMCResponse` is round-tripped through JSON when persisted; assert the
+    /// serialized form survives a deserialize back to the same fields. The error
+    /// type (`serde_json::Error`) isn't `PartialEq`, so map it away.
+    #[test]
+    fn bmc_response_round_trips_through_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "ok with empty body",
+                    input: bmc_response("200 OK", ""),
+                    expect: Yields(("200 OK".to_string(), String::new())),
+                },
+                Case {
+                    scenario: "ok with json body",
+                    input: bmc_response("200 OK", r#"{"k":"v"}"#),
+                    expect: Yields(("200 OK".to_string(), r#"{"k":"v"}"#.to_string())),
+                },
+                Case {
+                    scenario: "error status",
+                    input: bmc_response("500 Internal Server Error", "boom"),
+                    expect: Yields(("500 Internal Server Error".to_string(), "boom".to_string())),
+                },
+                Case {
+                    scenario: "unicode body",
+                    input: bmc_response("202 Accepted", "café ☕"),
+                    expect: Yields(("202 Accepted".to_string(), "café ☕".to_string())),
+                },
+            ],
+            |response| {
+                let json = serde_json::to_string(&response).map_err(drop)?;
+                let back: BMCResponse = serde_json::from_str(&json).map_err(drop)?;
+                Ok::<_, ()>((back.status, back.body))
+            },
+        );
+    }
+
+    /// Headers are an arbitrary map; assert the serialized form preserves a chosen
+    /// key after the JSON round-trip.
+    #[test]
+    fn bmc_response_round_trip_preserves_headers() {
+        check_cases(
+            [
+                Case {
+                    scenario: "single header",
+                    input: ("Content-Type", "application/json"),
+                    expect: Yields(Some("application/json".to_string())),
+                },
+                Case {
+                    scenario: "header value with spaces",
+                    input: ("ETag", "W/\"abc 123\""),
+                    expect: Yields(Some("W/\"abc 123\"".to_string())),
+                },
+                Case {
+                    scenario: "empty header value",
+                    input: ("X-Empty", ""),
+                    expect: Yields(Some(String::new())),
+                },
+            ],
+            |(key, value): (&str, &str)| {
+                let mut headers = HashMap::new();
+                headers.insert(key.to_string(), value.to_string());
+                let response = BMCResponse {
+                    headers,
+                    status: "200 OK".to_string(),
+                    body: String::new(),
+                    completed_at: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+                };
+                let json = serde_json::to_string(&response).map_err(drop)?;
+                let back: BMCResponse = serde_json::from_str(&json).map_err(drop)?;
+                Ok::<_, ()>(back.headers.get(key).cloned())
+            },
+        );
     }
 }

--- a/crates/api-model/src/resource_pool/mod.rs
+++ b/crates/api-model/src/resource_pool/mod.rs
@@ -177,6 +177,7 @@ impl FromStr for OwnerType {
             "network_segment" => Ok(Self::NetworkSegment),
             "ib_partition" => Ok(Self::IBPartition),
             "vpc" => Ok(Self::Vpc),
+            "spx_partition" => Ok(Self::SpxPartition),
             x => Err(ModelError::InvalidArgument(format!(
                 "Unknown owner_type '{x}'"
             ))),
@@ -233,30 +234,239 @@ pub enum ResourcePoolError {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
     #[test]
-    fn test_serialize_resource_pool_entry_state() {
-        let state = ResourcePoolEntryState::Free;
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, r#"{"state":"free"}"#);
-        assert_eq!(
-            serde_json::from_str::<ResourcePoolEntryState>(&serialized).unwrap(),
-            state
+    fn serialize_resource_pool_entry_state() {
+        // Each row carries the state and its canonical JSON; the operation
+        // serializes the state and confirms it round-trips back unchanged.
+        check_cases(
+            [
+                Case {
+                    scenario: "free",
+                    input: ResourcePoolEntryState::Free,
+                    expect: Yields(r#"{"state":"free"}"#.to_string()),
+                },
+                Case {
+                    scenario: "allocated",
+                    input: ResourcePoolEntryState::Allocated {
+                        owner: "me".to_string(),
+                        owner_type: "my_stuff".to_string(),
+                    },
+                    expect: Yields(
+                        r#"{"state":"allocated","owner":"me","owner_type":"my_stuff"}"#.to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "allocated with empty owner fields",
+                    input: ResourcePoolEntryState::Allocated {
+                        owner: String::new(),
+                        owner_type: String::new(),
+                    },
+                    expect: Yields(
+                        r#"{"state":"allocated","owner":"","owner_type":""}"#.to_string(),
+                    ),
+                },
+            ],
+            |state| {
+                let serialized = serde_json::to_string(&state).map_err(drop)?;
+                let parsed: ResourcePoolEntryState =
+                    serde_json::from_str(&serialized).map_err(drop)?;
+                if parsed != state {
+                    return Err(());
+                }
+                Ok::<_, ()>(serialized)
+            },
         );
+    }
 
-        let state = ResourcePoolEntryState::Allocated {
-            owner: "me".to_string(),
-            owner_type: "my_stuff".to_string(),
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(
-            serialized,
-            r#"{"state":"allocated","owner":"me","owner_type":"my_stuff"}"#
+    #[test]
+    fn deserialize_resource_pool_entry_state() {
+        check_cases(
+            [
+                Case {
+                    scenario: "free",
+                    input: r#"{"state":"free"}"#,
+                    expect: Yields(ResourcePoolEntryState::Free),
+                },
+                Case {
+                    scenario: "allocated",
+                    input: r#"{"state":"allocated","owner":"me","owner_type":"vpc"}"#,
+                    expect: Yields(ResourcePoolEntryState::Allocated {
+                        owner: "me".to_string(),
+                        owner_type: "vpc".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "unknown tag is rejected",
+                    input: r#"{"state":"borrowed"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "allocated missing owner_type is rejected",
+                    input: r#"{"state":"allocated","owner":"me"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "not an object is rejected",
+                    input: r#"42"#,
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<ResourcePoolEntryState>(json).map_err(drop),
         );
-        assert_eq!(
-            serde_json::from_str::<ResourcePoolEntryState>(&serialized).unwrap(),
-            state
+    }
+
+    #[test]
+    fn owner_type_from_str() {
+        // `ModelError` has no `PartialEq`, so error rows use `Fails` and the run
+        // closure drops the error to settle on `()`.
+        check_cases(
+            [
+                Case {
+                    scenario: "machine",
+                    input: "machine",
+                    expect: Yields(OwnerType::Machine),
+                },
+                Case {
+                    scenario: "network_segment",
+                    input: "network_segment",
+                    expect: Yields(OwnerType::NetworkSegment),
+                },
+                Case {
+                    scenario: "ib_partition",
+                    input: "ib_partition",
+                    expect: Yields(OwnerType::IBPartition),
+                },
+                Case {
+                    scenario: "vpc",
+                    input: "vpc",
+                    expect: Yields(OwnerType::Vpc),
+                },
+                Case {
+                    scenario: "spx_partition round-trips through Display/FromStr",
+                    input: "spx_partition",
+                    expect: Yields(OwnerType::SpxPartition),
+                },
+                Case {
+                    scenario: "unknown string",
+                    input: "nonsense",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wrong case is rejected",
+                    input: "Machine",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "leading whitespace is rejected",
+                    input: " machine",
+                    expect: Fails,
+                },
+            ],
+            |s| OwnerType::from_str(s).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn owner_type_display_round_trips_via_from_str() {
+        // Every variant that `from_str` accepts must display to a string that
+        // `from_str` accepts back as the same variant.
+        check_cases(
+            [
+                Case {
+                    scenario: "machine",
+                    input: OwnerType::Machine,
+                    expect: Yields(OwnerType::Machine),
+                },
+                Case {
+                    scenario: "network_segment",
+                    input: OwnerType::NetworkSegment,
+                    expect: Yields(OwnerType::NetworkSegment),
+                },
+                Case {
+                    scenario: "ib_partition",
+                    input: OwnerType::IBPartition,
+                    expect: Yields(OwnerType::IBPartition),
+                },
+                Case {
+                    scenario: "vpc",
+                    input: OwnerType::Vpc,
+                    expect: Yields(OwnerType::Vpc),
+                },
+            ],
+            |owner| OwnerType::from_str(&owner.to_string()).map_err(drop),
+        );
+    }
+
+    #[test]
+    fn owner_type_display() {
+        check_values(
+            [
+                Check {
+                    scenario: "machine",
+                    input: OwnerType::Machine,
+                    expect: "machine".to_string(),
+                },
+                Check {
+                    scenario: "network_segment",
+                    input: OwnerType::NetworkSegment,
+                    expect: "network_segment".to_string(),
+                },
+                Check {
+                    scenario: "ib_partition",
+                    input: OwnerType::IBPartition,
+                    expect: "ib_partition".to_string(),
+                },
+                Check {
+                    scenario: "vpc",
+                    input: OwnerType::Vpc,
+                    expect: "vpc".to_string(),
+                },
+                Check {
+                    scenario: "spx_partition",
+                    input: OwnerType::SpxPartition,
+                    expect: "spx_partition".to_string(),
+                },
+            ],
+            |owner| owner.to_string(),
+        );
+    }
+
+    #[test]
+    fn value_type_display() {
+        check_values(
+            [
+                Check {
+                    scenario: "integer",
+                    input: ValueType::Integer,
+                    expect: "Integer".to_string(),
+                },
+                Check {
+                    scenario: "ipv4",
+                    input: ValueType::Ipv4,
+                    expect: "Ipv4".to_string(),
+                },
+                Check {
+                    scenario: "ipv6",
+                    input: ValueType::Ipv6,
+                    expect: "Ipv6".to_string(),
+                },
+                Check {
+                    scenario: "ipv6_prefix",
+                    input: ValueType::Ipv6Prefix,
+                    expect: "Ipv6Prefix".to_string(),
+                },
+            ],
+            |value_type| value_type.to_string(),
         );
     }
 }

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -382,83 +382,441 @@ pub struct SwitchSearchFilter {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
+    /// Build a `FabricManagerStatus` with only the two fields `display_status`
+    /// inspects; the rest are irrelevant to its logic.
+    fn fm_status(state: FabricManagerState, addition_info: Option<&str>) -> FabricManagerStatus {
+        FabricManagerStatus {
+            fabric_manager_state: state,
+            addition_info: addition_info.map(str::to_string),
+            reason: None,
+            error_message: None,
+        }
+    }
+
     #[test]
-    fn serialize_controller_state() {
-        let state = SwitchControllerState::Created;
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"created\"}");
-        assert_eq!(
-            serde_json::from_str::<SwitchControllerState>(&serialized).unwrap(),
-            state
+    fn controller_state_serializes_to_expected_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "created",
+                    input: SwitchControllerState::Created,
+                    expect: Yields(r#"{"state":"created"}"#.to_string()),
+                },
+                Case {
+                    scenario: "initializing",
+                    input: SwitchControllerState::Initializing {
+                        initializing_state: InitializingState::WaitForOsMachineInterface,
+                    },
+                    expect: Yields(
+                        r#"{"state":"initializing","initializing_state":"WaitForOsMachineInterface"}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "configuring",
+                    input: SwitchControllerState::Configuring {
+                        config_state: ConfiguringState::RotateOsPassword,
+                    },
+                    expect: Yields(
+                        r#"{"state":"configuring","config_state":"RotateOsPassword"}"#.to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "validating",
+                    input: SwitchControllerState::Validating {
+                        validating_state: ValidatingState::ValidationComplete,
+                    },
+                    expect: Yields(
+                        r#"{"state":"validating","validating_state":"ValidationComplete"}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "bomvalidating",
+                    input: SwitchControllerState::BomValidating {
+                        bom_validating_state: BomValidatingState::BomValidationComplete,
+                    },
+                    expect: Yields(
+                        r#"{"state":"bomvalidating","bom_validating_state":"BomValidationComplete"}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "ready",
+                    input: SwitchControllerState::Ready,
+                    expect: Yields(r#"{"state":"ready"}"#.to_string()),
+                },
+                Case {
+                    scenario: "maintenance: power on",
+                    input: SwitchControllerState::Maintenance {
+                        operation: SwitchMaintenanceOperation::PowerOn,
+                    },
+                    expect: Yields(
+                        r#"{"state":"maintenance","operation":{"operation":"poweron"}}"#.to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "maintenance: power off",
+                    input: SwitchControllerState::Maintenance {
+                        operation: SwitchMaintenanceOperation::PowerOff,
+                    },
+                    expect: Yields(
+                        r#"{"state":"maintenance","operation":{"operation":"poweroff"}}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "maintenance: reset",
+                    input: SwitchControllerState::Maintenance {
+                        operation: SwitchMaintenanceOperation::Reset,
+                    },
+                    expect: Yields(
+                        r#"{"state":"maintenance","operation":{"operation":"reset"}}"#.to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "reprovisioning: firmware upgrade",
+                    input: SwitchControllerState::ReProvisioning {
+                        reprovisioning_state:
+                            ReProvisioningState::WaitingForRackFirmwareUpgrade,
+                    },
+                    expect: Yields(
+                        r#"{"state":"reprovisioning","reprovisioning_state":"WaitingForRackFirmwareUpgrade"}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "reprovisioning: nvos upgrade",
+                    input: SwitchControllerState::ReProvisioning {
+                        reprovisioning_state: ReProvisioningState::WaitingForNVOSUpgrade,
+                    },
+                    expect: Yields(
+                        r#"{"state":"reprovisioning","reprovisioning_state":"WaitingForNVOSUpgrade"}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "reprovisioning: nmxc configure",
+                    input: SwitchControllerState::ReProvisioning {
+                        reprovisioning_state: ReProvisioningState::WaitingForNMXCConfigure,
+                    },
+                    expect: Yields(
+                        r#"{"state":"reprovisioning","reprovisioning_state":"WaitingForNMXCConfigure"}"#
+                            .to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "error carries its cause",
+                    input: SwitchControllerState::Error {
+                        cause: "cause goes here".to_string(),
+                    },
+                    expect: Yields(
+                        r#"{"state":"error","cause":"cause goes here"}"#.to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "deleting",
+                    input: SwitchControllerState::Deleting,
+                    expect: Yields(r#"{"state":"deleting"}"#.to_string()),
+                },
+            ],
+            |state| serde_json::to_string(&state).map_err(drop),
         );
-        let state = SwitchControllerState::Initializing {
-            initializing_state: InitializingState::WaitForOsMachineInterface,
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(
-            serialized,
-            "{\"state\":\"initializing\",\"initializing_state\":\"WaitForOsMachineInterface\"}"
+    }
+
+    #[test]
+    fn controller_state_deserializes_from_json() {
+        check_cases(
+            [
+                Case {
+                    scenario: "created",
+                    input: r#"{"state":"created"}"#,
+                    expect: Yields(SwitchControllerState::Created),
+                },
+                Case {
+                    scenario: "initializing",
+                    input: r#"{"state":"initializing","initializing_state":"WaitForOsMachineInterface"}"#,
+                    expect: Yields(SwitchControllerState::Initializing {
+                        initializing_state: InitializingState::WaitForOsMachineInterface,
+                    }),
+                },
+                Case {
+                    scenario: "configuring",
+                    input: r#"{"state":"configuring","config_state":"RotateOsPassword"}"#,
+                    expect: Yields(SwitchControllerState::Configuring {
+                        config_state: ConfiguringState::RotateOsPassword,
+                    }),
+                },
+                Case {
+                    scenario: "validating",
+                    input: r#"{"state":"validating","validating_state":"ValidationComplete"}"#,
+                    expect: Yields(SwitchControllerState::Validating {
+                        validating_state: ValidatingState::ValidationComplete,
+                    }),
+                },
+                Case {
+                    scenario: "bomvalidating",
+                    input: r#"{"state":"bomvalidating","bom_validating_state":"BomValidationComplete"}"#,
+                    expect: Yields(SwitchControllerState::BomValidating {
+                        bom_validating_state: BomValidatingState::BomValidationComplete,
+                    }),
+                },
+                Case {
+                    scenario: "ready",
+                    input: r#"{"state":"ready"}"#,
+                    expect: Yields(SwitchControllerState::Ready),
+                },
+                Case {
+                    scenario: "legacy ready with stray ready_state still deserializes to Ready",
+                    input: r#"{"state":"ready","ready_state":"poweroff"}"#,
+                    expect: Yields(SwitchControllerState::Ready),
+                },
+                Case {
+                    scenario: "maintenance: reset",
+                    input: r#"{"state":"maintenance","operation":{"operation":"reset"}}"#,
+                    expect: Yields(SwitchControllerState::Maintenance {
+                        operation: SwitchMaintenanceOperation::Reset,
+                    }),
+                },
+                Case {
+                    scenario: "error",
+                    input: r#"{"state":"error","cause":"boom"}"#,
+                    expect: Yields(SwitchControllerState::Error {
+                        cause: "boom".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "deleting",
+                    input: r#"{"state":"deleting"}"#,
+                    expect: Yields(SwitchControllerState::Deleting),
+                },
+                Case {
+                    scenario: "unknown state tag is rejected",
+                    input: r#"{"state":"frobnicating"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "missing state tag is rejected",
+                    input: r#"{"cause":"boom"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "error without its cause is rejected",
+                    input: r#"{"state":"error"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "not even json",
+                    input: "not json",
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<SwitchControllerState>(json).map_err(drop),
         );
-        assert_eq!(
-            serde_json::from_str::<SwitchControllerState>(&serialized).unwrap(),
-            state
+    }
+
+    #[test]
+    fn maintenance_operation_serializes_lowercase() {
+        check_cases(
+            [
+                Case {
+                    scenario: "power on",
+                    input: SwitchMaintenanceOperation::PowerOn,
+                    expect: Yields(r#"{"operation":"poweron"}"#.to_string()),
+                },
+                Case {
+                    scenario: "power off",
+                    input: SwitchMaintenanceOperation::PowerOff,
+                    expect: Yields(r#"{"operation":"poweroff"}"#.to_string()),
+                },
+                Case {
+                    scenario: "reset",
+                    input: SwitchMaintenanceOperation::Reset,
+                    expect: Yields(r#"{"operation":"reset"}"#.to_string()),
+                },
+            ],
+            |op| serde_json::to_string(&op).map_err(drop),
         );
-        let state = SwitchControllerState::Configuring {
-            config_state: ConfiguringState::RotateOsPassword,
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(
-            serialized,
-            "{\"state\":\"configuring\",\"config_state\":\"RotateOsPassword\"}"
+    }
+
+    #[test]
+    fn maintenance_operation_deserializes() {
+        check_cases(
+            [
+                Case {
+                    scenario: "power on",
+                    input: r#"{"operation":"poweron"}"#,
+                    expect: Yields(SwitchMaintenanceOperation::PowerOn),
+                },
+                Case {
+                    scenario: "power off",
+                    input: r#"{"operation":"poweroff"}"#,
+                    expect: Yields(SwitchMaintenanceOperation::PowerOff),
+                },
+                Case {
+                    scenario: "reset",
+                    input: r#"{"operation":"reset"}"#,
+                    expect: Yields(SwitchMaintenanceOperation::Reset),
+                },
+                Case {
+                    scenario: "uppercase tag is rejected",
+                    input: r#"{"operation":"PowerOn"}"#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unknown operation is rejected",
+                    input: r#"{"operation":"explode"}"#,
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<SwitchMaintenanceOperation>(json).map_err(drop),
         );
-        assert_eq!(
-            serde_json::from_str::<SwitchControllerState>(&serialized).unwrap(),
-            state
+    }
+
+    #[test]
+    fn fabric_manager_state_serializes_snake_case() {
+        check_cases(
+            [
+                Case {
+                    scenario: "ok",
+                    input: FabricManagerState::Ok,
+                    expect: Yields(r#""ok""#.to_string()),
+                },
+                Case {
+                    scenario: "not ok renders snake_case",
+                    input: FabricManagerState::NotOk,
+                    expect: Yields(r#""not_ok""#.to_string()),
+                },
+                Case {
+                    scenario: "unknown",
+                    input: FabricManagerState::Unknown,
+                    expect: Yields(r#""unknown""#.to_string()),
+                },
+            ],
+            |state| serde_json::to_string(&state).map_err(drop),
         );
-        let state = SwitchControllerState::Ready;
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, r#"{"state":"ready"}"#);
-        assert_eq!(
-            serde_json::from_str::<SwitchControllerState>(&serialized).unwrap(),
-            state
+    }
+
+    #[test]
+    fn fabric_manager_state_deserializes() {
+        check_cases(
+            [
+                Case {
+                    scenario: "ok",
+                    input: r#""ok""#,
+                    expect: Yields(FabricManagerState::Ok),
+                },
+                Case {
+                    scenario: "not_ok",
+                    input: r#""not_ok""#,
+                    expect: Yields(FabricManagerState::NotOk),
+                },
+                Case {
+                    scenario: "unknown",
+                    input: r#""unknown""#,
+                    expect: Yields(FabricManagerState::Unknown),
+                },
+                Case {
+                    scenario: "camelCase NotOk is rejected",
+                    input: r#""NotOk""#,
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "unrecognized state is rejected",
+                    input: r#""degraded""#,
+                    expect: Fails,
+                },
+            ],
+            |json| serde_json::from_str::<FabricManagerState>(json).map_err(drop),
         );
-        assert_eq!(
-            serde_json::from_str::<SwitchControllerState>(
-                r#"{"state":"ready","ready_state":"poweroff"}"#
-            )
-            .unwrap(),
-            SwitchControllerState::Ready,
-            "legacy Ready JSON with ready_state deserializes to Ready",
+    }
+
+    #[test]
+    fn display_status_is_running_only_when_ok_and_configured() {
+        check_values(
+            [
+                Check {
+                    scenario: "ok + CONFIGURED is running",
+                    input: fm_status(
+                        FabricManagerState::Ok,
+                        Some("CONTROL_PLANE_STATE_CONFIGURED"),
+                    ),
+                    expect: "running",
+                },
+                Check {
+                    scenario: "ok but no addition_info is not running",
+                    input: fm_status(FabricManagerState::Ok, None),
+                    expect: "not_running",
+                },
+                Check {
+                    scenario: "ok but different addition_info is not running",
+                    input: fm_status(
+                        FabricManagerState::Ok,
+                        Some("CONTROL_PLANE_STATE_INITIALIZING"),
+                    ),
+                    expect: "not_running",
+                },
+                Check {
+                    scenario: "ok but empty addition_info is not running",
+                    input: fm_status(FabricManagerState::Ok, Some("")),
+                    expect: "not_running",
+                },
+                Check {
+                    scenario: "not_ok even when configured is not running",
+                    input: fm_status(
+                        FabricManagerState::NotOk,
+                        Some("CONTROL_PLANE_STATE_CONFIGURED"),
+                    ),
+                    expect: "not_running",
+                },
+                Check {
+                    scenario: "unknown even when configured is not running",
+                    input: fm_status(
+                        FabricManagerState::Unknown,
+                        Some("CONTROL_PLANE_STATE_CONFIGURED"),
+                    ),
+                    expect: "not_running",
+                },
+                Check {
+                    scenario: "not_ok with no info is not running",
+                    input: fm_status(FabricManagerState::NotOk, None),
+                    expect: "not_running",
+                },
+            ],
+            |status| status.display_status(),
         );
-        let state = SwitchControllerState::Maintenance {
-            operation: SwitchMaintenanceOperation::PowerOn,
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(
-            serialized,
-            r#"{"state":"maintenance","operation":{"operation":"poweron"}}"#
-        );
-        assert_eq!(
-            serde_json::from_str::<SwitchControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = SwitchControllerState::Error {
-            cause: "cause goes here".to_string(),
-        };
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, r#"{"state":"error","cause":"cause goes here"}"#);
-        assert_eq!(
-            serde_json::from_str::<SwitchControllerState>(&serialized).unwrap(),
-            state
-        );
-        let state = SwitchControllerState::Deleting;
-        let serialized = serde_json::to_string(&state).unwrap();
-        assert_eq!(serialized, "{\"state\":\"deleting\"}");
-        assert_eq!(
-            serde_json::from_str::<SwitchControllerState>(&serialized).unwrap(),
-            state
+    }
+
+    #[test]
+    fn reprovision_request_defaults_continue_after_firmware_upgrade_to_true() {
+        check_cases(
+            [
+                Case {
+                    scenario: "omitted flag defaults to true",
+                    input: r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op"}"#,
+                    expect: Yields(true),
+                },
+                Case {
+                    scenario: "explicit false is honored",
+                    input: r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op","continue_after_firmware_upgrade":false}"#,
+                    expect: Yields(false),
+                },
+                Case {
+                    scenario: "explicit true is honored",
+                    input: r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op","continue_after_firmware_upgrade":true}"#,
+                    expect: Yields(true),
+                },
+            ],
+            |json| {
+                serde_json::from_str::<SwitchReprovisionRequest>(json)
+                    .map(|r| r.continue_after_firmware_upgrade)
+                    .map_err(drop)
+            },
         );
     }
 }

--- a/crates/api-model/src/tenant/identity_config.rs
+++ b/crates/api-model/src/tenant/identity_config.rs
@@ -537,3 +537,103 @@ mod key_id_tests {
         p256::SecretKey::from_pkcs8_pem(std::str::from_utf8(&private_pem).unwrap()).unwrap();
     }
 }
+
+// Real Postgres round-trips for the sqlx `Encode`/`Decode` codecs. Binding a
+// value and reading it back exercises the `Decode`-from-`PgValueRef` path the
+// in-memory tests can't reach; the per-test pool comes from the shared
+// `sqlx_test` harness, so `carbide-test-support` itself stays db-agnostic.
+//
+// Deliberately one test covering every codec: the harness builds its template
+// database lazily on first use, and concurrent first-time builds race, so a
+// single `sqlx_test` per crate sidesteps that cold-start flake.
+#[cfg(test)]
+mod sqlx_db_tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases_async};
+
+    use super::*;
+    use crate::tenant::TenantOrganizationId;
+
+    #[crate::sqlx_test]
+    async fn codecs_round_trip_through_postgres(pool: sqlx::PgPool) -> eyre::Result<()> {
+        // SigningAlgorithm <-> VARCHAR
+        check_cases_async(
+            [Case {
+                scenario: "SigningAlgorithm Es256 round-trips",
+                input: SigningAlgorithm::Es256,
+                expect: Yields(SigningAlgorithm::Es256),
+            }],
+            |alg: SigningAlgorithm| {
+                let pool = pool.clone();
+                async move {
+                    sqlx::query_scalar::<_, SigningAlgorithm>("SELECT $1::varchar")
+                        .bind(alg)
+                        .fetch_one(&pool)
+                        .await
+                        .map_err(drop)
+                }
+            },
+        )
+        .await;
+
+        // TenantOrganizationId <-> TEXT
+        check_cases_async(
+            [
+                Case {
+                    scenario: "alphanumeric org id round-trips",
+                    input: TenantOrganizationId::try_from("acme123".to_string()).unwrap(),
+                    expect: Yields(TenantOrganizationId::try_from("acme123".to_string()).unwrap()),
+                },
+                Case {
+                    scenario: "org id with dashes and underscores round-trips",
+                    input: TenantOrganizationId::try_from("acme-corp_1".to_string()).unwrap(),
+                    expect: Yields(
+                        TenantOrganizationId::try_from("acme-corp_1".to_string()).unwrap(),
+                    ),
+                },
+            ],
+            |org: TenantOrganizationId| {
+                let pool = pool.clone();
+                async move {
+                    sqlx::query_scalar::<_, TenantOrganizationId>("SELECT $1::text")
+                        .bind(org)
+                        .fetch_one(&pool)
+                        .await
+                        .map_err(drop)
+                }
+            },
+        )
+        .await;
+
+        // KeyId (`NonEmptyStr`, no `PartialEq`) <-> TEXT; compare the text, and
+        // the decode still rejects an empty residue.
+        check_cases_async(
+            [
+                Case {
+                    scenario: "typical key id round-trips",
+                    input: "signing-key-1",
+                    expect: Yields("signing-key-1".to_string()),
+                },
+                Case {
+                    scenario: "single-character key id round-trips",
+                    input: "k",
+                    expect: Yields("k".to_string()),
+                },
+            ],
+            |raw: &str| {
+                let pool = pool.clone();
+                async move {
+                    let key = KeyId::try_from(raw.to_string()).map_err(drop)?;
+                    let back: KeyId = sqlx::query_scalar("SELECT $1::text")
+                        .bind(key)
+                        .fetch_one(&pool)
+                        .await
+                        .map_err(drop)?;
+                    Ok::<_, ()>(back.as_str().to_string())
+                }
+            },
+        )
+        .await;
+        Ok(())
+    }
+}

--- a/crates/api-model/src/vpc/capability.rs
+++ b/crates/api-model/src/vpc/capability.rs
@@ -947,6 +947,22 @@ mod tests {
                     ),
                     expect: Yields(()),
                 },
+                Case {
+                    scenario: "ETV rejects an IPv6-only Tenant segment",
+                    input: (
+                        VpcVirtualizationType::EthernetVirtualizer,
+                        segment_with(NetworkSegmentType::Tenant, vec!["2001:db8::/64"], None),
+                    ),
+                    expect: FailsWith(ipv6_unsupported),
+                },
+                Case {
+                    scenario: "Flat + HostInband accepts an IPv6-only segment",
+                    input: (
+                        VpcVirtualizationType::Flat,
+                        segment_with(NetworkSegmentType::HostInband, vec!["2001:db8::/64"], None),
+                    ),
+                    expect: Yields(()),
+                },
             ],
             // The operation under test: gate a segment against a VPC type. The
             // error type isn't `PartialEq`, so we project it to its discriminant


### PR DESCRIPTION
This supports #3914.

The fold onto `carbide-test-support` (#2502) moved the existing `api-model` tests onto `Case`/`Check` tables. This builds on that by enumerating the input variants each pure function accepts and rejects: every enum variant for `Display` and `FromStr`, both wire forms and the rejection paths for `serde`, every boundary for the validators, and both `Ok` and `Err` arms for the `TryFrom` conversions.

The sqlx `Encode`/`Decode` codecs (`SigningAlgorithm`, `TenantOrganizationId`, `NonEmptyStr`) are also round-tripped through `sqlx` via `carbide-test-support`'s async runner and the shared `sqlx_test` harness, so the `Decode` paths are covered too.

Enumerating surfaced two real round-trip inconsistencies, fixed here:
- `PartitionKey::from_str` accepted out-of-range keys (> `0x7fff`) that `TryFrom<u16>` rejects; it now delegates to `TryFrom<u16>` so every construction path agrees.
- `OwnerType::SpxPartition` displayed as `spx_partition` but `FromStr` rejected it; the missing arm is added so it round-trips with `Display`.

```
┌──────────┬─────────┬─────────┐
│ Metric   │ Before  │  After  │
├──────────┼─────────┼─────────┤
│ Region   │ 49.47%  │ 58.39%  │
│ Function │ 45.88%  │ 59.47%  │
│ Line     │ 56.26%  │ 70.86%  │
└──────────┴─────────┴─────────┘
```

The remaining uncovered surface is the larger behavioral modules (`machine`, `site-explorer`) and the `FromRow` / proto-bound glue, which need inserted rows and fixtures rather than additional table rows.

All tests pass and clippy is clean.

## Description
<!-- Describe what this PR does -->

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
<!-- If applicable, provide GitHub Issue. -->

## Breaking Changes
- [ ] This PR contains breaking changes

<!-- If checked above, describe the breaking changes and migration steps -->

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
<!-- Any additional context, deployment notes, or reviewer guidance -->