### PR TITLE
test(test-support): group table rows into scenarios

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,9 @@ cargo make correctly-execute-tests
 ```
 
 When writing tests, prefer the **table-driven** style — see the [Testing section in `STYLE_GUIDE.md`](STYLE_GUIDE.md#testing).
-Enumerating a function's input variants as `carbide-test-support` cases (`check_cases` / `check_values`) is the easiest
-way to reach thorough coverage of parsers, validators, conversions, and the like.
+Enumerating a function's input variants as grouped `carbide-test-support` scenarios (`scenarios!` / `value_scenarios!`)
+or explicit cases (`check_cases` / `check_values`) is the easiest way to reach thorough coverage of parsers, validators,
+conversions, and the like.
 
 ### Linting and Formatting
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -65,25 +65,30 @@ through one operation, written once:
 
 ```rust
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 
 #[test]
 fn parse_port() {
-    check_cases(
-        [
-            Case { scenario: "valid", input: "443", expect: Yields(443) },
-            Case { scenario: "zero is allowed", input: "0", expect: Yields(0) },
-            Case { scenario: "non-numeric", input: "https", expect: Fails },
-            Case { scenario: "out of range", input: "99999", expect: FailsWith(PortError::TooLarge) },
-        ],
-        |s| parse_port(s),
+    scenarios!(parse_port:
+        "valid ports" {
+            "0" => Yields(0),
+            "443" => Yields(443),
+        }
+
+        "invalid ports" {
+            "https" => Fails,
+            "99999" => FailsWith(PortError::TooLarge),
+        }
     );
 }
 ```
 
-- Use **`check_cases`** with `Outcome` (`Yields` / `Fails` / `FailsWith`) for **fallible** operations (those returning
-  `Result`).
-- Use **`check_values`** with `Check` for **total** operations (those returning a plain value, `Option`, or `bool`).
+- Use **`scenarios!`** with `Outcome` (`Yields` / `Fails` / `FailsWith`) for **fallible** operations (those returning
+  `Result`). It expands to `check_cases` and keeps failures labeled by both scenario and input.
+- Use **`value_scenarios!`** for **total** operations (those returning a plain value, `Option`, or `bool`). It expands to
+  `check_values`.
+- Use **`check_cases`** / **`check_values`** directly when a macro would obscure a table with several inputs or several
+  expected fields per row.
 - Reach for `FailsWith(err)` only when the error type is `PartialEq` and its exact value is the contract. Otherwise use
   `Fails` (with `.map_err(drop)` in the operation) when only "it failed" matters.
 

--- a/crates/config-version/src/lib.rs
+++ b/crates/config-version/src/lib.rs
@@ -434,7 +434,7 @@ fn plural(val: i64, period: &str) -> String {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
     use chrono::TimeDelta;
 
     use super::*;
@@ -487,6 +487,12 @@ mod tests {
                 ConfigVersionParseError::VersionFormat(_) => ParseFailure::VersionFormat,
                 ConfigVersionParseError::DateTime(_, _) => ParseFailure::DateTime,
             })
+    }
+
+    fn deserialize_config_version(input: &str) -> Result<VersionSummary, ()> {
+        serde_json::from_str::<ConfigVersion>(input)
+            .map(summarize)
+            .map_err(|_| ())
     }
 
     fn summarize_operation_version(version: ConfigVersion) -> OperationSummary {
@@ -573,226 +579,125 @@ mod tests {
 
     #[test]
     fn it_formats_durations() {
-        check_values(
-            [
-                Check {
-                    scenario: "zero seconds",
-                    input: 0,
-                    expect: "0 seconds".to_string(),
-                },
-                Check {
-                    scenario: "single second",
-                    input: 1,
-                    expect: "1 second".to_string(),
-                },
-                Check {
-                    scenario: "seconds",
-                    input: 44,
-                    expect: "44 seconds".to_string(),
-                },
-                Check {
-                    scenario: "negative seconds",
-                    input: -44,
-                    expect: "-44 seconds".to_string(),
-                },
-                Check {
-                    scenario: "minute",
-                    input: 60,
-                    expect: "1 minute".to_string(),
-                },
-                Check {
-                    scenario: "minute ignores remaining seconds",
-                    input: 61,
-                    expect: "1 minute".to_string(),
-                },
-                Check {
-                    scenario: "hours",
-                    input: 3600 * 2,
-                    expect: "2 hours".to_string(),
-                },
-                Check {
-                    scenario: "day",
-                    input: 86400,
-                    expect: "1 day".to_string(),
-                },
-                Check {
-                    scenario: "hour and minute",
-                    input: 3600 + 60,
-                    expect: "1 hour and 1 minute".to_string(),
-                },
-                Check {
-                    scenario: "day hour minute",
-                    input: 86400 + 3600 + 60 + 1,
-                    expect: "1 day, 1 hour and 1 minute".to_string(),
-                },
-            ],
-            |seconds| format_duration(TimeDelta::seconds(seconds)),
+        value_scenarios!(
+            run = |seconds| format_duration(TimeDelta::seconds(seconds));
+            "seconds" {
+                0 => "0 seconds".to_string(),
+                1 => "1 second".to_string(),
+                44 => "44 seconds".to_string(),
+                -44 => "-44 seconds".to_string(),
+            }
+
+            "minutes" {
+                60 => "1 minute".to_string(),
+                61 => "1 minute".to_string(),
+            }
+
+            "larger units" {
+                3600 * 2 => "2 hours".to_string(),
+                86400 => "1 day".to_string(),
+                3600 + 60 => "1 hour and 1 minute".to_string(),
+                86400 + 3600 + 60 + 1 => "1 day, 1 hour and 1 minute".to_string(),
+            }
         );
     }
 
     #[test]
     fn parse_config_version_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "epoch version",
-                    input: "V5-T0",
-                    expect: Yields(VersionSummary {
-                        version_nr: 5,
-                        timestamp_micros: 0,
-                        version_string: "V5-T0".to_string(),
-                        display: "V5-T0".to_string(),
-                    }),
-                },
-                Case {
-                    scenario: "trimmed version string",
-                    input: " V7-T1000000 ",
-                    expect: Yields(VersionSummary {
-                        version_nr: 7,
-                        timestamp_micros: 1_000_000,
-                        version_string: "V7-T1000000".to_string(),
-                        display: "V7-T1000000".to_string(),
-                    }),
-                },
-                Case {
-                    scenario: "empty string",
-                    input: "",
-                    expect: FailsWith(ParseFailure::VersionFormat),
-                },
-                Case {
-                    scenario: "missing timestamp",
-                    input: "V1",
-                    expect: FailsWith(ParseFailure::VersionFormat),
-                },
-                Case {
-                    scenario: "missing version prefix",
-                    input: "1-T0",
-                    expect: FailsWith(ParseFailure::VersionFormat),
-                },
-                Case {
-                    scenario: "invalid version number",
-                    input: "Vx-T0",
-                    expect: FailsWith(ParseFailure::VersionFormat),
-                },
-                Case {
-                    scenario: "invalid timestamp",
-                    input: "V1-Tx",
-                    expect: FailsWith(ParseFailure::VersionFormat),
-                },
-                Case {
-                    scenario: "extra segment",
-                    input: "V1-T0-extra",
-                    expect: FailsWith(ParseFailure::VersionFormat),
-                },
-                Case {
-                    scenario: "out-of-range datetime",
-                    input: "V1-T18446744073709551615",
-                    expect: FailsWith(ParseFailure::DateTime),
-                },
-            ],
-            parse_version,
+        scenarios!(parse_version:
+            "valid versions" {
+                "V5-T0" => Yields(VersionSummary {
+                    version_nr: 5,
+                    timestamp_micros: 0,
+                    version_string: "V5-T0".to_string(),
+                    display: "V5-T0".to_string(),
+                }),
+                " V7-T1000000 " => Yields(VersionSummary {
+                    version_nr: 7,
+                    timestamp_micros: 1_000_000,
+                    version_string: "V7-T1000000".to_string(),
+                    display: "V7-T1000000".to_string(),
+                }),
+            }
+
+            "format errors" {
+                "" => FailsWith(ParseFailure::VersionFormat),
+                "V1" => FailsWith(ParseFailure::VersionFormat),
+                "1-T0" => FailsWith(ParseFailure::VersionFormat),
+                "Vx-T0" => FailsWith(ParseFailure::VersionFormat),
+                "V1-Tx" => FailsWith(ParseFailure::VersionFormat),
+                "V1-T0-extra" => FailsWith(ParseFailure::VersionFormat),
+            }
+
+            "datetime errors" {
+                "V1-T18446744073709551615" => FailsWith(ParseFailure::DateTime),
+            }
         );
     }
 
     #[test]
     fn serde_config_version_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "valid version string",
-                    input: "\"V5-T0\"",
-                    expect: Yields(VersionSummary {
-                        version_nr: 5,
-                        timestamp_micros: 0,
-                        version_string: "V5-T0".to_string(),
-                        display: "V5-T0".to_string(),
-                    }),
-                },
-                Case {
-                    scenario: "invalid version string",
-                    input: "\"bad\"",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "non-string value",
-                    input: "42",
-                    expect: Fails,
-                },
-            ],
-            |input| {
-                serde_json::from_str::<ConfigVersion>(input)
-                    .map(summarize)
-                    .map_err(|_| ())
-            },
+        scenarios!(deserialize_config_version:
+            "valid version strings" {
+                "\"V5-T0\"" => Yields(VersionSummary {
+                    version_nr: 5,
+                    timestamp_micros: 0,
+                    version_string: "V5-T0".to_string(),
+                    display: "V5-T0".to_string(),
+                }),
+            }
+
+            "invalid json values" {
+                "\"bad\"" => Fails,
+                "42" => Fails,
+            }
         );
     }
 
     #[test]
     fn config_version_operation_cases() {
-        check_values(
-            [
-                Check {
-                    scenario: "initial",
-                    input: VersionOperation::Initial,
-                    expect: OperationSummary {
-                        version_nr: 1,
-                        timestamp_micros: None,
-                        current_version_nr: None,
-                        new_version_nr: None,
-                    },
+        value_scenarios!(apply_operation:
+            "constructors" {
+                VersionOperation::Initial => OperationSummary {
+                    version_nr: 1,
+                    timestamp_micros: None,
+                    current_version_nr: None,
+                    new_version_nr: None,
                 },
-                Check {
-                    scenario: "new",
-                    input: VersionOperation::New,
-                    expect: OperationSummary {
-                        version_nr: 7,
-                        timestamp_micros: None,
-                        current_version_nr: None,
-                        new_version_nr: None,
-                    },
+                VersionOperation::New => OperationSummary {
+                    version_nr: 7,
+                    timestamp_micros: None,
+                    current_version_nr: None,
+                    new_version_nr: None,
                 },
-                Check {
-                    scenario: "invalid",
-                    input: VersionOperation::Invalid,
-                    expect: OperationSummary {
-                        version_nr: 0,
-                        timestamp_micros: Some(0),
-                        current_version_nr: None,
-                        new_version_nr: None,
-                    },
+                VersionOperation::Invalid => OperationSummary {
+                    version_nr: 0,
+                    timestamp_micros: Some(0),
+                    current_version_nr: None,
+                    new_version_nr: None,
                 },
-                Check {
-                    scenario: "increment",
-                    input: VersionOperation::Increment,
-                    expect: OperationSummary {
-                        version_nr: 42,
-                        timestamp_micros: None,
-                        current_version_nr: None,
-                        new_version_nr: None,
-                    },
+            }
+
+            "increments" {
+                VersionOperation::Increment => OperationSummary {
+                    version_nr: 42,
+                    timestamp_micros: None,
+                    current_version_nr: None,
+                    new_version_nr: None,
                 },
-                Check {
-                    scenario: "overflow increment skips zero",
-                    input: VersionOperation::OverflowIncrement,
-                    expect: OperationSummary {
-                        version_nr: 1,
-                        timestamp_micros: None,
-                        current_version_nr: None,
-                        new_version_nr: None,
-                    },
+                VersionOperation::OverflowIncrement => OperationSummary {
+                    version_nr: 1,
+                    timestamp_micros: None,
+                    current_version_nr: None,
+                    new_version_nr: None,
                 },
-                Check {
-                    scenario: "incremental change",
-                    input: VersionOperation::IncrementalChange,
-                    expect: OperationSummary {
-                        version_nr: 41,
-                        timestamp_micros: None,
-                        current_version_nr: Some(41),
-                        new_version_nr: Some(42),
-                    },
+                VersionOperation::IncrementalChange => OperationSummary {
+                    version_nr: 41,
+                    timestamp_micros: None,
+                    current_version_nr: Some(41),
+                    new_version_nr: Some(42),
                 },
-            ],
-            apply_operation,
+            }
         );
     }
 
@@ -818,20 +723,12 @@ mod tests {
 
     #[test]
     fn since_state_change_humanized_parse_cases() {
-        check_values(
-            [
-                Check {
-                    scenario: "invalid version",
-                    input: "bad",
-                    expect: true,
-                },
-                Check {
-                    scenario: "valid version",
-                    input: "V1-T0",
-                    expect: false,
-                },
-            ],
-            |input| since_state_change_humanized(input) == STATE_VERSION_PARSE_ERROR,
+        value_scenarios!(
+            run = |input| since_state_change_humanized(input) == STATE_VERSION_PARSE_ERROR;
+            "parse status" {
+                "bad" => true,
+                "V1-T0" => false,
+            }
         );
     }
 

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -20,7 +20,8 @@
 //! Write a test as a list of labeled cases — each a `scenario`, an `input`, and an
 //! `expect`ed result — then run them all through one operation, written once.
 //! [`check_cases`] does the running and the asserting, [`Outcome`] is what a
-//! fallible operation should produce, and [`Case`] is one row.
+//! fallible operation should produce, and [`Case`] is one row. For concise
+//! grouped tables, use [`scenarios!`] or [`value_scenarios!`].
 //!
 //! # A table of cases
 //!
@@ -48,6 +49,33 @@
 //!     ],
 //!     // the operation under test, written once:
 //!     |s| s.parse::<u8>().map_err(|_| format!("bad byte: {s}")),
+//! );
+//! ```
+//!
+//! # Grouped scenarios
+//!
+//! When several rows belong to the same named condition, [`scenarios!`] keeps the
+//! inputs and expected outcomes visible while removing the repeated [`Case`]
+//! fields:
+//!
+//! ```
+//! use carbide_test_support::Outcome::*;
+//! use carbide_test_support::scenarios;
+//!
+//! fn parse_byte(input: &str) -> Result<u8, String> {
+//!     input.parse::<u8>().map_err(|_| format!("bad byte: {input}"))
+//! }
+//!
+//! scenarios!(parse_byte:
+//!     "valid bytes" {
+//!         "0" => Yields(0),
+//!         "42" => Yields(42),
+//!     }
+//!
+//!     "invalid bytes" {
+//!         "999" => FailsWith("bad byte: 999".to_string()),
+//!         "x" => Fails,
+//!     }
 //! );
 //! ```
 //!
@@ -123,15 +151,33 @@
 //! );
 //! ```
 //!
+//! The [`value_scenarios!`] macro provides the same grouping for total
+//! operations:
+//!
+//! ```
+//! use carbide_test_support::value_scenarios;
+//!
+//! fn is_even(input: u8) -> bool {
+//!     input % 2 == 0
+//! }
+//!
+//! value_scenarios!(is_even:
+//!     "parity" {
+//!         2 => true,
+//!         7 => false,
+//!     }
+//! );
+//! ```
+//!
 //! # What's shared, and what stays a convention
 //!
 //! [`Outcome`] is the one piece worth sharing — every fallible test otherwise
-//! re-invents the same "succeeds / fails / fails-with-a-specific-error" enum. There
-//! is deliberately no macro: that's a last-mile crystallization, not a starting
-//! point. And when a row carries several inputs or expected values, a *local*
-//! `struct Case` with content-named fields plus [`assert_outcome`] reads better
-//! than forcing it through the generic [`Case`] here — so that stays a convention,
-//! not a type.
+//! re-invents the same "succeeds / fails / fails-with-a-specific-error" enum.
+//! [`scenarios!`] and [`value_scenarios!`] are intentionally thin syntax over
+//! [`Case`] and [`Check`]: they make repeated one-input tables easier to read, but
+//! when a row carries several inputs or expected values, a *local* `struct Case`
+//! with content-named fields plus [`assert_outcome`] still reads better — so that
+//! stays a convention, not a type.
 
 use std::fmt::Debug;
 use std::future::Future;
@@ -275,6 +321,113 @@ where
     }
 }
 
