### PR TITLE
test(mqttea): group helper tables into scenarios

### DIFF
--- a/crates/mqttea/src/client/options.rs
+++ b/crates/mqttea/src/client/options.rs
@@ -168,7 +168,7 @@ pub struct ClientTlsIdentity {
 
 #[cfg(test)]
 mod tests {
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::value_scenarios;
 
     use super::*;
 
@@ -239,118 +239,106 @@ mod tests {
 
     #[test]
     fn test_client_options_builders() {
-        check_values(
-            [
-                Check {
-                    scenario: "default",
-                    input: OptionsBuild::Default,
-                    expect: OptionsSummary {
-                        keep_alive_secs: None,
-                        message_channel_capacity: None,
-                        qos: None,
-                        retain: None,
-                        max_concurrency: None,
-                        has_credentials_provider: false,
-                    },
+        value_scenarios!(
+            run = |build| summarize(build_options(build));
+            "default" {
+                OptionsBuild::Default => OptionsSummary {
+                    keep_alive_secs: None,
+                    message_channel_capacity: None,
+                    qos: None,
+                    retain: None,
+                    max_concurrency: None,
+                    has_credentials_provider: false,
                 },
-                Check {
-                    scenario: "keep alive",
-                    input: OptionsBuild::KeepAlive,
-                    expect: OptionsSummary {
-                        keep_alive_secs: Some(7),
-                        message_channel_capacity: None,
-                        qos: None,
-                        retain: None,
-                        max_concurrency: None,
-                        has_credentials_provider: false,
-                    },
+            }
+
+            "keep alive" {
+                OptionsBuild::KeepAlive => OptionsSummary {
+                    keep_alive_secs: Some(7),
+                    message_channel_capacity: None,
+                    qos: None,
+                    retain: None,
+                    max_concurrency: None,
+                    has_credentials_provider: false,
                 },
-                Check {
-                    scenario: "message capacity",
-                    input: OptionsBuild::MessageCapacity,
-                    expect: OptionsSummary {
-                        keep_alive_secs: None,
-                        message_channel_capacity: Some(512),
-                        qos: None,
-                        retain: None,
-                        max_concurrency: None,
-                        has_credentials_provider: false,
-                    },
+            }
+
+            "message capacity" {
+                OptionsBuild::MessageCapacity => OptionsSummary {
+                    keep_alive_secs: None,
+                    message_channel_capacity: Some(512),
+                    qos: None,
+                    retain: None,
+                    max_concurrency: None,
+                    has_credentials_provider: false,
                 },
-                Check {
-                    scenario: "qos",
-                    input: OptionsBuild::Qos,
-                    expect: OptionsSummary {
-                        keep_alive_secs: None,
-                        message_channel_capacity: None,
-                        qos: Some(QoS::AtLeastOnce),
-                        retain: None,
-                        max_concurrency: None,
-                        has_credentials_provider: false,
-                    },
+            }
+
+            "qos" {
+                OptionsBuild::Qos => OptionsSummary {
+                    keep_alive_secs: None,
+                    message_channel_capacity: None,
+                    qos: Some(QoS::AtLeastOnce),
+                    retain: None,
+                    max_concurrency: None,
+                    has_credentials_provider: false,
                 },
-                Check {
-                    scenario: "retain",
-                    input: OptionsBuild::Retain,
-                    expect: OptionsSummary {
-                        keep_alive_secs: None,
-                        message_channel_capacity: None,
-                        qos: None,
-                        retain: Some(true),
-                        max_concurrency: None,
-                        has_credentials_provider: false,
-                    },
+            }
+
+            "retain" {
+                OptionsBuild::Retain => OptionsSummary {
+                    keep_alive_secs: None,
+                    message_channel_capacity: None,
+                    qos: None,
+                    retain: Some(true),
+                    max_concurrency: None,
+                    has_credentials_provider: false,
                 },
-                Check {
-                    scenario: "publish options",
-                    input: OptionsBuild::PublishOptions,
-                    expect: OptionsSummary {
-                        keep_alive_secs: None,
-                        message_channel_capacity: None,
-                        qos: Some(QoS::ExactlyOnce),
-                        retain: Some(false),
-                        max_concurrency: None,
-                        has_credentials_provider: false,
-                    },
+            }
+
+            "publish options" {
+                OptionsBuild::PublishOptions => OptionsSummary {
+                    keep_alive_secs: None,
+                    message_channel_capacity: None,
+                    qos: Some(QoS::ExactlyOnce),
+                    retain: Some(false),
+                    max_concurrency: None,
+                    has_credentials_provider: false,
                 },
-                Check {
-                    scenario: "max concurrency",
-                    input: OptionsBuild::MaxConcurrency,
-                    expect: OptionsSummary {
-                        keep_alive_secs: None,
-                        message_channel_capacity: None,
-                        qos: None,
-                        retain: None,
-                        max_concurrency: Some(16),
-                        has_credentials_provider: false,
-                    },
+            }
+
+            "max concurrency" {
+                OptionsBuild::MaxConcurrency => OptionsSummary {
+                    keep_alive_secs: None,
+                    message_channel_capacity: None,
+                    qos: None,
+                    retain: None,
+                    max_concurrency: Some(16),
+                    has_credentials_provider: false,
                 },
-                Check {
-                    scenario: "credentials",
-                    input: OptionsBuild::Credentials,
-                    expect: OptionsSummary {
-                        keep_alive_secs: None,
-                        message_channel_capacity: None,
-                        qos: None,
-                        retain: None,
-                        max_concurrency: None,
-                        has_credentials_provider: true,
-                    },
+            }
+
+            "credentials" {
+                OptionsBuild::Credentials => OptionsSummary {
+                    keep_alive_secs: None,
+                    message_channel_capacity: None,
+                    qos: None,
+                    retain: None,
+                    max_concurrency: None,
+                    has_credentials_provider: true,
                 },
-                Check {
-                    scenario: "combined publish options",
-                    input: OptionsBuild::CombinedPublishOptions,
-                    expect: OptionsSummary {
-                        keep_alive_secs: None,
-                        message_channel_capacity: None,
-                        qos: Some(QoS::AtMostOnce),
-                        retain: Some(true),
-                        max_concurrency: None,
-                        has_credentials_provider: false,
-                    },
+            }
+
+            "combined publish options" {
+                OptionsBuild::CombinedPublishOptions => OptionsSummary {
+                    keep_alive_secs: None,
+                    message_channel_capacity: None,
+                    qos: Some(QoS::AtMostOnce),
+                    retain: Some(true),
+                    max_concurrency: None,
+                    has_credentials_provider: false,
                 },
-            ],
-            |build| summarize(build_options(build)),
+            }
         );
     }
 }

--- a/crates/mqttea/src/message_types/raw.rs
+++ b/crates/mqttea/src/message_types/raw.rs
@@ -39,7 +39,7 @@ impl RawMessageType for RawMessage {
 
 #[cfg(test)]
 mod tests {
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::value_scenarios;
 
     use super::*;
 
@@ -66,30 +66,25 @@ mod tests {
 
     #[test]
     fn test_raw_message_bytes() {
-        check_values(
-            [
-                Check {
-                    scenario: "empty payload",
-                    input: vec![],
-                    expect: RawSummary {
-                        payload: vec![],
-                        bytes: vec![],
-                        round_trip: RawMessage { payload: vec![] },
-                    },
+        value_scenarios!(
+            run = summarize;
+            "empty payload" {
+                vec![] => RawSummary {
+                    payload: vec![],
+                    bytes: vec![],
+                    round_trip: RawMessage { payload: vec![] },
                 },
-                Check {
-                    scenario: "binary payload",
-                    input: vec![0, 1, 2, 255],
-                    expect: RawSummary {
+            }
+
+            "binary payload" {
+                vec![0, 1, 2, 255] => RawSummary {
+                    payload: vec![0, 1, 2, 255],
+                    bytes: vec![0, 1, 2, 255],
+                    round_trip: RawMessage {
                         payload: vec![0, 1, 2, 255],
-                        bytes: vec![0, 1, 2, 255],
-                        round_trip: RawMessage {
-                            payload: vec![0, 1, 2, 255],
-                        },
                     },
                 },
-            ],
-            summarize,
+            }
         );
     }
 }

--- a/crates/mqttea/src/message_types/string.rs
+++ b/crates/mqttea/src/message_types/string.rs
@@ -110,7 +110,7 @@ impl std::fmt::Display for StringMessage {
 mod tests {
     use std::str::FromStr;
 
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::value_scenarios;
 
     use super::*;
 
@@ -169,35 +169,27 @@ mod tests {
             into_string: "hello".to_string(),
         };
 
-        check_values(
-            [
-                Check {
-                    scenario: "new",
-                    input: StringSource::New,
-                    expect: expected.clone(),
-                },
-                Check {
-                    scenario: "from borrowed",
-                    input: StringSource::FromBorrowed,
-                    expect: expected.clone(),
-                },
-                Check {
-                    scenario: "from owned",
-                    input: StringSource::FromOwned,
-                    expect: expected.clone(),
-                },
-                Check {
-                    scenario: "from bytes",
-                    input: StringSource::FromBytes,
-                    expect: expected.clone(),
-                },
-                Check {
-                    scenario: "from str",
-                    input: StringSource::FromStr,
-                    expect: expected,
-                },
-            ],
-            summarize,
+        value_scenarios!(
+            run = summarize;
+            "new" {
+                StringSource::New => expected.clone(),
+            }
+
+            "from borrowed" {
+                StringSource::FromBorrowed => expected.clone(),
+            }
+
+            "from owned" {
+                StringSource::FromOwned => expected.clone(),
+            }
+
+            "from bytes" {
+                StringSource::FromBytes => expected.clone(),
+            }
+
+            "from str" {
+                StringSource::FromStr => expected,
+            }
         );
     }
 

--- a/crates/mqttea/src/registry/entry.rs
+++ b/crates/mqttea/src/registry/entry.rs
@@ -160,7 +160,7 @@ impl MqttRegistryEntry {
 mod tests {
     use std::any::Any;
 
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::value_scenarios;
     use rumqttc::QoS;
 
     use super::*;
@@ -252,70 +252,64 @@ mod tests {
 
     #[test]
     fn test_registry_entry_accessors() {
-        check_values(
-            [
-                Check {
-                    scenario: "default JSON entry",
-                    input: EntryBuild::DefaultJson,
-                    expect: EntrySummary {
-                        type_name: "String".to_string(),
-                        patterns: vec!["alpha".to_string(), "beta".to_string()],
-                        publish_options: None,
-                        qos: None,
-                        retain: None,
-                        format: SerializationFormat::Json,
-                        pattern_count: 2,
-                        has_alpha: true,
-                        has_missing: false,
-                        uses_qos_override: false,
-                        effective_qos: QoS::AtMostOnce,
-                        is_json: true,
-                        debug_mentions_type: true,
-                        debug_hides_handlers: true,
-                    },
+        value_scenarios!(
+            run = |build| summarize(entry_from(build));
+            "default JSON entry" {
+                EntryBuild::DefaultJson => EntrySummary {
+                    type_name: "String".to_string(),
+                    patterns: vec!["alpha".to_string(), "beta".to_string()],
+                    publish_options: None,
+                    qos: None,
+                    retain: None,
+                    format: SerializationFormat::Json,
+                    pattern_count: 2,
+                    has_alpha: true,
+                    has_missing: false,
+                    uses_qos_override: false,
+                    effective_qos: QoS::AtMostOnce,
+                    is_json: true,
+                    debug_mentions_type: true,
+                    debug_hides_handlers: true,
                 },
-                Check {
-                    scenario: "QoS override",
-                    input: EntryBuild::QosOverride,
-                    expect: EntrySummary {
-                        type_name: "String".to_string(),
-                        patterns: vec!["alpha".to_string(), "beta".to_string()],
-                        publish_options: Some((Some(QoS::ExactlyOnce), None)),
-                        qos: Some(QoS::ExactlyOnce),
-                        retain: None,
-                        format: SerializationFormat::Raw,
-                        pattern_count: 2,
-                        has_alpha: true,
-                        has_missing: false,
-                        uses_qos_override: true,
-                        effective_qos: QoS::ExactlyOnce,
-                        is_json: false,
-                        debug_mentions_type: true,
-                        debug_hides_handlers: true,
-                    },
+            }
+
+            "QoS override" {
+                EntryBuild::QosOverride => EntrySummary {
+                    type_name: "String".to_string(),
+                    patterns: vec!["alpha".to_string(), "beta".to_string()],
+                    publish_options: Some((Some(QoS::ExactlyOnce), None)),
+                    qos: Some(QoS::ExactlyOnce),
+                    retain: None,
+                    format: SerializationFormat::Raw,
+                    pattern_count: 2,
+                    has_alpha: true,
+                    has_missing: false,
+                    uses_qos_override: true,
+                    effective_qos: QoS::ExactlyOnce,
+                    is_json: false,
+                    debug_mentions_type: true,
+                    debug_hides_handlers: true,
                 },
-                Check {
-                    scenario: "retain override",
-                    input: EntryBuild::RetainOverride,
-                    expect: EntrySummary {
-                        type_name: "String".to_string(),
-                        patterns: vec!["alpha".to_string(), "beta".to_string()],
-                        publish_options: Some((None, Some(true))),
-                        qos: None,
-                        retain: Some(true),
-                        format: SerializationFormat::Yaml,
-                        pattern_count: 2,
-                        has_alpha: true,
-                        has_missing: false,
-                        uses_qos_override: false,
-                        effective_qos: QoS::AtMostOnce,
-                        is_json: false,
-                        debug_mentions_type: true,
-                        debug_hides_handlers: true,
-                    },
+            }
+
+            "retain override" {
+                EntryBuild::RetainOverride => EntrySummary {
+                    type_name: "String".to_string(),
+                    patterns: vec!["alpha".to_string(), "beta".to_string()],
+                    publish_options: Some((None, Some(true))),
+                    qos: None,
+                    retain: Some(true),
+                    format: SerializationFormat::Yaml,
+                    pattern_count: 2,
+                    has_alpha: true,
+                    has_missing: false,
+                    uses_qos_override: false,
+                    effective_qos: QoS::AtMostOnce,
+                    is_json: false,
+                    debug_mentions_type: true,
+                    debug_hides_handlers: true,
                 },
-            ],
-            |build| summarize(entry_from(build)),
+            }
         );
     }
 

--- a/crates/mqttea/src/registry/types.rs
+++ b/crates/mqttea/src/registry/types.rs
@@ -140,7 +140,7 @@ impl MessageTypeInfo {
 
 #[cfg(test)]
 mod tests {
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::value_scenarios;
 
     use super::*;
 
@@ -222,87 +222,74 @@ mod tests {
 
     #[test]
     fn test_publish_options_builders() {
-        check_values(
-            [
-                Check {
-                    scenario: "default",
-                    input: PublishOptionsBuild::Default,
-                    expect: (None, None),
-                },
-                Check {
-                    scenario: "qos",
-                    input: PublishOptionsBuild::Qos,
-                    expect: (Some(QoS::AtLeastOnce), None),
-                },
-                Check {
-                    scenario: "retain",
-                    input: PublishOptionsBuild::Retain,
-                    expect: (None, Some(true)),
-                },
-                Check {
-                    scenario: "qos and retain",
-                    input: PublishOptionsBuild::QosAndRetain,
-                    expect: (Some(QoS::ExactlyOnce), Some(false)),
-                },
-            ],
-            |build| {
+        value_scenarios!(
+            run = |build| {
                 let options = build_publish_options(build);
                 (options.qos, options.retain)
-            },
+            };
+            "default" {
+                PublishOptionsBuild::Default => (None, None),
+            }
+
+            "qos" {
+                PublishOptionsBuild::Qos => (Some(QoS::AtLeastOnce), None),
+            }
+
+            "retain" {
+                PublishOptionsBuild::Retain => (None, Some(true)),
+            }
+
+            "qos and retain" {
+                PublishOptionsBuild::QosAndRetain => (Some(QoS::ExactlyOnce), Some(false)),
+            }
         );
     }
 
     #[test]
     fn test_message_type_info_helpers() {
-        check_values(
-            [
-                Check {
-                    scenario: "json default",
-                    input: MessageInfoBuild::JsonDefault,
-                    expect: MessageInfoSummary {
-                        has_alpha: true,
-                        has_missing: false,
-                        pattern_count: 2,
-                        uses_qos_override: false,
-                        effective_qos: QoS::AtMostOnce,
-                        effective_retain: false,
-                        is_json: true,
-                        is_protobuf: false,
-                        is_raw: false,
-                    },
+        value_scenarios!(
+            run = |build| summarize_message_info(build_message_info(build));
+            "json default" {
+                MessageInfoBuild::JsonDefault => MessageInfoSummary {
+                    has_alpha: true,
+                    has_missing: false,
+                    pattern_count: 2,
+                    uses_qos_override: false,
+                    effective_qos: QoS::AtMostOnce,
+                    effective_retain: false,
+                    is_json: true,
+                    is_protobuf: false,
+                    is_raw: false,
                 },
-                Check {
-                    scenario: "protobuf qos override",
-                    input: MessageInfoBuild::ProtobufQosOverride,
-                    expect: MessageInfoSummary {
-                        has_alpha: true,
-                        has_missing: false,
-                        pattern_count: 1,
-                        uses_qos_override: true,
-                        effective_qos: QoS::ExactlyOnce,
-                        effective_retain: false,
-                        is_json: false,
-                        is_protobuf: true,
-                        is_raw: false,
-                    },
+            }
+
+            "protobuf qos override" {
+                MessageInfoBuild::ProtobufQosOverride => MessageInfoSummary {
+                    has_alpha: true,
+                    has_missing: false,
+                    pattern_count: 1,
+                    uses_qos_override: true,
+                    effective_qos: QoS::ExactlyOnce,
+                    effective_retain: false,
+                    is_json: false,
+                    is_protobuf: true,
+                    is_raw: false,
                 },
-                Check {
-                    scenario: "raw retain override",
-                    input: MessageInfoBuild::RawRetainOverride,
-                    expect: MessageInfoSummary {
-                        has_alpha: true,
-                        has_missing: false,
-                        pattern_count: 1,
-                        uses_qos_override: false,
-                        effective_qos: QoS::AtMostOnce,
-                        effective_retain: true,
-                        is_json: false,
-                        is_protobuf: false,
-                        is_raw: true,
-                    },
+            }
+
+            "raw retain override" {
+                MessageInfoBuild::RawRetainOverride => MessageInfoSummary {
+                    has_alpha: true,
+                    has_missing: false,
+                    pattern_count: 1,
+                    uses_qos_override: false,
+                    effective_qos: QoS::AtMostOnce,
+                    effective_retain: true,
+                    is_json: false,
+                    is_protobuf: false,
+                    is_raw: true,
                 },
-            ],
-            |build| summarize_message_info(build_message_info(build)),
+            }
         );
     }
 }


### PR DESCRIPTION
This supports #3914.

## Description

The `mqttea` tests already enumerate the helper behavior we care about, but the row structs still made the pure cases a bit noisier than the MQTT inputs and outputs themselves.

This moves the straightforward helper tables onto `scenarios!`/`value_scenarios!` and leaves the more custom shapes alone. The expected values stay explicit in each row, with related cases grouped by the condition they are covering.

All tests pass, and formatting/clippy checks are clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Commands:
- `cargo make format-nightly`
- `cargo make check-format-nightly`
- `cargo test -p mqttea`
- `cargo clippy -p mqttea -- -D warnings`
- `cargo clippy -p mqttea --tests -- -D warnings`