### PR TITLE
test(network): group address tables into scenarios

### DIFF
--- a/crates/network/src/base_mac.rs
+++ b/crates/network/src/base_mac.rs
@@ -85,7 +85,7 @@ impl<'de> Deserialize<'de> for BaseMac {
 #[cfg(test)]
 mod test {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Case, check_cases, scenarios, value_scenarios};
 
     use super::*;
 
@@ -97,45 +97,35 @@ mod test {
 
     #[test]
     fn display_formats_uppercase_hex_without_colons() {
-        check_values(
-            [
-                Check {
-                    scenario: "ascending low bytes",
-                    input: mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
-                    expect: "010203040506".to_string(),
-                },
-                Check {
-                    scenario: "high bytes uppercase",
-                    input: mac([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]),
-                    expect: "AABBCCDDEEFF".to_string(),
-                },
-                Check {
-                    scenario: "all zeros",
-                    input: mac([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
-                    expect: "000000000000".to_string(),
-                },
-                Check {
-                    scenario: "all ones",
-                    input: mac([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
-                    expect: "FFFFFFFFFFFF".to_string(),
-                },
-                Check {
-                    scenario: "single-digit bytes zero-padded",
-                    input: mac([0x00, 0x0A, 0x00, 0x0B, 0x00, 0x0C]),
-                    expect: "000A000B000C".to_string(),
-                },
-                Check {
-                    scenario: "lowercase-hex digits rendered uppercase",
-                    input: mac([0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f]),
-                    expect: "0A0B0C0D0E0F".to_string(),
-                },
-                Check {
-                    scenario: "mixed bytes",
-                    input: mac([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]),
-                    expect: "FEDCBA987654".to_string(),
-                },
-            ],
-            |m| m.to_string(),
+        value_scenarios!(
+            run = |m| m.to_string();
+            "ascending low bytes" {
+                mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]) => "010203040506".to_string(),
+            }
+
+            "high bytes uppercase" {
+                mac([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]) => "AABBCCDDEEFF".to_string(),
+            }
+
+            "all zeros" {
+                mac([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]) => "000000000000".to_string(),
+            }
+
+            "all ones" {
+                mac([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]) => "FFFFFFFFFFFF".to_string(),
+            }
+
+            "single-digit bytes zero-padded" {
+                mac([0x00, 0x0A, 0x00, 0x0B, 0x00, 0x0C]) => "000A000B000C".to_string(),
+            }
+
+            "lowercase-hex digits rendered uppercase" {
+                mac([0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f]) => "0A0B0C0D0E0F".to_string(),
+            }
+
+            "mixed bytes" {
+                mac([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]) => "FEDCBA987654".to_string(),
+            }
         );
     }
 
@@ -143,25 +133,19 @@ mod test {
 
     #[test]
     fn to_mac_returns_wrapped_address() {
-        check_values(
-            [
-                Check {
-                    scenario: "ascending bytes",
-                    input: mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
-                    expect: MacAddress::new([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
-                },
-                Check {
-                    scenario: "zeros",
-                    input: mac([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
-                    expect: MacAddress::new([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
-                },
-                Check {
-                    scenario: "high bytes",
-                    input: mac([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]),
-                    expect: MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]),
-                },
-            ],
-            |m| m.to_mac(),
+        value_scenarios!(
+            run = |m| m.to_mac();
+            "ascending bytes" {
+                mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]) => MacAddress::new([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
+            }
+
+            "zeros" {
+                mac([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]) => MacAddress::new([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+            }
+
+            "high bytes" {
+                mac([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]) => MacAddress::new([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]),
+            }
         );
     }
 
@@ -169,20 +153,15 @@ mod test {
 
     #[test]
     fn from_macaddress_wraps_unchanged() {
-        check_values(
-            [
-                Check {
-                    scenario: "ascending bytes",
-                    input: MacAddress::new([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
-                    expect: mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
-                },
-                Check {
-                    scenario: "high bytes",
-                    input: MacAddress::new([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]),
-                    expect: mac([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]),
-                },
-            ],
-            BaseMac::from,
+        value_scenarios!(
+            run = BaseMac::from;
+            "ascending bytes" {
+                MacAddress::new([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]) => mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
+            }
+
+            "high bytes" {
+                MacAddress::new([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]) => mac([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]),
+            }
         );
     }
 
@@ -291,28 +270,22 @@ mod test {
         // Overlaps with `from_str_parses_accepted_forms` on the same inputs by
         // design: that test pins *which* inputs fail, this one pins *what the
         // error message says*.
-        check_cases(
-            [
-                Case {
-                    scenario: "too short reports invalid length",
-                    input: ("0102030405", &["Invalid stripped MAC length"][..]),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "too long reports invalid length",
-                    input: ("0102030405060708", &["Invalid stripped MAC length"][..]),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "empty reports invalid length",
-                    input: ("", &["Invalid stripped MAC length"][..]),
-                    expect: Yields(true),
-                },
-            ],
-            |(value, tokens)| {
+        scenarios!(
+            run = |(value, tokens)| {
                 let produced = BaseMac::from_str(value).unwrap_err().to_string();
                 Ok::<_, ()>(tokens.iter().all(|t| produced.contains(t)))
-            },
+            };
+            "too short reports invalid length" {
+                ("0102030405", &["Invalid stripped MAC length"][..]) => Yields(true),
+            }
+
+            "too long reports invalid length" {
+                ("0102030405060708", &["Invalid stripped MAC length"][..]) => Yields(true),
+            }
+
+            "empty reports invalid length" {
+                ("", &["Invalid stripped MAC length"][..]) => Yields(true),
+            }
         );
     }
 
@@ -320,25 +293,19 @@ mod test {
 
     #[test]
     fn serialize_emits_quoted_display_string() {
-        check_cases(
-            [
-                Case {
-                    scenario: "ascending bytes",
-                    input: mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
-                    expect: Yields("\"010203040506\"".to_string()),
-                },
-                Case {
-                    scenario: "high bytes uppercase",
-                    input: mac([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]),
-                    expect: Yields("\"FEDCBA987654\"".to_string()),
-                },
-                Case {
-                    scenario: "zeros",
-                    input: mac([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
-                    expect: Yields("\"000000000000\"".to_string()),
-                },
-            ],
-            |m| serde_json::to_string(&m).map_err(drop),
+        scenarios!(
+            run = |m| serde_json::to_string(&m).map_err(drop);
+            "ascending bytes" {
+                mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]) => Yields("\"010203040506\"".to_string()),
+            }
+
+            "high bytes uppercase" {
+                mac([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]) => Yields("\"FEDCBA987654\"".to_string()),
+            }
+
+            "zeros" {
+                mac([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]) => Yields("\"000000000000\"".to_string()),
+            }
         );
     }
 
@@ -346,78 +313,62 @@ mod test {
 
     #[test]
     fn deserialize_parses_accepted_json_strings() {
-        check_cases(
-            [
-                Case {
-                    scenario: "raw hex string",
-                    input: "\"0a0b0c0d0e0f\"",
-                    expect: Yields("0A0B0C0D0E0F".to_string()),
-                },
-                Case {
-                    scenario: "colon separated string",
-                    input: "\"11:22:33:44:55:66\"",
-                    expect: Yields("112233445566".to_string()),
-                },
-                Case {
-                    scenario: "uppercase round-trips",
-                    input: "\"FEDCBA987654\"",
-                    expect: Yields("FEDCBA987654".to_string()),
-                },
-                Case {
-                    scenario: "non-string json number",
-                    input: "1234",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "null",
-                    input: "null",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "invalid mac text",
-                    input: "\"invalid-mac\"",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "too-short string",
-                    input: "\"0102030405\"",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty string",
-                    input: "\"\"",
-                    expect: Fails,
-                },
-            ],
-            |json| {
+        scenarios!(
+            run = |json| {
                 serde_json::from_str::<BaseMac>(json)
                     .map(|m| m.to_string())
                     .map_err(drop)
-            },
+            };
+            "raw hex string" {
+                "\"0a0b0c0d0e0f\"" => Yields("0A0B0C0D0E0F".to_string()),
+            }
+
+            "colon separated string" {
+                "\"11:22:33:44:55:66\"" => Yields("112233445566".to_string()),
+            }
+
+            "uppercase round-trips" {
+                "\"FEDCBA987654\"" => Yields("FEDCBA987654".to_string()),
+            }
+
+            "non-string json number" {
+                "1234" => Fails,
+            }
+
+            "null" {
+                "null" => Fails,
+            }
+
+            "invalid mac text" {
+                "\"invalid-mac\"" => Fails,
+            }
+
+            "too-short string" {
+                "\"0102030405\"" => Fails,
+            }
+
+            "empty string" {
+                "\"\"" => Fails,
+            }
         );
     }
 
     #[test]
     fn deserialize_failure_carries_invalid_length_message() {
-        check_cases(
-            [
-                Case {
-                    scenario: "invalid text reports length",
-                    input: ("\"invalid-mac\"", &["Invalid stripped MAC length"][..]),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "short string reports length",
-                    input: ("\"0102030405\"", &["Invalid stripped MAC length"][..]),
-                    expect: Yields(true),
-                },
-            ],
-            |(json, tokens)| {
+        scenarios!(
+            run = |(json, tokens)| {
                 let produced = serde_json::from_str::<BaseMac>(json)
                     .unwrap_err()
                     .to_string();
                 Ok::<_, ()>(tokens.iter().all(|t| produced.contains(t)))
-            },
+            };
+            "invalid text reports length" {
+                ("\"invalid-mac\"", &["Invalid stripped MAC length"][..]) => Yields(true),
+            }
+
+            "short string reports length" {
+                ("\"0102030405\"", &["Invalid stripped MAC length"][..]) => Yields(true),
+            }
         );
     }
 
@@ -425,28 +376,22 @@ mod test {
 
     #[test]
     fn round_trips_through_json() {
-        check_cases(
-            [
-                Case {
-                    scenario: "high bytes",
-                    input: mac([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]),
-                    expect: Yields(mac([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54])),
-                },
-                Case {
-                    scenario: "ascending bytes",
-                    input: mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
-                    expect: Yields(mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06])),
-                },
-                Case {
-                    scenario: "zeros",
-                    input: mac([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
-                    expect: Yields(mac([0x00, 0x00, 0x00, 0x00, 0x00, 0x00])),
-                },
-            ],
-            |original| {
+        scenarios!(
+            run = |original| {
                 let serialized = serde_json::to_string(&original).map_err(drop)?;
                 serde_json::from_str::<BaseMac>(&serialized).map_err(drop)
-            },
+            };
+            "high bytes" {
+                mac([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54]) => Yields(mac([0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54])),
+            }
+
+            "ascending bytes" {
+                mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06]) => Yields(mac([0x01, 0x02, 0x03, 0x04, 0x05, 0x06])),
+            }
+
+            "zeros" {
+                mac([0x00, 0x00, 0x00, 0x00, 0x00, 0x00]) => Yields(mac([0x00, 0x00, 0x00, 0x00, 0x00, 0x00])),
+            }
         );
     }
 }

--- a/crates/network/src/ip/address_family.rs
+++ b/crates/network/src/ip/address_family.rs
@@ -103,139 +103,108 @@ mod tests {
     use std::net::IpAddr;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Case, scenarios, value_scenarios};
     use ipnet::IpNet;
 
     use super::*;
 
     #[test]
     fn test_interface_prefix_len() {
-        check_values(
-            [
-                Check {
-                    scenario: "ipv4 is /32",
-                    input: IpAddressFamily::Ipv4,
-                    expect: 32,
-                },
-                Check {
-                    scenario: "ipv6 is /128",
-                    input: IpAddressFamily::Ipv6,
-                    expect: 128,
-                },
-            ],
-            |family| family.interface_prefix_len(),
+        value_scenarios!(
+            run = |family| family.interface_prefix_len();
+            "ipv4 is /32" {
+                IpAddressFamily::Ipv4 => 32,
+            }
+
+            "ipv6 is /128" {
+                IpAddressFamily::Ipv6 => 128,
+            }
         );
     }
 
     #[test]
     fn test_pg_family() {
-        check_values(
-            [
-                Check {
-                    scenario: "ipv4 is postgres family 4",
-                    input: IpAddressFamily::Ipv4,
-                    expect: 4,
-                },
-                Check {
-                    scenario: "ipv6 is postgres family 6",
-                    input: IpAddressFamily::Ipv6,
-                    expect: 6,
-                },
-            ],
-            |family| family.pg_family(),
+        value_scenarios!(
+            run = |family| family.pg_family();
+            "ipv4 is postgres family 4" {
+                IpAddressFamily::Ipv4 => 4,
+            }
+
+            "ipv6 is postgres family 6" {
+                IpAddressFamily::Ipv6 => 6,
+            }
         );
     }
 
     #[test]
     fn test_ipaddr_address_family() {
-        check_values(
-            [
-                Check {
-                    scenario: "ipv4 loopback",
-                    input: "127.0.0.1",
-                    expect: IpAddressFamily::Ipv4,
-                },
-                Check {
-                    scenario: "ipv4 unspecified",
-                    input: "0.0.0.0",
-                    expect: IpAddressFamily::Ipv4,
-                },
-                Check {
-                    scenario: "ipv4 broadcast",
-                    input: "255.255.255.255",
-                    expect: IpAddressFamily::Ipv4,
-                },
-                Check {
-                    scenario: "ipv4 routable",
-                    input: "10.0.0.1",
-                    expect: IpAddressFamily::Ipv4,
-                },
-                Check {
-                    scenario: "ipv6 loopback",
-                    input: "::1",
-                    expect: IpAddressFamily::Ipv6,
-                },
-                Check {
-                    scenario: "ipv6 unspecified",
-                    input: "::",
-                    expect: IpAddressFamily::Ipv6,
-                },
-                Check {
-                    scenario: "ipv6 unique-local",
-                    input: "fd00::1",
-                    expect: IpAddressFamily::Ipv6,
-                },
-                Check {
-                    scenario: "ipv6 link-local",
-                    input: "fe80::1",
-                    expect: IpAddressFamily::Ipv6,
-                },
-                Check {
-                    scenario: "ipv4-mapped ipv6 stays ipv6",
-                    input: "::ffff:192.0.2.1",
-                    expect: IpAddressFamily::Ipv6,
-                },
-            ],
-            |s| s.parse::<IpAddr>().unwrap().address_family(),
+        value_scenarios!(
+            run = |s| s.parse::<IpAddr>().unwrap().address_family();
+            "ipv4 loopback" {
+                "127.0.0.1" => IpAddressFamily::Ipv4,
+            }
+
+            "ipv4 unspecified" {
+                "0.0.0.0" => IpAddressFamily::Ipv4,
+            }
+
+            "ipv4 broadcast" {
+                "255.255.255.255" => IpAddressFamily::Ipv4,
+            }
+
+            "ipv4 routable" {
+                "10.0.0.1" => IpAddressFamily::Ipv4,
+            }
+
+            "ipv6 loopback" {
+                "::1" => IpAddressFamily::Ipv6,
+            }
+
+            "ipv6 unspecified" {
+                "::" => IpAddressFamily::Ipv6,
+            }
+
+            "ipv6 unique-local" {
+                "fd00::1" => IpAddressFamily::Ipv6,
+            }
+
+            "ipv6 link-local" {
+                "fe80::1" => IpAddressFamily::Ipv6,
+            }
+
+            "ipv4-mapped ipv6 stays ipv6" {
+                "::ffff:192.0.2.1" => IpAddressFamily::Ipv6,
+            }
         );
     }
 
     #[test]
     fn test_ipnet_address_family() {
-        check_values(
-            [
-                Check {
-                    scenario: "ipv4 host route",
-                    input: "10.0.0.1/32",
-                    expect: IpAddressFamily::Ipv4,
-                },
-                Check {
-                    scenario: "ipv4 default route",
-                    input: "0.0.0.0/0",
-                    expect: IpAddressFamily::Ipv4,
-                },
-                Check {
-                    scenario: "ipv4 subnet",
-                    input: "192.168.0.0/24",
-                    expect: IpAddressFamily::Ipv4,
-                },
-                Check {
-                    scenario: "ipv6 host route",
-                    input: "fd00::1/128",
-                    expect: IpAddressFamily::Ipv6,
-                },
-                Check {
-                    scenario: "ipv6 default route",
-                    input: "::/0",
-                    expect: IpAddressFamily::Ipv6,
-                },
-                Check {
-                    scenario: "ipv6 subnet",
-                    input: "2001:db8::/64",
-                    expect: IpAddressFamily::Ipv6,
-                },
-            ],
-            |s| s.parse::<IpNet>().unwrap().address_family(),
+        value_scenarios!(
+            run = |s| s.parse::<IpNet>().unwrap().address_family();
+            "ipv4 host route" {
+                "10.0.0.1/32" => IpAddressFamily::Ipv4,
+            }
+
+            "ipv4 default route" {
+                "0.0.0.0/0" => IpAddressFamily::Ipv4,
+            }
+
+            "ipv4 subnet" {
+                "192.168.0.0/24" => IpAddressFamily::Ipv4,
+            }
+
+            "ipv6 host route" {
+                "fd00::1/128" => IpAddressFamily::Ipv6,
+            }
+
+            "ipv6 default route" {
+                "::/0" => IpAddressFamily::Ipv6,
+            }
+
+            "ipv6 subnet" {
+                "2001:db8::/64" => IpAddressFamily::Ipv6,
+            }
         );
     }
 
@@ -246,47 +215,40 @@ mod tests {
             family: IpAddressFamily,
         }
 
-        check_values(
-            [
-                Check {
-                    scenario: "ipv4 matches ipv4",
-                    input: Row {
-                        value: "10.0.0.1",
-                        family: IpAddressFamily::Ipv4,
-                    },
-                    expect: true,
-                },
-                Check {
-                    scenario: "ipv4 does not match ipv6",
-                    input: Row {
-                        value: "10.0.0.1",
-                        family: IpAddressFamily::Ipv6,
-                    },
-                    expect: false,
-                },
-                Check {
-                    scenario: "ipv6 matches ipv6",
-                    input: Row {
-                        value: "fd00::1",
-                        family: IpAddressFamily::Ipv6,
-                    },
-                    expect: true,
-                },
-                Check {
-                    scenario: "ipv6 does not match ipv4",
-                    input: Row {
-                        value: "fd00::1",
-                        family: IpAddressFamily::Ipv4,
-                    },
-                    expect: false,
-                },
-            ],
-            |row| {
+        value_scenarios!(
+            run = |row| {
                 row.value
                     .parse::<IpAddr>()
                     .unwrap()
                     .is_address_family(row.family)
-            },
+            };
+            "ipv4 matches ipv4" {
+                Row {
+                    value: "10.0.0.1",
+                    family: IpAddressFamily::Ipv4,
+                } => true,
+            }
+
+            "ipv4 does not match ipv6" {
+                Row {
+                    value: "10.0.0.1",
+                    family: IpAddressFamily::Ipv6,
+                } => false,
+            }
+
+            "ipv6 matches ipv6" {
+                Row {
+                    value: "fd00::1",
+                    family: IpAddressFamily::Ipv6,
+                } => true,
+            }
+
+            "ipv6 does not match ipv4" {
+                Row {
+                    value: "fd00::1",
+                    family: IpAddressFamily::Ipv4,
+                } => false,
+            }
         );
     }
 
@@ -297,45 +259,38 @@ mod tests {
             required: IpAddressFamily,
         }
 
-        check_cases(
-            [
-                Case {
-                    scenario: "ipv4 required and present yields the address",
-                    input: Row {
-                        value: "127.0.0.1",
-                        required: IpAddressFamily::Ipv4,
-                    },
-                    expect: Yields("127.0.0.1".parse::<IpAddr>().unwrap()),
-                },
-                Case {
-                    scenario: "ipv6 required and present yields the address",
-                    input: Row {
-                        value: "fd00::1",
-                        required: IpAddressFamily::Ipv6,
-                    },
-                    expect: Yields("fd00::1".parse::<IpAddr>().unwrap()),
-                },
-                Case {
-                    scenario: "ipv6 required but ipv4 given fails",
-                    input: Row {
-                        value: "127.0.0.1",
-                        required: IpAddressFamily::Ipv6,
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "ipv4 required but ipv6 given fails",
-                    input: Row {
-                        value: "fd00::1",
-                        required: IpAddressFamily::Ipv4,
-                    },
-                    expect: Fails,
-                },
-            ],
-            |row| {
+        scenarios!(
+            run = |row| {
                 let addr = row.value.parse::<IpAddr>().unwrap();
                 addr.require_address_family_or_else(row.required, |_| ())
-            },
+            };
+            "ipv4 required and present yields the address" {
+                Row {
+                    value: "127.0.0.1",
+                    required: IpAddressFamily::Ipv4,
+                } => Yields("127.0.0.1".parse::<IpAddr>().unwrap()),
+            }
+
+            "ipv6 required and present yields the address" {
+                Row {
+                    value: "fd00::1",
+                    required: IpAddressFamily::Ipv6,
+                } => Yields("fd00::1".parse::<IpAddr>().unwrap()),
+            }
+
+            "ipv6 required but ipv4 given fails" {
+                Row {
+                    value: "127.0.0.1",
+                    required: IpAddressFamily::Ipv6,
+                } => Fails,
+            }
+
+            "ipv4 required but ipv6 given fails" {
+                Row {
+                    value: "fd00::1",
+                    required: IpAddressFamily::Ipv4,
+                } => Fails,
+            }
         );
     }
 

--- a/crates/network/src/ip/ipset.rs
+++ b/crates/network/src/ip/ipset.rs
@@ -178,7 +178,7 @@ mod tests {
     use std::net::Ipv4Addr;
     use std::str::FromStr;
 
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::{Check, check_values, value_scenarios};
 
     use super::*;
 
@@ -208,85 +208,66 @@ mod tests {
         // The set is the whole 10/8 net; check addresses and prefixes inside it,
         // on each boundary, and just outside on either side.
         let ipset = IpSet::from(pfx("10.0.0.0/8"));
-        check_values(
-            [
-                Check {
-                    scenario: "the defining prefix itself",
-                    input: "10.0.0.0/8",
-                    expect: true,
-                },
-                Check {
-                    scenario: "first address in range",
-                    input: "10.0.0.0/32",
-                    expect: true,
-                },
-                Check {
-                    scenario: "last address in range",
-                    input: "10.255.255.255/32",
-                    expect: true,
-                },
-                Check {
-                    scenario: "an interior subprefix",
-                    input: "10.128.0.0/9",
-                    expect: true,
-                },
-                Check {
-                    scenario: "a deep interior address",
-                    input: "10.1.2.3/32",
-                    expect: true,
-                },
-                Check {
-                    scenario: "one address before the range",
-                    input: "9.255.255.255/32",
-                    expect: false,
-                },
-                Check {
-                    scenario: "one address after the range",
-                    input: "11.0.0.0/32",
-                    expect: false,
-                },
-                Check {
-                    scenario: "a wider prefix that is not contained",
-                    input: "10.0.0.0/7",
-                    expect: false,
-                },
-                Check {
-                    scenario: "an unrelated v4 prefix",
-                    input: "192.168.0.0/16",
-                    expect: false,
-                },
-                Check {
-                    scenario: "an IPv6 prefix is never in a v4-only set",
-                    input: "2001:db8::/32",
-                    expect: false,
-                },
-            ],
-            |s| ipset.contains(pfx(s)),
+        value_scenarios!(
+            run = |s| ipset.contains(pfx(s));
+            "the defining prefix itself" {
+                "10.0.0.0/8" => true,
+            }
+
+            "first address in range" {
+                "10.0.0.0/32" => true,
+            }
+
+            "last address in range" {
+                "10.255.255.255/32" => true,
+            }
+
+            "an interior subprefix" {
+                "10.128.0.0/9" => true,
+            }
+
+            "a deep interior address" {
+                "10.1.2.3/32" => true,
+            }
+
+            "one address before the range" {
+                "9.255.255.255/32" => false,
+            }
+
+            "one address after the range" {
+                "11.0.0.0/32" => false,
+            }
+
+            "a wider prefix that is not contained" {
+                "10.0.0.0/7" => false,
+            }
+
+            "an unrelated v4 prefix" {
+                "192.168.0.0/16" => false,
+            }
+
+            "an IPv6 prefix is never in a v4-only set" {
+                "2001:db8::/32" => false,
+            }
         );
     }
 
     #[test]
     fn membership_of_the_empty_set_is_always_false() {
         let ipset = IpSet::new_empty();
-        check_values(
-            [
-                Check {
-                    scenario: "v4 address",
-                    input: "10.0.0.1/32",
-                    expect: false,
-                },
-                Check {
-                    scenario: "v4 prefix",
-                    input: "0.0.0.0/0",
-                    expect: false,
-                },
-                Check {
-                    scenario: "v6 prefix",
-                    input: "::/0",
-                    expect: false,
-                },
-            ],
-            |s| ipset.contains(pfx(s)),
+        value_scenarios!(
+            run = |s| ipset.contains(pfx(s));
+            "v4 address" {
+                "10.0.0.1/32" => false,
+            }
+
+            "v4 prefix" {
+                "0.0.0.0/0" => false,
+            }
+
+            "v6 prefix" {
+                "::/0" => false,
+            }
         );
     }
 
@@ -295,30 +276,23 @@ mod tests {
         // A set holding both a v4 and a v6 prefix; each family answers
         // independently and never crosses over.
         let ipset = IpSet::from([pfx("10.0.0.0/8"), pfx("2001:db8::/32")]);
-        check_values(
-            [
-                Check {
-                    scenario: "inside the v4 member",
-                    input: "10.5.5.5/32",
-                    expect: true,
-                },
-                Check {
-                    scenario: "inside the v6 member",
-                    input: "2001:db8:abcd::/48",
-                    expect: true,
-                },
-                Check {
-                    scenario: "outside the v4 member",
-                    input: "11.0.0.0/8",
-                    expect: false,
-                },
-                Check {
-                    scenario: "outside the v6 member",
-                    input: "2001:db9::/32",
-                    expect: false,
-                },
-            ],
-            |s| ipset.contains(pfx(s)),
+        value_scenarios!(
+            run = |s| ipset.contains(pfx(s));
+            "inside the v4 member" {
+                "10.5.5.5/32" => true,
+            }
+
+            "inside the v6 member" {
+                "2001:db8:abcd::/48" => true,
+            }
+
+            "outside the v4 member" {
+                "11.0.0.0/8" => false,
+            }
+
+            "outside the v6 member" {
+                "2001:db9::/32" => false,
+            }
         );
     }
 
@@ -326,84 +300,69 @@ mod tests {
     fn adding_prefixes_aggregates_and_dedups() {
         // Each row builds a fresh set from the given inputs and asserts the
         // resulting aggregate prefixes. Order of insertion must not matter.
-        check_values(
-            [
-                Check {
-                    scenario: "single prefix is stored verbatim",
-                    input: &["10.0.0.0/24"][..],
-                    expect: vec!["10.0.0.0/24".to_string()],
-                },
-                Check {
-                    scenario: "exact duplicate is a no-op",
-                    input: &["10.0.0.0/24", "10.0.0.0/24"][..],
-                    expect: vec!["10.0.0.0/24".to_string()],
-                },
-                Check {
-                    scenario: "a subprefix already covered is absorbed",
-                    input: &["10.0.0.0/8", "10.1.2.0/24"][..],
-                    expect: vec!["10.0.0.0/8".to_string()],
-                },
-                Check {
-                    scenario: "a superprefix swallows an existing entry",
-                    input: &["10.1.2.0/24", "10.0.0.0/8"][..],
-                    expect: vec!["10.0.0.0/8".to_string()],
-                },
-                Check {
-                    scenario: "two siblings aggregate into their supernet",
-                    input: &["10.0.0.0/24", "10.0.1.0/24"][..],
-                    expect: vec!["10.0.0.0/23".to_string()],
-                },
-                Check {
-                    scenario: "siblings aggregate regardless of insertion order",
-                    input: &["10.0.1.0/24", "10.0.0.0/24"][..],
-                    expect: vec!["10.0.0.0/23".to_string()],
-                },
-                Check {
-                    scenario: "non-sibling neighbors stay separate",
-                    input: &["10.0.1.0/24", "10.0.2.0/24"][..],
-                    expect: vec!["10.0.1.0/24".to_string(), "10.0.2.0/24".to_string()],
-                },
-                Check {
-                    scenario: "cascading aggregation up several levels",
-                    input: &[
-                        "10.0.0.0/26",
-                        "10.0.0.64/26",
-                        "10.0.0.128/26",
-                        "10.0.0.192/26",
-                    ][..],
-                    expect: vec!["10.0.0.0/24".to_string()],
-                },
-                Check {
-                    scenario: "filling a /24 from a /25 plus power-of-two pieces",
-                    input: &[
-                        "10.0.1.4/30",
-                        "10.0.1.8/29",
-                        "10.0.1.16/28",
-                        "10.0.1.32/27",
-                        "10.0.1.64/26",
-                        "10.0.1.128/25",
-                        "10.0.0.0/24",
-                        "10.0.1.0/30",
-                    ][..],
-                    expect: vec!["10.0.0.0/23".to_string()],
-                },
-                Check {
-                    scenario: "a v4 and a v6 prefix coexist, v4 sorts first",
-                    input: &["2001:db8::/32", "10.0.0.0/8"][..],
-                    expect: vec!["10.0.0.0/8".to_string(), "2001:db8::/32".to_string()],
-                },
-                Check {
-                    scenario: "v6 siblings aggregate too",
-                    input: &["2001:db8:0000::/34", "2001:db8:4000::/34"][..],
-                    expect: vec!["2001:db8::/33".to_string()],
-                },
-                Check {
-                    scenario: "a default route swallows everything in its family",
-                    input: &["0.0.0.0/0", "10.0.0.0/8", "192.168.0.0/16"][..],
-                    expect: vec!["0.0.0.0/0".to_string()],
-                },
-            ],
-            add_all_and_dump,
+        value_scenarios!(
+            run = add_all_and_dump;
+            "single prefix is stored verbatim" {
+                &["10.0.0.0/24"][..] => vec!["10.0.0.0/24".to_string()],
+            }
+
+            "exact duplicate is a no-op" {
+                &["10.0.0.0/24", "10.0.0.0/24"][..] => vec!["10.0.0.0/24".to_string()],
+            }
+
+            "a subprefix already covered is absorbed" {
+                &["10.0.0.0/8", "10.1.2.0/24"][..] => vec!["10.0.0.0/8".to_string()],
+            }
+
+            "a superprefix swallows an existing entry" {
+                &["10.1.2.0/24", "10.0.0.0/8"][..] => vec!["10.0.0.0/8".to_string()],
+            }
+
+            "two siblings aggregate into their supernet" {
+                &["10.0.0.0/24", "10.0.1.0/24"][..] => vec!["10.0.0.0/23".to_string()],
+            }
+
+            "siblings aggregate regardless of insertion order" {
+                &["10.0.1.0/24", "10.0.0.0/24"][..] => vec!["10.0.0.0/23".to_string()],
+            }
+
+            "non-sibling neighbors stay separate" {
+                &["10.0.1.0/24", "10.0.2.0/24"][..] => vec!["10.0.1.0/24".to_string(), "10.0.2.0/24".to_string()],
+            }
+
+            "cascading aggregation up several levels" {
+                &[
+                    "10.0.0.0/26",
+                    "10.0.0.64/26",
+                    "10.0.0.128/26",
+                    "10.0.0.192/26",
+                ][..] => vec!["10.0.0.0/24".to_string()],
+            }
+
+            "filling a /24 from a /25 plus power-of-two pieces" {
+                &[
+                    "10.0.1.4/30",
+                    "10.0.1.8/29",
+                    "10.0.1.16/28",
+                    "10.0.1.32/27",
+                    "10.0.1.64/26",
+                    "10.0.1.128/25",
+                    "10.0.0.0/24",
+                    "10.0.1.0/30",
+                ][..] => vec!["10.0.0.0/23".to_string()],
+            }
+
+            "a v4 and a v6 prefix coexist, v4 sorts first" {
+                &["2001:db8::/32", "10.0.0.0/8"][..] => vec!["10.0.0.0/8".to_string(), "2001:db8::/32".to_string()],
+            }
+
+            "v6 siblings aggregate too" {
+                &["2001:db8:0000::/34", "2001:db8:4000::/34"][..] => vec!["2001:db8::/33".to_string()],
+            }
+
+            "a default route swallows everything in its family" {
+                &["0.0.0.0/0", "10.0.0.0/8", "192.168.0.0/16"][..] => vec!["0.0.0.0/0".to_string()],
+            }
         );
     }
 
@@ -535,39 +494,32 @@ mod tests {
                 .collect();
             (v4, v6, ipset.get_prefixes().len())
         };
-        check_values(
-            [
-                Check {
-                    scenario: "mixed set splits into its two families",
-                    input: IpSet::from([
-                        pfx("10.0.0.0/8"),
-                        pfx("192.168.0.0/16"),
-                        pfx("2001:db8::/32"),
-                        pfx("fd00::/8"),
-                    ]),
-                    expect: (
-                        vec!["10.0.0.0/8".to_string(), "192.168.0.0/16".to_string()],
-                        vec!["2001:db8::/32".to_string(), "fd00::/8".to_string()],
-                        4,
-                    ),
-                },
-                Check {
-                    scenario: "v4-only set yields nothing from the v6 getter",
-                    input: IpSet::from(pfx("10.0.0.0/8")),
-                    expect: (vec!["10.0.0.0/8".to_string()], vec![], 1),
-                },
-                Check {
-                    scenario: "v6-only set yields nothing from the v4 getter",
-                    input: IpSet::from(pfx("2001:db8::/32")),
-                    expect: (vec![], vec!["2001:db8::/32".to_string()], 1),
-                },
-                Check {
-                    scenario: "empty set yields nothing from either getter",
-                    input: IpSet::new_empty(),
-                    expect: (vec![], vec![], 0),
-                },
-            ],
-            project,
+        value_scenarios!(
+            run = project;
+            "mixed set splits into its two families" {
+                IpSet::from([
+                    pfx("10.0.0.0/8"),
+                    pfx("192.168.0.0/16"),
+                    pfx("2001:db8::/32"),
+                    pfx("fd00::/8"),
+                ]) => (
+                    vec!["10.0.0.0/8".to_string(), "192.168.0.0/16".to_string()],
+                    vec!["2001:db8::/32".to_string(), "fd00::/8".to_string()],
+                    4,
+                ),
+            }
+
+            "v4-only set yields nothing from the v6 getter" {
+                IpSet::from(pfx("10.0.0.0/8")) => (vec!["10.0.0.0/8".to_string()], vec![], 1),
+            }
+
+            "v6-only set yields nothing from the v4 getter" {
+                IpSet::from(pfx("2001:db8::/32")) => (vec![], vec!["2001:db8::/32".to_string()], 1),
+            }
+
+            "empty set yields nothing from either getter" {
+                IpSet::new_empty() => (vec![], vec![], 0),
+            }
         );
     }
 
@@ -575,28 +527,22 @@ mod tests {
     fn from_iterator_constructs_an_aggregated_set() {
         // The `From<IntoIterator>` impl runs every item through `add`, so the
         // result is already aggregated and deduplicated.
-        check_values(
-            [
-                Check {
-                    scenario: "empty iterator yields the empty set",
-                    input: &[][..],
-                    expect: Vec::<String>::new(),
-                },
-                Check {
-                    scenario: "duplicates collapse",
-                    input: &["10.0.0.0/24", "10.0.0.0/24", "10.0.0.0/24"][..],
-                    expect: vec!["10.0.0.0/24".to_string()],
-                },
-                Check {
-                    scenario: "siblings aggregate",
-                    input: &["10.0.0.0/24", "10.0.1.0/24"][..],
-                    expect: vec!["10.0.0.0/23".to_string()],
-                },
-            ],
-            |strs: &[&str]| {
+        value_scenarios!(
+            run = |strs: &[&str]| {
                 let ipset = IpSet::from(pfxs(strs));
                 ipset.get_prefixes().iter().map(|p| p.to_string()).collect()
-            },
+            };
+            "empty iterator yields the empty set" {
+                &[][..] => Vec::<String>::new(),
+            }
+
+            "duplicates collapse" {
+                &["10.0.0.0/24", "10.0.0.0/24", "10.0.0.0/24"][..] => vec!["10.0.0.0/24".to_string()],
+            }
+
+            "siblings aggregate" {
+                &["10.0.0.0/24", "10.0.1.0/24"][..] => vec!["10.0.0.0/23".to_string()],
+            }
         );
     }
 
@@ -617,37 +563,31 @@ mod tests {
         // The original `test_aggregate_prefixes`, generalized: each row feeds a
         // (deliberately scrambled) list through the free `aggregate_prefixes`
         // helper and asserts the merged, v4-before-v6 result.
-        check_values(
-            [
-                Check {
-                    scenario: "empty input yields nothing",
-                    input: &[][..],
-                    expect: Vec::<String>::new(),
-                },
-                Check {
-                    scenario: "a single prefix passes through",
-                    input: &["10.0.0.0/24"][..],
-                    expect: vec!["10.0.0.0/24".to_string()],
-                },
-                Check {
-                    scenario: "mixed v4 and v6 merge within each family and sort",
-                    input: &[
-                        "2001:db8:8000::/33",
-                        "2001:db8:4000::/34",
-                        "2001:db8:0000::/34",
-                        "10.0.2.0/23",
-                        "10.0.1.0/24",
-                        "10.0.0.0/24",
-                    ][..],
-                    expect: vec!["10.0.0.0/22".to_string(), "2001:db8::/32".to_string()],
-                },
-            ],
-            |strs: &[&str]| {
+        value_scenarios!(
+            run = |strs: &[&str]| {
                 aggregate_prefixes(pfxs(strs))
                     .iter()
                     .map(|p| p.to_string())
                     .collect()
-            },
+            };
+            "empty input yields nothing" {
+                &[][..] => Vec::<String>::new(),
+            }
+
+            "a single prefix passes through" {
+                &["10.0.0.0/24"][..] => vec!["10.0.0.0/24".to_string()],
+            }
+
+            "mixed v4 and v6 merge within each family and sort" {
+                &[
+                    "2001:db8:8000::/33",
+                    "2001:db8:4000::/34",
+                    "2001:db8:0000::/34",
+                    "10.0.2.0/23",
+                    "10.0.1.0/24",
+                    "10.0.0.0/24",
+                ][..] => vec!["10.0.0.0/22".to_string(), "2001:db8::/32".to_string()],
+            }
         );
     }
 }

--- a/crates/network/src/ip/prefix.rs
+++ b/crates/network/src/ip/prefix.rs
@@ -632,7 +632,7 @@ where
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -643,741 +643,572 @@ mod tests {
 
     #[test]
     fn ipv4_prefix_from_str_accepts_and_rejects() {
-        check_cases(
-            [
-                Case {
-                    scenario: "canonical /16",
-                    input: "192.168.0.0/16",
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "canonical /0",
-                    input: "0.0.0.0/0",
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "host /32",
-                    input: "10.0.0.1/32",
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "non-canonical host bits set",
-                    input: "192.168.1.2/16",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "non-canonical single low bit",
-                    input: "10.0.0.1/24",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "prefix length out of range",
-                    input: "192.168.0.0/33",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "garbage address",
-                    input: "not-an-ip/16",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "missing prefix length",
-                    input: "192.168.0.0",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty string",
-                    input: "",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "ipv6 text rejected by v4 parser",
-                    input: "2001:db8::/48",
-                    expect: Fails,
-                },
-            ],
-            // The Ok payload (the parsed prefix) varies per row, so success is
+        scenarios!(
+            run = // The Ok payload (the parsed prefix) varies per row, so success is
             // collapsed to the unit value; the contract under test is which
             // inputs parse and which are rejected.
-            |s| Ipv4Prefix::from_str(s).map(|_| ()).map_err(drop),
+            |s| Ipv4Prefix::from_str(s).map(|_| ()).map_err(drop);
+            "canonical /16" {
+                "192.168.0.0/16" => Yields(()),
+            }
+
+            "canonical /0" {
+                "0.0.0.0/0" => Yields(()),
+            }
+
+            "host /32" {
+                "10.0.0.1/32" => Yields(()),
+            }
+
+            "non-canonical host bits set" {
+                "192.168.1.2/16" => Fails,
+            }
+
+            "non-canonical single low bit" {
+                "10.0.0.1/24" => Fails,
+            }
+
+            "prefix length out of range" {
+                "192.168.0.0/33" => Fails,
+            }
+
+            "garbage address" {
+                "not-an-ip/16" => Fails,
+            }
+
+            "missing prefix length" {
+                "192.168.0.0" => Fails,
+            }
+
+            "empty string" {
+                "" => Fails,
+            }
+
+            "ipv6 text rejected by v4 parser" {
+                "2001:db8::/48" => Fails,
+            }
         );
     }
 
     #[test]
     fn ipv4_prefix_from_str_round_trips_canonical_inputs() {
-        check_values(
-            [
-                Check {
-                    scenario: "canonical /16 parses",
-                    input: "192.168.0.0/16",
-                    expect: true,
-                },
-                Check {
-                    scenario: "non-canonical /16 rejected",
-                    input: "192.168.1.2/16",
-                    expect: false,
-                },
-                Check {
-                    scenario: "length 33 rejected",
-                    input: "192.168.0.0/33",
-                    expect: false,
-                },
-                Check {
-                    scenario: "garbage rejected",
-                    input: "x/16",
-                    expect: false,
-                },
-            ],
-            |s| Ipv4Prefix::from_str(s).is_ok(),
+        value_scenarios!(
+            run = |s| Ipv4Prefix::from_str(s).is_ok();
+            "canonical /16 parses" {
+                "192.168.0.0/16" => true,
+            }
+
+            "non-canonical /16 rejected" {
+                "192.168.1.2/16" => false,
+            }
+
+            "length 33 rejected" {
+                "192.168.0.0/33" => false,
+            }
+
+            "garbage rejected" {
+                "x/16" => false,
+            }
         );
     }
 
     #[test]
     fn ipv6_prefix_from_str_round_trips_canonical_inputs() {
-        check_values(
-            [
-                Check {
-                    scenario: "canonical /48 parses",
-                    input: "2001:db8::/48",
-                    expect: true,
-                },
-                Check {
-                    scenario: "canonical /0 parses",
-                    input: "::/0",
-                    expect: true,
-                },
-                Check {
-                    scenario: "host /128 parses",
-                    input: "2001:db8::1/128",
-                    expect: true,
-                },
-                Check {
-                    scenario: "non-canonical host bits set",
-                    input: "2001:db8::2/64",
-                    expect: false,
-                },
-                Check {
-                    scenario: "length 129 rejected",
-                    input: "2001:db8::/129",
-                    expect: false,
-                },
-                Check {
-                    scenario: "garbage rejected",
-                    input: "nope/48",
-                    expect: false,
-                },
-                Check {
-                    scenario: "ipv4 text rejected by v6 parser",
-                    input: "10.0.0.0/8",
-                    expect: false,
-                },
-                Check {
-                    scenario: "empty string rejected",
-                    input: "",
-                    expect: false,
-                },
-            ],
-            |s| Ipv6Prefix::from_str(s).is_ok(),
+        value_scenarios!(
+            run = |s| Ipv6Prefix::from_str(s).is_ok();
+            "canonical /48 parses" {
+                "2001:db8::/48" => true,
+            }
+
+            "canonical /0 parses" {
+                "::/0" => true,
+            }
+
+            "host /128 parses" {
+                "2001:db8::1/128" => true,
+            }
+
+            "non-canonical host bits set" {
+                "2001:db8::2/64" => false,
+            }
+
+            "length 129 rejected" {
+                "2001:db8::/129" => false,
+            }
+
+            "garbage rejected" {
+                "nope/48" => false,
+            }
+
+            "ipv4 text rejected by v6 parser" {
+                "10.0.0.0/8" => false,
+            }
+
+            "empty string rejected" {
+                "" => false,
+            }
         );
     }
 
     #[test]
     fn ip_prefix_from_str_accepts_both_families() {
-        check_values(
-            [
-                Check {
-                    scenario: "ipv4 canonical",
-                    input: "10.0.0.0/8",
-                    expect: true,
-                },
-                Check {
-                    scenario: "ipv6 canonical",
-                    input: "2001:db8::/32",
-                    expect: true,
-                },
-                Check {
-                    scenario: "ipv4 non-canonical",
-                    input: "10.0.0.1/8",
-                    expect: false,
-                },
-                Check {
-                    scenario: "ipv6 non-canonical",
-                    input: "2001:db8::2/64",
-                    expect: false,
-                },
-                Check {
-                    scenario: "ipv4 bad length",
-                    input: "10.0.0.0/33",
-                    expect: false,
-                },
-                Check {
-                    scenario: "empty",
-                    input: "",
-                    expect: false,
-                },
-            ],
-            |s| IpPrefix::from_str(s).is_ok(),
+        value_scenarios!(
+            run = |s| IpPrefix::from_str(s).is_ok();
+            "ipv4 canonical" {
+                "10.0.0.0/8" => true,
+            }
+
+            "ipv6 canonical" {
+                "2001:db8::/32" => true,
+            }
+
+            "ipv4 non-canonical" {
+                "10.0.0.1/8" => false,
+            }
+
+            "ipv6 non-canonical" {
+                "2001:db8::2/64" => false,
+            }
+
+            "ipv4 bad length" {
+                "10.0.0.0/33" => false,
+            }
+
+            "empty" {
+                "" => false,
+            }
         );
     }
 
     #[test]
     fn try_from_ipnet_validates_canonical_representation() {
-        check_cases(
-            [
-                Case {
-                    scenario: "canonical v4 accepted",
-                    input: "10.0.0.0/8",
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "non-canonical v4 rejected",
-                    input: "10.0.0.1/8",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "canonical v6 accepted",
-                    input: "2001:db8::/32",
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "non-canonical v6 rejected",
-                    input: "2001:db8::1/32",
-                    expect: Fails,
-                },
-            ],
-            |s| {
+        scenarios!(
+            run = |s| {
                 let net = IpNet::from_str(s).expect("test net should parse");
                 IpPrefix::try_from(net).map(|_| ()).map_err(drop)
-            },
+            };
+            "canonical v4 accepted" {
+                "10.0.0.0/8" => Yields(()),
+            }
+
+            "non-canonical v4 rejected" {
+                "10.0.0.1/8" => Fails,
+            }
+
+            "canonical v6 accepted" {
+                "2001:db8::/32" => Yields(()),
+            }
+
+            "non-canonical v6 rejected" {
+                "2001:db8::1/32" => Fails,
+            }
         );
     }
 
     #[test]
     fn try_from_addr_and_length_validates() {
-        check_cases(
-            [
-                Case {
-                    scenario: "canonical v4",
-                    input: (IpAddr::from([10, 0, 0, 0]), 8u8),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "non-canonical v4",
-                    input: (IpAddr::from([10, 0, 0, 1]), 8u8),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "v4 length too long",
-                    input: (IpAddr::from([10, 0, 0, 0]), 33u8),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "v4 host /32",
-                    input: (IpAddr::from([10, 0, 0, 1]), 32u8),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "v6 length too long",
-                    input: (IpAddr::from(Ipv6Addr::LOCALHOST), 129u8),
-                    expect: Fails,
-                },
-            ],
-            |(addr, len)| IpPrefix::try_from((addr, len)).map(|_| ()).map_err(drop),
+        scenarios!(
+            run = |(addr, len)| IpPrefix::try_from((addr, len)).map(|_| ()).map_err(drop);
+            "canonical v4" {
+                (IpAddr::from([10, 0, 0, 0]), 8u8) => Yields(()),
+            }
+
+            "non-canonical v4" {
+                (IpAddr::from([10, 0, 0, 1]), 8u8) => Fails,
+            }
+
+            "v4 length too long" {
+                (IpAddr::from([10, 0, 0, 0]), 33u8) => Fails,
+            }
+
+            "v4 host /32" {
+                (IpAddr::from([10, 0, 0, 1]), 32u8) => Yields(()),
+            }
+
+            "v6 length too long" {
+                (IpAddr::from(Ipv6Addr::LOCALHOST), 129u8) => Fails,
+            }
         );
     }
 
     #[test]
     fn address_family_reports_variant() {
-        check_values(
-            [
-                Check {
-                    scenario: "v4 prefix",
-                    input: "10.0.0.0/8",
-                    expect: IpAddressFamily::Ipv4,
-                },
-                Check {
-                    scenario: "v6 prefix",
-                    input: "2001:db8::/32",
-                    expect: IpAddressFamily::Ipv6,
-                },
-            ],
-            |s| prefix(s).address_family(),
+        value_scenarios!(
+            run = |s| prefix(s).address_family();
+            "v4 prefix" {
+                "10.0.0.0/8" => IpAddressFamily::Ipv4,
+            }
+
+            "v6 prefix" {
+                "2001:db8::/32" => IpAddressFamily::Ipv6,
+            }
         );
     }
 
     #[test]
     fn is_address_family_matches_only_its_own() {
-        check_values(
-            [
-                Check {
-                    scenario: "v4 is v4",
-                    input: ("10.0.0.0/8", IpAddressFamily::Ipv4),
-                    expect: true,
-                },
-                Check {
-                    scenario: "v4 is not v6",
-                    input: ("10.0.0.0/8", IpAddressFamily::Ipv6),
-                    expect: false,
-                },
-                Check {
-                    scenario: "v6 is v6",
-                    input: ("2001:db8::/32", IpAddressFamily::Ipv6),
-                    expect: true,
-                },
-                Check {
-                    scenario: "v6 is not v4",
-                    input: ("2001:db8::/32", IpAddressFamily::Ipv4),
-                    expect: false,
-                },
-            ],
-            |(s, family)| prefix(s).is_address_family(family),
+        value_scenarios!(
+            run = |(s, family)| prefix(s).is_address_family(family);
+            "v4 is v4" {
+                ("10.0.0.0/8", IpAddressFamily::Ipv4) => true,
+            }
+
+            "v4 is not v6" {
+                ("10.0.0.0/8", IpAddressFamily::Ipv6) => false,
+            }
+
+            "v6 is v6" {
+                ("2001:db8::/32", IpAddressFamily::Ipv6) => true,
+            }
+
+            "v6 is not v4" {
+                ("2001:db8::/32", IpAddressFamily::Ipv4) => false,
+            }
         );
     }
 
     #[test]
     fn require_address_family_or_else_passes_or_runs_fallback() {
-        check_cases(
-            [
-                Case {
-                    scenario: "v4 required and present",
-                    input: ("10.0.0.0/8", IpAddressFamily::Ipv4),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "v6 required but is v4",
-                    input: ("10.0.0.0/8", IpAddressFamily::Ipv6),
-                    expect: FailsWith(42),
-                },
-                Case {
-                    scenario: "v6 required and present",
-                    input: ("2001:db8::/32", IpAddressFamily::Ipv6),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "v4 required but is v6",
-                    input: ("2001:db8::/32", IpAddressFamily::Ipv4),
-                    expect: FailsWith(42),
-                },
-            ],
-            |(s, family)| {
+        scenarios!(
+            run = |(s, family)| {
                 prefix(s)
                     .require_address_family_or_else(family, |_| 42)
                     .map(|_| ())
-            },
+            };
+            "v4 required and present" {
+                ("10.0.0.0/8", IpAddressFamily::Ipv4) => Yields(()),
+            }
+
+            "v6 required but is v4" {
+                ("10.0.0.0/8", IpAddressFamily::Ipv6) => FailsWith(42),
+            }
+
+            "v6 required and present" {
+                ("2001:db8::/32", IpAddressFamily::Ipv6) => Yields(()),
+            }
+
+            "v4 required but is v6" {
+                ("2001:db8::/32", IpAddressFamily::Ipv4) => FailsWith(42),
+            }
         );
     }
 
     #[test]
     fn contains_checks_membership_across_families() {
-        check_values(
-            [
-                Check {
-                    scenario: "v4 prefix holds member address",
-                    input: ("10.0.0.0/8", IpAddr::from([10, 0, 0, 1])),
-                    expect: true,
-                },
-                Check {
-                    scenario: "v4 prefix holds its own network address",
-                    input: ("10.0.0.0/8", IpAddr::from([10, 0, 0, 0])),
-                    expect: true,
-                },
-                Check {
-                    scenario: "v4 prefix excludes outside address",
-                    input: ("10.0.0.0/8", IpAddr::from([11, 0, 0, 1])),
-                    expect: false,
-                },
-                Check {
-                    scenario: "v4 prefix does not hold a v6 address",
-                    input: ("10.0.0.0/8", IpAddr::from(Ipv6Addr::LOCALHOST)),
-                    expect: false,
-                },
-                Check {
-                    scenario: "default route holds anything v4",
-                    input: ("0.0.0.0/0", IpAddr::from([200, 1, 2, 3])),
-                    expect: true,
-                },
-                Check {
-                    scenario: "v6 prefix holds member address",
-                    input: ("2001:db8::/32", IpAddr::from_str("2001:db8::1").unwrap()),
-                    expect: true,
-                },
-                Check {
-                    scenario: "v6 prefix excludes outside address",
-                    input: ("2001:db8::/32", IpAddr::from_str("2001:db9::1").unwrap()),
-                    expect: false,
-                },
-                Check {
-                    scenario: "v6 prefix does not hold a v4 address",
-                    input: ("2001:db8::/32", IpAddr::from([10, 0, 0, 1])),
-                    expect: false,
-                },
-            ],
-            |(p, addr)| prefix(p).contains(addr),
+        value_scenarios!(
+            run = |(p, addr)| prefix(p).contains(addr);
+            "v4 prefix holds member address" {
+                ("10.0.0.0/8", IpAddr::from([10, 0, 0, 1])) => true,
+            }
+
+            "v4 prefix holds its own network address" {
+                ("10.0.0.0/8", IpAddr::from([10, 0, 0, 0])) => true,
+            }
+
+            "v4 prefix excludes outside address" {
+                ("10.0.0.0/8", IpAddr::from([11, 0, 0, 1])) => false,
+            }
+
+            "v4 prefix does not hold a v6 address" {
+                ("10.0.0.0/8", IpAddr::from(Ipv6Addr::LOCALHOST)) => false,
+            }
+
+            "default route holds anything v4" {
+                ("0.0.0.0/0", IpAddr::from([200, 1, 2, 3])) => true,
+            }
+
+            "v6 prefix holds member address" {
+                ("2001:db8::/32", IpAddr::from_str("2001:db8::1").unwrap()) => true,
+            }
+
+            "v6 prefix excludes outside address" {
+                ("2001:db8::/32", IpAddr::from_str("2001:db9::1").unwrap()) => false,
+            }
+
+            "v6 prefix does not hold a v4 address" {
+                ("2001:db8::/32", IpAddr::from([10, 0, 0, 1])) => false,
+            }
         );
     }
 
     #[test]
     fn contains_subprefix_relationships() {
-        check_values(
-            [
-                Check {
-                    scenario: "broader holds narrower",
-                    input: ("10.0.0.0/8", "10.1.0.0/16"),
-                    expect: true,
-                },
-                Check {
-                    scenario: "prefix holds itself",
-                    input: ("10.0.0.0/8", "10.0.0.0/8"),
-                    expect: true,
-                },
-                Check {
-                    scenario: "narrower does not hold broader",
-                    input: ("10.0.0.0/16", "10.0.0.0/8"),
-                    expect: false,
-                },
-                Check {
-                    scenario: "disjoint v4 prefixes",
-                    input: ("10.0.0.0/8", "11.0.0.0/8"),
-                    expect: false,
-                },
-                Check {
-                    scenario: "v4 never holds v6",
-                    input: ("10.0.0.0/8", "2001:db8::/32"),
-                    expect: false,
-                },
-                Check {
-                    scenario: "v6 broader holds narrower",
-                    input: ("2001:db8::/32", "2001:db8:1::/48"),
-                    expect: true,
-                },
-            ],
-            |(outer, inner)| prefix(outer).contains(prefix(inner)),
+        value_scenarios!(
+            run = |(outer, inner)| prefix(outer).contains(prefix(inner));
+            "broader holds narrower" {
+                ("10.0.0.0/8", "10.1.0.0/16") => true,
+            }
+
+            "prefix holds itself" {
+                ("10.0.0.0/8", "10.0.0.0/8") => true,
+            }
+
+            "narrower does not hold broader" {
+                ("10.0.0.0/16", "10.0.0.0/8") => false,
+            }
+
+            "disjoint v4 prefixes" {
+                ("10.0.0.0/8", "11.0.0.0/8") => false,
+            }
+
+            "v4 never holds v6" {
+                ("10.0.0.0/8", "2001:db8::/32") => false,
+            }
+
+            "v6 broader holds narrower" {
+                ("2001:db8::/32", "2001:db8:1::/48") => true,
+            }
         );
     }
 
     #[test]
     fn prefix_length_reports_mask_bits() {
-        check_values(
-            [
-                Check {
-                    scenario: "v4 /8",
-                    input: "10.0.0.0/8",
-                    expect: 8usize,
-                },
-                Check {
-                    scenario: "v4 /0",
-                    input: "0.0.0.0/0",
-                    expect: 0usize,
-                },
-                Check {
-                    scenario: "v4 /32",
-                    input: "10.0.0.1/32",
-                    expect: 32usize,
-                },
-                Check {
-                    scenario: "v6 /48",
-                    input: "2001:db8::/48",
-                    expect: 48usize,
-                },
-                Check {
-                    scenario: "v6 /128",
-                    input: "2001:db8::1/128",
-                    expect: 128usize,
-                },
-            ],
-            |s| prefix(s).prefix_length(),
+        value_scenarios!(
+            run = |s| prefix(s).prefix_length();
+            "v4 /8" {
+                "10.0.0.0/8" => 8usize,
+            }
+
+            "v4 /0" {
+                "0.0.0.0/0" => 0usize,
+            }
+
+            "v4 /32" {
+                "10.0.0.1/32" => 32usize,
+            }
+
+            "v6 /48" {
+                "2001:db8::/48" => 48usize,
+            }
+
+            "v6 /128" {
+                "2001:db8::1/128" => 128usize,
+            }
         );
     }
 
     #[test]
     fn ordering_sorts_by_family_then_prefix() {
-        check_values(
-            [
-                Check {
-                    scenario: "shorter prefix sorts before longer at same address",
-                    input: ("10.0.0.0/8", "10.0.0.0/16"),
-                    expect: Ordering::Less,
-                },
-                Check {
-                    scenario: "longer prefix sorts after shorter",
-                    input: ("10.0.0.0/16", "10.0.0.0/8"),
-                    expect: Ordering::Greater,
-                },
-                Check {
-                    scenario: "equal prefixes compare equal",
-                    input: ("10.0.0.0/8", "10.0.0.0/8"),
-                    expect: Ordering::Equal,
-                },
-                Check {
-                    scenario: "lower address sorts first",
-                    input: ("10.0.0.0/8", "11.0.0.0/8"),
-                    expect: Ordering::Less,
-                },
-                Check {
-                    scenario: "v4 always sorts before v6",
-                    input: ("10.0.0.0/16", "2001:db8::/32"),
-                    expect: Ordering::Less,
-                },
-                Check {
-                    scenario: "v6 always sorts after v4",
-                    input: ("2001:db8::/32", "10.0.0.0/16"),
-                    expect: Ordering::Greater,
-                },
-                Check {
-                    scenario: "two v6 by address",
-                    input: ("2001:db8::/32", "2001:db9::/32"),
-                    expect: Ordering::Less,
-                },
-            ],
-            |(a, b)| prefix(a).cmp(&prefix(b)),
+        value_scenarios!(
+            run = |(a, b)| prefix(a).cmp(&prefix(b));
+            "shorter prefix sorts before longer at same address" {
+                ("10.0.0.0/8", "10.0.0.0/16") => Ordering::Less,
+            }
+
+            "longer prefix sorts after shorter" {
+                ("10.0.0.0/16", "10.0.0.0/8") => Ordering::Greater,
+            }
+
+            "equal prefixes compare equal" {
+                ("10.0.0.0/8", "10.0.0.0/8") => Ordering::Equal,
+            }
+
+            "lower address sorts first" {
+                ("10.0.0.0/8", "11.0.0.0/8") => Ordering::Less,
+            }
+
+            "v4 always sorts before v6" {
+                ("10.0.0.0/16", "2001:db8::/32") => Ordering::Less,
+            }
+
+            "v6 always sorts after v4" {
+                ("2001:db8::/32", "10.0.0.0/16") => Ordering::Greater,
+            }
+
+            "two v6 by address" {
+                ("2001:db8::/32", "2001:db9::/32") => Ordering::Less,
+            }
         );
     }
 
     #[test]
     fn display_renders_canonical_text() {
-        check_values(
-            [
-                Check {
-                    scenario: "v4 prefix",
-                    input: "10.0.0.0/8",
-                    expect: "10.0.0.0/8".to_string(),
-                },
-                Check {
-                    scenario: "v4 default route",
-                    input: "0.0.0.0/0",
-                    expect: "0.0.0.0/0".to_string(),
-                },
-                Check {
-                    scenario: "v6 prefix lowercased",
-                    input: "2001:DB8::/32",
-                    expect: "2001:db8::/32".to_string(),
-                },
-            ],
-            |s| prefix(s).to_string(),
+        value_scenarios!(
+            run = |s| prefix(s).to_string();
+            "v4 prefix" {
+                "10.0.0.0/8" => "10.0.0.0/8".to_string(),
+            }
+
+            "v4 default route" {
+                "0.0.0.0/0" => "0.0.0.0/0".to_string(),
+            }
+
+            "v6 prefix lowercased" {
+                "2001:DB8::/32" => "2001:db8::/32".to_string(),
+            }
         );
     }
 
     #[test]
     fn bifurcate_splits_into_two_halves() {
-        check_values(
-            [
-                Check {
-                    scenario: "v4 /24 splits at the midpoint",
-                    input: "10.0.0.0/24",
-                    expect: Some(("10.0.0.0/25".to_string(), "10.0.0.128/25".to_string())),
-                },
-                Check {
-                    scenario: "v4 /0 splits the whole space",
-                    input: "0.0.0.0/0",
-                    expect: Some(("0.0.0.0/1".to_string(), "128.0.0.0/1".to_string())),
-                },
-                Check {
-                    scenario: "v4 /32 cannot split",
-                    input: "10.0.0.1/32",
-                    expect: None,
-                },
-                Check {
-                    scenario: "v6 /32 splits at the midpoint",
-                    input: "2001:db8::/32",
-                    expect: Some((
-                        "2001:db8::/33".to_string(),
-                        "2001:db8:8000::/33".to_string(),
-                    )),
-                },
-                Check {
-                    scenario: "v6 /128 cannot split",
-                    input: "2001:db8::1/128",
-                    expect: None,
-                },
-            ],
-            |s| {
+        value_scenarios!(
+            run = |s| {
                 prefix(s)
                     .bifurcate()
                     .map(|(even, odd)| (even.to_string(), odd.to_string()))
-            },
+            };
+            "v4 /24 splits at the midpoint" {
+                "10.0.0.0/24" => Some(("10.0.0.0/25".to_string(), "10.0.0.128/25".to_string())),
+            }
+
+            "v4 /0 splits the whole space" {
+                "0.0.0.0/0" => Some(("0.0.0.0/1".to_string(), "128.0.0.0/1".to_string())),
+            }
+
+            "v4 /32 cannot split" {
+                "10.0.0.1/32" => None,
+            }
+
+            "v6 /32 splits at the midpoint" {
+                "2001:db8::/32" => Some((
+                    "2001:db8::/33".to_string(),
+                    "2001:db8:8000::/33".to_string(),
+                )),
+            }
+
+            "v6 /128 cannot split" {
+                "2001:db8::1/128" => None,
+            }
         );
     }
 
     #[test]
     fn get_sibling_flips_the_last_prefix_bit() {
-        check_values(
-            [
-                Check {
-                    scenario: "v4 /24 even sibling",
-                    input: "10.0.0.0/24",
-                    expect: Some("10.0.1.0/24".to_string()),
-                },
-                Check {
-                    scenario: "v4 /24 odd sibling flips back",
-                    input: "10.0.1.0/24",
-                    expect: Some("10.0.0.0/24".to_string()),
-                },
-                Check {
-                    scenario: "v4 /1 sibling",
-                    input: "0.0.0.0/1",
-                    expect: Some("128.0.0.0/1".to_string()),
-                },
-                Check {
-                    scenario: "v4 /0 has no sibling",
-                    input: "0.0.0.0/0",
-                    expect: None,
-                },
-                Check {
-                    scenario: "v6 /34 even sibling",
-                    input: "2001:db8::/34",
-                    expect: Some("2001:db8:4000::/34".to_string()),
-                },
-                Check {
-                    scenario: "v6 /34 odd sibling flips back",
-                    input: "2001:db8:4000::/34",
-                    expect: Some("2001:db8::/34".to_string()),
-                },
-                Check {
-                    scenario: "v6 /0 has no sibling",
-                    input: "::/0",
-                    expect: None,
-                },
-            ],
-            |s| prefix(s).get_sibling().map(|p| p.to_string()),
+        value_scenarios!(
+            run = |s| prefix(s).get_sibling().map(|p| p.to_string());
+            "v4 /24 even sibling" {
+                "10.0.0.0/24" => Some("10.0.1.0/24".to_string()),
+            }
+
+            "v4 /24 odd sibling flips back" {
+                "10.0.1.0/24" => Some("10.0.0.0/24".to_string()),
+            }
+
+            "v4 /1 sibling" {
+                "0.0.0.0/1" => Some("128.0.0.0/1".to_string()),
+            }
+
+            "v4 /0 has no sibling" {
+                "0.0.0.0/0" => None,
+            }
+
+            "v6 /34 even sibling" {
+                "2001:db8::/34" => Some("2001:db8:4000::/34".to_string()),
+            }
+
+            "v6 /34 odd sibling flips back" {
+                "2001:db8:4000::/34" => Some("2001:db8::/34".to_string()),
+            }
+
+            "v6 /0 has no sibling" {
+                "::/0" => None,
+            }
         );
     }
 
     #[test]
     fn get_last_subprefix_is_the_all_ones_host() {
-        check_values(
-            [
-                Check {
-                    scenario: "v4 /24 last host",
-                    input: "10.0.0.0/24",
-                    expect: "10.0.0.255/32".to_string(),
-                },
-                Check {
-                    scenario: "v4 /8 last host",
-                    input: "10.0.0.0/8",
-                    expect: "10.255.255.255/32".to_string(),
-                },
-                Check {
-                    scenario: "v4 /32 is its own last host",
-                    input: "10.0.0.1/32",
-                    expect: "10.0.0.1/32".to_string(),
-                },
-                Check {
-                    scenario: "v6 /32 last host",
-                    input: "2001:db8::/32",
-                    expect: "2001:db8:ffff:ffff:ffff:ffff:ffff:ffff/128".to_string(),
-                },
-            ],
-            |s| prefix(s).get_last_subprefix().to_string(),
+        value_scenarios!(
+            run = |s| prefix(s).get_last_subprefix().to_string();
+            "v4 /24 last host" {
+                "10.0.0.0/24" => "10.0.0.255/32".to_string(),
+            }
+
+            "v4 /8 last host" {
+                "10.0.0.0/8" => "10.255.255.255/32".to_string(),
+            }
+
+            "v4 /32 is its own last host" {
+                "10.0.0.1/32" => "10.0.0.1/32".to_string(),
+            }
+
+            "v6 /32 last host" {
+                "2001:db8::/32" => "2001:db8:ffff:ffff:ffff:ffff:ffff:ffff/128".to_string(),
+            }
         );
     }
 
     #[test]
     fn try_aggregate_combines_or_declines() {
-        check_values(
-            [
-                Check {
-                    scenario: "siblings aggregate to their supernet",
-                    input: ("10.0.0.0/25", "10.0.0.128/25"),
-                    expect: Some("10.0.0.0/24".to_string()),
-                },
-                Check {
-                    scenario: "containing prefix absorbs the contained",
-                    input: ("10.0.0.0/8", "10.1.0.0/16"),
-                    expect: Some("10.0.0.0/8".to_string()),
-                },
-                Check {
-                    scenario: "contained side absorbed by container",
-                    input: ("10.1.0.0/16", "10.0.0.0/8"),
-                    expect: Some("10.0.0.0/8".to_string()),
-                },
-                Check {
-                    scenario: "non-adjacent prefixes do not aggregate",
-                    input: ("10.0.0.0/24", "10.0.2.0/24"),
-                    expect: None,
-                },
-                Check {
-                    scenario: "sibling /24s aggregate to their /23 supernet",
-                    input: ("10.0.0.0/24", "10.0.1.0/24"),
-                    expect: Some("10.0.0.0/23".to_string()),
-                },
-                Check {
-                    scenario: "different families do not aggregate",
-                    input: ("10.0.0.0/8", "2001:db8::/32"),
-                    expect: None,
-                },
-                Check {
-                    scenario: "v6 siblings aggregate",
-                    input: ("2001:db8::/33", "2001:db8:8000::/33"),
-                    expect: Some("2001:db8::/32".to_string()),
-                },
-            ],
-            |(a, b)| prefix(a).try_aggregate(&prefix(b)).map(|p| p.to_string()),
+        value_scenarios!(
+            run = |(a, b)| prefix(a).try_aggregate(&prefix(b)).map(|p| p.to_string());
+            "siblings aggregate to their supernet" {
+                ("10.0.0.0/25", "10.0.0.128/25") => Some("10.0.0.0/24".to_string()),
+            }
+
+            "containing prefix absorbs the contained" {
+                ("10.0.0.0/8", "10.1.0.0/16") => Some("10.0.0.0/8".to_string()),
+            }
+
+            "contained side absorbed by container" {
+                ("10.1.0.0/16", "10.0.0.0/8") => Some("10.0.0.0/8".to_string()),
+            }
+
+            "non-adjacent prefixes do not aggregate" {
+                ("10.0.0.0/24", "10.0.2.0/24") => None,
+            }
+
+            "sibling /24s aggregate to their /23 supernet" {
+                ("10.0.0.0/24", "10.0.1.0/24") => Some("10.0.0.0/23".to_string()),
+            }
+
+            "different families do not aggregate" {
+                ("10.0.0.0/8", "2001:db8::/32") => None,
+            }
+
+            "v6 siblings aggregate" {
+                ("2001:db8::/33", "2001:db8:8000::/33") => Some("2001:db8::/32".to_string()),
+            }
         );
     }
 
     #[test]
     fn to_prefix_from_addresses_and_nets() {
-        check_values(
-            [
-                Check {
-                    scenario: "ipv4 address becomes /32",
-                    input: "10.0.0.1",
-                    expect: "10.0.0.1/32".to_string(),
-                },
-                Check {
-                    scenario: "ipv6 address becomes /128",
-                    input: "2001:db8::1",
-                    expect: "2001:db8::1/128".to_string(),
-                },
-            ],
-            |s| IpAddr::from_str(s).unwrap().to_prefix().to_string(),
+        value_scenarios!(
+            run = |s| IpAddr::from_str(s).unwrap().to_prefix().to_string();
+            "ipv4 address becomes /32" {
+                "10.0.0.1" => "10.0.0.1/32".to_string(),
+            }
+
+            "ipv6 address becomes /128" {
+                "2001:db8::1" => "2001:db8::1/128".to_string(),
+            }
         );
     }
 
     #[test]
     fn to_prefix_from_ipnet_truncates_host_bits() {
-        check_values(
-            [
-                Check {
-                    scenario: "v4 net truncated to network address",
-                    input: "10.0.0.1/8",
-                    expect: "10.0.0.0/8".to_string(),
-                },
-                Check {
-                    scenario: "v4 already canonical",
-                    input: "10.0.0.0/8",
-                    expect: "10.0.0.0/8".to_string(),
-                },
-                Check {
-                    scenario: "v6 net truncated to network address",
-                    input: "2001:db8::1/32",
-                    expect: "2001:db8::/32".to_string(),
-                },
-            ],
-            |s| IpNet::from_str(s).unwrap().to_prefix().to_string(),
+        value_scenarios!(
+            run = |s| IpNet::from_str(s).unwrap().to_prefix().to_string();
+            "v4 net truncated to network address" {
+                "10.0.0.1/8" => "10.0.0.0/8".to_string(),
+            }
+
+            "v4 already canonical" {
+                "10.0.0.0/8" => "10.0.0.0/8".to_string(),
+            }
+
+            "v6 net truncated to network address" {
+                "2001:db8::1/32" => "2001:db8::/32".to_string(),
+            }
         );
     }
 
     #[test]
     fn into_inner_round_trips_through_ipnet() {
-        check_values(
-            [
-                Check {
-                    scenario: "v4 round-trips",
-                    input: "10.0.0.0/8",
-                    expect: true,
-                },
-                Check {
-                    scenario: "v6 round-trips",
-                    input: "2001:db8::/32",
-                    expect: true,
-                },
-            ],
-            |s| {
+        value_scenarios!(
+            run = |s| {
                 let net = IpNet::from_str(s).unwrap();
                 let prefix = IpPrefix::try_from(net).unwrap();
                 IpNet::from(prefix) == net
-            },
+            };
+            "v4 round-trips" {
+                "10.0.0.0/8" => true,
+            }
+
+            "v6 round-trips" {
+                "2001:db8::/32" => true,
+            }
         );
     }
 }

--- a/crates/network/src/virtualization.rs
+++ b/crates/network/src/virtualization.rs
@@ -134,7 +134,7 @@ impl sqlx::Decode<'_, sqlx::Postgres> for VpcVirtualizationType {
 
 #[cfg(all(test, feature = "sqlx"))]
 mod sqlx_tests {
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::value_scenarios;
     use sqlx::Encode;
     use sqlx::postgres::PgArgumentBuffer;
 
@@ -148,30 +148,23 @@ mod sqlx_tests {
 
     #[test]
     fn encode_writes_the_wire_string_for_each_variant() {
-        check_values(
-            [
-                Check {
-                    scenario: "EthernetVirtualizer encodes as etv",
-                    input: VpcVirtualizationType::EthernetVirtualizer,
-                    expect: "etv".to_string(),
-                },
-                Check {
-                    scenario: "EthernetVirtualizerWithNvue encodes as legacy etv",
-                    input: VpcVirtualizationType::EthernetVirtualizerWithNvue,
-                    expect: "etv".to_string(),
-                },
-                Check {
-                    scenario: "Fnn encodes as fnn",
-                    input: VpcVirtualizationType::Fnn,
-                    expect: "fnn".to_string(),
-                },
-                Check {
-                    scenario: "Flat encodes as flat",
-                    input: VpcVirtualizationType::Flat,
-                    expect: "flat".to_string(),
-                },
-            ],
-            encode_to_string,
+        value_scenarios!(
+            run = encode_to_string;
+            "EthernetVirtualizer encodes as etv" {
+                VpcVirtualizationType::EthernetVirtualizer => "etv".to_string(),
+            }
+
+            "EthernetVirtualizerWithNvue encodes as legacy etv" {
+                VpcVirtualizationType::EthernetVirtualizerWithNvue => "etv".to_string(),
+            }
+
+            "Fnn encodes as fnn" {
+                VpcVirtualizationType::Fnn => "fnn".to_string(),
+            }
+
+            "Flat encodes as flat" {
+                VpcVirtualizationType::Flat => "flat".to_string(),
+            }
         );
     }
 }
@@ -325,328 +318,253 @@ pub fn get_svi_ip(
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
     #[test]
     fn from_str_maps_known_strings_and_rejects_the_rest() {
-        check_cases(
-            [
-                Case {
-                    scenario: "etv -> EthernetVirtualizer",
-                    input: "etv",
-                    expect: Yields(VpcVirtualizationType::EthernetVirtualizer),
-                },
-                Case {
-                    scenario: "etv_nvue is an alias for EthernetVirtualizer",
-                    input: "etv_nvue",
-                    expect: Yields(VpcVirtualizationType::EthernetVirtualizer),
-                },
-                Case {
-                    scenario: "fnn -> Fnn",
-                    input: "fnn",
-                    expect: Yields(VpcVirtualizationType::Fnn),
-                },
-                Case {
-                    scenario: "flat -> Flat",
-                    input: "flat",
-                    expect: Yields(VpcVirtualizationType::Flat),
-                },
-                Case {
-                    scenario: "unknown token is rejected",
-                    input: "bogus",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty string is rejected",
-                    input: "",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "wrong case is rejected (match is exact)",
-                    input: "ETV",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "leading whitespace is not trimmed",
-                    input: " etv",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "trailing whitespace is not trimmed",
-                    input: "flat ",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "etv-nvue with a hyphen is not the alias",
-                    input: "etv-nvue",
-                    expect: Fails,
-                },
-            ],
-            |s| s.parse::<VpcVirtualizationType>().map_err(drop),
+        scenarios!(
+            run = |s| s.parse::<VpcVirtualizationType>().map_err(drop);
+            "etv -> EthernetVirtualizer" {
+                "etv" => Yields(VpcVirtualizationType::EthernetVirtualizer),
+            }
+
+            "etv_nvue is an alias for EthernetVirtualizer" {
+                "etv_nvue" => Yields(VpcVirtualizationType::EthernetVirtualizer),
+            }
+
+            "fnn -> Fnn" {
+                "fnn" => Yields(VpcVirtualizationType::Fnn),
+            }
+
+            "flat -> Flat" {
+                "flat" => Yields(VpcVirtualizationType::Flat),
+            }
+
+            "unknown token is rejected" {
+                "bogus" => Fails,
+            }
+
+            "empty string is rejected" {
+                "" => Fails,
+            }
+
+            "wrong case is rejected (match is exact)" {
+                "ETV" => Fails,
+            }
+
+            "leading whitespace is not trimmed" {
+                " etv" => Fails,
+            }
+
+            "trailing whitespace is not trimmed" {
+                "flat " => Fails,
+            }
+
+            "etv-nvue with a hyphen is not the alias" {
+                "etv-nvue" => Fails,
+            }
         );
     }
 
     #[test]
     fn from_str_unknown_token_reports_the_input() {
-        check_cases(
-            [
-                Case {
-                    scenario: "error names the unknown token",
-                    input: ("bogus", &["Unknown virt type", "bogus"][..]),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "error echoes a numeric token",
-                    input: ("42", &["Unknown virt type", "42"][..]),
-                    expect: Yields(true),
-                },
-            ],
-            |(value, tokens)| {
+        scenarios!(
+            run = |(value, tokens)| {
                 let produced = value
                     .parse::<VpcVirtualizationType>()
                     .map_err(|e| e.to_string())
                     .expect_err("unknown token must fail");
                 Ok::<_, ()>(tokens.iter().all(|t| produced.contains(t)))
-            },
+            };
+            "error names the unknown token" {
+                ("bogus", &["Unknown virt type", "bogus"][..]) => Yields(true),
+            }
+
+            "error echoes a numeric token" {
+                ("42", &["Unknown virt type", "42"][..]) => Yields(true),
+            }
         );
     }
 
     #[test]
     fn as_str_renders_each_variant() {
-        check_values(
-            [
-                Check {
-                    scenario: "EthernetVirtualizer -> etv",
-                    input: VpcVirtualizationType::EthernetVirtualizer,
-                    expect: "etv",
-                },
-                Check {
-                    scenario: "EthernetVirtualizerWithNvue -> etv",
-                    input: VpcVirtualizationType::EthernetVirtualizerWithNvue,
-                    expect: "etv",
-                },
-                Check {
-                    scenario: "Fnn -> fnn",
-                    input: VpcVirtualizationType::Fnn,
-                    expect: "fnn",
-                },
-                Check {
-                    scenario: "Flat -> flat",
-                    input: VpcVirtualizationType::Flat,
-                    expect: "flat",
-                },
-            ],
-            |v| v.as_str(),
+        value_scenarios!(
+            run = |v| v.as_str();
+            "EthernetVirtualizer -> etv" {
+                VpcVirtualizationType::EthernetVirtualizer => "etv",
+            }
+
+            "EthernetVirtualizerWithNvue -> etv" {
+                VpcVirtualizationType::EthernetVirtualizerWithNvue => "etv",
+            }
+
+            "Fnn -> fnn" {
+                VpcVirtualizationType::Fnn => "fnn",
+            }
+
+            "Flat -> flat" {
+                VpcVirtualizationType::Flat => "flat",
+            }
         );
     }
 
     #[test]
     fn display_renders_each_variant() {
-        check_values(
-            [
-                Check {
-                    scenario: "EthernetVirtualizer displays etv",
-                    input: VpcVirtualizationType::EthernetVirtualizer,
-                    expect: "etv".to_string(),
-                },
-                Check {
-                    scenario: "EthernetVirtualizerWithNvue displays etv",
-                    input: VpcVirtualizationType::EthernetVirtualizerWithNvue,
-                    expect: "etv".to_string(),
-                },
-                Check {
-                    scenario: "Fnn displays fnn",
-                    input: VpcVirtualizationType::Fnn,
-                    expect: "fnn".to_string(),
-                },
-                Check {
-                    scenario: "Flat displays flat",
-                    input: VpcVirtualizationType::Flat,
-                    expect: "flat".to_string(),
-                },
-            ],
-            |v| v.to_string(),
+        value_scenarios!(
+            run = |v| v.to_string();
+            "EthernetVirtualizer displays etv" {
+                VpcVirtualizationType::EthernetVirtualizer => "etv".to_string(),
+            }
+
+            "EthernetVirtualizerWithNvue displays etv" {
+                VpcVirtualizationType::EthernetVirtualizerWithNvue => "etv".to_string(),
+            }
+
+            "Fnn displays fnn" {
+                VpcVirtualizationType::Fnn => "fnn".to_string(),
+            }
+
+            "Flat displays flat" {
+                VpcVirtualizationType::Flat => "flat".to_string(),
+            }
         );
     }
 
     #[test]
     fn display_agrees_with_as_str_for_every_variant() {
-        check_values(
-            [
-                Check {
-                    scenario: "EthernetVirtualizer",
-                    input: VpcVirtualizationType::EthernetVirtualizer,
-                    expect: true,
-                },
-                Check {
-                    scenario: "EthernetVirtualizerWithNvue",
-                    input: VpcVirtualizationType::EthernetVirtualizerWithNvue,
-                    expect: true,
-                },
-                Check {
-                    scenario: "Fnn",
-                    input: VpcVirtualizationType::Fnn,
-                    expect: true,
-                },
-                Check {
-                    scenario: "Flat",
-                    input: VpcVirtualizationType::Flat,
-                    expect: true,
-                },
-            ],
-            |v| v.to_string() == v.as_str(),
+        value_scenarios!(
+            run = |v| v.to_string() == v.as_str();
+            "EthernetVirtualizer" {
+                VpcVirtualizationType::EthernetVirtualizer => true,
+            }
+
+            "EthernetVirtualizerWithNvue" {
+                VpcVirtualizationType::EthernetVirtualizerWithNvue => true,
+            }
+
+            "Fnn" {
+                VpcVirtualizationType::Fnn => true,
+            }
+
+            "Flat" {
+                VpcVirtualizationType::Flat => true,
+            }
         );
     }
 
     #[test]
     fn default_is_ethernet_virtualizer() {
-        check_values(
-            [
-                Check {
-                    scenario: "Default trait yields EthernetVirtualizer",
-                    input: (),
-                    expect: VpcVirtualizationType::EthernetVirtualizer,
-                },
-                Check {
-                    scenario: "the DEFAULT_* constant agrees with Default",
-                    input: (),
-                    expect: DEFAULT_NETWORK_VIRTUALIZATION_TYPE,
-                },
-            ],
-            |()| VpcVirtualizationType::default(),
+        value_scenarios!(
+            run = |()| VpcVirtualizationType::default();
+            "Default trait yields EthernetVirtualizer" {
+                () => VpcVirtualizationType::EthernetVirtualizer,
+            }
+
+            "the DEFAULT_* constant agrees with Default" {
+                () => DEFAULT_NETWORK_VIRTUALIZATION_TYPE,
+            }
         );
     }
 
     #[test]
     fn from_str_round_trips_through_as_str() {
-        check_cases(
-            [
-                Case {
-                    scenario: "EthernetVirtualizer",
-                    input: VpcVirtualizationType::EthernetVirtualizer,
-                    expect: Yields(VpcVirtualizationType::EthernetVirtualizer),
-                },
-                Case {
-                    scenario: "Fnn",
-                    input: VpcVirtualizationType::Fnn,
-                    expect: Yields(VpcVirtualizationType::Fnn),
-                },
-                Case {
-                    scenario: "Flat",
-                    input: VpcVirtualizationType::Flat,
-                    expect: Yields(VpcVirtualizationType::Flat),
-                },
-            ],
-            |v| v.as_str().parse::<VpcVirtualizationType>().map_err(drop),
+        scenarios!(
+            run = |v| v.as_str().parse::<VpcVirtualizationType>().map_err(drop);
+            "EthernetVirtualizer" {
+                VpcVirtualizationType::EthernetVirtualizer => Yields(VpcVirtualizationType::EthernetVirtualizer),
+            }
+
+            "Fnn" {
+                VpcVirtualizationType::Fnn => Yields(VpcVirtualizationType::Fnn),
+            }
+
+            "Flat" {
+                VpcVirtualizationType::Flat => Yields(VpcVirtualizationType::Flat),
+            }
         );
     }
 
     #[test]
     fn serde_round_trips_through_json() {
-        check_cases(
-            [
-                Case {
-                    scenario: "EthernetVirtualizer serializes to \"etv\"",
-                    input: VpcVirtualizationType::EthernetVirtualizer,
-                    expect: Yields("\"etv\"".to_string()),
-                },
-                Case {
-                    scenario: "EthernetVirtualizerWithNvue also serializes to \"etv\"",
-                    input: VpcVirtualizationType::EthernetVirtualizerWithNvue,
-                    expect: Yields("\"etv\"".to_string()),
-                },
-                Case {
-                    scenario: "Fnn serializes to \"fnn\"",
-                    input: VpcVirtualizationType::Fnn,
-                    expect: Yields("\"fnn\"".to_string()),
-                },
-                Case {
-                    scenario: "Flat serializes to \"flat\"",
-                    input: VpcVirtualizationType::Flat,
-                    expect: Yields("\"flat\"".to_string()),
-                },
-            ],
-            |v| serde_json::to_string(&v).map_err(drop),
+        scenarios!(
+            run = |v| serde_json::to_string(&v).map_err(drop);
+            "EthernetVirtualizer serializes to \"etv\"" {
+                VpcVirtualizationType::EthernetVirtualizer => Yields("\"etv\"".to_string()),
+            }
+
+            "EthernetVirtualizerWithNvue also serializes to \"etv\"" {
+                VpcVirtualizationType::EthernetVirtualizerWithNvue => Yields("\"etv\"".to_string()),
+            }
+
+            "Fnn serializes to \"fnn\"" {
+                VpcVirtualizationType::Fnn => Yields("\"fnn\"".to_string()),
+            }
+
+            "Flat serializes to \"flat\"" {
+                VpcVirtualizationType::Flat => Yields("\"flat\"".to_string()),
+            }
         );
     }
 
     #[test]
     fn deserialize_accepts_known_strings_and_rejects_the_rest() {
-        check_cases(
-            [
-                Case {
-                    scenario: "\"etv\" -> EthernetVirtualizer",
-                    input: "\"etv\"",
-                    expect: Yields(VpcVirtualizationType::EthernetVirtualizer),
-                },
-                Case {
-                    scenario: "\"etv_nvue\" alias -> EthernetVirtualizer",
-                    input: "\"etv_nvue\"",
-                    expect: Yields(VpcVirtualizationType::EthernetVirtualizer),
-                },
-                Case {
-                    scenario: "\"fnn\" -> Fnn",
-                    input: "\"fnn\"",
-                    expect: Yields(VpcVirtualizationType::Fnn),
-                },
-                Case {
-                    scenario: "\"flat\" -> Flat",
-                    input: "\"flat\"",
-                    expect: Yields(VpcVirtualizationType::Flat),
-                },
-                Case {
-                    scenario: "unknown string is rejected",
-                    input: "\"bogus\"",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "a JSON number is rejected (expects a string)",
-                    input: "7",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "a JSON null is rejected",
-                    input: "null",
-                    expect: Fails,
-                },
-            ],
-            |json| serde_json::from_str::<VpcVirtualizationType>(json).map_err(drop),
+        scenarios!(
+            run = |json| serde_json::from_str::<VpcVirtualizationType>(json).map_err(drop);
+            "\"etv\" -> EthernetVirtualizer" {
+                "\"etv\"" => Yields(VpcVirtualizationType::EthernetVirtualizer),
+            }
+
+            "\"etv_nvue\" alias -> EthernetVirtualizer" {
+                "\"etv_nvue\"" => Yields(VpcVirtualizationType::EthernetVirtualizer),
+            }
+
+            "\"fnn\" -> Fnn" {
+                "\"fnn\"" => Yields(VpcVirtualizationType::Fnn),
+            }
+
+            "\"flat\" -> Flat" {
+                "\"flat\"" => Yields(VpcVirtualizationType::Flat),
+            }
+
+            "unknown string is rejected" {
+                "\"bogus\"" => Fails,
+            }
+
+            "a JSON number is rejected (expects a string)" {
+                "7" => Fails,
+            }
+
+            "a JSON null is rejected" {
+                "null" => Fails,
+            }
         );
     }
 
     #[test]
     fn build_dual_stack_list_assembles_the_address_list() {
-        check_values(
-            [
-                Check {
-                    scenario: "v4 only when v6 is absent",
-                    input: ("10.0.0.1".to_string(), None),
-                    expect: vec!["10.0.0.1".to_string()],
-                },
-                Check {
-                    scenario: "v4 then v6 when both present",
-                    input: ("10.0.0.1".to_string(), Some("2001:db8::1".to_string())),
-                    expect: vec!["10.0.0.1".to_string(), "2001:db8::1".to_string()],
-                },
-                Check {
-                    scenario: "empty v6 string is filtered out",
-                    input: ("10.0.0.1".to_string(), Some(String::new())),
-                    expect: vec!["10.0.0.1".to_string()],
-                },
-                Check {
-                    scenario: "v4 is kept even when empty (it is required)",
-                    input: (String::new(), None),
-                    expect: vec![String::new()],
-                },
-                Check {
-                    scenario: "empty v4 with a real v6 keeps both",
-                    input: (String::new(), Some("2001:db8::1".to_string())),
-                    expect: vec![String::new(), "2001:db8::1".to_string()],
-                },
-            ],
-            |(v4, v6)| build_dual_stack_list(v4, v6),
+        value_scenarios!(
+            run = |(v4, v6)| build_dual_stack_list(v4, v6);
+            "v4 only when v6 is absent" {
+                ("10.0.0.1".to_string(), None) => vec!["10.0.0.1".to_string()],
+            }
+
+            "v4 then v6 when both present" {
+                ("10.0.0.1".to_string(), Some("2001:db8::1".to_string())) => vec!["10.0.0.1".to_string(), "2001:db8::1".to_string()],
+            }
+
+            "empty v6 string is filtered out" {
+                ("10.0.0.1".to_string(), Some(String::new())) => vec!["10.0.0.1".to_string()],
+            }
+
+            "v4 is kept even when empty (it is required)" {
+                (String::new(), None) => vec![String::new()],
+            }
+
+            "empty v4 with a real v6 keeps both" {
+                (String::new(), Some("2001:db8::1".to_string())) => vec![String::new(), "2001:db8::1".to_string()],
+            }
         );
     }
 
@@ -655,7 +573,7 @@ mod tests {
         use std::net::IpAddr;
 
         use carbide_test_support::Outcome::*;
-        use carbide_test_support::{Case, check_cases};
+        use carbide_test_support::scenarios;
 
         use super::super::*;
 
@@ -665,77 +583,62 @@ mod tests {
 
         #[test]
         fn get_host_ip_picks_the_right_address_per_prefix() {
-            check_cases(
-                [
-                    Case {
-                        scenario: "ipv4 /32 single host is itself",
-                        input: net("10.0.0.5", 32),
-                        expect: Yields("10.0.0.5".parse::<IpAddr>().unwrap()),
-                    },
-                    Case {
-                        scenario: "ipv6 /128 single host is itself",
-                        input: net("2001:db8::1", 128),
-                        expect: Yields("2001:db8::1".parse::<IpAddr>().unwrap()),
-                    },
-                    Case {
-                        scenario: "ipv4 /31 point-to-point uses the second address",
-                        input: net("10.0.0.0", 31),
-                        expect: Yields("10.0.0.1".parse::<IpAddr>().unwrap()),
-                    },
-                    Case {
-                        scenario: "ipv6 /127 point-to-point uses the second address",
-                        input: net("2001:db8::0", 127),
-                        expect: Yields("2001:db8::1".parse::<IpAddr>().unwrap()),
-                    },
-                    Case {
-                        scenario: "ipv4 /30 legacy uses the fourth address",
-                        input: net("10.0.0.0", 30),
-                        expect: Yields("10.0.0.3".parse::<IpAddr>().unwrap()),
-                    },
-                    Case {
-                        scenario: "ipv4 /29 is too large to be supported",
-                        input: net("10.0.0.0", 29),
-                        expect: Fails,
-                    },
-                    Case {
-                        scenario: "ipv4 /24 is unsupported",
-                        input: net("10.0.0.0", 24),
-                        expect: Fails,
-                    },
-                    Case {
-                        scenario: "ipv4 /0 is unsupported",
-                        input: net("0.0.0.0", 0),
-                        expect: Fails,
-                    },
-                    Case {
-                        scenario: "ipv6 /64 is unsupported",
-                        input: net("2001:db8::", 64),
-                        expect: Fails,
-                    },
-                    Case {
-                        scenario: "ipv6 /126 is unsupported",
-                        input: net("2001:db8::", 126),
-                        expect: Fails,
-                    },
-                ],
-                |network| get_host_ip(&network).map_err(drop),
+            scenarios!(
+                run = |network| get_host_ip(&network).map_err(drop);
+                "ipv4 /32 single host is itself" {
+                    net("10.0.0.5", 32) => Yields("10.0.0.5".parse::<IpAddr>().unwrap()),
+                }
+
+                "ipv6 /128 single host is itself" {
+                    net("2001:db8::1", 128) => Yields("2001:db8::1".parse::<IpAddr>().unwrap()),
+                }
+
+                "ipv4 /31 point-to-point uses the second address" {
+                    net("10.0.0.0", 31) => Yields("10.0.0.1".parse::<IpAddr>().unwrap()),
+                }
+
+                "ipv6 /127 point-to-point uses the second address" {
+                    net("2001:db8::0", 127) => Yields("2001:db8::1".parse::<IpAddr>().unwrap()),
+                }
+
+                "ipv4 /30 legacy uses the fourth address" {
+                    net("10.0.0.0", 30) => Yields("10.0.0.3".parse::<IpAddr>().unwrap()),
+                }
+
+                "ipv4 /29 is too large to be supported" {
+                    net("10.0.0.0", 29) => Fails,
+                }
+
+                "ipv4 /24 is unsupported" {
+                    net("10.0.0.0", 24) => Fails,
+                }
+
+                "ipv4 /0 is unsupported" {
+                    net("0.0.0.0", 0) => Fails,
+                }
+
+                "ipv6 /64 is unsupported" {
+                    net("2001:db8::", 64) => Fails,
+                }
+
+                "ipv6 /126 is unsupported" {
+                    net("2001:db8::", 126) => Fails,
+                }
             );
         }
 
         #[test]
         fn get_host_ip_unsupported_prefix_names_the_problem() {
-            check_cases(
-                [Case {
-                    scenario: "error mentions it is unsupported",
-                    input: (net("10.0.0.0", 29), &["unsupported"][..]),
-                    expect: Yields(true),
-                }],
-                |(network, tokens)| {
+            scenarios!(
+                run = |(network, tokens)| {
                     let produced = get_host_ip(&network)
                         .map_err(|e| e.to_string())
                         .expect_err("oversized prefix must fail");
                     Ok::<_, ()>(tokens.iter().all(|t| produced.contains(t)))
-                },
+                };
+                "error mentions it is unsupported" {
+                    (net("10.0.0.0", 29), &["unsupported"][..]) => Yields(true),
+                }
             );
         }
 
@@ -743,47 +646,37 @@ mod tests {
         fn get_svi_ip_only_yields_for_fnn_l2_segments() {
             let svi_ip: IpAddr = "10.0.0.1".parse().unwrap();
             let svi: Option<IpAddr> = Some(svi_ip);
-            check_cases(
-                [
-                    Case {
-                        scenario: "fnn + l2 + allocated svi yields the network",
-                        input: (svi, VpcVirtualizationType::Fnn, true, 24u8),
-                        expect: Yields(Some(IpNetwork::new(svi_ip, 24).unwrap())),
-                    },
-                    Case {
-                        scenario: "fnn + l2 but no svi allocated fails",
-                        input: (None, VpcVirtualizationType::Fnn, true, 24u8),
-                        expect: Fails,
-                    },
-                    Case {
-                        scenario: "fnn but not an l2 segment yields none",
-                        input: (svi, VpcVirtualizationType::Fnn, false, 24u8),
-                        expect: Yields(None),
-                    },
-                    Case {
-                        scenario: "l2 but not fnn yields none",
-                        input: (svi, VpcVirtualizationType::EthernetVirtualizer, true, 24u8),
-                        expect: Yields(None),
-                    },
-                    Case {
-                        scenario: "flat l2 segment yields none",
-                        input: (svi, VpcVirtualizationType::Flat, true, 24u8),
-                        expect: Yields(None),
-                    },
-                    Case {
-                        scenario: "neither fnn nor l2 yields none",
-                        input: (svi, VpcVirtualizationType::EthernetVirtualizer, false, 24u8),
-                        expect: Yields(None),
-                    },
-                    Case {
-                        scenario: "fnn + l2 + invalid prefix for ipv4 fails",
-                        input: (svi, VpcVirtualizationType::Fnn, true, 33u8),
-                        expect: Fails,
-                    },
-                ],
-                |(svi_ip, virt, is_l2, prefix)| {
+            scenarios!(
+                run = |(svi_ip, virt, is_l2, prefix)| {
                     get_svi_ip(&svi_ip, virt, is_l2, prefix).map_err(drop)
-                },
+                };
+                "fnn + l2 + allocated svi yields the network" {
+                    (svi, VpcVirtualizationType::Fnn, true, 24u8) => Yields(Some(IpNetwork::new(svi_ip, 24).unwrap())),
+                }
+
+                "fnn + l2 but no svi allocated fails" {
+                    (None, VpcVirtualizationType::Fnn, true, 24u8) => Fails,
+                }
+
+                "fnn but not an l2 segment yields none" {
+                    (svi, VpcVirtualizationType::Fnn, false, 24u8) => Yields(None),
+                }
+
+                "l2 but not fnn yields none" {
+                    (svi, VpcVirtualizationType::EthernetVirtualizer, true, 24u8) => Yields(None),
+                }
+
+                "flat l2 segment yields none" {
+                    (svi, VpcVirtualizationType::Flat, true, 24u8) => Yields(None),
+                }
+
+                "neither fnn nor l2 yields none" {
+                    (svi, VpcVirtualizationType::EthernetVirtualizer, false, 24u8) => Yields(None),
+                }
+
+                "fnn + l2 + invalid prefix for ipv4 fails" {
+                    (svi, VpcVirtualizationType::Fnn, true, 33u8) => Fails,
+                }
             );
         }
     }


### PR DESCRIPTION
This supports #3914.

## Description

The `carbide-network` tests cover a lot of address parsing, formatting, and virtualization edge cases, and the table-driven rows are the right shape for that. The repeated `Case`/`Check` structs just made those network examples harder to scan.

This moves the straightforward literal tables onto `scenarios!`/`value_scenarios!` while keeping async SQLx and dynamic rows on the existing helpers. The address inputs, error expectations, and value outputs are still written directly in the tests, but related cases now group under the behavior they exercise.

All tests pass, and formatting/clippy checks are clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Commands:
- `cargo make format-nightly`
- `cargo make check-format-nightly`
- `cargo test -p carbide-network`
- `cargo clippy -p carbide-network -- -D warnings`
- `cargo clippy -p carbide-network --tests -- -D warnings`