### PR TITLE
test(uuid): fold ID tests onto carbide-test-support + raise coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3071,6 +3071,7 @@ dependencies = [
 name = "carbide-uuid"
 version = "0.0.0"
 dependencies = [
+ "carbide-test-support",
  "data-encoding",
  "eyre",
  "prost",

--- a/crates/uuid/Cargo.toml
+++ b/crates/uuid/Cargo.toml
@@ -51,5 +51,8 @@ thiserror = { workspace = true }
 uuid = { features = ["v4", "serde"], workspace = true }
 prost = { workspace = true }
 
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+
 [lints]
 workspace = true

--- a/crates/uuid/src/instance_type/mod.rs
+++ b/crates/uuid/src/instance_type/mod.rs
@@ -178,3 +178,116 @@ impl<'de> Deserialize<'de> for InstanceTypeId {
         Ok(id)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
+    use super::*;
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum ParseFailure {
+        Empty,
+    }
+
+    fn parse_instance_type_id(input: &str) -> Result<String, ParseFailure> {
+        InstanceTypeId::from_str(input)
+            .map(|id| id.to_string())
+            .map_err(|err| match err {
+                InstanceTypeIdParseError::Invalid(_) => unreachable!("parser only rejects empty"),
+                InstanceTypeIdParseError::Empty => ParseFailure::Empty,
+            })
+    }
+
+    fn deserialize_instance_type_id(input: &str) -> Result<String, ()> {
+        serde_json::from_str::<InstanceTypeId>(input)
+            .map(|id| id.to_string())
+            .map_err(|_| ())
+    }
+
+    #[test]
+    fn test_instance_type_id_parse_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "arbitrary instance type name",
+                    input: "gb200-nvl72",
+                    expect: Yields("gb200-nvl72".to_string()),
+                },
+                Case {
+                    scenario: "UUID-backed instance type name",
+                    input: "00000000-0000-0000-0000-000000000000",
+                    expect: Yields("00000000-0000-0000-0000-000000000000".to_string()),
+                },
+                Case {
+                    scenario: "empty value",
+                    input: "",
+                    expect: FailsWith(ParseFailure::Empty),
+                },
+            ],
+            parse_instance_type_id,
+        );
+    }
+
+    #[test]
+    fn test_instance_type_id_from_uuid() {
+        check_values(
+            [Check {
+                scenario: "nil UUID",
+                input: Uuid::nil(),
+                expect: "00000000-0000-0000-0000-000000000000".to_string(),
+            }],
+            |uuid| InstanceTypeId::from(uuid).to_string(),
+        );
+    }
+
+    #[test]
+    fn test_instance_type_id_serde_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid string",
+                    input: "\"gb200-nvl72\"",
+                    expect: Yields("gb200-nvl72".to_string()),
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "\"\"",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-string JSON",
+                    input: "42",
+                    expect: Fails,
+                },
+            ],
+            deserialize_instance_type_id,
+        );
+
+        let serialized = serde_json::to_string(
+            &InstanceTypeId::from_str("gb200-nvl72").expect("valid instance type ID"),
+        )
+        .expect("failed to serialize instance type ID");
+        assert_eq!(serialized, "\"gb200-nvl72\"");
+    }
+
+    #[test]
+    fn test_instance_type_id_parse_error_value() {
+        check_values(
+            [
+                Check {
+                    scenario: "invalid",
+                    input: InstanceTypeIdParseError::Invalid("bad".to_string()),
+                    expect: "bad".to_string(),
+                },
+                Check {
+                    scenario: "empty",
+                    input: InstanceTypeIdParseError::Empty,
+                    expect: String::new(),
+                },
+            ],
+            InstanceTypeIdParseError::value,
+        );
+    }
+}

