### PR TITLE
test(uuid): group typed ID test cases into scenario groupings

### DIFF
--- a/crates/uuid/src/instance_type/mod.rs
+++ b/crates/uuid/src/instance_type/mod.rs
@@ -182,7 +182,7 @@ impl<'de> Deserialize<'de> for InstanceTypeId {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -208,61 +208,47 @@ mod tests {
 
     #[test]
     fn test_instance_type_id_parse_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "arbitrary instance type name",
-                    input: "gb200-nvl72",
-                    expect: Yields("gb200-nvl72".to_string()),
-                },
-                Case {
-                    scenario: "UUID-backed instance type name",
-                    input: "00000000-0000-0000-0000-000000000000",
-                    expect: Yields("00000000-0000-0000-0000-000000000000".to_string()),
-                },
-                Case {
-                    scenario: "empty value",
-                    input: "",
-                    expect: FailsWith(ParseFailure::Empty),
-                },
-            ],
-            parse_instance_type_id,
+        scenarios!(
+            run = parse_instance_type_id;
+            "arbitrary instance type name" {
+                "gb200-nvl72" => Yields("gb200-nvl72".to_string()),
+            }
+
+            "UUID-backed instance type name" {
+                "00000000-0000-0000-0000-000000000000" => Yields("00000000-0000-0000-0000-000000000000".to_string()),
+            }
+
+            "empty value" {
+                "" => FailsWith(ParseFailure::Empty),
+            }
         );
     }
 
     #[test]
     fn test_instance_type_id_from_uuid() {
-        check_values(
-            [Check {
-                scenario: "nil UUID",
-                input: Uuid::nil(),
-                expect: "00000000-0000-0000-0000-000000000000".to_string(),
-            }],
-            |uuid| InstanceTypeId::from(uuid).to_string(),
+        value_scenarios!(
+            run = |uuid| InstanceTypeId::from(uuid).to_string();
+            "nil UUID" {
+                Uuid::nil() => "00000000-0000-0000-0000-000000000000".to_string(),
+            }
         );
     }
 
     #[test]
     fn test_instance_type_id_serde_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "valid string",
-                    input: "\"gb200-nvl72\"",
-                    expect: Yields("gb200-nvl72".to_string()),
-                },
-                Case {
-                    scenario: "empty string",
-                    input: "\"\"",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "non-string JSON",
-                    input: "42",
-                    expect: Fails,
-                },
-            ],
-            deserialize_instance_type_id,
+        scenarios!(
+            run = deserialize_instance_type_id;
+            "valid string" {
+                "\"gb200-nvl72\"" => Yields("gb200-nvl72".to_string()),
+            }
+
+            "empty string" {
+                "\"\"" => Fails,
+            }
+
+            "non-string JSON" {
+                "42" => Fails,
+            }
         );
 
         let serialized = serde_json::to_string(
@@ -274,20 +260,15 @@ mod tests {
 
     #[test]
     fn test_instance_type_id_parse_error_value() {
-        check_values(
-            [
-                Check {
-                    scenario: "invalid",
-                    input: InstanceTypeIdParseError::Invalid("bad".to_string()),
-                    expect: "bad".to_string(),
-                },
-                Check {
-                    scenario: "empty",
-                    input: InstanceTypeIdParseError::Empty,
-                    expect: String::new(),
-                },
-            ],
-            InstanceTypeIdParseError::value,
+        value_scenarios!(
+            run = InstanceTypeIdParseError::value;
+            "invalid" {
+                InstanceTypeIdParseError::Invalid("bad".to_string()) => "bad".to_string(),
+            }
+
+            "empty" {
+                InstanceTypeIdParseError::Empty => String::new(),
+            }
         );
     }
 }

--- a/crates/uuid/src/machine/mod.rs
+++ b/crates/uuid/src/machine/mod.rs
@@ -517,7 +517,7 @@ impl<'de> Deserialize<'de> for MachineId {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -543,85 +543,42 @@ mod tests {
         const VALID_MACHINE_ID: &str =
             "fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg";
 
-        check_cases(
-            [
-                Case {
-                    scenario: "valid host TPM machine ID",
-                    input: VALID_MACHINE_ID,
-                    expect: Yields(VALID_MACHINE_ID.to_string()),
-                },
-                Case {
-                    scenario: "one character short",
-                    input: "fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hc",
-                    expect: FailsWith(ParseFailure::Length),
-                },
-                Case {
-                    scenario: "empty string",
-                    input: "",
-                    expect: FailsWith(ParseFailure::Length),
-                },
-                Case {
-                    scenario: "invalid prefix casing",
-                    input: "FM100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
-                    expect: FailsWith(ParseFailure::Prefix),
-                },
-                Case {
-                    scenario: "invalid machine type",
-                    input: "fm100xt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
-                    expect: FailsWith(ParseFailure::Prefix),
-                },
-                Case {
-                    scenario: "invalid source",
-                    input: "fm100dx038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
-                    expect: FailsWith(ParseFailure::Prefix),
-                },
-                Case {
-                    scenario: "invalid base32 payload",
-                    input: "fm100ht038bg3qsho433vkg684heguv28!qaggmrsh2ugn1qk096n2c6hcg",
-                    expect: FailsWith(ParseFailure::Encoding),
-                },
-            ],
-            parse_machine_id,
+        scenarios!(
+            run = parse_machine_id;
+            "valid host TPM machine ID" {
+                VALID_MACHINE_ID => Yields(VALID_MACHINE_ID.to_string()),
+            }
+
+            "one character short" {
+                "fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hc" => FailsWith(ParseFailure::Length),
+            }
+
+            "empty string" {
+                "" => FailsWith(ParseFailure::Length),
+            }
+
+            "invalid prefix casing" {
+                "FM100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg" => FailsWith(ParseFailure::Prefix),
+            }
+
+            "invalid machine type" {
+                "fm100xt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg" => FailsWith(ParseFailure::Prefix),
+            }
+
+            "invalid source" {
+                "fm100dx038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg" => FailsWith(ParseFailure::Prefix),
+            }
+
+            "invalid base32 payload" {
+                "fm100ht038bg3qsho433vkg684heguv28!qaggmrsh2ugn1qk096n2c6hcg" => FailsWith(ParseFailure::Encoding),
+            }
         );
     }
 
     #[test]
     fn test_machine_type_mappings() {
-        check_values(
-            [
-                Check {
-                    scenario: "DPU",
-                    input: MachineType::Dpu,
-                    expect: ('d', "fm100d", "dpu", "DPU".to_string(), true, false, false),
-                },
-                Check {
-                    scenario: "host",
-                    input: MachineType::Host,
-                    expect: (
-                        'h',
-                        "fm100h",
-                        "host",
-                        "Host".to_string(),
-                        false,
-                        true,
-                        false,
-                    ),
-                },
-                Check {
-                    scenario: "predicted host",
-                    input: MachineType::PredictedHost,
-                    expect: (
-                        'p',
-                        "fm100p",
-                        "predictedhost",
-                        "Host (Predicted)".to_string(),
-                        false,
-                        false,
-                        true,
-                    ),
-                },
-            ],
-            |ty| {
+        value_scenarios!(
+            run = |ty| {
                 (
                     ty.id_char(),
                     ty.id_prefix(),
@@ -631,60 +588,74 @@ mod tests {
                     ty.is_host(),
                     ty.is_predicted_host(),
                 )
-            },
+            };
+            "DPU" {
+                MachineType::Dpu => ('d', "fm100d", "dpu", "DPU".to_string(), true, false, false),
+            }
+
+            "host" {
+                MachineType::Host => (
+                    'h',
+                    "fm100h",
+                    "host",
+                    "Host".to_string(),
+                    false,
+                    true,
+                    false,
+                ),
+            }
+
+            "predicted host" {
+                MachineType::PredictedHost => (
+                    'p',
+                    "fm100p",
+                    "predictedhost",
+                    "Host (Predicted)".to_string(),
+                    false,
+                    false,
+                    true,
+                ),
+            }
         );
     }
 
     #[test]
     fn test_machine_type_from_id_char() {
-        check_values(
-            [
-                Check {
-                    scenario: "DPU",
-                    input: 'd',
-                    expect: Some(MachineType::Dpu),
-                },
-                Check {
-                    scenario: "host",
-                    input: 'h',
-                    expect: Some(MachineType::Host),
-                },
-                Check {
-                    scenario: "predicted host",
-                    input: 'p',
-                    expect: Some(MachineType::PredictedHost),
-                },
-                Check {
-                    scenario: "unknown",
-                    input: 'x',
-                    expect: None,
-                },
-            ],
-            MachineType::from_id_char,
+        value_scenarios!(
+            run = MachineType::from_id_char;
+            "DPU" {
+                'd' => Some(MachineType::Dpu),
+            }
+
+            "host" {
+                'h' => Some(MachineType::Host),
+            }
+
+            "predicted host" {
+                'p' => Some(MachineType::PredictedHost),
+            }
+
+            "unknown" {
+                'x' => None,
+            }
         );
     }
 
     #[test]
     fn test_machine_id_source_from_id_char() {
-        check_values(
-            [
-                Check {
-                    scenario: "TPM",
-                    input: 't',
-                    expect: Some(MachineIdSource::Tpm),
-                },
-                Check {
-                    scenario: "product board chassis serial",
-                    input: 's',
-                    expect: Some(MachineIdSource::ProductBoardChassisSerial),
-                },
-                Check {
-                    scenario: "unknown",
-                    input: 'x',
-                    expect: None,
-                },
-            ],
-            MachineIdSource::from_id_char,
+        value_scenarios!(
+            run = MachineIdSource::from_id_char;
+            "TPM" {
+                't' => Some(MachineIdSource::Tpm),
+            }
+
+            "product board chassis serial" {
+                's' => Some(MachineIdSource::ProductBoardChassisSerial),
+            }
+
+            "unknown" {
+                'x' => None,
+            }
         );
     }
 }

--- a/crates/uuid/src/network_security_group/mod.rs
+++ b/crates/uuid/src/network_security_group/mod.rs
@@ -182,7 +182,7 @@ impl<'de> Deserialize<'de> for NetworkSecurityGroupId {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -210,61 +210,47 @@ mod tests {
 
     #[test]
     fn test_network_security_group_id_parse_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "arbitrary security group name",
-                    input: "tenant-edge",
-                    expect: Yields("tenant-edge".to_string()),
-                },
-                Case {
-                    scenario: "UUID-backed security group name",
-                    input: "00000000-0000-0000-0000-000000000000",
-                    expect: Yields("00000000-0000-0000-0000-000000000000".to_string()),
-                },
-                Case {
-                    scenario: "empty value",
-                    input: "",
-                    expect: FailsWith(ParseFailure::Empty),
-                },
-            ],
-            parse_network_security_group_id,
+        scenarios!(
+            run = parse_network_security_group_id;
+            "arbitrary security group name" {
+                "tenant-edge" => Yields("tenant-edge".to_string()),
+            }
+
+            "UUID-backed security group name" {
+                "00000000-0000-0000-0000-000000000000" => Yields("00000000-0000-0000-0000-000000000000".to_string()),
+            }
+
+            "empty value" {
+                "" => FailsWith(ParseFailure::Empty),
+            }
         );
     }
 
     #[test]
     fn test_network_security_group_id_from_uuid() {
-        check_values(
-            [Check {
-                scenario: "nil UUID",
-                input: Uuid::nil(),
-                expect: "00000000-0000-0000-0000-000000000000".to_string(),
-            }],
-            |uuid| NetworkSecurityGroupId::from(uuid).to_string(),
+        value_scenarios!(
+            run = |uuid| NetworkSecurityGroupId::from(uuid).to_string();
+            "nil UUID" {
+                Uuid::nil() => "00000000-0000-0000-0000-000000000000".to_string(),
+            }
         );
     }
 
     #[test]
     fn test_network_security_group_id_serde_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "valid string",
-                    input: "\"tenant-edge\"",
-                    expect: Yields("tenant-edge".to_string()),
-                },
-                Case {
-                    scenario: "empty string",
-                    input: "\"\"",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "non-string JSON",
-                    input: "42",
-                    expect: Fails,
-                },
-            ],
-            deserialize_network_security_group_id,
+        scenarios!(
+            run = deserialize_network_security_group_id;
+            "valid string" {
+                "\"tenant-edge\"" => Yields("tenant-edge".to_string()),
+            }
+
+            "empty string" {
+                "\"\"" => Fails,
+            }
+
+            "non-string JSON" {
+                "42" => Fails,
+            }
         );
 
         let serialized = serde_json::to_string(
@@ -277,20 +263,15 @@ mod tests {
 
     #[test]
     fn test_network_security_group_id_parse_error_value() {
-        check_values(
-            [
-                Check {
-                    scenario: "invalid",
-                    input: NetworkSecurityGroupIdParseError::Invalid("bad".to_string()),
-                    expect: "bad".to_string(),
-                },
-                Check {
-                    scenario: "empty",
-                    input: NetworkSecurityGroupIdParseError::Empty,
-                    expect: String::new(),
-                },
-            ],
-            NetworkSecurityGroupIdParseError::value,
+        value_scenarios!(
+            run = NetworkSecurityGroupIdParseError::value;
+            "invalid" {
+                NetworkSecurityGroupIdParseError::Invalid("bad".to_string()) => "bad".to_string(),
+            }
+
+            "empty" {
+                NetworkSecurityGroupIdParseError::Empty => String::new(),
+            }
         );
     }
 }

--- a/crates/uuid/src/power_shelf/mod.rs
+++ b/crates/uuid/src/power_shelf/mod.rs
@@ -480,7 +480,7 @@ mod legacy_rpc {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -506,112 +506,85 @@ mod tests {
         const VALID_POWER_SHELF_ID: &str =
             "ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg";
 
-        check_cases(
-            [
-                Case {
-                    scenario: "valid host TPM power shelf ID",
-                    input: VALID_POWER_SHELF_ID,
-                    expect: Yields(VALID_POWER_SHELF_ID.to_string()),
-                },
-                Case {
-                    scenario: "one character short",
-                    input: "ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hc",
-                    expect: FailsWith(ParseFailure::Length),
-                },
-                Case {
-                    scenario: "empty string",
-                    input: "",
-                    expect: FailsWith(ParseFailure::Length),
-                },
-                Case {
-                    scenario: "invalid prefix casing",
-                    input: "PS100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
-                    expect: FailsWith(ParseFailure::Prefix),
-                },
-                Case {
-                    scenario: "invalid power shelf type",
-                    input: "ps100xt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
-                    expect: FailsWith(ParseFailure::Prefix),
-                },
-                Case {
-                    scenario: "invalid source",
-                    input: "ps100dx038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
-                    expect: FailsWith(ParseFailure::Prefix),
-                },
-                Case {
-                    scenario: "invalid base32 payload",
-                    input: "ps100ht038bg3qsho433vkg684heguv28!qaggmrsh2ugn1qk096n2c6hcg",
-                    expect: FailsWith(ParseFailure::Encoding),
-                },
-            ],
-            parse_power_shelf_id,
+        scenarios!(
+            run = parse_power_shelf_id;
+            "valid host TPM power shelf ID" {
+                VALID_POWER_SHELF_ID => Yields(VALID_POWER_SHELF_ID.to_string()),
+            }
+
+            "one character short" {
+                "ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hc" => FailsWith(ParseFailure::Length),
+            }
+
+            "empty string" {
+                "" => FailsWith(ParseFailure::Length),
+            }
+
+            "invalid prefix casing" {
+                "PS100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg" => FailsWith(ParseFailure::Prefix),
+            }
+
+            "invalid power shelf type" {
+                "ps100xt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg" => FailsWith(ParseFailure::Prefix),
+            }
+
+            "invalid source" {
+                "ps100dx038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg" => FailsWith(ParseFailure::Prefix),
+            }
+
+            "invalid base32 payload" {
+                "ps100ht038bg3qsho433vkg684heguv28!qaggmrsh2ugn1qk096n2c6hcg" => FailsWith(ParseFailure::Encoding),
+            }
         );
     }
 
     #[test]
     fn test_power_shelf_type_mappings() {
-        check_values(
-            [
-                Check {
-                    scenario: "rack",
-                    input: PowerShelfType::Rack,
-                    expect: ('r', "Rack".to_string(), true, false),
-                },
-                Check {
-                    scenario: "host",
-                    input: PowerShelfType::Host,
-                    expect: ('h', "Host".to_string(), false, true),
-                },
-            ],
-            |ty| (ty.id_char(), ty.to_string(), ty.is_rack(), ty.is_host()),
+        value_scenarios!(
+            run = |ty| (ty.id_char(), ty.to_string(), ty.is_rack(), ty.is_host());
+            "rack" {
+                PowerShelfType::Rack => ('r', "Rack".to_string(), true, false),
+            }
+
+            "host" {
+                PowerShelfType::Host => ('h', "Host".to_string(), false, true),
+            }
         );
     }
 
     #[test]
     fn test_power_shelf_type_from_id_char() {
-        check_values(
-            [
-                Check {
-                    scenario: "rack",
-                    input: 'r',
-                    expect: Some(PowerShelfType::Rack),
-                },
-                Check {
-                    scenario: "host",
-                    input: 'h',
-                    expect: Some(PowerShelfType::Host),
-                },
-                Check {
-                    scenario: "unknown",
-                    input: 'x',
-                    expect: None,
-                },
-            ],
-            PowerShelfType::from_id_char,
+        value_scenarios!(
+            run = PowerShelfType::from_id_char;
+            "rack" {
+                'r' => Some(PowerShelfType::Rack),
+            }
+
+            "host" {
+                'h' => Some(PowerShelfType::Host),
+            }
+
+            "unknown" {
+                'x' => None,
+            }
         );
     }
 
     #[test]
     fn test_power_shelf_id_source_from_id_char() {
-        check_values(
-            [
-                Check {
-                    scenario: "TPM",
-                    input: 't',
-                    expect: Some(PowerShelfIdSource::Tpm),
-                },
-                Check {
-                    scenario: "product board chassis serial",
-                    input: 's',
-                    expect: Some(PowerShelfIdSource::ProductBoardChassisSerial),
-                },
-                Check {
-                    scenario: "unknown",
-                    input: 'x',
-                    expect: None,
-                },
-            ],
-            PowerShelfIdSource::from_id_char,
+        value_scenarios!(
+            run = PowerShelfIdSource::from_id_char;
+            "TPM" {
+                't' => Some(PowerShelfIdSource::Tpm),
+            }
+
+            "product board chassis serial" {
+                's' => Some(PowerShelfIdSource::ProductBoardChassisSerial),
+            }
+
+            "unknown" {
+                'x' => None,
+            }
         );
     }
 }

--- a/crates/uuid/src/rack/mod.rs
+++ b/crates/uuid/src/rack/mod.rs
@@ -288,7 +288,7 @@ pub enum RackIdParseError {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -327,103 +327,83 @@ mod tests {
 
     #[test]
     fn test_rack_id_parse_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "legacy ps100-encoded rack ID",
-                    input: "ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
-                    expect: Yields(
-                        "ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg".to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "DCIM rack name",
-                    input: "P20",
-                    expect: Yields("P20".to_string()),
-                },
-                Case {
-                    scenario: "regional rack name",
-                    input: "rack-42-us-west-2",
-                    expect: Yields("rack-42-us-west-2".to_string()),
-                },
-                Case {
-                    scenario: "descriptive rack name",
-                    input: "i-am-just-a-rack-id",
-                    expect: Yields("i-am-just-a-rack-id".to_string()),
-                },
-                Case {
-                    scenario: "empty rack ID",
-                    input: "",
-                    expect: FailsWith(ParseFailure::Empty),
-                },
-            ],
-            parse_rack_id,
+        scenarios!(
+            run = parse_rack_id;
+            "legacy ps100-encoded rack ID" {
+                "ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg" => Yields(
+                    "ps100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg".to_string(),
+                ),
+            }
+
+            "DCIM rack name" {
+                "P20" => Yields("P20".to_string()),
+            }
+
+            "regional rack name" {
+                "rack-42-us-west-2" => Yields("rack-42-us-west-2".to_string()),
+            }
+
+            "descriptive rack name" {
+                "i-am-just-a-rack-id" => Yields("i-am-just-a-rack-id".to_string()),
+            }
+
+            "empty rack ID" {
+                "" => FailsWith(ParseFailure::Empty),
+            }
         );
     }
 
     #[test]
     fn test_rack_id_conversions() {
-        check_values(
-            [
-                Check {
-                    scenario: "new",
-                    input: RackId::new("test-rack"),
-                    expect: (
-                        "test-rack".to_string(),
-                        "test-rack".to_string(),
-                        "test-rack".to_string(),
-                    ),
-                },
-                Check {
-                    scenario: "from str",
-                    input: RackId::from("another-rack"),
-                    expect: (
-                        "another-rack".to_string(),
-                        "another-rack".to_string(),
-                        "another-rack".to_string(),
-                    ),
-                },
-                Check {
-                    scenario: "from string",
-                    input: RackId::from(String::from("string-rack")),
-                    expect: (
-                        "string-rack".to_string(),
-                        "string-rack".to_string(),
-                        "string-rack".to_string(),
-                    ),
-                },
-            ],
-            |rack_id| {
+        value_scenarios!(
+            run = |rack_id| {
                 (
                     rack_id.as_str().to_string(),
                     rack_id.to_string(),
                     rack_id.as_ref().to_string(),
                 )
-            },
+            };
+            "new" {
+                RackId::new("test-rack") => (
+                    "test-rack".to_string(),
+                    "test-rack".to_string(),
+                    "test-rack".to_string(),
+                ),
+            }
+
+            "from str" {
+                RackId::from("another-rack") => (
+                    "another-rack".to_string(),
+                    "another-rack".to_string(),
+                    "another-rack".to_string(),
+                ),
+            }
+
+            "from string" {
+                RackId::from(String::from("string-rack")) => (
+                    "string-rack".to_string(),
+                    "string-rack".to_string(),
+                    "string-rack".to_string(),
+                ),
+            }
         );
     }
 
     #[test]
     fn test_rack_id_serde_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "valid string",
-                    input: "\"my-custom-rack\"",
-                    expect: Yields("my-custom-rack".to_string()),
-                },
-                Case {
-                    scenario: "empty string",
-                    input: "\"\"",
-                    expect: Yields(String::new()),
-                },
-                Case {
-                    scenario: "non-string JSON",
-                    input: "42",
-                    expect: Fails,
-                },
-            ],
-            deserialize_rack_id,
+        scenarios!(
+            run = deserialize_rack_id;
+            "valid string" {
+                "\"my-custom-rack\"" => Yields("my-custom-rack".to_string()),
+            }
+
+            "empty string" {
+                "\"\"" => Yields(String::new()),
+            }
+
+            "non-string JSON" {
+                "42" => Fails,
+            }
         );
 
         let serialized = serde_json::to_string(&RackId::new("my-custom-rack"))
@@ -433,91 +413,73 @@ mod tests {
 
     #[test]
     fn test_rack_profile_id_parse_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "rack profile name",
-                    input: "NVL72",
-                    expect: Yields("NVL72".to_string()),
-                },
-                Case {
-                    scenario: "lowercase rack profile name",
-                    input: "nvl36",
-                    expect: Yields("nvl36".to_string()),
-                },
-                Case {
-                    scenario: "empty rack profile ID",
-                    input: "",
-                    expect: FailsWith(ParseFailure::Empty),
-                },
-            ],
-            parse_rack_profile_id,
+        scenarios!(
+            run = parse_rack_profile_id;
+            "rack profile name" {
+                "NVL72" => Yields("NVL72".to_string()),
+            }
+
+            "lowercase rack profile name" {
+                "nvl36" => Yields("nvl36".to_string()),
+            }
+
+            "empty rack profile ID" {
+                "" => FailsWith(ParseFailure::Empty),
+            }
         );
     }
 
     #[test]
     fn test_rack_profile_id_conversions() {
-        check_values(
-            [
-                Check {
-                    scenario: "new",
-                    input: RackProfileId::new("NVL72"),
-                    expect: (
-                        "NVL72".to_string(),
-                        "NVL72".to_string(),
-                        "NVL72".to_string(),
-                    ),
-                },
-                Check {
-                    scenario: "from str",
-                    input: RackProfileId::from("NVL36"),
-                    expect: (
-                        "NVL36".to_string(),
-                        "NVL36".to_string(),
-                        "NVL36".to_string(),
-                    ),
-                },
-                Check {
-                    scenario: "from string",
-                    input: RackProfileId::from(String::from("GB200")),
-                    expect: (
-                        "GB200".to_string(),
-                        "GB200".to_string(),
-                        "GB200".to_string(),
-                    ),
-                },
-            ],
-            |profile_id| {
+        value_scenarios!(
+            run = |profile_id| {
                 (
                     profile_id.as_str().to_string(),
                     profile_id.to_string(),
                     profile_id.as_ref().to_string(),
                 )
-            },
+            };
+            "new" {
+                RackProfileId::new("NVL72") => (
+                    "NVL72".to_string(),
+                    "NVL72".to_string(),
+                    "NVL72".to_string(),
+                ),
+            }
+
+            "from str" {
+                RackProfileId::from("NVL36") => (
+                    "NVL36".to_string(),
+                    "NVL36".to_string(),
+                    "NVL36".to_string(),
+                ),
+            }
+
+            "from string" {
+                RackProfileId::from(String::from("GB200")) => (
+                    "GB200".to_string(),
+                    "GB200".to_string(),
+                    "GB200".to_string(),
+                ),
+            }
         );
     }
 
     #[test]
     fn test_rack_profile_id_serde_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "valid string",
-                    input: "\"NVL72\"",
-                    expect: Yields("NVL72".to_string()),
-                },
-                Case {
-                    scenario: "empty string",
-                    input: "\"\"",
-                    expect: Yields(String::new()),
-                },
-                Case {
-                    scenario: "non-string JSON",
-                    input: "42",
-                    expect: Fails,
-                },
-            ],
-            deserialize_rack_profile_id,
+        scenarios!(
+            run = deserialize_rack_profile_id;
+            "valid string" {
+                "\"NVL72\"" => Yields("NVL72".to_string()),
+            }
+
+            "empty string" {
+                "\"\"" => Yields(String::new()),
+            }
+
+            "non-string JSON" {
+                "42" => Fails,
+            }
         );
 
         let serialized = serde_json::to_string(&RackProfileId::new("NVL72"))

--- a/crates/uuid/src/switch/mod.rs
+++ b/crates/uuid/src/switch/mod.rs
@@ -462,7 +462,7 @@ mod legacy_rpc {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -487,100 +487,77 @@ mod tests {
     fn test_switch_id_parse_cases() {
         const VALID_SWITCH_ID: &str = "sw100nt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg";
 
-        check_cases(
-            [
-                Case {
-                    scenario: "valid NVLink TPM switch ID",
-                    input: VALID_SWITCH_ID,
-                    expect: Yields(VALID_SWITCH_ID.to_string()),
-                },
-                Case {
-                    scenario: "one character short",
-                    input: "sw100nt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hc",
-                    expect: FailsWith(ParseFailure::Length),
-                },
-                Case {
-                    scenario: "empty string",
-                    input: "",
-                    expect: FailsWith(ParseFailure::Length),
-                },
-                Case {
-                    scenario: "invalid prefix casing",
-                    input: "SW100nt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
-                    expect: FailsWith(ParseFailure::Prefix),
-                },
-                Case {
-                    scenario: "invalid switch type",
-                    input: "sw100xt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
-                    expect: FailsWith(ParseFailure::Prefix),
-                },
-                Case {
-                    scenario: "invalid source",
-                    input: "sw100nx038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg",
-                    expect: FailsWith(ParseFailure::Prefix),
-                },
-                Case {
-                    scenario: "invalid base32 payload",
-                    input: "sw100nt038bg3qsho433vkg684heguv28!qaggmrsh2ugn1qk096n2c6hcg",
-                    expect: FailsWith(ParseFailure::Encoding),
-                },
-            ],
-            parse_switch_id,
+        scenarios!(
+            run = parse_switch_id;
+            "valid NVLink TPM switch ID" {
+                VALID_SWITCH_ID => Yields(VALID_SWITCH_ID.to_string()),
+            }
+
+            "one character short" {
+                "sw100nt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hc" => FailsWith(ParseFailure::Length),
+            }
+
+            "empty string" {
+                "" => FailsWith(ParseFailure::Length),
+            }
+
+            "invalid prefix casing" {
+                "SW100nt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg" => FailsWith(ParseFailure::Prefix),
+            }
+
+            "invalid switch type" {
+                "sw100xt038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg" => FailsWith(ParseFailure::Prefix),
+            }
+
+            "invalid source" {
+                "sw100nx038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg" => FailsWith(ParseFailure::Prefix),
+            }
+
+            "invalid base32 payload" {
+                "sw100nt038bg3qsho433vkg684heguv28!qaggmrsh2ugn1qk096n2c6hcg" => FailsWith(ParseFailure::Encoding),
+            }
         );
     }
 
     #[test]
     fn test_switch_type_mappings() {
-        check_values(
-            [Check {
-                scenario: "NVLink",
-                input: SwitchType::NvLink,
-                expect: ('n', "NvLink".to_string()),
-            }],
-            |ty| (ty.id_char(), ty.to_string()),
+        value_scenarios!(
+            run = |ty| (ty.id_char(), ty.to_string());
+            "NVLink" {
+                SwitchType::NvLink => ('n', "NvLink".to_string()),
+            }
         );
     }
 
     #[test]
     fn test_switch_type_from_id_char() {
-        check_values(
-            [
-                Check {
-                    scenario: "NVLink",
-                    input: 'n',
-                    expect: Some(SwitchType::NvLink),
-                },
-                Check {
-                    scenario: "unknown",
-                    input: 'x',
-                    expect: None,
-                },
-            ],
-            SwitchType::from_id_char,
+        value_scenarios!(
+            run = SwitchType::from_id_char;
+            "NVLink" {
+                'n' => Some(SwitchType::NvLink),
+            }
+
+            "unknown" {
+                'x' => None,
+            }
         );
     }
 
     #[test]
     fn test_switch_id_source_from_id_char() {
-        check_values(
-            [
-                Check {
-                    scenario: "TPM",
-                    input: 't',
-                    expect: Some(SwitchIdSource::Tpm),
-                },
-                Check {
-                    scenario: "product board chassis serial",
-                    input: 's',
-                    expect: Some(SwitchIdSource::ProductBoardChassisSerial),
-                },
-                Check {
-                    scenario: "unknown",
-                    input: 'x',
-                    expect: None,
-                },
-            ],
-            SwitchIdSource::from_id_char,
+        value_scenarios!(
+            run = SwitchIdSource::from_id_char;
+            "TPM" {
+                't' => Some(SwitchIdSource::Tpm),
+            }
+
+            "product board chassis serial" {
+                's' => Some(SwitchIdSource::ProductBoardChassisSerial),
+            }
+
+            "unknown" {
+                'x' => None,
+            }
         );
     }
 }


### PR DESCRIPTION
This supports #3914.

## Description

The `carbide-uuid` tests are intentionally dense now: resource IDs, encoded IDs, prefixes, serde, and parsing boundaries all sit in table-driven rows. The coverage is useful, but the repeated row structs still pull attention away from the IDs being exercised.

This moves the literal typed-ID tables onto `scenarios!`/`value_scenarios!` and leaves the expected values right next to the inputs. The tests keep the same accepted and rejected ID examples, just grouped by the behavior a reader is usually looking for.

All tests pass, and formatting/clippy checks are clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Commands:
- `cargo make format-nightly`
- `cargo make check-format-nightly`
- `cargo test -p carbide-uuid`
- `cargo clippy -p carbide-uuid -- -D warnings`
- `cargo clippy -p carbide-uuid --tests -- -D warnings`