### PR TITLE
test(rpc): group conversion tables into scenarios

### DIFF
--- a/crates/rpc/src/forge_tls_client.rs
+++ b/crates/rpc/src/forge_tls_client.rs
@@ -749,7 +749,7 @@ pub type ForgeHttpsClientResult<T> = Result<T, ForgeTlsClientError>;
 mod tests {
     use std::net::SocketAddr;
 
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::value_scenarios;
     use forge_http_connector::connector::ConnectorMetrics;
     use hyper_rustls::HttpsConnector;
 
@@ -871,21 +871,16 @@ mod tests {
 
         // `format_error_chain` appends the deepest `source()` when it differs
         // from the top-level message, otherwise returns the top message alone.
-        check_values(
-            [
-                Check {
-                    scenario: "walks source chain to the root cause",
-                    input: Box::new(Outer::from(Inner)) as Box<dyn std::error::Error>,
-                    expect: "client error (Connect): invalid peer certificate: UnknownIssuer"
-                        .to_string(),
-                },
-                Check {
-                    scenario: "no source returns top message",
-                    input: Box::new(Plain) as Box<dyn std::error::Error>,
-                    expect: "only message".to_string(),
-                },
-            ],
-            |err| format_error_chain(err.as_ref()),
+        value_scenarios!(
+            run = |err| format_error_chain(err.as_ref());
+            "walks source chain to the root cause" {
+                Box::new(Outer::from(Inner)) as Box<dyn std::error::Error> => "client error (Connect): invalid peer certificate: UnknownIssuer"
+                .to_string(),
+            }
+
+            "no source returns top message" {
+                Box::new(Plain) as Box<dyn std::error::Error> => "only message".to_string(),
+            }
         );
     }
 }

--- a/crates/rpc/src/libmlx.rs
+++ b/crates/rpc/src/libmlx.rs
@@ -119,7 +119,7 @@ impl From<FirmwareFlashReportPb> for FirmwareFlashReport {
 #[cfg(test)]
 mod test {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -129,51 +129,45 @@ mod test {
     // `Into<MlxDeviceInfoPb>` first.
     #[test]
     fn device_info_proto_to_model() {
-        check_cases(
-            [
-                Case {
-                    scenario: "full device roundtrips",
-                    input: MlxDeviceInfo::create_test_device().into(),
-                    expect: Yields(MlxDeviceInfo::create_test_device()),
-                },
-                Case {
-                    scenario: "missing-data device roundtrips",
-                    input: MlxDeviceInfo::create_test_device_with_missing_data().into(),
-                    expect: Yields(MlxDeviceInfo::create_test_device_with_missing_data()),
-                },
-                Case {
-                    scenario: "empty string fields become none",
-                    input: MlxDeviceInfoPb {
-                        pci_name: "01:00.0".to_string(),
-                        device_type: "BlueField3".to_string(),
-                        psid: "".to_string(), // Empty string should become None
-                        device_description: "".to_string(),
-                        part_number: "".to_string(),
-                        fw_version_current: "".to_string(),
-                        pxe_version_current: "".to_string(),
-                        uefi_version_current: "".to_string(),
-                        uefi_version_virtio_blk_current: "".to_string(),
-                        uefi_version_virtio_net_current: "".to_string(),
-                        base_mac: "".to_string(), // Empty MAC becomes None
-                        status: "".to_string(),
-                    },
-                    expect: Yields(MlxDeviceInfo {
-                        pci_name: "01:00.0".to_string(),
-                        device_type: "BlueField3".to_string(),
-                        psid: None,
-                        device_description: None,
-                        part_number: None,
-                        fw_version_current: None,
-                        pxe_version_current: None,
-                        uefi_version_current: None,
-                        uefi_version_virtio_blk_current: None,
-                        uefi_version_virtio_net_current: None,
-                        base_mac: None,
-                        status: None,
-                    }),
-                },
-            ],
-            |proto: MlxDeviceInfoPb| MlxDeviceInfo::try_from(proto).map_err(drop),
+        scenarios!(
+            run = |proto: MlxDeviceInfoPb| MlxDeviceInfo::try_from(proto).map_err(drop);
+            "full device roundtrips" {
+                MlxDeviceInfo::create_test_device().into() => Yields(MlxDeviceInfo::create_test_device()),
+            }
+
+            "missing-data device roundtrips" {
+                MlxDeviceInfo::create_test_device_with_missing_data().into() => Yields(MlxDeviceInfo::create_test_device_with_missing_data()),
+            }
+
+            "empty string fields become none" {
+                MlxDeviceInfoPb {
+                    pci_name: "01:00.0".to_string(),
+                    device_type: "BlueField3".to_string(),
+                    psid: "".to_string(), // Empty string should become None
+                    device_description: "".to_string(),
+                    part_number: "".to_string(),
+                    fw_version_current: "".to_string(),
+                    pxe_version_current: "".to_string(),
+                    uefi_version_current: "".to_string(),
+                    uefi_version_virtio_blk_current: "".to_string(),
+                    uefi_version_virtio_net_current: "".to_string(),
+                    base_mac: "".to_string(), // Empty MAC becomes None
+                    status: "".to_string(),
+                } => Yields(MlxDeviceInfo {
+                    pci_name: "01:00.0".to_string(),
+                    device_type: "BlueField3".to_string(),
+                    psid: None,
+                    device_description: None,
+                    part_number: None,
+                    fw_version_current: None,
+                    pxe_version_current: None,
+                    uefi_version_current: None,
+                    uefi_version_virtio_blk_current: None,
+                    uefi_version_virtio_net_current: None,
+                    base_mac: None,
+                    status: None,
+                }),
+            }
         );
     }
 
@@ -182,60 +176,8 @@ mod test {
     // asserted; the conversions are total (`From`), hence `check_values`.
     #[test]
     fn firmware_flash_report_roundtrip() {
-        check_values(
-            [
-                Check {
-                    scenario: "all steps success",
-                    input: FirmwareFlashReport {
-                        flashed: true,
-                        reset: Some(true),
-                        verified_image: Some(true),
-                        verified_version: Some(true),
-                        observed_version: Some("32.43.1014".to_string()),
-                        expected_version: Some("32.43.1014".to_string()),
-                    },
-                    expect: (
-                        true,
-                        Some(true),
-                        Some(true),
-                        Some(true),
-                        Some("32.43.1014".to_string()),
-                        Some("32.43.1014".to_string()),
-                    ),
-                },
-                Check {
-                    scenario: "flash only",
-                    input: FirmwareFlashReport {
-                        flashed: true,
-                        reset: None,
-                        verified_image: None,
-                        verified_version: None,
-                        observed_version: None,
-                        expected_version: None,
-                    },
-                    expect: (true, None, None, None, None, None),
-                },
-                Check {
-                    scenario: "partial failure",
-                    input: FirmwareFlashReport {
-                        flashed: true,
-                        reset: Some(false),
-                        verified_image: Some(false),
-                        verified_version: Some(false),
-                        observed_version: Some("32.42.900".to_string()),
-                        expected_version: Some("32.43.1014".to_string()),
-                    },
-                    expect: (
-                        true,
-                        Some(false),
-                        Some(false),
-                        Some(false),
-                        Some("32.42.900".to_string()),
-                        Some("32.43.1014".to_string()),
-                    ),
-                },
-            ],
-            |original: FirmwareFlashReport| {
+        value_scenarios!(
+            run = |original: FirmwareFlashReport| {
                 let proto: FirmwareFlashReportPb = original.into();
                 let converted: FirmwareFlashReport = proto.into();
                 (
@@ -246,7 +188,53 @@ mod test {
                     converted.observed_version,
                     converted.expected_version,
                 )
-            },
+            };
+            "all steps success" {
+                FirmwareFlashReport {
+                    flashed: true,
+                    reset: Some(true),
+                    verified_image: Some(true),
+                    verified_version: Some(true),
+                    observed_version: Some("32.43.1014".to_string()),
+                    expected_version: Some("32.43.1014".to_string()),
+                } => (
+                    true,
+                    Some(true),
+                    Some(true),
+                    Some(true),
+                    Some("32.43.1014".to_string()),
+                    Some("32.43.1014".to_string()),
+                ),
+            }
+
+            "flash only" {
+                FirmwareFlashReport {
+                    flashed: true,
+                    reset: None,
+                    verified_image: None,
+                    verified_version: None,
+                    observed_version: None,
+                    expected_version: None,
+                } => (true, None, None, None, None, None),
+            }
+
+            "partial failure" {
+                FirmwareFlashReport {
+                    flashed: true,
+                    reset: Some(false),
+                    verified_image: Some(false),
+                    verified_version: Some(false),
+                    observed_version: Some("32.42.900".to_string()),
+                    expected_version: Some("32.43.1014".to_string()),
+                } => (
+                    true,
+                    Some(false),
+                    Some(false),
+                    Some(false),
+                    Some("32.42.900".to_string()),
+                    Some("32.43.1014".to_string()),
+                ),
+            }
         );
     }
 

--- a/crates/rpc/src/model/expected_machine.rs
+++ b/crates/rpc/src/model/expected_machine.rs
@@ -269,7 +269,7 @@ fn metadata_from_request(
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -280,30 +280,23 @@ mod tests {
     /// exactly what `rpc::forge::DpuMode::from(model)` produces.
     #[test]
     fn rpc_dpu_mode_maps_to_model() {
-        check_values(
-            [
-                Check {
-                    scenario: "unspecified maps to default",
-                    input: rpc::forge::DpuMode::Unspecified,
-                    expect: DpuMode::default(),
-                },
-                Check {
-                    scenario: "dpu mode round trips",
-                    input: rpc::forge::DpuMode::DpuMode,
-                    expect: DpuMode::DpuMode,
-                },
-                Check {
-                    scenario: "nic mode round trips",
-                    input: rpc::forge::DpuMode::NicMode,
-                    expect: DpuMode::NicMode,
-                },
-                Check {
-                    scenario: "no dpu round trips",
-                    input: rpc::forge::DpuMode::NoDpu,
-                    expect: DpuMode::NoDpu,
-                },
-            ],
-            DpuMode::from,
+        value_scenarios!(
+            run = DpuMode::from;
+            "unspecified maps to default" {
+                rpc::forge::DpuMode::Unspecified => DpuMode::default(),
+            }
+
+            "dpu mode round trips" {
+                rpc::forge::DpuMode::DpuMode => DpuMode::DpuMode,
+            }
+
+            "nic mode round trips" {
+                rpc::forge::DpuMode::NicMode => DpuMode::NicMode,
+            }
+
+            "no dpu round trips" {
+                rpc::forge::DpuMode::NoDpu => DpuMode::NoDpu,
+            }
         );
     }
 
@@ -363,25 +356,8 @@ mod tests {
     /// back, so the back-side projection is `None` rather than `Some(None)`.
     #[test]
     fn disable_lockdown_round_trips_through_proto() {
-        check_cases(
-            [
-                Case {
-                    scenario: "true",
-                    input: Some(true),
-                    expect: Yields((Some(true), Some(Some(true)))),
-                },
-                Case {
-                    scenario: "false",
-                    input: Some(false),
-                    expect: Yields((Some(false), Some(Some(false)))),
-                },
-                Case {
-                    scenario: "none",
-                    input: None,
-                    expect: Yields((None, None)),
-                },
-            ],
-            |disable_lockdown| {
+        scenarios!(
+            run = |disable_lockdown| {
                 let data =
                     ExpectedMachineData::try_from(make_rpc_expected_machine(disable_lockdown))
                         .map_err(drop)?;
@@ -396,7 +372,18 @@ mod tests {
                 let back_side = back.host_lifecycle_profile.map(|p| p.disable_lockdown);
 
                 Ok::<_, ()>((data_side, back_side))
-            },
+            };
+            "true" {
+                Some(true) => Yields((Some(true), Some(Some(true)))),
+            }
+
+            "false" {
+                Some(false) => Yields((Some(false), Some(Some(false)))),
+            }
+
+            "none" {
+                None => Yields((None, None)),
+            }
         );
     }
 }

--- a/crates/rpc/src/model/instance/config/network.rs
+++ b/crates/rpc/src/model/instance/config/network.rs
@@ -420,7 +420,7 @@ impl TryFrom<rpc::forge::instance_interface_config::NetworkDetails> for NetworkD
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
     use carbide_uuid::network::NetworkSegmentId;
     use carbide_uuid::vpc::VpcPrefixId;
     use model::instance::config::network::{INTERFACE_VFID_MAX, INTERFACE_VFID_MIN};
@@ -625,35 +625,8 @@ mod tests {
         let mut mix = get_rpc_instance_network_config();
         mix[2].virtual_function_id = None;
 
-        check_cases(
-            [
-                Case {
-                    scenario: "all VF ids present after converting",
-                    input: all,
-                    expect: Yields(vec![0, 1, 2]),
-                },
-                Case {
-                    scenario: "removed vf_id 1 is absent from the parsed config",
-                    input: missing_1,
-                    expect: Yields(vec![0, 2]),
-                },
-                Case {
-                    scenario: "only a physical interface yields no VF ids",
-                    input: only_physical,
-                    expect: Yields(vec![]),
-                },
-                Case {
-                    scenario: "duplicate VF id is rejected",
-                    input: duplicate,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "mix of None and valid VF ids is rejected",
-                    input: mix,
-                    expect: Fails,
-                },
-            ],
-            |interfaces| {
+        scenarios!(
+            run = |interfaces| {
                 let network_config = rpc::InstanceNetworkConfig {
                     interfaces,
                     auto: false,
@@ -670,7 +643,26 @@ mod tests {
                     .sorted()
                     .collect_vec();
                 Ok::<_, ()>(vf_ids)
-            },
+            };
+            "all VF ids present after converting" {
+                all => Yields(vec![0, 1, 2]),
+            }
+
+            "removed vf_id 1 is absent from the parsed config" {
+                missing_1 => Yields(vec![0, 2]),
+            }
+
+            "only a physical interface yields no VF ids" {
+                only_physical => Yields(vec![]),
+            }
+
+            "duplicate VF id is rejected" {
+                duplicate => Fails,
+            }
+
+            "mix of None and valid VF ids is rejected" {
+                mix => Fails,
+            }
         );
     }
 
@@ -911,31 +903,25 @@ mod tests {
             routing_profile: None,
         };
 
-        check_values(
-            [
-                Check {
-                    scenario: "ipv6 without vpc_prefix_id is rejected",
-                    input: ipv6_without_vpc_prefix,
-                    expect: false,
-                },
-                Check {
-                    scenario: "ipv6 ip_address with ipv6_interface_config is rejected",
-                    input: v6_ip_with_ipv6_config,
-                    expect: false,
-                },
-                Check {
-                    scenario: "ipv4 ip_address with ipv6_interface_config is allowed",
-                    input: v4_ip_with_ipv6_config,
-                    expect: true,
-                },
-            ],
-            |iface| {
+        value_scenarios!(
+            run = |iface| {
                 let rpc_config = rpc::InstanceNetworkConfig {
                     interfaces: vec![iface],
                     auto: false,
                 };
                 InstanceNetworkConfig::try_from(rpc_config).is_ok()
-            },
+            };
+            "ipv6 without vpc_prefix_id is rejected" {
+                ipv6_without_vpc_prefix => false,
+            }
+
+            "ipv6 ip_address with ipv6_interface_config is rejected" {
+                v6_ip_with_ipv6_config => false,
+            }
+
+            "ipv4 ip_address with ipv6_interface_config is allowed" {
+                v4_ip_with_ipv6_config => true,
+            }
         );
     }
 

--- a/crates/rpc/src/model/instance/status/tenant.rs
+++ b/crates/rpc/src/model/instance/status/tenant.rs
@@ -175,7 +175,7 @@ mod tests {
     use std::str::FromStr;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::scenarios;
     use carbide_uuid::machine::MachineId;
     use chrono::Utc;
     use health_report::{HealthReport, REPAIR_REQUEST_MERGE_SOURCE};
@@ -218,64 +218,8 @@ mod tests {
 
         // Each row: a (machine_state, configs_synced) pair under repair_active=true,
         // exercising which states repair-merge does or does not override.
-        check_cases(
-            [
-                Case {
-                    scenario: "tenant-ready with repair merge",
-                    input: (
-                        ManagedHostState::Assigned {
-                            instance_state: InstanceState::Ready,
-                        },
-                        SyncState::Synced,
-                    ),
-                    expect: Yields(TenantState::Repairing),
-                },
-                Case {
-                    scenario: "terminating with repair merge",
-                    input: (
-                        ManagedHostState::Assigned {
-                            instance_state: InstanceState::SwitchToAdminNetwork,
-                        },
-                        SyncState::Synced,
-                    ),
-                    expect: Yields(TenantState::Terminating),
-                },
-                Case {
-                    scenario: "reprovision with repair merge",
-                    input: (
-                        ManagedHostState::Assigned {
-                            instance_state: InstanceState::DPUReprovision {
-                                dpu_states: DpuReprovisionStates {
-                                    states: HashMap::new(),
-                                },
-                            },
-                        },
-                        SyncState::Synced,
-                    ),
-                    expect: Yields(TenantState::Updating),
-                },
-                Case {
-                    scenario: "configuring with repair merge",
-                    input: (
-                        ManagedHostState::Assigned {
-                            instance_state: InstanceState::Ready,
-                        },
-                        SyncState::Pending,
-                    ),
-                    expect: Yields(TenantState::Configuring),
-                },
-                Case {
-                    scenario: "failed with repair merge",
-                    input: (
-                        ManagedHostState::Assigned {
-                            instance_state: failed,
-                        },
-                        SyncState::Synced,
-                    ),
-                    expect: Yields(TenantState::Failed),
-                },
-            ],
-            |(machine_state, configs_synced)| {
+        scenarios!(
+            run = |(machine_state, configs_synced)| {
                 instance_status_tenant_state(
                     machine_state,
                     configs_synced,
@@ -286,7 +230,55 @@ mod tests {
                     true,
                 )
                 .map_err(drop)
-            },
+            };
+            "tenant-ready with repair merge" {
+                (
+                    ManagedHostState::Assigned {
+                        instance_state: InstanceState::Ready,
+                    },
+                    SyncState::Synced,
+                ) => Yields(TenantState::Repairing),
+            }
+
+            "terminating with repair merge" {
+                (
+                    ManagedHostState::Assigned {
+                        instance_state: InstanceState::SwitchToAdminNetwork,
+                    },
+                    SyncState::Synced,
+                ) => Yields(TenantState::Terminating),
+            }
+
+            "reprovision with repair merge" {
+                (
+                    ManagedHostState::Assigned {
+                        instance_state: InstanceState::DPUReprovision {
+                            dpu_states: DpuReprovisionStates {
+                                states: HashMap::new(),
+                            },
+                        },
+                    },
+                    SyncState::Synced,
+                ) => Yields(TenantState::Updating),
+            }
+
+            "configuring with repair merge" {
+                (
+                    ManagedHostState::Assigned {
+                        instance_state: InstanceState::Ready,
+                    },
+                    SyncState::Pending,
+                ) => Yields(TenantState::Configuring),
+            }
+
+            "failed with repair merge" {
+                (
+                    ManagedHostState::Assigned {
+                        instance_state: failed,
+                    },
+                    SyncState::Synced,
+                ) => Yields(TenantState::Failed),
+            }
         );
     }
 
@@ -294,39 +286,8 @@ mod tests {
     fn operator_managed_allocations_project_as_tenant_ready() {
         // Allocated/network-wait states where Flat has no NICo readiness signal:
         // operator-managed networking should not wait on network observations.
-        check_cases(
-            [
-                Case {
-                    scenario: "allocated before state controller pickup",
-                    input: ManagedHostState::Ready,
-                    expect: Yields(TenantState::Ready),
-                },
-                Case {
-                    scenario: "assigned init",
-                    input: ManagedHostState::Assigned {
-                        instance_state: InstanceState::Init,
-                    },
-                    expect: Yields(TenantState::Ready),
-                },
-                Case {
-                    scenario: "waiting for network config",
-                    input: ManagedHostState::Assigned {
-                        instance_state: InstanceState::WaitingForNetworkConfig,
-                    },
-                    expect: Yields(TenantState::Ready),
-                },
-                Case {
-                    scenario: "network config update",
-                    input: ManagedHostState::Assigned {
-                        instance_state: InstanceState::NetworkConfigUpdate {
-                            network_config_update_state:
-                                model::machine::NetworkConfigUpdateState::WaitingForNetworkSegmentToBeReady,
-                        },
-                    },
-                    expect: Yields(TenantState::Ready),
-                },
-            ],
-            |machine_state| {
+        scenarios!(
+            run = |machine_state| {
                 instance_status_tenant_state(
                     machine_state,
                     SyncState::Pending,
@@ -337,7 +298,31 @@ mod tests {
                     false,
                 )
                 .map_err(drop)
-            },
+            };
+            "allocated before state controller pickup" {
+                ManagedHostState::Ready => Yields(TenantState::Ready),
+            }
+
+            "assigned init" {
+                ManagedHostState::Assigned {
+                    instance_state: InstanceState::Init,
+                } => Yields(TenantState::Ready),
+            }
+
+            "waiting for network config" {
+                ManagedHostState::Assigned {
+                    instance_state: InstanceState::WaitingForNetworkConfig,
+                } => Yields(TenantState::Ready),
+            }
+
+            "network config update" {
+                ManagedHostState::Assigned {
+                    instance_state: InstanceState::NetworkConfigUpdate {
+                        network_config_update_state:
+                            model::machine::NetworkConfigUpdateState::WaitingForNetworkSegmentToBeReady,
+                    },
+                } => Yields(TenantState::Ready),
+            }
         );
     }
 }

--- a/crates/rpc/src/model/instance_type.rs
+++ b/crates/rpc/src/model/instance_type.rs
@@ -133,7 +133,7 @@ mod tests {
     use std::collections::HashMap;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_values};
+    use carbide_test_support::{Case, value_scenarios};
     use config_version::ConfigVersion;
     use model::machine::capabilities;
     use model::metadata::Metadata;
@@ -319,60 +319,78 @@ mod tests {
     // sets against the full set) into one table over (InstanceType, set).
     #[test]
     fn instance_type_matches_capability_set() {
-        check_values(
-            [
-                Check {
-                    scenario: "empty machine fails to match a typed filter",
-                    input: (
-                        inst_type_with(vec![InstanceTypeMachineCapabilityFilter {
+        value_scenarios!(
+            run = |(inst_type, machine_cap_set)| inst_type.matches_capability_set(&machine_cap_set);
+            "empty machine fails to match a typed filter" {
+                (
+                    inst_type_with(vec![InstanceTypeMachineCapabilityFilter {
+                        capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                            .try_into()
+                            .unwrap(),
+                        ..Default::default()
+                    }]),
+                    empty_cap_set(),
+                ) => false,
+            }
+
+            "loose match on just the type" {
+                (
+                    inst_type_with(vec![InstanceTypeMachineCapabilityFilter {
+                        capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                            .try_into()
+                            .unwrap(),
+                        ..Default::default()
+                    }]),
+                    cpu_only_cap_set(),
+                ) => true,
+            }
+
+            "zero-count filter for an absent type still matches" {
+                (
+                    inst_type_with(vec![
+                        InstanceTypeMachineCapabilityFilter {
                             capability_type: rpc::MachineCapabilityType::CapTypeCpu
                                 .try_into()
                                 .unwrap(),
                             ..Default::default()
-                        }]),
-                        empty_cap_set(),
-                    ),
-                    expect: false,
-                },
-                Check {
-                    scenario: "loose match on just the type",
-                    input: (
-                        inst_type_with(vec![InstanceTypeMachineCapabilityFilter {
-                            capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                        },
+                        InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeDpu
                                 .try_into()
                                 .unwrap(),
+                            count: Some(0),
                             ..Default::default()
-                        }]),
-                        cpu_only_cap_set(),
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "zero-count filter for an absent type still matches",
-                    input: (
-                        inst_type_with(vec![
-                            InstanceTypeMachineCapabilityFilter {
-                                capability_type: rpc::MachineCapabilityType::CapTypeCpu
-                                    .try_into()
-                                    .unwrap(),
-                                ..Default::default()
-                            },
-                            InstanceTypeMachineCapabilityFilter {
-                                capability_type: rpc::MachineCapabilityType::CapTypeDpu
-                                    .try_into()
-                                    .unwrap(),
-                                count: Some(0),
-                                ..Default::default()
-                            },
-                        ]),
-                        cpu_only_cap_set(),
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "specific single CPU filter matches the full set",
-                    input: (
-                        inst_type_with(vec![InstanceTypeMachineCapabilityFilter {
+                        },
+                    ]),
+                    cpu_only_cap_set(),
+                ) => true,
+            }
+
+            "specific single CPU filter matches the full set" {
+                (
+                    inst_type_with(vec![InstanceTypeMachineCapabilityFilter {
+                        capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                            .try_into()
+                            .unwrap(),
+                        name: Some("pentium 4 HT".to_string()),
+                        frequency: Some("1.3 GHz".to_string()),
+                        capacity: None,
+                        vendor: Some("intel".to_string()),
+                        count: Some(1),
+                        hardware_revision: None,
+                        cores: Some(1),
+                        threads: Some(2),
+                        inactive_devices: None,
+                        device_type: Some(capabilities::MachineCapabilityDeviceType::Unknown),
+                    }]),
+                    full_cap_set(),
+                ) => true,
+            }
+
+            "full multi-category filter set with names matches" {
+                (
+                    inst_type_with(vec![
+                        InstanceTypeMachineCapabilityFilter {
                             capability_type: rpc::MachineCapabilityType::CapTypeCpu
                                 .try_into()
                                 .unwrap(),
@@ -384,177 +402,150 @@ mod tests {
                             hardware_revision: None,
                             cores: Some(1),
                             threads: Some(2),
-                            inactive_devices: None,
-                            device_type: Some(capabilities::MachineCapabilityDeviceType::Unknown),
-                        }]),
-                        full_cap_set(),
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "full multi-category filter set with names matches",
-                    input: (
-                        inst_type_with(vec![
-                            InstanceTypeMachineCapabilityFilter {
-                                capability_type: rpc::MachineCapabilityType::CapTypeCpu
-                                    .try_into()
-                                    .unwrap(),
-                                name: Some("pentium 4 HT".to_string()),
-                                frequency: Some("1.3 GHz".to_string()),
-                                capacity: None,
-                                vendor: Some("intel".to_string()),
-                                count: Some(1),
-                                hardware_revision: None,
-                                cores: Some(1),
-                                threads: Some(2),
-                                ..Default::default()
-                            },
-                            InstanceTypeMachineCapabilityFilter {
-                                capability_type: rpc::MachineCapabilityType::CapTypeGpu
-                                    .try_into()
-                                    .unwrap(),
-                                name: Some("rtx6000".to_string()),
-                                frequency: None,
-                                vendor: Some("nvidia".to_string()),
-                                count: Some(1),
-                                cores: Some(1),
-                                threads: Some(2),
-                                capacity: Some("12 GB".to_string()),
-                                ..Default::default()
-                            },
-                            InstanceTypeMachineCapabilityFilter {
-                                capability_type: rpc::MachineCapabilityType::CapTypeMemory
-                                    .try_into()
-                                    .unwrap(),
-                                name: Some("ddr4".to_string()),
-                                vendor: Some("micron".to_string()),
-                                count: Some(1),
-                                capacity: Some("16 GB".to_string()),
-                                ..Default::default()
-                            },
-                            InstanceTypeMachineCapabilityFilter {
-                                capability_type: rpc::MachineCapabilityType::CapTypeStorage
-                                    .try_into()
-                                    .unwrap(),
-                                name: Some("HDD".to_string()),
-                                vendor: Some("western digital".to_string()),
-                                count: Some(1),
-                                capacity: Some("2 TB".to_string()),
-                                ..Default::default()
-                            },
-                            InstanceTypeMachineCapabilityFilter {
-                                capability_type: rpc::MachineCapabilityType::CapTypeNetwork
-                                    .try_into()
-                                    .unwrap(),
-                                name: Some("e10000".to_string()),
-                                vendor: Some("intel".to_string()),
-                                count: Some(1),
-                                ..Default::default()
-                            },
-                            InstanceTypeMachineCapabilityFilter {
-                                capability_type: rpc::MachineCapabilityType::CapTypeInfiniband
-                                    .try_into()
-                                    .unwrap(),
-                                name: Some("connectx7".to_string()),
-                                vendor: Some("nvidia".to_string()),
-                                count: Some(1),
-                                inactive_devices: Some(vec![2, 4]),
-                                ..Default::default()
-                            },
-                            InstanceTypeMachineCapabilityFilter {
-                                capability_type: rpc::MachineCapabilityType::CapTypeDpu
-                                    .try_into()
-                                    .unwrap(),
-                                name: Some("bluefield3".to_string()),
-                                hardware_revision: Some("abc123".to_string()),
-                                count: Some(1),
-                                ..Default::default()
-                            },
-                        ]),
-                        full_cap_set(),
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "full filter set without names/models matches by type/vendor",
-                    input: (
-                        inst_type_with(vec![
-                            InstanceTypeMachineCapabilityFilter {
-                                name: None,
-                                capability_type: rpc::MachineCapabilityType::CapTypeCpu
-                                    .try_into()
-                                    .unwrap(),
-                                frequency: Some("1.3 GHz".to_string()),
-                                capacity: None,
-                                vendor: Some("intel".to_string()),
-                                count: Some(1),
-                                hardware_revision: None,
-                                cores: Some(1),
-                                threads: Some(2),
-                                ..Default::default()
-                            },
-                            InstanceTypeMachineCapabilityFilter {
-                                capability_type: rpc::MachineCapabilityType::CapTypeGpu
-                                    .try_into()
-                                    .unwrap(),
-                                frequency: None,
-                                vendor: Some("nvidia".to_string()),
-                                count: Some(1),
-                                cores: Some(1),
-                                threads: Some(2),
-                                capacity: Some("12 GB".to_string()),
-                                ..Default::default()
-                            },
-                            InstanceTypeMachineCapabilityFilter {
-                                capability_type: rpc::MachineCapabilityType::CapTypeMemory
-                                    .try_into()
-                                    .unwrap(),
-                                vendor: Some("micron".to_string()),
-                                count: Some(1),
-                                capacity: Some("16 GB".to_string()),
-                                ..Default::default()
-                            },
-                            InstanceTypeMachineCapabilityFilter {
-                                capability_type: rpc::MachineCapabilityType::CapTypeStorage
-                                    .try_into()
-                                    .unwrap(),
-                                vendor: Some("western digital".to_string()),
-                                count: Some(1),
-                                capacity: Some("2 TB".to_string()),
-                                ..Default::default()
-                            },
-                            InstanceTypeMachineCapabilityFilter {
-                                capability_type: rpc::MachineCapabilityType::CapTypeNetwork
-                                    .try_into()
-                                    .unwrap(),
-                                vendor: Some("intel".to_string()),
-                                count: Some(3), // Two intel nics of different speeds: 2x one and 1x the other.
-                                ..Default::default()
-                            },
-                            InstanceTypeMachineCapabilityFilter {
-                                capability_type: rpc::MachineCapabilityType::CapTypeInfiniband
-                                    .try_into()
-                                    .unwrap(),
-                                vendor: Some("nvidia".to_string()),
-                                count: Some(1),
-                                inactive_devices: Some(vec![2, 4]),
-                                ..Default::default()
-                            },
-                            InstanceTypeMachineCapabilityFilter {
-                                capability_type: rpc::MachineCapabilityType::CapTypeDpu
-                                    .try_into()
-                                    .unwrap(),
-                                hardware_revision: Some("abc123".to_string()),
-                                count: Some(1),
-                                ..Default::default()
-                            },
-                        ]),
-                        full_cap_set(),
-                    ),
-                    expect: true,
-                },
-            ],
-            |(inst_type, machine_cap_set)| inst_type.matches_capability_set(&machine_cap_set),
+                            ..Default::default()
+                        },
+                        InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeGpu
+                                .try_into()
+                                .unwrap(),
+                            name: Some("rtx6000".to_string()),
+                            frequency: None,
+                            vendor: Some("nvidia".to_string()),
+                            count: Some(1),
+                            cores: Some(1),
+                            threads: Some(2),
+                            capacity: Some("12 GB".to_string()),
+                            ..Default::default()
+                        },
+                        InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeMemory
+                                .try_into()
+                                .unwrap(),
+                            name: Some("ddr4".to_string()),
+                            vendor: Some("micron".to_string()),
+                            count: Some(1),
+                            capacity: Some("16 GB".to_string()),
+                            ..Default::default()
+                        },
+                        InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeStorage
+                                .try_into()
+                                .unwrap(),
+                            name: Some("HDD".to_string()),
+                            vendor: Some("western digital".to_string()),
+                            count: Some(1),
+                            capacity: Some("2 TB".to_string()),
+                            ..Default::default()
+                        },
+                        InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeNetwork
+                                .try_into()
+                                .unwrap(),
+                            name: Some("e10000".to_string()),
+                            vendor: Some("intel".to_string()),
+                            count: Some(1),
+                            ..Default::default()
+                        },
+                        InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeInfiniband
+                                .try_into()
+                                .unwrap(),
+                            name: Some("connectx7".to_string()),
+                            vendor: Some("nvidia".to_string()),
+                            count: Some(1),
+                            inactive_devices: Some(vec![2, 4]),
+                            ..Default::default()
+                        },
+                        InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeDpu
+                                .try_into()
+                                .unwrap(),
+                            name: Some("bluefield3".to_string()),
+                            hardware_revision: Some("abc123".to_string()),
+                            count: Some(1),
+                            ..Default::default()
+                        },
+                    ]),
+                    full_cap_set(),
+                ) => true,
+            }
+
+            "full filter set without names/models matches by type/vendor" {
+                (
+                    inst_type_with(vec![
+                        InstanceTypeMachineCapabilityFilter {
+                            name: None,
+                            capability_type: rpc::MachineCapabilityType::CapTypeCpu
+                                .try_into()
+                                .unwrap(),
+                            frequency: Some("1.3 GHz".to_string()),
+                            capacity: None,
+                            vendor: Some("intel".to_string()),
+                            count: Some(1),
+                            hardware_revision: None,
+                            cores: Some(1),
+                            threads: Some(2),
+                            ..Default::default()
+                        },
+                        InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeGpu
+                                .try_into()
+                                .unwrap(),
+                            frequency: None,
+                            vendor: Some("nvidia".to_string()),
+                            count: Some(1),
+                            cores: Some(1),
+                            threads: Some(2),
+                            capacity: Some("12 GB".to_string()),
+                            ..Default::default()
+                        },
+                        InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeMemory
+                                .try_into()
+                                .unwrap(),
+                            vendor: Some("micron".to_string()),
+                            count: Some(1),
+                            capacity: Some("16 GB".to_string()),
+                            ..Default::default()
+                        },
+                        InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeStorage
+                                .try_into()
+                                .unwrap(),
+                            vendor: Some("western digital".to_string()),
+                            count: Some(1),
+                            capacity: Some("2 TB".to_string()),
+                            ..Default::default()
+                        },
+                        InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeNetwork
+                                .try_into()
+                                .unwrap(),
+                            vendor: Some("intel".to_string()),
+                            count: Some(3), // Two intel nics of different speeds: 2x one and 1x the other.
+                            ..Default::default()
+                        },
+                        InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeInfiniband
+                                .try_into()
+                                .unwrap(),
+                            vendor: Some("nvidia".to_string()),
+                            count: Some(1),
+                            inactive_devices: Some(vec![2, 4]),
+                            ..Default::default()
+                        },
+                        InstanceTypeMachineCapabilityFilter {
+                            capability_type: rpc::MachineCapabilityType::CapTypeDpu
+                                .try_into()
+                                .unwrap(),
+                            hardware_revision: Some("abc123".to_string()),
+                            count: Some(1),
+                            ..Default::default()
+                        },
+                    ]),
+                    full_cap_set(),
+                ) => true,
+            }
         );
     }
 }

--- a/crates/rpc/src/model/metadata.rs
+++ b/crates/rpc/src/model/metadata.rs
@@ -79,7 +79,7 @@ impl From<rpc::forge::Label> for LabelFilter {
 
 #[cfg(test)]
 mod tests {
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::value_scenarios;
 
     use super::*;
 
@@ -87,37 +87,31 @@ mod tests {
     // fields the originals asserted.
     #[test]
     fn label_filter_from_rpc() {
-        check_values(
-            [
-                Check {
-                    scenario: "with value",
-                    input: rpc::forge::Label {
-                        key: "env".to_string(),
-                        value: Some("prod".to_string()),
-                    },
-                    expect: ("env".to_string(), Some("prod".to_string())),
-                },
-                Check {
-                    scenario: "without value",
-                    input: rpc::forge::Label {
-                        key: "env".to_string(),
-                        value: None,
-                    },
-                    expect: ("env".to_string(), None),
-                },
-                Check {
-                    scenario: "empty key",
-                    input: rpc::forge::Label {
-                        key: String::new(),
-                        value: Some("prod".to_string()),
-                    },
-                    expect: (String::new(), Some("prod".to_string())),
-                },
-            ],
-            |label| {
+        value_scenarios!(
+            run = |label| {
                 let filter = LabelFilter::from(label);
                 (filter.key, filter.value)
-            },
+            };
+            "with value" {
+                rpc::forge::Label {
+                    key: "env".to_string(),
+                    value: Some("prod".to_string()),
+                } => ("env".to_string(), Some("prod".to_string())),
+            }
+
+            "without value" {
+                rpc::forge::Label {
+                    key: "env".to_string(),
+                    value: None,
+                } => ("env".to_string(), None),
+            }
+
+            "empty key" {
+                rpc::forge::Label {
+                    key: String::new(),
+                    value: Some("prod".to_string()),
+                } => (String::new(), Some("prod".to_string())),
+            }
         );
     }
 }

--- a/crates/rpc/src/model/network_security_group.rs
+++ b/crates/rpc/src/model/network_security_group.rs
@@ -630,7 +630,7 @@ mod tests {
     use std::collections::HashMap;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
     use config_version::ConfigVersion;
     use model::metadata::Metadata;
 
@@ -641,132 +641,124 @@ mod tests {
     // status (and any details) from the applied-vs-expected interface counts.
     #[test]
     fn test_model_nsg_prop_obj_status_to_rpc_conversion() {
-        check_values(
-            [
-                Check {
-                    scenario: "full, no interfaces",
-                    input: NetworkSecurityGroupPropagationObjectStatus {
-                        id: "any_id".to_string(),
-                        interfaces_expected: 0,
-                        interfaces_applied: 0,
-                        unpropagated_instance_ids: vec![],
-                        related_instance_ids: vec![],
-                    },
-                    expect: rpc::NetworkSecurityGroupPropagationObjectStatus {
-                        id: "any_id".to_string(),
-                        status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusFull
-                            .into(),
-                        details: None,
-                        unpropagated_instance_ids: vec![],
-                        related_instance_ids: vec![],
-                    },
+        value_scenarios!(
+            run = rpc::NetworkSecurityGroupPropagationObjectStatus::from;
+            "full, no interfaces" {
+                NetworkSecurityGroupPropagationObjectStatus {
+                    id: "any_id".to_string(),
+                    interfaces_expected: 0,
+                    interfaces_applied: 0,
+                    unpropagated_instance_ids: vec![],
+                    related_instance_ids: vec![],
+                } => rpc::NetworkSecurityGroupPropagationObjectStatus {
+                    id: "any_id".to_string(),
+                    status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusFull
+                        .into(),
+                    details: None,
+                    unpropagated_instance_ids: vec![],
+                    related_instance_ids: vec![],
                 },
-                Check {
-                    scenario: "full, all interfaces applied",
-                    input: NetworkSecurityGroupPropagationObjectStatus {
-                        id: "any_id".to_string(),
-                        interfaces_expected: 2,
-                        interfaces_applied: 2,
-                        related_instance_ids: vec![
-                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
-                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
-                        ],
-                        unpropagated_instance_ids: vec![],
-                    },
-                    expect: rpc::NetworkSecurityGroupPropagationObjectStatus {
-                        id: "any_id".to_string(),
-                        status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusFull
-                            .into(),
-                        details: None,
-                        related_instance_ids: vec![
-                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
-                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
-                        ],
-                        unpropagated_instance_ids: vec![],
-                    },
+            }
+
+            "full, all interfaces applied" {
+                NetworkSecurityGroupPropagationObjectStatus {
+                    id: "any_id".to_string(),
+                    interfaces_expected: 2,
+                    interfaces_applied: 2,
+                    related_instance_ids: vec![
+                        "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
+                        "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
+                    ],
+                    unpropagated_instance_ids: vec![],
+                } => rpc::NetworkSecurityGroupPropagationObjectStatus {
+                    id: "any_id".to_string(),
+                    status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusFull
+                        .into(),
+                    details: None,
+                    related_instance_ids: vec![
+                        "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
+                        "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+                    ],
+                    unpropagated_instance_ids: vec![],
                 },
-                Check {
-                    scenario: "partial, some interfaces applied",
-                    input: NetworkSecurityGroupPropagationObjectStatus {
-                        id: "any_id".to_string(),
-                        interfaces_expected: 2,
-                        interfaces_applied: 1,
-                        related_instance_ids: vec![
-                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
-                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
-                        ],
-                        unpropagated_instance_ids: vec![
-                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
-                        ],
-                    },
-                    expect: rpc::NetworkSecurityGroupPropagationObjectStatus {
-                        id: "any_id".to_string(),
-                        status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusPartial
-                            .into(),
-                        details: None,
-                        related_instance_ids: vec![
-                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
-                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
-                        ],
-                        unpropagated_instance_ids: vec![
-                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
-                        ],
-                    },
+            }
+
+            "partial, some interfaces applied" {
+                NetworkSecurityGroupPropagationObjectStatus {
+                    id: "any_id".to_string(),
+                    interfaces_expected: 2,
+                    interfaces_applied: 1,
+                    related_instance_ids: vec![
+                        "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
+                        "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
+                    ],
+                    unpropagated_instance_ids: vec![
+                        "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
+                    ],
+                } => rpc::NetworkSecurityGroupPropagationObjectStatus {
+                    id: "any_id".to_string(),
+                    status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusPartial
+                        .into(),
+                    details: None,
+                    related_instance_ids: vec![
+                        "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
+                        "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+                    ],
+                    unpropagated_instance_ids: vec![
+                        "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+                    ],
                 },
-                Check {
-                    scenario: "none, no interfaces applied",
-                    input: NetworkSecurityGroupPropagationObjectStatus {
-                        id: "any_id".to_string(),
-                        interfaces_expected: 2,
-                        interfaces_applied: 0,
-                        related_instance_ids: vec![],
-                        unpropagated_instance_ids: vec![
-                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
-                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
-                        ],
-                    },
-                    expect: rpc::NetworkSecurityGroupPropagationObjectStatus {
-                        id: "any_id".to_string(),
-                        status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusNone
-                            .into(),
-                        details: None,
-                        related_instance_ids: vec![],
-                        unpropagated_instance_ids: vec![
-                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
-                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
-                        ],
-                    },
+            }
+
+            "none, no interfaces applied" {
+                NetworkSecurityGroupPropagationObjectStatus {
+                    id: "any_id".to_string(),
+                    interfaces_expected: 2,
+                    interfaces_applied: 0,
+                    related_instance_ids: vec![],
+                    unpropagated_instance_ids: vec![
+                        "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
+                        "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
+                    ],
+                } => rpc::NetworkSecurityGroupPropagationObjectStatus {
+                    id: "any_id".to_string(),
+                    status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusNone
+                        .into(),
+                    details: None,
+                    related_instance_ids: vec![],
+                    unpropagated_instance_ids: vec![
+                        "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
+                        "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+                    ],
                 },
-                Check {
-                    scenario: "unknown, applied exceeds expected",
-                    input: NetworkSecurityGroupPropagationObjectStatus {
-                        id: "any_id".to_string(),
-                        interfaces_expected: 1,
-                        interfaces_applied: 2,
-                        related_instance_ids: vec![
-                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
-                        ],
-                        unpropagated_instance_ids: vec![
-                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
-                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
-                        ],
-                    },
-                    expect: rpc::NetworkSecurityGroupPropagationObjectStatus {
-                        id: "any_id".to_string(),
-                        status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusUnknown
-                            .into(),
-                        details: Some("propagated objects exceeds expected objects".to_string()),
-                        related_instance_ids: vec![
-                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
-                        ],
-                        unpropagated_instance_ids: vec![
-                            "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
-                            "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
-                        ],
-                    },
+            }
+
+            "unknown, applied exceeds expected" {
+                NetworkSecurityGroupPropagationObjectStatus {
+                    id: "any_id".to_string(),
+                    interfaces_expected: 1,
+                    interfaces_applied: 2,
+                    related_instance_ids: vec![
+                        "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
+                    ],
+                    unpropagated_instance_ids: vec![
+                        "200f1043-1653-426d-bd0e-97f5b06bdb3f".parse().unwrap(),
+                        "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".parse().unwrap(),
+                    ],
+                } => rpc::NetworkSecurityGroupPropagationObjectStatus {
+                    id: "any_id".to_string(),
+                    status: rpc::NetworkSecurityGroupPropagationStatus::NsgPropStatusUnknown
+                        .into(),
+                    details: Some("propagated objects exceeds expected objects".to_string()),
+                    related_instance_ids: vec![
+                        "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
+                    ],
+                    unpropagated_instance_ids: vec![
+                        "200f1043-1653-426d-bd0e-97f5b06bdb3f".to_string(),
+                        "fb02b51c-3f18-46b8-b2f1-bc4a6e9b2f3d".to_string(),
+                    ],
                 },
-            ],
-            rpc::NetworkSecurityGroupPropagationObjectStatus::from,
+            }
         );
     }
 
@@ -855,199 +847,189 @@ mod tests {
     // ports on port-less protocols, and prefix/protocol IP-version mismatches.
     #[test]
     fn test_rpc_rule_to_nsg_model_rule_conversion_failures() {
-        check_cases(
-            [
-                Case {
-                    scenario: "ICMP with ports",
-                    input: rpc::NetworkSecurityGroupRuleAttributes {
-                        id: Some("anything".to_string()),
-                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
-                            .into(),
-                        ipv6: false,
-                        src_port_start: Some(80),
-                        src_port_end: Some(32768),
-                        dst_port_start: Some(80),
-                        dst_port_end: Some(32768),
-                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
-                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-                        priority: 9001,
-                        source_net: Some(
-                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                                "0.0.0.0/0".to_string(),
-                            ),
+        scenarios!(
+            run = |req| NetworkSecurityGroupRule::try_from(req).map_err(drop);
+            "ICMP with ports" {
+                rpc::NetworkSecurityGroupRuleAttributes {
+                    id: Some("anything".to_string()),
+                    direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                        .into(),
+                    ipv6: false,
+                    src_port_start: Some(80),
+                    src_port_end: Some(32768),
+                    dst_port_start: Some(80),
+                    dst_port_end: Some(32768),
+                    protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
+                    action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                    priority: 9001,
+                    source_net: Some(
+                        rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                            "0.0.0.0/0".to_string(),
                         ),
-                        destination_net: Some(
-                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                                "0.0.0.0/0".to_string(),
-                            ),
+                    ),
+                    destination_net: Some(
+                        rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                            "0.0.0.0/0".to_string(),
                         ),
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "ICMP6 with ports",
-                    input: rpc::NetworkSecurityGroupRuleAttributes {
-                        id: Some("anything".to_string()),
-                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
-                            .into(),
-                        ipv6: true,
-                        src_port_start: Some(80),
-                        src_port_end: Some(32768),
-                        dst_port_start: Some(80),
-                        dst_port_end: Some(32768),
-                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
-                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-                        priority: 9001,
-                        source_net: Some(
-                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                            ),
+                    ),
+                } => Fails,
+            }
+
+            "ICMP6 with ports" {
+                rpc::NetworkSecurityGroupRuleAttributes {
+                    id: Some("anything".to_string()),
+                    direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                        .into(),
+                    ipv6: true,
+                    src_port_start: Some(80),
+                    src_port_end: Some(32768),
+                    dst_port_start: Some(80),
+                    dst_port_end: Some(32768),
+                    protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
+                    action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                    priority: 9001,
+                    source_net: Some(
+                        rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                            "2001:db8:1234::f350:2256:f3dd/64".to_string(),
                         ),
-                        destination_net: Some(
-                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                            ),
+                    ),
+                    destination_net: Some(
+                        rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                            "2001:db8:1234::f350:2256:f3dd/64".to_string(),
                         ),
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "ANY with ports",
-                    input: rpc::NetworkSecurityGroupRuleAttributes {
-                        id: Some("anything".to_string()),
-                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
-                            .into(),
-                        ipv6: true,
-                        src_port_start: Some(80),
-                        src_port_end: Some(32768),
-                        dst_port_start: Some(80),
-                        dst_port_end: Some(32768),
-                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoAny.into(),
-                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-                        priority: 9001,
-                        source_net: Some(
-                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                            ),
+                    ),
+                } => Fails,
+            }
+
+            "ANY with ports" {
+                rpc::NetworkSecurityGroupRuleAttributes {
+                    id: Some("anything".to_string()),
+                    direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                        .into(),
+                    ipv6: true,
+                    src_port_start: Some(80),
+                    src_port_end: Some(32768),
+                    dst_port_start: Some(80),
+                    dst_port_end: Some(32768),
+                    protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoAny.into(),
+                    action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                    priority: 9001,
+                    source_net: Some(
+                        rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                            "2001:db8:1234::f350:2256:f3dd/64".to_string(),
                         ),
-                        destination_net: Some(
-                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                            ),
+                    ),
+                    destination_net: Some(
+                        rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                            "2001:db8:1234::f350:2256:f3dd/64".to_string(),
                         ),
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "v4 prefixes with v6 rule",
-                    input: rpc::NetworkSecurityGroupRuleAttributes {
-                        id: Some("anything".to_string()),
-                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
-                            .into(),
-                        ipv6: true,
-                        src_port_start: Some(80),
-                        src_port_end: Some(32768),
-                        dst_port_start: Some(80),
-                        dst_port_end: Some(32768),
-                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoTcp.into(),
-                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-                        priority: 9001,
-                        source_net: Some(
-                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                                "0.0.0.0/0".to_string(),
-                            ),
+                    ),
+                } => Fails,
+            }
+
+            "v4 prefixes with v6 rule" {
+                rpc::NetworkSecurityGroupRuleAttributes {
+                    id: Some("anything".to_string()),
+                    direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                        .into(),
+                    ipv6: true,
+                    src_port_start: Some(80),
+                    src_port_end: Some(32768),
+                    dst_port_start: Some(80),
+                    dst_port_end: Some(32768),
+                    protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoTcp.into(),
+                    action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                    priority: 9001,
+                    source_net: Some(
+                        rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                            "0.0.0.0/0".to_string(),
                         ),
-                        destination_net: Some(
-                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                                "0.0.0.0/0".to_string(),
-                            ),
+                    ),
+                    destination_net: Some(
+                        rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                            "0.0.0.0/0".to_string(),
                         ),
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "v6 prefixes with v4 rule",
-                    input: rpc::NetworkSecurityGroupRuleAttributes {
-                        id: Some("anything".to_string()),
-                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
-                            .into(),
-                        ipv6: false,
-                        src_port_start: Some(80),
-                        src_port_end: Some(32768),
-                        dst_port_start: Some(80),
-                        dst_port_end: Some(32768),
-                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoTcp.into(),
-                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-                        priority: 9001,
-                        source_net: Some(
-                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                            ),
+                    ),
+                } => Fails,
+            }
+
+            "v6 prefixes with v4 rule" {
+                rpc::NetworkSecurityGroupRuleAttributes {
+                    id: Some("anything".to_string()),
+                    direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                        .into(),
+                    ipv6: false,
+                    src_port_start: Some(80),
+                    src_port_end: Some(32768),
+                    dst_port_start: Some(80),
+                    dst_port_end: Some(32768),
+                    protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoTcp.into(),
+                    action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                    priority: 9001,
+                    source_net: Some(
+                        rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                            "2001:db8:1234::f350:2256:f3dd/64".to_string(),
                         ),
-                        destination_net: Some(
-                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                            ),
+                    ),
+                    destination_net: Some(
+                        rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                            "2001:db8:1234::f350:2256:f3dd/64".to_string(),
                         ),
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "ICMP6 with v4 prefixes on v4 rule",
-                    input: rpc::NetworkSecurityGroupRuleAttributes {
-                        id: Some("anything".to_string()),
-                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
-                            .into(),
-                        ipv6: false,
-                        src_port_start: None,
-                        src_port_end: None,
-                        dst_port_start: None,
-                        dst_port_end: None,
-                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp6.into(),
-                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-                        priority: 9001,
-                        source_net: Some(
-                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                                "1.1.1.1/24".to_string(),
-                            ),
+                    ),
+                } => Fails,
+            }
+
+            "ICMP6 with v4 prefixes on v4 rule" {
+                rpc::NetworkSecurityGroupRuleAttributes {
+                    id: Some("anything".to_string()),
+                    direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                        .into(),
+                    ipv6: false,
+                    src_port_start: None,
+                    src_port_end: None,
+                    dst_port_start: None,
+                    dst_port_end: None,
+                    protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp6.into(),
+                    action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                    priority: 9001,
+                    source_net: Some(
+                        rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                            "1.1.1.1/24".to_string(),
                         ),
-                        destination_net: Some(
-                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                                "1.1.1.1/24".to_string(),
-                            ),
+                    ),
+                    destination_net: Some(
+                        rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                            "1.1.1.1/24".to_string(),
                         ),
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "ICMP on v6 rule",
-                    input: rpc::NetworkSecurityGroupRuleAttributes {
-                        id: Some("anything".to_string()),
-                        direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
-                            .into(),
-                        ipv6: true,
-                        src_port_start: None,
-                        src_port_end: None,
-                        dst_port_start: None,
-                        dst_port_end: None,
-                        protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
-                        action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
-                        priority: 9001,
-                        source_net: Some(
-                            rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
-                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                            ),
+                    ),
+                } => Fails,
+            }
+
+            "ICMP on v6 rule" {
+                rpc::NetworkSecurityGroupRuleAttributes {
+                    id: Some("anything".to_string()),
+                    direction: rpc::NetworkSecurityGroupRuleDirection::NsgRuleDirectionIngress
+                        .into(),
+                    ipv6: true,
+                    src_port_start: None,
+                    src_port_end: None,
+                    dst_port_start: None,
+                    dst_port_end: None,
+                    protocol: rpc::NetworkSecurityGroupRuleProtocol::NsgRuleProtoIcmp.into(),
+                    action: rpc::NetworkSecurityGroupRuleAction::NsgRuleActionDeny.into(),
+                    priority: 9001,
+                    source_net: Some(
+                        rpc::network_security_group_rule_attributes::SourceNet::SrcPrefix(
+                            "2001:db8:1234::f350:2256:f3dd/64".to_string(),
                         ),
-                        destination_net: Some(
-                            rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
-                                "2001:db8:1234::f350:2256:f3dd/64".to_string(),
-                            ),
+                    ),
+                    destination_net: Some(
+                        rpc::network_security_group_rule_attributes::DestinationNet::DstPrefix(
+                            "2001:db8:1234::f350:2256:f3dd/64".to_string(),
                         ),
-                    },
-                    expect: Fails,
-                },
-            ],
-            |req| NetworkSecurityGroupRule::try_from(req).map_err(drop),
+                    ),
+                } => Fails,
+            }
         );
     }
 

--- a/crates/rpc/src/model/network_segment.rs
+++ b/crates/rpc/src/model/network_segment.rs
@@ -254,7 +254,7 @@ impl TryFrom<NetworkSegment> for rpc::NetworkSegment {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::scenarios;
 
     use super::*;
 
@@ -307,84 +307,73 @@ mod tests {
     // is IPv6); rejecting rows assert only that the conversion fails.
     #[test]
     fn try_from_creation_request_validates_prefixes() {
-        check_cases(
-            [
-                Case {
-                    scenario: "ipv6 prefix accepted (admin)",
-                    input: make_test_creation_request(
-                        vec![ipv6_prefix("2001:db8::/64")],
-                        NetworkSegmentType::Admin,
-                    ),
-                    expect: Yields((1, true)),
-                },
-                Case {
-                    scenario: "dual-stack prefixes accepted (admin)",
-                    input: make_test_creation_request(
-                        vec![
-                            ipv4_prefix("192.0.2.0/24", Some("192.0.2.1")),
-                            ipv6_prefix("2001:db8::/64"),
-                        ],
-                        NetworkSegmentType::Admin,
-                    ),
-                    expect: Yields((2, false)),
-                },
-                Case {
-                    scenario: "tenant /64 IPv6 allowed",
-                    input: make_test_creation_request(
-                        vec![ipv6_prefix("2001:db8::/64")],
-                        NetworkSegmentType::Tenant,
-                    ),
-                    expect: Yields((1, true)),
-                },
-                Case {
-                    scenario: "tenant /127 IPv6 rejected",
-                    input: make_test_creation_request(
-                        vec![ipv6_prefix("2001:db8::1/127")],
-                        NetworkSegmentType::Tenant,
-                    ),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "tenant /128 IPv6 rejected",
-                    input: make_test_creation_request(
-                        vec![ipv6_prefix("2001:db8::1/128")],
-                        NetworkSegmentType::Tenant,
-                    ),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "tenant /24 IPv4 allowed",
-                    input: make_test_creation_request(
-                        vec![ipv4_prefix("192.0.2.0/24", Some("192.0.2.1"))],
-                        NetworkSegmentType::Tenant,
-                    ),
-                    expect: Yields((1, false)),
-                },
-                Case {
-                    scenario: "tenant /31 IPv4 rejected",
-                    input: make_test_creation_request(
-                        vec![ipv4_prefix("192.0.2.0/31", Some("192.0.2.1"))],
-                        NetworkSegmentType::Tenant,
-                    ),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "tenant /32 IPv4 rejected",
-                    input: make_test_creation_request(
-                        vec![ipv4_prefix("192.0.2.0/32", None)],
-                        NetworkSegmentType::Tenant,
-                    ),
-                    expect: Fails,
-                },
-            ],
+        scenarios!(
             // The error type (RpcDataConversionError) is not asserted by these rows,
             // so failing rows discard it; accepting rows project to the prefix count
             // and whether the first prefix is IPv6.
-            |request| {
+            run = |request| {
                 NewNetworkSegment::try_from(request)
                     .map(|segment| (segment.prefixes.len(), segment.prefixes[0].prefix.is_ipv6()))
                     .map_err(drop)
-            },
+            };
+            "ipv6 prefix accepted (admin)" {
+                make_test_creation_request(
+                    vec![ipv6_prefix("2001:db8::/64")],
+                    NetworkSegmentType::Admin,
+                ) => Yields((1, true)),
+            }
+
+            "dual-stack prefixes accepted (admin)" {
+                make_test_creation_request(
+                    vec![
+                        ipv4_prefix("192.0.2.0/24", Some("192.0.2.1")),
+                        ipv6_prefix("2001:db8::/64"),
+                    ],
+                    NetworkSegmentType::Admin,
+                ) => Yields((2, false)),
+            }
+
+            "tenant /64 IPv6 allowed" {
+                make_test_creation_request(
+                    vec![ipv6_prefix("2001:db8::/64")],
+                    NetworkSegmentType::Tenant,
+                ) => Yields((1, true)),
+            }
+
+            "tenant /127 IPv6 rejected" {
+                make_test_creation_request(
+                    vec![ipv6_prefix("2001:db8::1/127")],
+                    NetworkSegmentType::Tenant,
+                ) => Fails,
+            }
+
+            "tenant /128 IPv6 rejected" {
+                make_test_creation_request(
+                    vec![ipv6_prefix("2001:db8::1/128")],
+                    NetworkSegmentType::Tenant,
+                ) => Fails,
+            }
+
+            "tenant /24 IPv4 allowed" {
+                make_test_creation_request(
+                    vec![ipv4_prefix("192.0.2.0/24", Some("192.0.2.1"))],
+                    NetworkSegmentType::Tenant,
+                ) => Yields((1, false)),
+            }
+
+            "tenant /31 IPv4 rejected" {
+                make_test_creation_request(
+                    vec![ipv4_prefix("192.0.2.0/31", Some("192.0.2.1"))],
+                    NetworkSegmentType::Tenant,
+                ) => Fails,
+            }
+
+            "tenant /32 IPv4 rejected" {
+                make_test_creation_request(
+                    vec![ipv4_prefix("192.0.2.0/32", None)],
+                    NetworkSegmentType::Tenant,
+                ) => Fails,
+            }
         );
     }
 }

--- a/crates/rpc/src/model/rack.rs
+++ b/crates/rpc/src/model/rack.rs
@@ -71,7 +71,7 @@ impl From<rpc::forge::RackSearchFilter> for RackSearchFilter {
 
 #[cfg(test)]
 mod tests {
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::value_scenarios;
     use model::metadata::LabelFilter;
     use model::rack::{LABEL_CHASSIS_MANUFACTURER, LABEL_LOCATION_DATACENTER};
 
@@ -81,41 +81,35 @@ mod tests {
     // optional `LabelFilter`; project to that `label` field for each input.
     #[test]
     fn rack_search_filter_from_rpc() {
-        check_values(
-            [
-                Check {
-                    scenario: "label with key and value",
-                    input: rpc::forge::RackSearchFilter {
-                        label: Some(rpc::forge::Label {
-                            key: LABEL_LOCATION_DATACENTER.to_string(),
-                            value: Some("az01".to_string()),
-                        }),
-                    },
-                    expect: Some(LabelFilter {
+        value_scenarios!(
+            run = |rpc_filter| RackSearchFilter::from(rpc_filter).label;
+            "label with key and value" {
+                rpc::forge::RackSearchFilter {
+                    label: Some(rpc::forge::Label {
                         key: LABEL_LOCATION_DATACENTER.to_string(),
                         value: Some("az01".to_string()),
                     }),
-                },
-                Check {
-                    scenario: "label with key only",
-                    input: rpc::forge::RackSearchFilter {
-                        label: Some(rpc::forge::Label {
-                            key: LABEL_CHASSIS_MANUFACTURER.to_string(),
-                            value: None,
-                        }),
-                    },
-                    expect: Some(LabelFilter {
+                } => Some(LabelFilter {
+                    key: LABEL_LOCATION_DATACENTER.to_string(),
+                    value: Some("az01".to_string()),
+                }),
+            }
+
+            "label with key only" {
+                rpc::forge::RackSearchFilter {
+                    label: Some(rpc::forge::Label {
                         key: LABEL_CHASSIS_MANUFACTURER.to_string(),
                         value: None,
                     }),
-                },
-                Check {
-                    scenario: "no label",
-                    input: rpc::forge::RackSearchFilter { label: None },
-                    expect: None,
-                },
-            ],
-            |rpc_filter| RackSearchFilter::from(rpc_filter).label,
+                } => Some(LabelFilter {
+                    key: LABEL_CHASSIS_MANUFACTURER.to_string(),
+                    value: None,
+                }),
+            }
+
+            "no label" {
+                rpc::forge::RackSearchFilter { label: None } => None,
+            }
         );
     }
 }

--- a/crates/rpc/src/model/redfish.rs
+++ b/crates/rpc/src/model/redfish.rs
@@ -79,7 +79,7 @@ impl From<ActionRequest> for rpc::forge::RedfishAction {
 
 #[cfg(test)]
 mod tests {
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::{Check, value_scenarios};
 
     use super::*;
 
@@ -110,25 +110,23 @@ mod tests {
     // `From<rpc::forge::RedfishCreateActionRequest>` maps action/target/parameters across.
     #[test]
     fn redfish_create_action_from_rpc() {
-        check_values(
-            [Check {
-                scenario: "action, target, and parameters map across",
-                input: rpc::forge::RedfishCreateActionRequest {
+        value_scenarios!(
+            run = |req| {
+                let action = RedfishCreateAction::from(req);
+                (action.action, action.target, action.parameters)
+            };
+            "action, target, and parameters map across" {
+                rpc::forge::RedfishCreateActionRequest {
                     ips: vec!["10.0.0.1".to_string()],
                     action: "Reset".to_string(),
                     target: "/redfish/v1/Systems/1/Actions".to_string(),
                     parameters: r#"{"ResetType":"ForceRestart"}"#.to_string(),
-                },
-                expect: (
+                } => (
                     "Reset".to_string(),
                     "/redfish/v1/Systems/1/Actions".to_string(),
                     r#"{"ResetType":"ForceRestart"}"#.to_string(),
                 ),
-            }],
-            |req| {
-                let action = RedfishCreateAction::from(req);
-                (action.action, action.target, action.parameters)
-            },
+            }
         );
     }
 }

--- a/crates/rpc/src/model/tenant.rs
+++ b/crates/rpc/src/model/tenant.rs
@@ -524,7 +524,9 @@ pub fn validate_identity_overlap_for_rotation(
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{
+        Case, Check, check_cases, check_values, scenarios, value_scenarios,
+    };
     use model::tenant::{identity_config, validate_trust_domain_allowlist_patterns};
 
     use super::*;
@@ -564,39 +566,33 @@ mod tests {
     // hashing/truncating the client secret and dropping empty/None secrets.
     #[test]
     fn stored_to_response_auth_config_cases() {
-        check_values(
-            [
-                Check {
-                    scenario: "auth method None yields no config",
-                    input: (TokenDelegationAuthMethod::None, None),
-                    expect: None,
-                },
-                Check {
-                    scenario: "client secret basic yields truncated hash",
-                    input: (
-                        TokenDelegationAuthMethod::ClientSecretBasic,
-                        Some(ClientSecretBasic {
-                            client_id: "my-client".to_string(),
-                            client_secret: "secret".to_string(),
-                        }),
-                    ),
-                    expect: Some(("my-client".to_string(), true, true, true)),
-                },
-                Check {
-                    scenario: "empty client secret yields no config",
-                    input: (
-                        TokenDelegationAuthMethod::ClientSecretBasic,
-                        Some(ClientSecretBasic {
-                            client_id: "x".to_string(),
-                            client_secret: String::new(),
-                        }),
-                    ),
-                    expect: None,
-                },
-            ],
-            |(auth_method, stored)| {
+        value_scenarios!(
+            run = |(auth_method, stored)| {
                 project_auth_config(stored_to_response_auth_config(auth_method, stored))
-            },
+            };
+            "auth method None yields no config" {
+                (TokenDelegationAuthMethod::None, None) => None,
+            }
+
+            "client secret basic yields truncated hash" {
+                (
+                    TokenDelegationAuthMethod::ClientSecretBasic,
+                    Some(ClientSecretBasic {
+                        client_id: "my-client".to_string(),
+                        client_secret: "secret".to_string(),
+                    }),
+                ) => Some(("my-client".to_string(), true, true, true)),
+            }
+
+            "empty client secret yields no config" {
+                (
+                    TokenDelegationAuthMethod::ClientSecretBasic,
+                    Some(ClientSecretBasic {
+                        client_id: "x".to_string(),
+                        client_secret: String::new(),
+                    }),
+                ) => None,
+            }
         );
     }
 
@@ -969,31 +965,25 @@ mod tests {
                 signing_key_overlap_sec,
             }
         }
-        check_values(
-            [
-                Check {
-                    scenario: "missing overlap is rejected",
-                    input: (None, Some("signing_key_overlap_sec is required")),
-                    expect: true,
-                },
-                Check {
-                    scenario: "overlap shorter than token_ttl_sec is rejected",
-                    input: (Some(120), Some("must be at least token_ttl_sec")),
-                    expect: true,
-                },
-                Check {
-                    scenario: "overlap at least token_ttl_sec is accepted",
-                    input: (Some(3600), None),
-                    expect: true,
-                },
-            ],
-            |(overlap, want): (Option<i32>, Option<&str>)| {
+        value_scenarios!(
+            run = |(overlap, want): (Option<i32>, Option<&str>)| {
                 let result = validate_identity_overlap_for_rotation(&rotating_config(overlap));
                 match want {
                     Some(substr) => result.unwrap_err().0.contains(substr),
                     None => result.is_ok(),
                 }
-            },
+            };
+            "missing overlap is rejected" {
+                (None, Some("signing_key_overlap_sec is required")) => true,
+            }
+
+            "overlap shorter than token_ttl_sec is rejected" {
+                (Some(120), Some("must be at least token_ttl_sec")) => true,
+            }
+
+            "overlap at least token_ttl_sec is accepted" {
+                (Some(3600), None) => true,
+            }
         );
     }
 
@@ -1017,46 +1007,41 @@ mod tests {
     // and the auth method config maps to None or the client-secret-basic pair.
     #[test]
     fn token_delegation_try_from_success_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "no auth method config",
-                    input: rpc_forge::TokenDelegation {
-                        token_endpoint: "https://auth.example.com/token".to_string(),
-                        subject_token_audience: "https://api.example.com".to_string(),
-                        auth_method_config: None,
-                    },
-                    expect: Yields((
-                        "https://auth.example.com/token".to_string(),
-                        "https://api.example.com".to_string(),
-                        None,
-                    )),
-                },
-                Case {
-                    scenario: "client secret basic",
-                    input: rpc_forge::TokenDelegation {
-                        token_endpoint: "https://auth.example.com/token".to_string(),
-                        subject_token_audience: "https://api.example.com".to_string(),
-                        auth_method_config: Some(
-                            rpc_forge::token_delegation::AuthMethodConfig::ClientSecretBasic(
-                                rpc_forge::ClientSecretBasic {
-                                    client_id: "my-client".to_string(),
-                                    client_secret: "my-secret".to_string(),
-                                },
-                            ),
-                        ),
-                    },
-                    expect: Yields((
-                        "https://auth.example.com/token".to_string(),
-                        "https://api.example.com".to_string(),
-                        Some(("my-client".to_string(), "my-secret".to_string())),
-                    )),
-                },
-            ],
-            |proto| {
+        scenarios!(
+            run = |proto| {
                 let config = TokenDelegation::try_from(proto).map_err(drop)?;
                 Ok::<_, ()>(project_token_delegation(config))
-            },
+            };
+            "no auth method config" {
+                rpc_forge::TokenDelegation {
+                    token_endpoint: "https://auth.example.com/token".to_string(),
+                    subject_token_audience: "https://api.example.com".to_string(),
+                    auth_method_config: None,
+                } => Yields((
+                    "https://auth.example.com/token".to_string(),
+                    "https://api.example.com".to_string(),
+                    None,
+                )),
+            }
+
+            "client secret basic" {
+                rpc_forge::TokenDelegation {
+                    token_endpoint: "https://auth.example.com/token".to_string(),
+                    subject_token_audience: "https://api.example.com".to_string(),
+                    auth_method_config: Some(
+                        rpc_forge::token_delegation::AuthMethodConfig::ClientSecretBasic(
+                            rpc_forge::ClientSecretBasic {
+                                client_id: "my-client".to_string(),
+                                client_secret: "my-secret".to_string(),
+                            },
+                        ),
+                    ),
+                } => Yields((
+                    "https://auth.example.com/token".to_string(),
+                    "https://api.example.com".to_string(),
+                    Some(("my-client".to_string(), "my-secret".to_string())),
+                )),
+            }
         );
     }
 
@@ -1077,63 +1062,56 @@ mod tests {
                 ),
             )
         }
-        check_values(
-            [
-                Check {
-                    scenario: "empty token_endpoint",
-                    input: (
-                        rpc_forge::TokenDelegation {
-                            token_endpoint: String::new(),
-                            subject_token_audience: "https://api.example.com".to_string(),
-                            auth_method_config: None,
-                        },
-                        "token_endpoint is required",
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "empty subject_token_audience",
-                    input: (
-                        rpc_forge::TokenDelegation {
-                            token_endpoint: "https://auth.example.com/token".to_string(),
-                            subject_token_audience: String::new(),
-                            auth_method_config: None,
-                        },
-                        "subject_token_audience is required",
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "empty client_id",
-                    input: (
-                        rpc_forge::TokenDelegation {
-                            token_endpoint: "https://auth.example.com/token".to_string(),
-                            subject_token_audience: "https://api.example.com".to_string(),
-                            auth_method_config: client_secret_basic("", "secret"),
-                        },
-                        "client_id is required",
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "empty client_secret",
-                    input: (
-                        rpc_forge::TokenDelegation {
-                            token_endpoint: "https://auth.example.com/token".to_string(),
-                            subject_token_audience: "https://api.example.com".to_string(),
-                            auth_method_config: client_secret_basic("client", ""),
-                        },
-                        "client_secret is required",
-                    ),
-                    expect: true,
-                },
-            ],
-            |(proto, want): (rpc_forge::TokenDelegation, &str)| {
+        value_scenarios!(
+            run = |(proto, want): (rpc_forge::TokenDelegation, &str)| {
                 TokenDelegation::try_from(proto)
                     .unwrap_err()
                     .0
                     .contains(want)
-            },
+            };
+            "empty token_endpoint" {
+                (
+                    rpc_forge::TokenDelegation {
+                        token_endpoint: String::new(),
+                        subject_token_audience: "https://api.example.com".to_string(),
+                        auth_method_config: None,
+                    },
+                    "token_endpoint is required",
+                ) => true,
+            }
+
+            "empty subject_token_audience" {
+                (
+                    rpc_forge::TokenDelegation {
+                        token_endpoint: "https://auth.example.com/token".to_string(),
+                        subject_token_audience: String::new(),
+                        auth_method_config: None,
+                    },
+                    "subject_token_audience is required",
+                ) => true,
+            }
+
+            "empty client_id" {
+                (
+                    rpc_forge::TokenDelegation {
+                        token_endpoint: "https://auth.example.com/token".to_string(),
+                        subject_token_audience: "https://api.example.com".to_string(),
+                        auth_method_config: client_secret_basic("", "secret"),
+                    },
+                    "client_id is required",
+                ) => true,
+            }
+
+            "empty client_secret" {
+                (
+                    rpc_forge::TokenDelegation {
+                        token_endpoint: "https://auth.example.com/token".to_string(),
+                        subject_token_audience: "https://api.example.com".to_string(),
+                        auth_method_config: client_secret_basic("client", ""),
+                    },
+                    "client_secret is required",
+                ) => true,
+            }
         );
     }
 }

--- a/crates/rpc/src/model/vpc.rs
+++ b/crates/rpc/src/model/vpc.rs
@@ -233,7 +233,7 @@ impl From<VpcPeering> for rpc::forge::VpcPeering {
 
 #[cfg(test)]
 mod tests {
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::value_scenarios;
 
     use super::*;
 
@@ -248,47 +248,8 @@ mod tests {
             Option<(String, Option<String>)>,
         );
 
-        check_values(
-            [
-                Check {
-                    scenario: "all fields populated",
-                    input: rpc::forge::VpcSearchFilter {
-                        name: Some("my-vpc".to_string()),
-                        tenant_org_id: Some("org-123".to_string()),
-                        label: Some(rpc::forge::Label {
-                            key: "env".to_string(),
-                            value: Some("prod".to_string()),
-                        }),
-                    },
-                    expect: (
-                        Some("my-vpc".to_string()),
-                        Some("org-123".to_string()),
-                        Some(("env".to_string(), Some("prod".to_string()))),
-                    ),
-                },
-                Check {
-                    scenario: "no fields",
-                    input: rpc::forge::VpcSearchFilter {
-                        name: None,
-                        tenant_org_id: None,
-                        label: None,
-                    },
-                    expect: (None, None, None),
-                },
-                Check {
-                    scenario: "label key only",
-                    input: rpc::forge::VpcSearchFilter {
-                        name: None,
-                        tenant_org_id: None,
-                        label: Some(rpc::forge::Label {
-                            key: "team".to_string(),
-                            value: None,
-                        }),
-                    },
-                    expect: (None, None, Some(("team".to_string(), None))),
-                },
-            ],
-            |rpc_filter| {
+        value_scenarios!(
+            run = |rpc_filter| {
                 let filter = VpcSearchFilter::from(rpc_filter);
                 let projected: Projected = (
                     filter.name,
@@ -296,7 +257,40 @@ mod tests {
                     filter.label.map(|l| (l.key, l.value)),
                 );
                 projected
-            },
+            };
+            "all fields populated" {
+                rpc::forge::VpcSearchFilter {
+                    name: Some("my-vpc".to_string()),
+                    tenant_org_id: Some("org-123".to_string()),
+                    label: Some(rpc::forge::Label {
+                        key: "env".to_string(),
+                        value: Some("prod".to_string()),
+                    }),
+                } => (
+                    Some("my-vpc".to_string()),
+                    Some("org-123".to_string()),
+                    Some(("env".to_string(), Some("prod".to_string()))),
+                ),
+            }
+
+            "no fields" {
+                rpc::forge::VpcSearchFilter {
+                    name: None,
+                    tenant_org_id: None,
+                    label: None,
+                } => (None, None, None),
+            }
+
+            "label key only" {
+                rpc::forge::VpcSearchFilter {
+                    name: None,
+                    tenant_org_id: None,
+                    label: Some(rpc::forge::Label {
+                        key: "team".to_string(),
+                        value: None,
+                    }),
+                } => (None, None, Some(("team".to_string(), None))),
+            }
         );
     }
 }

--- a/crates/rpc/src/network.rs
+++ b/crates/rpc/src/network.rs
@@ -73,48 +73,39 @@ pub fn vpc_virtualization_type_try_from_rpc(
 mod test {
     use carbide_network::virtualization::VpcVirtualizationType;
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Case, check_cases, value_scenarios};
 
     use super::*;
 
     // proto -> model: `From<rpc::VpcVirtualizationType>` (infallible).
+    #[allow(deprecated)]
     #[test]
     fn from_rpc_maps_to_model() {
-        #[allow(deprecated)]
-        check_values(
-            [
-                Check {
-                    scenario: "etv-with-nvue maps to etv",
-                    input: rpc::VpcVirtualizationType::EthernetVirtualizerWithNvue,
-                    expect: VpcVirtualizationType::EthernetVirtualizer,
-                },
-                Check {
-                    scenario: "flat round-trips to flat",
-                    input: rpc::VpcVirtualizationType::Flat,
-                    expect: VpcVirtualizationType::Flat,
-                },
-            ],
-            |v| v.into(),
+        value_scenarios!(
+            run = |v| v.into();
+            "deprecated etv-with-nvue maps to etv" {
+                // deprecated: EthernetVirtualizerWithNvue remains accepted as etv.
+                rpc::VpcVirtualizationType::EthernetVirtualizerWithNvue => VpcVirtualizationType::EthernetVirtualizer,
+            }
+
+            "flat round-trips to flat" {
+                rpc::VpcVirtualizationType::Flat => VpcVirtualizationType::Flat,
+            }
         );
     }
 
     // model -> proto: `From<VpcVirtualizationType>` (infallible).
     #[test]
     fn to_rpc_maps_to_proto() {
-        check_values(
-            [
-                Check {
-                    scenario: "etv maps to proto etv",
-                    input: VpcVirtualizationType::EthernetVirtualizer,
-                    expect: rpc::VpcVirtualizationType::EthernetVirtualizer,
-                },
-                Check {
-                    scenario: "flat round-trips to proto flat",
-                    input: VpcVirtualizationType::Flat,
-                    expect: rpc::VpcVirtualizationType::Flat,
-                },
-            ],
-            |v| v.into(),
+        value_scenarios!(
+            run = |v| v.into();
+            "etv maps to proto etv" {
+                VpcVirtualizationType::EthernetVirtualizer => rpc::VpcVirtualizationType::EthernetVirtualizer,
+            }
+
+            "flat round-trips to proto flat" {
+                VpcVirtualizationType::Flat => rpc::VpcVirtualizationType::Flat,
+            }
         );
     }
 


### PR DESCRIPTION
This supports #3914.

## Description

The `carbide-rpc` conversion tests are mostly direct model/protobuf inputs with expected outputs, and the old `Case`/`Check` wrappers added a lot of scaffolding around those examples.

This keeps the conversion coverage exactly explicit while moving the straightforward tables onto `scenarios!`/`value_scenarios!`. Related inputs now sit under the behavior they are exercising, so the enum and message conversion tests read more like grouped protocol examples than repeated row structs.

All tests pass, and formatting/clippy checks are clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Commands:
- `cargo make format-nightly`
- `cargo make check-format-nightly`
- `cargo test -p carbide-rpc`
- `cargo clippy -p carbide-rpc -- -D warnings`
- `cargo clippy -p carbide-rpc --tests -- -D warnings`