+/// Run grouped fallible table rows through one operation.
+///
+/// Each group label is combined with the row input expression in failure output,
+/// so a failure points at both the broad scenario and the concrete input. This is
+/// equivalent to writing [`Case`] rows and passing them to [`check_cases`].
+///
+/// ```
+/// use carbide_test_support::Outcome::*;
+/// use carbide_test_support::scenarios;
+///
+/// fn checked_double(input: u8) -> Result<u8, &'static str> {
+///     input.checked_mul(2).ok_or("overflow")
+/// }
+///
+/// scenarios!(checked_double:
+///     "doubles" {
+///         2 => Yields(4),
+///     }
+///
+///     "overflow" {
+///         200 => Fails,
+///     }
+/// );
+/// ```
+#[macro_export]
+macro_rules! scenarios {
+    ($run:path: $($scenario:literal { $($input:expr => $expect:expr),+ $(,)? })+ $(,)?) => {
+        $crate::check_cases(
+            [
+                $($(
+                    $crate::Case {
+                        scenario: concat!($scenario, " / ", stringify!($input)),
+                        input: $input,
+                        expect: $expect,
+                    },
+                )+)+
+            ],
+            $run,
+        )
+    };
+    (run = $run:expr; $($scenario:literal { $($input:expr => $expect:expr),+ $(,)? })+ $(,)?) => {
+        $crate::check_cases(
+            [
+                $($(
+                    $crate::Case {
+                        scenario: concat!($scenario, " / ", stringify!($input)),
+                        input: $input,
+                        expect: $expect,
+                    },
+                )+)+
+            ],
+            $run,
+        )
+    };
+}
+
+/// Run grouped total-value table rows through one operation.
+///
+/// This is the total-function counterpart to [`scenarios!`], equivalent to
+/// writing [`Check`] rows and passing them to [`check_values`].
+///
+/// ```
+/// use carbide_test_support::value_scenarios;
+///
+/// fn double(input: u8) -> u8 {
+///     input * 2
+/// }
+///
+/// value_scenarios!(double:
+///     "doubles" {
+///         2 => 4,
+///         9 => 18,
+///     }
+/// );
+/// ```
+#[macro_export]
+macro_rules! value_scenarios {
+    ($run:path: $($scenario:literal { $($input:expr => $expect:expr),+ $(,)? })+ $(,)?) => {
+        $crate::check_values(
+            [
+                $($(
+                    $crate::Check {
+                        scenario: concat!($scenario, " / ", stringify!($input)),
+                        input: $input,
+                        expect: $expect,
+                    },
+                )+)+
+            ],
+            $run,
+        )
+    };
+    (run = $run:expr; $($scenario:literal { $($input:expr => $expect:expr),+ $(,)? })+ $(,)?) => {
+        $crate::check_values(
+            [
+                $($(
+                    $crate::Check {
+                        scenario: concat!($scenario, " / ", stringify!($input)),
+                        input: $input,
+                        expect: $expect,
+                    },
+                )+)+
+            ],
+            $run,
+        )
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::Outcome::*;
@@ -325,6 +478,61 @@ mod tests {
                 },
             ],
             |n| n % 2 == 0,
+        );
+    }
+
+    #[test]
+    fn scenarios_macro_runs_grouped_fallible_rows() {
+        fn checked_double(input: u8) -> Result<u8, &'static str> {
+            input.checked_mul(2).ok_or("overflow")
+        }
+
+        crate::scenarios!(checked_double:
+            "doubles" {
+                2 => Yields(4),
+                21 => Yields(42),
+            }
+
+            "overflow" {
+                200 => Fails,
+            }
+        );
+    }
+
+    #[test]
+    fn scenarios_macro_accepts_run_expression() {
+        crate::scenarios!(run = |n| n.checked_add(1).ok_or("overflow");
+            "increments" {
+                1u8 => Yields(2),
+            }
+
+            "overflow" {
+                u8::MAX => FailsWith("overflow"),
+            }
+        );
+    }
+
+    #[test]
+    fn value_scenarios_macro_runs_grouped_total_rows() {
+        fn double(input: u8) -> u8 {
+            input * 2
+        }
+
+        crate::value_scenarios!(double:
+            "doubles" {
+                2 => 4,
+                21 => 42,
+            }
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "label / 1")]
+    fn value_scenarios_macro_labels_failures_with_group_and_input() {
+        crate::value_scenarios!(run = |n| n;
+            "label" {
+                1 => 2,
+            }
         );
     }
 


