### PR TITLE
test(mqttea): fold helper tests onto carbide-test-support + raise coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7022,6 +7022,7 @@ name = "mqttea"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "carbide-test-support",
  "chrono",
  "clap",
  "oauth2",

--- a/crates/mqttea/Cargo.toml
+++ b/crates/mqttea/Cargo.toml
@@ -47,6 +47,7 @@ oauth2 = { workspace = true }
 reqwest = { workspace = true }
 
 [dev-dependencies]
+carbide-test-support = { path = "../test-support" }
 prost-build = { workspace = true }
 tokio-test = { workspace = true }
 

--- a/crates/mqttea/src/client/options.rs
+++ b/crates/mqttea/src/client/options.rs
@@ -165,3 +165,192 @@ pub struct ClientTlsIdentity {
     // wire or generated ephemerally.
     pub private_key: Vec<u8>,
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    enum OptionsBuild {
+        Default,
+        KeepAlive,
+        MessageCapacity,
+        Qos,
+        Retain,
+        PublishOptions,
+        MaxConcurrency,
+        Credentials,
+        CombinedPublishOptions,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct OptionsSummary {
+        keep_alive_secs: Option<u64>,
+        message_channel_capacity: Option<usize>,
+        qos: Option<QoS>,
+        retain: Option<bool>,
+        max_concurrency: Option<usize>,
+        has_credentials_provider: bool,
+    }
+
+    fn build_options(build: OptionsBuild) -> ClientOptions {
+        match build {
+            OptionsBuild::Default => ClientOptions::default(),
+            OptionsBuild::KeepAlive => {
+                ClientOptions::default().with_keep_alive(Duration::from_secs(7))
+            }
+            OptionsBuild::MessageCapacity => {
+                ClientOptions::default().with_message_channel_capacity(512)
+            }
+            OptionsBuild::Qos => ClientOptions::default().with_qos(QoS::AtLeastOnce),
+            OptionsBuild::Retain => ClientOptions::default().with_retain(true),
+            OptionsBuild::PublishOptions => ClientOptions::default().with_publish_options(
+                PublishOptions::default()
+                    .with_qos(QoS::ExactlyOnce)
+                    .with_retain(false),
+            ),
+            OptionsBuild::MaxConcurrency => ClientOptions::default().with_max_concurrency(16),
+            OptionsBuild::Credentials => {
+                ClientOptions::default().with_credentials(ClientCredentials {
+                    username: "user".to_string(),
+                    password: "pass".to_string(),
+                })
+            }
+            OptionsBuild::CombinedPublishOptions => ClientOptions::default()
+                .with_qos(QoS::AtMostOnce)
+                .with_retain(true),
+        }
+    }
+
+    fn summarize(options: ClientOptions) -> OptionsSummary {
+        let publish_options = options.publish_options.as_ref();
+
+        OptionsSummary {
+            keep_alive_secs: options.keep_alive.map(|duration| duration.as_secs()),
+            message_channel_capacity: options.message_channel_capacity,
+            qos: publish_options.and_then(|opts| opts.qos),
+            retain: publish_options.and_then(|opts| opts.retain),
+            max_concurrency: options.max_concurrency,
+            has_credentials_provider: options.credentials_provider.is_some(),
+        }
+    }
+
+    #[test]
+    fn test_client_options_builders() {
+        check_values(
+            [
+                Check {
+                    scenario: "default",
+                    input: OptionsBuild::Default,
+                    expect: OptionsSummary {
+                        keep_alive_secs: None,
+                        message_channel_capacity: None,
+                        qos: None,
+                        retain: None,
+                        max_concurrency: None,
+                        has_credentials_provider: false,
+                    },
+                },
+                Check {
+                    scenario: "keep alive",
+                    input: OptionsBuild::KeepAlive,
+                    expect: OptionsSummary {
+                        keep_alive_secs: Some(7),
+                        message_channel_capacity: None,
+                        qos: None,
+                        retain: None,
+                        max_concurrency: None,
+                        has_credentials_provider: false,
+                    },
+                },
+                Check {
+                    scenario: "message capacity",
+                    input: OptionsBuild::MessageCapacity,
+                    expect: OptionsSummary {
+                        keep_alive_secs: None,
+                        message_channel_capacity: Some(512),
+                        qos: None,
+                        retain: None,
+                        max_concurrency: None,
+                        has_credentials_provider: false,
+                    },
+                },
+                Check {
+                    scenario: "qos",
+                    input: OptionsBuild::Qos,
+                    expect: OptionsSummary {
+                        keep_alive_secs: None,
+                        message_channel_capacity: None,
+                        qos: Some(QoS::AtLeastOnce),
+                        retain: None,
+                        max_concurrency: None,
+                        has_credentials_provider: false,
+                    },
+                },
+                Check {
+                    scenario: "retain",
+                    input: OptionsBuild::Retain,
+                    expect: OptionsSummary {
+                        keep_alive_secs: None,
+                        message_channel_capacity: None,
+                        qos: None,
+                        retain: Some(true),
+                        max_concurrency: None,
+                        has_credentials_provider: false,
+                    },
+                },
+                Check {
+                    scenario: "publish options",
+                    input: OptionsBuild::PublishOptions,
+                    expect: OptionsSummary {
+                        keep_alive_secs: None,
+                        message_channel_capacity: None,
+                        qos: Some(QoS::ExactlyOnce),
+                        retain: Some(false),
+                        max_concurrency: None,
+                        has_credentials_provider: false,
+                    },
+                },
+                Check {
+                    scenario: "max concurrency",
+                    input: OptionsBuild::MaxConcurrency,
+                    expect: OptionsSummary {
+                        keep_alive_secs: None,
+                        message_channel_capacity: None,
+                        qos: None,
+                        retain: None,
+                        max_concurrency: Some(16),
+                        has_credentials_provider: false,
+                    },
+                },
+                Check {
+                    scenario: "credentials",
+                    input: OptionsBuild::Credentials,
+                    expect: OptionsSummary {
+                        keep_alive_secs: None,
+                        message_channel_capacity: None,
+                        qos: None,
+                        retain: None,
+                        max_concurrency: None,
+                        has_credentials_provider: true,
+                    },
+                },
+                Check {
+                    scenario: "combined publish options",
+                    input: OptionsBuild::CombinedPublishOptions,
+                    expect: OptionsSummary {
+                        keep_alive_secs: None,
+                        message_channel_capacity: None,
+                        qos: Some(QoS::AtMostOnce),
+                        retain: Some(true),
+                        max_concurrency: None,
+                        has_credentials_provider: false,
+                    },
+                },
+            ],
+            |build| summarize(build_options(build)),
+        );
+    }
+}

--- a/crates/mqttea/src/client/topic_patterns.rs
+++ b/crates/mqttea/src/client/topic_patterns.rs
@@ -168,3 +168,289 @@ impl std::fmt::Display for TopicPatterns {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    enum PatternSource {
+        BorrowedStr,
+        OwnedString,
+        VecBorrowed,
+        VecOwned,
+        ArrayBorrowed,
+        ArrayOwned,
+        SliceBorrowed,
+        SliceOwned,
+        FromSingle,
+        FromMultiple,
+        EmptySingle,
+        EmptyMultiple,
+        AllEmptyMultiple,
+        MixedEmptyMultiple,
+        SingleLevelWildcard,
+        MultiLevelWildcard,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct PatternSummary {
+        patterns: Vec<String>,
+        len: usize,
+        is_empty: bool,
+        contains_alpha: bool,
+        contains_beta: bool,
+        contains_single_level_wildcard: bool,
+        contains_multi_level_wildcard: bool,
+        as_slice: Vec<String>,
+        display: String,
+    }
+
+    fn patterns_from(source: PatternSource) -> TopicPatterns {
+        match source {
+            PatternSource::BorrowedStr => TopicPatterns::from("alpha"),
+            PatternSource::OwnedString => TopicPatterns::from(String::from("alpha")),
+            PatternSource::VecBorrowed => TopicPatterns::from(vec!["alpha", "beta"]),
+            PatternSource::VecOwned => {
+                TopicPatterns::from(vec![String::from("alpha"), String::from("beta")])
+            }
+            PatternSource::ArrayBorrowed => TopicPatterns::from(["alpha", "beta"]),
+            PatternSource::ArrayOwned => {
+                TopicPatterns::from([String::from("alpha"), String::from("beta")])
+            }
+            PatternSource::SliceBorrowed => TopicPatterns::from(["alpha", "beta"].as_slice()),
+            PatternSource::SliceOwned => {
+                let patterns = [String::from("alpha"), String::from("beta")];
+                TopicPatterns::from(patterns.as_slice())
+            }
+            PatternSource::FromSingle => TopicPatterns::from_single("alpha"),
+            PatternSource::FromMultiple => TopicPatterns::from_multiple(["alpha", "beta"]),
+            PatternSource::EmptySingle => TopicPatterns::from(""),
+            PatternSource::EmptyMultiple => TopicPatterns::from(Vec::<String>::new()),
+            PatternSource::AllEmptyMultiple => TopicPatterns::from(["", ""]),
+            PatternSource::MixedEmptyMultiple => TopicPatterns::from(["", "alpha"]),
+            PatternSource::SingleLevelWildcard => TopicPatterns::from("sensors/+/temp"),
+            PatternSource::MultiLevelWildcard => TopicPatterns::from("sensors/#"),
+        }
+    }
+
+    fn summarize(patterns: TopicPatterns) -> PatternSummary {
+        let len = patterns.len();
+        let is_empty = patterns.is_empty();
+        let contains_alpha = patterns.contains("alpha");
+        let contains_beta = patterns.contains("beta");
+        let contains_single_level_wildcard = patterns.contains("sensors/+/temp");
+        let contains_multi_level_wildcard = patterns.contains("sensors/#");
+        let as_slice = patterns
+            .as_slice()
+            .iter()
+            .copied()
+            .map(str::to_string)
+            .collect();
+        let display = patterns.to_string();
+        let patterns = patterns.into_vec();
+
+        PatternSummary {
+            patterns,
+            len,
+            is_empty,
+            contains_alpha,
+            contains_beta,
+            contains_single_level_wildcard,
+            contains_multi_level_wildcard,
+            as_slice,
+            display,
+        }
+    }
+
+    fn single_alpha() -> PatternSummary {
+        PatternSummary {
+            patterns: vec!["alpha".to_string()],
+            len: 1,
+            is_empty: false,
+            contains_alpha: true,
+            contains_beta: false,
+            contains_single_level_wildcard: false,
+            contains_multi_level_wildcard: false,
+            as_slice: vec!["alpha".to_string()],
+            display: "'alpha'".to_string(),
+        }
+    }
+
+    fn alpha_beta() -> PatternSummary {
+        PatternSummary {
+            patterns: vec!["alpha".to_string(), "beta".to_string()],
+            len: 2,
+            is_empty: false,
+            contains_alpha: true,
+            contains_beta: true,
+            contains_single_level_wildcard: false,
+            contains_multi_level_wildcard: false,
+            as_slice: vec!["alpha".to_string(), "beta".to_string()],
+            display: "['alpha', 'beta']".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_topic_patterns_sources() {
+        check_values(
+            [
+                Check {
+                    scenario: "borrowed str",
+                    input: PatternSource::BorrowedStr,
+                    expect: single_alpha(),
+                },
+                Check {
+                    scenario: "owned string",
+                    input: PatternSource::OwnedString,
+                    expect: single_alpha(),
+                },
+                Check {
+                    scenario: "vec borrowed",
+                    input: PatternSource::VecBorrowed,
+                    expect: alpha_beta(),
+                },
+                Check {
+                    scenario: "vec owned",
+                    input: PatternSource::VecOwned,
+                    expect: alpha_beta(),
+                },
+                Check {
+                    scenario: "array borrowed",
+                    input: PatternSource::ArrayBorrowed,
+                    expect: alpha_beta(),
+                },
+                Check {
+                    scenario: "array owned",
+                    input: PatternSource::ArrayOwned,
+                    expect: alpha_beta(),
+                },
+                Check {
+                    scenario: "slice borrowed",
+                    input: PatternSource::SliceBorrowed,
+                    expect: alpha_beta(),
+                },
+                Check {
+                    scenario: "slice owned",
+                    input: PatternSource::SliceOwned,
+                    expect: alpha_beta(),
+                },
+                Check {
+                    scenario: "from_single",
+                    input: PatternSource::FromSingle,
+                    expect: single_alpha(),
+                },
+                Check {
+                    scenario: "from_multiple",
+                    input: PatternSource::FromMultiple,
+                    expect: alpha_beta(),
+                },
+                // TopicPatterns stores MQTT wildcards as literal patterns; it
+                // does not evaluate topic-match semantics.
+                Check {
+                    scenario: "single-level wildcard",
+                    input: PatternSource::SingleLevelWildcard,
+                    expect: PatternSummary {
+                        patterns: vec!["sensors/+/temp".to_string()],
+                        len: 1,
+                        is_empty: false,
+                        contains_alpha: false,
+                        contains_beta: false,
+                        contains_single_level_wildcard: true,
+                        contains_multi_level_wildcard: false,
+                        as_slice: vec!["sensors/+/temp".to_string()],
+                        display: "'sensors/+/temp'".to_string(),
+                    },
+                },
+                Check {
+                    scenario: "multi-level wildcard",
+                    input: PatternSource::MultiLevelWildcard,
+                    expect: PatternSummary {
+                        patterns: vec!["sensors/#".to_string()],
+                        len: 1,
+                        is_empty: false,
+                        contains_alpha: false,
+                        contains_beta: false,
+                        contains_single_level_wildcard: false,
+                        contains_multi_level_wildcard: true,
+                        as_slice: vec!["sensors/#".to_string()],
+                        display: "'sensors/#'".to_string(),
+                    },
+                },
+            ],
+            |source| summarize(patterns_from(source)),
+        );
+    }
+
+    #[test]
+    fn test_topic_patterns_empty_cases() {
+        check_values(
+            [
+                Check {
+                    // `Single("")` still has one stored pattern, but is empty by content.
+                    scenario: "empty single reports empty by content",
+                    input: PatternSource::EmptySingle,
+                    expect: PatternSummary {
+                        patterns: vec![String::new()],
+                        len: 1,
+                        is_empty: true,
+                        contains_alpha: false,
+                        contains_beta: false,
+                        contains_single_level_wildcard: false,
+                        contains_multi_level_wildcard: false,
+                        as_slice: vec![String::new()],
+                        display: "''".to_string(),
+                    },
+                },
+                Check {
+                    scenario: "empty multiple",
+                    input: PatternSource::EmptyMultiple,
+                    expect: PatternSummary {
+                        patterns: vec![],
+                        len: 0,
+                        is_empty: true,
+                        contains_alpha: false,
+                        contains_beta: false,
+                        contains_single_level_wildcard: false,
+                        contains_multi_level_wildcard: false,
+                        as_slice: vec![],
+                        display: "[]".to_string(),
+                    },
+                },
+                Check {
+                    scenario: "all empty multiple",
+                    input: PatternSource::AllEmptyMultiple,
+                    expect: PatternSummary {
+                        patterns: vec![String::new(), String::new()],
+                        len: 2,
+                        is_empty: true,
+                        contains_alpha: false,
+                        contains_beta: false,
+                        contains_single_level_wildcard: false,
+                        contains_multi_level_wildcard: false,
+                        as_slice: vec![String::new(), String::new()],
+                        display: "['', '']".to_string(),
+                    },
+                },
+                Check {
+                    scenario: "mixed empty multiple",
+                    input: PatternSource::MixedEmptyMultiple,
+                    expect: PatternSummary {
+                        patterns: vec![String::new(), "alpha".to_string()],
+                        len: 2,
+                        is_empty: false,
+                        contains_alpha: true,
+                        contains_beta: false,
+                        contains_single_level_wildcard: false,
+                        contains_multi_level_wildcard: false,
+                        as_slice: vec![String::new(), "alpha".to_string()],
+                        display: "['', 'alpha']".to_string(),
+                    },
+                },
+            ],
+            |source| summarize(patterns_from(source)),
+        );
+    }
+}

--- a/crates/mqttea/src/message_types/raw.rs
+++ b/crates/mqttea/src/message_types/raw.rs
@@ -36,3 +36,60 @@ impl RawMessageType for RawMessage {
         Self { payload: bytes }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct RawSummary {
+        payload: Vec<u8>,
+        bytes: Vec<u8>,
+        round_trip: RawMessage,
+    }
+
+    fn summarize(payload: Vec<u8>) -> RawSummary {
+        let message = RawMessage {
+            payload: payload.clone(),
+        };
+        let bytes = message.to_bytes();
+        let round_trip = RawMessage::from_bytes(bytes.clone());
+
+        RawSummary {
+            payload,
+            bytes,
+            round_trip,
+        }
+    }
+
+    #[test]
+    fn test_raw_message_bytes() {
+        check_values(
+            [
+                Check {
+                    scenario: "empty payload",
+                    input: vec![],
+                    expect: RawSummary {
+                        payload: vec![],
+                        bytes: vec![],
+                        round_trip: RawMessage { payload: vec![] },
+                    },
+                },
+                Check {
+                    scenario: "binary payload",
+                    input: vec![0, 1, 2, 255],
+                    expect: RawSummary {
+                        payload: vec![0, 1, 2, 255],
+                        bytes: vec![0, 1, 2, 255],
+                        round_trip: RawMessage {
+                            payload: vec![0, 1, 2, 255],
+                        },
+                    },
+                },
+            ],
+            summarize,
+        );
+    }
+}

--- a/crates/mqttea/src/message_types/string.rs
+++ b/crates/mqttea/src/message_types/string.rs
@@ -105,3 +105,112 @@ impl std::fmt::Display for StringMessage {
         write!(f, "{}", self.content)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    enum StringSource {
+        New,
+        FromBorrowed,
+        FromOwned,
+        FromBytes,
+        FromStr,
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct StringSummary {
+        content: String,
+        as_str: String,
+        bytes: Vec<u8>,
+        display: String,
+        into_string: String,
+    }
+
+    fn message_from(source: StringSource) -> StringMessage {
+        match source {
+            StringSource::New => StringMessage::new("hello"),
+            StringSource::FromBorrowed => StringMessage::from("hello"),
+            StringSource::FromOwned => StringMessage::from(String::from("hello")),
+            StringSource::FromBytes => StringMessage::from_bytes(b"hello".to_vec()),
+            StringSource::FromStr => StringMessage::from_str("hello").expect("infallible parse"),
+        }
+    }
+
+    fn summarize(source: StringSource) -> StringSummary {
+        let message = message_from(source);
+        let content = message.content.clone();
+        let as_str = message.as_str().to_string();
+        let bytes = message.to_bytes();
+        let display = message.to_string();
+        let into_string = String::from(message);
+
+        StringSummary {
+            content,
+            as_str,
+            bytes,
+            display,
+            into_string,
+        }
+    }
+
+    #[test]
+    fn test_string_message_sources() {
+        let expected = StringSummary {
+            content: "hello".to_string(),
+            as_str: "hello".to_string(),
+            bytes: b"hello".to_vec(),
+            display: "hello".to_string(),
+            into_string: "hello".to_string(),
+        };
+
+        check_values(
+            [
+                Check {
+                    scenario: "new",
+                    input: StringSource::New,
+                    expect: expected.clone(),
+                },
+                Check {
+                    scenario: "from borrowed",
+                    input: StringSource::FromBorrowed,
+                    expect: expected.clone(),
+                },
+                Check {
+                    scenario: "from owned",
+                    input: StringSource::FromOwned,
+                    expect: expected.clone(),
+                },
+                Check {
+                    scenario: "from bytes",
+                    input: StringSource::FromBytes,
+                    expect: expected.clone(),
+                },
+                Check {
+                    scenario: "from str",
+                    input: StringSource::FromStr,
+                    expect: expected,
+                },
+            ],
+            summarize,
+        );
+    }
+
+    #[test]
+    fn test_string_message_into_string() {
+        assert_eq!(StringMessage::new("hello").into_string(), "hello");
+    }
+
+    #[test]
+    fn test_string_message_invalid_utf8() {
+        let message = StringMessage::from_bytes(vec![0xff]);
+
+        assert!(message.content.starts_with("Invalid UTF-8 data:"));
+        assert!(message.to_bytes().starts_with(b"Invalid UTF-8 data:"));
+    }
+}

--- a/crates/mqttea/src/registry/entry.rs
+++ b/crates/mqttea/src/registry/entry.rs
@@ -155,3 +155,186 @@ impl MqttRegistryEntry {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+
+    use carbide_test_support::{Check, check_values};
+    use rumqttc::QoS;
+
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    enum EntryBuild {
+        DefaultJson,
+        QosOverride,
+        RetainOverride,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct EntrySummary {
+        type_name: String,
+        patterns: Vec<String>,
+        publish_options: Option<(Option<QoS>, Option<bool>)>,
+        qos: Option<QoS>,
+        retain: Option<bool>,
+        format: SerializationFormat,
+        pattern_count: usize,
+        has_alpha: bool,
+        has_missing: bool,
+        uses_qos_override: bool,
+        effective_qos: QoS,
+        is_json: bool,
+        debug_mentions_type: bool,
+        debug_hides_handlers: bool,
+    }
+
+    fn string_entry(
+        publish_options: Option<PublishOptions>,
+        format: SerializationFormat,
+    ) -> MqttRegistryEntry {
+        MqttRegistryEntry {
+            message_type_info: MessageTypeInfo {
+                type_name: "String".to_string(),
+                patterns: vec!["alpha".to_string(), "beta".to_string()],
+                publish_options,
+                format,
+            },
+            serialize_handler: Box::new(|message| {
+                message
+                    .downcast_ref::<String>()
+                    .map(|message| message.as_bytes().to_vec())
+                    .ok_or_else(|| MqtteaClientError::raw_message_error("expected String"))
+            }),
+            deserialize_handler: Box::new(|bytes| {
+                String::from_utf8(bytes.to_vec())
+                    .map(|message| Box::new(message) as Box<dyn Any + Send>)
+                    .map_err(|err| MqtteaClientError::invalid_utf8(err.to_string()))
+            }),
+        }
+    }
+
+    fn entry_from(build: EntryBuild) -> MqttRegistryEntry {
+        match build {
+            EntryBuild::DefaultJson => string_entry(None, SerializationFormat::Json),
+            EntryBuild::QosOverride => string_entry(
+                Some(PublishOptions::default().with_qos(QoS::ExactlyOnce)),
+                SerializationFormat::Raw,
+            ),
+            EntryBuild::RetainOverride => string_entry(
+                Some(PublishOptions::default().with_retain(true)),
+                SerializationFormat::Yaml,
+            ),
+        }
+    }
+
+    fn summarize(entry: MqttRegistryEntry) -> EntrySummary {
+        EntrySummary {
+            type_name: entry.type_name().to_string(),
+            patterns: entry.patterns().to_vec(),
+            publish_options: entry
+                .publish_options()
+                .map(|options| (options.qos, options.retain)),
+            qos: entry.qos(),
+            retain: entry.retain(),
+            format: entry.format(),
+            pattern_count: entry.pattern_count(),
+            has_alpha: entry.has_pattern("alpha"),
+            has_missing: entry.has_pattern("missing"),
+            uses_qos_override: entry.uses_qos_override(),
+            effective_qos: entry.effective_qos(QoS::AtMostOnce),
+            is_json: entry.is_format(SerializationFormat::Json),
+            debug_mentions_type: format!("{entry:?}").contains("String"),
+            debug_hides_handlers: format!("{entry:?}").contains("<function>"),
+        }
+    }
+
+    #[test]
+    fn test_registry_entry_accessors() {
+        check_values(
+            [
+                Check {
+                    scenario: "default JSON entry",
+                    input: EntryBuild::DefaultJson,
+                    expect: EntrySummary {
+                        type_name: "String".to_string(),
+                        patterns: vec!["alpha".to_string(), "beta".to_string()],
+                        publish_options: None,
+                        qos: None,
+                        retain: None,
+                        format: SerializationFormat::Json,
+                        pattern_count: 2,
+                        has_alpha: true,
+                        has_missing: false,
+                        uses_qos_override: false,
+                        effective_qos: QoS::AtMostOnce,
+                        is_json: true,
+                        debug_mentions_type: true,
+                        debug_hides_handlers: true,
+                    },
+                },
+                Check {
+                    scenario: "QoS override",
+                    input: EntryBuild::QosOverride,
+                    expect: EntrySummary {
+                        type_name: "String".to_string(),
+                        patterns: vec!["alpha".to_string(), "beta".to_string()],
+                        publish_options: Some((Some(QoS::ExactlyOnce), None)),
+                        qos: Some(QoS::ExactlyOnce),
+                        retain: None,
+                        format: SerializationFormat::Raw,
+                        pattern_count: 2,
+                        has_alpha: true,
+                        has_missing: false,
+                        uses_qos_override: true,
+                        effective_qos: QoS::ExactlyOnce,
+                        is_json: false,
+                        debug_mentions_type: true,
+                        debug_hides_handlers: true,
+                    },
+                },
+                Check {
+                    scenario: "retain override",
+                    input: EntryBuild::RetainOverride,
+                    expect: EntrySummary {
+                        type_name: "String".to_string(),
+                        patterns: vec!["alpha".to_string(), "beta".to_string()],
+                        publish_options: Some((None, Some(true))),
+                        qos: None,
+                        retain: Some(true),
+                        format: SerializationFormat::Yaml,
+                        pattern_count: 2,
+                        has_alpha: true,
+                        has_missing: false,
+                        uses_qos_override: false,
+                        effective_qos: QoS::AtMostOnce,
+                        is_json: false,
+                        debug_mentions_type: true,
+                        debug_hides_handlers: true,
+                    },
+                },
+            ],
+            |build| summarize(entry_from(build)),
+        );
+    }
+
+    #[test]
+    fn test_registry_entry_handlers() {
+        let entry = entry_from(EntryBuild::DefaultJson);
+        let message = "hello".to_string();
+
+        assert_eq!(entry.serialize(&message).expect("serialize"), b"hello");
+
+        let restored = entry
+            .deserialize(b"hello")
+            .expect("deserialize")
+            .downcast::<String>()
+            .expect("restored String");
+        assert_eq!(*restored, "hello");
+
+        assert!(entry.validate_serialization_round_trip(&message).is_ok());
+        assert!(entry.serialize(&42usize).is_err());
+        assert!(entry.deserialize(&[0xff]).is_err());
+    }
+}

--- a/crates/mqttea/src/registry/types.rs
+++ b/crates/mqttea/src/registry/types.rs
@@ -137,3 +137,172 @@ impl MessageTypeInfo {
         self.format == format
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    enum PublishOptionsBuild {
+        Default,
+        Qos,
+        Retain,
+        QosAndRetain,
+    }
+
+    #[derive(Clone, Copy)]
+    enum MessageInfoBuild {
+        JsonDefault,
+        ProtobufQosOverride,
+        RawRetainOverride,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct MessageInfoSummary {
+        has_alpha: bool,
+        has_missing: bool,
+        pattern_count: usize,
+        uses_qos_override: bool,
+        effective_qos: QoS,
+        effective_retain: bool,
+        is_json: bool,
+        is_protobuf: bool,
+        is_raw: bool,
+    }
+
+    fn build_publish_options(build: PublishOptionsBuild) -> PublishOptions {
+        match build {
+            PublishOptionsBuild::Default => PublishOptions::default(),
+            PublishOptionsBuild::Qos => PublishOptions::default().with_qos(QoS::AtLeastOnce),
+            PublishOptionsBuild::Retain => PublishOptions::default().with_retain(true),
+            PublishOptionsBuild::QosAndRetain => PublishOptions::default()
+                .with_qos(QoS::ExactlyOnce)
+                .with_retain(false),
+        }
+    }
+
+    fn build_message_info(build: MessageInfoBuild) -> MessageTypeInfo {
+        match build {
+            MessageInfoBuild::JsonDefault => MessageTypeInfo {
+                type_name: "JsonMessage".to_string(),
+                patterns: vec!["alpha".to_string(), "beta".to_string()],
+                publish_options: None,
+                format: SerializationFormat::Json,
+            },
+            MessageInfoBuild::ProtobufQosOverride => MessageTypeInfo {
+                type_name: "ProtoMessage".to_string(),
+                patterns: vec!["alpha".to_string()],
+                publish_options: Some(PublishOptions::default().with_qos(QoS::ExactlyOnce)),
+                format: SerializationFormat::Protobuf,
+            },
+            MessageInfoBuild::RawRetainOverride => MessageTypeInfo {
+                type_name: "RawMessage".to_string(),
+                patterns: vec!["alpha".to_string()],
+                publish_options: Some(PublishOptions::default().with_retain(true)),
+                format: SerializationFormat::Raw,
+            },
+        }
+    }
+
+    fn summarize_message_info(info: MessageTypeInfo) -> MessageInfoSummary {
+        MessageInfoSummary {
+            has_alpha: info.has_pattern("alpha"),
+            has_missing: info.has_pattern("missing"),
+            pattern_count: info.pattern_count(),
+            uses_qos_override: info.uses_qos_override(),
+            effective_qos: info.effective_qos(QoS::AtMostOnce),
+            effective_retain: info.effective_retain(false),
+            is_json: info.is_format(SerializationFormat::Json),
+            is_protobuf: info.is_format(SerializationFormat::Protobuf),
+            is_raw: info.is_format(SerializationFormat::Raw),
+        }
+    }
+
+    #[test]
+    fn test_publish_options_builders() {
+        check_values(
+            [
+                Check {
+                    scenario: "default",
+                    input: PublishOptionsBuild::Default,
+                    expect: (None, None),
+                },
+                Check {
+                    scenario: "qos",
+                    input: PublishOptionsBuild::Qos,
+                    expect: (Some(QoS::AtLeastOnce), None),
+                },
+                Check {
+                    scenario: "retain",
+                    input: PublishOptionsBuild::Retain,
+                    expect: (None, Some(true)),
+                },
+                Check {
+                    scenario: "qos and retain",
+                    input: PublishOptionsBuild::QosAndRetain,
+                    expect: (Some(QoS::ExactlyOnce), Some(false)),
+                },
+            ],
+            |build| {
+                let options = build_publish_options(build);
+                (options.qos, options.retain)
+            },
+        );
+    }
+
+    #[test]
+    fn test_message_type_info_helpers() {
+        check_values(
+            [
+                Check {
+                    scenario: "json default",
+                    input: MessageInfoBuild::JsonDefault,
+                    expect: MessageInfoSummary {
+                        has_alpha: true,
+                        has_missing: false,
+                        pattern_count: 2,
+                        uses_qos_override: false,
+                        effective_qos: QoS::AtMostOnce,
+                        effective_retain: false,
+                        is_json: true,
+                        is_protobuf: false,
+                        is_raw: false,
+                    },
+                },
+                Check {
+                    scenario: "protobuf qos override",
+                    input: MessageInfoBuild::ProtobufQosOverride,
+                    expect: MessageInfoSummary {
+                        has_alpha: true,
+                        has_missing: false,
+                        pattern_count: 1,
+                        uses_qos_override: true,
+                        effective_qos: QoS::ExactlyOnce,
+                        effective_retain: false,
+                        is_json: false,
+                        is_protobuf: true,
+                        is_raw: false,
+                    },
+                },
+                Check {
+                    scenario: "raw retain override",
+                    input: MessageInfoBuild::RawRetainOverride,
+                    expect: MessageInfoSummary {
+                        has_alpha: true,
+                        has_missing: false,
+                        pattern_count: 1,
+                        uses_qos_override: false,
+                        effective_qos: QoS::AtMostOnce,
+                        effective_retain: true,
+                        is_json: false,
+                        is_protobuf: false,
+                        is_raw: true,
+                    },
+                },
+            ],
+            |build| summarize_message_info(build_message_info(build)),
+        );
+    }
+}


### PR DESCRIPTION
This supports #3914.

## Description

The `mqttea` crate's pure helpers around topic patterns, client options, message wrappers, and registry entries had a small set of one-off assertions.

This adds `carbide-test-support` and folds those helpers onto labeled `Case`/`Check` rows: topic pattern accept/reject paths, raw and string message conversion, client option builders, registry metadata keys, and registry type/entry accessors.

Coverage (cargo-llvm-cov), before (origin/main) vs after.

```
┌──────────┬─────────┬─────────┐
│ Metric   │ Before  │  After  │
├──────────┼─────────┼─────────┤
│ Region   │ 49.79%  │ 74.38%  │
│ Function │ 49.78%  │ 76.95%  │
│ Line     │ 50.73%  │ 78.72%  │
└──────────┴─────────┴─────────┘
```

The remaining uncovered surface is mostly the runtime MQTT/client flow, which needs integration-style harnessing rather than more table rows.

All tests pass, and formatting/clippy checks are clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)