--- a/crates/uuid/src/machine/mod.rs
+++ b/crates/uuid/src/machine/mod.rs
@@ -516,60 +516,175 @@ impl<'de> Deserialize<'de> for MachineId {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
-    #[test]
-    fn test_machine_id_round_trip() {
-        let machine_id_str = "fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg";
-        let machine_id = MachineId::from_str(machine_id_str)
-            .expect("Should have successfully converted from a valid string");
-        let round_tripped = machine_id.to_string();
-        assert_eq!(machine_id_str, round_tripped);
+    #[derive(Debug, PartialEq, Eq)]
+    enum ParseFailure {
+        Length,
+        Prefix,
+        Encoding,
+    }
+
+    fn parse_machine_id(input: &str) -> Result<String, ParseFailure> {
+        MachineId::from_str(input)
+            .map(|id| id.to_string())
+            .map_err(|err| match err {
+                MachineIdParseError::Length(_) => ParseFailure::Length,
+                MachineIdParseError::Prefix(_) => ParseFailure::Prefix,
+                MachineIdParseError::Encoding(_) => ParseFailure::Encoding,
+            })
     }
 
     #[test]
-    fn test_invalid_machine_ids() {
-        match MachineId::from_str("fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hc") {
-            // one character short
-            Err(MachineIdParseError::Length(_)) => {} // Expect an error
-            Ok(_) => panic!("Converting from a too-short machine ID should have failed"),
-            Err(e) => panic!(
-                "Converting from a too-short string should have failed with a length error, got {e}"
-            ),
-        }
+    fn test_machine_id_parse_cases() {
+        const VALID_MACHINE_ID: &str =
+            "fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg";
 
-        match MachineId::from_str("FM100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg") {
-            Err(MachineIdParseError::Prefix(_)) => {} // Expect an error
-            Ok(_) => {
-                panic!("Converting from a machine ID with an invalid prefix should have failed")
-            }
-            Err(e) => panic!(
-                "Converting from a machine ID with an invalid prefix should have failed with a Prefix error, got {e}"
-            ),
-        }
+        check_cases(
+            [
+                Case {
+                    scenario: "valid host TPM machine ID",
+                    input: VALID_MACHINE_ID,
+                    expect: Yields(VALID_MACHINE_ID.to_string()),
+                },
+                Case {
+                    scenario: "one character short",
+                    input: "fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hc",
+                    expect: FailsWith(ParseFailure::Length),
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: FailsWith(ParseFailure::Length),
+                },
+                Case {
+                    scenario: "invalid prefix casing",
+                    input: "FM100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
+                    expect: FailsWith(ParseFailure::Prefix),
+                },
+                Case {
+                    scenario: "invalid machine type",
+                    input: "fm100xt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
+                    expect: FailsWith(ParseFailure::Prefix),
+                },
+                Case {
+                    scenario: "invalid source",
+                    input: "fm100dx038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
+                    expect: FailsWith(ParseFailure::Prefix),
+                },
+                Case {
+                    scenario: "invalid base32 payload",
+                    input: "fm100ht038bg3qsho433vkg684heguv28!qaggmrsh2ugn1qk096n2c6hcg",
+                    expect: FailsWith(ParseFailure::Encoding),
+                },
+            ],
+            parse_machine_id,
+        );
+    }
 
-        match MachineId::from_str("fm100xt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg") {
-            Err(MachineIdParseError::Prefix(_)) => {} // Expect an error
-            Ok(_) => panic!("Converting from a machine ID with type `x` should have failed"),
-            Err(e) => panic!(
-                "Converting from a machine ID with type `x` should have failed with a Prefix error, got {e}"
-            ),
-        }
+    #[test]
+    fn test_machine_type_mappings() {
+        check_values(
+            [
+                Check {
+                    scenario: "DPU",
+                    input: MachineType::Dpu,
+                    expect: ('d', "fm100d", "dpu", "DPU".to_string(), true, false, false),
+                },
+                Check {
+                    scenario: "host",
+                    input: MachineType::Host,
+                    expect: (
+                        'h',
+                        "fm100h",
+                        "host",
+                        "Host".to_string(),
+                        false,
+                        true,
+                        false,
+                    ),
+                },
+                Check {
+                    scenario: "predicted host",
+                    input: MachineType::PredictedHost,
+                    expect: (
+                        'p',
+                        "fm100p",
+                        "predictedhost",
+                        "Host (Predicted)".to_string(),
+                        false,
+                        false,
+                        true,
+                    ),
+                },
+            ],
+            |ty| {
+                (
+                    ty.id_char(),
+                    ty.id_prefix(),
+                    ty.metrics_value(),
+                    ty.to_string(),
+                    ty.is_dpu(),
+                    ty.is_host(),
+                    ty.is_predicted_host(),
+                )
+            },
+        );
+    }
 
-        match MachineId::from_str("fm100dx038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg") {
-            Err(MachineIdParseError::Prefix(_)) => {} // Expect an error
-            Ok(_) => panic!("Converting from a machine ID with source `x` should have failed"),
-            Err(e) => panic!(
-                "Converting from a machine ID with source `x` should have failed with a Prefix error, got {e}"
-            ),
-        }
+    #[test]
+    fn test_machine_type_from_id_char() {
+        check_values(
+            [
+                Check {
+                    scenario: "DPU",
+                    input: 'd',
+                    expect: Some(MachineType::Dpu),
+                },
+                Check {
+                    scenario: "host",
+                    input: 'h',
+                    expect: Some(MachineType::Host),
+                },
+                Check {
+                    scenario: "predicted host",
+                    input: 'p',
+                    expect: Some(MachineType::PredictedHost),
+                },
+                Check {
+                    scenario: "unknown",
+                    input: 'x',
+                    expect: None,
+                },
+            ],
+            MachineType::from_id_char,
+        );
+    }
 
-        match MachineId::from_str("fm100ht038bg3qsho433vkg684heguv28!qaggmrsh2ugn1qk096n2c6hcg") {
-            Err(MachineIdParseError::Encoding(_)) => {} // Expect an error
-            Ok(_) => panic!("Converting from a machine ID with a `!` should have failed"),
-            Err(e) => panic!(
-                "Converting from a machine ID with a `!` should have failed with an Encoding error, got {e}"
-            ),
-        }
+    #[test]
+    fn test_machine_id_source_from_id_char() {
+        check_values(
+            [
+                Check {
+                    scenario: "TPM",
+                    input: 't',
+                    expect: Some(MachineIdSource::Tpm),
+                },
+                Check {
+                    scenario: "product board chassis serial",
+                    input: 's',
+                    expect: Some(MachineIdSource::ProductBoardChassisSerial),
+                },
+                Check {
+                    scenario: "unknown",
+                    input: 'x',
+                    expect: None,
+                },
+            ],
+            MachineIdSource::from_id_char,
+        );
     }
 }

--- a/crates/uuid/src/network_security_group/mod.rs
+++ b/crates/uuid/src/network_security_group/mod.rs
@@ -178,3 +178,119 @@ impl<'de> Deserialize<'de> for NetworkSecurityGroupId {
         Ok(id)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
+    use super::*;
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum ParseFailure {
+        Empty,
+    }
+
+    fn parse_network_security_group_id(input: &str) -> Result<String, ParseFailure> {
+        NetworkSecurityGroupId::from_str(input)
+            .map(|id| id.to_string())
+            .map_err(|err| match err {
+                NetworkSecurityGroupIdParseError::Invalid(_) => {
+                    unreachable!("parser only rejects empty")
+                }
+                NetworkSecurityGroupIdParseError::Empty => ParseFailure::Empty,
+            })
+    }
+
+    fn deserialize_network_security_group_id(input: &str) -> Result<String, ()> {
+        serde_json::from_str::<NetworkSecurityGroupId>(input)
+            .map(|id| id.to_string())
+            .map_err(|_| ())
+    }
+
+    #[test]
+    fn test_network_security_group_id_parse_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "arbitrary security group name",
+                    input: "tenant-edge",
+                    expect: Yields("tenant-edge".to_string()),
+                },
+                Case {
+                    scenario: "UUID-backed security group name",
+                    input: "00000000-0000-0000-0000-000000000000",
+                    expect: Yields("00000000-0000-0000-0000-000000000000".to_string()),
+                },
+                Case {
+                    scenario: "empty value",
+                    input: "",
+                    expect: FailsWith(ParseFailure::Empty),
+                },
+            ],
+            parse_network_security_group_id,
+        );
+    }
+
+    #[test]
+    fn test_network_security_group_id_from_uuid() {
+        check_values(
+            [Check {
+                scenario: "nil UUID",
+                input: Uuid::nil(),
+                expect: "00000000-0000-0000-0000-000000000000".to_string(),
+            }],
+            |uuid| NetworkSecurityGroupId::from(uuid).to_string(),
+        );
+    }
+
+    #[test]
+    fn test_network_security_group_id_serde_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid string",
+                    input: "\"tenant-edge\"",
+                    expect: Yields("tenant-edge".to_string()),
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "\"\"",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-string JSON",
+                    input: "42",
+                    expect: Fails,
+                },
+            ],
+            deserialize_network_security_group_id,
+        );
+
+        let serialized = serde_json::to_string(
+            &NetworkSecurityGroupId::from_str("tenant-edge")
+                .expect("valid network security group ID"),
+        )
+        .expect("failed to serialize network security group ID");
+        assert_eq!(serialized, "\"tenant-edge\"");
+    }
+
+    #[test]
+    fn test_network_security_group_id_parse_error_value() {
+        check_values(
+            [
+                Check {
+                    scenario: "invalid",
+                    input: NetworkSecurityGroupIdParseError::Invalid("bad".to_string()),
+                    expect: "bad".to_string(),
+                },
+                Check {
+                    scenario: "empty",
+                    input: NetworkSecurityGroupIdParseError::Empty,
+                    expect: String::new(),
+                },
+            ],
+            NetworkSecurityGroupIdParseError::value,
+        );
+    }
+}

