### PR TITLE
test(bmc-proxy): fold helper tests onto carbide-test-support + raise coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,6 +1518,7 @@ dependencies = [
  "bytes",
  "carbide-authn",
  "carbide-rpc",
+ "carbide-test-support",
  "carbide-tls",
  "carbide-utils",
  "carbide-version",

--- a/crates/bmc-proxy/Cargo.toml
+++ b/crates/bmc-proxy/Cargo.toml
@@ -101,5 +101,8 @@ serde = { features = ["derive"], workspace = true }
 [build-dependencies]
 carbide-version = { path = "../version" }
 
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+
 [lints]
 workspace = true

--- a/crates/bmc-proxy/src/bmc_proxy.rs
+++ b/crates/bmc-proxy/src/bmc_proxy.rs
@@ -737,6 +737,8 @@ fn copy_request_headers(source: &HeaderMap, dest: &mut HeaderMap) {
 }
 
 fn method_supports_body(method: &Method) -> bool {
+    // Redfish services can accept DELETE payloads, so only the methods this
+    // proxy treats as bodyless are excluded.
     !matches!(*method, Method::GET | Method::HEAD)
 }
 
@@ -1001,16 +1003,21 @@ async fn evict_cached_credentials(ip: IpAddr, credential_cache: &CredentialCache
 mod tests {
     use std::collections::HashMap;
     use std::convert::Infallible;
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use std::net::{IpAddr, Ipv4Addr};
     use std::str::FromStr;
     use std::sync::Arc;
 
     use axum::body::Body;
-    use axum::http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
+    use axum::http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode};
     use bytes::Bytes;
+    use carbide_authn::middleware::{AuthContext, ExternalUserInfo, Principal};
+    use carbide_test_support::Outcome::{Fails, Yields};
+    use carbide_test_support::{Case, Check, check_cases, check_cases_async, check_values};
+    use carbide_utils::HostPortPair;
     use http_body_util::BodyExt;
     use mac_address::MacAddress;
     use opentelemetry::global;
+    use rpc::forge;
     use rpc::forge::find_bmc_ips_request::LookupBy;
     use rpc::forge_api_client::ForgeApiClient;
     use rpc::forge_tls_client::{ApiConfig, ForgeClientConfig};
@@ -1019,9 +1026,65 @@ mod tests {
 
     use super::{
         BmcCredentials, BmcProxyState, CredentialCache, ForwardedTarget, build_response,
-        evict_cached_credentials, forwarded_header_value, ip_for_forwarded_target,
-        parse_forwarded_host_value,
+        copy_request_headers, create_client, evict_cached_credentials, forwarded_header_value,
+        get_http_client, ip_for_forwarded_target, is_hop_by_hop_header, method_supports_body,
+        parse_forwarded_host_value, request_principal_ids,
     };
+
+    #[derive(Clone, Copy)]
+    enum ForwardedHeaderCase {
+        Missing,
+        InvalidUtf8ThenHost,
+        HostAmongParameters,
+        HostInLaterElement,
+        QuotedIpv4Host,
+        Mac,
+        Serial,
+        InvalidHost,
+        InvalidMac,
+    }
+
+    #[derive(Debug, PartialEq)]
+    enum ForwardedTargetSummary {
+        None,
+        Ip(String),
+        Mac(String),
+        Serial(String),
+        Error(&'static str),
+    }
+
+    #[derive(Clone, Copy)]
+    enum HeaderCopyCase {
+        ContentType,
+        Custom,
+        Host,
+        Authorization,
+        Forwarded,
+        ContentLength,
+        Connection,
+        Upgrade,
+    }
+
+    #[derive(Clone, Copy)]
+    enum ProxyOverrideCase {
+        Direct,
+        HostOnly,
+        PortOnly,
+        HostAndPort,
+    }
+
+    #[derive(Debug, PartialEq)]
+    enum CredentialSummary {
+        UsernamePassword { username: String, password: String },
+        SessionToken { token: String },
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct ClientSummary {
+        base_upstream_uri: String,
+        forwarded_header: Option<String>,
+        credentials: CredentialSummary,
+    }
 
     fn test_state_with_ip_cache(ip_cache: HashMap<LookupBy, IpAddr>) -> BmcProxyState {
         let client_config = ForgeClientConfig::default();
@@ -1050,19 +1113,278 @@ mod tests {
         }
     }
 
+    fn forwarded_headers(case: ForwardedHeaderCase) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        match case {
+            ForwardedHeaderCase::Missing => {}
+            ForwardedHeaderCase::InvalidUtf8ThenHost => {
+                headers.append(
+                    HeaderName::from_static("forwarded"),
+                    HeaderValue::from_bytes(&[0xff]).expect("non-UTF8 header value"),
+                );
+                headers.append(
+                    HeaderName::from_static("forwarded"),
+                    HeaderValue::from_static("proto=https;host=10.1.2.3"),
+                );
+            }
+            ForwardedHeaderCase::HostAmongParameters => {
+                headers.insert(
+                    HeaderName::from_static("forwarded"),
+                    HeaderValue::from_static("proto=https;host=10.1.2.3;for=10.0.0.1"),
+                );
+            }
+            ForwardedHeaderCase::HostInLaterElement => {
+                headers.insert(
+                    HeaderName::from_static("forwarded"),
+                    HeaderValue::from_static("for=10.0.0.1, proto=https; host=10.2.3.4"),
+                );
+            }
+            ForwardedHeaderCase::QuotedIpv4Host => {
+                headers.insert(
+                    HeaderName::from_static("forwarded"),
+                    HeaderValue::from_static(r#"host="10.3.4.5""#),
+                );
+            }
+            ForwardedHeaderCase::Mac => {
+                headers.insert(
+                    HeaderName::from_static("forwarded"),
+                    HeaderValue::from_static("proto=https;mac=00:11:22:33:44:55;for=10.0.0.1"),
+                );
+            }
+            ForwardedHeaderCase::Serial => {
+                headers.insert(
+                    HeaderName::from_static("forwarded"),
+                    HeaderValue::from_static("proto=https; serial = DGX-A100-0001 ; for=10.0.0.1"),
+                );
+            }
+            ForwardedHeaderCase::InvalidHost => {
+                headers.insert(
+                    HeaderName::from_static("forwarded"),
+                    HeaderValue::from_static("host=not-an-ip"),
+                );
+            }
+            ForwardedHeaderCase::InvalidMac => {
+                headers.insert(
+                    HeaderName::from_static("forwarded"),
+                    HeaderValue::from_static("mac=not-a-mac-address"),
+                );
+            }
+        }
+        headers
+    }
+
+    fn summarize_forwarded_header(case: ForwardedHeaderCase) -> ForwardedTargetSummary {
+        match forwarded_header_value(&forwarded_headers(case)) {
+            Ok(Some(ForwardedTarget::Ip(ip))) => ForwardedTargetSummary::Ip(ip.to_string()),
+            Ok(Some(ForwardedTarget::Mac(mac))) => ForwardedTargetSummary::Mac(mac.to_string()),
+            Ok(Some(ForwardedTarget::Serial(serial))) => {
+                ForwardedTargetSummary::Serial(serial.to_string())
+            }
+            Ok(None) => ForwardedTargetSummary::None,
+            Err(super::ForwardedHeaderParseError::Ip(_)) => ForwardedTargetSummary::Error("ip"),
+            Err(super::ForwardedHeaderParseError::Mac(_)) => ForwardedTargetSummary::Error("mac"),
+        }
+    }
+
+    fn header_for_copy_case(case: HeaderCopyCase) -> (HeaderName, HeaderValue) {
+        match case {
+            HeaderCopyCase::ContentType => (
+                axum::http::header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            ),
+            HeaderCopyCase::Custom => (
+                HeaderName::from_static("x-request-id"),
+                HeaderValue::from_static("request-1"),
+            ),
+            HeaderCopyCase::Host => (
+                axum::http::header::HOST,
+                HeaderValue::from_static("bmc.example.com"),
+            ),
+            HeaderCopyCase::Authorization => (
+                axum::http::header::AUTHORIZATION,
+                HeaderValue::from_static("Bearer secret"),
+            ),
+            HeaderCopyCase::Forwarded => (
+                HeaderName::from_static("forwarded"),
+                HeaderValue::from_static("host=10.0.0.1"),
+            ),
+            HeaderCopyCase::ContentLength => (
+                axum::http::header::CONTENT_LENGTH,
+                HeaderValue::from_static("42"),
+            ),
+            HeaderCopyCase::Connection => (
+                axum::http::header::CONNECTION,
+                HeaderValue::from_static("keep-alive"),
+            ),
+            HeaderCopyCase::Upgrade => (
+                axum::http::header::UPGRADE,
+                HeaderValue::from_static("websocket"),
+            ),
+        }
+    }
+
+    fn copied_header_names(case: HeaderCopyCase) -> Vec<String> {
+        let (name, value) = header_for_copy_case(case);
+        let mut source = HeaderMap::new();
+        source.insert(name, value);
+        let mut dest = HeaderMap::new();
+
+        copy_request_headers(&source, &mut dest);
+
+        dest.keys().map(|name| name.to_string()).collect()
+    }
+
+    fn summarize_credentials(credentials: BmcCredentials) -> CredentialSummary {
+        match credentials {
+            BmcCredentials::UsernamePassword { username, password } => {
+                CredentialSummary::UsernamePassword { username, password }
+            }
+            BmcCredentials::SessionToken { token } => CredentialSummary::SessionToken { token },
+        }
+    }
+
+    fn proxy_override(case: ProxyOverrideCase) -> Option<HostPortPair> {
+        match case {
+            ProxyOverrideCase::Direct => None,
+            ProxyOverrideCase::HostOnly => Some(HostPortPair::HostOnly("proxy.local".to_string())),
+            ProxyOverrideCase::PortOnly => Some(HostPortPair::PortOnly(8443)),
+            ProxyOverrideCase::HostAndPort => {
+                Some(HostPortPair::HostAndPort("proxy.local".to_string(), 8443))
+            }
+        }
+    }
+
+    async fn summarize_created_client(case: ProxyOverrideCase) -> Result<ClientSummary, String> {
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
+        // Prepopulate the cache so this test never falls through to the real
+        // ForgeApiClient path.
+        let credential_cache: CredentialCache = Arc::new(Mutex::new(HashMap::from([(
+            ip,
+            BmcCredentials::UsernamePassword {
+                username: "admin".to_string(),
+                password: "secret".to_string(),
+            },
+        )])));
+        let client_cache = Default::default();
+        let client_config = ForgeClientConfig::default();
+        let api_config = ApiConfig::new("https://example.com", &client_config);
+        let api_client = ForgeApiClient::new(&api_config);
+
+        create_client(
+            ip,
+            &api_client,
+            &credential_cache,
+            &client_cache,
+            &proxy_override(case),
+        )
+        .await
+        .map(|client| ClientSummary {
+            base_upstream_uri: client.base_upstream_uri.to_string(),
+            forwarded_header: client.header_map.get("forwarded").map(|value| {
+                value
+                    .to_str()
+                    .expect("forwarded header is UTF-8")
+                    .to_string()
+            }),
+            credentials: summarize_credentials(client.credentials),
+        })
+        .map_err(|error| error.to_string())
+    }
+
     #[test]
-    fn parses_forwarded_ipv4() {
-        assert_eq!(
-            parse_forwarded_host_value("10.0.0.5").unwrap(),
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5))
+    fn forwarded_host_value_parsing() {
+        check_values(
+            [
+                Check {
+                    scenario: "IPv4",
+                    input: "10.0.0.5",
+                    expect: Some("10.0.0.5".to_string()),
+                },
+                Check {
+                    scenario: "raw IPv6",
+                    input: "2001:db8::1",
+                    expect: Some("2001:db8::1".to_string()),
+                },
+                Check {
+                    scenario: "quoted bracketed IPv6 with port",
+                    input: "\"[2001:db8::1]:443\"",
+                    expect: Some("2001:db8::1".to_string()),
+                },
+                Check {
+                    scenario: "bracketed IPv6 without port",
+                    input: "[2001:db8::2]",
+                    expect: Some("2001:db8::2".to_string()),
+                },
+                Check {
+                    scenario: "hostname rejected",
+                    input: "bmc.example.com",
+                    expect: None,
+                },
+                Check {
+                    scenario: "IPv4 with port rejected",
+                    input: "10.0.0.5:443",
+                    expect: None,
+                },
+            ],
+            |value| {
+                parse_forwarded_host_value(value)
+                    .ok()
+                    .map(|ip| ip.to_string())
+            },
         );
     }
 
     #[test]
-    fn parses_forwarded_ipv6_with_port() {
-        assert_eq!(
-            parse_forwarded_host_value("\"[2001:db8::1]:443\"").unwrap(),
-            IpAddr::V6(Ipv6Addr::from_str("2001:db8::1").unwrap())
+    fn forwarded_header_targets() {
+        check_values(
+            [
+                Check {
+                    scenario: "missing forwarded header",
+                    input: ForwardedHeaderCase::Missing,
+                    expect: ForwardedTargetSummary::None,
+                },
+                Check {
+                    scenario: "invalid UTF-8 value skipped",
+                    input: ForwardedHeaderCase::InvalidUtf8ThenHost,
+                    expect: ForwardedTargetSummary::Ip("10.1.2.3".to_string()),
+                },
+                Check {
+                    scenario: "host among parameters",
+                    input: ForwardedHeaderCase::HostAmongParameters,
+                    expect: ForwardedTargetSummary::Ip("10.1.2.3".to_string()),
+                },
+                Check {
+                    scenario: "host in later element",
+                    input: ForwardedHeaderCase::HostInLaterElement,
+                    expect: ForwardedTargetSummary::Ip("10.2.3.4".to_string()),
+                },
+                Check {
+                    scenario: "quoted IPv4 host",
+                    input: ForwardedHeaderCase::QuotedIpv4Host,
+                    expect: ForwardedTargetSummary::Ip("10.3.4.5".to_string()),
+                },
+                Check {
+                    scenario: "MAC target",
+                    input: ForwardedHeaderCase::Mac,
+                    expect: ForwardedTargetSummary::Mac("00:11:22:33:44:55".to_string()),
+                },
+                Check {
+                    scenario: "serial target",
+                    input: ForwardedHeaderCase::Serial,
+                    expect: ForwardedTargetSummary::Serial("DGX-A100-0001".to_string()),
+                },
+                Check {
+                    scenario: "invalid host",
+                    input: ForwardedHeaderCase::InvalidHost,
+                    expect: ForwardedTargetSummary::Error("ip"),
+                },
+                Check {
+                    scenario: "invalid MAC",
+                    input: ForwardedHeaderCase::InvalidMac,
+                    expect: ForwardedTargetSummary::Error("mac"),
+                },
+            ],
+            summarize_forwarded_header,
         );
     }
 
@@ -1121,6 +1443,195 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn body_method_support() {
+        check_values(
+            [
+                Check {
+                    scenario: "GET has no upstream body",
+                    input: Method::GET,
+                    expect: false,
+                },
+                Check {
+                    scenario: "HEAD has no upstream body",
+                    input: Method::HEAD,
+                    expect: false,
+                },
+                Check {
+                    scenario: "POST supports body",
+                    input: Method::POST,
+                    expect: true,
+                },
+                Check {
+                    scenario: "PUT supports body",
+                    input: Method::PUT,
+                    expect: true,
+                },
+                Check {
+                    scenario: "PATCH supports body",
+                    input: Method::PATCH,
+                    expect: true,
+                },
+                Check {
+                    scenario: "DELETE supports body for Redfish compatibility",
+                    input: Method::DELETE,
+                    expect: true,
+                },
+            ],
+            |method| method_supports_body(&method),
+        );
+    }
+
+    #[test]
+    fn hop_by_hop_header_detection() {
+        check_values(
+            [
+                Check {
+                    scenario: "connection",
+                    input: "connection",
+                    expect: true,
+                },
+                Check {
+                    scenario: "case-insensitive keep-alive",
+                    input: "Keep-Alive",
+                    expect: true,
+                },
+                Check {
+                    scenario: "proxy authenticate",
+                    input: "proxy-authenticate",
+                    expect: true,
+                },
+                Check {
+                    scenario: "proxy authorization",
+                    input: "proxy-authorization",
+                    expect: true,
+                },
+                Check {
+                    scenario: "te",
+                    input: "te",
+                    expect: true,
+                },
+                Check {
+                    scenario: "trailer",
+                    input: "trailer",
+                    expect: true,
+                },
+                Check {
+                    scenario: "transfer encoding",
+                    input: "transfer-encoding",
+                    expect: true,
+                },
+                Check {
+                    scenario: "upgrade",
+                    input: "upgrade",
+                    expect: true,
+                },
+                Check {
+                    scenario: "content type is safe",
+                    input: "content-type",
+                    expect: false,
+                },
+            ],
+            is_hop_by_hop_header,
+        );
+    }
+
+    #[test]
+    fn request_header_copying_filters_proxy_owned_headers() {
+        check_values(
+            [
+                Check {
+                    scenario: "content type copied",
+                    input: HeaderCopyCase::ContentType,
+                    expect: vec!["content-type".to_string()],
+                },
+                Check {
+                    scenario: "custom header copied",
+                    input: HeaderCopyCase::Custom,
+                    expect: vec!["x-request-id".to_string()],
+                },
+                Check {
+                    scenario: "host filtered",
+                    input: HeaderCopyCase::Host,
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "authorization filtered",
+                    input: HeaderCopyCase::Authorization,
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "forwarded filtered",
+                    input: HeaderCopyCase::Forwarded,
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "content length filtered",
+                    input: HeaderCopyCase::ContentLength,
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "connection filtered",
+                    input: HeaderCopyCase::Connection,
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "upgrade filtered",
+                    input: HeaderCopyCase::Upgrade,
+                    expect: vec![],
+                },
+            ],
+            copied_header_names,
+        );
+    }
+
+    #[test]
+    fn request_principal_identifiers_include_anonymous_fallback() {
+        check_values(
+            [
+                Check {
+                    scenario: "no authenticated principals",
+                    input: vec![],
+                    expect: vec!["anonymous".to_string()],
+                },
+                Check {
+                    scenario: "service principal",
+                    input: vec![Principal::SpiffeServiceIdentifier(
+                        "forge-system/carbide-api".to_string(),
+                    )],
+                    expect: vec![
+                        "spiffe-service-id/forge-system/carbide-api".to_string(),
+                        "anonymous".to_string(),
+                    ],
+                },
+                Check {
+                    scenario: "machine and external user principals",
+                    input: vec![
+                        // Machine identities currently authorize by type token;
+                        // the concrete machine id is intentionally not included.
+                        Principal::SpiffeMachineIdentifier("machine-1".to_string()),
+                        Principal::ExternalUser(ExternalUserInfo::new(
+                            Some("nvidia".to_string()),
+                            "admin".to_string(),
+                            Some("chet".to_string()),
+                        )),
+                    ],
+                    expect: vec![
+                        "spiffe-machine-id".to_string(),
+                        "external-role/admin".to_string(),
+                        "anonymous".to_string(),
+                    ],
+                },
+            ],
+            |principals| {
+                request_principal_ids(&AuthContext {
+                    principals,
+                    authorization: None,
+                })
+            },
+        );
+    }
+
     #[tokio::test]
     async fn forwarded_ip_target_resolves_without_lookup() {
         let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
@@ -1165,6 +1676,52 @@ mod tests {
     }
 
     #[test]
+    fn bmc_credentials_convert_from_api_response() {
+        check_cases(
+            [
+                Case {
+                    scenario: "username and password",
+                    input: forge::BmcCredentials {
+                        r#type: Some(forge::bmc_credentials::Type::UsernamePassword(
+                            forge::UsernamePassword {
+                                username: "admin".to_string(),
+                                password: "secret".to_string(),
+                            },
+                        )),
+                    },
+                    expect: Yields(CredentialSummary::UsernamePassword {
+                        username: "admin".to_string(),
+                        password: "secret".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "session token",
+                    input: forge::BmcCredentials {
+                        r#type: Some(forge::bmc_credentials::Type::SessionToken(
+                            forge::SessionToken {
+                                token: "token-123".to_string(),
+                            },
+                        )),
+                    },
+                    expect: Yields(CredentialSummary::SessionToken {
+                        token: "token-123".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "missing credential type",
+                    input: forge::BmcCredentials { r#type: None },
+                    expect: Fails,
+                },
+            ],
+            |credentials| {
+                BmcCredentials::try_from(credentials)
+                    .map(summarize_credentials)
+                    .map_err(|error| error.to_string())
+            },
+        );
+    }
+
+    #[test]
     fn bmc_username_password_credentials_use_basic_auth() {
         let request = reqwest::Client::new().get("https://example.com/redfish/v1");
         let request = BmcCredentials::UsernamePassword {
@@ -1195,6 +1752,84 @@ mod tests {
         .expect("request should build");
 
         assert_eq!(request.headers().get("X-Auth-Token").unwrap(), "token-123");
+    }
+
+    #[tokio::test]
+    async fn http_clients_are_cached_per_ip() {
+        let cache = Default::default();
+        let first_ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
+        let second_ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 6));
+
+        get_http_client(first_ip, &cache)
+            .await
+            .expect("first client");
+        get_http_client(first_ip, &cache)
+            .await
+            .expect("cached client");
+        assert_eq!(cache.lock().await.len(), 1);
+
+        get_http_client(second_ip, &cache)
+            .await
+            .expect("second client");
+        assert_eq!(cache.lock().await.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn client_creation_applies_proxy_overrides() {
+        check_cases_async(
+            [
+                Case {
+                    scenario: "direct BMC IP",
+                    input: ProxyOverrideCase::Direct,
+                    expect: Yields(ClientSummary {
+                        base_upstream_uri: "https://10.0.0.5/".to_string(),
+                        forwarded_header: None,
+                        credentials: CredentialSummary::UsernamePassword {
+                            username: "admin".to_string(),
+                            password: "secret".to_string(),
+                        },
+                    }),
+                },
+                Case {
+                    scenario: "proxy host only",
+                    input: ProxyOverrideCase::HostOnly,
+                    expect: Yields(ClientSummary {
+                        base_upstream_uri: "https://proxy.local/".to_string(),
+                        forwarded_header: Some("host=10.0.0.5".to_string()),
+                        credentials: CredentialSummary::UsernamePassword {
+                            username: "admin".to_string(),
+                            password: "secret".to_string(),
+                        },
+                    }),
+                },
+                Case {
+                    scenario: "proxy port only",
+                    input: ProxyOverrideCase::PortOnly,
+                    expect: Yields(ClientSummary {
+                        base_upstream_uri: "https://10.0.0.5:8443/".to_string(),
+                        forwarded_header: None,
+                        credentials: CredentialSummary::UsernamePassword {
+                            username: "admin".to_string(),
+                            password: "secret".to_string(),
+                        },
+                    }),
+                },
+                Case {
+                    scenario: "proxy host and port",
+                    input: ProxyOverrideCase::HostAndPort,
+                    expect: Yields(ClientSummary {
+                        base_upstream_uri: "https://proxy.local:8443/".to_string(),
+                        forwarded_header: Some("host=10.0.0.5".to_string()),
+                        credentials: CredentialSummary::UsernamePassword {
+                            username: "admin".to_string(),
+                            password: "secret".to_string(),
+                        },
+                    }),
+                },
+            ],
+            summarize_created_client,
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/crates/bmc-proxy/src/config.rs
+++ b/crates/bmc-proxy/src/config.rs
@@ -144,3 +144,251 @@ impl Config {
             .map_err(Into::into)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    const MINIMAL_TLS: &str = r#"
+        [tls]
+        identity_pemfile_path = "/tls/cert.pem"
+        identity_keyfile_path = "/tls/key.pem"
+        root_cafile_path = "/tls/ca.pem"
+        admin_root_cafile_path = "/tls/admin-ca.pem"
+
+        [auth]
+    "#;
+
+    #[derive(Clone, Copy)]
+    enum ConfigCase {
+        Minimal,
+        ExplicitListeners,
+        AllowedPrincipals,
+        ProxyHostOnly,
+        ProxyPortOnly,
+        ProxyHostAndPort,
+        ExplicitCarbideApi,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct ConfigSummary {
+        listen: String,
+        metrics_endpoint: String,
+        allowed_principals: Vec<String>,
+        identity_pemfile_path: String,
+        root_cafile_path: String,
+        trust_domain: String,
+        service_base_paths: Vec<String>,
+        carbide_api_url: String,
+        bmc_proxy: Option<String>,
+    }
+
+    fn config_source(case: ConfigCase) -> String {
+        let extra = match case {
+            ConfigCase::Minimal => "",
+            ConfigCase::ExplicitListeners => {
+                r#"
+                listen = "127.0.0.1:2079"
+                metrics_endpoint = "127.0.0.1:2080"
+            "#
+            }
+            ConfigCase::AllowedPrincipals => {
+                r#"
+                allowed_principals = ["spiffe-service-id/carbide-api", "trusted-certificate"]
+            "#
+            }
+            ConfigCase::ProxyHostOnly => {
+                r#"
+                bmc_proxy = "proxy.local"
+            "#
+            }
+            ConfigCase::ProxyPortOnly => {
+                r#"
+                bmc_proxy = ":8443"
+            "#
+            }
+            ConfigCase::ProxyHostAndPort => {
+                r#"
+                bmc_proxy = "proxy.local:8443"
+            "#
+            }
+            ConfigCase::ExplicitCarbideApi => {
+                r#"
+                [carbide_api]
+                root_ca = "/api/ca.pem"
+                client_cert = "/api/cert.pem"
+                client_key = "/api/key.pem"
+                api_url = "https://api.example.com:1079"
+            "#
+            }
+        };
+
+        format!("{extra}\n{MINIMAL_TLS}")
+    }
+
+    fn summarize_config(case: ConfigCase) -> ConfigSummary {
+        let config = Config::parse(&config_source(case)).expect("config parses");
+        let mut allowed_principals = config.allowed_principals.into_iter().collect::<Vec<_>>();
+        // Config stores this as a HashSet; sort the summary for deterministic
+        // table comparisons.
+        allowed_principals.sort();
+
+        ConfigSummary {
+            listen: config.listen.to_string(),
+            metrics_endpoint: config.metrics_endpoint.to_string(),
+            allowed_principals,
+            identity_pemfile_path: config.tls.identity_pemfile_path,
+            root_cafile_path: config.tls.root_cafile_path,
+            trust_domain: config.auth.trust.spiffe_trust_domain,
+            service_base_paths: config.auth.trust.spiffe_service_base_paths,
+            carbide_api_url: config.carbide_api.api_url.to_string(),
+            bmc_proxy: config.bmc_proxy.map(|pair| pair.to_string()),
+        }
+    }
+
+    #[test]
+    fn parses_config_shapes() {
+        check_values(
+            [
+                Check {
+                    scenario: "minimal config uses defaults",
+                    input: ConfigCase::Minimal,
+                    expect: ConfigSummary {
+                        listen: "[::]:1079".to_string(),
+                        metrics_endpoint: "[::]:1080".to_string(),
+                        allowed_principals: vec![],
+                        identity_pemfile_path: "/tls/cert.pem".to_string(),
+                        root_cafile_path: "/tls/ca.pem".to_string(),
+                        trust_domain: "forge.local".to_string(),
+                        service_base_paths: vec![
+                            "/forge-system/sa/".to_string(),
+                            "/default/sa/".to_string(),
+                        ],
+                        carbide_api_url: "https://carbide-api.forge-system.svc.cluster.local:1079/"
+                            .to_string(),
+                        bmc_proxy: None,
+                    },
+                },
+                Check {
+                    scenario: "explicit listeners",
+                    input: ConfigCase::ExplicitListeners,
+                    expect: ConfigSummary {
+                        listen: "127.0.0.1:2079".to_string(),
+                        metrics_endpoint: "127.0.0.1:2080".to_string(),
+                        allowed_principals: vec![],
+                        identity_pemfile_path: "/tls/cert.pem".to_string(),
+                        root_cafile_path: "/tls/ca.pem".to_string(),
+                        trust_domain: "forge.local".to_string(),
+                        service_base_paths: vec![
+                            "/forge-system/sa/".to_string(),
+                            "/default/sa/".to_string(),
+                        ],
+                        carbide_api_url: "https://carbide-api.forge-system.svc.cluster.local:1079/"
+                            .to_string(),
+                        bmc_proxy: None,
+                    },
+                },
+                Check {
+                    scenario: "allowed principals",
+                    input: ConfigCase::AllowedPrincipals,
+                    expect: ConfigSummary {
+                        listen: "[::]:1079".to_string(),
+                        metrics_endpoint: "[::]:1080".to_string(),
+                        allowed_principals: vec![
+                            "spiffe-service-id/carbide-api".to_string(),
+                            "trusted-certificate".to_string(),
+                        ],
+                        identity_pemfile_path: "/tls/cert.pem".to_string(),
+                        root_cafile_path: "/tls/ca.pem".to_string(),
+                        trust_domain: "forge.local".to_string(),
+                        service_base_paths: vec![
+                            "/forge-system/sa/".to_string(),
+                            "/default/sa/".to_string(),
+                        ],
+                        carbide_api_url: "https://carbide-api.forge-system.svc.cluster.local:1079/"
+                            .to_string(),
+                        bmc_proxy: None,
+                    },
+                },
+                Check {
+                    scenario: "proxy host only",
+                    input: ConfigCase::ProxyHostOnly,
+                    expect: ConfigSummary {
+                        listen: "[::]:1079".to_string(),
+                        metrics_endpoint: "[::]:1080".to_string(),
+                        allowed_principals: vec![],
+                        identity_pemfile_path: "/tls/cert.pem".to_string(),
+                        root_cafile_path: "/tls/ca.pem".to_string(),
+                        trust_domain: "forge.local".to_string(),
+                        service_base_paths: vec![
+                            "/forge-system/sa/".to_string(),
+                            "/default/sa/".to_string(),
+                        ],
+                        carbide_api_url: "https://carbide-api.forge-system.svc.cluster.local:1079/"
+                            .to_string(),
+                        bmc_proxy: Some("proxy.local".to_string()),
+                    },
+                },
+                Check {
+                    scenario: "proxy port only",
+                    input: ConfigCase::ProxyPortOnly,
+                    expect: ConfigSummary {
+                        listen: "[::]:1079".to_string(),
+                        metrics_endpoint: "[::]:1080".to_string(),
+                        allowed_principals: vec![],
+                        identity_pemfile_path: "/tls/cert.pem".to_string(),
+                        root_cafile_path: "/tls/ca.pem".to_string(),
+                        trust_domain: "forge.local".to_string(),
+                        service_base_paths: vec![
+                            "/forge-system/sa/".to_string(),
+                            "/default/sa/".to_string(),
+                        ],
+                        carbide_api_url: "https://carbide-api.forge-system.svc.cluster.local:1079/"
+                            .to_string(),
+                        bmc_proxy: Some("8443".to_string()),
+                    },
+                },
+                Check {
+                    scenario: "proxy host and port",
+                    input: ConfigCase::ProxyHostAndPort,
+                    expect: ConfigSummary {
+                        listen: "[::]:1079".to_string(),
+                        metrics_endpoint: "[::]:1080".to_string(),
+                        allowed_principals: vec![],
+                        identity_pemfile_path: "/tls/cert.pem".to_string(),
+                        root_cafile_path: "/tls/ca.pem".to_string(),
+                        trust_domain: "forge.local".to_string(),
+                        service_base_paths: vec![
+                            "/forge-system/sa/".to_string(),
+                            "/default/sa/".to_string(),
+                        ],
+                        carbide_api_url: "https://carbide-api.forge-system.svc.cluster.local:1079/"
+                            .to_string(),
+                        bmc_proxy: Some("proxy.local:8443".to_string()),
+                    },
+                },
+                Check {
+                    scenario: "explicit Carbide API",
+                    input: ConfigCase::ExplicitCarbideApi,
+                    expect: ConfigSummary {
+                        listen: "[::]:1079".to_string(),
+                        metrics_endpoint: "[::]:1080".to_string(),
+                        allowed_principals: vec![],
+                        identity_pemfile_path: "/tls/cert.pem".to_string(),
+                        root_cafile_path: "/tls/ca.pem".to_string(),
+                        trust_domain: "forge.local".to_string(),
+                        service_base_paths: vec![
+                            "/forge-system/sa/".to_string(),
+                            "/default/sa/".to_string(),
+                        ],
+                        carbide_api_url: "https://api.example.com:1079/".to_string(),
+                        bmc_proxy: None,
+                    },
+                },
+            ],
+            summarize_config,
+        );
+    }
+}

--- a/crates/bmc-proxy/src/metrics.rs
+++ b/crates/bmc-proxy/src/metrics.rs
@@ -52,3 +52,40 @@ pub async fn start(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::time::timeout;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn start_binds_listener_and_spawns_endpoint_task() {
+        let address = "127.0.0.1:0".parse().expect("valid listen address");
+        let metrics_setup =
+            metrics_endpoint::new_metrics_setup("carbide-bmc-proxy-test", "test", false)
+                .expect("metrics setup succeeds");
+        let cancellation_token = CancellationToken::new();
+        let mut join_set = JoinSet::new();
+
+        start(
+            address,
+            metrics_setup,
+            cancellation_token.clone(),
+            &mut join_set,
+        )
+        .await
+        .expect("metrics endpoint starts");
+
+        assert_eq!(join_set.len(), 1);
+
+        cancellation_token.cancel();
+        timeout(Duration::from_secs(5), join_set.join_next())
+            .await
+            .expect("metrics endpoint exits after cancellation")
+            .expect("metrics endpoint task is joined")
+            .expect("metrics endpoint task succeeds");
+    }
+}

--- a/crates/bmc-proxy/src/setup.rs
+++ b/crates/bmc-proxy/src/setup.rs
@@ -85,3 +85,102 @@ pub fn dep_log_filter(env_filter: EnvFilter) -> EnvFilter {
         )
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+    use tracing_subscriber::prelude::*;
+
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    enum FilterCase {
+        DefaultAllowsApplicationInfo,
+        DefaultSuppressesHyperInfo,
+        DefaultAllowsHyperError,
+        UserOverrideAllowsApplicationDebug,
+        DependencyCapOverridesVaultrsDebug,
+        UserOverrideDoesNotAffectHyperCap,
+    }
+
+    fn filter_allows(case: FilterCase) -> bool {
+        let directives = match case {
+            FilterCase::DefaultAllowsApplicationInfo
+            | FilterCase::DefaultSuppressesHyperInfo
+            | FilterCase::DefaultAllowsHyperError => "info",
+            FilterCase::UserOverrideAllowsApplicationDebug => "info,carbide_bmc_proxy=debug",
+            FilterCase::DependencyCapOverridesVaultrsDebug
+            | FilterCase::UserOverrideDoesNotAffectHyperCap => "info,vaultrs=debug",
+        };
+        let user = EnvFilter::builder().parse(directives).unwrap();
+        let subscriber = tracing_subscriber::registry().with(dep_log_filter(user));
+
+        tracing::subscriber::with_default(subscriber, || match case {
+            FilterCase::DefaultAllowsApplicationInfo => {
+                tracing::enabled!(target: "carbide_bmc_proxy", tracing::Level::INFO)
+            }
+            FilterCase::DefaultSuppressesHyperInfo => {
+                tracing::enabled!(target: "hyper", tracing::Level::INFO)
+            }
+            FilterCase::DefaultAllowsHyperError => {
+                tracing::enabled!(target: "hyper", tracing::Level::ERROR)
+            }
+            FilterCase::UserOverrideAllowsApplicationDebug => {
+                tracing::enabled!(target: "carbide_bmc_proxy", tracing::Level::DEBUG)
+            }
+            FilterCase::DependencyCapOverridesVaultrsDebug => {
+                tracing::enabled!(target: "vaultrs", tracing::Level::DEBUG)
+            }
+            FilterCase::UserOverrideDoesNotAffectHyperCap => {
+                tracing::enabled!(target: "hyper", tracing::Level::INFO)
+            }
+        })
+    }
+
+    #[test]
+    fn dependency_log_filter_applies_caps_and_user_overrides() {
+        check_values(
+            [
+                Check {
+                    scenario: "application info allowed by default directive",
+                    input: FilterCase::DefaultAllowsApplicationInfo,
+                    expect: true,
+                },
+                Check {
+                    scenario: "hyper info suppressed by dependency cap",
+                    input: FilterCase::DefaultSuppressesHyperInfo,
+                    expect: false,
+                },
+                Check {
+                    scenario: "hyper error allowed by dependency cap",
+                    input: FilterCase::DefaultAllowsHyperError,
+                    expect: true,
+                },
+                Check {
+                    scenario: "user override allows application debug",
+                    input: FilterCase::UserOverrideAllowsApplicationDebug,
+                    expect: true,
+                },
+                Check {
+                    scenario: "dependency cap overrides vaultrs debug",
+                    input: FilterCase::DependencyCapOverridesVaultrsDebug,
+                    expect: false,
+                },
+                Check {
+                    scenario: "user override leaves unrelated dependency capped",
+                    input: FilterCase::UserOverrideDoesNotAffectHyperCap,
+                    expect: false,
+                },
+            ],
+            filter_allows,
+        );
+    }
+
+    #[test]
+    fn metrics_setup_initializes_health_controller() {
+        let setup = setup_metrics().expect("metrics setup succeeds");
+
+        assert!(setup.health_controller.is_ready());
+        assert!(setup.health_controller.is_healthy());
+    }
+}


### PR DESCRIPTION
This supports #3914.

## Description

The `carbide-bmc-proxy` crate already had strong ACL coverage, but the pure proxy helpers around forwarded headers, credentials, config, and request construction were mostly uncovered.

This adds `carbide-test-support` and enumerates that helper surface as `Case`/`Check` rows: forwarded header parsing, proxy-owned header filtering, request body policy, principal identifiers, BMC credential conversions, proxy override URI/header construction, config parsing, logging filter behavior, and metrics startup.

Coverage (cargo-llvm-cov), before (origin/main) vs after.

```
┌──────────┬─────────┬─────────┐
│ Metric   │ Before  │  After  │
├──────────┼─────────┼─────────┤
│ Region   │ 52.02%  │ 69.18%  │
│ Function │ 47.17%  │ 65.31%  │
│ Line     │ 47.11%  │ 73.18%  │
└──────────┴─────────┴─────────┘
```

The listener, TLS, and upstream request paths remain service-level work, but the helper coverage now accounts for the behavior reviewers can validate from table rows.

All tests pass, and formatting/clippy checks are clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)