### PR TITLE
test(config-version): fold tests onto carbide-test-support + raise coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3503,6 +3503,7 @@ dependencies = [
 name = "config-version"
 version = "0.1.0"
 dependencies = [
+ "carbide-test-support",
  "chrono",
  "serde",
  "serde_json",

--- a/crates/config-version/Cargo.toml
+++ b/crates/config-version/Cargo.toml
@@ -42,5 +42,8 @@ sqlx = { workspace = true, features = [
 ], optional = true }
 thiserror = { workspace = true }
 
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+
 [lints]
 workspace = true

--- a/crates/config-version/src/lib.rs
+++ b/crates/config-version/src/lib.rs
@@ -378,10 +378,12 @@ impl<'r> sqlx::FromRow<'r, sqlx::postgres::PgRow> for ConfigVersion {
     }
 }
 
+const STATE_VERSION_PARSE_ERROR: &str = "state version parse error";
+
 /// Human readable amount of time since we entered the given state version
 pub fn since_state_change_humanized(ver: &str) -> String {
     let Ok(state_version_t) = ver.parse::<ConfigVersion>() else {
-        return "state version parse error".to_string();
+        return STATE_VERSION_PARSE_ERROR.to_string();
     };
     state_version_t.since_state_change_humanized()
 }
@@ -431,11 +433,115 @@ fn plural(val: i64, period: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, Check, check_cases, check_values};
     use chrono::TimeDelta;
 
     use super::*;
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum ParseFailure {
+        VersionFormat,
+        DateTime,
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct VersionSummary {
+        version_nr: u64,
+        timestamp_micros: i64,
+        version_string: String,
+        display: String,
+    }
+
+    #[derive(Clone, Copy)]
+    enum VersionOperation {
+        Initial,
+        New,
+        Invalid,
+        Increment,
+        OverflowIncrement,
+        IncrementalChange,
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct OperationSummary {
+        version_nr: u64,
+        timestamp_micros: Option<i64>,
+        current_version_nr: Option<u64>,
+        new_version_nr: Option<u64>,
+    }
+
+    fn summarize(version: ConfigVersion) -> VersionSummary {
+        VersionSummary {
+            version_nr: version.version_nr(),
+            timestamp_micros: version.timestamp().timestamp_micros(),
+            version_string: version.version_string(),
+            display: version.to_string(),
+        }
+    }
+
+    fn parse_version(input: &str) -> Result<VersionSummary, ParseFailure> {
+        ConfigVersion::from_str(input)
+            .map(summarize)
+            .map_err(|err| match err {
+                ConfigVersionParseError::VersionFormat(_) => ParseFailure::VersionFormat,
+                ConfigVersionParseError::DateTime(_, _) => ParseFailure::DateTime,
+            })
+    }
+
+    fn summarize_operation_version(version: ConfigVersion) -> OperationSummary {
+        OperationSummary {
+            version_nr: version.version_nr(),
+            // These operations stamp wall-clock timestamps, so table rows compare
+            // the deterministic version fields instead.
+            timestamp_micros: None,
+            current_version_nr: None,
+            new_version_nr: None,
+        }
+    }
+
+    fn apply_operation(operation: VersionOperation) -> OperationSummary {
+        match operation {
+            VersionOperation::Initial => summarize_operation_version(ConfigVersion::initial()),
+            VersionOperation::New => summarize_operation_version(ConfigVersion::new(7)),
+            VersionOperation::Invalid => {
+                let version = ConfigVersion::invalid();
+                OperationSummary {
+                    version_nr: version.version_nr(),
+                    timestamp_micros: Some(version.timestamp().timestamp_micros()),
+                    current_version_nr: None,
+                    new_version_nr: None,
+                }
+            }
+            VersionOperation::Increment => summarize_operation_version(
+                ConfigVersion {
+                    version_nr: 41,
+                    timestamp: tzero(),
+                }
+                .increment(),
+            ),
+            VersionOperation::OverflowIncrement => summarize_operation_version(
+                ConfigVersion {
+                    version_nr: u64::MAX,
+                    timestamp: tzero(),
+                }
+                .increment(),
+            ),
+            VersionOperation::IncrementalChange => {
+                let version = ConfigVersion {
+                    version_nr: 41,
+                    timestamp: tzero(),
+                };
+                let change = version.incremental_change();
+                OperationSummary {
+                    version_nr: version.version_nr(),
+                    timestamp_micros: None,
+                    current_version_nr: Some(change.current.version_nr()),
+                    new_version_nr: Some(change.new.version_nr()),
+                }
+            }
+        }
+    }
 
     #[test]
     fn serialize_and_deserialize_config_version_as_string() {
@@ -466,42 +572,267 @@ mod tests {
     }
 
     #[test]
-    fn it_formats_seconds() {
-        let td = TimeDelta::from_std(Duration::from_secs(44)).unwrap();
-        assert_eq!(format_duration(td), "44 seconds");
+    fn it_formats_durations() {
+        check_values(
+            [
+                Check {
+                    scenario: "zero seconds",
+                    input: 0,
+                    expect: "0 seconds".to_string(),
+                },
+                Check {
+                    scenario: "single second",
+                    input: 1,
+                    expect: "1 second".to_string(),
+                },
+                Check {
+                    scenario: "seconds",
+                    input: 44,
+                    expect: "44 seconds".to_string(),
+                },
+                Check {
+                    scenario: "negative seconds",
+                    input: -44,
+                    expect: "-44 seconds".to_string(),
+                },
+                Check {
+                    scenario: "minute",
+                    input: 60,
+                    expect: "1 minute".to_string(),
+                },
+                Check {
+                    scenario: "minute ignores remaining seconds",
+                    input: 61,
+                    expect: "1 minute".to_string(),
+                },
+                Check {
+                    scenario: "hours",
+                    input: 3600 * 2,
+                    expect: "2 hours".to_string(),
+                },
+                Check {
+                    scenario: "day",
+                    input: 86400,
+                    expect: "1 day".to_string(),
+                },
+                Check {
+                    scenario: "hour and minute",
+                    input: 3600 + 60,
+                    expect: "1 hour and 1 minute".to_string(),
+                },
+                Check {
+                    scenario: "day hour minute",
+                    input: 86400 + 3600 + 60 + 1,
+                    expect: "1 day, 1 hour and 1 minute".to_string(),
+                },
+            ],
+            |seconds| format_duration(TimeDelta::seconds(seconds)),
+        );
     }
 
     #[test]
-    fn it_formats_minutes() {
-        // 60 seconds make a minute
-        let td = TimeDelta::from_std(Duration::from_secs(60)).unwrap();
-        assert_eq!(format_duration(td), "1 minute");
+    fn parse_config_version_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "epoch version",
+                    input: "V5-T0",
+                    expect: Yields(VersionSummary {
+                        version_nr: 5,
+                        timestamp_micros: 0,
+                        version_string: "V5-T0".to_string(),
+                        display: "V5-T0".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "trimmed version string",
+                    input: " V7-T1000000 ",
+                    expect: Yields(VersionSummary {
+                        version_nr: 7,
+                        timestamp_micros: 1_000_000,
+                        version_string: "V7-T1000000".to_string(),
+                        display: "V7-T1000000".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "empty string",
+                    input: "",
+                    expect: FailsWith(ParseFailure::VersionFormat),
+                },
+                Case {
+                    scenario: "missing timestamp",
+                    input: "V1",
+                    expect: FailsWith(ParseFailure::VersionFormat),
+                },
+                Case {
+                    scenario: "missing version prefix",
+                    input: "1-T0",
+                    expect: FailsWith(ParseFailure::VersionFormat),
+                },
+                Case {
+                    scenario: "invalid version number",
+                    input: "Vx-T0",
+                    expect: FailsWith(ParseFailure::VersionFormat),
+                },
+                Case {
+                    scenario: "invalid timestamp",
+                    input: "V1-Tx",
+                    expect: FailsWith(ParseFailure::VersionFormat),
+                },
+                Case {
+                    scenario: "extra segment",
+                    input: "V1-T0-extra",
+                    expect: FailsWith(ParseFailure::VersionFormat),
+                },
+                Case {
+                    scenario: "out-of-range datetime",
+                    input: "V1-T18446744073709551615",
+                    expect: FailsWith(ParseFailure::DateTime),
+                },
+            ],
+            parse_version,
+        );
     }
 
     #[test]
-    fn it_formats_hours() {
-        // 3600 seconds make an hour
-        let td = TimeDelta::from_std(Duration::from_secs(3600 * 2)).unwrap();
-        assert_eq!(format_duration(td), "2 hours");
+    fn serde_config_version_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "valid version string",
+                    input: "\"V5-T0\"",
+                    expect: Yields(VersionSummary {
+                        version_nr: 5,
+                        timestamp_micros: 0,
+                        version_string: "V5-T0".to_string(),
+                        display: "V5-T0".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "invalid version string",
+                    input: "\"bad\"",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-string value",
+                    input: "42",
+                    expect: Fails,
+                },
+            ],
+            |input| {
+                serde_json::from_str::<ConfigVersion>(input)
+                    .map(summarize)
+                    .map_err(|_| ())
+            },
+        );
     }
 
     #[test]
-    fn it_formats_days() {
-        // 86400 seconds make a day
-        let td = TimeDelta::from_std(Duration::from_secs(86400)).unwrap();
-        assert_eq!(format_duration(td), "1 day");
+    fn config_version_operation_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "initial",
+                    input: VersionOperation::Initial,
+                    expect: OperationSummary {
+                        version_nr: 1,
+                        timestamp_micros: None,
+                        current_version_nr: None,
+                        new_version_nr: None,
+                    },
+                },
+                Check {
+                    scenario: "new",
+                    input: VersionOperation::New,
+                    expect: OperationSummary {
+                        version_nr: 7,
+                        timestamp_micros: None,
+                        current_version_nr: None,
+                        new_version_nr: None,
+                    },
+                },
+                Check {
+                    scenario: "invalid",
+                    input: VersionOperation::Invalid,
+                    expect: OperationSummary {
+                        version_nr: 0,
+                        timestamp_micros: Some(0),
+                        current_version_nr: None,
+                        new_version_nr: None,
+                    },
+                },
+                Check {
+                    scenario: "increment",
+                    input: VersionOperation::Increment,
+                    expect: OperationSummary {
+                        version_nr: 42,
+                        timestamp_micros: None,
+                        current_version_nr: None,
+                        new_version_nr: None,
+                    },
+                },
+                Check {
+                    scenario: "overflow increment skips zero",
+                    input: VersionOperation::OverflowIncrement,
+                    expect: OperationSummary {
+                        version_nr: 1,
+                        timestamp_micros: None,
+                        current_version_nr: None,
+                        new_version_nr: None,
+                    },
+                },
+                Check {
+                    scenario: "incremental change",
+                    input: VersionOperation::IncrementalChange,
+                    expect: OperationSummary {
+                        version_nr: 41,
+                        timestamp_micros: None,
+                        current_version_nr: Some(41),
+                        new_version_nr: Some(42),
+                    },
+                },
+            ],
+            apply_operation,
+        );
     }
 
     #[test]
-    fn it_formats_combinations_no_seconds() {
-        let td = TimeDelta::from_std(Duration::from_secs(86400 + 3600 + 60 + 1)).unwrap();
-        assert_eq!(format_duration(td), "1 day, 1 hour and 1 minute");
+    fn versioned_wrapper_methods() {
+        let version = ConfigVersion {
+            version_nr: 3,
+            timestamp: tzero(),
+        };
+        let mut versioned = Versioned::new("payload".to_string(), version);
+
+        assert_eq!(&*versioned, "payload");
+        versioned.push_str("-updated");
+
+        let borrowed = versioned.as_ref();
+        assert_eq!(borrowed.value.as_str(), "payload-updated");
+        assert_eq!(borrowed.version, version);
+
+        let (value, taken_version) = versioned.take();
+        assert_eq!(value, "payload-updated");
+        assert_eq!(taken_version, version);
     }
 
     #[test]
-    fn it_formats_zero_seconds() {
-        let td = TimeDelta::from_std(Duration::from_secs(0)).unwrap();
-        assert_eq!(format_duration(td), "0 seconds");
+    fn since_state_change_humanized_parse_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "invalid version",
+                    input: "bad",
+                    expect: true,
+                },
+                Check {
+                    scenario: "valid version",
+                    input: "V1-T0",
+                    expect: false,
+                },
+            ],
+            |input| since_state_change_humanized(input) == STATE_VERSION_PARSE_ERROR,
+        );
     }
 
     #[test]


### PR DESCRIPTION
This supports #3914.

## Description

The `config-version` crate is small, but its behavior was spread across duration formatting, version parsing, serde, operation semantics, and `Versioned` wrapper construction.

This adds `carbide-test-support` and turns that surface into labeled `Case`/`Check` rows. The tables enumerate the accepted and rejected duration strings, version parsing, serde round-trips, comparison/update behavior, and the wrapper helpers.

Coverage (cargo-llvm-cov), before (origin/main) vs after.

```
┌──────────┬─────────┬─────────┐
│ Metric   │ Before  │  After  │
├──────────┼─────────┼─────────┤
│ Region   │ 75.81%  │ 99.61%  │
│ Function │ 51.35%  │ 100.00% │
│ Line     │ 68.40%  │ 99.63%  │
└──────────┴─────────┴─────────┘
```

The remaining uncovered surface is just defensive edge code; the crate's public helpers now have direct table coverage.

All tests pass, and formatting/clippy checks are clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)