--- a/crates/uuid/src/power_shelf/mod.rs
+++ b/crates/uuid/src/power_shelf/mod.rs
@@ -479,64 +479,139 @@ mod legacy_rpc {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
-    #[test]
-    fn test_power_shelf_id_round_trip() {
-        let power_shelf_id_str = "ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg";
-        let power_shelf_id = PowerShelfId::from_str(power_shelf_id_str)
-            .expect("Should have successfully converted from a valid string");
-        let round_tripped = power_shelf_id.to_string();
-        assert_eq!(power_shelf_id_str, round_tripped);
+    #[derive(Debug, PartialEq, Eq)]
+    enum ParseFailure {
+        Length,
+        Prefix,
+        Encoding,
+    }
+
+    fn parse_power_shelf_id(input: &str) -> Result<String, ParseFailure> {
+        PowerShelfId::from_str(input)
+            .map(|id| id.to_string())
+            .map_err(|err| match err {
+                PowerShelfIdParseError::Length(_) => ParseFailure::Length,
+                PowerShelfIdParseError::Prefix(_) => ParseFailure::Prefix,
+                PowerShelfIdParseError::Encoding(_) => ParseFailure::Encoding,
+            })
     }
 
     #[test]
-    fn test_invalid_power_shelf_ids() {
-        match PowerShelfId::from_str("ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hc") {
-            // one character short
-            Err(PowerShelfIdParseError::Length(_)) => {} // Expect an error
-            Ok(_) => panic!("Converting from a too-short power shelf ID should have failed"),
-            Err(e) => panic!(
-                "Converting from a too-short string should have failed with a length error, got {e}"
-            ),
-        }
+    fn test_power_shelf_id_parse_cases() {
+        const VALID_POWER_SHELF_ID: &str =
+            "ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg";
 
-        match PowerShelfId::from_str("PS100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg")
-        {
-            Err(PowerShelfIdParseError::Prefix(_)) => {} // Expect an error
-            Ok(_) => {
-                panic!("Converting from a power shelf ID with an invalid prefix should have failed")
-            }
-            Err(e) => panic!(
-                "Converting from a power shelf ID with an invalid prefix should have failed with a Prefix error, got {e}"
-            ),
-        }
+        check_cases(
+            [
+                Case {
+                    scenario: "valid host TPM power shelf ID",
+                    input: VALID_POWER_SHELF_ID,
+                    expect: Yields(VALID_POWER_SHELF_ID.to_string()),
+                },
+                Case {
+                    scenario: "one character short",
+                    input: "ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hc",
+                    expect: FailsWith(ParseFailure::Length),
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: FailsWith(ParseFailure::Length),
+                },
+                Case {
+                    scenario: "invalid prefix casing",
+                    input: "PS100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
+                    expect: FailsWith(ParseFailure::Prefix),
+                },
+                Case {
+                    scenario: "invalid power shelf type",
+                    input: "ps100xt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
+                    expect: FailsWith(ParseFailure::Prefix),
+                },
+                Case {
+                    scenario: "invalid source",
+                    input: "ps100dx038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
+                    expect: FailsWith(ParseFailure::Prefix),
+                },
+                Case {
+                    scenario: "invalid base32 payload",
+                    input: "ps100ht038bg3qsho433vkg684heguv28!qaggmrsh2ugn1qk096n2c6hcg",
+                    expect: FailsWith(ParseFailure::Encoding),
+                },
+            ],
+            parse_power_shelf_id,
+        );
+    }
 
-        match PowerShelfId::from_str("ps100xt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg")
-        {
-            Err(PowerShelfIdParseError::Prefix(_)) => {} // Expect an error
-            Ok(_) => panic!("Converting from a power shelf ID with type `x` should have failed"),
-            Err(e) => panic!(
-                "Converting from a power shelf ID with type `x` should have failed with a Prefix error, got {e}"
-            ),
-        }
+    #[test]
+    fn test_power_shelf_type_mappings() {
+        check_values(
+            [
+                Check {
+                    scenario: "rack",
+                    input: PowerShelfType::Rack,
+                    expect: ('r', "Rack".to_string(), true, false),
+                },
+                Check {
+                    scenario: "host",
+                    input: PowerShelfType::Host,
+                    expect: ('h', "Host".to_string(), false, true),
+                },
+            ],
+            |ty| (ty.id_char(), ty.to_string(), ty.is_rack(), ty.is_host()),
+        );
+    }
 
-        match PowerShelfId::from_str("ps100dx038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg")
-        {
-            Err(PowerShelfIdParseError::Prefix(_)) => {} // Expect an error
-            Ok(_) => panic!("Converting from a power shelf ID with source `x` should have failed"),
-            Err(e) => panic!(
-                "Converting from a power shelf ID with source `x` should have failed with a Prefix error, got {e}"
-            ),
-        }
+    #[test]
+    fn test_power_shelf_type_from_id_char() {
+        check_values(
+            [
+                Check {
+                    scenario: "rack",
+                    input: 'r',
+                    expect: Some(PowerShelfType::Rack),
+                },
+                Check {
+                    scenario: "host",
+                    input: 'h',
+                    expect: Some(PowerShelfType::Host),
+                },
+                Check {
+                    scenario: "unknown",
+                    input: 'x',
+                    expect: None,
+                },
+            ],
+            PowerShelfType::from_id_char,
+        );
+    }
 
-        match PowerShelfId::from_str("ps100ht038bg3qsho433vkg684heguv28!qaggmrsh2ugn1qk096n2c6hcg")
-        {
-            Err(PowerShelfIdParseError::Encoding(_)) => {} // Expect an error
-            Ok(_) => panic!("Converting from a power shelf ID with a `!` should have failed"),
-            Err(e) => panic!(
-                "Converting from a power shelf ID with a `!` should have failed with an Encoding error, got {e}"
-            ),
-        }
+    #[test]
+    fn test_power_shelf_id_source_from_id_char() {
+        check_values(
+            [
+                Check {
+                    scenario: "TPM",
+                    input: 't',
+                    expect: Some(PowerShelfIdSource::Tpm),
+                },
+                Check {
+                    scenario: "product board chassis serial",
+                    input: 's',
+                    expect: Some(PowerShelfIdSource::ProductBoardChassisSerial),
+                },
+                Check {
+                    scenario: "unknown",
+                    input: 'x',
+                    expect: None,
+                },
+            ],
+            PowerShelfIdSource::from_id_char,
+        );
     }
 }

--- a/crates/uuid/src/rack/mod.rs
+++ b/crates/uuid/src/rack/mod.rs
@@ -287,54 +287,241 @@ pub enum RackIdParseError {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
-    #[test]
-    fn test_rack_id_round_trip_legacy() {
-        // Legacy ps100-encoded rack IDs should still work.
-        let rack_id_str = "ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg";
-        let rack_id = RackId::from_str(rack_id_str)
-            .expect("Should have successfully converted from a valid string");
-        let round_tripped = rack_id.to_string();
-        assert_eq!(rack_id_str, round_tripped);
+    #[derive(Debug, PartialEq, Eq)]
+    enum ParseFailure {
+        Empty,
+    }
+
+    fn parse_rack_id(input: &str) -> Result<String, ParseFailure> {
+        RackId::from_str(input)
+            .map(|id| id.to_string())
+            .map_err(|err| match err {
+                RackIdParseError::Empty => ParseFailure::Empty,
+            })
+    }
+
+    fn parse_rack_profile_id(input: &str) -> Result<String, ParseFailure> {
+        RackProfileId::from_str(input)
+            .map(|id| id.to_string())
+            .map_err(|err| match err {
+                RackIdParseError::Empty => ParseFailure::Empty,
+            })
+    }
+
+    fn deserialize_rack_id(input: &str) -> Result<String, ()> {
+        serde_json::from_str::<RackId>(input)
+            .map(|id| id.to_string())
+            .map_err(|_| ())
+    }
+
+    fn deserialize_rack_profile_id(input: &str) -> Result<String, ()> {
+        serde_json::from_str::<RackProfileId>(input)
+            .map(|id| id.to_string())
+            .map_err(|_| ())
     }
 
     #[test]
-    fn test_rack_id_arbitrary_string() {
-        // DCIM-provided rack IDs can be any non-empty string.
-        let rack_id = RackId::from_str("P20").unwrap();
-        assert_eq!(rack_id.to_string(), "P20");
-
-        let rack_id = RackId::from_str("rack-42-us-west-2").unwrap();
-        assert_eq!(rack_id.to_string(), "rack-42-us-west-2");
-
-        let rack_id = RackId::from_str("i-am-just-a-rack-id").unwrap();
-        assert_eq!(rack_id.to_string(), "i-am-just-a-rack-id");
+    fn test_rack_id_parse_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "legacy ps100-encoded rack ID",
+                    input: "ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
+                    expect: Yields(
+                        "ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg".to_string(),
+                    ),
+                },
+                Case {
+                    scenario: "DCIM rack name",
+                    input: "P20",
+                    expect: Yields("P20".to_string()),
+                },
+                Case {
+                    scenario: "regional rack name",
+                    input: "rack-42-us-west-2",
+                    expect: Yields("rack-42-us-west-2".to_string()),
+                },
+                Case {
+                    scenario: "descriptive rack name",
+                    input: "i-am-just-a-rack-id",
+                    expect: Yields("i-am-just-a-rack-id".to_string()),
+                },
+                Case {
+                    scenario: "empty rack ID",
+                    input: "",
+                    expect: FailsWith(ParseFailure::Empty),
+                },
+            ],
+            parse_rack_id,
+        );
     }
 
     #[test]
-    fn test_rack_id_empty_fails() {
-        assert!(RackId::from_str("").is_err());
+    fn test_rack_id_conversions() {
+        check_values(
+            [
+                Check {
+                    scenario: "new",
+                    input: RackId::new("test-rack"),
+                    expect: (
+                        "test-rack".to_string(),
+                        "test-rack".to_string(),
+                        "test-rack".to_string(),
+                    ),
+                },
+                Check {
+                    scenario: "from str",
+                    input: RackId::from("another-rack"),
+                    expect: (
+                        "another-rack".to_string(),
+                        "another-rack".to_string(),
+                        "another-rack".to_string(),
+                    ),
+                },
+                Check {
+                    scenario: "from string",
+                    input: RackId::from(String::from("string-rack")),
+                    expect: (
+                        "string-rack".to_string(),
+                        "string-rack".to_string(),
+                        "string-rack".to_string(),
+                    ),
+                },
+            ],
+            |rack_id| {
+                (
+                    rack_id.as_str().to_string(),
+                    rack_id.to_string(),
+                    rack_id.as_ref().to_string(),
+                )
+            },
+        );
     }
 
     #[test]
-    fn test_rack_id_serde_round_trip() {
-        let rack_id = RackId::new("my-custom-rack");
-        let json = serde_json::to_string(&rack_id).unwrap();
-        assert_eq!(json, "\"my-custom-rack\"");
-        let deserialized: RackId = serde_json::from_str(&json).unwrap();
-        assert_eq!(rack_id, deserialized);
+    fn test_rack_id_serde_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid string",
+                    input: "\"my-custom-rack\"",
+                    expect: Yields("my-custom-rack".to_string()),
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "\"\"",
+                    expect: Yields(String::new()),
+                },
+                Case {
+                    scenario: "non-string JSON",
+                    input: "42",
+                    expect: Fails,
+                },
+            ],
+            deserialize_rack_id,
+        );
+
+        let serialized = serde_json::to_string(&RackId::new("my-custom-rack"))
+            .expect("failed to serialize rack ID");
+        assert_eq!(serialized, "\"my-custom-rack\"");
     }
 
     #[test]
