### PR TITLE
[#2060] fix: rename forge.local to nico.local

### DIFF
--- a/crates/bmc-proxy/src/config.rs
+++ b/crates/bmc-proxy/src/config.rs
@@ -70,7 +70,7 @@ impl Defaults {
 
     fn trust_config() -> TrustConfig {
         TrustConfig {
-            spiffe_trust_domain: "forge.local".to_string(),
+            spiffe_trust_domain: "nico.local".to_string(),
             spiffe_service_base_paths: vec![
                 "/forge-system/sa/".to_string(),
                 "/default/sa/".to_string(),

--- a/crates/bmc-proxy/src/config.rs
+++ b/crates/bmc-proxy/src/config.rs
@@ -259,7 +259,7 @@ mod tests {
                     allowed_principals: vec![],
                     identity_pemfile_path: "/tls/cert.pem".to_string(),
                     root_cafile_path: "/tls/ca.pem".to_string(),
-                    trust_domain: "forge.local".to_string(),
+                    trust_domain: "nico.local".to_string(),
                     service_base_paths: vec![
                         "/forge-system/sa/".to_string(),
                         "/default/sa/".to_string(),
@@ -277,7 +277,7 @@ mod tests {
                     allowed_principals: vec![],
                     identity_pemfile_path: "/tls/cert.pem".to_string(),
                     root_cafile_path: "/tls/ca.pem".to_string(),
-                    trust_domain: "forge.local".to_string(),
+                    trust_domain: "nico.local".to_string(),
                     service_base_paths: vec![
                         "/forge-system/sa/".to_string(),
                         "/default/sa/".to_string(),
@@ -298,7 +298,7 @@ mod tests {
                     ],
                     identity_pemfile_path: "/tls/cert.pem".to_string(),
                     root_cafile_path: "/tls/ca.pem".to_string(),
-                    trust_domain: "forge.local".to_string(),
+                    trust_domain: "nico.local".to_string(),
                     service_base_paths: vec![
                         "/forge-system/sa/".to_string(),
                         "/default/sa/".to_string(),
@@ -316,7 +316,7 @@ mod tests {
                     allowed_principals: vec![],
                     identity_pemfile_path: "/tls/cert.pem".to_string(),
                     root_cafile_path: "/tls/ca.pem".to_string(),
-                    trust_domain: "forge.local".to_string(),
+                    trust_domain: "nico.local".to_string(),
                     service_base_paths: vec![
                         "/forge-system/sa/".to_string(),
                         "/default/sa/".to_string(),
@@ -334,7 +334,7 @@ mod tests {
                     allowed_principals: vec![],
                     identity_pemfile_path: "/tls/cert.pem".to_string(),
                     root_cafile_path: "/tls/ca.pem".to_string(),
-                    trust_domain: "forge.local".to_string(),
+                    trust_domain: "nico.local".to_string(),
                     service_base_paths: vec![
                         "/forge-system/sa/".to_string(),
                         "/default/sa/".to_string(),
@@ -352,7 +352,7 @@ mod tests {
                     allowed_principals: vec![],
                     identity_pemfile_path: "/tls/cert.pem".to_string(),
                     root_cafile_path: "/tls/ca.pem".to_string(),
-                    trust_domain: "forge.local".to_string(),
+                    trust_domain: "nico.local".to_string(),
                     service_base_paths: vec![
                         "/forge-system/sa/".to_string(),
                         "/default/sa/".to_string(),
@@ -370,7 +370,7 @@ mod tests {
                     allowed_principals: vec![],
                     identity_pemfile_path: "/tls/cert.pem".to_string(),
                     root_cafile_path: "/tls/ca.pem".to_string(),
-                    trust_domain: "forge.local".to_string(),
+                    trust_domain: "nico.local".to_string(),
                     service_base_paths: vec![
                         "/forge-system/sa/".to_string(),
                         "/default/sa/".to_string(),

--- a/crates/secrets/src/forge_vault.rs
+++ b/crates/secrets/src/forge_vault.rs
@@ -46,7 +46,7 @@ use crate::credentials::{
 
 const DEFAULT_VAULT_CA_PATH: &str = "/var/run/secrets/forge-roots/ca.crt";
 const VAULT_CACERT_ENV_VAR: &str = "VAULT_CACERT";
-const DEFAULT_SPIFFE_TRUST_DOMAIN: &str = "forge.local";
+const DEFAULT_SPIFFE_TRUST_DOMAIN: &str = "nico.local";
 const DEFAULT_SPIFFE_MACHINE_BASE_PATH: &str = "/forge-system/machine/";
 const VAULT_SPIFFE_TRUST_DOMAIN_ENV_VAR: &str = "VAULT_SPIFFE_TRUST_DOMAIN";
 const VAULT_SPIFFE_MACHINE_BASE_PATH_ENV_VAR: &str = "VAULT_SPIFFE_MACHINE_BASE_PATH";
@@ -907,7 +907,7 @@ pub struct VaultConfig {
     pub pki_role_name: Option<String>,
     pub token: Option<String>,
     pub vault_cacert: Option<String>,
-    /// SPIFFE trust domain for machine PKI URI SANs. Defaults to `forge.local`.
+    /// SPIFFE trust domain for machine PKI URI SANs. Defaults to `nico.local`.
     pub spiffe_trust_domain: Option<String>,
     /// Path prefix after the trust domain, e.g. `/forge-system/machine/`.
     pub spiffe_machine_base_path: Option<String>,
@@ -1058,6 +1058,14 @@ mod tests {
             machine_spiffe_uri("forge.local", "forge-system/machine", "abc-123"),
             "spiffe://forge.local/forge-system/machine/abc-123"
         );
+    }
+
+    #[test]
+    fn vault_config_spiffe_trust_domain_defaults_to_nico_local() {
+        use super::VaultConfig;
+
+        let config = VaultConfig::default();
+        assert_eq!(config.spiffe_trust_domain(), "nico.local");
     }
 
     fn jwt_from_payload(payload_value: serde_json::Value) -> String {

--- a/dev/mac-local-dev/carbide-api-config.toml
+++ b/dev/mac-local-dev/carbide-api-config.toml
@@ -78,7 +78,7 @@ admin_root_cafile_path = "dev/certs/localhost/ca.crt"
 permissive_mode = true
 
 [auth.trust]
-spiffe_trust_domain = "forge.local"
+spiffe_trust_domain = "nico.local"
 spiffe_service_base_paths = ["/forge-system/sa/", "/default/sa/"]
 spiffe_machine_base_path = "/forge-system/machine/"
 additional_issuer_cns = []

--- a/dev/mac-local-dev/run-carbide-api.sh
+++ b/dev/mac-local-dev/run-carbide-api.sh
@@ -94,7 +94,7 @@ else
     vault secrets enable -path=certs pki
     vault write certs/root/generate/internal common_name=myvault.com ttl=87600h
     vault write certs/config/urls issuing_certificates=\"http://vault.example.com:8200/v1/pki/ca\" crl_distribution_points=\"http://vault.example.com:8200/v1/pki/crl\"
-    vault write certs/roles/role allowed_domains=example.com allow_subdomains=true max_ttl=72h require_cn=false allowed_uri_sans=\"spiffe://forge.local/*\"
+    vault write certs/roles/role allowed_domains=example.com allow_subdomains=true max_ttl=72h require_cn=false allowed_uri_sans=\"spiffe://nico.local/*\"
   " >/dev/null 2>&1
 
   ok "Vault initialized at $VAULT_ADDR"

--- a/helm/examples/carbide-legacy.yaml
+++ b/helm/examples/carbide-legacy.yaml
@@ -14,6 +14,10 @@
 ## trust domain).
 global:
   spiffe:
+    # Legacy SPIFFE trust domain (see GH-2060). Rust/Helm default is nico.local;
+    # keep forge.local here until every client cert and Vault URI SAN is issued
+    # under nico.local. Path prefixes (/forge-system/machine/, /forge-system/sa/)
+    # come from auth.namespace below, not from this trustDomain field.
     trustDomain: forge.local
 
 nico-api:


### PR DESCRIPTION
## Description
This fix aligns SPIFFE trust domain defaults with Helm’s existing `nico.local` convention.

Helm already sets `global.spiffe.trustDomain: nico.local` and renders it into `[auth.trust]` via ConfigMap. Rust code still defaulted to `forge.local` when no config/env override was present, which could produce Vault machine PKI URI SANs under the wrong trust domain on non-Helm or misconfigured paths.

This PR changes only the trust domain default 

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)
#2060 

## Breaking Changes
### Migration / rollout
Legacy sites with existing `forge.local` machine/service certs must keep an explicit override before upgrading:

```
global:
  spiffe:
    trustDomain: forge.local
```
Or layer `helm/examples/carbide-legacy.yaml`.

## Testing
<!-- How was this tested? Check all that apply -->
- [x] Unit tests added/updated
- [ ] Integration tests added/updated  
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