### PR DESCRIPTION
This supports #3914.

## Description

So, our table-driven tests are now enumerating each scenario, so it's "clean" to read, BUT, the repeated `Case { scenario, input, expect }` blocks starts to get in the way once a function has several enumerations, whether its inputs, related error classes, etc.

This adds `scenarios!` and `value_scenarios!` as a small syntax layer over the existing `Case` and `Check` runners. Expected values are still written directly in the test, but related inputs can now sit under a shared label so failures name both the condition and the concrete input.

`config-version` is the first adopter: duration formatting, version parsing, serde parsing, version operations, and the parse-status helper now use the grouped shape. The style guide and agent notes are updated so follow-on table-driven tests have the same pattern to copy. We can now do things like:

```
  #[test]
  fn parse_config_version_cases() {
      scenarios!(parse_version:
          "format errors" {
              "" => FailsWith(ParseFailure::VersionFormat),
              "V1" => FailsWith(ParseFailure::VersionFormat),
              "1-T0" => FailsWith(ParseFailure::VersionFormat),
              "Vx-T0" => FailsWith(ParseFailure::VersionFormat),
              "V1-Tx" => FailsWith(ParseFailure::VersionFormat),
              "V1-T0-extra" => FailsWith(ParseFailure::VersionFormat),
          }

          "datetime errors" {
              "V1-T18446744073709551615" => FailsWith(ParseFailure::DateTime),
          }
      );
  }
```

All tests pass, and formatting/clippy checks are clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)