-    fn test_rack_id_from_str_impls() {
-        let rack_id: RackId = "test-rack".into();
-        assert_eq!(rack_id.as_str(), "test-rack");
+    fn test_rack_profile_id_parse_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "rack profile name",
+                    input: "NVL72",
+                    expect: Yields("NVL72".to_string()),
+                },
+                Case {
+                    scenario: "lowercase rack profile name",
+                    input: "nvl36",
+                    expect: Yields("nvl36".to_string()),
+                },
+                Case {
+                    scenario: "empty rack profile ID",
+                    input: "",
+                    expect: FailsWith(ParseFailure::Empty),
+                },
+            ],
+            parse_rack_profile_id,
+        );
+    }
 
-        let rack_id = RackId::from("another-rack");
-        assert_eq!(rack_id.as_str(), "another-rack");
+    #[test]
+    fn test_rack_profile_id_conversions() {
+        check_values(
+            [
+                Check {
+                    scenario: "new",
+                    input: RackProfileId::new("NVL72"),
+                    expect: (
+                        "NVL72".to_string(),
+                        "NVL72".to_string(),
+                        "NVL72".to_string(),
+                    ),
+                },
+                Check {
+                    scenario: "from str",
+                    input: RackProfileId::from("NVL36"),
+                    expect: (
+                        "NVL36".to_string(),
+                        "NVL36".to_string(),
+                        "NVL36".to_string(),
+                    ),
+                },
+                Check {
+                    scenario: "from string",
+                    input: RackProfileId::from(String::from("GB200")),
+                    expect: (
+                        "GB200".to_string(),
+                        "GB200".to_string(),
+                        "GB200".to_string(),
+                    ),
+                },
+            ],
+            |profile_id| {
+                (
+                    profile_id.as_str().to_string(),
+                    profile_id.to_string(),
+                    profile_id.as_ref().to_string(),
+                )
+            },
+        );
+    }
 
