### PR TITLE
test(admin-cli): group command tables into scenarios

### DIFF
--- a/crates/admin-cli/src/bmc_machine/tests.rs
+++ b/crates/admin-cli/src/bmc_machine/tests.rs
@@ -26,7 +26,7 @@
 // ValueEnum Parsing - Test string parsing for types deriving claps ValueEnum.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::common::AdminPowerControlAction;
@@ -56,33 +56,28 @@ fn verify_cmd_structure() {
 // captured verbatim and --use-ipmitool toggles the flag (default off).
 #[test]
 fn parse_bmc_reset() {
-    check_cases(
-        [
-            Case {
-                scenario: "bmc-reset with required args, ipmitool off",
-                input: &["bmc-machine", "bmc-reset", "--machine", "machine-123"][..],
-                expect: Yields(("machine-123".to_string(), false)),
-            },
-            Case {
-                scenario: "bmc-reset with --use-ipmitool",
-                input: &[
-                    "bmc-machine",
-                    "bmc-reset",
-                    "--machine",
-                    "machine-123",
-                    "--use-ipmitool",
-                ][..],
-                expect: Yields(("machine-123".to_string(), true)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::BmcReset(args) => (args.machine, args.use_ipmitool),
                     _ => panic!("expected BmcReset variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "bmc-reset with required args, ipmitool off" {
+            &["bmc-machine", "bmc-reset", "--machine", "machine-123"][..] => Yields(("machine-123".to_string(), false)),
+        }
+
+        "bmc-reset with --use-ipmitool" {
+            &[
+                "bmc-machine",
+                "bmc-reset",
+                "--machine",
+                "machine-123",
+                "--use-ipmitool",
+            ][..] => Yields(("machine-123".to_string(), true)),
+        }
     );
 }
 
@@ -90,20 +85,8 @@ fn parse_bmc_reset() {
 // --machine value is captured and --action on maps to the On action.
 #[test]
 fn parse_admin_power_control() {
-    check_cases(
-        [Case {
-            scenario: "admin-power-control --action on",
-            input: &[
-                "bmc-machine",
-                "admin-power-control",
-                "--machine",
-                "machine-123",
-                "--action",
-                "on",
-            ][..],
-            expect: Yields(("machine-123".to_string(), true)),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::AdminPowerControl(args) => (
@@ -113,7 +96,17 @@ fn parse_admin_power_control() {
                     _ => panic!("expected AdminPowerControl variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "admin-power-control --action on" {
+            &[
+                "bmc-machine",
+                "admin-power-control",
+                "--machine",
+                "machine-123",
+                "--action",
+                "on",
+            ][..] => Yields(("machine-123".to_string(), true)),
+        }
     );
 }
 
@@ -121,39 +114,34 @@ fn parse_admin_power_control() {
 // mutually exclusive flags, each setting exactly its own bool.
 #[test]
 fn parse_lockdown() {
-    check_cases(
-        [
-            Case {
-                scenario: "lockdown --enable",
-                input: &[
-                    "bmc-machine",
-                    "lockdown",
-                    "--machine",
-                    TEST_MACHINE_ID,
-                    "--enable",
-                ][..],
-                expect: Yields((true, false)),
-            },
-            Case {
-                scenario: "lockdown --disable",
-                input: &[
-                    "bmc-machine",
-                    "lockdown",
-                    "--machine",
-                    TEST_MACHINE_ID,
-                    "--disable",
-                ][..],
-                expect: Yields((false, true)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Lockdown(args) => (args.enable, args.disable),
                     _ => panic!("expected Lockdown variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "lockdown --enable" {
+            &[
+                "bmc-machine",
+                "lockdown",
+                "--machine",
+                TEST_MACHINE_ID,
+                "--enable",
+            ][..] => Yields((true, false)),
+        }
+
+        "lockdown --disable" {
+            &[
+                "bmc-machine",
+                "lockdown",
+                "--machine",
+                TEST_MACHINE_ID,
+                "--disable",
+            ][..] => Yields((false, true)),
+        }
     );
 }
 
@@ -161,10 +149,17 @@ fn parse_lockdown() {
 // username, password, and optional IP address.
 #[test]
 fn parse_create_bmc_user() {
-    check_cases(
-        [Case {
-            scenario: "create-bmc-user with username, password, and ip",
-            input: &[
+    scenarios!(
+        run = |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::CreateBmcUser(args) => (args.username, args.password, args.ip_address),
+                    _ => panic!("expected CreateBmcUser variant"),
+                })
+                .map_err(drop)
+        };
+        "create-bmc-user with username, password, and ip" {
+            &[
                 "bmc-machine",
                 "create-bmc-user",
                 "--username",
@@ -173,21 +168,12 @@ fn parse_create_bmc_user() {
                 "secret123",
                 "--ip-address",
                 "192.168.1.100",
-            ][..],
-            expect: Yields((
+            ][..] => Yields((
                 "admin".to_string(),
                 "secret123".to_string(),
                 Some("192.168.1.100".to_string()),
             )),
-        }],
-        |argv| {
-            Cmd::try_parse_from(argv.iter().copied())
-                .map(|cmd| match cmd {
-                    Cmd::CreateBmcUser(args) => (args.username, args.password, args.ip_address),
-                    _ => panic!("expected CreateBmcUser variant"),
-                })
-                .map_err(drop)
-        },
+        }
     );
 }
 
@@ -195,31 +181,26 @@ fn parse_create_bmc_user() {
 // --enable nor --disable, or both at once (a conflict).
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "lockdown without --enable or --disable",
-                input: &["bmc-machine", "lockdown", "--machine", TEST_MACHINE_ID][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "lockdown with both --enable and --disable",
-                input: &[
-                    "bmc-machine",
-                    "lockdown",
-                    "--machine",
-                    TEST_MACHINE_ID,
-                    "--enable",
-                    "--disable",
-                ][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "lockdown without --enable or --disable" {
+            &["bmc-machine", "lockdown", "--machine", TEST_MACHINE_ID][..] => Fails,
+        }
+
+        "lockdown with both --enable and --disable" {
+            &[
+                "bmc-machine",
+                "lockdown",
+                "--machine",
+                TEST_MACHINE_ID,
+                "--enable",
+                "--disable",
+            ][..] => Fails,
+        }
     );
 }
 

--- a/crates/admin-cli/src/boot_override/tests.rs
+++ b/crates/admin-cli/src/boot_override/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -50,24 +50,22 @@ fn verify_cmd_structure() {
 // parses its interface_id.
 #[test]
 fn parse_get() {
-    check_cases(
-        [Case {
-            scenario: "get parses interface_id",
-            input: &[
-                "boot-override",
-                "get",
-                "550e8400-e29b-41d4-a716-446655440000",
-            ][..],
-            expect: Yields("550e8400-e29b-41d4-a716-446655440000".to_string()),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Get(args) => args.inner.interface_id.to_string(),
                     _ => panic!("expected Get variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "get parses interface_id" {
+            &[
+                "boot-override",
+                "get",
+                "550e8400-e29b-41d4-a716-446655440000",
+            ][..] => Yields("550e8400-e29b-41d4-a716-446655440000".to_string()),
+        }
     );
 }
 
@@ -75,24 +73,22 @@ fn parse_get() {
 // parses its interface_id.
 #[test]
 fn parse_clear() {
-    check_cases(
-        [Case {
-            scenario: "clear parses interface_id",
-            input: &[
-                "boot-override",
-                "clear",
-                "550e8400-e29b-41d4-a716-446655440000",
-            ][..],
-            expect: Yields("550e8400-e29b-41d4-a716-446655440000".to_string()),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Clear(args) => args.inner.interface_id.to_string(),
                     _ => panic!("expected Clear variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "clear parses interface_id" {
+            &[
+                "boot-override",
+                "clear",
+                "550e8400-e29b-41d4-a716-446655440000",
+            ][..] => Yields("550e8400-e29b-41d4-a716-446655440000".to_string()),
+        }
     );
 }
 
@@ -102,59 +98,8 @@ fn parse_clear() {
 // (interface_id, custom_pxe, custom_user_data).
 #[test]
 fn parse_set() {
-    type SetFields = (String, Option<String>, Option<String>);
-
-    check_cases(
-        [
-            Case {
-                scenario: "set with just interface_id leaves the custom flags unset",
-                input: &[
-                    "boot-override",
-                    "set",
-                    "550e8400-e29b-41d4-a716-446655440000",
-                ][..],
-                expect: Yields((
-                    "550e8400-e29b-41d4-a716-446655440000".to_string(),
-                    None,
-                    None,
-                )),
-            },
-            Case {
-                scenario: "set with the long --custom-pxe/--custom-user-data flags",
-                input: &[
-                    "boot-override",
-                    "set",
-                    "550e8400-e29b-41d4-a716-446655440000",
-                    "--custom-pxe",
-                    "http://pxe.example.com/boot",
-                    "--custom-user-data",
-                    "some-user-data",
-                ][..],
-                expect: Yields((
-                    "550e8400-e29b-41d4-a716-446655440000".to_string(),
-                    Some("http://pxe.example.com/boot".to_string()),
-                    Some("some-user-data".to_string()),
-                )),
-            },
-            Case {
-                scenario: "set with the short -p/-u aliases",
-                input: &[
-                    "boot-override",
-                    "set",
-                    "550e8400-e29b-41d4-a716-446655440000",
-                    "-p",
-                    "http://pxe.example.com/boot",
-                    "-u",
-                    "some-user-data",
-                ][..],
-                expect: Yields((
-                    "550e8400-e29b-41d4-a716-446655440000".to_string(),
-                    Some("http://pxe.example.com/boot".to_string()),
-                    Some("some-user-data".to_string()),
-                )),
-            },
-        ],
-        |argv| -> Result<SetFields, ()> {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Set(args) => (
@@ -165,7 +110,50 @@ fn parse_set() {
                     _ => panic!("expected Set variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "set with just interface_id leaves the custom flags unset" {
+            &[
+                "boot-override",
+                "set",
+                "550e8400-e29b-41d4-a716-446655440000",
+            ][..] => Yields((
+                "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                None,
+                None,
+            )),
+        }
+
+        "set with the long --custom-pxe/--custom-user-data flags" {
+            &[
+                "boot-override",
+                "set",
+                "550e8400-e29b-41d4-a716-446655440000",
+                "--custom-pxe",
+                "http://pxe.example.com/boot",
+                "--custom-user-data",
+                "some-user-data",
+            ][..] => Yields((
+                "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                Some("http://pxe.example.com/boot".to_string()),
+                Some("some-user-data".to_string()),
+            )),
+        }
+
+        "set with the short -p/-u aliases" {
+            &[
+                "boot-override",
+                "set",
+                "550e8400-e29b-41d4-a716-446655440000",
+                "-p",
+                "http://pxe.example.com/boot",
+                "-u",
+                "some-user-data",
+            ][..] => Yields((
+                "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                Some("http://pxe.example.com/boot".to_string()),
+                Some("some-user-data".to_string()),
+            )),
+        }
     );
 }
 
@@ -173,16 +161,14 @@ fn parse_set() {
 // invoked without its required interface_id.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [Case {
-            scenario: "get without interface_id",
-            input: &["boot-override", "get"][..],
-            expect: Fails,
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "get without interface_id" {
+            &["boot-override", "get"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/component_manager/update_firmware/args.rs
+++ b/crates/admin-cli/src/component_manager/update_firmware/args.rs
@@ -325,7 +325,7 @@ impl TryFrom<Args> for rpc::forge::UpdateComponentFirmwareRequest {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::scenarios;
 
     use super::*;
 
@@ -352,49 +352,42 @@ mod tests {
         let sot_no_token = temp_sot_file(r#"{"Id":"fw-object"}"#);
         let sot_empty_token = temp_sot_file(r#"{"Id":"fw-object"}"#);
 
-        check_cases(
-            [
-                Case {
-                    scenario: "legacy --target-version passes through with no token",
-                    input: FirmwareSourceArgs {
-                        target_version: Some("fw-1.0".to_string()),
-                        sot_json_file: None,
-                        access_token: None,
-                    },
-                    expect: Yields(("fw-1.0".to_string(), None)),
-                },
-                Case {
-                    scenario: "SOT JSON file resolves to its contents and the access token",
-                    input: FirmwareSourceArgs {
-                        target_version: None,
-                        sot_json_file: Some(sot_token.clone()),
-                        access_token: Some("token".to_string()),
-                    },
-                    expect: Yields((
-                        r#"{"Id":"fw-object"}"#.to_string(),
-                        Some("token".to_string()),
-                    )),
-                },
-                Case {
-                    scenario: "SOT JSON file resolves without an access token",
-                    input: FirmwareSourceArgs {
-                        target_version: None,
-                        sot_json_file: Some(sot_no_token.clone()),
-                        access_token: None,
-                    },
-                    expect: Yields((r#"{"Id":"fw-object"}"#.to_string(), None)),
-                },
-                Case {
-                    scenario: "an empty access token collapses to None",
-                    input: FirmwareSourceArgs {
-                        target_version: None,
-                        sot_json_file: Some(sot_empty_token.clone()),
-                        access_token: Some(String::new()),
-                    },
-                    expect: Yields((r#"{"Id":"fw-object"}"#.to_string(), None)),
-                },
-            ],
-            |source| resolve_firmware_source(source).map_err(drop),
+        scenarios!(
+            run = |source| resolve_firmware_source(source).map_err(drop);
+            "legacy --target-version passes through with no token" {
+                FirmwareSourceArgs {
+                    target_version: Some("fw-1.0".to_string()),
+                    sot_json_file: None,
+                    access_token: None,
+                } => Yields(("fw-1.0".to_string(), None)),
+            }
+
+            "SOT JSON file resolves to its contents and the access token" {
+                FirmwareSourceArgs {
+                    target_version: None,
+                    sot_json_file: Some(sot_token.clone()),
+                    access_token: Some("token".to_string()),
+                } => Yields((
+                    r#"{"Id":"fw-object"}"#.to_string(),
+                    Some("token".to_string()),
+                )),
+            }
+
+            "SOT JSON file resolves without an access token" {
+                FirmwareSourceArgs {
+                    target_version: None,
+                    sot_json_file: Some(sot_no_token.clone()),
+                    access_token: None,
+                } => Yields((r#"{"Id":"fw-object"}"#.to_string(), None)),
+            }
+
+            "an empty access token collapses to None" {
+                FirmwareSourceArgs {
+                    target_version: None,
+                    sot_json_file: Some(sot_empty_token.clone()),
+                    access_token: Some(String::new()),
+                } => Yields((r#"{"Id":"fw-object"}"#.to_string(), None)),
+            }
         );
 
         let _ = std::fs::remove_file(sot_token);
@@ -410,28 +403,23 @@ mod tests {
     fn firmware_source_rejects_incoherent_inputs() {
         let invalid_json = temp_sot_file("not-json");
 
-        check_cases(
-            [
-                Case {
-                    scenario: "access token without a SOT JSON file",
-                    input: FirmwareSourceArgs {
-                        target_version: Some("fw-1.0".to_string()),
-                        sot_json_file: None,
-                        access_token: Some("token".to_string()),
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "SOT JSON file whose contents are not valid JSON",
-                    input: FirmwareSourceArgs {
-                        target_version: None,
-                        sot_json_file: Some(invalid_json.clone()),
-                        access_token: Some("token".to_string()),
-                    },
-                    expect: Fails,
-                },
-            ],
-            |source| resolve_firmware_source(source).map_err(drop),
+        scenarios!(
+            run = |source| resolve_firmware_source(source).map_err(drop);
+            "access token without a SOT JSON file" {
+                FirmwareSourceArgs {
+                    target_version: Some("fw-1.0".to_string()),
+                    sot_json_file: None,
+                    access_token: Some("token".to_string()),
+                } => Fails,
+            }
+
+            "SOT JSON file whose contents are not valid JSON" {
+                FirmwareSourceArgs {
+                    target_version: None,
+                    sot_json_file: Some(invalid_json.clone()),
+                    access_token: Some("token".to_string()),
+                } => Fails,
+            }
         );
 
         let _ = std::fs::remove_file(invalid_json);

--- a/crates/admin-cli/src/credential/tests.rs
+++ b/crates/admin-cli/src/credential/tests.rs
@@ -27,7 +27,7 @@
 // Custom Validators - Test external input validation functions.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::common::{BmcCredentialType, UefiCredentialType, password_validator, url_validator};
@@ -54,37 +54,32 @@ fn verify_cmd_structure() {
 // token defaults to the empty string when its optional flag is omitted.
 #[test]
 fn parse_add_ufm_fields() {
-    check_cases(
-        [
-            Case {
-                scenario: "required args only -- token defaults to empty",
-                input: &["credential", "add-ufm", "--url", "https://ufm.example.com"][..],
-                expect: Yields(("https://ufm.example.com".to_string(), String::new())),
-            },
-            Case {
-                scenario: "with optional --token",
-                input: &[
-                    "credential",
-                    "add-ufm",
-                    "--url",
-                    "https://ufm.example.com",
-                    "--token",
-                    "my-secret-token",
-                ][..],
-                expect: Yields((
-                    "https://ufm.example.com".to_string(),
-                    "my-secret-token".to_string(),
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::AddUFM(args) => (args.url, args.token),
                     _ => panic!("expected AddUFM variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "required args only -- token defaults to empty" {
+            &["credential", "add-ufm", "--url", "https://ufm.example.com"][..] => Yields(("https://ufm.example.com".to_string(), String::new())),
+        }
+
+        "with optional --token" {
+            &[
+                "credential",
+                "add-ufm",
+                "--url",
+                "https://ufm.example.com",
+                "--token",
+                "my-secret-token",
+            ][..] => Yields((
+                "https://ufm.example.com".to_string(),
+                "my-secret-token".to_string(),
+            )),
+        }
     );
 }
 
@@ -160,36 +155,30 @@ fn parse_add_nic_lockdown_ikm() {
 // its required flag, or a --kind value passed without the required `=` separator.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "add-ufm without required --url",
-                input: &["credential", "add-ufm"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "add-bmc --kind without the = separator",
-                input: &[
-                    "credential",
-                    "add-bmc",
-                    "--kind",
-                    "site-wide-root",
-                    "--password",
-                    "secret",
-                ][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "add-nic-lockdown-ikm without required --password",
-                input: &["credential", "add-nic-lockdown-ikm"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "add-ufm without required --url" {
+            &["credential", "add-ufm"][..] => Fails,
+        }
+
+        "add-bmc --kind without the = separator" {
+            &[
+                "credential",
+                "add-bmc",
+                "--kind",
+                "site-wide-root",
+                "--password",
+                "secret",
+            ][..] => Fails,
+        }
+
+        "add-nic-lockdown-ikm without required --password" {
+            &["credential", "add-nic-lockdown-ikm"][..] => Fails,
+        }
     );
 }
 
@@ -312,35 +301,27 @@ fn uefi_credential_type_value_enum() {
 // not parse as a URL (including the empty string).
 #[test]
 fn url_validator_accepts_only_valid_urls() {
-    check_cases(
-        [
-            Case {
-                scenario: "https host",
-                input: "https://example.com",
-                expect: Yields(()),
-            },
-            Case {
-                scenario: "http host with port",
-                input: "http://localhost:8080",
-                expect: Yields(()),
-            },
-            Case {
-                scenario: "https host with path",
-                input: "https://ufm.corp.example.com/api",
-                expect: Yields(()),
-            },
-            Case {
-                scenario: "not a url",
-                input: "not a url",
-                expect: Fails,
-            },
-            Case {
-                scenario: "empty string",
-                input: "",
-                expect: Fails,
-            },
-        ],
-        |url| url_validator(url.to_string()).map(|_| ()).map_err(drop),
+    scenarios!(
+        run = |url| url_validator(url.to_string()).map(|_| ()).map_err(drop);
+        "https host" {
+            "https://example.com" => Yields(()),
+        }
+
+        "http host with port" {
+            "http://localhost:8080" => Yields(()),
+        }
+
+        "https host with path" {
+            "https://ufm.corp.example.com/api" => Yields(()),
+        }
+
+        "not a url" {
+            "not a url" => Fails,
+        }
+
+        "empty string" {
+            "" => Fails,
+        }
     );
 }
 
@@ -348,29 +329,22 @@ fn url_validator_accepts_only_valid_urls() {
 // string.
 #[test]
 fn password_validator_accepts_only_non_empty() {
-    check_cases(
-        [
-            Case {
-                scenario: "ordinary password",
-                input: "secret123",
-                expect: Yields(()),
-            },
-            Case {
-                scenario: "single character",
-                input: "a",
-                expect: Yields(()),
-            },
-            Case {
-                scenario: "spaces are allowed",
-                input: "spaces are ok",
-                expect: Yields(()),
-            },
-            Case {
-                scenario: "empty string is rejected",
-                input: "",
-                expect: Fails,
-            },
-        ],
-        |pw| password_validator(pw.to_string()).map(|_| ()).map_err(drop),
+    scenarios!(
+        run = |pw| password_validator(pw.to_string()).map(|_| ()).map_err(drop);
+        "ordinary password" {
+            "secret123" => Yields(()),
+        }
+
+        "single character" {
+            "a" => Yields(()),
+        }
+
+        "spaces are allowed" {
+            "spaces are ok" => Yields(()),
+        }
+
+        "empty string is rejected" {
+            "" => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/devenv/tests.rs
+++ b/crates/admin-cli/src/devenv/tests.rs
@@ -25,7 +25,7 @@
 // ValueEnum Parsing - Test string parsing for types deriving claps ValueEnum.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -52,91 +52,83 @@ fn verify_cmd_structure() {
 // (config) and `a` (apply) aliases. Each row yields the parsed (path, mode).
 #[test]
 fn config_apply_parses_path_and_mode() {
-    check_cases(
-        [
-            Case {
-                scenario: "network-segment mode parses path and mode",
-                input: &[
-                    "devenv",
-                    "config",
-                    "apply",
-                    "/path/to/config.toml",
-                    "--mode",
-                    "network-segment",
-                ][..],
-                expect: Yields((
-                    "/path/to/config.toml".to_string(),
-                    config::NetworkChoice::NetworkSegment,
-                )),
-            },
-            Case {
-                scenario: "vpc-prefix mode parses",
-                input: &[
-                    "devenv",
-                    "config",
-                    "apply",
-                    "/path/to/config.toml",
-                    "--mode",
-                    "vpc-prefix",
-                ][..],
-                expect: Yields((
-                    "/path/to/config.toml".to_string(),
-                    config::NetworkChoice::VpcPrefix,
-                )),
-            },
-            Case {
-                scenario: "-m short flag parses",
-                input: &[
-                    "devenv",
-                    "config",
-                    "apply",
-                    "/path/to/config.toml",
-                    "-m",
-                    "network-segment",
-                ][..],
-                expect: Yields((
-                    "/path/to/config.toml".to_string(),
-                    config::NetworkChoice::NetworkSegment,
-                )),
-            },
-            Case {
-                scenario: "config alias 'c' routes to apply",
-                input: &[
-                    "devenv",
-                    "c",
-                    "apply",
-                    "/path/to/config.toml",
-                    "-m",
-                    "network-segment",
-                ][..],
-                expect: Yields((
-                    "/path/to/config.toml".to_string(),
-                    config::NetworkChoice::NetworkSegment,
-                )),
-            },
-            Case {
-                scenario: "apply alias 'a' routes to apply",
-                input: &[
-                    "devenv",
-                    "config",
-                    "a",
-                    "/path/to/config.toml",
-                    "-m",
-                    "network-segment",
-                ][..],
-                expect: Yields((
-                    "/path/to/config.toml".to_string(),
-                    config::NetworkChoice::NetworkSegment,
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Config(config::Cmd::Apply(args)) => (args.path, args.mode),
                 })
                 .map_err(drop)
-        },
+        };
+        "network-segment mode parses path and mode" {
+            &[
+                "devenv",
+                "config",
+                "apply",
+                "/path/to/config.toml",
+                "--mode",
+                "network-segment",
+            ][..] => Yields((
+                "/path/to/config.toml".to_string(),
+                config::NetworkChoice::NetworkSegment,
+            )),
+        }
+
+        "vpc-prefix mode parses" {
+            &[
+                "devenv",
+                "config",
+                "apply",
+                "/path/to/config.toml",
+                "--mode",
+                "vpc-prefix",
+            ][..] => Yields((
+                "/path/to/config.toml".to_string(),
+                config::NetworkChoice::VpcPrefix,
+            )),
+        }
+
+        "-m short flag parses" {
+            &[
+                "devenv",
+                "config",
+                "apply",
+                "/path/to/config.toml",
+                "-m",
+                "network-segment",
+            ][..] => Yields((
+                "/path/to/config.toml".to_string(),
+                config::NetworkChoice::NetworkSegment,
+            )),
+        }
+
+        "config alias 'c' routes to apply" {
+            &[
+                "devenv",
+                "c",
+                "apply",
+                "/path/to/config.toml",
+                "-m",
+                "network-segment",
+            ][..] => Yields((
+                "/path/to/config.toml".to_string(),
+                config::NetworkChoice::NetworkSegment,
+            )),
+        }
+
+        "apply alias 'a' routes to apply" {
+            &[
+                "devenv",
+                "config",
+                "a",
+                "/path/to/config.toml",
+                "-m",
+                "network-segment",
+            ][..] => Yields((
+                "/path/to/config.toml".to_string(),
+                config::NetworkChoice::NetworkSegment,
+            )),
+        }
     );
 }
 
@@ -144,24 +136,19 @@ fn config_apply_parses_path_and_mode() {
 // one missing is rejected at parse time.
 #[test]
 fn config_apply_rejects_missing_required_args() {
-    check_cases(
-        [
-            Case {
-                scenario: "missing path",
-                input: &["devenv", "config", "apply", "-m", "network-segment"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "missing --mode",
-                input: &["devenv", "config", "apply", "/path/to/config.toml"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "missing path" {
+            &["devenv", "config", "apply", "-m", "network-segment"][..] => Fails,
+        }
+
+        "missing --mode" {
+            &["devenv", "config", "apply", "/path/to/config.toml"][..] => Fails,
+        }
     );
 }
 
@@ -179,24 +166,18 @@ fn config_apply_rejects_missing_required_args() {
 fn network_choice_value_enum() {
     use clap::ValueEnum;
 
-    check_cases(
-        [
-            Case {
-                scenario: "network-segment",
-                input: "network-segment",
-                expect: Yields(config::NetworkChoice::NetworkSegment),
-            },
-            Case {
-                scenario: "vpc-prefix",
-                input: "vpc-prefix",
-                expect: Yields(config::NetworkChoice::VpcPrefix),
-            },
-            Case {
-                scenario: "invalid value",
-                input: "invalid",
-                expect: Fails,
-            },
-        ],
-        |s| config::NetworkChoice::from_str(s, false).map_err(drop),
+    scenarios!(
+        run = |s| config::NetworkChoice::from_str(s, false).map_err(drop);
+        "network-segment" {
+            "network-segment" => Yields(config::NetworkChoice::NetworkSegment),
+        }
+
+        "vpc-prefix" {
+            "vpc-prefix" => Yields(config::NetworkChoice::VpcPrefix),
+        }
+
+        "invalid value" {
+            "invalid" => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/domain/tests.rs
+++ b/crates/admin-cli/src/domain/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -51,25 +51,20 @@ fn verify_cmd_structure() {
 // row yields the `(all, domain.is_some())` pair the originals asserted.
 #[test]
 fn parse_show_variants() {
-    check_cases(
-        [
-            Case {
-                scenario: "no arguments (all domains)",
-                input: &["domain", "show"][..],
-                expect: Yields((false, false)),
-            },
-            Case {
-                scenario: "--all flag (deprecated)",
-                input: &["domain", "show", "--all"][..],
-                expect: Yields((true, false)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => (args.all, args.domain.is_some()),
                 })
                 .map_err(drop)
-        },
+        };
+        "no arguments (all domains)" {
+            &["domain", "show"][..] => Yields((false, false)),
+        }
+
+        "--all flag (deprecated)" {
+            &["domain", "show", "--all"][..] => Yields((true, false)),
+        }
     );
 }

--- a/crates/admin-cli/src/dpa/tests.rs
+++ b/crates/admin-cli/src/dpa/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 use rpc::forge::DpaInterfaceType;
 
@@ -51,20 +51,18 @@ fn verify_cmd_structure() {
 // is left unset (the "all DPAs" case).
 #[test]
 fn parse_show() {
-    check_cases(
-        [Case {
-            scenario: "show with no arguments leaves id unset",
-            input: &["dpa", "show"][..],
-            expect: Yields(true),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => args.id.is_none(),
                     other => panic!("expected Show, got {other:?}"),
                 })
                 .map_err(drop)
-        },
+        };
+        "show with no arguments leaves id unset" {
+            &["dpa", "show"][..] => Yields(true),
+        }
     );
 }
 
@@ -72,27 +70,8 @@ fn parse_show() {
 // to the parsed fields (machine id, MAC, device type, PCI name, interface).
 #[test]
 fn parse_ensure() {
-    check_cases(
-        [Case {
-            scenario: "ensure with all positional arguments",
-            input: &[
-                "dpa",
-                "ensure",
-                "fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30",
-                "00:11:22:33:44:55",
-                "BlueField3",
-                "01:00.0",
-                "svpc",
-            ][..],
-            expect: Yields((
-                "fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30".to_string(),
-                "00:11:22:33:44:55".to_string(),
-                "BlueField3".to_string(),
-                "01:00.0".to_string(),
-                DpaInterfaceType::Svpc,
-            )),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Ensure(args) => (
@@ -105,6 +84,23 @@ fn parse_ensure() {
                     other => panic!("expected Ensure, got {other:?}"),
                 })
                 .map_err(drop)
-        },
+        };
+        "ensure with all positional arguments" {
+            &[
+                "dpa",
+                "ensure",
+                "fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30",
+                "00:11:22:33:44:55",
+                "BlueField3",
+                "01:00.0",
+                "svpc",
+            ][..] => Yields((
+                "fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30".to_string(),
+                "00:11:22:33:44:55".to_string(),
+                "BlueField3".to_string(),
+                "01:00.0".to_string(),
+                DpaInterfaceType::Svpc,
+            )),
+        }
     );
 }

--- a/crates/admin-cli/src/dpu/tests.rs
+++ b/crates/admin-cli/src/dpu/tests.rs
@@ -25,7 +25,7 @@
 // ValueEnum Parsing - Test string parsing for types deriving claps ValueEnum.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -62,27 +62,22 @@ fn parse_status() {
 // whether the switch was supplied.
 #[test]
 fn parse_versions() {
-    check_cases(
-        [
-            Case {
-                scenario: "versions with no flags leaves updates_only off",
-                input: &["dpu", "versions"][..],
-                expect: Yields(false),
-            },
-            Case {
-                scenario: "versions --updates-only sets the flag",
-                input: &["dpu", "versions", "--updates-only"][..],
-                expect: Yields(true),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Versions(args) => args.updates_only,
                     _ => panic!("expected Versions variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "versions with no flags leaves updates_only off" {
+            &["dpu", "versions"][..] => Yields(false),
+        }
+
+        "versions --updates-only sets the flag" {
+            &["dpu", "versions", "--updates-only"][..] => Yields(true),
+        }
     );
 }
 
@@ -92,25 +87,8 @@ fn parse_versions() {
 // update_firmware flag.
 #[test]
 fn parse_reprovision() {
-    check_cases(
-        [
-            Case {
-                scenario: "reprovision list routes to List",
-                input: &["dpu", "reprovision", "list"][..],
-                expect: Yields(("list", String::new(), false)),
-            },
-            Case {
-                scenario: "reprovision set carries the machine id, firmware off",
-                input: &["dpu", "reprovision", "set", "--id", TEST_MACHINE_ID][..],
-                expect: Yields(("set", TEST_MACHINE_ID.to_string(), false)),
-            },
-            Case {
-                scenario: "reprovision clear carries the machine id",
-                input: &["dpu", "reprovision", "clear", "--id", TEST_MACHINE_ID][..],
-                expect: Yields(("clear", TEST_MACHINE_ID.to_string(), false)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Reprovision(reprovision::Args::List) => ("list", String::new(), false),
@@ -123,7 +101,18 @@ fn parse_reprovision() {
                     _ => panic!("expected Reprovision variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "reprovision list routes to List" {
+            &["dpu", "reprovision", "list"][..] => Yields(("list", String::new(), false)),
+        }
+
+        "reprovision set carries the machine id, firmware off" {
+            &["dpu", "reprovision", "set", "--id", TEST_MACHINE_ID][..] => Yields(("set", TEST_MACHINE_ID.to_string(), false)),
+        }
+
+        "reprovision clear carries the machine id" {
+            &["dpu", "reprovision", "clear", "--id", TEST_MACHINE_ID][..] => Yields(("clear", TEST_MACHINE_ID.to_string(), false)),
+        }
     );
 }
 
@@ -132,20 +121,8 @@ fn parse_reprovision() {
 // name the parsed --set resolves to ("<get>" when unset).
 #[test]
 fn parse_agent_upgrade_policy() {
-    check_cases(
-        [
-            Case {
-                scenario: "no --set is a get and leaves the policy unset",
-                input: &["dpu", "agent-upgrade-policy"][..],
-                expect: Yields("<get>"),
-            },
-            Case {
-                scenario: "--set up-only selects the UpOnly policy",
-                input: &["dpu", "agent-upgrade-policy", "--set", "up-only"][..],
-                expect: Yields("up-only"),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             use agent_upgrade_policy::args::AgentUpgradePolicyChoice;
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
@@ -158,7 +135,14 @@ fn parse_agent_upgrade_policy() {
                     _ => panic!("expected AgentUpgradePolicy variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "no --set is a get and leaves the policy unset" {
+            &["dpu", "agent-upgrade-policy"][..] => Yields("<get>"),
+        }
+
+        "--set up-only selects the UpOnly policy" {
+            &["dpu", "agent-upgrade-policy", "--set", "up-only"][..] => Yields("up-only"),
+        }
     );
 }
 
@@ -179,30 +163,8 @@ fn agent_upgrade_policy_choice_value_enum() {
     use agent_upgrade_policy::args::AgentUpgradePolicyChoice;
     use clap::ValueEnum;
 
-    check_cases(
-        [
-            Case {
-                scenario: "\"off\" parses to Off",
-                input: "off",
-                expect: Yields("off"),
-            },
-            Case {
-                scenario: "\"up-only\" parses to UpOnly",
-                input: "up-only",
-                expect: Yields("up-only"),
-            },
-            Case {
-                scenario: "\"up-down\" parses to UpDown",
-                input: "up-down",
-                expect: Yields("up-down"),
-            },
-            Case {
-                scenario: "an unknown value is rejected",
-                input: "invalid",
-                expect: Fails,
-            },
-        ],
-        |s| {
+    scenarios!(
+        run = |s| {
             AgentUpgradePolicyChoice::from_str(s, false)
                 .map(|choice| match choice {
                     AgentUpgradePolicyChoice::Off => "off",
@@ -210,6 +172,21 @@ fn agent_upgrade_policy_choice_value_enum() {
                     AgentUpgradePolicyChoice::UpDown => "up-down",
                 })
                 .map_err(drop)
-        },
+        };
+        "\"off\" parses to Off" {
+            "off" => Yields("off"),
+        }
+
+        "\"up-only\" parses to UpOnly" {
+            "up-only" => Yields("up-only"),
+        }
+
+        "\"up-down\" parses to UpDown" {
+            "up-down" => Yields("up-down"),
+        }
+
+        "an unknown value is rejected" {
+            "invalid" => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/dpu_remediation/tests.rs
+++ b/crates/admin-cli/src/dpu_remediation/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -51,44 +51,8 @@ fn verify_cmd_structure() {
 // (script_filename, retries, meta_name, meta_description, has_labels).
 #[test]
 fn parse_create_routes_and_fills_fields() {
-    check_cases(
-        [
-            Case {
-                scenario: "required script-filename only",
-                input: &[
-                    "dpu-remediation",
-                    "create",
-                    "--script-filename",
-                    "/path/to/script.sh",
-                ][..],
-                expect: Yields(("/path/to/script.sh".to_string(), None, None, None, false)),
-            },
-            Case {
-                scenario: "all options supplied",
-                input: &[
-                    "dpu-remediation",
-                    "create",
-                    "--script-filename",
-                    "/path/to/script.sh",
-                    "--retries",
-                    "3",
-                    "--meta-name",
-                    "My Remediation",
-                    "--meta-description",
-                    "Fixes a bug",
-                    "--label",
-                    "env:prod",
-                ][..],
-                expect: Yields((
-                    "/path/to/script.sh".to_string(),
-                    Some(3),
-                    Some("My Remediation".to_string()),
-                    Some("Fixes a bug".to_string()),
-                    true,
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Create(args) => (
@@ -101,7 +65,38 @@ fn parse_create_routes_and_fills_fields() {
                     _ => panic!("expected Create variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "required script-filename only" {
+            &[
+                "dpu-remediation",
+                "create",
+                "--script-filename",
+                "/path/to/script.sh",
+            ][..] => Yields(("/path/to/script.sh".to_string(), None, None, None, false)),
+        }
+
+        "all options supplied" {
+            &[
+                "dpu-remediation",
+                "create",
+                "--script-filename",
+                "/path/to/script.sh",
+                "--retries",
+                "3",
+                "--meta-name",
+                "My Remediation",
+                "--meta-description",
+                "Fixes a bug",
+                "--label",
+                "env:prod",
+            ][..] => Yields((
+                "/path/to/script.sh".to_string(),
+                Some(3),
+                Some("My Remediation".to_string()),
+                Some("Fixes a bug".to_string()),
+                true,
+            )),
+        }
     );
 }
 
@@ -110,27 +105,22 @@ fn parse_create_routes_and_fills_fields() {
 // turns the flag on.
 #[test]
 fn parse_show_routes_and_fills_fields() {
-    check_cases(
-        [
-            Case {
-                scenario: "no arguments",
-                input: &["dpu-remediation", "show"][..],
-                expect: Yields((false, false)),
-            },
-            Case {
-                scenario: "with --display-script",
-                input: &["dpu-remediation", "show", "--display-script"][..],
-                expect: Yields((false, true)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => (args.id.is_some(), args.display_script),
                     _ => panic!("expected Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "no arguments" {
+            &["dpu-remediation", "show"][..] => Yields((false, false)),
+        }
+
+        "with --display-script" {
+            &["dpu-remediation", "show", "--display-script"][..] => Yields((false, true)),
+        }
     );
 }
 
@@ -138,13 +128,8 @@ fn parse_show_routes_and_fills_fields() {
 // optional filters unset; the row yields (remediation_id_present, machine_id_present).
 #[test]
 fn parse_list_applied_routes_and_fills_fields() {
-    check_cases(
-        [Case {
-            scenario: "no arguments",
-            input: &["dpu-remediation", "list-applied"][..],
-            expect: Yields((false, false)),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::ListApplied(args) => {
@@ -153,7 +138,10 @@ fn parse_list_applied_routes_and_fills_fields() {
                     _ => panic!("expected ListApplied variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "no arguments" {
+            &["dpu-remediation", "list-applied"][..] => Yields((false, false)),
+        }
     );
 }
 
@@ -161,16 +149,14 @@ fn parse_list_applied_routes_and_fills_fields() {
 // its required --script-filename.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [Case {
-            scenario: "create without --script-filename",
-            input: &["dpu-remediation", "create"][..],
-            expect: Fails,
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "create without --script-filename" {
+            &["dpu-remediation", "create"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/expected_machines/tests.rs
+++ b/crates/admin-cli/src/expected_machines/tests.rs
@@ -25,7 +25,7 @@
 // Validation Logic    - Test business logic validators on parsed arguments.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -234,65 +234,57 @@ fn parse_erase() {
 // argument, one half of a paired credential, or a flag left without its value.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "add without its required arguments",
-                input: &["expected-machine", "add"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "patch with a username but no password",
-                input: &[
-                    "expected-machine",
-                    "patch",
-                    "--bmc-mac-address",
-                    "00:00:00:00:00:00",
-                    "--bmc-username",
-                    "admin",
-                ][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "patch with a password but no username",
-                input: &[
-                    "expected-machine",
-                    "patch",
-                    "--bmc-mac-address",
-                    "00:00:00:00:00:00",
-                    "--bmc-password",
-                    "secret",
-                ][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "update without --filename",
-                input: &["expected-machine", "update"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "add with --fallback-dpu-serial-number missing its value",
-                input: &[
-                    "expected-machine",
-                    "add",
-                    "--bmc-mac-address",
-                    "0a:0b:0c:0d:0e:0f",
-                    "--bmc-username",
-                    "admin",
-                    "--bmc-password",
-                    "secret",
-                    "--chassis-serial-number",
-                    "SN12345",
-                    "--fallback-dpu-serial-number",
-                ][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "add without its required arguments" {
+            &["expected-machine", "add"][..] => Fails,
+        }
+
+        "patch with a username but no password" {
+            &[
+                "expected-machine",
+                "patch",
+                "--bmc-mac-address",
+                "00:00:00:00:00:00",
+                "--bmc-username",
+                "admin",
+            ][..] => Fails,
+        }
+
+        "patch with a password but no username" {
+            &[
+                "expected-machine",
+                "patch",
+                "--bmc-mac-address",
+                "00:00:00:00:00:00",
+                "--bmc-password",
+                "secret",
+            ][..] => Fails,
+        }
+
+        "update without --filename" {
+            &["expected-machine", "update"][..] => Fails,
+        }
+
+        "add with --fallback-dpu-serial-number missing its value" {
+            &[
+                "expected-machine",
+                "add",
+                "--bmc-mac-address",
+                "0a:0b:0c:0d:0e:0f",
+                "--bmc-username",
+                "admin",
+                "--bmc-password",
+                "secret",
+                "--chassis-serial-number",
+                "SN12345",
+                "--fallback-dpu-serial-number",
+            ][..] => Fails,
+        }
     );
 }
 
@@ -306,73 +298,67 @@ fn invalid_invocations_are_rejected() {
 // add: unique serials and the no-serials case are clean, a repeat is caught.
 #[test]
 fn has_duplicate_dpu_serials_flags_repeats() {
-    check_cases(
-        [
-            Case {
-                scenario: "three unique serials",
-                input: &[
-                    "ExpectedMachine",
-                    "--bmc-mac-address",
-                    "0a:0b:0c:0d:0e:0f",
-                    "--bmc-username",
-                    "admin",
-                    "--bmc-password",
-                    "secret",
-                    "--chassis-serial-number",
-                    "SN12345",
-                    "--fallback-dpu-serial-number",
-                    "dpu1",
-                    "-d",
-                    "dpu2",
-                    "-d",
-                    "dpu3",
-                ][..],
-                expect: Yields(false),
-            },
-            Case {
-                scenario: "a repeated serial is detected",
-                input: &[
-                    "ExpectedMachine",
-                    "--bmc-mac-address",
-                    "0a:0b:0c:0d:0e:0f",
-                    "--bmc-username",
-                    "admin",
-                    "--bmc-password",
-                    "secret",
-                    "--chassis-serial-number",
-                    "SN12345",
-                    "-d",
-                    "dpu1",
-                    "-d",
-                    "dpu2",
-                    "-d",
-                    "dpu3",
-                    "-d",
-                    "dpu1",
-                ][..],
-                expect: Yields(true),
-            },
-            Case {
-                scenario: "no serials at all",
-                input: &[
-                    "ExpectedMachine",
-                    "--bmc-mac-address",
-                    "0a:0b:0c:0d:0e:0f",
-                    "--bmc-username",
-                    "admin",
-                    "--bmc-password",
-                    "secret",
-                    "--chassis-serial-number",
-                    "SN12345",
-                ][..],
-                expect: Yields(false),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             add::Args::try_parse_from(argv.iter().copied())
                 .map(|m| m.has_duplicate_dpu_serials())
                 .map_err(drop)
-        },
+        };
+        "three unique serials" {
+            &[
+                "ExpectedMachine",
+                "--bmc-mac-address",
+                "0a:0b:0c:0d:0e:0f",
+                "--bmc-username",
+                "admin",
+                "--bmc-password",
+                "secret",
+                "--chassis-serial-number",
+                "SN12345",
+                "--fallback-dpu-serial-number",
+                "dpu1",
+                "-d",
+                "dpu2",
+                "-d",
+                "dpu3",
+            ][..] => Yields(false),
+        }
+
+        "a repeated serial is detected" {
+            &[
+                "ExpectedMachine",
+                "--bmc-mac-address",
+                "0a:0b:0c:0d:0e:0f",
+                "--bmc-username",
+                "admin",
+                "--bmc-password",
+                "secret",
+                "--chassis-serial-number",
+                "SN12345",
+                "-d",
+                "dpu1",
+                "-d",
+                "dpu2",
+                "-d",
+                "dpu3",
+                "-d",
+                "dpu1",
+            ][..] => Yields(true),
+        }
+
+        "no serials at all" {
+            &[
+                "ExpectedMachine",
+                "--bmc-mac-address",
+                "0a:0b:0c:0d:0e:0f",
+                "--bmc-username",
+                "admin",
+                "--bmc-password",
+                "secret",
+                "--chassis-serial-number",
+                "SN12345",
+            ][..] => Yields(false),
+        }
     );
 }
 

--- a/crates/admin-cli/src/expected_power_shelf/tests.rs
+++ b/crates/admin-cli/src/expected_power_shelf/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -63,24 +63,19 @@ fn variant(cmd: &Cmd) -> &'static str {
 // yielded bool is whether `bmc_mac_address` was supplied.
 #[test]
 fn parse_show() {
-    check_cases(
-        [
-            Case {
-                scenario: "show with no arguments (all power shelves)",
-                input: &["expected-power-shelf", "show"][..],
-                expect: Yields(false),
-            },
-            Case {
-                scenario: "show with a MAC address",
-                input: &["expected-power-shelf", "show", "1a:2b:3c:4d:5e:6f"][..],
-                expect: Yields(true),
-            },
-        ],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
             Ok(Cmd::Show(args)) => Ok(args.bmc_mac_address.is_some()),
             Ok(other) => panic!("expected Show variant, got {}", variant(&other)),
             Err(_) => Err(()),
-        },
+        };
+        "show with no arguments (all power shelves)" {
+            &["expected-power-shelf", "show"][..] => Yields(false),
+        }
+
+        "show with a MAC address" {
+            &["expected-power-shelf", "show", "1a:2b:3c:4d:5e:6f"][..] => Yields(true),
+        }
     );
 }
 
@@ -89,54 +84,49 @@ fn parse_show() {
 // and the optional meta-name).
 #[test]
 fn parse_add() {
-    check_cases(
-        [
-            Case {
-                scenario: "add with required arguments",
-                input: &[
-                    "expected-power-shelf",
-                    "add",
-                    "--bmc-mac-address",
-                    "1a:2b:3c:4d:5e:6f",
-                    "--bmc-username",
-                    "admin",
-                    "--bmc-password",
-                    "secret",
-                    "--shelf-serial-number",
-                    "SHELF12345",
-                ][..],
-                expect: Yields(("admin".to_string(), "SHELF12345".to_string(), None)),
-            },
-            Case {
-                scenario: "add with all options",
-                input: &[
-                    "expected-power-shelf",
-                    "add",
-                    "--bmc-mac-address",
-                    "1a:2b:3c:4d:5e:6f",
-                    "--bmc-username",
-                    "admin",
-                    "--bmc-password",
-                    "secret",
-                    "--shelf-serial-number",
-                    "SHELF12345",
-                    "--meta-name",
-                    "MyPowerShelf",
-                    "--label",
-                    "env:prod",
-                ][..],
-                expect: Yields((
-                    "admin".to_string(),
-                    "SHELF12345".to_string(),
-                    Some("MyPowerShelf".to_string()),
-                )),
-            },
-        ],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
             Ok(Cmd::Add(args)) => Ok((args.bmc_username, args.shelf_serial_number, args.meta_name)),
             Ok(other) => panic!("expected Add variant, got {}", variant(&other)),
             Err(_) => Err(()),
-        },
+        };
+        "add with required arguments" {
+            &[
+                "expected-power-shelf",
+                "add",
+                "--bmc-mac-address",
+                "1a:2b:3c:4d:5e:6f",
+                "--bmc-username",
+                "admin",
+                "--bmc-password",
+                "secret",
+                "--shelf-serial-number",
+                "SHELF12345",
+            ][..] => Yields(("admin".to_string(), "SHELF12345".to_string(), None)),
+        }
+
+        "add with all options" {
+            &[
+                "expected-power-shelf",
+                "add",
+                "--bmc-mac-address",
+                "1a:2b:3c:4d:5e:6f",
+                "--bmc-username",
+                "admin",
+                "--bmc-password",
+                "secret",
+                "--shelf-serial-number",
+                "SHELF12345",
+                "--meta-name",
+                "MyPowerShelf",
+                "--label",
+                "env:prod",
+            ][..] => Yields((
+                "admin".to_string(),
+                "SHELF12345".to_string(),
+                Some("MyPowerShelf".to_string()),
+            )),
+        }
     );
 }
 
@@ -144,46 +134,42 @@ fn parse_add() {
 // serial number the original asserted.
 #[test]
 fn parse_update() {
-    check_cases(
-        [Case {
-            scenario: "update with required arguments",
-            input: &[
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::Update(args)) => Ok(args.shelf_serial_number),
+            Ok(other) => panic!("expected Update variant, got {}", variant(&other)),
+            Err(_) => Err(()),
+        };
+        "update with required arguments" {
+            &[
                 "expected-power-shelf",
                 "update",
                 "--bmc-mac-address",
                 "1a:2b:3c:4d:5e:6f",
                 "--shelf-serial-number",
                 "NEW_SERIAL",
-            ][..],
-            expect: Yields(Some("NEW_SERIAL".to_string())),
-        }],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
-            Ok(Cmd::Update(args)) => Ok(args.shelf_serial_number),
-            Ok(other) => panic!("expected Update variant, got {}", variant(&other)),
-            Err(_) => Err(()),
-        },
+            ][..] => Yields(Some("NEW_SERIAL".to_string())),
+        }
     );
 }
 
 // replace-all parses with a filename; the yielded value is that filename.
 #[test]
 fn parse_replace_all() {
-    check_cases(
-        [Case {
-            scenario: "replace-all with a filename",
-            input: &[
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+            Ok(Cmd::ReplaceAll(args)) => Ok(args.filename),
+            Ok(other) => panic!("expected ReplaceAll variant, got {}", variant(&other)),
+            Err(_) => Err(()),
+        };
+        "replace-all with a filename" {
+            &[
                 "expected-power-shelf",
                 "replace-all",
                 "--filename",
                 "shelves.json",
-            ][..],
-            expect: Yields("shelves.json".to_string()),
-        }],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
-            Ok(Cmd::ReplaceAll(args)) => Ok(args.filename),
-            Ok(other) => panic!("expected ReplaceAll variant, got {}", variant(&other)),
-            Err(_) => Err(()),
-        },
+            ][..] => Yields("shelves.json".to_string()),
+        }
     );
 }
 
@@ -191,24 +177,19 @@ fn parse_replace_all() {
 // the yielded value is the variant name.
 #[test]
 fn parse_routes_to_variant() {
-    check_cases(
-        [
-            Case {
-                scenario: "delete with a MAC address",
-                input: &["expected-power-shelf", "delete", "1a:2b:3c:4d:5e:6f"][..],
-                expect: Yields("delete"),
-            },
-            Case {
-                scenario: "erase with no arguments",
-                input: &["expected-power-shelf", "erase"][..],
-                expect: Yields("erase"),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| variant(&cmd))
                 .map_err(drop)
-        },
+        };
+        "delete with a MAC address" {
+            &["expected-power-shelf", "delete", "1a:2b:3c:4d:5e:6f"][..] => Yields("delete"),
+        }
+
+        "erase with no arguments" {
+            &["expected-power-shelf", "erase"][..] => Yields("erase"),
+        }
     );
 }
 
@@ -216,16 +197,14 @@ fn parse_routes_to_variant() {
 // its required arguments.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [Case {
-            scenario: "add without its required arguments",
-            input: &["expected-power-shelf", "add"][..],
-            expect: Fails,
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "add without its required arguments" {
+            &["expected-power-shelf", "add"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/expected_switch/tests.rs
+++ b/crates/admin-cli/src/expected_switch/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -50,27 +50,22 @@ fn verify_cmd_structure() {
 // whether a MAC was supplied.
 #[test]
 fn parse_show() {
-    check_cases(
-        [
-            Case {
-                scenario: "show with no arguments (all switches)",
-                input: &["expected-switch", "show"][..],
-                expect: Yields(false),
-            },
-            Case {
-                scenario: "show with a MAC address",
-                input: &["expected-switch", "show", "1a:2b:3c:4d:5e:6f"][..],
-                expect: Yields(true),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => args.bmc_mac_address.is_some(),
                     _ => panic!("expected Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "show with no arguments (all switches)" {
+            &["expected-switch", "show"][..] => Yields(false),
+        }
+
+        "show with a MAC address" {
+            &["expected-switch", "show", "1a:2b:3c:4d:5e:6f"][..] => Yields(true),
+        }
     );
 }
 
@@ -79,50 +74,8 @@ fn parse_show() {
 // meta_name).
 #[test]
 fn parse_add() {
-    check_cases(
-        [
-            Case {
-                scenario: "add with required arguments",
-                input: &[
-                    "expected-switch",
-                    "add",
-                    "--bmc-mac-address",
-                    "1a:2b:3c:4d:5e:6f",
-                    "--bmc-username",
-                    "admin",
-                    "--bmc-password",
-                    "secret",
-                    "--switch-serial-number",
-                    "SW12345",
-                ][..],
-                expect: Yields(("admin".to_string(), "SW12345".to_string(), None)),
-            },
-            Case {
-                scenario: "add with all options",
-                input: &[
-                    "expected-switch",
-                    "add",
-                    "--bmc-mac-address",
-                    "1a:2b:3c:4d:5e:6f",
-                    "--bmc-username",
-                    "admin",
-                    "--bmc-password",
-                    "secret",
-                    "--switch-serial-number",
-                    "SW12345",
-                    "--meta-name",
-                    "MySwitch",
-                    "--label",
-                    "env:prod",
-                ][..],
-                expect: Yields((
-                    "admin".to_string(),
-                    "SW12345".to_string(),
-                    Some("MySwitch".to_string()),
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Add(args) => {
@@ -131,7 +84,44 @@ fn parse_add() {
                     _ => panic!("expected Add variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "add with required arguments" {
+            &[
+                "expected-switch",
+                "add",
+                "--bmc-mac-address",
+                "1a:2b:3c:4d:5e:6f",
+                "--bmc-username",
+                "admin",
+                "--bmc-password",
+                "secret",
+                "--switch-serial-number",
+                "SW12345",
+            ][..] => Yields(("admin".to_string(), "SW12345".to_string(), None)),
+        }
+
+        "add with all options" {
+            &[
+                "expected-switch",
+                "add",
+                "--bmc-mac-address",
+                "1a:2b:3c:4d:5e:6f",
+                "--bmc-username",
+                "admin",
+                "--bmc-password",
+                "secret",
+                "--switch-serial-number",
+                "SW12345",
+                "--meta-name",
+                "MySwitch",
+                "--label",
+                "env:prod",
+            ][..] => Yields((
+                "admin".to_string(),
+                "SW12345".to_string(),
+                Some("MySwitch".to_string()),
+            )),
+        }
     );
 }
 
@@ -139,52 +129,48 @@ fn parse_add() {
 // the yielded value is the parsed switch_serial_number.
 #[test]
 fn parse_update() {
-    check_cases(
-        [Case {
-            scenario: "update with required arguments",
-            input: &[
-                "expected-switch",
-                "update",
-                "--bmc-mac-address",
-                "1a:2b:3c:4d:5e:6f",
-                "--switch-serial-number",
-                "NEW_SERIAL",
-            ][..],
-            expect: Yields(Some("NEW_SERIAL".to_string())),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Update(args) => args.switch_serial_number,
                     _ => panic!("expected Update variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "update with required arguments" {
+            &[
+                "expected-switch",
+                "update",
+                "--bmc-mac-address",
+                "1a:2b:3c:4d:5e:6f",
+                "--switch-serial-number",
+                "NEW_SERIAL",
+            ][..] => Yields(Some("NEW_SERIAL".to_string())),
+        }
     );
 }
 
 // replace-all parses with a filename; the yielded value is the parsed filename.
 #[test]
 fn parse_replace_all() {
-    check_cases(
-        [Case {
-            scenario: "replace-all with a filename",
-            input: &[
-                "expected-switch",
-                "replace-all",
-                "--filename",
-                "switches.json",
-            ][..],
-            expect: Yields("switches.json".to_string()),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::ReplaceAll(args) => args.filename,
                     _ => panic!("expected ReplaceAll variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "replace-all with a filename" {
+            &[
+                "expected-switch",
+                "replace-all",
+                "--filename",
+                "switches.json",
+            ][..] => Yields("switches.json".to_string()),
+        }
     );
 }
 
@@ -203,40 +189,33 @@ fn parse_routes_to_variant() {
         }
     }
 
-    check_cases(
-        [
-            Case {
-                scenario: "delete with a MAC address",
-                input: &["expected-switch", "delete", "1a:2b:3c:4d:5e:6f"][..],
-                expect: Yields("delete"),
-            },
-            Case {
-                scenario: "erase with no arguments",
-                input: &["expected-switch", "erase"][..],
-                expect: Yields("erase"),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| variant(&cmd))
                 .map_err(drop)
-        },
+        };
+        "delete with a MAC address" {
+            &["expected-switch", "delete", "1a:2b:3c:4d:5e:6f"][..] => Yields("delete"),
+        }
+
+        "erase with no arguments" {
+            &["expected-switch", "erase"][..] => Yields("erase"),
+        }
     );
 }
 
 // Every malformed invocation is rejected at parse time.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [Case {
-            scenario: "add without its required arguments",
-            input: &["expected-switch", "add"][..],
-            expect: Fails,
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "add without its required arguments" {
+            &["expected-switch", "add"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/extension_service/tests.rs
+++ b/crates/admin-cli/src/extension_service/tests.rs
@@ -25,7 +25,7 @@
 // ValueEnum Parsing - Test string parsing for types deriving claps ValueEnum.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::{Case, check_cases, scenarios};
 use clap::{CommandFactory, Parser};
 
 use super::common::ExtensionServiceType;
@@ -285,17 +285,15 @@ fn parse_show_instances_routes_and_binds_fields() {
 // Every malformed invocation is rejected at parse time.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [Case {
-            scenario: "create without its required arguments",
-            input: &["extension-service", "create"][..],
-            expect: Fails,
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "create without its required arguments" {
+            &["extension-service", "create"][..] => Fails,
+        }
     );
 }
 
@@ -314,24 +312,18 @@ fn invalid_invocations_are_rejected() {
 fn extension_service_type_value_enum() {
     use clap::ValueEnum;
 
-    check_cases(
-        [
-            Case {
-                scenario: "canonical kubernetes-pod",
-                input: "kubernetes-pod",
-                expect: Yields(ExtensionServiceType::KubernetesPod),
-            },
-            Case {
-                scenario: "k8s alias maps to KubernetesPod",
-                input: "k8s",
-                expect: Yields(ExtensionServiceType::KubernetesPod),
-            },
-            Case {
-                scenario: "unknown value is rejected",
-                input: "invalid",
-                expect: Fails,
-            },
-        ],
-        |s| ExtensionServiceType::from_str(s, false).map_err(drop),
+    scenarios!(
+        run = |s| ExtensionServiceType::from_str(s, false).map_err(drop);
+        "canonical kubernetes-pod" {
+            "kubernetes-pod" => Yields(ExtensionServiceType::KubernetesPod),
+        }
+
+        "k8s alias maps to KubernetesPod" {
+            "k8s" => Yields(ExtensionServiceType::KubernetesPod),
+        }
+
+        "unknown value is rejected" {
+            "invalid" => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/generate_shell_complete/tests.rs
+++ b/crates/admin-cli/src/generate_shell_complete/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::args::*;
@@ -57,52 +57,41 @@ fn shell_names_parse_to_their_variant() {
         }
     }
 
-    check_cases(
-        [
-            Case {
-                scenario: "bash subcommand",
-                input: &["generate-shell-complete", "bash"][..],
-                expect: Yields("bash"),
-            },
-            Case {
-                scenario: "fish subcommand",
-                input: &["generate-shell-complete", "fish"][..],
-                expect: Yields("fish"),
-            },
-            Case {
-                scenario: "zsh subcommand",
-                input: &["generate-shell-complete", "zsh"][..],
-                expect: Yields("zsh"),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| shell(&cmd.shell))
                 .map_err(drop)
-        },
+        };
+        "bash subcommand" {
+            &["generate-shell-complete", "bash"][..] => Yields("bash"),
+        }
+
+        "fish subcommand" {
+            &["generate-shell-complete", "fish"][..] => Yields("fish"),
+        }
+
+        "zsh subcommand" {
+            &["generate-shell-complete", "zsh"][..] => Yields("zsh"),
+        }
     );
 }
 
 // A shell subcommand is required, and an unknown shell is rejected.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "missing shell subcommand",
-                input: &["generate-shell-complete"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "unknown shell",
-                input: &["generate-shell-complete", "powershell"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "missing shell subcommand" {
+            &["generate-shell-complete"][..] => Fails,
+        }
+
+        "unknown shell" {
+            &["generate-shell-complete", "powershell"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/host/tests.rs
+++ b/crates/admin-cli/src/host/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -64,29 +64,23 @@ fn variant(cmd: &Cmd) -> &'static str {
 // set/clear take a machine query, generate takes no args.
 #[test]
 fn uefi_password_subcommands_route_to_their_variant() {
-    check_cases(
-        [
-            Case {
-                scenario: "set-uefi-password with machine query",
-                input: &["host", "set-uefi-password", "--query", "machine-123"][..],
-                expect: Yields("set-uefi-password"),
-            },
-            Case {
-                scenario: "clear-uefi-password with machine query",
-                input: &["host", "clear-uefi-password", "--query", "machine-123"][..],
-                expect: Yields("clear-uefi-password"),
-            },
-            Case {
-                scenario: "generate-host-uefi-password with no args",
-                input: &["host", "generate-host-uefi-password"][..],
-                expect: Yields("generate-host-uefi-password"),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| variant(&cmd))
                 .map_err(drop)
-        },
+        };
+        "set-uefi-password with machine query" {
+            &["host", "set-uefi-password", "--query", "machine-123"][..] => Yields("set-uefi-password"),
+        }
+
+        "clear-uefi-password with machine query" {
+            &["host", "clear-uefi-password", "--query", "machine-123"][..] => Yields("clear-uefi-password"),
+        }
+
+        "generate-host-uefi-password with no args" {
+            &["host", "generate-host-uefi-password"][..] => Yields("generate-host-uefi-password"),
+        }
     );
 }
 
@@ -96,33 +90,8 @@ fn uefi_password_subcommands_route_to_their_variant() {
 // (id, update_firmware, update_message).
 #[test]
 fn reprovision_set_parses_fields() {
-    check_cases(
-        [
-            Case {
-                scenario: "set with only required --id",
-                input: &["host", "reprovision", "set", "--id", TEST_MACHINE_ID][..],
-                expect: Yields((TEST_MACHINE_ID.to_string(), false, None)),
-            },
-            Case {
-                scenario: "set with all options",
-                input: &[
-                    "host",
-                    "reprovision",
-                    "set",
-                    "--id",
-                    TEST_MACHINE_ID,
-                    "--update-firmware",
-                    "--update-message",
-                    "Maintenance in progress",
-                ][..],
-                expect: Yields((
-                    TEST_MACHINE_ID.to_string(),
-                    true,
-                    Some("Maintenance in progress".to_string()),
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Reprovision(reprovision::args::Args::Set(args)) => (
@@ -133,7 +102,27 @@ fn reprovision_set_parses_fields() {
                     _ => panic!("expected Reprovision Set variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "set with only required --id" {
+            &["host", "reprovision", "set", "--id", TEST_MACHINE_ID][..] => Yields((TEST_MACHINE_ID.to_string(), false, None)),
+        }
+
+        "set with all options" {
+            &[
+                "host",
+                "reprovision",
+                "set",
+                "--id",
+                TEST_MACHINE_ID,
+                "--update-firmware",
+                "--update-message",
+                "Maintenance in progress",
+            ][..] => Yields((
+                TEST_MACHINE_ID.to_string(),
+                true,
+                Some("Maintenance in progress".to_string()),
+            )),
+        }
     );
 }
 
@@ -142,13 +131,8 @@ fn reprovision_set_parses_fields() {
 // (id, update_firmware).
 #[test]
 fn reprovision_clear_parses_fields() {
-    check_cases(
-        [Case {
-            scenario: "clear with required --id",
-            input: &["host", "reprovision", "clear", "--id", TEST_MACHINE_ID][..],
-            expect: Yields((TEST_MACHINE_ID.to_string(), false)),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Reprovision(reprovision::args::Args::Clear(args)) => {
@@ -157,7 +141,10 @@ fn reprovision_clear_parses_fields() {
                     _ => panic!("expected Reprovision Clear variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "clear with required --id" {
+            &["host", "reprovision", "clear", "--id", TEST_MACHINE_ID][..] => Yields((TEST_MACHINE_ID.to_string(), false)),
+        }
     );
 }
 
@@ -165,19 +152,8 @@ fn reprovision_clear_parses_fields() {
 // required --id; the asserted value is the id.
 #[test]
 fn reprovision_mark_manual_upgrade_complete_parses_fields() {
-    check_cases(
-        [Case {
-            scenario: "mark-manual-upgrade-complete with required --id",
-            input: &[
-                "host",
-                "reprovision",
-                "mark-manual-upgrade-complete",
-                "--id",
-                TEST_MACHINE_ID,
-            ][..],
-            expect: Yields(TEST_MACHINE_ID.to_string()),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Reprovision(reprovision::args::Args::MarkManualUpgradeComplete(args)) => {
@@ -186,27 +162,34 @@ fn reprovision_mark_manual_upgrade_complete_parses_fields() {
                     _ => panic!("expected Reprovision MarkManualUpgradeComplete variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "mark-manual-upgrade-complete with required --id" {
+            &[
+                "host",
+                "reprovision",
+                "mark-manual-upgrade-complete",
+                "--id",
+                TEST_MACHINE_ID,
+            ][..] => Yields(TEST_MACHINE_ID.to_string()),
+        }
     );
 }
 
 // reprovision list parses to the List variant with no args.
 #[test]
 fn reprovision_list_parses() {
-    check_cases(
-        [Case {
-            scenario: "list with no args",
-            input: &["host", "reprovision", "list"][..],
-            expect: Yields("list"),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Reprovision(reprovision::args::Args::List) => "list",
                     _ => panic!("expected Reprovision List variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "list with no args" {
+            &["host", "reprovision", "list"][..] => Yields("list"),
+        }
     );
 }
 
@@ -214,23 +197,18 @@ fn reprovision_list_parses() {
 // subcommands that need --id refuse to parse without it.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "reprovision set without --id",
-                input: &["host", "reprovision", "set"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "reprovision mark-manual-upgrade-complete without --id",
-                input: &["host", "reprovision", "mark-manual-upgrade-complete"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "reprovision set without --id" {
+            &["host", "reprovision", "set"][..] => Fails,
+        }
+
+        "reprovision mark-manual-upgrade-complete without --id" {
+            &["host", "reprovision", "mark-manual-upgrade-complete"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/ib_partition/tests.rs
+++ b/crates/admin-cli/src/ib_partition/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -52,30 +52,24 @@ fn verify_cmd_structure() {
 // originals asserted on.
 #[test]
 fn parse_show_routes_to_show_variant() {
-    check_cases(
-        [
-            Case {
-                scenario: "no args lists all partitions",
-                input: &["ib-partition", "show"][..],
-                expect: Yields((true, None, None)),
-            },
-            Case {
-                scenario: "--tenant-org-id filters by tenant",
-                input: &["ib-partition", "show", "--tenant-org-id", "tenant-123"][..],
-                expect: Yields((true, Some("tenant-123".to_string()), None)),
-            },
-            Case {
-                scenario: "--name filters by partition name",
-                input: &["ib-partition", "show", "--name", "my-partition"][..],
-                expect: Yields((true, None, Some("my-partition".to_string()))),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => (args.id.is_none(), args.tenant_org_id, args.name),
                 })
                 .map_err(drop)
-        },
+        };
+        "no args lists all partitions" {
+            &["ib-partition", "show"][..] => Yields((true, None, None)),
+        }
+
+        "--tenant-org-id filters by tenant" {
+            &["ib-partition", "show", "--tenant-org-id", "tenant-123"][..] => Yields((true, Some("tenant-123".to_string()), None)),
+        }
+
+        "--name filters by partition name" {
+            &["ib-partition", "show", "--name", "my-partition"][..] => Yields((true, None, Some("my-partition".to_string()))),
+        }
     );
 }

--- a/crates/admin-cli/src/instance/tests.rs
+++ b/crates/admin-cli/src/instance/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -56,33 +56,8 @@ fn verify_cmd_structure() {
 // the tuple is (id.is_empty(), tenant_org_id, vpc_id, extrainfo).
 #[test]
 fn parse_show_routes_and_carries_filters() {
-    check_cases(
-        [
-            Case {
-                scenario: "show with no arguments",
-                input: &["instance", "show"][..],
-                expect: Yields((true, None, None, false)),
-            },
-            Case {
-                scenario: "show with filter options",
-                input: &[
-                    "instance",
-                    "show",
-                    "--tenant-org-id",
-                    "tenant-123",
-                    "--vpc-id",
-                    "vpc-456",
-                    "--extrainfo",
-                ][..],
-                expect: Yields((
-                    true,
-                    Some("tenant-123".to_string()),
-                    Some("vpc-456".to_string()),
-                    true,
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => (
@@ -94,7 +69,27 @@ fn parse_show_routes_and_carries_filters() {
                     _ => panic!("expected Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "show with no arguments" {
+            &["instance", "show"][..] => Yields((true, None, None, false)),
+        }
+
+        "show with filter options" {
+            &[
+                "instance",
+                "show",
+                "--tenant-org-id",
+                "tenant-123",
+                "--vpc-id",
+                "vpc-456",
+                "--extrainfo",
+            ][..] => Yields((
+                true,
+                Some("tenant-123".to_string()),
+                Some("vpc-456".to_string()),
+                true,
+            )),
+        }
     );
 }
 
@@ -102,27 +97,8 @@ fn parse_show_routes_and_carries_filters() {
 // the tuple is (instance, custom_pxe, apply_updates_on_reboot).
 #[test]
 fn parse_reboot_routes_and_carries_options() {
-    check_cases(
-        [
-            Case {
-                scenario: "reboot with instance only",
-                input: &["instance", "reboot", "--instance", TEST_INSTANCE_ID][..],
-                expect: Yields((TEST_INSTANCE_ID.to_string(), false, false)),
-            },
-            Case {
-                scenario: "reboot with all options",
-                input: &[
-                    "instance",
-                    "reboot",
-                    "--instance",
-                    TEST_INSTANCE_ID,
-                    "--custom-pxe",
-                    "--apply-updates-on-reboot",
-                ][..],
-                expect: Yields((TEST_INSTANCE_ID.to_string(), true, true)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Reboot(args) => (
@@ -133,7 +109,21 @@ fn parse_reboot_routes_and_carries_options() {
                     _ => panic!("expected Reboot variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "reboot with instance only" {
+            &["instance", "reboot", "--instance", TEST_INSTANCE_ID][..] => Yields((TEST_INSTANCE_ID.to_string(), false, false)),
+        }
+
+        "reboot with all options" {
+            &[
+                "instance",
+                "reboot",
+                "--instance",
+                TEST_INSTANCE_ID,
+                "--custom-pxe",
+                "--apply-updates-on-reboot",
+            ][..] => Yields((TEST_INSTANCE_ID.to_string(), true, true)),
+        }
     );
 }
 
@@ -141,27 +131,22 @@ fn parse_reboot_routes_and_carries_options() {
 // (instance, machine.is_some()).
 #[test]
 fn parse_release_routes_by_target() {
-    check_cases(
-        [
-            Case {
-                scenario: "release by --instance",
-                input: &["instance", "release", "--instance", TEST_INSTANCE_ID][..],
-                expect: Yields((Some(TEST_INSTANCE_ID.to_string()), false)),
-            },
-            Case {
-                scenario: "release by --machine",
-                input: &["instance", "release", "--machine", TEST_MACHINE_ID][..],
-                expect: Yields((None, true)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Release(args) => (args.instance, args.machine.is_some()),
                     _ => panic!("expected Release variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "release by --instance" {
+            &["instance", "release", "--instance", TEST_INSTANCE_ID][..] => Yields((Some(TEST_INSTANCE_ID.to_string()), false)),
+        }
+
+        "release by --machine" {
+            &["instance", "release", "--machine", TEST_MACHINE_ID][..] => Yields((None, true)),
+        }
     );
 }
 
@@ -169,51 +154,8 @@ fn parse_release_routes_by_target() {
 // the tuple is (subnet, prefix_name, number, tenant_org, transactional).
 #[test]
 fn parse_allocate_routes_and_carries_options() {
-    check_cases(
-        [
-            Case {
-                scenario: "allocate with required arguments",
-                input: &[
-                    "instance",
-                    "allocate",
-                    "--subnet",
-                    "10.0.0.0/24",
-                    "--prefix-name",
-                    "my-prefix",
-                ][..],
-                expect: Yields((
-                    vec!["10.0.0.0/24".to_string()],
-                    "my-prefix".to_string(),
-                    None,
-                    None,
-                    false,
-                )),
-            },
-            Case {
-                scenario: "allocate with all options",
-                input: &[
-                    "instance",
-                    "allocate",
-                    "--subnet",
-                    "10.0.0.0/24",
-                    "--prefix-name",
-                    "my-prefix",
-                    "--number",
-                    "5",
-                    "--tenant-org",
-                    "tenant-123",
-                    "--transactional",
-                ][..],
-                expect: Yields((
-                    vec!["10.0.0.0/24".to_string()],
-                    "my-prefix".to_string(),
-                    Some(5),
-                    Some("tenant-123".to_string()),
-                    true,
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Allocate(args) => (
@@ -226,7 +168,45 @@ fn parse_allocate_routes_and_carries_options() {
                     _ => panic!("expected Allocate variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "allocate with required arguments" {
+            &[
+                "instance",
+                "allocate",
+                "--subnet",
+                "10.0.0.0/24",
+                "--prefix-name",
+                "my-prefix",
+            ][..] => Yields((
+                vec!["10.0.0.0/24".to_string()],
+                "my-prefix".to_string(),
+                None,
+                None,
+                false,
+            )),
+        }
+
+        "allocate with all options" {
+            &[
+                "instance",
+                "allocate",
+                "--subnet",
+                "10.0.0.0/24",
+                "--prefix-name",
+                "my-prefix",
+                "--number",
+                "5",
+                "--tenant-org",
+                "tenant-123",
+                "--transactional",
+            ][..] => Yields((
+                vec!["10.0.0.0/24".to_string()],
+                "my-prefix".to_string(),
+                Some(5),
+                Some("tenant-123".to_string()),
+                true,
+            )),
+        }
     );
 }
 
@@ -234,23 +214,18 @@ fn parse_allocate_routes_and_carries_options() {
 // invoked without the required arguments it needs to act on.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "release without instance/machine/label",
-                input: &["instance", "release"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "allocate without subnet/vpc_prefix and prefix-name",
-                input: &["instance", "allocate"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "release without instance/machine/label" {
+            &["instance", "release"][..] => Fails,
+        }
+
+        "allocate without subnet/vpc_prefix and prefix-name" {
+            &["instance", "allocate"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/instance_type/tests.rs
+++ b/crates/admin-cli/src/instance_type/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -53,42 +53,37 @@ fn verify_cmd_structure() {
 // id/name/description unset, while supplying them threads each value through.
 #[test]
 fn parse_create_routes_and_binds_fields() {
-    check_cases(
-        [
-            Case {
-                scenario: "create with no arguments leaves every field unset",
-                input: &["instance-type", "create"][..],
-                expect: Yields((None, None, None)),
-            },
-            Case {
-                scenario: "create with all options binds each field",
-                input: &[
-                    "instance-type",
-                    "create",
-                    "--id",
-                    "type-123",
-                    "--name",
-                    "GPU Instance",
-                    "--description",
-                    "High-performance GPU instance",
-                    "--labels",
-                    r#"{"gpu":"true"}"#,
-                ][..],
-                expect: Yields((
-                    Some("type-123".to_string()),
-                    Some("GPU Instance".to_string()),
-                    Some("High-performance GPU instance".to_string()),
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Create(args) => (args.id, args.name, args.description),
                     _ => panic!("expected Create variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "create with no arguments leaves every field unset" {
+            &["instance-type", "create"][..] => Yields((None, None, None)),
+        }
+
+        "create with all options binds each field" {
+            &[
+                "instance-type",
+                "create",
+                "--id",
+                "type-123",
+                "--name",
+                "GPU Instance",
+                "--description",
+                "High-performance GPU instance",
+                "--labels",
+                r#"{"gpu":"true"}"#,
+            ][..] => Yields((
+                Some("type-123".to_string()),
+                Some("GPU Instance".to_string()),
+                Some("High-performance GPU instance".to_string()),
+            )),
+        }
     );
 }
 
@@ -96,74 +91,65 @@ fn parse_create_routes_and_binds_fields() {
 // while supplying `--id` narrows to one.
 #[test]
 fn parse_show_routes_and_binds_id() {
-    check_cases(
-        [
-            Case {
-                scenario: "show with no arguments leaves id unset",
-                input: &["instance-type", "show"][..],
-                expect: Yields(None),
-            },
-            Case {
-                scenario: "show with --id binds the id",
-                input: &["instance-type", "show", "--id", "type-123"][..],
-                expect: Yields(Some("type-123".to_string())),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => args.id,
                     _ => panic!("expected Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "show with no arguments leaves id unset" {
+            &["instance-type", "show"][..] => Yields(None),
+        }
+
+        "show with --id binds the id" {
+            &["instance-type", "show", "--id", "type-123"][..] => Yields(Some("type-123".to_string())),
+        }
     );
 }
 
 // The `delete` subcommand binds its required `--id`.
 #[test]
 fn parse_delete_binds_id() {
-    check_cases(
-        [Case {
-            scenario: "delete with required --id",
-            input: &["instance-type", "delete", "--id", "type-123"][..],
-            expect: Yields("type-123".to_string()),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Delete(args) => args.id,
                     _ => panic!("expected Delete variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "delete with required --id" {
+            &["instance-type", "delete", "--id", "type-123"][..] => Yields("type-123".to_string()),
+        }
     );
 }
 
 // The `update` subcommand binds its required `--id` and any optional fields.
 #[test]
 fn parse_update_binds_fields() {
-    check_cases(
-        [Case {
-            scenario: "update with required --id and a new name",
-            input: &[
-                "instance-type",
-                "update",
-                "--id",
-                "type-123",
-                "--name",
-                "Updated Name",
-            ][..],
-            expect: Yields(("type-123".to_string(), Some("Updated Name".to_string()))),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Update(args) => (args.id, args.name),
                     _ => panic!("expected Update variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "update with required --id and a new name" {
+            &[
+                "instance-type",
+                "update",
+                "--id",
+                "type-123",
+                "--name",
+                "Updated Name",
+            ][..] => Yields(("type-123".to_string(), Some("Updated Name".to_string()))),
+        }
     );
 }
 
@@ -172,47 +158,40 @@ fn parse_update_binds_fields() {
 #[test]
 fn parse_associate_binds_type_and_machines() {
     let two_machines = format!("{TEST_MACHINE_ID},{TEST_MACHINE_ID}");
-    check_cases(
-        [
-            Case {
-                scenario: "associate a single machine",
-                input: &["instance-type", "associate", "type-123", TEST_MACHINE_ID][..],
-                expect: Yields(("type-123".to_string(), 1)),
-            },
-            Case {
-                scenario: "associate comma-separated machines",
-                input: &["instance-type", "associate", "type-123", &two_machines][..],
-                expect: Yields(("type-123".to_string(), 2)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Associate(args) => (args.instance_type_id, args.machine_ids.len()),
                     _ => panic!("expected Associate variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "associate a single machine" {
+            &["instance-type", "associate", "type-123", TEST_MACHINE_ID][..] => Yields(("type-123".to_string(), 1)),
+        }
+
+        "associate comma-separated machines" {
+            &["instance-type", "associate", "type-123", &two_machines][..] => Yields(("type-123".to_string(), 2)),
+        }
     );
 }
 
 // The `disassociate` subcommand binds its required machine id.
 #[test]
 fn parse_disassociate_binds_machine_id() {
-    check_cases(
-        [Case {
-            scenario: "disassociate with a machine id",
-            input: &["instance-type", "disassociate", TEST_MACHINE_ID][..],
-            expect: Yields(TEST_MACHINE_ID.to_string()),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Disassociate(args) => args.machine_id.to_string(),
                     _ => panic!("expected Disassociate variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "disassociate with a machine id" {
+            &["instance-type", "disassociate", TEST_MACHINE_ID][..] => Yields(TEST_MACHINE_ID.to_string()),
+        }
     );
 }
 
@@ -220,23 +199,18 @@ fn parse_disassociate_binds_machine_id() {
 // whose required `--id` is missing.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "delete without --id",
-                input: &["instance-type", "delete"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "update without --id",
-                input: &["instance-type", "update"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "delete without --id" {
+            &["instance-type", "delete"][..] => Fails,
+        }
+
+        "update without --id" {
+            &["instance-type", "update"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/inventory/tests.rs
+++ b/crates/admin-cli/src/inventory/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::args::*;
@@ -51,38 +51,30 @@ fn verify_cmd_structure() {
 // invocation lands in `cmd.filename`.
 #[test]
 fn parses_optional_filename() {
-    check_cases(
-        [
-            Case {
-                scenario: "no arguments leaves filename unset",
-                input: &["inventory"][..],
-                expect: Yields(None),
-            },
-            Case {
-                scenario: "--filename long flag",
-                input: &["inventory", "--filename", "output.json"][..],
-                expect: Yields(Some("output.json".to_string())),
-            },
-            Case {
-                scenario: "-f short flag",
-                input: &["inventory", "-f", "output.json"][..],
-                expect: Yields(Some("output.json".to_string())),
-            },
-            Case {
-                scenario: "absolute path",
-                input: &["inventory", "-f", "/tmp/inventory.json"][..],
-                expect: Yields(Some("/tmp/inventory.json".to_string())),
-            },
-            Case {
-                scenario: "relative path",
-                input: &["inventory", "-f", "./relative/path.csv"][..],
-                expect: Yields(Some("./relative/path.csv".to_string())),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| cmd.filename)
                 .map_err(drop)
-        },
+        };
+        "no arguments leaves filename unset" {
+            &["inventory"][..] => Yields(None),
+        }
+
+        "--filename long flag" {
+            &["inventory", "--filename", "output.json"][..] => Yields(Some("output.json".to_string())),
+        }
+
+        "-f short flag" {
+            &["inventory", "-f", "output.json"][..] => Yields(Some("output.json".to_string())),
+        }
+
+        "absolute path" {
+            &["inventory", "-f", "/tmp/inventory.json"][..] => Yields(Some("/tmp/inventory.json".to_string())),
+        }
+
+        "relative path" {
+            &["inventory", "-f", "./relative/path.csv"][..] => Yields(Some("./relative/path.csv".to_string())),
+        }
     );
 }

--- a/crates/admin-cli/src/ip/tests.rs
+++ b/crates/admin-cli/src/ip/tests.rs
@@ -23,7 +23,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -50,42 +50,34 @@ fn verify_cmd_structure() {
 // round-trips to the canonical string the original argv supplied.
 #[test]
 fn parse_find_accepts_valid_ips() {
-    check_cases(
-        [
-            Case {
-                scenario: "standard IPv4 address",
-                input: &["ip", "find", "192.168.1.100"][..],
-                expect: Yields("192.168.1.100".to_string()),
-            },
-            Case {
-                scenario: "10.x IPv4 address",
-                input: &["ip", "find", "10.0.0.1"][..],
-                expect: Yields("10.0.0.1".to_string()),
-            },
-            Case {
-                scenario: "172.x IPv4 address",
-                input: &["ip", "find", "172.16.0.1"][..],
-                expect: Yields("172.16.0.1".to_string()),
-            },
-            Case {
-                scenario: "0.0.0.0 IPv4 address",
-                input: &["ip", "find", "0.0.0.0"][..],
-                expect: Yields("0.0.0.0".to_string()),
-            },
-            Case {
-                scenario: "IPv6 loopback address",
-                input: &["ip", "find", "::1"][..],
-                expect: Yields("::1".to_string()),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| {
                     let Cmd::Find(args) = cmd;
                     args.ip.to_string()
                 })
                 .map_err(drop)
-        },
+        };
+        "standard IPv4 address" {
+            &["ip", "find", "192.168.1.100"][..] => Yields("192.168.1.100".to_string()),
+        }
+
+        "10.x IPv4 address" {
+            &["ip", "find", "10.0.0.1"][..] => Yields("10.0.0.1".to_string()),
+        }
+
+        "172.x IPv4 address" {
+            &["ip", "find", "172.16.0.1"][..] => Yields("172.16.0.1".to_string()),
+        }
+
+        "0.0.0.0 IPv4 address" {
+            &["ip", "find", "0.0.0.0"][..] => Yields("0.0.0.0".to_string()),
+        }
+
+        "IPv6 loopback address" {
+            &["ip", "find", "::1"][..] => Yields("::1".to_string()),
+        }
     );
 }
 
@@ -93,23 +85,18 @@ fn parse_find_accepts_valid_ips() {
 // and a missing required ip argument.
 #[test]
 fn parse_find_rejects_invalid_invocations() {
-    check_cases(
-        [
-            Case {
-                scenario: "value is not a valid IP",
-                input: &["ip", "find", "not-an-ip"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "missing required ip argument",
-                input: &["ip", "find"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "value is not a valid IP" {
+            &["ip", "find", "not-an-ip"][..] => Fails,
+        }
+
+        "missing required ip argument" {
+            &["ip", "find"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/jump/tests.rs
+++ b/crates/admin-cli/src/jump/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::args::Cmd;
@@ -50,34 +50,27 @@ fn verify_cmd_structure() {
 // UUID, or MAC address -- and round-trips it verbatim onto `cmd.id`.
 #[test]
 fn parse_accepts_any_id_format() {
-    check_cases(
-        [
-            Case {
-                scenario: "machine ID",
-                input: &["jump", "machine-123"][..],
-                expect: Yields("machine-123".to_string()),
-            },
-            Case {
-                scenario: "IP address",
-                input: &["jump", "192.168.1.100"][..],
-                expect: Yields("192.168.1.100".to_string()),
-            },
-            Case {
-                scenario: "UUID",
-                input: &["jump", "550e8400-e29b-41d4-a716-446655440000"][..],
-                expect: Yields("550e8400-e29b-41d4-a716-446655440000".to_string()),
-            },
-            Case {
-                scenario: "MAC address",
-                input: &["jump", "00:11:22:33:44:55"][..],
-                expect: Yields("00:11:22:33:44:55".to_string()),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| cmd.id)
                 .map_err(drop)
-        },
+        };
+        "machine ID" {
+            &["jump", "machine-123"][..] => Yields("machine-123".to_string()),
+        }
+
+        "IP address" {
+            &["jump", "192.168.1.100"][..] => Yields("192.168.1.100".to_string()),
+        }
+
+        "UUID" {
+            &["jump", "550e8400-e29b-41d4-a716-446655440000"][..] => Yields("550e8400-e29b-41d4-a716-446655440000".to_string()),
+        }
+
+        "MAC address" {
+            &["jump", "00:11:22:33:44:55"][..] => Yields("00:11:22:33:44:55".to_string()),
+        }
     );
 }
 
@@ -85,16 +78,14 @@ fn parse_accepts_any_id_format() {
 // time.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [Case {
-            scenario: "no id argument",
-            input: &["jump"][..],
-            expect: Fails,
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "no id argument" {
+            &["jump"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/machine/tests.rs
+++ b/crates/admin-cli/src/machine/tests.rs
@@ -25,7 +25,7 @@
 // ValueEnum Parsing - Test string parsing for types deriving claps ValueEnum.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 use metadata::args::Args as MachineMetadataCommand;
 use network::args::Args as NetworkCommand;
@@ -57,32 +57,26 @@ fn verify_cmd_structure() {
 // machine/all/dpus/hosts state in each case.
 #[test]
 fn parse_show_variants() {
-    check_cases(
-        [
-            Case {
-                scenario: "no arguments (all machines)",
-                input: &["machine", "show"][..],
-                expect: Yields((false, false, false, false)),
-            },
-            Case {
-                scenario: "--dpus flag",
-                input: &["machine", "show", "--dpus"][..],
-                expect: Yields((false, false, true, false)),
-            },
-            Case {
-                scenario: "--hosts flag",
-                input: &["machine", "show", "--hosts"][..],
-                expect: Yields((false, false, false, true)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => (args.machine.is_some(), args.all, args.dpus, args.hosts),
                     _ => panic!("expected Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "no arguments (all machines)" {
+            &["machine", "show"][..] => Yields((false, false, false, false)),
+        }
+
+        "--dpus flag" {
+            &["machine", "show", "--dpus"][..] => Yields((false, false, true, false)),
+        }
+
+        "--hosts flag" {
+            &["machine", "show", "--hosts"][..] => Yields((false, false, false, true)),
+        }
     );
 }
 
@@ -121,20 +115,8 @@ fn parse_network_config() {
 // same Show variant; both expose the machine ID.
 #[test]
 fn parse_health_report_show_variants() {
-    check_cases(
-        [
-            Case {
-                scenario: "health-report show",
-                input: &["machine", "health-report", "show", TEST_MACHINE_ID][..],
-                expect: Yields(TEST_MACHINE_ID.to_string()),
-            },
-            Case {
-                scenario: "legacy health-override show alias",
-                input: &["machine", "health-override", "show", TEST_MACHINE_ID][..],
-                expect: Yields(TEST_MACHINE_ID.to_string()),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::HealthReport(HealthReportCommand::Show { machine_id }) => {
@@ -143,7 +125,14 @@ fn parse_health_report_show_variants() {
                     _ => panic!("expected HealthReport Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "health-report show" {
+            &["machine", "health-report", "show", TEST_MACHINE_ID][..] => Yields(TEST_MACHINE_ID.to_string()),
+        }
+
+        "legacy health-override show alias" {
+            &["machine", "health-override", "show", TEST_MACHINE_ID][..] => Yields(TEST_MACHINE_ID.to_string()),
+        }
     );
 }
 
@@ -305,48 +294,38 @@ fn health_override_templates_value_enum() {
         }
     }
 
-    check_cases(
-        [
-            Case {
-                scenario: "host-update",
-                input: "host-update",
-                expect: Yields("host-update"),
-            },
-            Case {
-                scenario: "internal-maintenance",
-                input: "internal-maintenance",
-                expect: Yields("internal-maintenance"),
-            },
-            Case {
-                scenario: "out-for-repair",
-                input: "out-for-repair",
-                expect: Yields("out-for-repair"),
-            },
-            Case {
-                scenario: "degraded",
-                input: "degraded",
-                expect: Yields("degraded"),
-            },
-            Case {
-                scenario: "validation",
-                input: "validation",
-                expect: Yields("validation"),
-            },
-            Case {
-                scenario: "request-online-repair",
-                input: "request-online-repair",
-                expect: Yields("request-online-repair"),
-            },
-            Case {
-                scenario: "invalid string is rejected",
-                input: "invalid",
-                expect: Fails,
-            },
-        ],
-        |s| {
+    scenarios!(
+        run = |s| {
             HealthReportTemplates::from_str(s, false)
                 .map(|t| template_name(&t))
                 .map_err(drop)
-        },
+        };
+        "host-update" {
+            "host-update" => Yields("host-update"),
+        }
+
+        "internal-maintenance" {
+            "internal-maintenance" => Yields("internal-maintenance"),
+        }
+
+        "out-for-repair" {
+            "out-for-repair" => Yields("out-for-repair"),
+        }
+
+        "degraded" {
+            "degraded" => Yields("degraded"),
+        }
+
+        "validation" {
+            "validation" => Yields("validation"),
+        }
+
+        "request-online-repair" {
+            "request-online-repair" => Yields("request-online-repair"),
+        }
+
+        "invalid string is rejected" {
+            "invalid" => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/machine_interfaces/tests.rs
+++ b/crates/admin-cli/src/machine_interfaces/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -54,32 +54,26 @@ fn verify_cmd_structure() {
 // interface-id cases are all checked against one parse.
 #[test]
 fn parse_show_variants() {
-    check_cases(
-        [
-            Case {
-                scenario: "no arguments (all interfaces)",
-                input: &["machine-interface", "show"][..],
-                expect: Yields((false, false, false)),
-            },
-            Case {
-                scenario: "--more flag",
-                input: &["machine-interface", "show", "--more"][..],
-                expect: Yields((false, false, true)),
-            },
-            Case {
-                scenario: "with an interface ID",
-                input: &["machine-interface", "show", TEST_INTERFACE_ID][..],
-                expect: Yields((true, false, false)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => (args.interface_id.is_some(), args.all, args.more),
                     _ => panic!("expected Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "no arguments (all interfaces)" {
+            &["machine-interface", "show"][..] => Yields((false, false, false)),
+        }
+
+        "--more flag" {
+            &["machine-interface", "show", "--more"][..] => Yields((false, false, true)),
+        }
+
+        "with an interface ID" {
+            &["machine-interface", "show", TEST_INTERFACE_ID][..] => Yields((true, false, false)),
+        }
     );
 }
 
@@ -87,20 +81,18 @@ fn parse_show_variants() {
 // round-tripping the ID through its string form.
 #[test]
 fn parse_delete_variants() {
-    check_cases(
-        [Case {
-            scenario: "with an interface ID",
-            input: &["machine-interface", "delete", TEST_INTERFACE_ID][..],
-            expect: Yields(TEST_INTERFACE_ID.to_string()),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Delete(args) => args.interface_id.to_string(),
                     _ => panic!("expected Delete variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "with an interface ID" {
+            &["machine-interface", "delete", TEST_INTERFACE_ID][..] => Yields(TEST_INTERFACE_ID.to_string()),
+        }
     );
 }
 
@@ -108,16 +100,14 @@ fn parse_delete_variants() {
 // without its required interface ID.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [Case {
-            scenario: "delete without an interface ID",
-            input: &["machine-interface", "delete"][..],
-            expect: Fails,
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "delete without an interface ID" {
+            &["machine-interface", "delete"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/machine_validation/tests.rs
+++ b/crates/admin-cli/src/machine_validation/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use carbide_uuid::machine_validation::MachineValidationId;
 use clap::{CommandFactory, Parser};
 
@@ -54,30 +54,8 @@ fn verify_cmd_structure() {
 // empty name filter, and `add-update` carries its file-name/name through.
 #[test]
 fn parse_external_config_routes_and_carries_fields() {
-    check_cases(
-        [
-            Case {
-                scenario: "show defaults to an empty name filter",
-                input: &["machine-validation", "external-config", "show"][..],
-                expect: Yields((String::new(), String::new())),
-            },
-            Case {
-                scenario: "add-update carries file-name and name",
-                input: &[
-                    "machine-validation",
-                    "external-config",
-                    "add-update",
-                    "--file-name",
-                    "config.yaml",
-                    "--name",
-                    "my-config",
-                    "--description",
-                    "Test config",
-                ][..],
-                expect: Yields(("config.yaml".to_string(), "my-config".to_string())),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::ExternalConfig(external_config::Args::Show(args)) => {
@@ -91,7 +69,24 @@ fn parse_external_config_routes_and_carries_fields() {
                     _ => panic!("expected ExternalConfig variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "show defaults to an empty name filter" {
+            &["machine-validation", "external-config", "show"][..] => Yields((String::new(), String::new())),
+        }
+
+        "add-update carries file-name and name" {
+            &[
+                "machine-validation",
+                "external-config",
+                "add-update",
+                "--file-name",
+                "config.yaml",
+                "--name",
+                "my-config",
+                "--description",
+                "Test config",
+            ][..] => Yields(("config.yaml".to_string(), "my-config".to_string())),
+        }
     );
 }
 
@@ -99,19 +94,8 @@ fn parse_external_config_routes_and_carries_fields() {
 // and defaulting --run-unverified-tests to false.
 #[test]
 fn parse_on_demand_start_carries_machine() {
-    check_cases(
-        [Case {
-            scenario: "start with a machine ID",
-            input: &[
-                "machine-validation",
-                "on-demand",
-                "start",
-                "--machine",
-                TEST_MACHINE_ID,
-            ][..],
-            expect: Yields((TEST_MACHINE_ID.to_string(), false)),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::OnDemand(on_demand::Args::Start(args)) => {
@@ -120,7 +104,16 @@ fn parse_on_demand_start_carries_machine() {
                     _ => panic!("expected OnDemand Start variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "start with a machine ID" {
+            &[
+                "machine-validation",
+                "on-demand",
+                "start",
+                "--machine",
+                TEST_MACHINE_ID,
+            ][..] => Yields((TEST_MACHINE_ID.to_string(), false)),
+        }
     );
 }
 
@@ -128,33 +121,28 @@ fn parse_on_demand_start_carries_machine() {
 // unset (and --history defaults off), with --machine the filter is present.
 #[test]
 fn parse_runs_show_machine_filter() {
-    check_cases(
-        [
-            Case {
-                scenario: "no machine filter (and history defaults off)",
-                input: &["machine-validation", "runs", "show"][..],
-                expect: Yields((false, false)),
-            },
-            Case {
-                scenario: "with a machine filter",
-                input: &[
-                    "machine-validation",
-                    "runs",
-                    "show",
-                    "--machine",
-                    TEST_MACHINE_ID,
-                ][..],
-                expect: Yields((true, false)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Runs(runs::Args::Show(args)) => (args.machine.is_some(), args.history),
                     _ => panic!("expected Runs Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "no machine filter (and history defaults off)" {
+            &["machine-validation", "runs", "show"][..] => Yields((false, false)),
+        }
+
+        "with a machine filter" {
+            &[
+                "machine-validation",
+                "runs",
+                "show",
+                "--machine",
+                TEST_MACHINE_ID,
+            ][..] => Yields((true, false)),
+        }
     );
 }
 
@@ -163,32 +151,8 @@ fn parse_runs_show_machine_filter() {
 #[test]
 fn parse_results_show_filters() {
     let validation_id = MachineValidationId::new();
-    check_cases(
-        [
-            Case {
-                scenario: "with a machine filter",
-                input: &[
-                    "machine-validation",
-                    "results",
-                    "show",
-                    "--machine",
-                    TEST_MACHINE_ID,
-                ][..],
-                expect: Yields((true, None)),
-            },
-            Case {
-                scenario: "with a validation-id filter",
-                input: &[
-                    "machine-validation",
-                    "results",
-                    "show",
-                    "--validation-id",
-                    validation_id.to_string().as_str(),
-                ][..],
-                expect: Yields((false, Some(validation_id))),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Results(results::Args::Show(args)) => {
@@ -197,7 +161,26 @@ fn parse_results_show_filters() {
                     _ => panic!("expected Results Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "with a machine filter" {
+            &[
+                "machine-validation",
+                "results",
+                "show",
+                "--machine",
+                TEST_MACHINE_ID,
+            ][..] => Yields((true, None)),
+        }
+
+        "with a validation-id filter" {
+            &[
+                "machine-validation",
+                "results",
+                "show",
+                "--validation-id",
+                validation_id.to_string().as_str(),
+            ][..] => Yields((false, Some(validation_id))),
+        }
     );
 }
 
@@ -205,43 +188,8 @@ fn parse_results_show_filters() {
 // carries test-id/version, and `add` carries name/command/args.
 #[test]
 fn parse_tests_subcommands() {
-    check_cases(
-        [
-            Case {
-                scenario: "show leaves test-id unset",
-                input: &["machine-validation", "tests", "show"][..],
-                expect: Yields((false, String::new(), String::new())),
-            },
-            Case {
-                scenario: "verify carries test-id and version",
-                input: &[
-                    "machine-validation",
-                    "tests",
-                    "verify",
-                    "--test-id",
-                    "test-123",
-                    "--version",
-                    "v1",
-                ][..],
-                expect: Yields((true, "test-123".to_string(), "v1".to_string())),
-            },
-            Case {
-                scenario: "add carries name, command, and args",
-                input: &[
-                    "machine-validation",
-                    "tests",
-                    "add",
-                    "--name",
-                    "my-test",
-                    "--command",
-                    "/bin/test",
-                    "--args",
-                    "--verbose",
-                ][..],
-                expect: Yields((true, "my-test".to_string(), "/bin/test".to_string())),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Tests(tests_cmd::Args::Show(args)) => {
@@ -260,7 +208,36 @@ fn parse_tests_subcommands() {
                     _ => panic!("expected Tests variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "show leaves test-id unset" {
+            &["machine-validation", "tests", "show"][..] => Yields((false, String::new(), String::new())),
+        }
+
+        "verify carries test-id and version" {
+            &[
+                "machine-validation",
+                "tests",
+                "verify",
+                "--test-id",
+                "test-123",
+                "--version",
+                "v1",
+            ][..] => Yields((true, "test-123".to_string(), "v1".to_string())),
+        }
+
+        "add carries name, command, and args" {
+            &[
+                "machine-validation",
+                "tests",
+                "add",
+                "--name",
+                "my-test",
+                "--command",
+                "/bin/test",
+                "--args",
+                "--verbose",
+            ][..] => Yields((true, "my-test".to_string(), "/bin/test".to_string())),
+        }
     );
 }
 
@@ -268,16 +245,14 @@ fn parse_tests_subcommands() {
 // its required filters cannot parse.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [Case {
-            scenario: "results show without machine/validation_id/test_name",
-            input: &["machine-validation", "results", "show"][..],
-            expect: Fails,
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "results show without machine/validation_id/test_name" {
+            &["machine-validation", "results", "show"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/managed_host/tests.rs
+++ b/crates/admin-cli/src/managed_host/tests.rs
@@ -25,7 +25,7 @@
 // ValueEnum Parsing - Test string parsing for types deriving claps ValueEnum.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::maintenance::args::Args as MaintenanceAction;
@@ -58,25 +58,8 @@ fn verify_cmd_structure() {
 // (machine.is_some(), all, ips, more, fix) so every original assertion holds.
 #[test]
 fn parse_show_routes_to_show() {
-    check_cases(
-        [
-            Case {
-                scenario: "no args (all hosts)",
-                input: &["managed-host", "show"][..],
-                expect: Yields((false, false, false, false, false)),
-            },
-            Case {
-                scenario: "with machine id",
-                input: &["managed-host", "show", TEST_MACHINE_ID][..],
-                expect: Yields((true, false, false, false, false)),
-            },
-            Case {
-                scenario: "with --fix flag",
-                input: &["managed-host", "show", "--fix"][..],
-                expect: Yields((false, false, false, false, true)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => (
@@ -89,7 +72,18 @@ fn parse_show_routes_to_show() {
                     _ => panic!("expected Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "no args (all hosts)" {
+            &["managed-host", "show"][..] => Yields((false, false, false, false, false)),
+        }
+
+        "with machine id" {
+            &["managed-host", "show", TEST_MACHINE_ID][..] => Yields((true, false, false, false, false)),
+        }
+
+        "with --fix flag" {
+            &["managed-host", "show", "--fix"][..] => Yields((false, false, false, false, true)),
+        }
     );
 }
 
@@ -98,34 +92,8 @@ fn parse_show_routes_to_show() {
 // empty for the `off` case which carries none.
 #[test]
 fn parse_maintenance_routes_to_maintenance() {
-    check_cases(
-        [
-            Case {
-                scenario: "on with host and reference",
-                input: &[
-                    "managed-host",
-                    "maintenance",
-                    "on",
-                    "--host",
-                    TEST_MACHINE_ID,
-                    "--reference",
-                    "TICKET-123",
-                ][..],
-                expect: Yields((TEST_MACHINE_ID.to_string(), "TICKET-123".to_string())),
-            },
-            Case {
-                scenario: "off with host",
-                input: &[
-                    "managed-host",
-                    "maintenance",
-                    "off",
-                    "--host",
-                    TEST_MACHINE_ID,
-                ][..],
-                expect: Yields((TEST_MACHINE_ID.to_string(), String::new())),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Maintenance(MaintenanceAction::On(args)) => {
@@ -137,7 +105,28 @@ fn parse_maintenance_routes_to_maintenance() {
                     _ => panic!("expected Maintenance variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "on with host and reference" {
+            &[
+                "managed-host",
+                "maintenance",
+                "on",
+                "--host",
+                TEST_MACHINE_ID,
+                "--reference",
+                "TICKET-123",
+            ][..] => Yields((TEST_MACHINE_ID.to_string(), "TICKET-123".to_string())),
+        }
+
+        "off with host" {
+            &[
+                "managed-host",
+                "maintenance",
+                "off",
+                "--host",
+                TEST_MACHINE_ID,
+            ][..] => Yields((TEST_MACHINE_ID.to_string(), String::new())),
+        }
     );
 }
 
@@ -146,34 +135,8 @@ fn parse_maintenance_routes_to_maintenance() {
 // for the `off` case which carries none.
 #[test]
 fn parse_quarantine_routes_to_quarantine() {
-    check_cases(
-        [
-            Case {
-                scenario: "on with host and reason",
-                input: &[
-                    "managed-host",
-                    "quarantine",
-                    "on",
-                    "--host",
-                    TEST_MACHINE_ID,
-                    "--reason",
-                    "Security issue",
-                ][..],
-                expect: Yields((TEST_MACHINE_ID.to_string(), "Security issue".to_string())),
-            },
-            Case {
-                scenario: "off with host",
-                input: &[
-                    "managed-host",
-                    "quarantine",
-                    "off",
-                    "--host",
-                    TEST_MACHINE_ID,
-                ][..],
-                expect: Yields((TEST_MACHINE_ID.to_string(), String::new())),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Quarantine(QuarantineAction::On(args)) => {
@@ -185,7 +148,28 @@ fn parse_quarantine_routes_to_quarantine() {
                     _ => panic!("expected Quarantine variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "on with host and reason" {
+            &[
+                "managed-host",
+                "quarantine",
+                "on",
+                "--host",
+                TEST_MACHINE_ID,
+                "--reason",
+                "Security issue",
+            ][..] => Yields((TEST_MACHINE_ID.to_string(), "Security issue".to_string())),
+        }
+
+        "off with host" {
+            &[
+                "managed-host",
+                "quarantine",
+                "off",
+                "--host",
+                TEST_MACHINE_ID,
+            ][..] => Yields((TEST_MACHINE_ID.to_string(), String::new())),
+        }
     );
 }
 
@@ -214,30 +198,8 @@ fn parse_reset_host_reprovisioning() {
 // (machine, desired-power-state-string) -- show yields (empty, empty).
 #[test]
 fn parse_power_options_routes_to_power_options() {
-    check_cases(
-        [
-            Case {
-                scenario: "show with no machine",
-                input: &["managed-host", "power-options", "show"][..],
-                expect: Yields((String::new(), String::new())),
-            },
-            Case {
-                scenario: "update with machine and desired power state",
-                input: &[
-                    "managed-host",
-                    "power-options",
-                    "update",
-                    TEST_MACHINE_ID,
-                    "--desired-power-state",
-                    "on",
-                ][..],
-                expect: Yields((
-                    TEST_MACHINE_ID.to_string(),
-                    format!("{:?}", DesiredPowerState::On),
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::PowerOptions(PowerOptions::Show(args)) => {
@@ -251,7 +213,24 @@ fn parse_power_options_routes_to_power_options() {
                     _ => panic!("expected PowerOptions variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "show with no machine" {
+            &["managed-host", "power-options", "show"][..] => Yields((String::new(), String::new())),
+        }
+
+        "update with machine and desired power state" {
+            &[
+                "managed-host",
+                "power-options",
+                "update",
+                TEST_MACHINE_ID,
+                "--desired-power-state",
+                "on",
+            ][..] => Yields((
+                TEST_MACHINE_ID.to_string(),
+                format!("{:?}", DesiredPowerState::On),
+            )),
+        }
     );
 }
 
@@ -321,17 +300,15 @@ fn parse_debug_bundle() {
 // Every malformed invocation is rejected at parse time.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [Case {
-            scenario: "maintenance on without --host and --reference",
-            input: &["managed-host", "maintenance", "on"][..],
-            expect: Fails,
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "maintenance on without --host and --reference" {
+            &["managed-host", "maintenance", "on"][..] => Fails,
+        }
     );
 }
 
@@ -350,29 +327,22 @@ fn invalid_invocations_are_rejected() {
 fn desired_power_state_value_enum() {
     use clap::ValueEnum;
 
-    check_cases(
-        [
-            Case {
-                scenario: "on",
-                input: "on",
-                expect: Yields(format!("{:?}", DesiredPowerState::On)),
-            },
-            Case {
-                scenario: "off",
-                input: "off",
-                expect: Yields(format!("{:?}", DesiredPowerState::Off)),
-            },
-            Case {
-                scenario: "power-manager-disabled",
-                input: "power-manager-disabled",
-                expect: Yields(format!("{:?}", DesiredPowerState::PowerManagerDisabled)),
-            },
-            Case {
-                scenario: "invalid value",
-                input: "invalid",
-                expect: Fails,
-            },
-        ],
-        |s| DesiredPowerState::from_str(s, false).map(|v| format!("{v:?}")),
+    scenarios!(
+        run = |s| DesiredPowerState::from_str(s, false).map(|v| format!("{v:?}"));
+        "on" {
+            "on" => Yields(format!("{:?}", DesiredPowerState::On)),
+        }
+
+        "off" {
+            "off" => Yields(format!("{:?}", DesiredPowerState::Off)),
+        }
+
+        "power-manager-disabled" {
+            "power-manager-disabled" => Yields(format!("{:?}", DesiredPowerState::PowerManagerDisabled)),
+        }
+
+        "invalid value" {
+            "invalid" => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/managed_switch/tests.rs
+++ b/crates/admin-cli/src/managed_switch/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -50,27 +50,22 @@ fn verify_cmd_structure() {
 // is None when omitted and carries the given value when supplied.
 #[test]
 fn parse_show_identifier() {
-    check_cases(
-        [
-            Case {
-                scenario: "show with no arguments (all switches)",
-                input: &["managed-switch", "show"][..],
-                expect: Yields(None),
-            },
-            Case {
-                scenario: "show with an identifier",
-                input: &["managed-switch", "show", "switch-123"][..],
-                expect: Yields(Some("switch-123".to_string())),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => args.identifier,
                     _ => panic!("expected Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "show with no arguments (all switches)" {
+            &["managed-switch", "show"][..] => Yields(None),
+        }
+
+        "show with an identifier" {
+            &["managed-switch", "show", "switch-123"][..] => Yields(Some("switch-123".to_string())),
+        }
     );
 }
 

--- a/crates/admin-cli/src/metadata.rs
+++ b/crates/admin-cli/src/metadata.rs
@@ -195,7 +195,7 @@ pub(crate) fn parse_rpc_labels(labels: Vec<String>) -> Vec<rpc::forge::Label> {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::scenarios;
 
     use super::*;
 
@@ -219,42 +219,35 @@ mod tests {
     // resulting (name, description) pair.
     #[test]
     fn apply_set_applies_overrides() {
-        check_cases(
-            [
-                Case {
-                    scenario: "name override updates name, leaves description",
-                    input: (
-                        Some(metadata_with("old", "desc", vec![])),
-                        Some("new".to_string()),
-                        None,
-                    ),
-                    expect: Yields(("new".to_string(), "desc".to_string())),
-                },
-                Case {
-                    scenario: "description override updates description, leaves name",
-                    input: (
-                        Some(metadata_with("name", "old", vec![])),
-                        None,
-                        Some("new".to_string()),
-                    ),
-                    expect: Yields(("name".to_string(), "new".to_string())),
-                },
-                Case {
-                    scenario: "no overrides leaves both unchanged",
-                    input: (Some(metadata_with("name", "desc", vec![])), None, None),
-                    expect: Yields(("name".to_string(), "desc".to_string())),
-                },
-                Case {
-                    scenario: "missing metadata errors",
-                    input: (None, Some("x".to_string()), None),
-                    expect: Fails,
-                },
-            ],
-            |(metadata, name, description)| {
+        scenarios!(
+            run = |(metadata, name, description)| {
                 apply_set(metadata, name, description)
                     .map(|m| (m.name, m.description))
                     .map_err(drop)
-            },
+            };
+            "name override updates name, leaves description" {
+                (
+                    Some(metadata_with("old", "desc", vec![])),
+                    Some("new".to_string()),
+                    None,
+                ) => Yields(("new".to_string(), "desc".to_string())),
+            }
+
+            "description override updates description, leaves name" {
+                (
+                    Some(metadata_with("name", "old", vec![])),
+                    None,
+                    Some("new".to_string()),
+                ) => Yields(("name".to_string(), "new".to_string())),
+            }
+
+            "no overrides leaves both unchanged" {
+                (Some(metadata_with("name", "desc", vec![])), None, None) => Yields(("name".to_string(), "desc".to_string())),
+            }
+
+            "missing metadata errors" {
+                (None, Some("x".to_string()), None) => Fails,
+            }
         );
     }
 
@@ -263,49 +256,42 @@ mod tests {
     // Each row yields the resulting label list.
     #[test]
     fn apply_add_label_adds_or_replaces() {
-        check_cases(
-            [
-                Case {
-                    scenario: "adds a new label",
-                    input: (
-                        Some(metadata_with("n", "", vec![])),
-                        "env".to_string(),
-                        Some("prod".to_string()),
-                    ),
-                    expect: Yields(vec![label("env", Some("prod"))]),
-                },
-                Case {
-                    scenario: "replaces an existing key",
-                    input: (
-                        Some(metadata_with("n", "", vec![label("env", Some("staging"))])),
-                        "env".to_string(),
-                        Some("prod".to_string()),
-                    ),
-                    expect: Yields(vec![label("env", Some("prod"))]),
-                },
-                Case {
-                    scenario: "preserves other labels",
-                    input: (
-                        Some(metadata_with("n", "", vec![label("team", Some("infra"))])),
-                        "env".to_string(),
-                        Some("prod".to_string()),
-                    ),
-                    expect: Yields(vec![
-                        label("team", Some("infra")),
-                        label("env", Some("prod")),
-                    ]),
-                },
-                Case {
-                    scenario: "missing metadata errors",
-                    input: (None, "k".to_string(), None),
-                    expect: Fails,
-                },
-            ],
-            |(metadata, key, value)| {
+        scenarios!(
+            run = |(metadata, key, value)| {
                 apply_add_label(metadata, key, value)
                     .map(|m| m.labels)
                     .map_err(drop)
-            },
+            };
+            "adds a new label" {
+                (
+                    Some(metadata_with("n", "", vec![])),
+                    "env".to_string(),
+                    Some("prod".to_string()),
+                ) => Yields(vec![label("env", Some("prod"))]),
+            }
+
+            "replaces an existing key" {
+                (
+                    Some(metadata_with("n", "", vec![label("env", Some("staging"))])),
+                    "env".to_string(),
+                    Some("prod".to_string()),
+                ) => Yields(vec![label("env", Some("prod"))]),
+            }
+
+            "preserves other labels" {
+                (
+                    Some(metadata_with("n", "", vec![label("team", Some("infra"))])),
+                    "env".to_string(),
+                    Some("prod".to_string()),
+                ) => Yields(vec![
+                    label("team", Some("infra")),
+                    label("env", Some("prod")),
+                ]),
+            }
+
+            "missing metadata errors" {
+                (None, "k".to_string(), None) => Fails,
+            }
         );
     }
 
@@ -313,39 +299,33 @@ mod tests {
     // and a missing Metadata is rejected. Each row yields the surviving labels.
     #[test]
     fn apply_remove_labels_drops_matching() {
-        check_cases(
-            [
-                Case {
-                    scenario: "removes the matching key",
-                    input: (
-                        Some(metadata_with(
-                            "n",
-                            "",
-                            vec![label("a", None), label("b", None)],
-                        )),
-                        vec!["a".to_string()],
-                    ),
-                    expect: Yields(vec![label("b", None)]),
-                },
-                Case {
-                    scenario: "ignores keys that don't exist",
-                    input: (
-                        Some(metadata_with("n", "", vec![label("a", None)])),
-                        vec!["nonexistent".to_string()],
-                    ),
-                    expect: Yields(vec![label("a", None)]),
-                },
-                Case {
-                    scenario: "missing metadata errors",
-                    input: (None, vec!["k".to_string()]),
-                    expect: Fails,
-                },
-            ],
-            |(metadata, keys)| {
+        scenarios!(
+            run = |(metadata, keys)| {
                 apply_remove_labels(metadata, keys)
                     .map(|m| m.labels)
                     .map_err(drop)
-            },
+            };
+            "removes the matching key" {
+                (
+                    Some(metadata_with(
+                        "n",
+                        "",
+                        vec![label("a", None), label("b", None)],
+                    )),
+                    vec!["a".to_string()],
+                ) => Yields(vec![label("b", None)]),
+            }
+
+            "ignores keys that don't exist" {
+                (
+                    Some(metadata_with("n", "", vec![label("a", None)])),
+                    vec!["nonexistent".to_string()],
+                ) => Yields(vec![label("a", None)]),
+            }
+
+            "missing metadata errors" {
+                (None, vec!["k".to_string()]) => Fails,
+            }
         );
     }
 }

--- a/crates/admin-cli/src/network_devices/tests.rs
+++ b/crates/admin-cli/src/network_devices/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -50,30 +50,24 @@ fn verify_cmd_structure() {
 // deprecated --all flag; each row asserts the resulting (id, all) pair.
 #[test]
 fn parse_show_variants() {
-    check_cases(
-        [
-            Case {
-                scenario: "no arguments parses (all devices)",
-                input: &["network-device", "show"][..],
-                expect: Yields((String::new(), false)),
-            },
-            Case {
-                scenario: "with a device ID",
-                input: &["network-device", "show", "mac=00:11:22:33:44:55"][..],
-                expect: Yields(("mac=00:11:22:33:44:55".to_string(), false)),
-            },
-            Case {
-                scenario: "with the deprecated --all flag",
-                input: &["network-device", "show", "--all"][..],
-                expect: Yields((String::new(), true)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => (args.id, args.all),
                 })
                 .map_err(drop)
-        },
+        };
+        "no arguments parses (all devices)" {
+            &["network-device", "show"][..] => Yields((String::new(), false)),
+        }
+
+        "with a device ID" {
+            &["network-device", "show", "mac=00:11:22:33:44:55"][..] => Yields(("mac=00:11:22:33:44:55".to_string(), false)),
+        }
+
+        "with the deprecated --all flag" {
+            &["network-device", "show", "--all"][..] => Yields((String::new(), true)),
+        }
     );
 }

--- a/crates/admin-cli/src/network_security_group/tests.rs
+++ b/crates/admin-cli/src/network_security_group/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -51,42 +51,8 @@ fn verify_cmd_structure() {
 // options unset, the fully-flagged invocation carries them through.
 #[test]
 fn parse_create_routes_to_create_variant() {
-    check_cases(
-        [
-            Case {
-                scenario: "create with only the required tenant org id",
-                input: &[
-                    "network-security-group",
-                    "create",
-                    "--tenant-organization-id",
-                    "tenant-123",
-                ][..],
-                expect: Yields(("tenant-123".to_string(), None, None, false)),
-            },
-            Case {
-                scenario: "create with all options",
-                input: &[
-                    "network-security-group",
-                    "create",
-                    "--tenant-organization-id",
-                    "tenant-123",
-                    "--id",
-                    "nsg-123",
-                    "--name",
-                    "my-nsg",
-                    "--description",
-                    "Test NSG",
-                    "--stateful-egress",
-                ][..],
-                expect: Yields((
-                    "tenant-123".to_string(),
-                    Some("nsg-123".to_string()),
-                    Some("my-nsg".to_string()),
-                    true,
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Create(args) => (
@@ -98,7 +64,36 @@ fn parse_create_routes_to_create_variant() {
                     _ => panic!("expected Create variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "create with only the required tenant org id" {
+            &[
+                "network-security-group",
+                "create",
+                "--tenant-organization-id",
+                "tenant-123",
+            ][..] => Yields(("tenant-123".to_string(), None, None, false)),
+        }
+
+        "create with all options" {
+            &[
+                "network-security-group",
+                "create",
+                "--tenant-organization-id",
+                "tenant-123",
+                "--id",
+                "nsg-123",
+                "--name",
+                "my-nsg",
+                "--description",
+                "Test NSG",
+                "--stateful-egress",
+            ][..] => Yields((
+                "tenant-123".to_string(),
+                Some("nsg-123".to_string()),
+                Some("my-nsg".to_string()),
+                true,
+            )),
+        }
     );
 }
 
@@ -106,27 +101,22 @@ fn parse_create_routes_to_create_variant() {
 // it unset, a supplied id is captured.
 #[test]
 fn parse_show_routes_to_show_variant() {
-    check_cases(
-        [
-            Case {
-                scenario: "show with no args (all groups)",
-                input: &["network-security-group", "show"][..],
-                expect: Yields(None),
-            },
-            Case {
-                scenario: "show with a group id",
-                input: &["network-security-group", "show", "nsg-123"][..],
-                expect: Yields(Some("nsg-123".to_string())),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => args.id,
                     _ => panic!("expected Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "show with no args (all groups)" {
+            &["network-security-group", "show"][..] => Yields(None),
+        }
+
+        "show with a group id" {
+            &["network-security-group", "show", "nsg-123"][..] => Yields(Some("nsg-123".to_string())),
+        }
     );
 }
 
@@ -134,27 +124,25 @@ fn parse_show_routes_to_show_variant() {
 // tenant org id.
 #[test]
 fn parse_delete_routes_to_delete_variant() {
-    check_cases(
-        [Case {
-            scenario: "delete with required id and tenant org id",
-            input: &[
-                "network-security-group",
-                "delete",
-                "--id",
-                "nsg-123",
-                "--tenant-organization-id",
-                "tenant-123",
-            ][..],
-            expect: Yields(("nsg-123".to_string(), "tenant-123".to_string())),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Delete(args) => (args.id, args.tenant_organization_id),
                     _ => panic!("expected Delete variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "delete with required id and tenant org id" {
+            &[
+                "network-security-group",
+                "delete",
+                "--id",
+                "nsg-123",
+                "--tenant-organization-id",
+                "tenant-123",
+            ][..] => Yields(("nsg-123".to_string(), "tenant-123".to_string())),
+        }
     );
 }
 
@@ -162,27 +150,25 @@ fn parse_delete_routes_to_delete_variant() {
 // tenant org id.
 #[test]
 fn parse_update_routes_to_update_variant() {
-    check_cases(
-        [Case {
-            scenario: "update with required id and tenant org id",
-            input: &[
-                "network-security-group",
-                "update",
-                "--id",
-                "nsg-123",
-                "--tenant-organization-id",
-                "tenant-123",
-            ][..],
-            expect: Yields(("nsg-123".to_string(), "tenant-123".to_string())),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Update(args) => (args.id, args.tenant_organization_id),
                     _ => panic!("expected Update variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "update with required id and tenant org id" {
+            &[
+                "network-security-group",
+                "update",
+                "--id",
+                "nsg-123",
+                "--tenant-organization-id",
+                "tenant-123",
+            ][..] => Yields(("nsg-123".to_string(), "tenant-123".to_string())),
+        }
     );
 }
 
@@ -190,25 +176,23 @@ fn parse_update_routes_to_update_variant() {
 // required id; --include-indirect defaults off.
 #[test]
 fn parse_show_attachments_routes_to_show_attachments_variant() {
-    check_cases(
-        [Case {
-            scenario: "show-attachments with required id",
-            input: &[
-                "network-security-group",
-                "show-attachments",
-                "--id",
-                "nsg-123",
-            ][..],
-            expect: Yields(("nsg-123".to_string(), false)),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::ShowAttachments(args) => (args.id, args.include_indirect),
                     _ => panic!("expected ShowAttachments variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "show-attachments with required id" {
+            &[
+                "network-security-group",
+                "show-attachments",
+                "--id",
+                "nsg-123",
+            ][..] => Yields(("nsg-123".to_string(), false)),
+        }
     );
 }
 
@@ -216,20 +200,18 @@ fn parse_show_attachments_routes_to_show_attachments_variant() {
 // the optional vpc/instance targets default unset.
 #[test]
 fn parse_attach_routes_to_attach_variant() {
-    check_cases(
-        [Case {
-            scenario: "attach with NSG id",
-            input: &["network-security-group", "attach", "--id", "nsg-123"][..],
-            expect: Yields(("nsg-123".to_string(), None, None)),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Attach(args) => (args.id, args.vpc_id, args.instance_id),
                     _ => panic!("expected Attach variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "attach with NSG id" {
+            &["network-security-group", "attach", "--id", "nsg-123"][..] => Yields(("nsg-123".to_string(), None, None)),
+        }
     );
 }
 
@@ -237,20 +219,18 @@ fn parse_attach_routes_to_attach_variant() {
 // vpc/instance targets default unset.
 #[test]
 fn parse_detach_routes_to_detach_variant() {
-    check_cases(
-        [Case {
-            scenario: "detach with no required args",
-            input: &["network-security-group", "detach"][..],
-            expect: Yields((None, None)),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Detach(args) => (args.vpc_id, args.instance_id),
                     _ => panic!("expected Detach variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "detach with no required args" {
+            &["network-security-group", "detach"][..] => Yields((None, None)),
+        }
     );
 }
 
@@ -258,16 +238,14 @@ fn parse_detach_routes_to_detach_variant() {
 // its required --tenant-organization-id.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [Case {
-            scenario: "create without --tenant-organization-id",
-            input: &["network-security-group", "create"][..],
-            expect: Fails,
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "create without --tenant-organization-id" {
+            &["network-security-group", "create"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/network_segment/tests.rs
+++ b/crates/admin-cli/src/network_segment/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -51,48 +51,40 @@ fn verify_cmd_structure() {
 // `tenant_org_id` and `name`.
 #[test]
 fn parse_show_routes_to_show() {
-    check_cases(
-        [
-            Case {
-                scenario: "no arguments (all segments)",
-                input: &["network-segment", "show"][..],
-                expect: Yields((false, None, None)),
-            },
-            Case {
-                scenario: "with --tenant-org-id",
-                input: &["network-segment", "show", "--tenant-org-id", "tenant-123"][..],
-                expect: Yields((false, Some("tenant-123".to_string()), None)),
-            },
-            Case {
-                scenario: "with --name",
-                input: &["network-segment", "show", "--name", "my-segment"][..],
-                expect: Yields((false, None, Some("my-segment".to_string()))),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => (args.network.is_some(), args.tenant_org_id, args.name),
                     _ => panic!("expected Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "no arguments (all segments)" {
+            &["network-segment", "show"][..] => Yields((false, None, None)),
+        }
+
+        "with --tenant-org-id" {
+            &["network-segment", "show", "--tenant-org-id", "tenant-123"][..] => Yields((false, Some("tenant-123".to_string()), None)),
+        }
+
+        "with --name" {
+            &["network-segment", "show", "--name", "my-segment"][..] => Yields((false, None, Some("my-segment".to_string()))),
+        }
     );
 }
 
 // Every malformed invocation is rejected at parse time.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [Case {
-            scenario: "delete without --id",
-            input: &["network-segment", "delete"][..],
-            expect: Fails,
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "delete without --id" {
+            &["network-segment", "delete"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/nvl_domain/tests.rs
+++ b/crates/admin-cli/src/nvl_domain/tests.rs
@@ -16,7 +16,7 @@
  */
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::health_report::args::Args as HealthReportCommand;
@@ -35,29 +35,8 @@ fn verify_cmd_structure() {
 // the originals asserted.
 #[test]
 fn parse_health_report_subcommands() {
-    check_cases(
-        [
-            Case {
-                scenario: "show routes to HealthReport Show with the domain id",
-                input: &["nvl-domain", "health-report", "show", TEST_DOMAIN_ID][..],
-                expect: Yields((TEST_DOMAIN_ID.to_string(), None)),
-            },
-            Case {
-                scenario: "remove routes to HealthReport Remove with domain id and source",
-                input: &[
-                    "nvl-domain",
-                    "health-report",
-                    "remove",
-                    TEST_DOMAIN_ID,
-                    "haas-log-analyzer",
-                ][..],
-                expect: Yields((
-                    TEST_DOMAIN_ID.to_string(),
-                    Some("haas-log-analyzer".to_string()),
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| {
                     let Cmd::HealthReport(command) = cmd;
@@ -71,6 +50,22 @@ fn parse_health_report_subcommands() {
                     }
                 })
                 .map_err(drop)
-        },
+        };
+        "show routes to HealthReport Show with the domain id" {
+            &["nvl-domain", "health-report", "show", TEST_DOMAIN_ID][..] => Yields((TEST_DOMAIN_ID.to_string(), None)),
+        }
+
+        "remove routes to HealthReport Remove with domain id and source" {
+            &[
+                "nvl-domain",
+                "health-report",
+                "remove",
+                TEST_DOMAIN_ID,
+                "haas-log-analyzer",
+            ][..] => Yields((
+                TEST_DOMAIN_ID.to_string(),
+                Some("haas-log-analyzer".to_string()),
+            )),
+        }
     );
 }

--- a/crates/admin-cli/src/nvl_logical_partition/tests.rs
+++ b/crates/admin-cli/src/nvl_logical_partition/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -51,27 +51,22 @@ fn verify_cmd_structure() {
 // threads the filter through.
 #[test]
 fn parse_show() {
-    check_cases(
-        [
-            Case {
-                scenario: "no arguments targets all partitions",
-                input: &["nvl-logical-partition", "show"][..],
-                expect: Yields((true, None)),
-            },
-            Case {
-                scenario: "with a --name filter",
-                input: &["nvl-logical-partition", "show", "--name", "my-partition"][..],
-                expect: Yields((true, Some("my-partition".to_string()))),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => (args.id.is_empty(), args.name),
                     _ => panic!("expected Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "no arguments targets all partitions" {
+            &["nvl-logical-partition", "show"][..] => Yields((true, None)),
+        }
+
+        "with a --name filter" {
+            &["nvl-logical-partition", "show", "--name", "my-partition"][..] => Yields((true, Some("my-partition".to_string()))),
+        }
     );
 }
 
@@ -79,47 +74,43 @@ fn parse_show() {
 // threading both through to the Create variant.
 #[test]
 fn parse_create() {
-    check_cases(
-        [Case {
-            scenario: "create with required arguments",
-            input: &[
-                "nvl-logical-partition",
-                "create",
-                "--name",
-                "my-partition",
-                "--tenant-organization-id",
-                "tenant-123",
-            ][..],
-            expect: Yields(("my-partition".to_string(), "tenant-123".to_string())),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Create(args) => (args.name, args.tenant_organization_id),
                     _ => panic!("expected Create variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "create with required arguments" {
+            &[
+                "nvl-logical-partition",
+                "create",
+                "--name",
+                "my-partition",
+                "--tenant-organization-id",
+                "tenant-123",
+            ][..] => Yields(("my-partition".to_string(), "tenant-123".to_string())),
+        }
     );
 }
 
 // delete parses with its required --name, routing to the Delete variant.
 #[test]
 fn parse_delete() {
-    check_cases(
-        [Case {
-            scenario: "delete with required --name",
-            input: &["nvl-logical-partition", "delete", "--name", "my-partition"][..],
-            expect: Yields("my-partition".to_string()),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Delete(args) => args.name,
                     _ => panic!("expected Delete variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "delete with required --name" {
+            &["nvl-logical-partition", "delete", "--name", "my-partition"][..] => Yields("my-partition".to_string()),
+        }
     );
 }
 
@@ -128,23 +119,18 @@ fn parse_delete() {
 // without its required --name.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "create without --name and --tenant-organization-id",
-                input: &["nvl-logical-partition", "create"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "delete without --name",
-                input: &["nvl-logical-partition", "delete"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "create without --name and --tenant-organization-id" {
+            &["nvl-logical-partition", "create"][..] => Fails,
+        }
+
+        "delete without --name" {
+            &["nvl-logical-partition", "delete"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/nvl_partition/tests.rs
+++ b/crates/admin-cli/src/nvl_partition/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -58,29 +58,22 @@ fn show_parses_filters() {
         }
     }
 
-    check_cases(
-        [
-            Case {
-                scenario: "no arguments (all partitions)",
-                input: &["nvl-partition", "show"][..],
-                expect: Yields((String::new(), None, None)),
-            },
-            Case {
-                scenario: "with --tenant-org-id",
-                input: &["nvl-partition", "show", "--tenant-org-id", "tenant-123"][..],
-                expect: Yields((String::new(), Some("tenant-123".to_string()), None)),
-            },
-            Case {
-                scenario: "with --name",
-                input: &["nvl-partition", "show", "--name", "my-partition"][..],
-                expect: Yields((String::new(), None, Some("my-partition".to_string()))),
-            },
-            Case {
-                scenario: "with positional id",
-                input: &["nvl-partition", "show", "partition-123"][..],
-                expect: Yields(("partition-123".to_string(), None, None)),
-            },
-        ],
-        show_filters,
+    scenarios!(
+        run = show_filters;
+        "no arguments (all partitions)" {
+            &["nvl-partition", "show"][..] => Yields((String::new(), None, None)),
+        }
+
+        "with --tenant-org-id" {
+            &["nvl-partition", "show", "--tenant-org-id", "tenant-123"][..] => Yields((String::new(), Some("tenant-123".to_string()), None)),
+        }
+
+        "with --name" {
+            &["nvl-partition", "show", "--name", "my-partition"][..] => Yields((String::new(), None, Some("my-partition".to_string()))),
+        }
+
+        "with positional id" {
+            &["nvl-partition", "show", "partition-123"][..] => Yields(("partition-123".to_string(), None, None)),
+        }
     );
 }

--- a/crates/admin-cli/src/os_image/tests.rs
+++ b/crates/admin-cli/src/os_image/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -74,87 +74,81 @@ fn parse_create_routes_to_create() {
         }
     }
 
-    check_cases(
-        [
-            Case {
-                scenario: "create with required args (long flags)",
-                input: &[
-                    "os-image",
-                    "create",
-                    "--id",
-                    "550e8400-e29b-41d4-a716-446655440000",
-                    "--url",
-                    "https://images.example.com/ubuntu.qcow2",
-                    "--digest",
-                    "sha256:abc123",
-                    "--tenant-org-id",
-                    "tenant-123",
-                ][..],
-                expect: Yields((
-                    "550e8400-e29b-41d4-a716-446655440000".to_string(),
-                    "https://images.example.com/ubuntu.qcow2".to_string(),
-                    "sha256:abc123".to_string(),
-                    "tenant-123".to_string(),
-                    None,
-                    None,
-                )),
-            },
-            Case {
-                scenario: "create with optional args (short flags)",
-                input: &[
-                    "os-image",
-                    "create",
-                    "-i",
-                    "550e8400-e29b-41d4-a716-446655440000",
-                    "-u",
-                    "https://images.example.com/ubuntu.qcow2",
-                    "-m",
-                    "sha256:abc123",
-                    "-t",
-                    "tenant-123",
-                    "-n",
-                    "Ubuntu 22.04",
-                    "-d",
-                    "Ubuntu 22.04 LTS Server",
-                ][..],
-                expect: Yields((
-                    "550e8400-e29b-41d4-a716-446655440000".to_string(),
-                    "https://images.example.com/ubuntu.qcow2".to_string(),
-                    "sha256:abc123".to_string(),
-                    "tenant-123".to_string(),
-                    Some("Ubuntu 22.04".to_string()),
-                    Some("Ubuntu 22.04 LTS Server".to_string()),
-                )),
-            },
-            Case {
-                scenario: "create via visible alias 'c'",
-                input: &[
-                    "os-image",
-                    "c",
-                    "-i",
-                    "550e8400-e29b-41d4-a716-446655440000",
-                    "-u",
-                    "https://images.example.com/ubuntu.qcow2",
-                    "-m",
-                    "sha256:abc123",
-                    "-t",
-                    "tenant-123",
-                ][..],
-                expect: Yields((
-                    "550e8400-e29b-41d4-a716-446655440000".to_string(),
-                    "https://images.example.com/ubuntu.qcow2".to_string(),
-                    "sha256:abc123".to_string(),
-                    "tenant-123".to_string(),
-                    None,
-                    None,
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(create_fields)
                 .map_err(drop)
-        },
+        };
+        "create with required args (long flags)" {
+            &[
+                "os-image",
+                "create",
+                "--id",
+                "550e8400-e29b-41d4-a716-446655440000",
+                "--url",
+                "https://images.example.com/ubuntu.qcow2",
+                "--digest",
+                "sha256:abc123",
+                "--tenant-org-id",
+                "tenant-123",
+            ][..] => Yields((
+                "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                "https://images.example.com/ubuntu.qcow2".to_string(),
+                "sha256:abc123".to_string(),
+                "tenant-123".to_string(),
+                None,
+                None,
+            )),
+        }
+
+        "create with optional args (short flags)" {
+            &[
+                "os-image",
+                "create",
+                "-i",
+                "550e8400-e29b-41d4-a716-446655440000",
+                "-u",
+                "https://images.example.com/ubuntu.qcow2",
+                "-m",
+                "sha256:abc123",
+                "-t",
+                "tenant-123",
+                "-n",
+                "Ubuntu 22.04",
+                "-d",
+                "Ubuntu 22.04 LTS Server",
+            ][..] => Yields((
+                "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                "https://images.example.com/ubuntu.qcow2".to_string(),
+                "sha256:abc123".to_string(),
+                "tenant-123".to_string(),
+                Some("Ubuntu 22.04".to_string()),
+                Some("Ubuntu 22.04 LTS Server".to_string()),
+            )),
+        }
+
+        "create via visible alias 'c'" {
+            &[
+                "os-image",
+                "c",
+                "-i",
+                "550e8400-e29b-41d4-a716-446655440000",
+                "-u",
+                "https://images.example.com/ubuntu.qcow2",
+                "-m",
+                "sha256:abc123",
+                "-t",
+                "tenant-123",
+            ][..] => Yields((
+                "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                "https://images.example.com/ubuntu.qcow2".to_string(),
+                "sha256:abc123".to_string(),
+                "tenant-123".to_string(),
+                None,
+                None,
+            )),
+        }
     );
 }
 
@@ -169,34 +163,29 @@ fn parse_show_routes_to_show() {
         }
     }
 
-    check_cases(
-        [
-            Case {
-                scenario: "show with no filters",
-                input: &["os-image", "show"][..],
-                expect: Yields((None, None)),
-            },
-            Case {
-                scenario: "show with id and tenant filters",
-                input: &[
-                    "os-image",
-                    "show",
-                    "-i",
-                    "550e8400-e29b-41d4-a716-446655440000",
-                    "-t",
-                    "tenant-123",
-                ][..],
-                expect: Yields((
-                    Some("550e8400-e29b-41d4-a716-446655440000".to_string()),
-                    Some("tenant-123".to_string()),
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(show_fields)
                 .map_err(drop)
-        },
+        };
+        "show with no filters" {
+            &["os-image", "show"][..] => Yields((None, None)),
+        }
+
+        "show with id and tenant filters" {
+            &[
+                "os-image",
+                "show",
+                "-i",
+                "550e8400-e29b-41d4-a716-446655440000",
+                "-t",
+                "tenant-123",
+            ][..] => Yields((
+                Some("550e8400-e29b-41d4-a716-446655440000".to_string()),
+                Some("tenant-123".to_string()),
+            )),
+        }
     );
 }
 
@@ -211,27 +200,25 @@ fn parse_delete_routes_to_delete() {
         }
     }
 
-    check_cases(
-        [Case {
-            scenario: "delete with required args",
-            input: &[
+    scenarios!(
+        run = |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(delete_fields)
+                .map_err(drop)
+        };
+        "delete with required args" {
+            &[
                 "os-image",
                 "delete",
                 "-i",
                 "550e8400-e29b-41d4-a716-446655440000",
                 "-t",
                 "tenant-123",
-            ][..],
-            expect: Yields((
+            ][..] => Yields((
                 "550e8400-e29b-41d4-a716-446655440000".to_string(),
                 "tenant-123".to_string(),
             )),
-        }],
-        |argv| {
-            Cmd::try_parse_from(argv.iter().copied())
-                .map(delete_fields)
-                .map_err(drop)
-        },
+        }
     );
 }
 
@@ -246,27 +233,25 @@ fn parse_update_routes_to_update() {
         }
     }
 
-    check_cases(
-        [Case {
-            scenario: "update with required id and a name",
-            input: &[
+    scenarios!(
+        run = |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(update_fields)
+                .map_err(drop)
+        };
+        "update with required id and a name" {
+            &[
                 "os-image",
                 "update",
                 "-i",
                 "550e8400-e29b-41d4-a716-446655440000",
                 "-n",
                 "New Name",
-            ][..],
-            expect: Yields((
+            ][..] => Yields((
                 "550e8400-e29b-41d4-a716-446655440000".to_string(),
                 Some("New Name".to_string()),
             )),
-        }],
-        |argv| {
-            Cmd::try_parse_from(argv.iter().copied())
-                .map(update_fields)
-                .map_err(drop)
-        },
+        }
     );
 }
 
@@ -274,16 +259,14 @@ fn parse_update_routes_to_update() {
 // of its required arguments.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [Case {
-            scenario: "create missing required args",
-            input: &["os-image", "create", "-i", "some-id"][..],
-            expect: Fails,
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "create missing required args" {
+            &["os-image", "create", "-i", "some-id"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/ping/tests.rs
+++ b/crates/admin-cli/src/ping/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::args::*;
@@ -47,28 +47,22 @@ fn verify_cmd_structure() {
 // are exactly representable in f32, so equality is exact.
 #[test]
 fn parse_interval() {
-    check_cases(
-        [
-            Case {
-                scenario: "default interval",
-                input: &["ping"][..],
-                expect: Yields(1.0f32),
-            },
-            Case {
-                scenario: "custom --interval",
-                input: &["ping", "--interval", "2.5"][..],
-                expect: Yields(2.5f32),
-            },
-            Case {
-                scenario: "short -i flag",
-                input: &["ping", "-i", "0.5"][..],
-                expect: Yields(0.5f32),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Opts::try_parse_from(argv.iter().copied())
                 .map(|opts| opts.interval)
                 .map_err(drop)
-        },
+        };
+        "default interval" {
+            &["ping"][..] => Yields(1.0f32),
+        }
+
+        "custom --interval" {
+            &["ping", "--interval", "2.5"][..] => Yields(2.5f32),
+        }
+
+        "short -i flag" {
+            &["ping", "-i", "0.5"][..] => Yields(0.5f32),
+        }
     );
 }

--- a/crates/admin-cli/src/power_shelf/tests.rs
+++ b/crates/admin-cli/src/power_shelf/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -50,27 +50,22 @@ fn verify_cmd_structure() {
 // supplied value or `None` when omitted (all shelves).
 #[test]
 fn parse_show_identifier() {
-    check_cases(
-        [
-            Case {
-                scenario: "no identifier (all shelves)",
-                input: &["power-shelf", "show"][..],
-                expect: Yields(None),
-            },
-            Case {
-                scenario: "with identifier",
-                input: &["power-shelf", "show", "shelf-123"][..],
-                expect: Yields(Some("shelf-123".to_string())),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => args.identifier,
                     _ => panic!("expected Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "no identifier (all shelves)" {
+            &["power-shelf", "show"][..] => Yields(None),
+        }
+
+        "with identifier" {
+            &["power-shelf", "show", "shelf-123"][..] => Yields(Some("shelf-123".to_string())),
+        }
     );
 }
 
@@ -86,22 +81,8 @@ fn parse_list() {
 // the controller-state string, and a parsed `--bmc-mac`.
 #[test]
 fn parse_list_with_filters() {
-    check_cases(
-        [Case {
-            scenario: "deleted + controller-state + bmc-mac",
-            input: &[
-                "power-shelf",
-                "list",
-                "--deleted",
-                "only",
-                "--controller-state",
-                "ready",
-                "--bmc-mac",
-                "AA:BB:CC:DD:EE:FF",
-            ][..],
-            expect: Yields((true, Some("ready".to_string()), true)),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::List(args) => (
@@ -112,7 +93,19 @@ fn parse_list_with_filters() {
                     _ => panic!("expected List variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "deleted + controller-state + bmc-mac" {
+            &[
+                "power-shelf",
+                "list",
+                "--deleted",
+                "only",
+                "--controller-state",
+                "ready",
+                "--bmc-mac",
+                "AA:BB:CC:DD:EE:FF",
+            ][..] => Yields((true, Some("ready".to_string()), true)),
+        }
     );
 }
 
@@ -121,40 +114,33 @@ fn parse_list_with_filters() {
 // id, and an unknown maintenance subcommand.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "list with an invalid --deleted value",
-                input: &["power-shelf", "list", "--deleted", "bogus"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "list with an invalid --bmc-mac",
-                input: &["power-shelf", "list", "--bmc-mac", "not-a-mac"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "maintenance power-on missing required --power-shelf-id",
-                input: &["power-shelf", "maintenance", "power-on"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "maintenance unknown subcommand power-cycle",
-                input: &[
-                    "power-shelf",
-                    "maintenance",
-                    "power-cycle",
-                    "--power-shelf-id",
-                    SAMPLE_PS_ID_1,
-                ][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "list with an invalid --deleted value" {
+            &["power-shelf", "list", "--deleted", "bogus"][..] => Fails,
+        }
+
+        "list with an invalid --bmc-mac" {
+            &["power-shelf", "list", "--bmc-mac", "not-a-mac"][..] => Fails,
+        }
+
+        "maintenance power-on missing required --power-shelf-id" {
+            &["power-shelf", "maintenance", "power-on"][..] => Fails,
+        }
+
+        "maintenance unknown subcommand power-cycle" {
+            &[
+                "power-shelf",
+                "maintenance",
+                "power-cycle",
+                "--power-shelf-id",
+                SAMPLE_PS_ID_1,
+            ][..] => Fails,
+        }
     );
 }
 
@@ -189,63 +175,8 @@ fn parse_ps_id(id: &str) -> PowerShelfId {
 /// row yields the parsed `(power_shelf_ids, reference)`.
 #[test]
 fn parse_maintenance_power_on() {
-    check_cases(
-        [
-            Case {
-                scenario: "single id",
-                input: &[
-                    "power-shelf",
-                    "maintenance",
-                    "power-on",
-                    "--power-shelf-id",
-                    SAMPLE_PS_ID_1,
-                ][..],
-                expect: Yields((vec![parse_ps_id(SAMPLE_PS_ID_1)], None)),
-            },
-            Case {
-                scenario: "two ids on a single flag occurrence (num_args = 1..)",
-                input: &[
-                    "power-shelf",
-                    "maintenance",
-                    "power-on",
-                    "--power-shelf-id",
-                    SAMPLE_PS_ID_1,
-                    SAMPLE_PS_ID_2,
-                ][..],
-                expect: Yields((
-                    vec![parse_ps_id(SAMPLE_PS_ID_1), parse_ps_id(SAMPLE_PS_ID_2)],
-                    None,
-                )),
-            },
-            Case {
-                scenario: "--reference is captured",
-                input: &[
-                    "power-shelf",
-                    "maintenance",
-                    "power-on",
-                    "--power-shelf-id",
-                    SAMPLE_PS_ID_1,
-                    "--reference",
-                    "https://issues.example.com/TICKET-1",
-                ][..],
-                expect: Yields((
-                    vec![parse_ps_id(SAMPLE_PS_ID_1)],
-                    Some("https://issues.example.com/TICKET-1".to_string()),
-                )),
-            },
-            Case {
-                scenario: "--id alias captures the power-shelf id",
-                input: &[
-                    "power-shelf",
-                    "maintenance",
-                    "power-on",
-                    "--id",
-                    SAMPLE_PS_ID_1,
-                ][..],
-                expect: Yields((vec![parse_ps_id(SAMPLE_PS_ID_1)], None)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Maintenance(maintenance::Args::PowerOn(args)) => {
@@ -254,7 +185,55 @@ fn parse_maintenance_power_on() {
                     other => panic!("expected Maintenance(PowerOn(_)), got: {other:?}"),
                 })
                 .map_err(drop)
-        },
+        };
+        "single id" {
+            &[
+                "power-shelf",
+                "maintenance",
+                "power-on",
+                "--power-shelf-id",
+                SAMPLE_PS_ID_1,
+            ][..] => Yields((vec![parse_ps_id(SAMPLE_PS_ID_1)], None)),
+        }
+
+        "two ids on a single flag occurrence (num_args = 1..)" {
+            &[
+                "power-shelf",
+                "maintenance",
+                "power-on",
+                "--power-shelf-id",
+                SAMPLE_PS_ID_1,
+                SAMPLE_PS_ID_2,
+            ][..] => Yields((
+                vec![parse_ps_id(SAMPLE_PS_ID_1), parse_ps_id(SAMPLE_PS_ID_2)],
+                None,
+            )),
+        }
+
+        "--reference is captured" {
+            &[
+                "power-shelf",
+                "maintenance",
+                "power-on",
+                "--power-shelf-id",
+                SAMPLE_PS_ID_1,
+                "--reference",
+                "https://issues.example.com/TICKET-1",
+            ][..] => Yields((
+                vec![parse_ps_id(SAMPLE_PS_ID_1)],
+                Some("https://issues.example.com/TICKET-1".to_string()),
+            )),
+        }
+
+        "--id alias captures the power-shelf id" {
+            &[
+                "power-shelf",
+                "maintenance",
+                "power-on",
+                "--id",
+                SAMPLE_PS_ID_1,
+            ][..] => Yields((vec![parse_ps_id(SAMPLE_PS_ID_1)], None)),
+        }
     );
 }
 
@@ -263,42 +242,8 @@ fn parse_maintenance_power_on() {
 /// `--reference`. Each row yields the parsed `(power_shelf_ids, reference)`.
 #[test]
 fn parse_maintenance_power_off() {
-    check_cases(
-        [
-            Case {
-                scenario: "two ids via repeated --power-shelf-id flags",
-                input: &[
-                    "power-shelf",
-                    "maintenance",
-                    "power-off",
-                    "--power-shelf-id",
-                    SAMPLE_PS_ID_1,
-                    "--power-shelf-id",
-                    SAMPLE_PS_ID_2,
-                ][..],
-                expect: Yields((
-                    vec![parse_ps_id(SAMPLE_PS_ID_1), parse_ps_id(SAMPLE_PS_ID_2)],
-                    None,
-                )),
-            },
-            Case {
-                scenario: "--ref alias captures the reference",
-                input: &[
-                    "power-shelf",
-                    "maintenance",
-                    "power-off",
-                    "--power-shelf-id",
-                    SAMPLE_PS_ID_1,
-                    "--ref",
-                    "TICKET-2",
-                ][..],
-                expect: Yields((
-                    vec![parse_ps_id(SAMPLE_PS_ID_1)],
-                    Some("TICKET-2".to_string()),
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Maintenance(maintenance::Args::PowerOff(args)) => {
@@ -307,7 +252,36 @@ fn parse_maintenance_power_off() {
                     other => panic!("expected Maintenance(PowerOff(_)), got: {other:?}"),
                 })
                 .map_err(drop)
-        },
+        };
+        "two ids via repeated --power-shelf-id flags" {
+            &[
+                "power-shelf",
+                "maintenance",
+                "power-off",
+                "--power-shelf-id",
+                SAMPLE_PS_ID_1,
+                "--power-shelf-id",
+                SAMPLE_PS_ID_2,
+            ][..] => Yields((
+                vec![parse_ps_id(SAMPLE_PS_ID_1), parse_ps_id(SAMPLE_PS_ID_2)],
+                None,
+            )),
+        }
+
+        "--ref alias captures the reference" {
+            &[
+                "power-shelf",
+                "maintenance",
+                "power-off",
+                "--power-shelf-id",
+                SAMPLE_PS_ID_1,
+                "--ref",
+                "TICKET-2",
+            ][..] => Yields((
+                vec![parse_ps_id(SAMPLE_PS_ID_1)],
+                Some("TICKET-2".to_string()),
+            )),
+        }
     );
 }
 

--- a/crates/admin-cli/src/rack/maintenance/cmd.rs
+++ b/crates/admin-cli/src/rack/maintenance/cmd.rs
@@ -147,7 +147,7 @@ pub async fn on_demand_rack_maintenance(
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::scenarios;
     use carbide_uuid::rack::RackId;
 
     use super::*;
@@ -176,64 +176,55 @@ mod tests {
     // access_token) tuple the originals asserted on.
     #[test]
     fn resolve_firmware_upgrade_source_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "firmware-upgrade without a SOT JSON source is rejected",
-                    input: MaintenanceOptions {
-                        activities: Some(vec!["firmware-upgrade".to_string()]),
-                        access_token: Some("token".to_string()),
-                        ..options()
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "firmware-upgrade with inline JSON allows a missing access token",
-                    input: MaintenanceOptions {
-                        activities: Some(vec!["firmware-upgrade".to_string()]),
-                        firmware_version: Some(r#"{"Id":"fw"}"#.to_string()),
-                        ..options()
-                    },
-                    expect: Yields((r#"{"Id":"fw"}"#.to_string(), None)),
-                },
-                Case {
-                    scenario: "firmware-upgrade treats an empty access token as missing",
-                    input: MaintenanceOptions {
-                        activities: Some(vec!["firmware-upgrade".to_string()]),
-                        firmware_version: Some(r#"{"Id":"fw"}"#.to_string()),
-                        access_token: Some(String::new()),
-                        ..options()
-                    },
-                    expect: Yields((r#"{"Id":"fw"}"#.to_string(), None)),
-                },
-                Case {
-                    scenario: "firmware-upgrade rejects invalid inline JSON",
-                    input: MaintenanceOptions {
-                        activities: Some(vec!["firmware-upgrade".to_string()]),
-                        firmware_version: Some("not-json".to_string()),
-                        access_token: Some("token".to_string()),
-                        ..options()
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "--firmware-version without a firmware-upgrade activity is rejected",
-                    input: MaintenanceOptions {
-                        firmware_version: Some(r#"{"Id":"fw"}"#.to_string()),
-                        ..options()
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "--access-token without a firmware-upgrade activity is rejected",
-                    input: MaintenanceOptions {
-                        access_token: Some("token".to_string()),
-                        ..options()
-                    },
-                    expect: Fails,
-                },
-            ],
-            |args| resolve_firmware_upgrade_source(&args).map_err(drop),
+        scenarios!(
+            run = |args| resolve_firmware_upgrade_source(&args).map_err(drop);
+            "firmware-upgrade without a SOT JSON source is rejected" {
+                MaintenanceOptions {
+                    activities: Some(vec!["firmware-upgrade".to_string()]),
+                    access_token: Some("token".to_string()),
+                    ..options()
+                } => Fails,
+            }
+
+            "firmware-upgrade with inline JSON allows a missing access token" {
+                MaintenanceOptions {
+                    activities: Some(vec!["firmware-upgrade".to_string()]),
+                    firmware_version: Some(r#"{"Id":"fw"}"#.to_string()),
+                    ..options()
+                } => Yields((r#"{"Id":"fw"}"#.to_string(), None)),
+            }
+
+            "firmware-upgrade treats an empty access token as missing" {
+                MaintenanceOptions {
+                    activities: Some(vec!["firmware-upgrade".to_string()]),
+                    firmware_version: Some(r#"{"Id":"fw"}"#.to_string()),
+                    access_token: Some(String::new()),
+                    ..options()
+                } => Yields((r#"{"Id":"fw"}"#.to_string(), None)),
+            }
+
+            "firmware-upgrade rejects invalid inline JSON" {
+                MaintenanceOptions {
+                    activities: Some(vec!["firmware-upgrade".to_string()]),
+                    firmware_version: Some("not-json".to_string()),
+                    access_token: Some("token".to_string()),
+                    ..options()
+                } => Fails,
+            }
+
+            "--firmware-version without a firmware-upgrade activity is rejected" {
+                MaintenanceOptions {
+                    firmware_version: Some(r#"{"Id":"fw"}"#.to_string()),
+                    ..options()
+                } => Fails,
+            }
+
+            "--access-token without a firmware-upgrade activity is rejected" {
+                MaintenanceOptions {
+                    access_token: Some("token".to_string()),
+                    ..options()
+                } => Fails,
+            }
         );
     }
 }

--- a/crates/admin-cli/src/rack/tests.rs
+++ b/crates/admin-cli/src/rack/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -50,27 +50,22 @@ fn verify_cmd_structure() {
 // racks (no rack), while a trailing identifier scopes it to that one rack.
 #[test]
 fn parse_show_routes_to_show_variant() {
-    check_cases(
-        [
-            Case {
-                scenario: "no args targets all racks",
-                input: &["rack", "show"][..],
-                expect: Yields(None),
-            },
-            Case {
-                scenario: "trailing identifier scopes to one rack",
-                input: &["rack", "show", "rack-123"][..],
-                expect: Yields(Some("rack-123".to_string())),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => args.rack.map(|r| r.to_string()),
                     _ => panic!("expected Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "no args targets all racks" {
+            &["rack", "show"][..] => Yields(None),
+        }
+
+        "trailing identifier scopes to one rack" {
+            &["rack", "show", "rack-123"][..] => Yields(Some("rack-123".to_string())),
+        }
     );
 }
 
@@ -113,23 +108,18 @@ fn parse_profile_show() {
 // profile-show left without its required rack identifier.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "delete without an identifier",
-                input: &["rack", "delete"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "profile show without a rack_id",
-                input: &["rack", "profile", "show"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "delete without an identifier" {
+            &["rack", "delete"][..] => Fails,
+        }
+
+        "profile show without a rack_id" {
+            &["rack", "profile", "show"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/redfish/tests.rs
+++ b/crates/admin-cli/src/redfish/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::args::*;
@@ -65,49 +65,39 @@ fn variant(cmd: &Cmd) -> &'static str {
 // a valid global --address.
 #[test]
 fn payload_free_subcommands_route_to_their_variant() {
-    check_cases(
-        [
-            Case {
-                scenario: "bios-attrs",
-                input: &["redfish", "--address", "192.0.2.10", "bios-attrs"][..],
-                expect: Yields("bios-attrs"),
-            },
-            Case {
-                scenario: "boot-hdd",
-                input: &["redfish", "--address", "192.0.2.10", "boot-hdd"][..],
-                expect: Yields("boot-hdd"),
-            },
-            Case {
-                scenario: "boot-pxe",
-                input: &["redfish", "--address", "192.0.2.10", "boot-pxe"][..],
-                expect: Yields("boot-pxe"),
-            },
-            Case {
-                scenario: "get-power-state",
-                input: &["redfish", "--address", "192.0.2.10", "get-power-state"][..],
-                expect: Yields("get-power-state"),
-            },
-            Case {
-                scenario: "force-off",
-                input: &["redfish", "--address", "192.0.2.10", "force-off"][..],
-                expect: Yields("force-off"),
-            },
-            Case {
-                scenario: "force-restart",
-                input: &["redfish", "--address", "192.0.2.10", "force-restart"][..],
-                expect: Yields("force-restart"),
-            },
-            Case {
-                scenario: "on",
-                input: &["redfish", "--address", "192.0.2.10", "on"][..],
-                expect: Yields("on"),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             RedfishAction::try_parse_from(argv.iter().copied())
                 .map(|a| variant(&a.command))
                 .map_err(drop)
-        },
+        };
+        "bios-attrs" {
+            &["redfish", "--address", "192.0.2.10", "bios-attrs"][..] => Yields("bios-attrs"),
+        }
+
+        "boot-hdd" {
+            &["redfish", "--address", "192.0.2.10", "boot-hdd"][..] => Yields("boot-hdd"),
+        }
+
+        "boot-pxe" {
+            &["redfish", "--address", "192.0.2.10", "boot-pxe"][..] => Yields("boot-pxe"),
+        }
+
+        "get-power-state" {
+            &["redfish", "--address", "192.0.2.10", "get-power-state"][..] => Yields("get-power-state"),
+        }
+
+        "force-off" {
+            &["redfish", "--address", "192.0.2.10", "force-off"][..] => Yields("force-off"),
+        }
+
+        "force-restart" {
+            &["redfish", "--address", "192.0.2.10", "force-restart"][..] => Yields("force-restart"),
+        }
+
+        "on" {
+            &["redfish", "--address", "192.0.2.10", "on"][..] => Yields("on"),
+        }
     );
 }
 
@@ -159,10 +149,17 @@ fn parse_with_credentials() {
 // new-password through to the CreateBmcUser variant.
 #[test]
 fn parse_create_bmc_user() {
-    check_cases(
-        [Case {
-            scenario: "create-bmc-user with user and new-password",
-            input: &[
+    scenarios!(
+        run = |argv| {
+            RedfishAction::try_parse_from(argv.iter().copied())
+                .map(|a| match a.command {
+                    Cmd::CreateBmcUser(args) => (args.user, args.new_password),
+                    _ => panic!("expected CreateBmcUser variant"),
+                })
+                .map_err(drop)
+        };
+        "create-bmc-user with user and new-password" {
+            &[
                 "redfish",
                 "--address",
                 "192.0.2.10",
@@ -171,17 +168,8 @@ fn parse_create_bmc_user() {
                 "secret",
                 "--user",
                 "admin",
-            ][..],
-            expect: Yields(("admin".to_string(), "secret".to_string())),
-        }],
-        |argv| {
-            RedfishAction::try_parse_from(argv.iter().copied())
-                .map(|a| match a.command {
-                    Cmd::CreateBmcUser(args) => (args.user, args.new_password),
-                    _ => panic!("expected CreateBmcUser variant"),
-                })
-                .map_err(drop)
-        },
+            ][..] => Yields(("admin".to_string(), "secret".to_string())),
+        }
     );
 }
 
@@ -189,26 +177,24 @@ fn parse_create_bmc_user() {
 // subcommands to the Dpu Firmware Status variant.
 #[test]
 fn parse_dpu_firmware_status() {
-    check_cases(
-        [Case {
-            scenario: "dpu firmware status",
-            input: &[
-                "redfish",
-                "--address",
-                "192.0.2.10",
-                "dpu",
-                "firmware",
-                "status",
-            ][..],
-            expect: Yields("dpu firmware status"),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             RedfishAction::try_parse_from(argv.iter().copied())
                 .map(|a| match a.command {
                     Cmd::Dpu(DpuOperations::Firmware(FwCommand::Status)) => "dpu firmware status",
                     _ => panic!("expected Dpu Firmware Status variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "dpu firmware status" {
+            &[
+                "redfish",
+                "--address",
+                "192.0.2.10",
+                "dpu",
+                "firmware",
+                "status",
+            ][..] => Yields("dpu firmware status"),
+        }
     );
 }

--- a/crates/admin-cli/src/resource_pool/tests.rs
+++ b/crates/admin-cli/src/resource_pool/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -58,37 +58,33 @@ fn variant(cmd: &Cmd) -> &'static str {
 // list parses with no arguments and routes to the List variant.
 #[test]
 fn parse_list() {
-    check_cases(
-        [Case {
-            scenario: "list with no arguments",
-            input: &["resource-pool", "list"][..],
-            expect: Yields("list"),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| variant(&cmd))
                 .map_err(drop)
-        },
+        };
+        "list with no arguments" {
+            &["resource-pool", "list"][..] => Yields("list"),
+        }
     );
 }
 
 // grow parses with --filename and surfaces that filename on the Grow variant.
 #[test]
 fn parse_grow() {
-    check_cases(
-        [Case {
-            scenario: "grow with --filename",
-            input: &["resource-pool", "grow", "--filename", "config.toml"][..],
-            expect: Yields("config.toml".to_string()),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Grow(args) => args.filename,
                     _ => panic!("expected Grow variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "grow with --filename" {
+            &["resource-pool", "grow", "--filename", "config.toml"][..] => Yields("config.toml".to_string()),
+        }
     );
 }
 
@@ -96,16 +92,14 @@ fn parse_grow() {
 // its required --filename.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [Case {
-            scenario: "grow without --filename",
-            input: &["resource-pool", "grow"][..],
-            expect: Fails,
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "grow without --filename" {
+            &["resource-pool", "grow"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/rms/tests.rs
+++ b/crates/admin-cli/src/rms/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::args::*;
@@ -67,41 +67,34 @@ fn route(cmd: &Cmd) -> (&'static str, String, String) {
 // the expected positional arguments.
 #[test]
 fn valid_invocations_route_to_their_subcommand() {
-    check_cases(
-        [
-            Case {
-                scenario: "inventory takes no args",
-                input: &["rms", "inventory"][..],
-                expect: Yields(("inventory", String::new(), String::new())),
-            },
-            Case {
-                scenario: "power-on-sequence carries rack_id",
-                input: &["rms", "power-on-sequence", "rack-123"][..],
-                expect: Yields(("power-on-sequence", "rack-123".to_string(), String::new())),
-            },
-            Case {
-                scenario: "power-state carries rack_id and node_id",
-                input: &["rms", "power-state", "rack-123", "node-123"][..],
-                expect: Yields((
-                    "power-state",
-                    "rack-123".to_string(),
-                    "node-123".to_string(),
-                )),
-            },
-            Case {
-                scenario: "firmware-inventory carries rack_id and node_id",
-                input: &["rms", "firmware-inventory", "rack-123", "node-123"][..],
-                expect: Yields((
-                    "firmware-inventory",
-                    "rack-123".to_string(),
-                    "node-123".to_string(),
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| route(&cmd))
                 .map_err(drop)
-        },
+        };
+        "inventory takes no args" {
+            &["rms", "inventory"][..] => Yields(("inventory", String::new(), String::new())),
+        }
+
+        "power-on-sequence carries rack_id" {
+            &["rms", "power-on-sequence", "rack-123"][..] => Yields(("power-on-sequence", "rack-123".to_string(), String::new())),
+        }
+
+        "power-state carries rack_id and node_id" {
+            &["rms", "power-state", "rack-123", "node-123"][..] => Yields((
+                "power-state",
+                "rack-123".to_string(),
+                "node-123".to_string(),
+            )),
+        }
+
+        "firmware-inventory carries rack_id and node_id" {
+            &["rms", "firmware-inventory", "rack-123", "node-123"][..] => Yields((
+                "firmware-inventory",
+                "rack-123".to_string(),
+                "node-123".to_string(),
+            )),
+        }
     );
 }

--- a/crates/admin-cli/src/route_server/tests.rs
+++ b/crates/admin-cli/src/route_server/tests.rs
@@ -25,7 +25,7 @@
 // ValueEnum Parsing - Test clap ValueEnum translations (if applicable).
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -62,29 +62,23 @@ fn verify_cmd_structure() {
 // `get` always, and `add`/`remove`/`replace` accept an empty IP list too.
 #[test]
 fn subcommands_route_to_their_variant() {
-    check_cases(
-        [
-            Case {
-                scenario: "get with no args",
-                input: &["route-server", "get"][..],
-                expect: Yields("get"),
-            },
-            Case {
-                scenario: "remove with an IP",
-                input: &["route-server", "remove", "192.168.1.1"][..],
-                expect: Yields("remove"),
-            },
-            Case {
-                scenario: "replace with an IP",
-                input: &["route-server", "replace", "192.168.1.1"][..],
-                expect: Yields("replace"),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| variant(&cmd))
                 .map_err(drop)
-        },
+        };
+        "get with no args" {
+            &["route-server", "get"][..] => Yields("get"),
+        }
+
+        "remove with an IP" {
+            &["route-server", "remove", "192.168.1.1"][..] => Yields("remove"),
+        }
+
+        "replace with an IP" {
+            &["route-server", "replace", "192.168.1.1"][..] => Yields("replace"),
+        }
     );
 }
 
@@ -102,39 +96,31 @@ fn ip_list_parses_for_each_subcommand() {
         }
     }
 
-    check_cases(
-        [
-            Case {
-                scenario: "add with a single IP",
-                input: &["route-server", "add", "192.168.1.1"][..],
-                expect: Yields(1),
-            },
-            Case {
-                scenario: "add with comma-separated IPs",
-                input: &["route-server", "add", "192.168.1.1,192.168.1.2,10.0.0.1"][..],
-                expect: Yields(3),
-            },
-            Case {
-                scenario: "add with no IPs",
-                input: &["route-server", "add"][..],
-                expect: Yields(0),
-            },
-            Case {
-                scenario: "remove with no IPs",
-                input: &["route-server", "remove"][..],
-                expect: Yields(0),
-            },
-            Case {
-                scenario: "replace with no IPs",
-                input: &["route-server", "replace"][..],
-                expect: Yields(0),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| ip_count(&cmd))
                 .map_err(drop)
-        },
+        };
+        "add with a single IP" {
+            &["route-server", "add", "192.168.1.1"][..] => Yields(1),
+        }
+
+        "add with comma-separated IPs" {
+            &["route-server", "add", "192.168.1.1,192.168.1.2,10.0.0.1"][..] => Yields(3),
+        }
+
+        "add with no IPs" {
+            &["route-server", "add"][..] => Yields(0),
+        }
+
+        "remove with no IPs" {
+            &["route-server", "remove"][..] => Yields(0),
+        }
+
+        "replace with no IPs" {
+            &["route-server", "replace"][..] => Yields(0),
+        }
     );
 }
 
@@ -142,20 +128,18 @@ fn ip_list_parses_for_each_subcommand() {
 // argument is parsed into a real address type rather than a raw string.
 #[test]
 fn parse_add_single_ip_renders_back() {
-    check_cases(
-        [Case {
-            scenario: "single IP round-trips its string form",
-            input: &["route-server", "add", "192.168.1.1"][..],
-            expect: Yields("192.168.1.1".to_string()),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Add(args) => args.inner.ip[0].to_string(),
                     _ => panic!("expected Add variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "single IP round-trips its string form" {
+            &["route-server", "add", "192.168.1.1"][..] => Yields("192.168.1.1".to_string()),
+        }
     );
 }
 
@@ -169,39 +153,34 @@ fn parse_add_single_ip_renders_back() {
 // config_file = 0, admin_api = 1. Yields the parsed source_type as i32.
 #[test]
 fn add_source_type_maps_to_proto_int() {
-    check_cases(
-        [
-            Case {
-                scenario: "admin_api is 1",
-                input: &[
-                    "route-server",
-                    "add",
-                    "192.168.1.1",
-                    "--source-type",
-                    "admin_api",
-                ][..],
-                expect: Yields(1),
-            },
-            Case {
-                scenario: "config_file is 0",
-                input: &[
-                    "route-server",
-                    "add",
-                    "192.168.1.1",
-                    "--source-type",
-                    "config_file",
-                ][..],
-                expect: Yields(0),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Add(args) => args.inner.source_type as i32,
                     _ => panic!("expected Add variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "admin_api is 1" {
+            &[
+                "route-server",
+                "add",
+                "192.168.1.1",
+                "--source-type",
+                "admin_api",
+            ][..] => Yields(1),
+        }
+
+        "config_file is 0" {
+            &[
+                "route-server",
+                "add",
+                "192.168.1.1",
+                "--source-type",
+                "config_file",
+            ][..] => Yields(0),
+        }
     );
 }
 
@@ -209,29 +188,24 @@ fn add_source_type_maps_to_proto_int() {
 // --source-type value, and a positional that isn't a valid IP address.
 #[test]
 fn invalid_add_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "unknown --source-type value",
-                input: &[
-                    "route-server",
-                    "add",
-                    "192.168.1.1",
-                    "--source-type",
-                    "invalid",
-                ][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "positional is not an IP",
-                input: &["route-server", "add", "not-an-ip"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "unknown --source-type value" {
+            &[
+                "route-server",
+                "add",
+                "192.168.1.1",
+                "--source-type",
+                "invalid",
+            ][..] => Fails,
+        }
+
+        "positional is not an IP" {
+            &["route-server", "add", "not-an-ip"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/scout_stream/tests.rs
+++ b/crates/admin-cli/src/scout_stream/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -52,17 +52,15 @@ fn verify_cmd_structure() {
 // variant.
 #[test]
 fn parse_show() {
-    check_cases(
-        [Case {
-            scenario: "show with no arguments",
-            input: &["scout-stream", "show"][..],
-            expect: Yields("show"),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             ScoutStreamAction::try_parse_from(argv.iter().copied())
                 .map(|a| variant(&a))
                 .map_err(drop)
-        },
+        };
+        "show with no arguments" {
+            &["scout-stream", "show"][..] => Yields("show"),
+        }
     );
 }
 
@@ -70,20 +68,8 @@ fn parse_show() {
 // to their respective variant; this table confirms each one round-trips the id.
 #[test]
 fn parse_machine_id_subcommands() {
-    check_cases(
-        [
-            Case {
-                scenario: "disconnect parses machine_id",
-                input: &["scout-stream", "disconnect", TEST_MACHINE_ID][..],
-                expect: Yields(("disconnect", TEST_MACHINE_ID.to_string())),
-            },
-            Case {
-                scenario: "ping parses machine_id",
-                input: &["scout-stream", "ping", TEST_MACHINE_ID][..],
-                expect: Yields(("ping", TEST_MACHINE_ID.to_string())),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             ScoutStreamAction::try_parse_from(argv.iter().copied())
                 .map(|a| match a {
                     ScoutStreamAction::Disconnect(cmd) => {
@@ -93,7 +79,14 @@ fn parse_machine_id_subcommands() {
                     _ => panic!("expected Disconnect or Ping variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "disconnect parses machine_id" {
+            &["scout-stream", "disconnect", TEST_MACHINE_ID][..] => Yields(("disconnect", TEST_MACHINE_ID.to_string())),
+        }
+
+        "ping parses machine_id" {
+            &["scout-stream", "ping", TEST_MACHINE_ID][..] => Yields(("ping", TEST_MACHINE_ID.to_string())),
+        }
     );
 }
 
@@ -101,24 +94,19 @@ fn parse_machine_id_subcommands() {
 // machine_id positional argument.
 #[test]
 fn missing_machine_id_is_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "disconnect without machine_id",
-                input: &["scout-stream", "disconnect"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "ping without machine_id",
-                input: &["scout-stream", "ping"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             ScoutStreamAction::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "disconnect without machine_id" {
+            &["scout-stream", "disconnect"][..] => Fails,
+        }
+
+        "ping without machine_id" {
+            &["scout-stream", "ping"][..] => Fails,
+        }
     );
 }
 

--- a/crates/admin-cli/src/set/tests.rs
+++ b/crates/admin-cli/src/set/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -51,29 +51,23 @@ fn verify_cmd_structure() {
 // --enable/--disable choice.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "log-filter without --filter",
-                input: &["set", "log-filter"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "create-machines without --enable/--disable",
-                input: &["set", "create-machines"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "site-explorer without --enable/--disable",
-                input: &["set", "site-explorer"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "log-filter without --filter" {
+            &["set", "log-filter"][..] => Fails,
+        }
+
+        "create-machines without --enable/--disable" {
+            &["set", "create-machines"][..] => Fails,
+        }
+
+        "site-explorer without --enable/--disable" {
+            &["set", "site-explorer"][..] => Fails,
+        }
     );
 }
 
@@ -81,34 +75,29 @@ fn invalid_invocations_are_rejected() {
 // defaults to "1h"; the yielded tuple is (filter, expiry).
 #[test]
 fn parse_log_filter_routes_to_variant() {
-    check_cases(
-        [
-            Case {
-                scenario: "filter only, expiry defaults",
-                input: &["set", "log-filter", "--filter", "debug"][..],
-                expect: Yields(("debug".to_string(), "1h".to_string())),
-            },
-            Case {
-                scenario: "filter with custom expiry",
-                input: &[
-                    "set",
-                    "log-filter",
-                    "--filter",
-                    "trace",
-                    "--expiry",
-                    "30min",
-                ][..],
-                expect: Yields(("trace".to_string(), "30min".to_string())),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::LogFilter(args) => (args.filter, args.expiry),
                     _ => panic!("expected LogFilter variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "filter only, expiry defaults" {
+            &["set", "log-filter", "--filter", "debug"][..] => Yields(("debug".to_string(), "1h".to_string())),
+        }
+
+        "filter with custom expiry" {
+            &[
+                "set",
+                "log-filter",
+                "--filter",
+                "trace",
+                "--expiry",
+                "30min",
+            ][..] => Yields(("trace".to_string(), "30min".to_string())),
+        }
     );
 }
 
@@ -116,27 +105,22 @@ fn parse_log_filter_routes_to_variant() {
 // is_enabled() == true, --disable yields false.
 #[test]
 fn parse_create_machines_toggle() {
-    check_cases(
-        [
-            Case {
-                scenario: "--enable",
-                input: &["set", "create-machines", "--enable"][..],
-                expect: Yields(true),
-            },
-            Case {
-                scenario: "--disable",
-                input: &["set", "create-machines", "--disable"][..],
-                expect: Yields(false),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::CreateMachines(args) => args.is_enabled(),
                     _ => panic!("expected CreateMachines variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "--enable" {
+            &["set", "create-machines", "--enable"][..] => Yields(true),
+        }
+
+        "--disable" {
+            &["set", "create-machines", "--disable"][..] => Yields(false),
+        }
     );
 }
 
@@ -144,27 +128,22 @@ fn parse_create_machines_toggle() {
 // is_enabled() == true, --disable yields false.
 #[test]
 fn parse_site_explorer_toggle() {
-    check_cases(
-        [
-            Case {
-                scenario: "--enable",
-                input: &["set", "site-explorer", "--enable"][..],
-                expect: Yields(true),
-            },
-            Case {
-                scenario: "--disable",
-                input: &["set", "site-explorer", "--disable"][..],
-                expect: Yields(false),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::SiteExplorer(args) => args.is_enabled(),
                     _ => panic!("expected SiteExplorer variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "--enable" {
+            &["set", "site-explorer", "--enable"][..] => Yields(true),
+        }
+
+        "--disable" {
+            &["set", "site-explorer", "--disable"][..] => Yields(false),
+        }
     );
 }
 
@@ -172,27 +151,25 @@ fn parse_site_explorer_toggle() {
 // (enabled, proxy).
 #[test]
 fn parse_bmc_proxy_routes_to_variant() {
-    check_cases(
-        [Case {
-            scenario: "enabled with a proxy address",
-            input: &[
-                "set",
-                "bmc-proxy",
-                "--enabled",
-                "true",
-                "--proxy",
-                "proxy.example.com:8080",
-            ][..],
-            expect: Yields((true, Some("proxy.example.com:8080".to_string()))),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::BmcProxy(args) => (args.enabled, args.proxy),
                     _ => panic!("expected BmcProxy variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "enabled with a proxy address" {
+            &[
+                "set",
+                "bmc-proxy",
+                "--enabled",
+                "true",
+                "--proxy",
+                "proxy.example.com:8080",
+            ][..] => Yields((true, Some("proxy.example.com:8080".to_string()))),
+        }
     );
 }
 
@@ -200,26 +177,21 @@ fn parse_bmc_proxy_routes_to_variant() {
 // value == true, "false" yields false.
 #[test]
 fn parse_tracing_enabled_value() {
-    check_cases(
-        [
-            Case {
-                scenario: "true",
-                input: &["set", "tracing-enabled", "true"][..],
-                expect: Yields(true),
-            },
-            Case {
-                scenario: "false",
-                input: &["set", "tracing-enabled", "false"][..],
-                expect: Yields(false),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::TracingEnabled(args) => args.value,
                     _ => panic!("expected TracingEnabled variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "true" {
+            &["set", "tracing-enabled", "true"][..] => Yields(true),
+        }
+
+        "false" {
+            &["set", "tracing-enabled", "false"][..] => Yields(false),
+        }
     );
 }

--- a/crates/admin-cli/src/site_explorer/tests.rs
+++ b/crates/admin-cli/src/site_explorer/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 use get_report::args::Args as GetReportMode;
 
@@ -94,33 +94,28 @@ fn parse_get_report_endpoint() {
 // (parsed address, whether a MAC was supplied).
 #[test]
 fn parse_explore() {
-    check_cases(
-        [
-            Case {
-                scenario: "address only, no mac",
-                input: &["site-explorer", "explore", "192.168.1.100"][..],
-                expect: Yields(("192.168.1.100".to_string(), false)),
-            },
-            Case {
-                scenario: "address with mac",
-                input: &[
-                    "site-explorer",
-                    "explore",
-                    "192.168.1.100",
-                    "--mac",
-                    "00:11:22:33:44:55",
-                ][..],
-                expect: Yields(("192.168.1.100".to_string(), true)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Explore(args) => (args.inner.address, args.inner.mac.is_some()),
                     _ => panic!("expected Explore variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "address only, no mac" {
+            &["site-explorer", "explore", "192.168.1.100"][..] => Yields(("192.168.1.100".to_string(), false)),
+        }
+
+        "address with mac" {
+            &[
+                "site-explorer",
+                "explore",
+                "192.168.1.100",
+                "--mac",
+                "00:11:22:33:44:55",
+            ][..] => Yields(("192.168.1.100".to_string(), true)),
+        }
     );
 }
 
@@ -187,16 +182,14 @@ fn parse_remediation() {
 // without its required positional address.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [Case {
-            scenario: "explore without an address",
-            input: &["site-explorer", "explore"][..],
-            expect: Fails,
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "explore without an address" {
+            &["site-explorer", "explore"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/sku/tests.rs
+++ b/crates/admin-cli/src/sku/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -52,24 +52,19 @@ fn verify_cmd_structure() {
 // positional sku_id (present).
 #[test]
 fn parse_show() {
-    check_cases(
-        [
-            Case {
-                scenario: "no args leaves sku_id unset",
-                input: &["sku", "show"][..],
-                expect: Yields(None),
-            },
-            Case {
-                scenario: "positional sku_id is captured",
-                input: &["sku", "show", "sku-123"][..],
-                expect: Yields(Some("sku-123".to_string())),
-            },
-        ],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
             Ok(Cmd::Show(args)) => Ok(args.sku_id),
             Ok(_) => panic!("expected Show variant"),
             Err(_) => Err(()),
-        },
+        };
+        "no args leaves sku_id unset" {
+            &["sku", "show"][..] => Yields(None),
+        }
+
+        "positional sku_id is captured" {
+            &["sku", "show", "sku-123"][..] => Yields(Some("sku-123".to_string())),
+        }
     );
 }
 
@@ -77,17 +72,15 @@ fn parse_show() {
 // inner args.
 #[test]
 fn parse_show_machines() {
-    check_cases(
-        [Case {
-            scenario: "positional sku_id is captured on inner",
-            input: &["sku", "show-machines", "sku-123"][..],
-            expect: Yields(Some("sku-123".to_string())),
-        }],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
             Ok(Cmd::ShowMachines(args)) => Ok(args.inner.sku_id),
             Ok(_) => panic!("expected ShowMachines variant"),
             Err(_) => Err(()),
-        },
+        };
+        "positional sku_id is captured on inner" {
+            &["sku", "show-machines", "sku-123"][..] => Yields(Some("sku-123".to_string())),
+        }
     );
 }
 
@@ -95,24 +88,19 @@ fn parse_show_machines() {
 // override; the tuple is (machine_id, id).
 #[test]
 fn parse_generate() {
-    check_cases(
-        [
-            Case {
-                scenario: "machine_id only leaves id unset",
-                input: &["sku", "generate", TEST_MACHINE_ID][..],
-                expect: Yields((TEST_MACHINE_ID.to_string(), None)),
-            },
-            Case {
-                scenario: "--id override is captured",
-                input: &["sku", "generate", TEST_MACHINE_ID, "--id", "custom-sku"][..],
-                expect: Yields((TEST_MACHINE_ID.to_string(), Some("custom-sku".to_string()))),
-            },
-        ],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
             Ok(Cmd::Generate(args)) => Ok((args.machine_id.to_string(), args.id)),
             Ok(_) => panic!("expected Generate variant"),
             Err(_) => Err(()),
-        },
+        };
+        "machine_id only leaves id unset" {
+            &["sku", "generate", TEST_MACHINE_ID][..] => Yields((TEST_MACHINE_ID.to_string(), None)),
+        }
+
+        "--id override is captured" {
+            &["sku", "generate", TEST_MACHINE_ID, "--id", "custom-sku"][..] => Yields((TEST_MACHINE_ID.to_string(), Some("custom-sku".to_string()))),
+        }
     );
 }
 
@@ -120,34 +108,30 @@ fn parse_generate() {
 // The tuple is (filename, id).
 #[test]
 fn parse_create() {
-    check_cases(
-        [Case {
-            scenario: "filename captured, id unset",
-            input: &["sku", "create", "sku.json"][..],
-            expect: Yields(("sku.json".to_string(), None)),
-        }],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
             Ok(Cmd::Create(args)) => Ok((args.filename, args.id)),
             Ok(_) => panic!("expected Create variant"),
             Err(_) => Err(()),
-        },
+        };
+        "filename captured, id unset" {
+            &["sku", "create", "sku.json"][..] => Yields(("sku.json".to_string(), None)),
+        }
     );
 }
 
 // delete parses with a positional sku_id.
 #[test]
 fn parse_delete() {
-    check_cases(
-        [Case {
-            scenario: "positional sku_id is captured",
-            input: &["sku", "delete", "sku-123"][..],
-            expect: Yields("sku-123".to_string()),
-        }],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
             Ok(Cmd::Delete(args)) => Ok(args.sku_id),
             Ok(_) => panic!("expected Delete variant"),
             Err(_) => Err(()),
-        },
+        };
+        "positional sku_id is captured" {
+            &["sku", "delete", "sku-123"][..] => Yields("sku-123".to_string()),
+        }
     );
 }
 
@@ -155,24 +139,19 @@ fn parse_delete() {
 // flag. The tuple is (sku_id, machine_id, force).
 #[test]
 fn parse_assign() {
-    check_cases(
-        [
-            Case {
-                scenario: "force defaults off",
-                input: &["sku", "assign", "sku-123", TEST_MACHINE_ID][..],
-                expect: Yields(("sku-123".to_string(), TEST_MACHINE_ID.to_string(), false)),
-            },
-            Case {
-                scenario: "--force flag sets force",
-                input: &["sku", "assign", "sku-123", TEST_MACHINE_ID, "--force"][..],
-                expect: Yields(("sku-123".to_string(), TEST_MACHINE_ID.to_string(), true)),
-            },
-        ],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
             Ok(Cmd::Assign(args)) => Ok((args.sku_id, args.machine_id.to_string(), args.force)),
             Ok(_) => panic!("expected Assign variant"),
             Err(_) => Err(()),
-        },
+        };
+        "force defaults off" {
+            &["sku", "assign", "sku-123", TEST_MACHINE_ID][..] => Yields(("sku-123".to_string(), TEST_MACHINE_ID.to_string(), false)),
+        }
+
+        "--force flag sets force" {
+            &["sku", "assign", "sku-123", TEST_MACHINE_ID, "--force"][..] => Yields(("sku-123".to_string(), TEST_MACHINE_ID.to_string(), true)),
+        }
     );
 }
 
@@ -180,34 +159,30 @@ fn parse_assign() {
 // is (machine_id, force).
 #[test]
 fn parse_unassign() {
-    check_cases(
-        [Case {
-            scenario: "machine_id captured, force defaults off",
-            input: &["sku", "unassign", TEST_MACHINE_ID][..],
-            expect: Yields((TEST_MACHINE_ID.to_string(), false)),
-        }],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
             Ok(Cmd::Unassign(args)) => Ok((args.machine_id.to_string(), args.force)),
             Ok(_) => panic!("expected Unassign variant"),
             Err(_) => Err(()),
-        },
+        };
+        "machine_id captured, force defaults off" {
+            &["sku", "unassign", TEST_MACHINE_ID][..] => Yields((TEST_MACHINE_ID.to_string(), false)),
+        }
     );
 }
 
 // verify parses with a machine_id.
 #[test]
 fn parse_verify() {
-    check_cases(
-        [Case {
-            scenario: "machine_id is captured",
-            input: &["sku", "verify", TEST_MACHINE_ID][..],
-            expect: Yields(TEST_MACHINE_ID.to_string()),
-        }],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
             Ok(Cmd::Verify(args)) => Ok(args.machine_id.to_string()),
             Ok(_) => panic!("expected Verify variant"),
             Err(_) => Err(()),
-        },
+        };
+        "machine_id is captured" {
+            &["sku", "verify", TEST_MACHINE_ID][..] => Yields(TEST_MACHINE_ID.to_string()),
+        }
     );
 }
 
@@ -215,59 +190,53 @@ fn parse_verify() {
 // defaults to unset. The tuple is (sku_id, description, device_type).
 #[test]
 fn parse_update_metadata() {
-    check_cases(
-        [Case {
-            scenario: "sku_id and description captured, device_type unset",
-            input: &[
-                "sku",
-                "update-metadata",
-                "sku-123",
-                "--description",
-                "New desc",
-            ][..],
-            expect: Yields(("sku-123".to_string(), Some("New desc".to_string()), true)),
-        }],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
             Ok(Cmd::UpdateMetadata(args)) => {
                 Ok((args.sku_id, args.description, args.device_type.is_none()))
             }
             Ok(_) => panic!("expected UpdateMetadata variant"),
             Err(_) => Err(()),
-        },
+        };
+        "sku_id and description captured, device_type unset" {
+            &[
+                "sku",
+                "update-metadata",
+                "sku-123",
+                "--description",
+                "New desc",
+            ][..] => Yields(("sku-123".to_string(), Some("New desc".to_string()), true)),
+        }
     );
 }
 
 // bulk-update-metadata parses with a positional filename.
 #[test]
 fn parse_bulk_update_metadata() {
-    check_cases(
-        [Case {
-            scenario: "filename is captured",
-            input: &["sku", "bulk-update-metadata", "updates.csv"][..],
-            expect: Yields("updates.csv".to_string()),
-        }],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
             Ok(Cmd::BulkUpdateMetadata(args)) => Ok(args.filename),
             Ok(_) => panic!("expected BulkUpdateMetadata variant"),
             Err(_) => Err(()),
-        },
+        };
+        "filename is captured" {
+            &["sku", "bulk-update-metadata", "updates.csv"][..] => Yields("updates.csv".to_string()),
+        }
     );
 }
 
 // replace parses with a positional filename, captured on the inner args.
 #[test]
 fn parse_replace() {
-    check_cases(
-        [Case {
-            scenario: "filename is captured on inner",
-            input: &["sku", "replace", "sku.json"][..],
-            expect: Yields("sku.json".to_string()),
-        }],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
             Ok(Cmd::Replace(args)) => Ok(args.inner.filename),
             Ok(_) => panic!("expected Replace variant"),
             Err(_) => Err(()),
-        },
+        };
+        "filename is captured on inner" {
+            &["sku", "replace", "sku.json"][..] => Yields("sku.json".to_string()),
+        }
     );
 }
 
@@ -276,23 +245,18 @@ fn parse_replace() {
 // description nor a device_type to change.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "generate without machine_id",
-                input: &["sku", "generate"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "update-metadata without description or device_type",
-                input: &["sku", "update-metadata", "sku-123"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "generate without machine_id" {
+            &["sku", "generate"][..] => Fails,
+        }
+
+        "update-metadata without description or device_type" {
+            &["sku", "update-metadata", "sku-123"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/spx_partition/tests.rs
+++ b/crates/admin-cli/src/spx_partition/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -51,30 +51,24 @@ fn verify_cmd_structure() {
 // through. Each row yields the (id, tenant_org_id, name) the originals asserted.
 #[test]
 fn show_parses_optional_filters() {
-    check_cases(
-        [
-            Case {
-                scenario: "no args (all partitions)",
-                input: &["ib-partition", "show"][..],
-                expect: Yields((None, None, None)),
-            },
-            Case {
-                scenario: "with --tenant-org-id",
-                input: &["ib-partition", "show", "--tenant-org-id", "tenant-123"][..],
-                expect: Yields((None, Some("tenant-123".to_string()), None)),
-            },
-            Case {
-                scenario: "with --name",
-                input: &["ib-partition", "show", "--name", "my-partition"][..],
-                expect: Yields((None, None, Some("my-partition".to_string()))),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => (args.id, args.tenant_org_id, args.name),
                 })
                 .map_err(drop)
-        },
+        };
+        "no args (all partitions)" {
+            &["ib-partition", "show"][..] => Yields((None, None, None)),
+        }
+
+        "with --tenant-org-id" {
+            &["ib-partition", "show", "--tenant-org-id", "tenant-123"][..] => Yields((None, Some("tenant-123".to_string()), None)),
+        }
+
+        "with --name" {
+            &["ib-partition", "show", "--name", "my-partition"][..] => Yields((None, None, Some("my-partition".to_string()))),
+        }
     );
 }

--- a/crates/admin-cli/src/ssh/tests.rs
+++ b/crates/admin-cli/src/ssh/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -50,23 +50,8 @@ fn verify_cmd_structure() {
 // with credentials and routes them onto the credential fields.
 #[test]
 fn parse_get_rshim_status() {
-    check_cases(
-        [Case {
-            scenario: "get-rshim-status with credentials",
-            input: &[
-                "ssh",
-                "get-rshim-status",
-                "192.168.1.100:443",
-                "admin",
-                "password123",
-            ][..],
-            expect: Yields((
-                "192.168.1.100:443".to_string(),
-                "admin".to_string(),
-                "password123".to_string(),
-            )),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::GetRshimStatus(args) => (
@@ -77,34 +62,45 @@ fn parse_get_rshim_status() {
                     _ => panic!("expected GetRshimStatus variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "get-rshim-status with credentials" {
+            &[
+                "ssh",
+                "get-rshim-status",
+                "192.168.1.100:443",
+                "admin",
+                "password123",
+            ][..] => Yields((
+                "192.168.1.100:443".to_string(),
+                "admin".to_string(),
+                "password123".to_string(),
+            )),
+        }
     );
 }
 
 // parse_copy_bfb ensures copy-bfb parses with bfb_path.
 #[test]
 fn parse_copy_bfb() {
-    check_cases(
-        [Case {
-            scenario: "copy-bfb with bfb path",
-            input: &[
-                "ssh",
-                "copy-bfb",
-                "192.168.1.100:443",
-                "admin",
-                "password123",
-                "/path/to/image.bfb",
-            ][..],
-            expect: Yields("/path/to/image.bfb".to_string()),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::CopyBfb(args) => args.bfb_path,
                     _ => panic!("expected CopyBfb variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "copy-bfb with bfb path" {
+            &[
+                "ssh",
+                "copy-bfb",
+                "192.168.1.100:443",
+                "admin",
+                "password123",
+                "/path/to/image.bfb",
+            ][..] => Yields("/path/to/image.bfb".to_string()),
+        }
     );
 }
 
@@ -120,63 +116,55 @@ fn credential_subcommands_route_to_variant() {
         }
     }
 
-    check_cases(
-        [
-            Case {
-                scenario: "disable-rshim routes to DisableRshim",
-                input: &[
-                    "ssh",
-                    "disable-rshim",
-                    "192.168.1.100:443",
-                    "admin",
-                    "password123",
-                ][..],
-                expect: Yields("disable-rshim"),
-            },
-            Case {
-                scenario: "enable-rshim routes to EnableRshim",
-                input: &[
-                    "ssh",
-                    "enable-rshim",
-                    "192.168.1.100:443",
-                    "admin",
-                    "password123",
-                ][..],
-                expect: Yields("enable-rshim"),
-            },
-            Case {
-                scenario: "show-obmc-log routes to ShowObmcLog",
-                input: &[
-                    "ssh",
-                    "show-obmc-log",
-                    "192.168.1.100:443",
-                    "admin",
-                    "password123",
-                ][..],
-                expect: Yields("show-obmc-log"),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| variant(&cmd))
                 .map_err(drop)
-        },
+        };
+        "disable-rshim routes to DisableRshim" {
+            &[
+                "ssh",
+                "disable-rshim",
+                "192.168.1.100:443",
+                "admin",
+                "password123",
+            ][..] => Yields("disable-rshim"),
+        }
+
+        "enable-rshim routes to EnableRshim" {
+            &[
+                "ssh",
+                "enable-rshim",
+                "192.168.1.100:443",
+                "admin",
+                "password123",
+            ][..] => Yields("enable-rshim"),
+        }
+
+        "show-obmc-log routes to ShowObmcLog" {
+            &[
+                "ssh",
+                "show-obmc-log",
+                "192.168.1.100:443",
+                "admin",
+                "password123",
+            ][..] => Yields("show-obmc-log"),
+        }
     );
 }
 
 // Every malformed invocation is rejected at parse time.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [Case {
-            scenario: "get-rshim-status without username and password",
-            input: &["ssh", "get-rshim-status", "192.168.1.100:443"][..],
-            expect: Fails,
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "get-rshim-status without username and password" {
+            &["ssh", "get-rshim-status", "192.168.1.100:443"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/switch/tests.rs
+++ b/crates/admin-cli/src/switch/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use carbide_uuid::switch::SwitchId;
 use clap::{CommandFactory, Parser};
 
@@ -55,27 +55,22 @@ fn parse_show_routes_to_show() {
 
     let switch_id = "sw100nsmnq69j4ntqlj162fnnbvg747gfqbicaa6tqgq6spocirfle7rom0";
 
-    check_cases(
-        [
-            Case {
-                scenario: "no args parses with no switch id",
-                input: &["switch", "show"][..],
-                expect: Yields(None),
-            },
-            Case {
-                scenario: "an identifier parses to that switch id",
-                input: &["switch", "show", switch_id][..],
-                expect: Yields(Some(SwitchId::from_str(switch_id).unwrap())),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => args.switch_id,
                     _ => panic!("expected Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "no args parses with no switch id" {
+            &["switch", "show"][..] => Yields(None),
+        }
+
+        "an identifier parses to that switch id" {
+            &["switch", "show", switch_id][..] => Yields(Some(SwitchId::from_str(switch_id).unwrap())),
+        }
     );
 }
 
@@ -85,29 +80,8 @@ fn parse_show_routes_to_show() {
 // (deleted == Only, controller_state, bmc_mac.is_some()).
 #[test]
 fn parse_list_routes_to_list() {
-    check_cases(
-        [
-            Case {
-                scenario: "no args parses with default filters",
-                input: &["switch", "list"][..],
-                expect: Yields((false, None, false)),
-            },
-            Case {
-                scenario: "filter flags parse onto the args",
-                input: &[
-                    "switch",
-                    "list",
-                    "--deleted",
-                    "only",
-                    "--controller-state",
-                    "ready",
-                    "--bmc-mac",
-                    "AA:BB:CC:DD:EE:FF",
-                ][..],
-                expect: Yields((true, Some("ready".to_string()), true)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::List(args) => (
@@ -118,7 +92,23 @@ fn parse_list_routes_to_list() {
                     _ => panic!("expected List variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "no args parses with default filters" {
+            &["switch", "list"][..] => Yields((false, None, false)),
+        }
+
+        "filter flags parse onto the args" {
+            &[
+                "switch",
+                "list",
+                "--deleted",
+                "only",
+                "--controller-state",
+                "ready",
+                "--bmc-mac",
+                "AA:BB:CC:DD:EE:FF",
+            ][..] => Yields((true, Some("ready".to_string()), true)),
+        }
     );
 }
 
@@ -126,23 +116,18 @@ fn parse_list_routes_to_list() {
 // `--deleted` value, or a `--bmc-mac` that isn't a MAC address.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "list with an invalid --deleted value",
-                input: &["switch", "list", "--deleted", "bogus"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "list with an invalid --bmc-mac",
-                input: &["switch", "list", "--bmc-mac", "not-a-mac"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "list with an invalid --deleted value" {
+            &["switch", "list", "--deleted", "bogus"][..] => Fails,
+        }
+
+        "list with an invalid --bmc-mac" {
+            &["switch", "list", "--bmc-mac", "not-a-mac"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/tenant/tests.rs
+++ b/crates/admin-cli/src/tenant/tests.rs
@@ -25,7 +25,7 @@
 // Routing Profile Parsing - Ensure profile strings are accepted unchanged.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -51,24 +51,19 @@ fn verify_cmd_structure() {
 // value flows straight through, so each row yields the resulting Option.
 #[test]
 fn parse_show_tenant_org() {
-    check_cases(
-        [
-            Case {
-                scenario: "no arguments",
-                input: &["tenant", "show"][..],
-                expect: Yields(None),
-            },
-            Case {
-                scenario: "with tenant_org",
-                input: &["tenant", "show", "org-123"][..],
-                expect: Yields(Some("org-123".to_string())),
-            },
-        ],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
             Ok(Cmd::Show(args)) => Ok(args.tenant_org),
             Ok(_) => panic!("expected Show variant"),
             Err(_) => Err(()),
-        },
+        };
+        "no arguments" {
+            &["tenant", "show"][..] => Yields(None),
+        }
+
+        "with tenant_org" {
+            &["tenant", "show", "org-123"][..] => Yields(Some("org-123".to_string())),
+        }
     );
 }
 
@@ -76,40 +71,8 @@ fn parse_show_tenant_org() {
 // row yields the full (tenant_org, routing_profile_type, version, name) tuple.
 #[test]
 fn parse_update_fields() {
-    check_cases(
-        [
-            Case {
-                scenario: "tenant_org only",
-                input: &["tenant", "update", "org-123"][..],
-                expect: Yields(("org-123".to_string(), None, None, None)),
-            },
-            Case {
-                scenario: "with -p routing profile",
-                input: &["tenant", "update", "org-123", "-p", "profile-a"][..],
-                expect: Yields((
-                    "org-123".to_string(),
-                    Some("profile-a".to_string()),
-                    None,
-                    None,
-                )),
-            },
-            Case {
-                scenario: "with -v version",
-                input: &["tenant", "update", "org-123", "-v", "1.0"][..],
-                expect: Yields(("org-123".to_string(), None, Some("1.0".to_string()), None)),
-            },
-            Case {
-                scenario: "with -n name",
-                input: &["tenant", "update", "org-123", "-n", "New Name"][..],
-                expect: Yields((
-                    "org-123".to_string(),
-                    None,
-                    None,
-                    Some("New Name".to_string()),
-                )),
-            },
-        ],
-        |argv| match Cmd::try_parse_from(argv.iter().copied()) {
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied()) {
             Ok(Cmd::Update(args)) => Ok((
                 args.tenant_org,
                 args.routing_profile_type,
@@ -118,7 +81,32 @@ fn parse_update_fields() {
             )),
             Ok(_) => panic!("expected Update variant"),
             Err(_) => Err(()),
-        },
+        };
+        "tenant_org only" {
+            &["tenant", "update", "org-123"][..] => Yields(("org-123".to_string(), None, None, None)),
+        }
+
+        "with -p routing profile" {
+            &["tenant", "update", "org-123", "-p", "profile-a"][..] => Yields((
+                "org-123".to_string(),
+                Some("profile-a".to_string()),
+                None,
+                None,
+            )),
+        }
+
+        "with -v version" {
+            &["tenant", "update", "org-123", "-v", "1.0"][..] => Yields(("org-123".to_string(), None, Some("1.0".to_string()), None)),
+        }
+
+        "with -n name" {
+            &["tenant", "update", "org-123", "-n", "New Name"][..] => Yields((
+                "org-123".to_string(),
+                None,
+                None,
+                Some("New Name".to_string()),
+            )),
+        }
     );
 }
 
@@ -126,16 +114,14 @@ fn parse_update_fields() {
 // required tenant_org positional omitted.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [Case {
-            scenario: "update without tenant_org",
-            input: &["tenant", "update"][..],
-            expect: Fails,
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "update without tenant_org" {
+            &["tenant", "update"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/tenant_keyset/tests.rs
+++ b/crates/admin-cli/src/tenant_keyset/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -51,45 +51,38 @@ fn verify_cmd_structure() {
 // Each row yields the parsed (id, tenant_org_id) pair.
 #[test]
 fn parse_show_arg_combinations() {
-    check_cases(
-        [
-            Case {
-                scenario: "no arguments (all keysets)",
-                input: &["tenant-keyset", "show"][..],
-                expect: Yields((String::new(), None)),
-            },
-            Case {
-                scenario: "with keyset id",
-                input: &["tenant-keyset", "show", "org-123/keyset-456"][..],
-                expect: Yields(("org-123/keyset-456".to_string(), None)),
-            },
-            Case {
-                scenario: "with --tenant-org-id",
-                input: &["tenant-keyset", "show", "--tenant-org-id", "org-123"][..],
-                expect: Yields((String::new(), Some("org-123".to_string()))),
-            },
-            Case {
-                scenario: "with both id and --tenant-org-id",
-                input: &[
-                    "tenant-keyset",
-                    "show",
-                    "org-123/keyset-456",
-                    "--tenant-org-id",
-                    "org-123",
-                ][..],
-                expect: Yields((
-                    "org-123/keyset-456".to_string(),
-                    Some("org-123".to_string()),
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| {
                     let Cmd::Show(args) = cmd;
                     (args.id, args.tenant_org_id)
                 })
                 .map_err(drop)
-        },
+        };
+        "no arguments (all keysets)" {
+            &["tenant-keyset", "show"][..] => Yields((String::new(), None)),
+        }
+
+        "with keyset id" {
+            &["tenant-keyset", "show", "org-123/keyset-456"][..] => Yields(("org-123/keyset-456".to_string(), None)),
+        }
+
+        "with --tenant-org-id" {
+            &["tenant-keyset", "show", "--tenant-org-id", "org-123"][..] => Yields((String::new(), Some("org-123".to_string()))),
+        }
+
+        "with both id and --tenant-org-id" {
+            &[
+                "tenant-keyset",
+                "show",
+                "org-123/keyset-456",
+                "--tenant-org-id",
+                "org-123",
+            ][..] => Yields((
+                "org-123/keyset-456".to_string(),
+                Some("org-123".to_string()),
+            )),
+        }
     );
 }

--- a/crates/admin-cli/src/tpm_ca/tests.rs
+++ b/crates/admin-cli/src/tpm_ca/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -58,79 +58,74 @@ fn parse_routes_argument_free_subcommands() {
         }
     }
 
-    check_cases(
-        [
-            Case {
-                scenario: "show parses with no arguments",
-                input: &["tpm-ca", "show"][..],
-                expect: Yields("show"),
-            },
-            Case {
-                scenario: "show-unmatched-ek parses with no arguments",
-                input: &["tpm-ca", "show-unmatched-ek"][..],
-                expect: Yields("show-unmatched-ek"),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| variant(&cmd))
                 .map_err(drop)
-        },
+        };
+        "show parses with no arguments" {
+            &["tpm-ca", "show"][..] => Yields("show"),
+        }
+
+        "show-unmatched-ek parses with no arguments" {
+            &["tpm-ca", "show-unmatched-ek"][..] => Yields("show-unmatched-ek"),
+        }
     );
 }
 
 // parse_delete ensures delete parses with ca_id.
 #[test]
 fn parse_delete() {
-    Case {
-        scenario: "delete parses with --ca-id",
-        input: &["tpm-ca", "delete", "--ca-id", "123"][..],
-        expect: Yields(123),
-    }
-    .check(|argv| {
-        Cmd::try_parse_from(argv.iter().copied())
-            .map(|cmd| match cmd {
-                Cmd::Delete(args) => args.ca_id,
-                _ => panic!("expected Delete variant"),
-            })
-            .map_err(drop)
-    });
+    scenarios!(
+        run = |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Delete(args) => args.ca_id,
+                    _ => panic!("expected Delete variant"),
+                })
+                .map_err(drop)
+        };
+        "delete parses with --ca-id" {
+            &["tpm-ca", "delete", "--ca-id", "123"][..] => Yields(123),
+        }
+    );
 }
 
 // parse_add ensures add parses with filename.
 #[test]
 fn parse_add() {
-    Case {
-        scenario: "add parses with --filename",
-        input: &["tpm-ca", "add", "--filename", "ca.pem"][..],
-        expect: Yields("ca.pem".to_string()),
-    }
-    .check(|argv| {
-        Cmd::try_parse_from(argv.iter().copied())
-            .map(|cmd| match cmd {
-                Cmd::Add(args) => args.filename,
-                _ => panic!("expected Add variant"),
-            })
-            .map_err(drop)
-    });
+    scenarios!(
+        run = |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Add(args) => args.filename,
+                    _ => panic!("expected Add variant"),
+                })
+                .map_err(drop)
+        };
+        "add parses with --filename" {
+            &["tpm-ca", "add", "--filename", "ca.pem"][..] => Yields("ca.pem".to_string()),
+        }
+    );
 }
 
 // parse_add_bulk ensures add-bulk parses with dirname.
 #[test]
 fn parse_add_bulk() {
-    Case {
-        scenario: "add-bulk parses with --dirname",
-        input: &["tpm-ca", "add-bulk", "--dirname", "/path/to/certs"][..],
-        expect: Yields("/path/to/certs".to_string()),
-    }
-    .check(|argv| {
-        Cmd::try_parse_from(argv.iter().copied())
-            .map(|cmd| match cmd {
-                Cmd::AddBulk(args) => args.dirname,
-                _ => panic!("expected AddBulk variant"),
-            })
-            .map_err(drop)
-    });
+    scenarios!(
+        run = |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::AddBulk(args) => args.dirname,
+                    _ => panic!("expected AddBulk variant"),
+                })
+                .map_err(drop)
+        };
+        "add-bulk parses with --dirname" {
+            &["tpm-ca", "add-bulk", "--dirname", "/path/to/certs"][..] => Yields("/path/to/certs".to_string()),
+        }
+    );
 }
 
 // Every subcommand that takes a required argument is rejected at parse time when
@@ -138,28 +133,22 @@ fn parse_add_bulk() {
 // add-bulk without --dirname.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "delete without --ca-id",
-                input: &["tpm-ca", "delete"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "add without --filename",
-                input: &["tpm-ca", "add"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "add-bulk without --dirname",
-                input: &["tpm-ca", "add-bulk"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "delete without --ca-id" {
+            &["tpm-ca", "delete"][..] => Fails,
+        }
+
+        "add without --filename" {
+            &["tpm-ca", "add"][..] => Fails,
+        }
+
+        "add-bulk without --dirname" {
+            &["tpm-ca", "add-bulk"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/trim_table/tests.rs
+++ b/crates/admin-cli/src/trim_table/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -50,31 +50,25 @@ fn verify_cmd_structure() {
 // through verbatim: a typical count, zero, and a large value all parse.
 #[test]
 fn parse_measured_boot_keep_entries() {
-    check_cases(
-        [
-            Case {
-                scenario: "typical count",
-                input: &["trim-table", "measured-boot", "--keep-entries", "100"][..],
-                expect: Yields(100),
-            },
-            Case {
-                scenario: "zero entries",
-                input: &["trim-table", "measured-boot", "--keep-entries", "0"][..],
-                expect: Yields(0),
-            },
-            Case {
-                scenario: "large value",
-                input: &["trim-table", "measured-boot", "--keep-entries", "1000000"][..],
-                expect: Yields(1000000),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::MeasuredBoot(args) => args.keep_entries,
                 })
                 .map_err(drop)
-        },
+        };
+        "typical count" {
+            &["trim-table", "measured-boot", "--keep-entries", "100"][..] => Yields(100),
+        }
+
+        "zero entries" {
+            &["trim-table", "measured-boot", "--keep-entries", "0"][..] => Yields(0),
+        }
+
+        "large value" {
+            &["trim-table", "measured-boot", "--keep-entries", "1000000"][..] => Yields(1000000),
+        }
     );
 }
 
@@ -82,28 +76,22 @@ fn parse_measured_boot_keep_entries() {
 // required --keep-entries, a non-numeric value, and a negative value.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "missing --keep-entries",
-                input: &["trim-table", "measured-boot"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "non-numeric value",
-                input: &["trim-table", "measured-boot", "--keep-entries", "abc"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "negative value",
-                input: &["trim-table", "measured-boot", "--keep-entries", "-1"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "missing --keep-entries" {
+            &["trim-table", "measured-boot"][..] => Fails,
+        }
+
+        "non-numeric value" {
+            &["trim-table", "measured-boot", "--keep-entries", "abc"][..] => Fails,
+        }
+
+        "negative value" {
+            &["trim-table", "measured-boot", "--keep-entries", "-1"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/version/tests.rs
+++ b/crates/admin-cli/src/version/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::args::*;
@@ -50,28 +50,22 @@ fn verify_cmd_structure() {
 // its short `-s` or long form -- each invocation parses and yields the flag.
 #[test]
 fn parse_show_runtime_config_flag() {
-    check_cases(
-        [
-            Case {
-                scenario: "no args defaults the flag off",
-                input: &["version"][..],
-                expect: Yields(false),
-            },
-            Case {
-                scenario: "-s turns the flag on",
-                input: &["version", "-s"][..],
-                expect: Yields(true),
-            },
-            Case {
-                scenario: "--show-runtime-config turns the flag on",
-                input: &["version", "--show-runtime-config"][..],
-                expect: Yields(true),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Opts::try_parse_from(argv.iter().copied())
                 .map(|opts| opts.show_runtime_config)
                 .map_err(drop)
-        },
+        };
+        "no args defaults the flag off" {
+            &["version"][..] => Yields(false),
+        }
+
+        "-s turns the flag on" {
+            &["version", "-s"][..] => Yields(true),
+        }
+
+        "--show-runtime-config turns the flag on" {
+            &["version", "--show-runtime-config"][..] => Yields(true),
+        }
     );
 }

--- a/crates/admin-cli/src/vpc/tests.rs
+++ b/crates/admin-cli/src/vpc/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::{Case, check_cases, scenarios};
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -116,30 +116,24 @@ fn parse_show_routes_and_captures_filters() {
 // etv_nvue all parse to the SetVirtualizer variant carrying the id.
 #[test]
 fn parse_set_virtualizer_routes_with_id() {
-    check_cases(
-        [
-            Case {
-                scenario: "fnn virtualizer",
-                input: &["vpc", "set-virtualizer", TEST_VPC_ID, "fnn"][..],
-                expect: Yields(TEST_VPC_ID.to_string()),
-            },
-            Case {
-                scenario: "etv virtualizer",
-                input: &["vpc", "set-virtualizer", TEST_VPC_ID, "etv"][..],
-                expect: Yields(TEST_VPC_ID.to_string()),
-            },
-            Case {
-                scenario: "etv_nvue virtualizer",
-                input: &["vpc", "set-virtualizer", TEST_VPC_ID, "etv_nvue"][..],
-                expect: Yields(TEST_VPC_ID.to_string()),
-            },
-        ],
-        |argv| match Cmd::try_parse_from(argv.iter().copied())
+    scenarios!(
+        run = |argv| match Cmd::try_parse_from(argv.iter().copied())
             .expect("should parse set-virtualizer")
         {
             Cmd::SetVirtualizer(args) => Ok::<_, ()>(args.id.to_string()),
             _ => panic!("expected SetVirtualizer variant"),
-        },
+        };
+        "fnn virtualizer" {
+            &["vpc", "set-virtualizer", TEST_VPC_ID, "fnn"][..] => Yields(TEST_VPC_ID.to_string()),
+        }
+
+        "etv virtualizer" {
+            &["vpc", "set-virtualizer", TEST_VPC_ID, "etv"][..] => Yields(TEST_VPC_ID.to_string()),
+        }
+
+        "etv_nvue virtualizer" {
+            &["vpc", "set-virtualizer", TEST_VPC_ID, "etv_nvue"][..] => Yields(TEST_VPC_ID.to_string()),
+        }
     );
 }
 
@@ -147,23 +141,18 @@ fn parse_set_virtualizer_routes_with_id() {
 // missing both positional arguments, or an unknown virtualizer name.
 #[test]
 fn invalid_set_virtualizer_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "missing id and virtualizer",
-                input: &["vpc", "set-virtualizer"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "invalid virtualizer name",
-                input: &["vpc", "set-virtualizer", TEST_VPC_ID, "invalid"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "missing id and virtualizer" {
+            &["vpc", "set-virtualizer"][..] => Fails,
+        }
+
+        "invalid virtualizer name" {
+            &["vpc", "set-virtualizer", TEST_VPC_ID, "invalid"][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/vpc_peering/tests.rs
+++ b/crates/admin-cli/src/vpc_peering/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -54,20 +54,18 @@ fn verify_cmd_structure() {
 // variant, preserving each id in order.
 #[test]
 fn parse_create() {
-    check_cases(
-        [Case {
-            scenario: "create with two VPC IDs",
-            input: &["vpc-peering", "create", TEST_VPC_ID_1, TEST_VPC_ID_2][..],
-            expect: Yields((TEST_VPC_ID_1.to_string(), TEST_VPC_ID_2.to_string())),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Create(args) => (args.vpc1_id.to_string(), args.vpc2_id.to_string()),
                     _ => panic!("expected Create variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "create with two VPC IDs" {
+            &["vpc-peering", "create", TEST_VPC_ID_1, TEST_VPC_ID_2][..] => Yields((TEST_VPC_ID_1.to_string(), TEST_VPC_ID_2.to_string())),
+        }
     );
 }
 
@@ -75,32 +73,26 @@ fn parse_create() {
 // and --vpc-id alone each parse, yielding which of (id, vpc_id) is set.
 #[test]
 fn parse_show() {
-    check_cases(
-        [
-            Case {
-                scenario: "no arguments",
-                input: &["vpc-peering", "show"][..],
-                expect: Yields((false, false)),
-            },
-            Case {
-                scenario: "with --id",
-                input: &["vpc-peering", "show", "--id", TEST_PEERING_ID][..],
-                expect: Yields((true, false)),
-            },
-            Case {
-                scenario: "with --vpc-id",
-                input: &["vpc-peering", "show", "--vpc-id", TEST_VPC_ID_1][..],
-                expect: Yields((false, true)),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => (args.id.is_some(), args.vpc_id.is_some()),
                     _ => panic!("expected Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "no arguments" {
+            &["vpc-peering", "show"][..] => Yields((false, false)),
+        }
+
+        "with --id" {
+            &["vpc-peering", "show", "--id", TEST_PEERING_ID][..] => Yields((true, false)),
+        }
+
+        "with --vpc-id" {
+            &["vpc-peering", "show", "--vpc-id", TEST_VPC_ID_1][..] => Yields((false, true)),
+        }
     );
 }
 
@@ -108,20 +100,18 @@ fn parse_show() {
 // preserving the peering id.
 #[test]
 fn parse_delete() {
-    check_cases(
-        [Case {
-            scenario: "delete with --id",
-            input: &["vpc-peering", "delete", "--id", TEST_PEERING_ID][..],
-            expect: Yields(TEST_PEERING_ID.to_string()),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Delete(args) => args.id.to_string(),
                     _ => panic!("expected Delete variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "delete with --id" {
+            &["vpc-peering", "delete", "--id", TEST_PEERING_ID][..] => Yields(TEST_PEERING_ID.to_string()),
+        }
     );
 }
 
@@ -129,40 +119,33 @@ fn parse_delete() {
 // on show, or a required argument left off create/delete.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "show with both --id and --vpc-id",
-                input: &[
-                    "vpc-peering",
-                    "show",
-                    "--id",
-                    TEST_PEERING_ID,
-                    "--vpc-id",
-                    TEST_VPC_ID_1,
-                ][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "delete without --id",
-                input: &["vpc-peering", "delete"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "create without VPC IDs",
-                input: &["vpc-peering", "create"][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "create with only one VPC ID",
-                input: &["vpc-peering", "create", TEST_VPC_ID_1][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "show with both --id and --vpc-id" {
+            &[
+                "vpc-peering",
+                "show",
+                "--id",
+                TEST_PEERING_ID,
+                "--vpc-id",
+                TEST_VPC_ID_1,
+            ][..] => Fails,
+        }
+
+        "delete without --id" {
+            &["vpc-peering", "delete"][..] => Fails,
+        }
+
+        "create without VPC IDs" {
+            &["vpc-peering", "create"][..] => Fails,
+        }
+
+        "create with only one VPC ID" {
+            &["vpc-peering", "create", TEST_VPC_ID_1][..] => Fails,
+        }
     );
 }

--- a/crates/admin-cli/src/vpc_prefix/tests.rs
+++ b/crates/admin-cli/src/vpc_prefix/tests.rs
@@ -24,7 +24,7 @@
 // Argument Parsing  - Ensure required/optional arg combinations parse correctly.
 
 use carbide_test_support::Outcome::*;
-use carbide_test_support::{Case, check_cases};
+use carbide_test_support::scenarios;
 use clap::{CommandFactory, Parser};
 
 use super::*;
@@ -63,45 +63,8 @@ fn parse_show_routes_to_show_variant() {
         }
     }
 
-    check_cases(
-        [
-            Case {
-                scenario: "show with no arguments",
-                input: &["vpc-prefix", "show"][..],
-                expect: Yields((false, false, false, false, "exclude")),
-            },
-            Case {
-                scenario: "show with --deleted only",
-                input: &["vpc-prefix", "show", "--deleted", "only"][..],
-                expect: Yields((false, false, false, false, "only")),
-            },
-            Case {
-                scenario: "show with a prefix-selector id",
-                input: &["vpc-prefix", "show", TEST_VPC_PREFIX_ID][..],
-                expect: Yields((true, false, false, false, "exclude")),
-            },
-            Case {
-                scenario: "show with a prefix-selector cidr",
-                input: &["vpc-prefix", "show", "10.0.0.0/8"][..],
-                expect: Yields((true, false, false, false, "exclude")),
-            },
-            Case {
-                scenario: "show with --vpc-id",
-                input: &["vpc-prefix", "show", "--vpc-id", TEST_VPC_ID][..],
-                expect: Yields((false, true, false, false, "exclude")),
-            },
-            Case {
-                scenario: "show with --contains",
-                input: &["vpc-prefix", "show", "--contains", "10.0.0.0/24"][..],
-                expect: Yields((false, false, true, false, "exclude")),
-            },
-            Case {
-                scenario: "show with --contained-by",
-                input: &["vpc-prefix", "show", "--contained-by", "10.0.0.0/8"][..],
-                expect: Yields((false, false, false, true, "exclude")),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Show(args) => (
@@ -114,7 +77,34 @@ fn parse_show_routes_to_show_variant() {
                     _ => panic!("expected Show variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "show with no arguments" {
+            &["vpc-prefix", "show"][..] => Yields((false, false, false, false, "exclude")),
+        }
+
+        "show with --deleted only" {
+            &["vpc-prefix", "show", "--deleted", "only"][..] => Yields((false, false, false, false, "only")),
+        }
+
+        "show with a prefix-selector id" {
+            &["vpc-prefix", "show", TEST_VPC_PREFIX_ID][..] => Yields((true, false, false, false, "exclude")),
+        }
+
+        "show with a prefix-selector cidr" {
+            &["vpc-prefix", "show", "10.0.0.0/8"][..] => Yields((true, false, false, false, "exclude")),
+        }
+
+        "show with --vpc-id" {
+            &["vpc-prefix", "show", "--vpc-id", TEST_VPC_ID][..] => Yields((false, true, false, false, "exclude")),
+        }
+
+        "show with --contains" {
+            &["vpc-prefix", "show", "--contains", "10.0.0.0/24"][..] => Yields((false, false, true, false, "exclude")),
+        }
+
+        "show with --contained-by" {
+            &["vpc-prefix", "show", "--contained-by", "10.0.0.0/8"][..] => Yields((false, false, false, true, "exclude")),
+        }
     );
 }
 
@@ -123,50 +113,8 @@ fn parse_show_routes_to_show_variant() {
 // optional-id assertions each become a row.
 #[test]
 fn parse_create_routes_to_create_variant() {
-    check_cases(
-        [
-            Case {
-                scenario: "create with required args",
-                input: &[
-                    "vpc-prefix",
-                    "create",
-                    "--vpc-id",
-                    TEST_VPC_ID,
-                    "--prefix",
-                    "10.0.0.0/8",
-                    "--name",
-                    "test-prefix",
-                ][..],
-                expect: Yields((
-                    TEST_VPC_ID.to_string(),
-                    "10.0.0.0/8".to_string(),
-                    "test-prefix".to_string(),
-                    false,
-                )),
-            },
-            Case {
-                scenario: "create with optional --vpc-prefix-id",
-                input: &[
-                    "vpc-prefix",
-                    "create",
-                    "--vpc-id",
-                    TEST_VPC_ID,
-                    "--prefix",
-                    "10.0.0.0/8",
-                    "--name",
-                    "test-prefix",
-                    "--vpc-prefix-id",
-                    TEST_VPC_PREFIX_ID,
-                ][..],
-                expect: Yields((
-                    TEST_VPC_ID.to_string(),
-                    "10.0.0.0/8".to_string(),
-                    "test-prefix".to_string(),
-                    true,
-                )),
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Create(args) => (
@@ -178,7 +126,44 @@ fn parse_create_routes_to_create_variant() {
                     _ => panic!("expected Create variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "create with required args" {
+            &[
+                "vpc-prefix",
+                "create",
+                "--vpc-id",
+                TEST_VPC_ID,
+                "--prefix",
+                "10.0.0.0/8",
+                "--name",
+                "test-prefix",
+            ][..] => Yields((
+                TEST_VPC_ID.to_string(),
+                "10.0.0.0/8".to_string(),
+                "test-prefix".to_string(),
+                false,
+            )),
+        }
+
+        "create with optional --vpc-prefix-id" {
+            &[
+                "vpc-prefix",
+                "create",
+                "--vpc-id",
+                TEST_VPC_ID,
+                "--prefix",
+                "10.0.0.0/8",
+                "--name",
+                "test-prefix",
+                "--vpc-prefix-id",
+                TEST_VPC_PREFIX_ID,
+            ][..] => Yields((
+                TEST_VPC_ID.to_string(),
+                "10.0.0.0/8".to_string(),
+                "test-prefix".to_string(),
+                true,
+            )),
+        }
     );
 }
 
@@ -186,20 +171,18 @@ fn parse_create_routes_to_create_variant() {
 // reporting the parsed vpc_prefix_id.
 #[test]
 fn parse_delete_routes_to_delete_variant() {
-    check_cases(
-        [Case {
-            scenario: "delete with a vpc-prefix-id",
-            input: &["vpc-prefix", "delete", TEST_VPC_PREFIX_ID][..],
-            expect: Yields(TEST_VPC_PREFIX_ID.to_string()),
-        }],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|cmd| match cmd {
                     Cmd::Delete(args) => args.vpc_prefix_id.to_string(),
                     _ => panic!("expected Delete variant"),
                 })
                 .map_err(drop)
-        },
+        };
+        "delete with a vpc-prefix-id" {
+            &["vpc-prefix", "delete", TEST_VPC_PREFIX_ID][..] => Yields(TEST_VPC_PREFIX_ID.to_string()),
+        }
     );
 }
 
@@ -208,42 +191,36 @@ fn parse_delete_routes_to_delete_variant() {
 // positional id.
 #[test]
 fn invalid_invocations_are_rejected() {
-    check_cases(
-        [
-            Case {
-                scenario: "show with both --contains and --contained-by",
-                input: &[
-                    "vpc-prefix",
-                    "show",
-                    "--contains",
-                    "10.0.0.0/24",
-                    "--contained-by",
-                    "10.0.0.0/8",
-                ][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "create without --vpc-id",
-                input: &[
-                    "vpc-prefix",
-                    "create",
-                    "--prefix",
-                    "10.0.0.0/8",
-                    "--name",
-                    "test",
-                ][..],
-                expect: Fails,
-            },
-            Case {
-                scenario: "delete without a vpc-prefix-id",
-                input: &["vpc-prefix", "delete"][..],
-                expect: Fails,
-            },
-        ],
-        |argv| {
+    scenarios!(
+        run = |argv| {
             Cmd::try_parse_from(argv.iter().copied())
                 .map(|_| ())
                 .map_err(drop)
-        },
+        };
+        "show with both --contains and --contained-by" {
+            &[
+                "vpc-prefix",
+                "show",
+                "--contains",
+                "10.0.0.0/24",
+                "--contained-by",
+                "10.0.0.0/8",
+            ][..] => Fails,
+        }
+
+        "create without --vpc-id" {
+            &[
+                "vpc-prefix",
+                "create",
+                "--prefix",
+                "10.0.0.0/8",
+                "--name",
+                "test",
+            ][..] => Fails,
+        }
+
+        "delete without a vpc-prefix-id" {
+            &["vpc-prefix", "delete"][..] => Fails,
+        }
     );
 }


### PR DESCRIPTION
This supports #3914.

## Description

The admin CLI tests already had broad command parsing coverage, but the repeated `Case` wrappers made the argument tables heavier than the commands they were validating.

This keeps the same explicit argv inputs and expected command variants while moving the straightforward parser tables onto `scenarios!`. The larger command surface now reads as grouped examples for each subcommand instead of repeated row structs.

All tests pass, and formatting/clippy checks are clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Commands:
- `cargo make format-nightly`
- `cargo make check-format-nightly`
- `cargo test -p nico-admin-cli`
- `cargo clippy -p nico-admin-cli -- -D warnings`
- `cargo clippy -p nico-admin-cli --tests -- -D warnings`