### PR TITLE
tests(api-web): use test harness fixtures in api-web tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,6 +1466,7 @@ dependencies = [
  "carbide-rpc",
  "carbide-rpc-utils",
  "carbide-sqlx-testing",
+ "carbide-test-harness",
  "carbide-uuid",
  "carbide-version",
  "chrono",

--- a/crates/api-core/src/lib.rs
+++ b/crates/api-core/src/lib.rs
@@ -25,9 +25,9 @@
 //! the two together.
 
 // It's too cumbersome for tests to adhere to these, which are less important in testing anyway.
-// Gated on `any(test, feature = "test-support")` to match the `tests` module below: the fixtures
-// also compile (without `cfg(test)`) when a dependent enables `test-support`, so the allow must
-// cover that build too — otherwise the custom txn lints fire on the fixtures under `--all-features`.
+// The `test_support` module also compiles when a dependent enables the `test-support` feature, so
+// the allow must cover that build too; otherwise the custom txn lints fire on shared test helpers
+// under `--all-features`.
 #![cfg_attr(any(test, feature = "test-support"), allow(txn_held_across_await))]
 #![cfg_attr(any(test, feature = "test-support"), allow(txn_without_commit))]
 
@@ -74,11 +74,7 @@ mod storage;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
 
-// Compiled for our own tests, and also when the `test-support` feature is enabled so that
-// dependents (notably `carbide-api-web`) can reuse the `tests::common` fixtures to build a real
-// `Api`. Only `tests::common` is exposed under `test-support`; the actual test cases stay
-// `#[cfg(test)]` (see `tests/mod.rs`).
-#[cfg(any(test, feature = "test-support"))]
+#[cfg(test)]
 pub mod tests;
 
 use std::sync::OnceLock;

--- a/crates/api-core/src/test_support/network_segment.rs
+++ b/crates/api-core/src/test_support/network_segment.rs
@@ -162,15 +162,13 @@ pub async fn create_host_inband_network_segment(
 /// Creates a Flat VPC for the default test tenant and returns its id. Used as
 /// the implicit parent VPC for HostInband segment fixtures.
 pub async fn create_default_flat_vpc(api: &Api, name: &str) -> VpcId {
-    let request = crate::tests::common::rpc_builder::VpcCreationRequest::builder(
-        "2829bbe3-c169-4cd9-8b2a-19a8b1618a93",
-    )
-    .metadata(rpc::forge::Metadata {
-        name: name.to_string(),
-        ..Default::default()
-    })
-    .network_virtualization_type(rpc::forge::VpcVirtualizationType::Flat as i32)
-    .tonic_request();
+    let request = rpc::forge::VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+        .metadata(rpc::forge::Metadata {
+            name: name.to_string(),
+            ..Default::default()
+        })
+        .network_virtualization_type(rpc::forge::VpcVirtualizationType::Flat as i32)
+        .tonic_request();
     let vpc = api
         .create_vpc(request)
         .await

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -15,233 +15,121 @@
  * limitations under the License.
  */
 
-#[cfg(test)]
 mod boot_interface_resolution;
-#[cfg(test)]
 mod client_resolution;
 pub mod common;
-#[cfg(test)]
 mod compute_allocation;
-#[cfg(test)]
 mod connected_device;
-#[cfg(test)]
 mod create_domain;
-#[cfg(test)]
 mod credential;
-#[cfg(test)]
 mod dhcp_lease_expiration;
-#[cfg(test)]
 mod dns;
-#[cfg(test)]
 mod dpa_interfaces;
-#[cfg(test)]
 mod dpf;
-#[cfg(test)]
 mod dpu_agent_upgrade;
-#[cfg(test)]
 mod dpu_info_list;
-#[cfg(test)]
 mod dpu_machine_inventory;
-#[cfg(test)]
 mod dpu_machine_update;
-#[cfg(test)]
 mod dpu_nic_firmware;
-#[cfg(test)]
 mod dpu_remediation;
-#[cfg(test)]
 mod dpu_reprovisioning;
-#[cfg(test)]
 mod dynamic_config;
-#[cfg(test)]
 mod expected_machine;
-#[cfg(test)]
 mod expected_power_shelf;
-#[cfg(test)]
 mod expected_rack;
-#[cfg(test)]
 mod expected_switch;
-#[cfg(test)]
 mod explored_endpoint_find;
-#[cfg(test)]
 mod explored_managed_host_find;
-#[cfg(test)]
 mod extension_service;
-#[cfg(test)]
 mod finder;
-#[cfg(test)]
 mod host_bmc_firmware_test;
-#[cfg(test)]
 mod ib_fabric_find;
-#[cfg(test)]
 mod ib_fabric_monitor;
-#[cfg(test)]
 mod ib_instance;
-#[cfg(test)]
 mod ib_machine;
-#[cfg(test)]
 mod ib_partition_find;
-#[cfg(test)]
 mod ib_partition_lifecycle;
-#[cfg(test)]
 mod instance;
-#[cfg(test)]
 mod instance_allocate;
-#[cfg(test)]
 mod instance_batch_allocate;
-#[cfg(test)]
 mod instance_config_update;
-#[cfg(test)]
 mod instance_find;
-#[cfg(test)]
 mod instance_ipxe_behaviors;
-#[cfg(test)]
 mod instance_os;
-#[cfg(test)]
 mod instance_type;
-#[cfg(test)]
 mod ip_allocator;
-#[cfg(test)]
 mod ipxe;
-#[cfg(test)]
 mod level_filter;
-#[cfg(test)]
 mod lldp;
-#[cfg(test)]
 mod mac_address_pool;
-#[cfg(test)]
 mod machine_admin_force_delete;
-#[cfg(test)]
 mod machine_bmc_metadata;
-#[cfg(test)]
 mod machine_boot_override;
-#[cfg(test)]
 mod machine_creator;
-#[cfg(test)]
 mod machine_dhcp;
-#[cfg(test)]
 mod machine_discovery;
-#[cfg(test)]
 mod machine_find;
-#[cfg(test)]
 mod machine_health;
-#[cfg(test)]
 mod machine_history;
-#[cfg(test)]
 mod machine_interface_addresses;
-#[cfg(test)]
 mod machine_interfaces;
-#[cfg(test)]
 mod machine_metadata;
-#[cfg(test)]
 mod machine_network;
-#[cfg(test)]
 mod machine_power;
-#[cfg(test)]
 mod machine_setup;
-#[cfg(test)]
 mod machine_states;
-#[cfg(test)]
 mod machine_topology;
-#[cfg(test)]
 pub mod machine_update_manager;
-#[cfg(test)]
 mod machine_validation;
-#[cfg(test)]
 mod maintenance;
 #[cfg(feature = "linux-build")]
-#[cfg(test)]
 mod measured_boot;
-#[cfg(test)]
 mod mqtt_state_change_hook;
-#[cfg(test)]
 mod network_device;
-#[cfg(test)]
 mod network_security_group;
-#[cfg(test)]
 mod network_segment;
-#[cfg(test)]
 mod network_segment_find;
-#[cfg(test)]
 mod network_segment_lifecycle;
-#[cfg(test)]
 mod nvl_instance;
-#[cfg(test)]
 mod nvl_logical_partition;
-#[cfg(test)]
 mod nvlink_domain_health;
-#[cfg(test)]
 mod operating_system;
-#[cfg(test)]
 mod power_shelf;
-#[cfg(test)]
 mod power_shelf_find;
-#[cfg(test)]
 mod power_shelf_health;
-#[cfg(test)]
 mod power_shelf_metadata;
-#[cfg(test)]
 mod power_shelf_state_controller;
-#[cfg(test)]
 mod preingestion_dpu_nic_mode;
-#[cfg(test)]
 mod prevent_duplicate_mac_addresses;
-#[cfg(test)]
 mod rack_find;
-#[cfg(test)]
 mod rack_health;
-#[cfg(test)]
 mod rack_metadata;
-#[cfg(test)]
 mod rack_state_controller;
-#[cfg(test)]
 mod redfish_actions;
-#[cfg(test)]
 mod resource_pool;
-#[cfg(test)]
 mod route_servers;
-#[cfg(test)]
 mod service_health_metrics;
-#[cfg(test)]
 mod set_primary_dpu;
-#[cfg(test)]
 mod set_primary_interface;
-#[cfg(test)]
 mod site_explorer;
-#[cfg(test)]
 mod sku;
-#[cfg(test)]
 mod spdm;
-#[cfg(test)]
 mod static_address_management;
-#[cfg(test)]
 mod storage;
-#[cfg(test)]
 mod switch;
-#[cfg(test)]
 mod switch_find;
-#[cfg(test)]
 mod switch_health;
-#[cfg(test)]
 mod switch_metadata;
-#[cfg(test)]
 mod switch_state_controller;
-#[cfg(test)]
 mod tenant_keyset_find;
-#[cfg(test)]
 mod tenants;
-#[cfg(test)]
 mod tpm_ca;
-#[cfg(test)]
 mod vpc;
-#[cfg(test)]
 mod vpc_find;
-#[cfg(test)]
 mod vpc_peering;
-#[cfg(test)]
 mod vpc_prefix;
 // NOTE: the admin web UI tests moved to the `carbide-api-web` crate (alongside the web code they
-// exercise). They build an `Api` via the `tests::common` fixtures, which `carbide-api-web` reaches
-// through this crate's `test-support` feature.
+// exercise).
 
 /// Make these symbol available as
 /// crate::tests::sqlx_fixture_from_str, so that the
@@ -250,7 +138,6 @@ pub use crate::tests::common::sqlx_fixtures::sqlx_fixture_from_str;
 
 /// Setup logging for tests. Only our own test binary needs this global initializer (it depends on
 /// the dev-only `ctor` crate); consumers of the `test-support` fixtures bring their own logging.
-#[cfg(test)]
 #[ctor::ctor(unsafe)]
 fn setup_test_logging() {
     crate::test_support::setup_test_logging()

--- a/crates/api-core/src/tests/site_explorer.rs
+++ b/crates/api-core/src/tests/site_explorer.rs
@@ -32,7 +32,6 @@ use model::site_explorer::{
 };
 use model::test_support::{DpuConfig, ManagedHostConfig};
 use rpc::forge::forge_server::Forge;
-use rpc::forge::{self};
 use rpc::{DiscoveryData, DiscoveryInfo, MachineDiscoveryInfo};
 use sqlx::PgPool;
 use tonic::Request;
@@ -44,45 +43,10 @@ use crate::tests::common::api_fixtures;
 use crate::tests::common::api_fixtures::TestEnvOverrides;
 use crate::tests::common::api_fixtures::network_segment::{
     FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY,
-    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY, create_host_inband_network_segment,
+    create_host_inband_network_segment,
 };
 use crate::tests::common::api_fixtures::site_explorer::MockExploredHost;
 use crate::tests::common::rpc_builder::DhcpDiscovery;
-
-const HOST_BMC_VENDOR_STRING: &str = "SomeVendor";
-const DPU_BMC_VENDOR_STRING: &str = "NVIDIA/BF/BMC";
-
-trait TestEnvExt {
-    async fn dhcp_discover(
-        &self,
-        bmc_mac_address: MacAddress,
-        vendor_string: &str,
-    ) -> eyre::Result<(forge::DhcpRecord, IpAddr)>;
-}
-
-impl TestEnvExt for TestEnv {
-    async fn dhcp_discover(
-        &self,
-        bmc_mac_address: MacAddress,
-        vendor_string: &str,
-    ) -> eyre::Result<(forge::DhcpRecord, IpAddr)> {
-        let response = self
-            .api
-            .discover_dhcp(
-                DhcpDiscovery::builder(
-                    bmc_mac_address,
-                    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.ip(),
-                )
-                .vendor_string(vendor_string)
-                .tonic_request(),
-            )
-            .await?
-            .into_inner();
-        let bmc_ip = response.address.parse()?;
-
-        Ok((response, bmc_ip))
-    }
-}
 
 // Test that discover_machines will reject request of machine that was not created by site-explorer when create_machines = true
 #[sqlx_test]
@@ -751,141 +715,6 @@ async fn test_get_machine_position_info_no_endpoint(
     assert_eq!(info.compute_tray_index, None);
     assert_eq!(info.topology_id, None);
     assert_eq!(info.revision_id, None);
-
-    Ok(())
-}
-
-/// A queued `set_nic_mode` only takes effect after a host power cycle, and
-/// site-explorer drives that power cycle itself for every vendor -- the
-/// Redfish `ComputerSystem.Reset` action is standard across BMCs. This is
-/// the non-Dell guard for that behavior: a Lenovo host whose DPU needs the
-/// mode correction gets an automatic `PowerCycle` on its host BMC in the
-/// same pass that issued `set_nic_mode`, rather than parking on a manual
-/// power cycle.
-#[sqlx_test]
-async fn test_site_explorer_power_cycles_non_dell_host_to_apply_nic_mode(
-    pool: PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    use model::expected_machine::{DpuMode, ExpectedMachine, ExpectedMachineData};
-    use model::site_explorer::NicMode;
-
-    let env = common::api_fixtures::create_test_env(pool).await;
-
-    // DPU hardware reports DPU mode; the operator-declared NicMode override
-    // is what forces the correction (and therefore the power cycle).
-    let dpu_config = DpuConfig {
-        nic_mode: Some(NicMode::Dpu),
-        ..DpuConfig::default()
-    };
-    let mock_host = ManagedHostConfig {
-        dpus: vec![dpu_config],
-        vendor: Some(bmc_vendor::BMCVendor::Lenovo),
-        ..ManagedHostConfig::default()
-    };
-    let host_bmc_mac = mock_host.bmc_mac_address;
-
-    let mut txn = env.pool.begin().await?;
-    db::expected_machine::create(
-        &mut txn,
-        ExpectedMachine {
-            id: None,
-            bmc_mac_address: host_bmc_mac,
-            data: ExpectedMachineData {
-                bmc_username: "ADMIN".to_string(),
-                bmc_password: "PASS".to_string(),
-                serial_number: "EM-866-NIC-POWERCYCLE".to_string(),
-                metadata: model::metadata::Metadata::new_with_default_name(),
-                dpu_mode: DpuMode::NicMode,
-                ..Default::default()
-            },
-        },
-    )
-    .await?;
-    txn.commit().await?;
-
-    let (_, host_bmc_ip) = env
-        .dhcp_discover(mock_host.bmc_mac_address, HOST_BMC_VENDOR_STRING)
-        .await?;
-    let (_, dpu_bmc_ip) = env
-        .dhcp_discover(mock_host.dpus[0].bmc_mac_address, DPU_BMC_VENDOR_STRING)
-        .await?;
-
-    env.endpoint_explorer.insert_endpoints(
-        mock_host
-            .exploration_results(Some(host_bmc_ip), &[(0, dpu_bmc_ip)])?
-            .into_endpoints(),
-    );
-    // First iteration: initial endpoint exploration.
-    env.run_site_explorer_iteration().await;
-    let mut txn = env.pool.begin().await?;
-    db::explored_endpoints::set_preingestion_complete(host_bmc_ip, &mut txn).await?;
-    db::explored_endpoints::set_preingestion_complete(dpu_bmc_ip, &mut txn).await?;
-    txn.commit().await?;
-    // Second iteration: the matching loop issues `set_nic_mode` and,
-    // with the DPU now needing reconfiguration, power-cycles the host
-    // so the queued mode change applies.
-    env.run_site_explorer_iteration().await;
-
-    let nic_mode_calls = env.endpoint_explorer.set_nic_mode_calls.lock().unwrap();
-    assert!(
-        nic_mode_calls.iter().any(|(_, mode)| *mode == NicMode::Nic),
-        "expected set_nic_mode(Nic) before the power cycle; calls so far: {nic_mode_calls:?}"
-    );
-
-    let power_calls = env
-        .endpoint_explorer
-        .redfish_power_control_calls
-        .lock()
-        .unwrap();
-    assert!(
-        power_calls
-            .iter()
-            .any(|(_, action)| matches!(action, libredfish::SystemPowerControl::PowerCycle)),
-        "expected an automatic host PowerCycle on the non-Dell (Lenovo) host to apply the queued NIC mode change; power calls so far: {power_calls:?}"
-    );
-
-    Ok(())
-}
-
-/// A managed host's DPU-facing `machine_interface` is created (via DHCP) with
-/// just a MAC and no `boot_interface_id`. The exploration that ingests the host
-/// then backfills the vendor-specific Redfish interface id onto that row, matched
-/// by MAC, at which the primary interface ends up with a full `MachineBootInterface`.
-/// This is the same backfill path any DHCP-derived interface takes (the capture is
-/// keyed on MAC, not on how the row was created).
-#[sqlx_test]
-async fn test_site_explorer_backfills_boot_interface_id_onto_machine_interface(
-    pool: PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env = common::api_fixtures::create_test_env(pool.clone()).await;
-
-    let dpu = DpuConfig::default();
-    let host_pf_mac = dpu.host_mac_address;
-    let mh = common::api_fixtures::create_managed_host_with_config(
-        &env,
-        ManagedHostConfig::with_dpus(vec![dpu]),
-    )
-    .await;
-
-    let mut txn = env.pool.begin().await?;
-    let interfaces = db::machine_interface::find_by_machine_ids(&mut txn, &[mh.id]).await?;
-    let primary = interfaces
-        .get(&mh.id)
-        .into_iter()
-        .flatten()
-        .find(|i| i.primary_interface)
-        .expect("ingested host should have a primary machine_interface");
-
-    // The primary row is the DPU host-PF interface (same factory MAC), now
-    // holding both halves of the pair: its MAC plus the Redfish interface id the
-    // host report named for it. The `ManagedHostConfig` fixture ids its DPU
-    // interfaces "NIC.Slot.{index + 5}-1", so the first DPU is "NIC.Slot.5-1".
-    assert_eq!(primary.mac_address, host_pf_mac);
-    assert_eq!(
-        primary.boot_interface_id.as_deref(),
-        Some("NIC.Slot.5-1"),
-        "exploration should backfill the Redfish interface id onto the machine_interface row",
-    );
 
     Ok(())
 }

--- a/crates/api-web/Cargo.toml
+++ b/crates/api-web/Cargo.toml
@@ -98,13 +98,13 @@ carbide-version = { path = "../version" }
 workspace = true
 
 [dev-dependencies]
-# The admin-UI tests build a real `Api` via carbide-api-core's `test-support` fixtures. The other
-# entries provide test-only crates not needed by the library itself (e.g. db access, the sqlx_test
-# macro, request-body helpers). `db`/`model` resolve via carbide-api-db/carbide-api-model's lib
-# names, already normal deps.
-carbide-api-core = { path = "../api-core", features = ["test-support"] }
+# The admin-UI tests build a real `Api` through carbide-test-harness. The other entries provide
+# test-only crates not needed by the library itself (e.g. the sqlx_test macro and request-body
+# helpers). `db`/`model` resolve via carbide-api-db/carbide-api-model's lib names, already normal
+# deps.
 carbide-macros = { path = "../macros" }
 carbide-sqlx-testing = { path = "../sqlx-testing", default-features = false }
+carbide-test-harness = { path = "../test-harness" }
 http-body-util = { workspace = true }
 sqlx = { workspace = true, features = [
   "runtime-tokio",

--- a/crates/api-web/src/tests/env.rs
+++ b/crates/api-web/src/tests/env.rs
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_test_harness::dns::TestDomain;
+use carbide_test_harness::network::segment::TestNetworkSegment;
+use carbide_test_harness::prelude::*;
+use model::machine::ManagedHostState;
+
+pub struct TestEnv {
+    pub test_harness: TestHarness,
+    site_explorer: TestSiteExplorer,
+    domain: TestDomain,
+    underlay_segment: TestNetworkSegment,
+    admin_segment: TestNetworkSegment,
+}
+
+impl TestEnv {
+    pub async fn new(pool: PgPool) -> Self {
+        let test_harness = TestHarness::builder(pool)
+            .with_resource_pools(
+                ResourcePoolBuilder::default()
+                    .with_vlan_ids(1, 64)
+                    .with_vnis(10001, 10064)
+                    .with_secondary_vtep_ip("192.0.7.0/24")
+                    .build(),
+            )
+            .build()
+            .await;
+        let domain = test_harness.test_domain().await;
+        let network_controller = test_harness.network_controller();
+        let underlay_segment = network_controller.create_underlay_segment(&domain).await;
+        let admin_segment = network_controller.create_admin_segment(&domain).await;
+        let site_explorer = test_harness.default_test_site_explorer();
+        Self {
+            test_harness,
+            site_explorer,
+            domain,
+            underlay_segment,
+            admin_segment,
+        }
+    }
+
+    pub fn api(&self) -> &Api {
+        self.test_harness.api()
+    }
+
+    pub fn domain(&self) -> &TestDomain {
+        &self.domain
+    }
+
+    pub async fn create_ready_managed_host(&self, dpu_count: usize) -> TestManagedHost {
+        let mut host = self
+            .test_harness
+            .managed_host_builder(&self.site_explorer, self.underlay_segment)
+            .with_dpu_count(dpu_count)
+            .build()
+            .await;
+
+        host.discover_host_primary_iface(self.api(), self.admin_segment)
+            .await;
+        host.discover_dpu_oob_ifaces(self.api(), self.admin_segment)
+            .await;
+        host.report_dpu_network_status(self.api()).await;
+        host.insert_empty_host_health_report(self.api(), "test-harness-health")
+            .await;
+        host.advance_host_state(&self.test_harness, ManagedHostState::Ready)
+            .await;
+        host
+    }
+}

--- a/crates/api-web/src/tests/explored_endpoint.rs
+++ b/crates/api-web/src/tests/explored_endpoint.rs
@@ -25,7 +25,7 @@ use rpc::forge::{
 };
 use tower::ServiceExt;
 
-use crate::tests::common::api_fixtures::{TestEnv, create_test_env};
+use crate::tests::env::TestEnv;
 use crate::tests::{make_test_app, web_request_builder};
 
 const BANNER_TITLE: &str = "Default credential configuration incomplete";
@@ -65,7 +65,7 @@ async fn get_page(app: &axum::Router, uri: &str) -> String {
 }
 
 async fn configure_default(env: &TestEnv, credential_type: RpcCredentialType) {
-    env.api
+    env.api()
         .create_credential(tonic::Request::new(CredentialCreationRequest {
             credential_type: credential_type.into(),
             username: None,
@@ -79,12 +79,12 @@ async fn configure_default(env: &TestEnv, credential_type: RpcCredentialType) {
 
 #[crate::sqlx_test]
 async fn test_missing_credentials_banner(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-    let app = make_test_app(&env);
+    let env = TestEnv::new(pool).await;
+    let app = make_test_app(&env.test_harness);
 
     // The root /admin page renders the active DPU agent-upgrade policy, which has
     // no row in a fresh database; set one so the page returns 200.
-    env.api
+    env.api()
         .dpu_agent_upgrade_policy_action(tonic::Request::new(DpuAgentUpgradePolicyRequest {
             new_policy: Some(AgentUpgradePolicy::Off as i32),
         }))

--- a/crates/api-web/src/tests/health.rs
+++ b/crates/api-web/src/tests/health.rs
@@ -22,16 +22,13 @@ use rpc::forge::AdminForceDeleteMachineRequest;
 use rpc::forge::forge_server::Forge;
 use tower::ServiceExt;
 
-use crate::tests::common::api_fixtures::site_explorer::{
-    TestRackDbBuilder, new_power_shelf, new_switch,
-};
-use crate::tests::common::api_fixtures::{create_managed_host, create_test_env};
+use crate::tests::env::TestEnv;
 use crate::tests::{make_test_app, web_request_builder};
 
 #[crate::sqlx_test]
 async fn test_health_of_nonexisting_machine(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-    let app = make_test_app(&env);
+    let env = TestEnv::new(pool).await;
+    let app = make_test_app(&env.test_harness);
 
     async fn verify_history(app: &axum::Router, machine_id: String) {
         let response = app
@@ -65,8 +62,8 @@ async fn test_health_of_nonexisting_machine(pool: sqlx::PgPool) {
     .await;
 
     // Health page for Machine which was force deleted
-    let (host_machine_id, _dpu_machine_id) = create_managed_host(&env).await.into();
-    env.api
+    let host_machine_id = env.create_ready_managed_host(1).await.host_machine_id;
+    env.api()
         .admin_force_delete_machine(tonic::Request::new(AdminForceDeleteMachineRequest {
             host_query: host_machine_id.to_string(),
             delete_interfaces: false,
@@ -78,16 +75,21 @@ async fn test_health_of_nonexisting_machine(pool: sqlx::PgPool) {
         .unwrap()
         .into_inner();
 
-    assert!(env.find_machine(host_machine_id).await.is_empty());
+    assert!(
+        env.test_harness
+            .find_machine(host_machine_id)
+            .await
+            .is_empty()
+    );
 
     verify_history(&app, host_machine_id.to_string()).await;
 }
 
 #[crate::sqlx_test]
 async fn test_add_remove_health_report_via_web_ui(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-    let app = make_test_app(&env);
-    let (host_machine_id, _dpu_machine_id) = create_managed_host(&env).await.into();
+    let env = TestEnv::new(pool).await;
+    let app = make_test_app(&env.test_harness);
+    let host_machine_id = env.create_ready_managed_host(1).await.host_machine_id;
 
     let payload = r#"{
         "mode": "Merge",
@@ -119,8 +121,8 @@ async fn test_add_remove_health_report_via_web_ui(pool: sqlx::PgPool) {
 
 #[crate::sqlx_test]
 async fn test_add_remove_nvlink_domain_health_report_via_web_ui(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-    let app = make_test_app(&env);
+    let env = TestEnv::new(pool).await;
+    let app = make_test_app(&env.test_harness);
     let domain_id = "00000000-0000-0000-0000-000000000001";
 
     let payload = r#"{
@@ -163,9 +165,11 @@ async fn test_add_remove_nvlink_domain_health_report_via_web_ui(pool: sqlx::PgPo
 
 #[crate::sqlx_test]
 async fn test_add_replace_remove_dpu_health_report_via_web_ui(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-    let app = make_test_app(&env);
-    let (host_machine_id, dpu_machine_id) = create_managed_host(&env).await.into();
+    let env = TestEnv::new(pool).await;
+    let app = make_test_app(&env.test_harness);
+    let host = env.create_ready_managed_host(1).await;
+    let host_machine_id = host.host_machine_id;
+    let dpu_machine_id = host.dpu_machine_id(0);
 
     let merge_payload = r#"{
         "mode": "Merge",
@@ -282,12 +286,9 @@ async fn test_add_replace_remove_dpu_health_report_via_web_ui(pool: sqlx::PgPool
 
 #[crate::sqlx_test]
 async fn test_health_of_rack(pool: sqlx::PgPool) {
-    let env = create_test_env(pool.clone()).await;
-    let app = make_test_app(&env);
-
-    let mut txn = pool.acquire().await.unwrap();
-    let rack_id = TestRackDbBuilder::new().persist(&mut txn).await.unwrap();
-    drop(txn);
+    let env = TestEnv::new(pool).await;
+    let app = make_test_app(&env.test_harness);
+    let rack_id = env.test_harness.create_rack().await.id;
 
     let response = app
         .clone()
@@ -402,9 +403,9 @@ async fn test_health_of_rack(pool: sqlx::PgPool) {
 
 #[crate::sqlx_test]
 async fn test_health_of_switch(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-    let app = make_test_app(&env);
-    let switch_id = new_switch(&env, None, None).await.unwrap();
+    let env = TestEnv::new(pool).await;
+    let app = make_test_app(&env.test_harness);
+    let switch_id = env.test_harness.create_switch(1, 1).await.id;
 
     let response = app
         .clone()
@@ -519,9 +520,9 @@ async fn test_health_of_switch(pool: sqlx::PgPool) {
 
 #[crate::sqlx_test]
 async fn test_health_of_power_shelf(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-    let app = make_test_app(&env);
-    let power_shelf_id = new_power_shelf(&env, None, None, None, None).await.unwrap();
+    let env = TestEnv::new(pool).await;
+    let app = make_test_app(&env.test_harness);
+    let power_shelf_id = env.test_harness.create_power_shelf().await.id;
 
     let response = app
         .clone()

--- a/crates/api-web/src/tests/managed_host.rs
+++ b/crates/api-web/src/tests/managed_host.rs
@@ -15,29 +15,23 @@
  * limitations under the License.
  */
 use axum::body::Body;
-use carbide_api_core::test_support::fixture_config::{
-    FixtureDefault as _, ManagedHostConfigExt as _,
-};
 use carbide_rpc_utils::ManagedHostOutput;
 use db::{machine, managed_host};
 use http_body_util::BodyExt;
 use hyper::http::StatusCode;
 use model::hardware_info::HardwareInfo;
 use model::machine::{InstanceState, LoadSnapshotOptions, ManagedHostState, RetryInfo};
-use model::test_support::{DpuConfig, ManagedHostConfig};
 use tower::ServiceExt;
 
 use crate::managed_host::ManagedHostRowDisplay;
-use crate::tests::common::api_fixtures::{
-    create_managed_host_multi_dpu, create_test_env, site_explorer,
-};
+use crate::tests::env::TestEnv;
 use crate::tests::{make_test_app, web_request_builder};
 
 #[crate::sqlx_test]
 async fn test_ok(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-    let app = make_test_app(&env);
-    _ = create_managed_host_multi_dpu(&env, 1).await;
+    let env = TestEnv::new(pool).await;
+    let app = make_test_app(&env.test_harness);
+    _ = env.create_ready_managed_host(1).await;
 
     let response = app
         .oneshot(
@@ -81,9 +75,9 @@ async fn test_ok(pool: sqlx::PgPool) {
 
 #[crate::sqlx_test]
 async fn test_multi_dpu(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-    let app = make_test_app(&env);
-    let host_machine_id = create_managed_host_multi_dpu(&env, 2).await.host().id;
+    let env = TestEnv::new(pool).await;
+    let app = make_test_app(&env.test_harness);
+    let host_machine_id = env.create_ready_managed_host(2).await.host_machine_id;
 
     let response = app
         .oneshot(
@@ -136,33 +130,22 @@ async fn test_multi_dpu(pool: sqlx::PgPool) {
 // managed_host::show_html (parsing the HTML string is prohibitive)
 #[crate::sqlx_test]
 async fn test_managed_host_row_display(pool: sqlx::PgPool) -> eyre::Result<()> {
-    let env = create_test_env(pool).await;
-    let config = ManagedHostConfig::with_dpus((0..2).map(|_| DpuConfig::default()).collect());
-    let hardware_info = HardwareInfo::from(&config);
-    let mock_host = site_explorer::new_mock_host(&env, config).await?;
+    let env = TestEnv::new(pool).await;
+    let host = env.create_ready_managed_host(2).await;
+    let hardware_info = HardwareInfo::from(&host.managed_host);
 
-    // Get info from what we mocked for site explorer so we know what to assert on in the ManagedHostRowDisplay
-    let machine_id = mock_host
-        .discovered_machine_id()
-        .expect("mock host should have gotten a machine ID");
-    let host_bmc_ip = mock_host
-        .host_bmc_ip
-        .expect("mock host should have gotten a BMC IP");
-    let dpu_1_bmc_ip = *mock_host
-        .dpu_bmc_ips
-        .get(&0)
-        .expect("mock DPU should have gotten a BMC IP");
-    let dpu_2_bmc_ip = *mock_host
-        .dpu_bmc_ips
-        .get(&1)
-        .expect("mock DPU should have gotten a BMC IP");
+    // Get info from the test managed host so we know what to assert on in the ManagedHostRowDisplay.
+    let machine_id = host.host_machine_id;
+    let host_bmc_ip = host.host_bmc_ip;
+    let dpu_1_bmc_ip = host.dpu_bmc_ip(0);
+    let dpu_2_bmc_ip = host.dpu_bmc_ip(1);
 
     let snapshots = managed_host::load_all(
-        &env.pool,
+        &env.api().database_connection,
         LoadSnapshotOptions {
             include_history: false,
             include_instance_data: false,
-            host_health_config: env.config.host_health,
+            host_health_config: env.api().runtime_config.host_health,
         },
     )
     .await?;
@@ -177,7 +160,10 @@ async fn test_managed_host_row_display(pool: sqlx::PgPool) -> eyre::Result<()> {
     assert_eq!(snapshot.host_snapshot.id, machine_id);
 
     let sla_config = model::machine::slas::MachineSlaConfig::new(
-        env.config.machine_state_controller.failure_retry_time,
+        env.api()
+            .runtime_config
+            .machine_state_controller
+            .failure_retry_time,
     );
     let row = ManagedHostRowDisplay::from_snapshot(snapshot.clone(), &sla_config);
 
@@ -191,7 +177,7 @@ async fn test_managed_host_row_display(pool: sqlx::PgPool) -> eyre::Result<()> {
     assert_eq!(row.host_bmc_ip, host_bmc_ip.to_string());
     assert_eq!(
         row.host_bmc_mac,
-        mock_host.managed_host.bmc_mac_address.to_string()
+        host.managed_host.bmc_mac_address.to_string()
     );
     assert_eq!(
         row.vendor,
@@ -225,11 +211,11 @@ async fn test_managed_host_row_display(pool: sqlx::PgPool) -> eyre::Result<()> {
     assert_eq!(row.dpus[0].bmc_ip, dpu_1_bmc_ip.to_string());
     assert_eq!(
         row.dpus[0].bmc_mac,
-        mock_host.managed_host.dpus[0].bmc_mac_address.to_string()
+        host.managed_host.dpus[0].bmc_mac_address.to_string()
     );
     assert_eq!(
         row.dpus[0].oob_mac,
-        mock_host.managed_host.dpus[0].oob_mac_address.to_string()
+        host.managed_host.dpus[0].oob_mac_address.to_string()
     );
     assert!(!row.dpus[0].oob_ip.is_empty(), "dpu should show an oob ip");
 
@@ -240,11 +226,11 @@ async fn test_managed_host_row_display(pool: sqlx::PgPool) -> eyre::Result<()> {
     assert_eq!(row.dpus[1].bmc_ip, dpu_2_bmc_ip.to_string());
     assert_eq!(
         row.dpus[1].bmc_mac,
-        mock_host.managed_host.dpus[1].bmc_mac_address.to_string()
+        host.managed_host.dpus[1].bmc_mac_address.to_string()
     );
     assert_eq!(
         row.dpus[1].oob_mac,
-        mock_host.managed_host.dpus[1].oob_mac_address.to_string()
+        host.managed_host.dpus[1].oob_mac_address.to_string()
     );
     assert!(!row.dpus[1].oob_ip.is_empty(), "dpu should show an oob ip");
 
@@ -253,8 +239,8 @@ async fn test_managed_host_row_display(pool: sqlx::PgPool) -> eyre::Result<()> {
 
 #[crate::sqlx_test]
 async fn test_managed_host_html_uses_runtime_sla_config(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-    let host = create_managed_host_multi_dpu(&env, 1).await;
+    let env = TestEnv::new(pool).await;
+    let host = env.create_ready_managed_host(1).await;
 
     let assigned_booting_state = ManagedHostState::Assigned {
         instance_state: InstanceState::BootingWithDiscoveryImage {
@@ -267,8 +253,8 @@ async fn test_managed_host_html_uses_runtime_sla_config(pool: sqlx::PgPool) {
             .parse()
             .unwrap();
 
-    let mut txn = env.db_txn().await;
-    let host_machine = host.host().db_machine(&mut txn).await;
+    let mut txn = env.test_harness.db_txn().await;
+    let host_machine = host.host_db_machine(&mut txn).await;
     machine::advance(
         &host_machine,
         &mut txn,
@@ -279,7 +265,7 @@ async fn test_managed_host_html_uses_runtime_sla_config(pool: sqlx::PgPool) {
     .unwrap();
     txn.commit().await.unwrap();
 
-    let app = make_test_app(&env);
+    let app = make_test_app(&env.test_harness);
     let response = app
         .oneshot(
             web_request_builder()

--- a/crates/api-web/src/tests/mod.rs
+++ b/crates/api-web/src/tests/mod.rs
@@ -15,24 +15,20 @@
  * limitations under the License.
  */
 use axum::Router;
-// The admin-UI tests build a real `Api` from the `carbide-api-core` fixtures, which are exposed via
-// that crate's `test-support` feature (see this crate's dev-dependencies). Re-export the fixtures as
-// `crate::tests::common` so the test modules below can use the same paths they did when they lived
-// in `carbide-api-core`.
-pub use carbide_api_core::tests::common;
-use carbide_api_core::tests::common::api_fixtures::TestEnv;
+use carbide_test_harness::prelude::TestHarness;
 use hyper::http::Request;
 use hyper::http::request::Builder;
 
 use crate::routes;
 
+mod env;
 mod explored_endpoint;
 mod health;
 mod managed_host;
 mod vpc;
 
-fn make_test_app(env: &TestEnv) -> Router {
-    let r = routes(env.api.clone()).unwrap();
+fn make_test_app(test_harness: &TestHarness) -> Router {
+    let r = routes(test_harness.api_arc()).unwrap();
     Router::new().nest_service("/admin", r)
 }
 

--- a/crates/api-web/src/tests/vpc.rs
+++ b/crates/api-web/src/tests/vpc.rs
@@ -23,7 +23,7 @@ use rpc::forge;
 use rpc::forge::forge_server::Forge;
 use tower::ServiceExt;
 
-use crate::tests::common::api_fixtures::{create_test_env, get_vpc_fixture_id};
+use crate::tests::env::TestEnv;
 use crate::tests::{make_test_app, web_request_builder};
 
 /// Collects a web response body into a UTF-8 string.
@@ -41,14 +41,17 @@ async fn response_body(response: Response) -> String {
 
 #[crate::sqlx_test]
 async fn vpc_pages_show_status_vni(pool: sqlx::PgPool) {
-    let env = create_test_env(pool).await;
-    let app = make_test_app(&env);
+    let env = TestEnv::new(pool).await;
+    let app = make_test_app(&env.test_harness);
 
     // Create a VPC with an auto-allocated VNI stored in status.
-    env.create_vpc_and_tenant_segment().await;
-    let vpc_id = get_vpc_fixture_id(&env).await;
+    let network_controller = env.test_harness.network_controller();
+    let vpc_id = network_controller.create_vpc("test vpc 1").await;
+    network_controller
+        .create_tenant_segment(env.domain(), vpc_id)
+        .await;
     let mut vpcs = env
-        .api
+        .api()
         .find_vpcs_by_ids(tonic::Request::new(forge::VpcsByIdsRequest {
             vpc_ids: vec![vpc_id],
         }))
@@ -69,7 +72,7 @@ async fn vpc_pages_show_status_vni(pool: sqlx::PgPool) {
 
     // Add a VPC prefix so the IPAM prefix detail page can render parent VPC data.
     let vpc_prefix = env
-        .api
+        .api()
         .create_vpc_prefix(tonic::Request::new(forge::VpcPrefixCreationRequest {
             id: None,
             prefix: String::new(),

--- a/crates/site-explorer/tests/env.rs
+++ b/crates/site-explorer/tests/env.rs
@@ -23,6 +23,9 @@ use carbide_site_explorer::test_support::{MockEndpointExplorer, TestSiteExplorer
 use carbide_test_harness::network::segment::TestNetworkSegment;
 use carbide_test_harness::prelude::*;
 
+/// Keep this shared env to the setup common to most site-explorer tests.
+/// Tests that need extra domains, segments, or other one-off objects should
+/// create those objects locally instead of adding fields here.
 pub struct Env {
     pub pool: PgPool,
     pub underlay_segment: TestNetworkSegment,

--- a/crates/site-explorer/tests/site_explorer.rs
+++ b/crates/site-explorer/tests/site_explorer.rs
@@ -30,13 +30,13 @@ use db::ObjectFilter;
 use db::sku::CURRENT_SKU_VERSION;
 use itertools::Itertools;
 use mac_address::MacAddress;
-use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
+use model::expected_machine::{DpuMode, ExpectedMachine, ExpectedMachineData};
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{LoadSnapshotOptions, Machine};
 use model::metadata::Metadata;
 use model::site_explorer::{
     ComputerSystem, EndpointExplorationError, EndpointExplorationReport, EndpointType, ExploredDpu,
-    ExploredManagedHost, PreingestionState, UefiDevicePath,
+    ExploredManagedHost, NicMode, PreingestionState, UefiDevicePath,
 };
 use model::test_support::{DpuConfig, ManagedHostConfig};
 use rpc::forge::GetSiteExplorationRequest;
@@ -2495,6 +2495,181 @@ async fn test_site_explorer_auto_corrects_nic_mode_per_expected_machine(
     assert!(
         calls.iter().any(|(_, mode)| *mode == NicMode::Nic),
         "expected at least one set_nic_mode(Nic) call triggered by the operator's NicMode declaration; calls so far: {calls:?}"
+    );
+
+    Ok(())
+}
+
+/// A queued `set_nic_mode` only takes effect after a host power cycle, and
+/// site-explorer drives that power cycle itself for every vendor -- the
+/// Redfish `ComputerSystem.Reset` action is standard across BMCs. This is
+/// the non-Dell guard for that behavior: a Lenovo host whose DPU needs the
+/// mode correction gets an automatic `PowerCycle` on its host BMC in the
+/// same pass that issued `set_nic_mode`, rather than parking on a manual
+/// power cycle.
+#[sqlx_test]
+async fn test_site_explorer_power_cycles_non_dell_host_to_apply_nic_mode(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = Env::new(pool).await;
+
+    // DPU hardware reports DPU mode; the operator-declared NicMode override
+    // is what forces the correction (and therefore the power cycle).
+    let dpu_config = DpuConfig {
+        nic_mode: Some(NicMode::Dpu),
+        ..DpuConfig::default()
+    };
+    let mock_host = ManagedHostConfig {
+        dpus: vec![dpu_config.clone()],
+        vendor: Some(bmc_vendor::BMCVendor::Lenovo),
+        ..ManagedHostConfig::default()
+    };
+    let host_bmc_mac = mock_host.bmc_mac_address;
+
+    let mut txn = env.pool.begin().await?;
+    db::expected_machine::create(
+        &mut txn,
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: host_bmc_mac,
+            data: ExpectedMachineData {
+                bmc_username: "ADMIN".to_string(),
+                bmc_password: "PASS".to_string(),
+                serial_number: "EM-866-NIC-POWERCYCLE".to_string(),
+                metadata: Metadata::new_with_default_name(),
+                dpu_mode: DpuMode::NicMode,
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    let mut host_bmc = env.new_machine(&host_bmc_mac.to_string(), "SomeVendor");
+    let mut dpu_bmc = env.new_machine(&dpu_config.bmc_mac_address.to_string(), "NVIDIA/BF/BMC");
+    host_bmc.discover_dhcp(env.api()).await?;
+    dpu_bmc.discover_dhcp(env.api()).await?;
+
+    let host_bmc_ip: IpAddr = host_bmc.ip.parse()?;
+    let dpu_bmc_ip: IpAddr = dpu_bmc.ip.parse()?;
+    let explorer_config = SiteExplorerConfig {
+        enabled: Arc::new(true.into()),
+        retained_boot_interface_window: None,
+        explorations_per_run: 10,
+        concurrent_explorations: 1,
+        run_interval: std::time::Duration::from_secs(1),
+        create_machines: Arc::new(true.into()),
+        ..Default::default()
+    };
+    let explorer = env.test_site_explorer(explorer_config);
+    explorer.insert_endpoints(
+        mock_host
+            .exploration_results(Some(host_bmc_ip), &[(0, dpu_bmc_ip)])?
+            .into_endpoints(),
+    );
+
+    // First iteration: initial endpoint exploration.
+    explorer.run_single_iteration().await.unwrap();
+    let mut txn = env.pool.begin().await?;
+    db::explored_endpoints::set_preingestion_complete(host_bmc_ip, &mut txn).await?;
+    db::explored_endpoints::set_preingestion_complete(dpu_bmc_ip, &mut txn).await?;
+    txn.commit().await?;
+    // Second iteration: the matching loop issues `set_nic_mode` and,
+    // with the DPU now needing reconfiguration, power-cycles the host
+    // so the queued mode change applies.
+    explorer.run_single_iteration().await.unwrap();
+
+    let nic_mode_calls = explorer
+        .endpoint_explorer()
+        .set_nic_mode_calls
+        .lock()
+        .unwrap();
+    assert!(
+        nic_mode_calls.iter().any(|(_, mode)| *mode == NicMode::Nic),
+        "expected set_nic_mode(Nic) before the power cycle; calls so far: {nic_mode_calls:?}"
+    );
+
+    let power_calls = explorer
+        .endpoint_explorer()
+        .redfish_power_control_calls
+        .lock()
+        .unwrap();
+    assert!(
+        power_calls
+            .iter()
+            .any(|(_, action)| matches!(action, libredfish::SystemPowerControl::PowerCycle)),
+        "expected an automatic host PowerCycle on the non-Dell (Lenovo) host to apply the queued NIC mode change; power calls so far: {power_calls:?}"
+    );
+
+    Ok(())
+}
+
+/// A managed host's DPU-facing `machine_interface` is created (via DHCP) with
+/// just a MAC and no `boot_interface_id`. The exploration that ingests the host
+/// then backfills the vendor-specific Redfish interface id onto that row, matched
+/// by MAC, at which the primary interface ends up with a full `MachineBootInterface`.
+/// This is the same backfill path any DHCP-derived interface takes (the capture is
+/// keyed on MAC, not on how the row was created).
+#[sqlx_test]
+async fn test_site_explorer_backfills_boot_interface_id_onto_machine_interface(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let test_harness = TestHarness::builder(pool).build().await;
+    let domain = test_harness.test_domain().await;
+    let network_controller = test_harness.network_controller();
+    let underlay_segment = network_controller.create_underlay_segment(&domain).await;
+    let admin_segment = network_controller.create_admin_segment(&domain).await;
+    let explorer_config = SiteExplorerConfig {
+        enabled: Arc::new(true.into()),
+        retained_boot_interface_window: None,
+        explorations_per_run: 10,
+        concurrent_explorations: 1,
+        run_interval: std::time::Duration::from_secs(1),
+        create_machines: Arc::new(true.into()),
+        ..Default::default()
+    };
+    let explorer = env::test_site_explorer(&test_harness, explorer_config);
+
+    let dpu = DpuConfig::default();
+    let host_pf_mac = dpu.host_mac_address;
+    let managed_host = ManagedHostConfig::with_dpus(vec![dpu]);
+    let created_host = test_harness
+        .managed_host_builder(&explorer, underlay_segment)
+        .with_config(managed_host)
+        .build()
+        .await;
+
+    // TestManagedHostBuilder runs initial endpoint exploration and marks
+    // preingestion complete. Its second iteration creates the predicted host-PF
+    // interface with the Redfish boot interface id from the endpoint report.
+    created_host
+        .dhcp_discover_host_primary_iface(test_harness.api(), admin_segment)
+        .await;
+
+    // Third iteration: the DHCP-created row is matched by MAC and receives
+    // the boot interface id from the predicted interface.
+    explorer.run_single_iteration().await.unwrap();
+
+    let mut txn = test_harness.db_txn().await;
+    let interfaces =
+        db::machine_interface::find_by_machine_ids(&mut txn, &[created_host.host_machine_id])
+            .await?;
+    let primary = interfaces
+        .get(&created_host.host_machine_id)
+        .into_iter()
+        .flatten()
+        .find(|i| i.primary_interface)
+        .expect("ingested host should have a primary machine_interface");
+
+    // The primary row is the DPU host-PF interface (same factory MAC), now
+    // holding both halves of the pair: its MAC plus the Redfish interface id the
+    // host report named for it. The `ManagedHostConfig` fixture ids its DPU
+    // interfaces "NIC.Slot.{index + 5}-1", so the first DPU is "NIC.Slot.5-1".
+    assert_eq!(primary.mac_address, host_pf_mac);
+    assert_eq!(
+        primary.boot_interface_id.as_deref(),
+        Some("NIC.Slot.5-1"),
+        "exploration should backfill the Redfish interface id onto the machine_interface row",
     );
 
     Ok(())

--- a/crates/site-explorer/tests/site_explorer.rs
+++ b/crates/site-explorer/tests/site_explorer.rs
@@ -2654,6 +2654,7 @@ async fn test_site_explorer_backfills_boot_interface_id_onto_machine_interface(
     let interfaces =
         db::machine_interface::find_by_machine_ids(&mut txn, &[created_host.host_machine_id])
             .await?;
+    txn.commit().await?;
     let primary = interfaces
         .get(&created_host.host_machine_id)
         .into_iter()

--- a/crates/test-harness/src/asset.rs
+++ b/crates/test-harness/src/asset.rs
@@ -1,0 +1,135 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::power_shelf::{PowerShelfId, PowerShelfIdSource, PowerShelfType};
+use carbide_uuid::rack::{RackId, RackProfileId};
+use carbide_uuid::switch::{SwitchId, SwitchIdSource, SwitchType};
+use model::power_shelf::{NewPowerShelf, PowerShelfConfig, power_shelf_id};
+use model::rack::RackConfig;
+use model::switch::{NewSwitch, SwitchConfig, switch_id};
+
+use crate::TestHarness;
+
+pub struct TestRack {
+    pub id: RackId,
+}
+
+impl TestRack {
+    pub(crate) async fn create(test_harness: &TestHarness) -> Self {
+        let id = RackId::new(uuid::Uuid::new_v4().to_string());
+        let rack_profile_id = RackProfileId::new("rack");
+        let mut txn = test_harness.db_txn().await;
+        db::rack::create(
+            &mut txn,
+            &id,
+            Some(&rack_profile_id),
+            &RackConfig::default(),
+            None,
+        )
+        .await
+        .expect("rack should be created");
+        txn.commit()
+            .await
+            .expect("database transaction should commit");
+        Self { id }
+    }
+}
+
+pub struct TestSwitch {
+    pub id: SwitchId,
+}
+
+impl TestSwitch {
+    pub(crate) async fn create(
+        test_harness: &TestHarness,
+        slot_number: i32,
+        tray_index: i32,
+    ) -> Self {
+        let name = format!("Test Switch {}", &uuid::Uuid::new_v4().to_string()[..8]);
+        let id = switch_id::from_hardware_info(
+            &name,
+            "NVIDIA",
+            "Switch",
+            SwitchIdSource::ProductBoardChassisSerial,
+            SwitchType::NvLink,
+        )
+        .expect("switch id should be derived from test hardware info");
+        let new_switch = NewSwitch {
+            id,
+            config: SwitchConfig {
+                name,
+                enable_nmxc: false,
+                fabric_manager_config: None,
+            },
+            bmc_mac_address: None,
+            metadata: None,
+            rack_id: None,
+            slot_number: Some(slot_number),
+            tray_index: Some(tray_index),
+        };
+
+        let mut txn = test_harness.db_txn().await;
+        db::switch::create(&mut txn, &new_switch)
+            .await
+            .expect("switch should be created");
+        txn.commit()
+            .await
+            .expect("database transaction should commit");
+        Self { id }
+    }
+}
+
+pub struct TestPowerShelf {
+    pub id: PowerShelfId,
+}
+
+impl TestPowerShelf {
+    pub(crate) async fn create(test_harness: &TestHarness) -> Self {
+        let name = format!(
+            "Test Power Shelf {}",
+            &uuid::Uuid::new_v4().to_string()[..8]
+        );
+        let id = power_shelf_id::from_hardware_info(
+            &name,
+            "NVIDIA",
+            "PowerShelf",
+            PowerShelfIdSource::ProductBoardChassisSerial,
+            PowerShelfType::Rack,
+        )
+        .expect("power shelf id should be derived from test hardware info");
+        let new_power_shelf = NewPowerShelf {
+            id,
+            config: PowerShelfConfig {
+                name,
+                capacity: Some(100),
+                voltage: Some(240),
+            },
+            bmc_mac_address: None,
+            metadata: None,
+            rack_id: None,
+        };
+
+        let mut txn = test_harness.db_txn().await;
+        db::power_shelf::create(&mut txn, &new_power_shelf)
+            .await
+            .expect("power shelf should be created");
+        txn.commit()
+            .await
+            .expect("database transaction should commit");
+        Self { id }
+    }
+}

--- a/crates/test-harness/src/builder.rs
+++ b/crates/test-harness/src/builder.rs
@@ -16,6 +16,7 @@
  */
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use carbide_api_core::test_support::ApiMetricsEmitter;
 use carbide_api_core::test_support::builder::TestApiBuilder;
@@ -93,7 +94,7 @@ impl TestHarnessBuilder {
             .with_metric_emitter(ApiMetricsEmitter::new(&test_meter.meter()))
             .build();
         ApiHandle {
-            api,
+            api: Arc::new(api),
             _drop_guard: cancel_token.clone().drop_guard(),
             cancel_token,
             _js: join_set,

--- a/crates/test-harness/src/lib.rs
+++ b/crates/test-harness/src/lib.rs
@@ -20,18 +20,23 @@ use std::sync::Arc;
 
 use carbide_api_core::test_support::rpc::forge::forge_server::Forge;
 pub use carbide_api_core::test_support::{self, Api, rpc};
-use carbide_site_explorer::test_support::TestSiteExplorer;
+use carbide_site_explorer::SiteExplorer;
+use carbide_site_explorer::config::SiteExplorerConfig;
+pub use carbide_site_explorer::test_support::{MockEndpointExplorer, TestSiteExplorer};
 use carbide_utils::test_support::test_meter::TestMeter;
+use carbide_uuid::machine::MachineId;
 use sqlx::{PgPool, PgTransaction};
 use tokio::task::JoinSet;
 use tokio_util::sync::{CancellationToken, DropGuard};
 use tonic::Request;
 
+use crate::asset::{TestPowerShelf, TestRack, TestSwitch};
 use crate::builder::TestHarnessBuilder;
 use crate::dns::TestDomain;
 use crate::network::controller::TestNetworkController;
 use crate::network::segment::TestNetworkSegment;
 
+pub mod asset;
 pub mod builder;
 pub mod dns;
 pub mod managed_host;
@@ -59,6 +64,10 @@ impl TestHarness {
 
     pub fn api(&self) -> &Api {
         self.api.deref()
+    }
+
+    pub fn api_arc(&self) -> Arc<Api> {
+        self.api.api.clone()
     }
 
     pub async fn db_txn(&self) -> PgTransaction<'static> {
@@ -101,10 +110,55 @@ impl TestHarness {
     ) -> TestManagedHostBuilder<'a> {
         TestManagedHostBuilder::new(self, site_explorer, segment)
     }
+
+    pub fn test_site_explorer(&self, config: SiteExplorerConfig) -> TestSiteExplorer {
+        let endpoint_explorer = Arc::new(MockEndpointExplorer::default());
+        let api = self.api();
+        let site_explorer = SiteExplorer::new(
+            api.database_connection.clone(),
+            config,
+            self.test_meter.meter(),
+            endpoint_explorer.clone(),
+            Arc::new(api.runtime_config.get_firmware_config()),
+            api.common_pools().clone(),
+            api.work_lock_manager_handle(),
+            None,
+            api.credential_manager().clone(),
+        );
+        TestSiteExplorer::new(site_explorer, endpoint_explorer)
+    }
+
+    pub fn default_test_site_explorer(&self) -> TestSiteExplorer {
+        self.test_site_explorer(SiteExplorerConfig::default())
+    }
+
+    pub async fn find_machine(&self, id: MachineId) -> Vec<rpc::forge::Machine> {
+        self.api
+            .find_machines_by_ids(Request::new(rpc::forge::MachinesByIdsRequest {
+                machine_ids: vec![id],
+                include_history: true,
+            }))
+            .await
+            .expect("machine lookup by id should succeed")
+            .into_inner()
+            .machines
+    }
+
+    pub async fn create_rack(&self) -> TestRack {
+        TestRack::create(self).await
+    }
+
+    pub async fn create_switch(&self, slot_number: i32, tray_index: i32) -> TestSwitch {
+        TestSwitch::create(self, slot_number, tray_index).await
+    }
+
+    pub async fn create_power_shelf(&self) -> TestPowerShelf {
+        TestPowerShelf::create(self).await
+    }
 }
 
-struct ApiHandle {
-    api: Api,
+pub(crate) struct ApiHandle {
+    api: Arc<Api>,
     cancel_token: CancellationToken,
     _drop_guard: DropGuard,
     _js: JoinSet<()>,
@@ -113,7 +167,7 @@ struct ApiHandle {
 impl Deref for ApiHandle {
     type Target = Api;
     fn deref(&self) -> &Self::Target {
-        &self.api
+        self.api.as_ref()
     }
 }
 

--- a/crates/test-harness/src/managed_host.rs
+++ b/crates/test-harness/src/managed_host.rs
@@ -40,6 +40,16 @@ pub struct TestManagedHost {
 }
 
 impl TestManagedHost {
+    pub async fn dhcp_discover_host_primary_iface(&self, api: &Api, segment: TestNetworkSegment) {
+        api.discover_dhcp(
+            DhcpDiscovery::builder(self.managed_host.dhcp_mac_address(), segment.relay_address)
+                .vendor_string("Bluefield")
+                .tonic_request(),
+        )
+        .await
+        .expect("host primary interface DHCP discovery should succeed");
+    }
+
     /// Simulate forge-dpu-agent fetching, applying, and reporting DPU network status.
     pub async fn report_dpu_network_status(&self, api: &Api) {
         for dpu_machine_id in self.dpu_machine_ids.values() {

--- a/crates/test-harness/src/managed_host.rs
+++ b/crates/test-harness/src/managed_host.rs
@@ -19,17 +19,26 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 
 use carbide_api_core::test_support::Api;
-use carbide_api_core::test_support::fixture_config::FixtureDefault as _;
+use carbide_api_core::test_support::fixture_config::{
+    FixtureDefault as _, ManagedHostConfigExt as _,
+};
 use carbide_site_explorer::test_support::TestSiteExplorer;
 use carbide_uuid::machine::MachineId;
 use mac_address::MacAddress;
 use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
-use model::test_support::ManagedHostConfig;
+use model::hardware_info::HardwareInfo;
+use model::machine::machine_search_config::MachineSearchConfig;
+use model::machine::{Machine, ManagedHostState};
+use model::test_support::{DpuConfig, ManagedHostConfig};
 
 use crate::TestHarness;
 use crate::network::segment::TestNetworkSegment;
 use crate::rpc::forge::forge_server::Forge;
-use crate::rpc::forge::{DhcpDiscovery, ManagedHostNetworkConfigRequest};
+use crate::rpc::forge::{
+    DhcpDiscovery, DhcpRecord, HealthReportEntry, InsertMachineHealthReportRequest,
+    MachineDiscoveryResult, ManagedHostNetworkConfigRequest,
+};
+use crate::rpc::{DiscoveryData, DiscoveryInfo};
 
 pub struct TestManagedHost {
     pub managed_host: ManagedHostConfig,
@@ -40,14 +49,124 @@ pub struct TestManagedHost {
 }
 
 impl TestManagedHost {
-    pub async fn dhcp_discover_host_primary_iface(&self, api: &Api, segment: TestNetworkSegment) {
+    pub fn dpu_machine_id(&self, dpu_index: u8) -> MachineId {
+        *self
+            .dpu_machine_ids
+            .get(&dpu_index)
+            .expect("DPU machine id should exist")
+    }
+
+    pub fn dpu_bmc_ip(&self, dpu_index: u8) -> IpAddr {
+        self.dpu_bmc_ips
+            .iter()
+            .find(|(index, _)| *index == dpu_index)
+            .map(|(_, ip)| *ip)
+            .expect("DPU BMC IP should exist")
+    }
+
+    pub async fn dhcp_discover_host_primary_iface(
+        &self,
+        api: &Api,
+        segment: TestNetworkSegment,
+    ) -> DhcpRecord {
         api.discover_dhcp(
             DhcpDiscovery::builder(self.managed_host.dhcp_mac_address(), segment.relay_address)
                 .vendor_string("Bluefield")
                 .tonic_request(),
         )
         .await
-        .expect("host primary interface DHCP discovery should succeed");
+        .expect("host primary interface DHCP discovery should succeed")
+        .into_inner()
+    }
+
+    pub async fn discover_host_primary_iface(&mut self, api: &Api, segment: TestNetworkSegment) {
+        let dhcp_record = self.dhcp_discover_host_primary_iface(api, segment).await;
+        self.host_machine_id =
+            discover_machine(api, &dhcp_record, HardwareInfo::from(&self.managed_host))
+                .await
+                .machine_id
+                .expect("host discovery should return a machine id");
+    }
+
+    pub async fn dhcp_discover_dpu_oob_ifaces(
+        &self,
+        api: &Api,
+        segment: TestNetworkSegment,
+    ) -> Vec<DhcpRecord> {
+        let mut dhcp_records = Vec::new();
+        for dpu in &self.managed_host.dpus {
+            let dhcp_record = api
+                .discover_dhcp(
+                    DhcpDiscovery::builder(dpu.oob_mac_address, segment.relay_address)
+                        .vendor_string("SomeVendor")
+                        .tonic_request(),
+                )
+                .await
+                .expect("DPU OOB interface DHCP discovery should succeed")
+                .into_inner();
+            dhcp_records.push(dhcp_record);
+        }
+        dhcp_records
+    }
+
+    pub async fn discover_dpu_oob_ifaces(&mut self, api: &Api, segment: TestNetworkSegment) {
+        let dhcp_records = self.dhcp_discover_dpu_oob_ifaces(api, segment).await;
+        for (dpu_index, (dpu, dhcp_record)) in self
+            .managed_host
+            .dpus
+            .iter()
+            .zip(dhcp_records.iter())
+            .enumerate()
+        {
+            let dpu_index = dpu_index.try_into().expect("DPU index should fit into u8");
+            self.dpu_machine_ids.insert(
+                dpu_index,
+                discover_machine(api, dhcp_record, HardwareInfo::from(dpu))
+                    .await
+                    .machine_id
+                    .expect("DPU discovery should return a machine id"),
+            );
+        }
+    }
+
+    pub async fn insert_empty_host_health_report(&self, api: &Api, source: impl Into<String>) {
+        api.insert_machine_health_report(tonic::Request::new(InsertMachineHealthReportRequest {
+            health_report_entry: Some(HealthReportEntry {
+                report: Some(crate::rpc::health::HealthReport {
+                    source: source.into(),
+                    triggered_by: None,
+                    observed_at: None,
+                    successes: vec![],
+                    alerts: vec![],
+                }),
+                ..Default::default()
+            }),
+            machine_id: Some(self.host_machine_id),
+        }))
+        .await
+        .expect("empty host health report should be inserted");
+    }
+
+    pub async fn advance_host_state(&self, test_harness: &TestHarness, state: ManagedHostState) {
+        let mut txn = test_harness.db_txn().await;
+        let machine = self.host_db_machine(&mut txn).await;
+        db::machine::advance(&machine, &mut txn, &state, None)
+            .await
+            .expect("host state should be advanced");
+        txn.commit()
+            .await
+            .expect("database transaction should commit");
+    }
+
+    pub async fn host_db_machine(&self, txn: &mut sqlx::PgTransaction<'_>) -> Machine {
+        db::machine::find_one(
+            txn.as_mut(),
+            &self.host_machine_id,
+            MachineSearchConfig::default(),
+        )
+        .await
+        .expect("host machine lookup should succeed")
+        .expect("host machine should exist")
     }
 
     /// Simulate forge-dpu-agent fetching, applying, and reporting DPU network status.
@@ -84,6 +203,13 @@ impl<'a> TestManagedHostBuilder<'a> {
     pub fn with_config(mut self, managed_host: ManagedHostConfig) -> Self {
         self.managed_host = managed_host;
         self
+    }
+
+    pub fn with_dpu_count(self, dpu_count: usize) -> Self {
+        assert!(dpu_count >= 1, "need to specify at least 1 DPU");
+        self.with_config(ManagedHostConfig::with_dpus(
+            (0..dpu_count).map(|_| DpuConfig::default()).collect(),
+        ))
     }
 
     /// Report DPU network status as part of `build`.
@@ -215,6 +341,32 @@ async fn discover_bmc(
     .address
     .parse()
     .expect("DHCP response address should be an IP address")
+}
+
+async fn discover_machine(
+    api: &Api,
+    dhcp_record: &DhcpRecord,
+    hardware_info: HardwareInfo,
+) -> MachineDiscoveryResult {
+    api.discover_machine(tonic::Request::new(
+        crate::rpc::forge::MachineDiscoveryInfo {
+            machine_interface_id: Some(
+                *dhcp_record
+                    .machine_interface_id
+                    .as_ref()
+                    .expect("DHCP record should include a machine interface id"),
+            ),
+            create_machine: true,
+            discovery_data: Some(DiscoveryData::Info(
+                DiscoveryInfo::try_from(hardware_info)
+                    .expect("hardware info should convert to discovery info"),
+            )),
+            ..Default::default()
+        },
+    ))
+    .await
+    .expect("machine discovery should succeed")
+    .into_inner()
 }
 
 async fn record_dpu_network_status(api: &Api, dpu_machine_id: MachineId) {

--- a/crates/test-harness/src/network/controller.rs
+++ b/crates/test-harness/src/network/controller.rs
@@ -19,13 +19,14 @@ use std::sync::Arc;
 
 use carbide_api_core::test_support::network_segment::{
     FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY,
-    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY,
+    FIXTURE_TENANT_NETWORK_SEGMENT_GATEWAYS, FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY,
 };
 use carbide_api_core::test_support::rpc::forge::forge_server::Forge;
 use carbide_network_segment_controller::context::NetworkSegmentStateHandlerServices;
 use carbide_network_segment_controller::handler::NetworkSegmentStateHandler;
 use carbide_network_segment_controller::io::NetworkSegmentStateControllerIO;
 use carbide_utils::test_support::test_meter::TestMeter;
+use carbide_uuid::vpc::VpcId;
 use ipnetwork::IpNetwork;
 use state_controller::controller::StateController;
 use tokio::sync::Mutex;
@@ -200,6 +201,68 @@ impl TestNetworkController {
             .create_network_segment(tonic::Request::new(request))
             .await
             .expect("Unable to create network segment")
+            .into_inner();
+
+        self.run_single_iteration().await;
+        self.run_single_iteration().await;
+
+        TestNetworkSegment {
+            id: segment
+                .id
+                .expect("Id must be returned by create_network_segment API request"),
+            relay_address: gateway,
+        }
+    }
+
+    pub async fn create_vpc(&self, name: &str) -> VpcId {
+        let vpc = self
+            .api
+            .create_vpc(
+                rpc::forge::VpcCreationRequest::builder("2829bbe3-c169-4cd9-8b2a-19a8b1618a93")
+                    .metadata(rpc::forge::Metadata {
+                        name: name.to_string(),
+                        ..Default::default()
+                    })
+                    .tonic_request(),
+            )
+            .await
+            .expect("Unable to create VPC")
+            .into_inner();
+        vpc.id.expect("Created VPC must have an id")
+    }
+
+    pub async fn create_tenant_segment(
+        &self,
+        domain: &TestDomain,
+        vpc_id: VpcId,
+    ) -> TestNetworkSegment {
+        let network = FIXTURE_TENANT_NETWORK_SEGMENT_GATEWAYS[0];
+        let prefix = IpNetwork::new(network.network(), network.prefix())
+            .unwrap()
+            .to_string();
+        let gateway = network.ip();
+        let request = rpc::forge::NetworkSegmentCreationRequest {
+            id: None,
+            mtu: Some(1500),
+            name: "TENANT".to_string(),
+            prefixes: vec![rpc::forge::NetworkPrefix {
+                id: None,
+                prefix,
+                gateway: Some(gateway.to_string()),
+                reserve_first: 3,
+                free_ip_count: 0,
+                svi_ip: None,
+            }],
+            subdomain_id: Some(domain.id),
+            vpc_id: Some(vpc_id),
+            segment_type: rpc::forge::NetworkSegmentType::Tenant.into(),
+        };
+
+        let segment = self
+            .api
+            .create_network_segment(tonic::Request::new(request))
+            .await
+            .expect("Unable to create tenant network segment")
             .into_inner();
 
         self.run_single_iteration().await;

--- a/crates/test-harness/src/prelude.rs
+++ b/crates/test-harness/src/prelude.rs
@@ -20,5 +20,6 @@ pub use rpc::forge::forge_server::Forge;
 pub use sqlx::PgPool;
 pub use sqlx_testing;
 
+pub use crate::asset::{TestPowerShelf, TestRack, TestSwitch};
 pub use crate::resource_pool::ResourcePoolBuilder;
-pub use crate::{Api, TestHarness, TestManagedHost, TestManagedHostBuilder, rpc};
+pub use crate::{Api, TestHarness, TestManagedHost, TestManagedHostBuilder, TestSiteExplorer, rpc};

--- a/crates/test-harness/src/resource_pool.rs
+++ b/crates/test-harness/src/resource_pool.rs
@@ -26,6 +26,8 @@ use model::resource_pool::{ResourcePoolDef, ResourcePoolType};
 #[derive(Default)]
 pub struct ResourcePoolBuilder {
     secondary_vtep_ip: Option<IpNetwork>,
+    vlan_id_ranges: Option<Vec<(u32, u32)>>,
+    vni_ranges: Option<Vec<(u32, u32)>>,
 }
 
 impl ResourcePoolBuilder {
@@ -42,6 +44,24 @@ impl ResourcePoolBuilder {
         }
     }
 
+    pub fn with_vlan_ids(mut self, start: u32, end: u32) -> Self {
+        assert!(
+            start <= end,
+            "VLAN ID range start must be less than or equal to end"
+        );
+        self.vlan_id_ranges = Some(vec![(start, end)]);
+        self
+    }
+
+    pub fn with_vnis(mut self, start: u32, end: u32) -> Self {
+        assert!(
+            start <= end,
+            "VNI range start must be less than or equal to end"
+        );
+        self.vni_ranges = Some(vec![(start, end)]);
+        self
+    }
+
     pub fn build(self) -> HashMap<String, ResourcePoolDef> {
         let int_range_pool = |ranges: &[(u32, u32)]| resource_pool::ResourcePoolDef {
             pool_type: resource_pool::ResourcePoolType::Integer,
@@ -56,6 +76,8 @@ impl ResourcePoolBuilder {
             prefix: None,
             delegate_prefix_len: None,
         };
+        let vlan_id_ranges = self.vlan_id_ranges.unwrap_or_else(|| vec![(1, 2)]);
+        let vni_ranges = self.vni_ranges.unwrap_or_else(|| vec![(10001, 10002)]);
 
         [
             (
@@ -69,11 +91,11 @@ impl ResourcePoolBuilder {
             ),
             (
                 resource_pool::common::VLANID.to_string(),
-                int_range_pool(&[(1, 2)]),
+                int_range_pool(&vlan_id_ranges),
             ),
             (
                 resource_pool::common::VNI.to_string(),
-                int_range_pool(&[(10001, 10002)]),
+                int_range_pool(&vni_ranges),
             ),
             (
                 resource_pool::common::VPC_VNI.to_string(),


### PR DESCRIPTION
## Description

When api-web and api-core was split stop api-core/tests/common was exposed as stop gap to support
tests in api-web. This PR closes the gap by migrating web tests to brand new test-harness fixtures.

In addition, it moves couple site-explorer tests to the corresponding crate. 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality  
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Related Issues (Optional)

#2001 

## Breaking Changes
- [ ] This PR contains breaking changes

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated  
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