-        let rack_id = RackId::from(String::from("string-rack"));
-        assert_eq!(rack_id.as_str(), "string-rack");
+    #[test]
+    fn test_rack_profile_id_serde_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid string",
+                    input: "\"NVL72\"",
+                    expect: Yields("NVL72".to_string()),
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "\"\"",
+                    expect: Yields(String::new()),
+                },
+                Case {
+                    scenario: "non-string JSON",
+                    input: "42",
+                    expect: Fails,
+                },
+            ],
+            deserialize_rack_profile_id,
+        );
+
+        let serialized = serde_json::to_string(&RackProfileId::new("NVL72"))
+            .expect("failed to serialize rack profile ID");
+        assert_eq!(serialized, "\"NVL72\"");
     }
 }

--- a/crates/uuid/src/switch/mod.rs
+++ b/crates/uuid/src/switch/mod.rs
@@ -461,60 +461,126 @@ mod legacy_rpc {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
     use super::*;
 
-    #[test]
-    fn test_switch_id_round_trip() {
-        let switch_id_str = "sw100nt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg";
-        let switch_id = SwitchId::from_str(switch_id_str)
-            .expect("Should have successfully converted from a valid string");
-        let round_tripped = switch_id.to_string();
-        assert_eq!(switch_id_str, round_tripped);
+    #[derive(Debug, PartialEq, Eq)]
+    enum ParseFailure {
+        Length,
+        Prefix,
+        Encoding,
+    }
+
+    fn parse_switch_id(input: &str) -> Result<String, ParseFailure> {
+        SwitchId::from_str(input)
+            .map(|id| id.to_string())
+            .map_err(|err| match err {
+                SwitchIdParseError::Length(_) => ParseFailure::Length,
+                SwitchIdParseError::Prefix(_) => ParseFailure::Prefix,
+                SwitchIdParseError::Encoding(_) => ParseFailure::Encoding,
+            })
     }
 
     #[test]
-    fn test_invalid_switch_ids() {
-        match SwitchId::from_str("sw100nt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hc") {
-            // one character short
-            Err(SwitchIdParseError::Length(_)) => {} // Expect an error
-            Ok(_) => panic!("Converting from a too-short switch ID should have failed"),
-            Err(e) => panic!(
-                "Converting from a too-short string should have failed with a length error, got {e}"
-            ),
-        }
+    fn test_switch_id_parse_cases() {
+        const VALID_SWITCH_ID: &str = "sw100nt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg";
 
-        match SwitchId::from_str("SW100nt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg") {
-            Err(SwitchIdParseError::Prefix(_)) => {} // Expect an error
-            Ok(_) => {
-                panic!("Converting from a switch ID with an invalid prefix should have failed")
-            }
-            Err(e) => panic!(
-                "Converting from a switch ID with an invalid prefix should have failed with a Prefix error, got {e}"
-            ),
-        }
+        check_cases(
+            [
+                Case {
+                    scenario: "valid NVLink TPM switch ID",
+                    input: VALID_SWITCH_ID,
+                    expect: Yields(VALID_SWITCH_ID.to_string()),
+                },
+                Case {
+                    scenario: "one character short",
+                    input: "sw100nt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hc",
+                    expect: FailsWith(ParseFailure::Length),
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: FailsWith(ParseFailure::Length),
+                },
+                Case {
+                    scenario: "invalid prefix casing",
+                    input: "SW100nt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
+                    expect: FailsWith(ParseFailure::Prefix),
+                },
+                Case {
+                    scenario: "invalid switch type",
+                    input: "sw100xt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
+                    expect: FailsWith(ParseFailure::Prefix),
+                },
+                Case {
+                    scenario: "invalid source",
+                    input: "sw100nx038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
+                    expect: FailsWith(ParseFailure::Prefix),
+                },
+                Case {
+                    scenario: "invalid base32 payload",
+                    input: "sw100nt038bg3qsho433vkg684heguv28!qaggmrsh2ugn1qk096n2c6hcg",
+                    expect: FailsWith(ParseFailure::Encoding),
+                },
+            ],
+            parse_switch_id,
+        );
+    }
 
-        match SwitchId::from_str("sw100xt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg") {
-            Err(SwitchIdParseError::Prefix(_)) => {} // Expect an error
-            Ok(_) => panic!("Converting from a switch ID with type `x` should have failed"),
-            Err(e) => panic!(
-                "Converting from a switch ID with type `x` should have failed with a Prefix error, got {e}"
-            ),
-        }
+    #[test]
+    fn test_switch_type_mappings() {
+        check_values(
+            [Check {
+                scenario: "NVLink",
+                input: SwitchType::NvLink,
+                expect: ('n', "NvLink".to_string()),
+            }],
+            |ty| (ty.id_char(), ty.to_string()),
+        );
+    }
 
-        match SwitchId::from_str("sw100nx038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg") {
-            Err(SwitchIdParseError::Prefix(_)) => {} // Expect an error
-            Ok(_) => panic!("Converting from a switch ID with source `x` should have failed"),
-            Err(e) => panic!(
-                "Converting from a switch ID with source `x` should have failed with a Prefix error, got {e}"
-            ),
-        }
+    #[test]
+    fn test_switch_type_from_id_char() {
+        check_values(
+            [
+                Check {
+                    scenario: "NVLink",
+                    input: 'n',
+                    expect: Some(SwitchType::NvLink),
+                },
+                Check {
+                    scenario: "unknown",
+                    input: 'x',
+                    expect: None,
+                },
+            ],
+            SwitchType::from_id_char,
+        );
+    }
 
-        match SwitchId::from_str("sw100nt038bg3qsho433vkg684heguv28!qaggmrsh2ugn1qk096n2c6hcg") {
-            Err(SwitchIdParseError::Encoding(_)) => {} // Expect an error
-            Ok(_) => panic!("Converting from a switch ID with a `!` should have failed"),
-            Err(e) => panic!(
-                "Converting from a switch ID with a `!` should have failed with an Encoding error, got {e}"
-            ),
-        }
+    #[test]
+    fn test_switch_id_source_from_id_char() {
+        check_values(
+            [
+                Check {
+                    scenario: "TPM",
+                    input: 't',
+                    expect: Some(SwitchIdSource::Tpm),
+                },
+                Check {
+                    scenario: "product board chassis serial",
+                    input: 's',
+                    expect: Some(SwitchIdSource::ProductBoardChassisSerial),
+                },
+                Check {
+                    scenario: "unknown",
+                    input: 'x',
+                    expect: None,
+                },
+            ],
+            SwitchIdSource::from_id_char,
+        );
     }
 }


### PR DESCRIPTION
This supports #3914.

## Description

The `carbide-uuid` crate had a lot of ID parsing and conversion behavior living in one-off tests or not directly exercised at all, especially the string-backed resource IDs and the encoded machine, switch, and power-shelf IDs.

This adds `carbide-test-support` and enumerates those pure inputs as `Case`/`Check` rows: accepted and rejected strings, serde round-trips, prefix/type conversions, and the encoded ID boundaries. The dense per-row enumeration is what moves the numbers.

Coverage (cargo-llvm-cov), before (origin/main) vs after.

```
┌──────────┬─────────┬─────────┐
│ Metric   │ Before  │  After  │
├──────────┼─────────┼─────────┤
│ Region   │ 51.36%  │ 69.70%  │
│ Function │ 41.97%  │ 67.21%  │
│ Line     │ 45.78%  │ 76.79%  │
└──────────┴─────────┴─────────┘
```

All tests pass, and formatting/clippy checks are clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)