### PR TITLE
test(api-model): group model tables into scenarios

### DIFF
--- a/crates/api-model/src/allocation_type.rs
+++ b/crates/api-model/src/allocation_type.rs
@@ -91,7 +91,7 @@ mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
     use crate::address_selection_strategy::AddressSelectionStrategy;
@@ -103,79 +103,63 @@ mod tests {
     // confirm the discriminant alone — not the payload — drives the result.
     #[test]
     fn strategy_maps_to_allocation_type() {
-        check_values(
-            [
-                Check {
-                    scenario: "next available ip -> dhcp",
-                    input: AddressSelectionStrategy::NextAvailableIp,
-                    expect: AllocationType::Dhcp,
-                },
-                Check {
-                    scenario: "automatic alias -> dhcp",
-                    input: AddressSelectionStrategy::Automatic,
-                    expect: AllocationType::Dhcp,
-                },
-                Check {
-                    scenario: "next available prefix /30 -> dhcp",
-                    input: AddressSelectionStrategy::NextAvailablePrefix(30),
-                    expect: AllocationType::Dhcp,
-                },
-                Check {
-                    scenario: "next available prefix /0 (boundary low) -> dhcp",
-                    input: AddressSelectionStrategy::NextAvailablePrefix(0),
-                    expect: AllocationType::Dhcp,
-                },
-                Check {
-                    scenario: "next available prefix /32 -> dhcp",
-                    input: AddressSelectionStrategy::NextAvailablePrefix(32),
-                    expect: AllocationType::Dhcp,
-                },
-                Check {
-                    scenario: "next available prefix /128 -> dhcp",
-                    input: AddressSelectionStrategy::NextAvailablePrefix(128),
-                    expect: AllocationType::Dhcp,
-                },
-                Check {
-                    scenario: "next available prefix /255 (boundary high) -> dhcp",
-                    input: AddressSelectionStrategy::NextAvailablePrefix(u8::MAX),
-                    expect: AllocationType::Dhcp,
-                },
-                Check {
-                    scenario: "static ipv4 -> static",
-                    input: AddressSelectionStrategy::StaticAddress(
-                        Ipv4Addr::new(10, 0, 0, 1).into(),
-                    ),
-                    expect: AllocationType::Static,
-                },
-                Check {
-                    scenario: "static ipv4 unspecified (0.0.0.0) -> static",
-                    input: AddressSelectionStrategy::StaticAddress(Ipv4Addr::UNSPECIFIED.into()),
-                    expect: AllocationType::Static,
-                },
-                Check {
-                    scenario: "static ipv4 broadcast (255.255.255.255) -> static",
-                    input: AddressSelectionStrategy::StaticAddress(Ipv4Addr::BROADCAST.into()),
-                    expect: AllocationType::Static,
-                },
-                Check {
-                    scenario: "static ipv6 -> static",
-                    input: AddressSelectionStrategy::StaticAddress(
-                        Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1).into(),
-                    ),
-                    expect: AllocationType::Static,
-                },
-                Check {
-                    scenario: "static ipv6 unspecified (::) -> static",
-                    input: AddressSelectionStrategy::StaticAddress(Ipv6Addr::UNSPECIFIED.into()),
-                    expect: AllocationType::Static,
-                },
-                Check {
-                    scenario: "static ipv6 localhost (::1) -> static",
-                    input: AddressSelectionStrategy::StaticAddress(Ipv6Addr::LOCALHOST.into()),
-                    expect: AllocationType::Static,
-                },
-            ],
-            AllocationType::from,
+        value_scenarios!(
+            run = AllocationType::from;
+            "next available ip -> dhcp" {
+                AddressSelectionStrategy::NextAvailableIp => AllocationType::Dhcp,
+            }
+
+            "automatic alias -> dhcp" {
+                AddressSelectionStrategy::Automatic => AllocationType::Dhcp,
+            }
+
+            "next available prefix /30 -> dhcp" {
+                AddressSelectionStrategy::NextAvailablePrefix(30) => AllocationType::Dhcp,
+            }
+
+            "next available prefix /0 (boundary low) -> dhcp" {
+                AddressSelectionStrategy::NextAvailablePrefix(0) => AllocationType::Dhcp,
+            }
+
+            "next available prefix /32 -> dhcp" {
+                AddressSelectionStrategy::NextAvailablePrefix(32) => AllocationType::Dhcp,
+            }
+
+            "next available prefix /128 -> dhcp" {
+                AddressSelectionStrategy::NextAvailablePrefix(128) => AllocationType::Dhcp,
+            }
+
+            "next available prefix /255 (boundary high) -> dhcp" {
+                AddressSelectionStrategy::NextAvailablePrefix(u8::MAX) => AllocationType::Dhcp,
+            }
+
+            "static ipv4 -> static" {
+                AddressSelectionStrategy::StaticAddress(
+                    Ipv4Addr::new(10, 0, 0, 1).into(),
+                ) => AllocationType::Static,
+            }
+
+            "static ipv4 unspecified (0.0.0.0) -> static" {
+                AddressSelectionStrategy::StaticAddress(Ipv4Addr::UNSPECIFIED.into()) => AllocationType::Static,
+            }
+
+            "static ipv4 broadcast (255.255.255.255) -> static" {
+                AddressSelectionStrategy::StaticAddress(Ipv4Addr::BROADCAST.into()) => AllocationType::Static,
+            }
+
+            "static ipv6 -> static" {
+                AddressSelectionStrategy::StaticAddress(
+                    Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 1).into(),
+                ) => AllocationType::Static,
+            }
+
+            "static ipv6 unspecified (::) -> static" {
+                AddressSelectionStrategy::StaticAddress(Ipv6Addr::UNSPECIFIED.into()) => AllocationType::Static,
+            }
+
+            "static ipv6 localhost (::1) -> static" {
+                AddressSelectionStrategy::StaticAddress(Ipv6Addr::LOCALHOST.into()) => AllocationType::Static,
+            }
         );
     }
 
@@ -183,20 +167,15 @@ mod tests {
     // form. Total operation, so the produced string is checked directly.
     #[test]
     fn serializes_to_snake_case() {
-        check_values(
-            [
-                Check {
-                    scenario: "dhcp",
-                    input: AllocationType::Dhcp,
-                    expect: r#""dhcp""#.to_string(),
-                },
-                Check {
-                    scenario: "static",
-                    input: AllocationType::Static,
-                    expect: r#""static""#.to_string(),
-                },
-            ],
-            |value| serde_json::to_string(&value).expect("serialization is infallible"),
+        value_scenarios!(
+            run = |value| serde_json::to_string(&value).expect("serialization is infallible");
+            "dhcp" {
+                AllocationType::Dhcp => r#""dhcp""#.to_string(),
+            }
+
+            "static" {
+                AllocationType::Static => r#""static""#.to_string(),
+            }
         );
     }
 
@@ -205,25 +184,20 @@ mod tests {
     // wire string plus the recovered value so each row pins down both directions.
     #[test]
     fn serde_roundtrip() {
-        check_cases(
-            [
-                Case {
-                    scenario: "dhcp",
-                    input: AllocationType::Dhcp,
-                    expect: Yields((r#""dhcp""#.to_string(), AllocationType::Dhcp)),
-                },
-                Case {
-                    scenario: "static",
-                    input: AllocationType::Static,
-                    expect: Yields((r#""static""#.to_string(), AllocationType::Static)),
-                },
-            ],
+        scenarios!(
             // serialize, then deserialize the wire form back into a value
-            |value| {
+            run = |value| {
                 let wire = serde_json::to_string(&value).map_err(drop)?;
                 let recovered: AllocationType = serde_json::from_str(&wire).map_err(drop)?;
                 Ok::<_, ()>((wire, recovered))
-            },
+            };
+            "dhcp" {
+                AllocationType::Dhcp => Yields((r#""dhcp""#.to_string(), AllocationType::Dhcp)),
+            }
+
+            "static" {
+                AllocationType::Static => Yields((r#""static""#.to_string(), AllocationType::Static)),
+            }
         );
     }
 
@@ -233,65 +207,51 @@ mod tests {
     // with `.map_err(drop)`.
     #[test]
     fn deserializes_known_forms_and_rejects_the_rest() {
-        check_cases(
-            [
-                Case {
-                    scenario: "dhcp",
-                    input: r#""dhcp""#,
-                    expect: Yields(AllocationType::Dhcp),
-                },
-                Case {
-                    scenario: "static",
-                    input: r#""static""#,
-                    expect: Yields(AllocationType::Static),
-                },
-                Case {
-                    scenario: "wrong case rejected",
-                    input: r#""Dhcp""#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "uppercase rejected",
-                    input: r#""STATIC""#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "unknown variant rejected",
-                    input: r#""bootp""#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty string rejected",
-                    input: r#""""#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "leading whitespace in tag rejected",
-                    input: r#"" dhcp""#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "number rejected",
-                    input: "0",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "null rejected",
-                    input: "null",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "object rejected",
-                    input: r#"{"dhcp":true}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "malformed json rejected",
-                    input: r#""dhcp"#,
-                    expect: Fails,
-                },
-            ],
-            |wire| serde_json::from_str::<AllocationType>(wire).map_err(drop),
+        scenarios!(
+            run = |wire| serde_json::from_str::<AllocationType>(wire).map_err(drop);
+            "dhcp" {
+                r#""dhcp""# => Yields(AllocationType::Dhcp),
+            }
+
+            "static" {
+                r#""static""# => Yields(AllocationType::Static),
+            }
+
+            "wrong case rejected" {
+                r#""Dhcp""# => Fails,
+            }
+
+            "uppercase rejected" {
+                r#""STATIC""# => Fails,
+            }
+
+            "unknown variant rejected" {
+                r#""bootp""# => Fails,
+            }
+
+            "empty string rejected" {
+                r#""""# => Fails,
+            }
+
+            "leading whitespace in tag rejected" {
+                r#"" dhcp""# => Fails,
+            }
+
+            "number rejected" {
+                "0" => Fails,
+            }
+
+            "null rejected" {
+                "null" => Fails,
+            }
+
+            "object rejected" {
+                r#"{"dhcp":true}"# => Fails,
+            }
+
+            "malformed json rejected" {
+                r#""dhcp"# => Fails,
+            }
         );
     }
 
@@ -300,76 +260,61 @@ mod tests {
     // equality across its full variant set is its coverage.
     #[test]
     fn variants_compare_by_identity() {
-        check_values(
-            [
-                Check {
-                    scenario: "dhcp == dhcp",
-                    input: (AllocationType::Dhcp, AllocationType::Dhcp),
-                    expect: true,
-                },
-                Check {
-                    scenario: "static == static",
-                    input: (AllocationType::Static, AllocationType::Static),
-                    expect: true,
-                },
-                Check {
-                    scenario: "dhcp != static",
-                    input: (AllocationType::Dhcp, AllocationType::Static),
-                    expect: false,
-                },
-            ],
-            |(left, right)| left == right,
+        value_scenarios!(
+            run = |(left, right)| left == right;
+            "dhcp == dhcp" {
+                (AllocationType::Dhcp, AllocationType::Dhcp) => true,
+            }
+
+            "static == static" {
+                (AllocationType::Static, AllocationType::Static) => true,
+            }
+
+            "dhcp != static" {
+                (AllocationType::Dhcp, AllocationType::Static) => false,
+            }
         );
 
-        check_values(
-            [
-                Check {
-                    scenario: "assigned == assigned",
-                    input: (AssignStaticResult::Assigned, AssignStaticResult::Assigned),
-                    expect: true,
-                },
-                Check {
-                    scenario: "replaced static == replaced static",
-                    input: (
-                        AssignStaticResult::ReplacedStatic,
-                        AssignStaticResult::ReplacedStatic,
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "replaced dhcp == replaced dhcp",
-                    input: (
-                        AssignStaticResult::ReplacedDhcp,
-                        AssignStaticResult::ReplacedDhcp,
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "assigned != replaced static",
-                    input: (
-                        AssignStaticResult::Assigned,
-                        AssignStaticResult::ReplacedStatic,
-                    ),
-                    expect: false,
-                },
-                Check {
-                    scenario: "replaced static != replaced dhcp",
-                    input: (
-                        AssignStaticResult::ReplacedStatic,
-                        AssignStaticResult::ReplacedDhcp,
-                    ),
-                    expect: false,
-                },
-                Check {
-                    scenario: "assigned != replaced dhcp",
-                    input: (
-                        AssignStaticResult::Assigned,
-                        AssignStaticResult::ReplacedDhcp,
-                    ),
-                    expect: false,
-                },
-            ],
-            |(left, right)| left == right,
+        value_scenarios!(
+            run = |(left, right)| left == right;
+            "assigned == assigned" {
+                (AssignStaticResult::Assigned, AssignStaticResult::Assigned) => true,
+            }
+
+            "replaced static == replaced static" {
+                (
+                    AssignStaticResult::ReplacedStatic,
+                    AssignStaticResult::ReplacedStatic,
+                ) => true,
+            }
+
+            "replaced dhcp == replaced dhcp" {
+                (
+                    AssignStaticResult::ReplacedDhcp,
+                    AssignStaticResult::ReplacedDhcp,
+                ) => true,
+            }
+
+            "assigned != replaced static" {
+                (
+                    AssignStaticResult::Assigned,
+                    AssignStaticResult::ReplacedStatic,
+                ) => false,
+            }
+
+            "replaced static != replaced dhcp" {
+                (
+                    AssignStaticResult::ReplacedStatic,
+                    AssignStaticResult::ReplacedDhcp,
+                ) => false,
+            }
+
+            "assigned != replaced dhcp" {
+                (
+                    AssignStaticResult::Assigned,
+                    AssignStaticResult::ReplacedDhcp,
+                ) => false,
+            }
         );
     }
 }

--- a/crates/api-model/src/attestation.rs
+++ b/crates/api-model/src/attestation.rs
@@ -357,7 +357,7 @@ pub mod spdm {
 #[cfg(test)]
 mod test {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Case, check_cases, scenarios, value_scenarios};
 
     use super::*;
     use crate::attestation::spdm::{
@@ -384,30 +384,23 @@ mod test {
 
     #[test]
     fn spdm_object_id_display() {
-        check_values(
-            [
-                Check {
-                    scenario: "simple device id",
-                    input: SpdmObjectId(machine_id(), "Device-1".to_string()),
-                    expect: format!("{VALID_MACHINE_ID},Device-1"),
-                },
-                Check {
-                    scenario: "empty device id",
-                    input: SpdmObjectId(machine_id(), String::new()),
-                    expect: format!("{VALID_MACHINE_ID},"),
-                },
-                Check {
-                    scenario: "device id with internal comma",
-                    input: SpdmObjectId(machine_id(), "a,b".to_string()),
-                    expect: format!("{VALID_MACHINE_ID},a,b"),
-                },
-                Check {
-                    scenario: "device id with spaces",
-                    input: SpdmObjectId(machine_id(), "HGX IRoT GPU 0".to_string()),
-                    expect: format!("{VALID_MACHINE_ID},HGX IRoT GPU 0"),
-                },
-            ],
-            |id| id.to_string(),
+        value_scenarios!(
+            run = |id| id.to_string();
+            "simple device id" {
+                SpdmObjectId(machine_id(), "Device-1".to_string()) => format!("{VALID_MACHINE_ID},Device-1"),
+            }
+
+            "empty device id" {
+                SpdmObjectId(machine_id(), String::new()) => format!("{VALID_MACHINE_ID},"),
+            }
+
+            "device id with internal comma" {
+                SpdmObjectId(machine_id(), "a,b".to_string()) => format!("{VALID_MACHINE_ID},a,b"),
+            }
+
+            "device id with spaces" {
+                SpdmObjectId(machine_id(), "HGX IRoT GPU 0".to_string()) => format!("{VALID_MACHINE_ID},HGX IRoT GPU 0"),
+            }
         );
     }
 
@@ -461,65 +454,52 @@ mod test {
     fn device_type_from_str() {
         // SpdmHandlerError is PartialEq, but from_str never errors — it always
         // classifies. Use the Display name as the observable, pure result.
-        check_cases(
-            [
-                Case {
-                    scenario: "gpu token present",
-                    input: "HGX_IRoT_GPU_0",
-                    expect: Yields("Gpu".to_string()),
-                },
-                Case {
-                    scenario: "gpu token bare",
-                    input: "GPU",
-                    expect: Yields("Gpu".to_string()),
-                },
-                Case {
-                    scenario: "cx7 token present",
-                    input: "HGX_ERoT_CX7_1",
-                    expect: Yields("Cx7".to_string()),
-                },
-                Case {
-                    scenario: "cx7 token bare",
-                    input: "CX7",
-                    expect: Yields("Cx7".to_string()),
-                },
-                Case {
-                    scenario: "gpu wins when both present (checked first)",
-                    input: "GPU_CX7",
-                    expect: Yields("Gpu".to_string()),
-                },
-                Case {
-                    scenario: "cpu is unknown",
-                    input: "HGX_ERoT_CPU_0",
-                    expect: Yields("Unknown".to_string()),
-                },
-                Case {
-                    scenario: "bmc is unknown",
-                    input: "BMC",
-                    expect: Yields("Unknown".to_string()),
-                },
-                Case {
-                    scenario: "empty is unknown",
-                    input: "",
-                    expect: Yields("Unknown".to_string()),
-                },
-                Case {
-                    scenario: "lowercase gpu does not match (case sensitive)",
-                    input: "gpu",
-                    expect: Yields("Unknown".to_string()),
-                },
-                Case {
-                    scenario: "lowercase cx7 does not match (case sensitive)",
-                    input: "cx7",
-                    expect: Yields("Unknown".to_string()),
-                },
-            ],
-            |s| {
+        scenarios!(
+            run = |s| {
                 Ok::<_, ()>(format!(
                     "{:?}",
                     s.parse::<DeviceType>().expect("never errors")
                 ))
-            },
+            };
+            "gpu token present" {
+                "HGX_IRoT_GPU_0" => Yields("Gpu".to_string()),
+            }
+
+            "gpu token bare" {
+                "GPU" => Yields("Gpu".to_string()),
+            }
+
+            "cx7 token present" {
+                "HGX_ERoT_CX7_1" => Yields("Cx7".to_string()),
+            }
+
+            "cx7 token bare" {
+                "CX7" => Yields("Cx7".to_string()),
+            }
+
+            "gpu wins when both present (checked first)" {
+                "GPU_CX7" => Yields("Gpu".to_string()),
+            }
+
+            "cpu is unknown" {
+                "HGX_ERoT_CPU_0" => Yields("Unknown".to_string()),
+            }
+
+            "bmc is unknown" {
+                "BMC" => Yields("Unknown".to_string()),
+            }
+
+            "empty is unknown" {
+                "" => Yields("Unknown".to_string()),
+            }
+
+            "lowercase gpu does not match (case sensitive)" {
+                "gpu" => Yields("Unknown".to_string()),
+            }
+
+            "lowercase cx7 does not match (case sensitive)" {
+                "cx7" => Yields("Unknown".to_string()),
+            }
         );
     }
 
@@ -537,67 +517,54 @@ mod test {
 
     #[test]
     fn get_failure_cause() {
-        check_values(
-            [
-                Check {
-                    scenario: "failed state yields a cause naming device and reason",
-                    input: details_with_state(SpdmAttestationState::Failed(
-                        "signature mismatch".to_string(),
-                    )),
-                    expect: Some("Device: GPU_0, failed reason: signature mismatch".to_string()),
-                },
-                Check {
-                    scenario: "failed with empty reason",
-                    input: details_with_state(SpdmAttestationState::Failed(String::new())),
-                    expect: Some("Device: GPU_0, failed reason: ".to_string()),
-                },
-                Check {
-                    scenario: "passed state has no cause",
-                    input: details_with_state(SpdmAttestationState::Passed),
-                    expect: None,
-                },
-                Check {
-                    scenario: "cancelled state has no cause",
-                    input: details_with_state(SpdmAttestationState::Cancelled),
-                    expect: None,
-                },
-                Check {
-                    scenario: "fetch metadata state has no cause",
-                    input: details_with_state(SpdmAttestationState::FetchMetadata),
-                    expect: None,
-                },
-                Check {
-                    scenario: "fetch certificate state has no cause",
-                    input: details_with_state(SpdmAttestationState::FetchCertificate),
-                    expect: None,
-                },
-                Check {
-                    scenario: "trigger evidence collection state has no cause",
-                    input: details_with_state(SpdmAttestationState::TriggerEvidenceCollection {
-                        retry_count: 0,
-                    }),
-                    expect: None,
-                },
-                Check {
-                    scenario: "poll evidence collection state has no cause",
-                    input: details_with_state(SpdmAttestationState::PollEvidenceCollection {
-                        task_id: "t1".to_string(),
-                        retry_count: 2,
-                    }),
-                    expect: None,
-                },
-                Check {
-                    scenario: "nras verification state has no cause",
-                    input: details_with_state(SpdmAttestationState::NrasVerification),
-                    expect: None,
-                },
-                Check {
-                    scenario: "apply appraisal policy state has no cause",
-                    input: details_with_state(SpdmAttestationState::ApplyAppraisalPolicy),
-                    expect: None,
-                },
-            ],
-            |details| details.get_failure_cause(),
+        value_scenarios!(
+            run = |details| details.get_failure_cause();
+            "failed state yields a cause naming device and reason" {
+                details_with_state(SpdmAttestationState::Failed(
+                    "signature mismatch".to_string(),
+                )) => Some("Device: GPU_0, failed reason: signature mismatch".to_string()),
+            }
+
+            "failed with empty reason" {
+                details_with_state(SpdmAttestationState::Failed(String::new())) => Some("Device: GPU_0, failed reason: ".to_string()),
+            }
+
+            "passed state has no cause" {
+                details_with_state(SpdmAttestationState::Passed) => None,
+            }
+
+            "cancelled state has no cause" {
+                details_with_state(SpdmAttestationState::Cancelled) => None,
+            }
+
+            "fetch metadata state has no cause" {
+                details_with_state(SpdmAttestationState::FetchMetadata) => None,
+            }
+
+            "fetch certificate state has no cause" {
+                details_with_state(SpdmAttestationState::FetchCertificate) => None,
+            }
+
+            "trigger evidence collection state has no cause" {
+                details_with_state(SpdmAttestationState::TriggerEvidenceCollection {
+                    retry_count: 0,
+                }) => None,
+            }
+
+            "poll evidence collection state has no cause" {
+                details_with_state(SpdmAttestationState::PollEvidenceCollection {
+                    task_id: "t1".to_string(),
+                    retry_count: 2,
+                }) => None,
+            }
+
+            "nras verification state has no cause" {
+                details_with_state(SpdmAttestationState::NrasVerification) => None,
+            }
+
+            "apply appraisal policy state has no cause" {
+                details_with_state(SpdmAttestationState::ApplyAppraisalPolicy) => None,
+            }
         );
     }
 }

--- a/crates/api-model/src/controller_outcome.rs
+++ b/crates/api-model/src/controller_outcome.rs
@@ -79,7 +79,7 @@ impl From<&&'static Location<'static>> for PersistentSourceReference {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Case, check_cases, scenarios, value_scenarios};
 
     use super::*;
 
@@ -97,91 +97,78 @@ mod tests {
     // when None.
     #[test]
     fn test_state_outcome_serialize() {
-        check_cases(
-            [
-                Case {
-                    scenario: "wait with reason, no source ref",
-                    input: PersistentStateHandlerOutcome::Wait {
-                        reason: "Reason goes here".to_string(),
-                        source_ref: None,
-                    },
-                    expect: Yields(r#"{"outcome":"wait","reason":"Reason goes here"}"#.to_string()),
-                },
-                Case {
-                    scenario: "wait with empty reason",
-                    input: PersistentStateHandlerOutcome::Wait {
-                        reason: String::new(),
-                        source_ref: None,
-                    },
-                    expect: Yields(r#"{"outcome":"wait","reason":""}"#.to_string()),
-                },
-                Case {
-                    scenario: "wait with reason and source ref",
-                    input: PersistentStateHandlerOutcome::Wait {
-                        reason: "waiting".to_string(),
-                        source_ref: Some(source_ref()),
-                    },
-                    expect: Yields(
-                        r#"{"outcome":"wait","reason":"waiting","source_ref":{"file":"a.rs","line":100}}"#
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "error variant, no source ref",
-                    input: PersistentStateHandlerOutcome::Error {
-                        err: "boom".to_string(),
-                        source_ref: None,
-                    },
-                    expect: Yields(r#"{"outcome":"error","err":"boom"}"#.to_string()),
-                },
-                Case {
-                    scenario: "error variant with source ref",
-                    input: PersistentStateHandlerOutcome::Error {
-                        err: "boom".to_string(),
-                        source_ref: Some(source_ref()),
-                    },
-                    expect: Yields(
-                        r#"{"outcome":"error","err":"boom","source_ref":{"file":"a.rs","line":100}}"#
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "transition, no source ref",
-                    input: PersistentStateHandlerOutcome::Transition { source_ref: None },
-                    expect: Yields(r#"{"outcome":"transition"}"#.to_string()),
-                },
-                Case {
-                    scenario: "transition with source ref",
-                    input: PersistentStateHandlerOutcome::Transition {
-                        source_ref: Some(source_ref()),
-                    },
-                    expect: Yields(
-                        r#"{"outcome":"transition","source_ref":{"file":"a.rs","line":100}}"#
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "donothing, no source ref",
-                    input: PersistentStateHandlerOutcome::DoNothing { source_ref: None },
-                    expect: Yields(r#"{"outcome":"donothing"}"#.to_string()),
-                },
-                Case {
-                    scenario: "donothing with source ref details",
-                    input: PersistentStateHandlerOutcome::DoNothing {
-                        source_ref: Some(source_ref()),
-                    },
-                    expect: Yields(
-                        r#"{"outcome":"donothing","source_ref":{"file":"a.rs","line":100}}"#
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "donothingwithdetails legacy variant",
-                    input: PersistentStateHandlerOutcome::DoNothingWithDetails,
-                    expect: Yields(r#"{"outcome":"donothingwithdetails"}"#.to_string()),
-                },
-            ],
-            |outcome| serde_json::to_string(&outcome).map_err(drop),
+        scenarios!(
+            run = |outcome| serde_json::to_string(&outcome).map_err(drop);
+            "wait with reason, no source ref" {
+                PersistentStateHandlerOutcome::Wait {
+                    reason: "Reason goes here".to_string(),
+                    source_ref: None,
+                } => Yields(r#"{"outcome":"wait","reason":"Reason goes here"}"#.to_string()),
+            }
+
+            "wait with empty reason" {
+                PersistentStateHandlerOutcome::Wait {
+                    reason: String::new(),
+                    source_ref: None,
+                } => Yields(r#"{"outcome":"wait","reason":""}"#.to_string()),
+            }
+
+            "wait with reason and source ref" {
+                PersistentStateHandlerOutcome::Wait {
+                    reason: "waiting".to_string(),
+                    source_ref: Some(source_ref()),
+                } => Yields(
+                    r#"{"outcome":"wait","reason":"waiting","source_ref":{"file":"a.rs","line":100}}"#
+                        .to_string(),
+                ),
+            }
+
+            "error variant, no source ref" {
+                PersistentStateHandlerOutcome::Error {
+                    err: "boom".to_string(),
+                    source_ref: None,
+                } => Yields(r#"{"outcome":"error","err":"boom"}"#.to_string()),
+            }
+
+            "error variant with source ref" {
+                PersistentStateHandlerOutcome::Error {
+                    err: "boom".to_string(),
+                    source_ref: Some(source_ref()),
+                } => Yields(
+                    r#"{"outcome":"error","err":"boom","source_ref":{"file":"a.rs","line":100}}"#
+                        .to_string(),
+                ),
+            }
+
+            "transition, no source ref" {
+                PersistentStateHandlerOutcome::Transition { source_ref: None } => Yields(r#"{"outcome":"transition"}"#.to_string()),
+            }
+
+            "transition with source ref" {
+                PersistentStateHandlerOutcome::Transition {
+                    source_ref: Some(source_ref()),
+                } => Yields(
+                    r#"{"outcome":"transition","source_ref":{"file":"a.rs","line":100}}"#
+                        .to_string(),
+                ),
+            }
+
+            "donothing, no source ref" {
+                PersistentStateHandlerOutcome::DoNothing { source_ref: None } => Yields(r#"{"outcome":"donothing"}"#.to_string()),
+            }
+
+            "donothing with source ref details" {
+                PersistentStateHandlerOutcome::DoNothing {
+                    source_ref: Some(source_ref()),
+                } => Yields(
+                    r#"{"outcome":"donothing","source_ref":{"file":"a.rs","line":100}}"#
+                        .to_string(),
+                ),
+            }
+
+            "donothingwithdetails legacy variant" {
+                PersistentStateHandlerOutcome::DoNothingWithDetails => Yields(r#"{"outcome":"donothingwithdetails"}"#.to_string()),
+            }
         );
     }
 
@@ -297,59 +284,51 @@ mod tests {
     // without hard-coding the exact derived layout.
     #[test]
     fn test_display_matches_debug() {
-        check_values(
-            [
-                Check {
-                    scenario: "source reference display equals debug",
-                    input: format!("{}", source_ref()),
-                    expect: format!("{:?}", source_ref()),
-                },
-                Check {
-                    scenario: "transition outcome display equals debug",
-                    input: format!(
-                        "{}",
-                        PersistentStateHandlerOutcome::Transition { source_ref: None }
-                    ),
-                    expect: format!(
-                        "{:?}",
-                        PersistentStateHandlerOutcome::Transition { source_ref: None }
-                    ),
-                },
-                Check {
-                    scenario: "wait outcome display equals debug",
-                    input: format!(
-                        "{}",
-                        PersistentStateHandlerOutcome::Wait {
-                            reason: "r".to_string(),
-                            source_ref: Some(source_ref()),
-                        }
-                    ),
-                    expect: format!(
-                        "{:?}",
-                        PersistentStateHandlerOutcome::Wait {
-                            reason: "r".to_string(),
-                            source_ref: Some(source_ref()),
-                        }
-                    ),
-                },
-            ],
-            |rendered| rendered,
+        value_scenarios!(
+            run = |rendered| rendered;
+            "source reference display equals debug" {
+                format!("{}", source_ref()) => format!("{:?}", source_ref()),
+            }
+
+            "transition outcome display equals debug" {
+                format!(
+                    "{}",
+                    PersistentStateHandlerOutcome::Transition { source_ref: None }
+                ) => format!(
+                    "{:?}",
+                    PersistentStateHandlerOutcome::Transition { source_ref: None }
+                ),
+            }
+
+            "wait outcome display equals debug" {
+                format!(
+                    "{}",
+                    PersistentStateHandlerOutcome::Wait {
+                        reason: "r".to_string(),
+                        source_ref: Some(source_ref()),
+                    }
+                ) => format!(
+                    "{:?}",
+                    PersistentStateHandlerOutcome::Wait {
+                        reason: "r".to_string(),
+                        source_ref: Some(source_ref()),
+                    }
+                ),
+            }
         );
     }
 
     // Display for the source reference contains both the file and the line.
     #[test]
     fn test_source_reference_display_tokens() {
-        check_cases(
-            [Case {
-                scenario: "display carries file and line",
-                input: (source_ref(), &["a.rs", "100"][..]),
-                expect: Yields(true),
-            }],
-            |(reference, tokens): (PersistentSourceReference, &[&str])| {
+        scenarios!(
+            run = |(reference, tokens): (PersistentSourceReference, &[&str])| {
                 let produced = format!("{reference}");
                 Ok::<_, ()>(tokens.iter().all(|t| produced.contains(t)))
-            },
+            };
+            "display carries file and line" {
+                (source_ref(), &["a.rs", "100"][..]) => Yields(true),
+            }
         );
     }
 
@@ -360,20 +339,15 @@ mod tests {
     fn test_source_reference_from_location() {
         let location = Location::caller();
         let reference = PersistentSourceReference::from(&location);
-        check_values(
-            [
-                Check {
-                    scenario: "line carried from location",
-                    input: reference.line == location.line(),
-                    expect: true,
-                },
-                Check {
-                    scenario: "file carried from location",
-                    input: reference.file.as_str() == location.file(),
-                    expect: true,
-                },
-            ],
-            |value| value,
+        value_scenarios!(
+            run = |value| value;
+            "line carried from location" {
+                reference.line == location.line() => true,
+            }
+
+            "file carried from location" {
+                reference.file.as_str() == location.file() => true,
+            }
         );
     }
 }

--- a/crates/api-model/src/dpa_interface/mod.rs
+++ b/crates/api-model/src/dpa_interface/mod.rs
@@ -439,7 +439,7 @@ mod tests {
     use std::str::FromStr;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Case, check_cases, scenarios, value_scenarios};
 
     use super::*;
 
@@ -463,80 +463,8 @@ mod tests {
         // the Option to a Result and, for the success row, yield the asserted
         // (machine_id, mac_address, device_type, pci_name) fields.
         let machine_id = test_machine_id();
-        check_cases(
-            [
-                Case {
-                    scenario: "extracts fields when base mac present",
-                    input: DeviceInfoInput {
-                        base_mac: Some(MacAddress::from_str("00:11:22:33:44:55").unwrap()),
-                        device_type: "BlueField3".to_string(),
-                        pci_name: "01:00.0".to_string(),
-                        device_description: Some("SuperNIC".to_string()),
-                        interface_type: DpaInterfaceType::Svpc,
-                    },
-                    expect: Yields((
-                        machine_id,
-                        MacAddress::from_str("00:11:22:33:44:55").unwrap(),
-                        "BlueField3".to_string(),
-                        "01:00.0".to_string(),
-                    )),
-                },
-                Case {
-                    scenario: "extracts fields for astra interface type",
-                    input: DeviceInfoInput {
-                        base_mac: Some(MacAddress::from_str("aa:bb:cc:dd:ee:ff").unwrap()),
-                        device_type: "ConnectX7".to_string(),
-                        pci_name: "02:00.1".to_string(),
-                        device_description: None,
-                        interface_type: DpaInterfaceType::Astra,
-                    },
-                    expect: Yields((
-                        machine_id,
-                        MacAddress::from_str("aa:bb:cc:dd:ee:ff").unwrap(),
-                        "ConnectX7".to_string(),
-                        "02:00.1".to_string(),
-                    )),
-                },
-                Case {
-                    scenario: "extracts fields with empty device type and pci name",
-                    input: DeviceInfoInput {
-                        base_mac: Some(MacAddress::from_str("00:00:00:00:00:00").unwrap()),
-                        device_type: String::new(),
-                        pci_name: String::new(),
-                        device_description: Some(String::new()),
-                        interface_type: DpaInterfaceType::Svpc,
-                    },
-                    expect: Yields((
-                        machine_id,
-                        MacAddress::from_str("00:00:00:00:00:00").unwrap(),
-                        String::new(),
-                        String::new(),
-                    )),
-                },
-                Case {
-                    scenario: "returns none without base mac",
-                    input: DeviceInfoInput {
-                        base_mac: None,
-                        device_type: "BlueField3".to_string(),
-                        pci_name: "01:00.0".to_string(),
-                        device_description: None,
-                        interface_type: DpaInterfaceType::Svpc,
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "returns none without base mac for astra",
-                    input: DeviceInfoInput {
-                        base_mac: None,
-                        device_type: "ConnectX7".to_string(),
-                        pci_name: "02:00.1".to_string(),
-                        device_description: Some("desc".to_string()),
-                        interface_type: DpaInterfaceType::Astra,
-                    },
-                    expect: Fails,
-                },
-            ],
-            |i| {
+        scenarios!(
+            run = |i| {
                 NewDpaInterface::from_device_info(
                     machine_id,
                     i.base_mac,
@@ -547,7 +475,71 @@ mod tests {
                 )
                 .map(|n| (n.machine_id, n.mac_address, n.device_type, n.pci_name))
                 .ok_or(())
-            },
+            };
+            "extracts fields when base mac present" {
+                DeviceInfoInput {
+                    base_mac: Some(MacAddress::from_str("00:11:22:33:44:55").unwrap()),
+                    device_type: "BlueField3".to_string(),
+                    pci_name: "01:00.0".to_string(),
+                    device_description: Some("SuperNIC".to_string()),
+                    interface_type: DpaInterfaceType::Svpc,
+                } => Yields((
+                    machine_id,
+                    MacAddress::from_str("00:11:22:33:44:55").unwrap(),
+                    "BlueField3".to_string(),
+                    "01:00.0".to_string(),
+                )),
+            }
+
+            "extracts fields for astra interface type" {
+                DeviceInfoInput {
+                    base_mac: Some(MacAddress::from_str("aa:bb:cc:dd:ee:ff").unwrap()),
+                    device_type: "ConnectX7".to_string(),
+                    pci_name: "02:00.1".to_string(),
+                    device_description: None,
+                    interface_type: DpaInterfaceType::Astra,
+                } => Yields((
+                    machine_id,
+                    MacAddress::from_str("aa:bb:cc:dd:ee:ff").unwrap(),
+                    "ConnectX7".to_string(),
+                    "02:00.1".to_string(),
+                )),
+            }
+
+            "extracts fields with empty device type and pci name" {
+                DeviceInfoInput {
+                    base_mac: Some(MacAddress::from_str("00:00:00:00:00:00").unwrap()),
+                    device_type: String::new(),
+                    pci_name: String::new(),
+                    device_description: Some(String::new()),
+                    interface_type: DpaInterfaceType::Svpc,
+                } => Yields((
+                    machine_id,
+                    MacAddress::from_str("00:00:00:00:00:00").unwrap(),
+                    String::new(),
+                    String::new(),
+                )),
+            }
+
+            "returns none without base mac" {
+                DeviceInfoInput {
+                    base_mac: None,
+                    device_type: "BlueField3".to_string(),
+                    pci_name: "01:00.0".to_string(),
+                    device_description: None,
+                    interface_type: DpaInterfaceType::Svpc,
+                } => Fails,
+            }
+
+            "returns none without base mac for astra" {
+                DeviceInfoInput {
+                    base_mac: None,
+                    device_type: "ConnectX7".to_string(),
+                    pci_name: "02:00.1".to_string(),
+                    device_description: Some("desc".to_string()),
+                    interface_type: DpaInterfaceType::Astra,
+                } => Fails,
+            }
         );
     }
 
@@ -610,45 +602,35 @@ mod tests {
         // `DpaLockMode::try_from(i32)` accepts only 1 (Locked) and 2 (Unlocked);
         // every other value — including the zero and the values just outside the
         // accepted pair — is rejected with the same static error.
-        check_cases(
-            [
-                Case {
-                    scenario: "one is locked",
-                    input: 1,
-                    expect: Yields(DpaLockMode::Locked),
-                },
-                Case {
-                    scenario: "two is unlocked",
-                    input: 2,
-                    expect: Yields(DpaLockMode::Unlocked),
-                },
-                Case {
-                    scenario: "zero is invalid",
-                    input: 0,
-                    expect: FailsWith("Invalid value for DpaLockMode"),
-                },
-                Case {
-                    scenario: "three is invalid",
-                    input: 3,
-                    expect: FailsWith("Invalid value for DpaLockMode"),
-                },
-                Case {
-                    scenario: "negative is invalid",
-                    input: -1,
-                    expect: FailsWith("Invalid value for DpaLockMode"),
-                },
-                Case {
-                    scenario: "max is invalid",
-                    input: i32::MAX,
-                    expect: FailsWith("Invalid value for DpaLockMode"),
-                },
-                Case {
-                    scenario: "min is invalid",
-                    input: i32::MIN,
-                    expect: FailsWith("Invalid value for DpaLockMode"),
-                },
-            ],
-            DpaLockMode::try_from,
+        scenarios!(
+            run = DpaLockMode::try_from;
+            "one is locked" {
+                1 => Yields(DpaLockMode::Locked),
+            }
+
+            "two is unlocked" {
+                2 => Yields(DpaLockMode::Unlocked),
+            }
+
+            "zero is invalid" {
+                0 => FailsWith("Invalid value for DpaLockMode"),
+            }
+
+            "three is invalid" {
+                3 => FailsWith("Invalid value for DpaLockMode"),
+            }
+
+            "negative is invalid" {
+                -1 => FailsWith("Invalid value for DpaLockMode"),
+            }
+
+            "max is invalid" {
+                i32::MAX => FailsWith("Invalid value for DpaLockMode"),
+            }
+
+            "min is invalid" {
+                i32::MIN => FailsWith("Invalid value for DpaLockMode"),
+            }
         );
     }
 
@@ -656,45 +638,35 @@ mod tests {
     fn controller_state_display() {
         // The `Display` impl defers to `Debug`, so each variant renders as its
         // bare Rust identifier — distinct from the lowercase serde tag.
-        check_values(
-            [
-                Check {
-                    scenario: "provisioning",
-                    input: DpaInterfaceControllerState::Provisioning,
-                    expect: "Provisioning".to_string(),
-                },
-                Check {
-                    scenario: "ready",
-                    input: DpaInterfaceControllerState::Ready,
-                    expect: "Ready".to_string(),
-                },
-                Check {
-                    scenario: "unlocking",
-                    input: DpaInterfaceControllerState::Unlocking,
-                    expect: "Unlocking".to_string(),
-                },
-                Check {
-                    scenario: "applyfirmware",
-                    input: DpaInterfaceControllerState::ApplyFirmware,
-                    expect: "ApplyFirmware".to_string(),
-                },
-                Check {
-                    scenario: "applyprofile",
-                    input: DpaInterfaceControllerState::ApplyProfile,
-                    expect: "ApplyProfile".to_string(),
-                },
-                Check {
-                    scenario: "locking",
-                    input: DpaInterfaceControllerState::Locking,
-                    expect: "Locking".to_string(),
-                },
-                Check {
-                    scenario: "assigned",
-                    input: DpaInterfaceControllerState::Assigned,
-                    expect: "Assigned".to_string(),
-                },
-            ],
-            |state| state.to_string(),
+        value_scenarios!(
+            run = |state| state.to_string();
+            "provisioning" {
+                DpaInterfaceControllerState::Provisioning => "Provisioning".to_string(),
+            }
+
+            "ready" {
+                DpaInterfaceControllerState::Ready => "Ready".to_string(),
+            }
+
+            "unlocking" {
+                DpaInterfaceControllerState::Unlocking => "Unlocking".to_string(),
+            }
+
+            "applyfirmware" {
+                DpaInterfaceControllerState::ApplyFirmware => "ApplyFirmware".to_string(),
+            }
+
+            "applyprofile" {
+                DpaInterfaceControllerState::ApplyProfile => "ApplyProfile".to_string(),
+            }
+
+            "locking" {
+                DpaInterfaceControllerState::Locking => "Locking".to_string(),
+            }
+
+            "assigned" {
+                DpaInterfaceControllerState::Assigned => "Assigned".to_string(),
+            }
         );
     }
 
@@ -702,30 +674,23 @@ mod tests {
     fn controller_state_deserialize_rejects_unknown_tag() {
         // The accepted tags are exactly the lowercase variant names; an unknown
         // tag and a missing tag are both rejected.
-        check_cases(
-            [
-                Case {
-                    scenario: "known tag deserializes",
-                    input: "{\"state\":\"ready\"}",
-                    expect: Yields(DpaInterfaceControllerState::Ready),
-                },
-                Case {
-                    scenario: "capitalized tag is rejected",
-                    input: "{\"state\":\"Ready\"}",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "unknown tag is rejected",
-                    input: "{\"state\":\"bogus\"}",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "missing tag is rejected",
-                    input: "{}",
-                    expect: Fails,
-                },
-            ],
-            |json| serde_json::from_str::<DpaInterfaceControllerState>(json).map_err(|_| ()),
+        scenarios!(
+            run = |json| serde_json::from_str::<DpaInterfaceControllerState>(json).map_err(|_| ());
+            "known tag deserializes" {
+                "{\"state\":\"ready\"}" => Yields(DpaInterfaceControllerState::Ready),
+            }
+
+            "capitalized tag is rejected" {
+                "{\"state\":\"Ready\"}" => Fails,
+            }
+
+            "unknown tag is rejected" {
+                "{\"state\":\"bogus\"}" => Fails,
+            }
+
+            "missing tag is rejected" {
+                "{}" => Fails,
+            }
         );
     }
 
@@ -733,16 +698,14 @@ mod tests {
     fn network_config_default_uses_admin_network() {
         // The default network config opts into the admin network and carries no
         // quarantine state.
-        check_values(
-            [Check {
-                scenario: "defaults to admin network",
-                input: (),
-                expect: (Some(true), None),
-            }],
-            |()| {
+        value_scenarios!(
+            run = |()| {
                 let cfg = DpaInterfaceNetworkConfig::default();
                 (cfg.use_admin_network, cfg.quarantine_state)
-            },
+            };
+            "defaults to admin network" {
+                () => (Some(true), None),
+            }
         );
     }
 

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -254,7 +254,7 @@ pub struct UnexpectedMachine {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::scenarios;
 
     use super::*;
 
@@ -362,36 +362,31 @@ mod tests {
     /// `HostLifecycleProfile::default()`, whose only field is `disable_lockdown`).
     #[test]
     fn host_lifecycle_profile_deserializes_from_json() {
-        check_cases(
-            [
-                Case {
-                    scenario: "missing host_lifecycle_profile defaults to None",
-                    input: r#"{
-                        "bmc_mac_address": "AA:BB:CC:DD:EE:FF",
-                        "bmc_username": "root",
-                        "bmc_password": "pass",
-                        "serial_number": "SN-1"
-                    }"#,
-                    expect: Yields(None),
-                },
-                Case {
-                    scenario: "present host_lifecycle_profile parses disable_lockdown",
-                    input: r#"{
-                        "bmc_mac_address": "AA:BB:CC:DD:EE:FF",
-                        "bmc_username": "root",
-                        "bmc_password": "pass",
-                        "serial_number": "SN-1",
-                        "host_lifecycle_profile": {"disable_lockdown": true}
-                    }"#,
-                    expect: Yields(Some(true)),
-                },
-            ],
+        scenarios!(
             // serde_json::Error is not PartialEq, so discard it on the error path.
-            |json| {
+            run = |json| {
                 serde_json::from_str::<ExpectedMachine>(json)
                     .map(|em| em.data.host_lifecycle_profile.disable_lockdown)
                     .map_err(drop)
-            },
+            };
+            "missing host_lifecycle_profile defaults to None" {
+                r#"{
+                            "bmc_mac_address": "AA:BB:CC:DD:EE:FF",
+                            "bmc_username": "root",
+                            "bmc_password": "pass",
+                            "serial_number": "SN-1"
+                        }"# => Yields(None),
+            }
+
+            "present host_lifecycle_profile parses disable_lockdown" {
+                r#"{
+                            "bmc_mac_address": "AA:BB:CC:DD:EE:FF",
+                            "bmc_username": "root",
+                            "bmc_password": "pass",
+                            "serial_number": "SN-1",
+                            "host_lifecycle_profile": {"disable_lockdown": true}
+                        }"# => Yields(Some(true)),
+            }
         );
     }
 

--- a/crates/api-model/src/extension_service/mod.rs
+++ b/crates/api-model/src/extension_service/mod.rs
@@ -242,7 +242,7 @@ mod tests {
     use std::str::FromStr;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::scenarios;
 
     use super::*;
 
@@ -250,38 +250,30 @@ mod tests {
     // unknown string is rejected.
     #[test]
     fn extension_service_type_from_str() {
-        check_cases(
-            [
-                Case {
-                    scenario: "canonical kubernetes_pod",
-                    input: "kubernetes_pod",
-                    expect: Yields(ExtensionServiceType::KubernetesPod),
-                },
-                Case {
-                    scenario: "mixed case is normalized",
-                    input: "Kubernetes_Pod",
-                    expect: Yields(ExtensionServiceType::KubernetesPod),
-                },
-                Case {
-                    scenario: "unknown type is rejected",
-                    input: "virtual_machine",
-                    expect: Fails,
-                },
-            ],
-            |s| ExtensionServiceType::from_str(s).map_err(drop),
+        scenarios!(
+            run = |s| ExtensionServiceType::from_str(s).map_err(drop);
+            "canonical kubernetes_pod" {
+                "kubernetes_pod" => Yields(ExtensionServiceType::KubernetesPod),
+            }
+
+            "mixed case is normalized" {
+                "Kubernetes_Pod" => Yields(ExtensionServiceType::KubernetesPod),
+            }
+
+            "unknown type is rejected" {
+                "virtual_machine" => Fails,
+            }
         );
     }
 
     // Display is the inverse of from_str: each variant's wire form parses back to it.
     #[test]
     fn extension_service_type_display_round_trips() {
-        check_cases(
-            [Case {
-                scenario: "kubernetes_pod",
-                input: ExtensionServiceType::KubernetesPod,
-                expect: Yields(ExtensionServiceType::KubernetesPod),
-            }],
-            |t| ExtensionServiceType::from_str(&t.to_string()).map_err(drop),
+        scenarios!(
+            run = |t| ExtensionServiceType::from_str(&t.to_string()).map_err(drop);
+            "kubernetes_pod" {
+                ExtensionServiceType::KubernetesPod => Yields(ExtensionServiceType::KubernetesPod),
+            }
         );
     }
 
@@ -310,23 +302,18 @@ mod tests {
                 ),
             }],
         };
-        check_cases(
-            [
-                Case {
-                    scenario: "prometheus config",
-                    input: prometheus.clone(),
-                    expect: Yields(prometheus),
-                },
-                Case {
-                    scenario: "logging config",
-                    input: logging.clone(),
-                    expect: Yields(logging),
-                },
-            ],
-            |obs| {
+        scenarios!(
+            run = |obs| {
                 let json = serde_json::to_string(&obs).map_err(drop)?;
                 serde_json::from_str::<ExtensionServiceObservability>(&json).map_err(drop)
-            },
+            };
+            "prometheus config" {
+                prometheus.clone() => Yields(prometheus),
+            }
+
+            "logging config" {
+                logging.clone() => Yields(logging),
+            }
         );
     }
 }

--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -397,7 +397,7 @@ impl From<libnmxm::nmxm_model::Gpu> for NvLinkGpu {
 mod tests {
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -442,35 +442,30 @@ mod tests {
     // list: invalid entries are dropped lossily and a null list defaults to empty.
     #[test]
     fn lldp_switch_data_management_addresses() {
-        check_cases(
-            [
-                Case {
-                    scenario: "filters invalid management addresses",
-                    input: r#"{
-                        "ip_address": [
-                            "192.0.2.10",
-                            "not-an-ip",
-                            "2001:db8::1"
-                        ]
-                    }"#,
-                    expect: Yields(vec![
-                        "192.0.2.10".parse::<IpAddr>().unwrap(),
-                        "2001:db8::1".parse::<IpAddr>().unwrap(),
-                    ]),
-                },
-                Case {
-                    scenario: "defaults null management addresses to empty",
-                    input: r#"{"ip_address":null}"#,
-                    expect: Yields(vec![]),
-                },
-            ],
+        scenarios!(
             // serde_json::Error is not PartialEq, so deserialization failure would
             // be Fails; here every row parses, so the error type is irrelevant.
-            |json| {
+            run = |json| {
                 serde_json::from_str::<LldpSwitchData>(json)
                     .map(|switch| switch.ip_address)
                     .map_err(drop)
-            },
+            };
+            "filters invalid management addresses" {
+                r#"{
+                            "ip_address": [
+                                "192.0.2.10",
+                                "not-an-ip",
+                                "2001:db8::1"
+                            ]
+                        }"# => Yields(vec![
+                    "192.0.2.10".parse::<IpAddr>().unwrap(),
+                    "2001:db8::1".parse::<IpAddr>().unwrap(),
+                ]),
+            }
+
+            "defaults null management addresses to empty" {
+                r#"{"ip_address":null}"# => Yields(vec![]),
+            }
         );
     }
 
@@ -577,31 +572,25 @@ mod tests {
     // a DPU: x86 hardware is not, both BlueField fixtures are.
     #[test]
     fn deserialize_info_is_dpu() {
-        check_cases(
-            [
-                Case {
-                    scenario: "x86 host is not a DPU",
-                    input: X86_INFO_JSON,
-                    expect: Yields(false),
-                },
-                Case {
-                    scenario: "dpu info is a DPU",
-                    input: DPU_INFO_JSON,
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "bf3 dpu info is a DPU",
-                    input: DPU_BF3_INFO_JSON,
-                    expect: Yields(true),
-                },
-            ],
+        scenarios!(
             // serde_json::Error is not PartialEq; every fixture parses, so the error
             // type is irrelevant here.
-            |bytes| {
+            run = |bytes| {
                 serde_json::from_slice::<HardwareInfo>(bytes)
                     .map(|info| info.is_dpu())
                     .map_err(drop)
-            },
+            };
+            "x86 host is not a DPU" {
+                X86_INFO_JSON => Yields(false),
+            }
+
+            "dpu info is a DPU" {
+                DPU_INFO_JSON => Yields(true),
+            }
+
+            "bf3 dpu info is a DPU" {
+                DPU_BF3_INFO_JSON => Yields(true),
+            }
         );
     }
 
@@ -669,90 +658,79 @@ mod tests {
     // name contains "bluefield" (case-insensitively). Both conditions must hold.
     #[test]
     fn hardware_info_is_dpu() {
-        check_values(
-            [
-                Check {
-                    scenario: "aarch64 with bluefield board is a DPU",
-                    input: info_with_dmi(
-                        CpuArchitecture::Aarch64,
-                        DmiData {
-                            board_name: "BlueField-3".to_string(),
-                            ..Default::default()
-                        },
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "board name match is case-insensitive",
-                    input: info_with_dmi(
-                        CpuArchitecture::Aarch64,
-                        DmiData {
-                            board_name: "MY-BLUEFIELD-CARD".to_string(),
-                            ..Default::default()
-                        },
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "bluefield as a lowercase substring still matches",
-                    input: info_with_dmi(
-                        CpuArchitecture::Aarch64,
-                        DmiData {
-                            board_name: "prefix-bluefield-suffix".to_string(),
-                            ..Default::default()
-                        },
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "aarch64 without bluefield board is not a DPU",
-                    input: info_with_dmi(
-                        CpuArchitecture::Aarch64,
-                        DmiData {
-                            board_name: "GenericBoard".to_string(),
-                            ..Default::default()
-                        },
-                    ),
-                    expect: false,
-                },
-                Check {
-                    scenario: "aarch64 with empty board name is not a DPU",
-                    input: info_with_dmi(CpuArchitecture::Aarch64, DmiData::default()),
-                    expect: false,
-                },
-                Check {
-                    scenario: "x86_64 with bluefield board is not a DPU",
-                    input: info_with_dmi(
-                        CpuArchitecture::X86_64,
-                        DmiData {
-                            board_name: "BlueField-3".to_string(),
-                            ..Default::default()
-                        },
-                    ),
-                    expect: false,
-                },
-                Check {
-                    scenario: "unknown arch with bluefield board is not a DPU",
-                    input: info_with_dmi(
-                        CpuArchitecture::Unknown,
-                        DmiData {
-                            board_name: "BlueField-3".to_string(),
-                            ..Default::default()
-                        },
-                    ),
-                    expect: false,
-                },
-                Check {
-                    scenario: "aarch64 with no dmi data at all is not a DPU",
-                    input: HardwareInfo {
-                        machine_type: CpuArchitecture::Aarch64,
-                        dmi_data: None,
+        value_scenarios!(
+            run = |info| info.is_dpu();
+            "aarch64 with bluefield board is a DPU" {
+                info_with_dmi(
+                    CpuArchitecture::Aarch64,
+                    DmiData {
+                        board_name: "BlueField-3".to_string(),
                         ..Default::default()
                     },
-                    expect: false,
-                },
-            ],
-            |info| info.is_dpu(),
+                ) => true,
+            }
+
+            "board name match is case-insensitive" {
+                info_with_dmi(
+                    CpuArchitecture::Aarch64,
+                    DmiData {
+                        board_name: "MY-BLUEFIELD-CARD".to_string(),
+                        ..Default::default()
+                    },
+                ) => true,
+            }
+
+            "bluefield as a lowercase substring still matches" {
+                info_with_dmi(
+                    CpuArchitecture::Aarch64,
+                    DmiData {
+                        board_name: "prefix-bluefield-suffix".to_string(),
+                        ..Default::default()
+                    },
+                ) => true,
+            }
+
+            "aarch64 without bluefield board is not a DPU" {
+                info_with_dmi(
+                    CpuArchitecture::Aarch64,
+                    DmiData {
+                        board_name: "GenericBoard".to_string(),
+                        ..Default::default()
+                    },
+                ) => false,
+            }
+
+            "aarch64 with empty board name is not a DPU" {
+                info_with_dmi(CpuArchitecture::Aarch64, DmiData::default()) => false,
+            }
+
+            "x86_64 with bluefield board is not a DPU" {
+                info_with_dmi(
+                    CpuArchitecture::X86_64,
+                    DmiData {
+                        board_name: "BlueField-3".to_string(),
+                        ..Default::default()
+                    },
+                ) => false,
+            }
+
+            "unknown arch with bluefield board is not a DPU" {
+                info_with_dmi(
+                    CpuArchitecture::Unknown,
+                    DmiData {
+                        board_name: "BlueField-3".to_string(),
+                        ..Default::default()
+                    },
+                ) => false,
+            }
+
+            "aarch64 with no dmi data at all is not a DPU" {
+                HardwareInfo {
+                    machine_type: CpuArchitecture::Aarch64,
+                    dmi_data: None,
+                    ..Default::default()
+                } => false,
+            }
         );
     }
 
@@ -760,61 +738,53 @@ mod tests {
     // it; its error type is not PartialEq, so failures are asserted as `Fails`.
     #[test]
     fn hardware_info_factory_mac_address() {
-        check_cases(
-            [
-                Case {
-                    scenario: "valid mac in dpu info yields the address",
-                    input: HardwareInfo {
-                        dpu_info: Some(DpuData {
-                            factory_mac_address: "00:11:22:33:44:55".to_string(),
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    },
-                    expect: Yields(MacAddress::from_str("00:11:22:33:44:55").unwrap()),
-                },
-                Case {
-                    scenario: "missing dpu info fails",
-                    input: HardwareInfo::default(),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty mac string fails to parse",
-                    input: HardwareInfo {
-                        dpu_info: Some(DpuData {
-                            factory_mac_address: String::new(),
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "malformed mac string fails to parse",
-                    input: HardwareInfo {
-                        dpu_info: Some(DpuData {
-                            factory_mac_address: "not-a-mac".to_string(),
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "too-short mac string fails to parse",
-                    input: HardwareInfo {
-                        dpu_info: Some(DpuData {
-                            factory_mac_address: "00:11:22".to_string(),
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    },
-                    expect: Fails,
-                },
-            ],
+        scenarios!(
             // HardwareInfoError is not PartialEq, so drop the error to make the run
             // closure's error type `()`.
-            |info| info.factory_mac_address().map_err(drop),
+            run = |info| info.factory_mac_address().map_err(drop);
+            "valid mac in dpu info yields the address" {
+                HardwareInfo {
+                    dpu_info: Some(DpuData {
+                        factory_mac_address: "00:11:22:33:44:55".to_string(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                } => Yields(MacAddress::from_str("00:11:22:33:44:55").unwrap()),
+            }
+
+            "missing dpu info fails" {
+                HardwareInfo::default() => Fails,
+            }
+
+            "empty mac string fails to parse" {
+                HardwareInfo {
+                    dpu_info: Some(DpuData {
+                        factory_mac_address: String::new(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                } => Fails,
+            }
+
+            "malformed mac string fails to parse" {
+                HardwareInfo {
+                    dpu_info: Some(DpuData {
+                        factory_mac_address: "not-a-mac".to_string(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                } => Fails,
+            }
+
+            "too-short mac string fails to parse" {
+                HardwareInfo {
+                    dpu_info: Some(DpuData {
+                        factory_mac_address: "00:11:22".to_string(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                } => Fails,
+            }
         );
     }
 
@@ -822,103 +792,91 @@ mod tests {
     // falls back to `Unknown` when there is no DMI data at all.
     #[test]
     fn hardware_info_bmc_vendor() {
-        check_values(
-            [
-                Check {
-                    scenario: "lenovo sys vendor",
-                    input: info_with_dmi(
-                        CpuArchitecture::X86_64,
-                        DmiData {
-                            sys_vendor: "Lenovo".to_string(),
-                            ..Default::default()
-                        },
-                    ),
-                    expect: bmc_vendor::BMCVendor::Lenovo,
-                },
-                Check {
-                    scenario: "dell sys vendor",
-                    input: info_with_dmi(
-                        CpuArchitecture::X86_64,
-                        DmiData {
-                            sys_vendor: "Dell Inc.".to_string(),
-                            ..Default::default()
-                        },
-                    ),
-                    expect: bmc_vendor::BMCVendor::Dell,
-                },
-                Check {
-                    scenario: "nvidia sys vendor",
-                    input: info_with_dmi(
-                        CpuArchitecture::Aarch64,
-                        DmiData {
-                            sys_vendor: "NVIDIA".to_string(),
-                            ..Default::default()
-                        },
-                    ),
-                    expect: bmc_vendor::BMCVendor::Nvidia,
-                },
-                Check {
-                    scenario: "mellanox url maps to nvidia",
-                    input: info_with_dmi(
-                        CpuArchitecture::Aarch64,
-                        DmiData {
-                            sys_vendor: "https://www.mellanox.com".to_string(),
-                            ..Default::default()
-                        },
-                    ),
-                    expect: bmc_vendor::BMCVendor::Nvidia,
-                },
-                Check {
-                    scenario: "supermicro sys vendor",
-                    input: info_with_dmi(
-                        CpuArchitecture::X86_64,
-                        DmiData {
-                            sys_vendor: "Supermicro".to_string(),
-                            ..Default::default()
-                        },
-                    ),
-                    expect: bmc_vendor::BMCVendor::Supermicro,
-                },
-                Check {
-                    scenario: "hpe sys vendor",
-                    input: info_with_dmi(
-                        CpuArchitecture::X86_64,
-                        DmiData {
-                            sys_vendor: "HPE".to_string(),
-                            ..Default::default()
-                        },
-                    ),
-                    expect: bmc_vendor::BMCVendor::Hpe,
-                },
-                Check {
-                    scenario: "unrecognized sys vendor is unknown",
-                    input: info_with_dmi(
-                        CpuArchitecture::X86_64,
-                        DmiData {
-                            sys_vendor: "Acme Corp".to_string(),
-                            ..Default::default()
-                        },
-                    ),
-                    expect: bmc_vendor::BMCVendor::Unknown,
-                },
-                Check {
-                    scenario: "case-sensitive: lowercase dell is unknown",
-                    input: info_with_dmi(
-                        CpuArchitecture::X86_64,
-                        DmiData {
-                            sys_vendor: "dell inc.".to_string(),
-                            ..Default::default()
-                        },
-                    ),
-                    expect: bmc_vendor::BMCVendor::Unknown,
-                },
-                Check {
-                    scenario: "no dmi data is unknown",
-                    input: HardwareInfo::default(),
-                    expect: bmc_vendor::BMCVendor::Unknown,
-                },
-            ],
-            |info| info.bmc_vendor(),
+        value_scenarios!(
+            run = |info| info.bmc_vendor();
+            "lenovo sys vendor" {
+                info_with_dmi(
+                    CpuArchitecture::X86_64,
+                    DmiData {
+                        sys_vendor: "Lenovo".to_string(),
+                        ..Default::default()
+                    },
+                ) => bmc_vendor::BMCVendor::Lenovo,
+            }
+
+            "dell sys vendor" {
+                info_with_dmi(
+                    CpuArchitecture::X86_64,
+                    DmiData {
+                        sys_vendor: "Dell Inc.".to_string(),
+                        ..Default::default()
+                    },
+                ) => bmc_vendor::BMCVendor::Dell,
+            }
+
+            "nvidia sys vendor" {
+                info_with_dmi(
+                    CpuArchitecture::Aarch64,
+                    DmiData {
+                        sys_vendor: "NVIDIA".to_string(),
+                        ..Default::default()
+                    },
+                ) => bmc_vendor::BMCVendor::Nvidia,
+            }
+
+            "mellanox url maps to nvidia" {
+                info_with_dmi(
+                    CpuArchitecture::Aarch64,
+                    DmiData {
+                        sys_vendor: "https://www.mellanox.com".to_string(),
+                        ..Default::default()
+                    },
+                ) => bmc_vendor::BMCVendor::Nvidia,
+            }
+
+            "supermicro sys vendor" {
+                info_with_dmi(
+                    CpuArchitecture::X86_64,
+                    DmiData {
+                        sys_vendor: "Supermicro".to_string(),
+                        ..Default::default()
+                    },
+                ) => bmc_vendor::BMCVendor::Supermicro,
+            }
+
+            "hpe sys vendor" {
+                info_with_dmi(
+                    CpuArchitecture::X86_64,
+                    DmiData {
+                        sys_vendor: "HPE".to_string(),
+                        ..Default::default()
+                    },
+                ) => bmc_vendor::BMCVendor::Hpe,
+            }
+
+            "unrecognized sys vendor is unknown" {
+                info_with_dmi(
+                    CpuArchitecture::X86_64,
+                    DmiData {
+                        sys_vendor: "Acme Corp".to_string(),
+                        ..Default::default()
+                    },
+                ) => bmc_vendor::BMCVendor::Unknown,
+            }
+
+            "case-sensitive: lowercase dell is unknown" {
+                info_with_dmi(
+                    CpuArchitecture::X86_64,
+                    DmiData {
+                        sys_vendor: "dell inc.".to_string(),
+                        ..Default::default()
+                    },
+                ) => bmc_vendor::BMCVendor::Unknown,
+            }
+
+            "no dmi data is unknown" {
+                HardwareInfo::default() => bmc_vendor::BMCVendor::Unknown,
+            }
         );
     }
 
@@ -926,35 +884,8 @@ mod tests {
     // wants an exact NVIDIA / DGXH100 pairing.
     #[test]
     fn hardware_info_product_predicates() {
-        check_values(
-            [
-                Check {
-                    scenario: "exact GB200 product name",
-                    input: ("GB200", false),
-                    expect: true,
-                },
-                Check {
-                    scenario: "GB200 as a substring",
-                    input: ("NVIDIA GB200 NVL72", false),
-                    expect: true,
-                },
-                Check {
-                    scenario: "different product is not gbx00",
-                    input: ("GB300", false),
-                    expect: false,
-                },
-                Check {
-                    scenario: "empty product name is not gbx00",
-                    input: ("", false),
-                    expect: false,
-                },
-                Check {
-                    scenario: "case-sensitive: lowercase gb200 is not gbx00",
-                    input: ("gb200", false),
-                    expect: false,
-                },
-            ],
-            |(product_name, _)| {
+        value_scenarios!(
+            run = |(product_name, _)| {
                 info_with_dmi(
                     CpuArchitecture::Aarch64,
                     DmiData {
@@ -963,42 +894,34 @@ mod tests {
                     },
                 )
                 .is_gbx00()
-            },
+            };
+            "exact GB200 product name" {
+                ("GB200", false) => true,
+            }
+
+            "GB200 as a substring" {
+                ("NVIDIA GB200 NVL72", false) => true,
+            }
+
+            "different product is not gbx00" {
+                ("GB300", false) => false,
+            }
+
+            "empty product name is not gbx00" {
+                ("", false) => false,
+            }
+
+            "case-sensitive: lowercase gb200 is not gbx00" {
+                ("gb200", false) => false,
+            }
         );
     }
 
     // `is_dgx_h100()` requires both sys_vendor == "NVIDIA" and product_name == "DGXH100".
     #[test]
     fn hardware_info_is_dgx_h100() {
-        check_values(
-            [
-                Check {
-                    scenario: "nvidia vendor and dgxh100 product",
-                    input: ("NVIDIA", "DGXH100"),
-                    expect: true,
-                },
-                Check {
-                    scenario: "wrong product is not a dgx h100",
-                    input: ("NVIDIA", "DGXH200"),
-                    expect: false,
-                },
-                Check {
-                    scenario: "wrong vendor is not a dgx h100",
-                    input: ("Supermicro", "DGXH100"),
-                    expect: false,
-                },
-                Check {
-                    scenario: "both empty is not a dgx h100",
-                    input: ("", ""),
-                    expect: false,
-                },
-                Check {
-                    scenario: "product as substring is rejected (exact match required)",
-                    input: ("NVIDIA", "DGXH100-rev2"),
-                    expect: false,
-                },
-            ],
-            |(sys_vendor, product_name)| {
+        value_scenarios!(
+            run = |(sys_vendor, product_name)| {
                 info_with_dmi(
                     CpuArchitecture::X86_64,
                     DmiData {
@@ -1008,7 +931,26 @@ mod tests {
                     },
                 )
                 .is_dgx_h100()
-            },
+            };
+            "nvidia vendor and dgxh100 product" {
+                ("NVIDIA", "DGXH100") => true,
+            }
+
+            "wrong product is not a dgx h100" {
+                ("NVIDIA", "DGXH200") => false,
+            }
+
+            "wrong vendor is not a dgx h100" {
+                ("Supermicro", "DGXH100") => false,
+            }
+
+            "both empty is not a dgx h100" {
+                ("", "") => false,
+            }
+
+            "product as substring is rejected (exact match required)" {
+                ("NVIDIA", "DGXH100-rev2") => false,
+            }
         );
     }
 
@@ -1019,34 +961,28 @@ mod tests {
             mac_address: MacAddress::from_str(mac).unwrap(),
             pci_properties: None,
         };
-        check_values(
-            [
-                Check {
-                    scenario: "no interfaces yields an empty list",
-                    input: vec![],
-                    expect: vec![],
-                },
-                Check {
-                    scenario: "one interface yields its mac",
-                    input: vec![iface("00:11:22:33:44:55")],
-                    expect: vec![MacAddress::from_str("00:11:22:33:44:55").unwrap()],
-                },
-                Check {
-                    scenario: "several interfaces preserve order",
-                    input: vec![iface("00:11:22:33:44:55"), iface("aa:bb:cc:dd:ee:ff")],
-                    expect: vec![
-                        MacAddress::from_str("00:11:22:33:44:55").unwrap(),
-                        MacAddress::from_str("aa:bb:cc:dd:ee:ff").unwrap(),
-                    ],
-                },
-            ],
-            |network_interfaces| {
+        value_scenarios!(
+            run = |network_interfaces| {
                 HardwareInfo {
                     network_interfaces,
                     ..Default::default()
                 }
                 .all_mac_addresses()
-            },
+            };
+            "no interfaces yields an empty list" {
+                vec![] => vec![],
+            }
+
+            "one interface yields its mac" {
+                vec![iface("00:11:22:33:44:55")] => vec![MacAddress::from_str("00:11:22:33:44:55").unwrap()],
+            }
+
+            "several interfaces preserve order" {
+                vec![iface("00:11:22:33:44:55"), iface("aa:bb:cc:dd:ee:ff")] => vec![
+                    MacAddress::from_str("00:11:22:33:44:55").unwrap(),
+                    MacAddress::from_str("aa:bb:cc:dd:ee:ff").unwrap(),
+                ],
+            }
         );
     }
 
@@ -1054,32 +990,26 @@ mod tests {
     // the empty-url case.
     #[test]
     fn machine_inventory_component_display() {
-        check_values(
-            [
-                Check {
-                    scenario: "all fields populated",
-                    input: ("nvidia.com", "bar", "2.0"),
-                    expect: "nvidia.com/bar:2.0".to_string(),
-                },
-                Check {
-                    scenario: "empty url keeps the leading slash",
-                    input: ("", "foo", "1.0"),
-                    expect: "/foo:1.0".to_string(),
-                },
-                Check {
-                    scenario: "all fields empty",
-                    input: ("", "", ""),
-                    expect: "/:".to_string(),
-                },
-            ],
-            |(url, name, version)| {
+        value_scenarios!(
+            run = |(url, name, version)| {
                 MachineInventorySoftwareComponent {
                     name: name.to_string(),
                     version: version.to_string(),
                     url: url.to_string(),
                 }
                 .to_string()
-            },
+            };
+            "all fields populated" {
+                ("nvidia.com", "bar", "2.0") => "nvidia.com/bar:2.0".to_string(),
+            }
+
+            "empty url keeps the leading slash" {
+                ("", "foo", "1.0") => "/foo:1.0".to_string(),
+            }
+
+            "all fields empty" {
+                ("", "", "") => "/:".to_string(),
+            }
         );
     }
 
@@ -1087,24 +1017,19 @@ mod tests {
     // `into_bytes`, including the empty-certificate case.
     #[test]
     fn tpm_ek_certificate_byte_accessors() {
-        check_values(
-            [
-                Check {
-                    scenario: "non-empty certificate round-trips",
-                    input: vec![1u8, 2, 3, 4],
-                    expect: vec![1u8, 2, 3, 4],
-                },
-                Check {
-                    scenario: "empty certificate round-trips",
-                    input: vec![],
-                    expect: vec![],
-                },
-            ],
-            |bytes: Vec<u8>| {
+        value_scenarios!(
+            run = |bytes: Vec<u8>| {
                 let cert = TpmEkCertificate::from(bytes.clone());
                 assert_eq!(cert.as_bytes(), bytes.as_slice());
                 cert.into_bytes()
-            },
+            };
+            "non-empty certificate round-trips" {
+                vec![1u8, 2, 3, 4] => vec![1u8, 2, 3, 4],
+            }
+
+            "empty certificate round-trips" {
+                vec![] => vec![],
+            }
         );
     }
 
@@ -1112,66 +1037,60 @@ mod tests {
     // absent or unset) and copies device_id / device_uid straight across.
     #[test]
     fn nvlink_gpu_from_nmxm_gpu() {
-        check_values(
-            [
-                Check {
-                    scenario: "full location info is carried through",
-                    input: r#"{
-                        "LocationInfo": {"TrayIndex": 3, "SlotID": 7},
-                        "DeviceUID": 42,
-                        "DeviceID": 5,
-                        "DevicePcieID": 0,
-                        "SystemUID": 0,
-                        "VendorID": 0,
-                        "ALIDList": []
-                    }"#,
-                    expect: NvLinkGpu {
-                        tray_index: 3,
-                        slot_id: 7,
-                        device_id: 5,
-                        guid: 42,
-                    },
-                },
-                Check {
-                    scenario: "absent location info defaults tray and slot to zero",
-                    input: r#"{
-                        "DeviceUID": 99,
-                        "DeviceID": 1,
-                        "DevicePcieID": 0,
-                        "SystemUID": 0,
-                        "VendorID": 0,
-                        "ALIDList": []
-                    }"#,
-                    expect: NvLinkGpu {
-                        tray_index: 0,
-                        slot_id: 0,
-                        device_id: 1,
-                        guid: 99,
-                    },
-                },
-                Check {
-                    scenario: "partial location info defaults the missing field",
-                    input: r#"{
-                        "LocationInfo": {"TrayIndex": 2},
-                        "DeviceUID": 0,
-                        "DeviceID": 0,
-                        "DevicePcieID": 0,
-                        "SystemUID": 0,
-                        "VendorID": 0,
-                        "ALIDList": []
-                    }"#,
-                    expect: NvLinkGpu {
-                        tray_index: 2,
-                        slot_id: 0,
-                        device_id: 0,
-                        guid: 0,
-                    },
-                },
-            ],
-            |json| {
+        value_scenarios!(
+            run = |json| {
                 let gpu = serde_json::from_str::<libnmxm::nmxm_model::Gpu>(json).unwrap();
                 NvLinkGpu::from(gpu)
-            },
+            };
+            "full location info is carried through" {
+                r#"{
+                            "LocationInfo": {"TrayIndex": 3, "SlotID": 7},
+                            "DeviceUID": 42,
+                            "DeviceID": 5,
+                            "DevicePcieID": 0,
+                            "SystemUID": 0,
+                            "VendorID": 0,
+                            "ALIDList": []
+                        }"# => NvLinkGpu {
+                    tray_index: 3,
+                    slot_id: 7,
+                    device_id: 5,
+                    guid: 42,
+                },
+            }
+
+            "absent location info defaults tray and slot to zero" {
+                r#"{
+                            "DeviceUID": 99,
+                            "DeviceID": 1,
+                            "DevicePcieID": 0,
+                            "SystemUID": 0,
+                            "VendorID": 0,
+                            "ALIDList": []
+                        }"# => NvLinkGpu {
+                    tray_index: 0,
+                    slot_id: 0,
+                    device_id: 1,
+                    guid: 99,
+                },
+            }
+
+            "partial location info defaults the missing field" {
+                r#"{
+                            "LocationInfo": {"TrayIndex": 2},
+                            "DeviceUID": 0,
+                            "DeviceID": 0,
+                            "DevicePcieID": 0,
+                            "SystemUID": 0,
+                            "VendorID": 0,
+                            "ALIDList": []
+                        }"# => NvLinkGpu {
+                    tray_index: 2,
+                    slot_id: 0,
+                    device_id: 0,
+                    guid: 0,
+                },
+            }
         );
     }
 }

--- a/crates/api-model/src/health.rs
+++ b/crates/api-model/src/health.rs
@@ -80,7 +80,7 @@ impl HealthReportSources {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::{Case, check_cases, scenarios};
 
     use super::*;
 
@@ -185,46 +185,39 @@ mod tests {
         // `iter` borrows rather than consuming, but yields the same (source, mode)
         // sequence as `into_iter`: merges first in sorted key order, then the
         // replace source. Infallible, so every row `Yields`.
-        check_cases(
-            [
-                Case {
-                    scenario: "empty borrows nothing",
-                    input: sources(None, &[]),
-                    expect: Yields(vec![]),
-                },
-                Case {
-                    scenario: "merges only",
-                    input: sources(None, &["source-b", "source-a"]),
-                    expect: Yields(vec![
-                        ("source-a".to_string(), HealthReportApplyMode::Merge),
-                        ("source-b".to_string(), HealthReportApplyMode::Merge),
-                    ]),
-                },
-                Case {
-                    scenario: "replace only",
-                    input: sources(Some("admin-replace"), &[]),
-                    expect: Yields(vec![(
-                        "admin-replace".to_string(),
-                        HealthReportApplyMode::Replace,
-                    )]),
-                },
-                Case {
-                    scenario: "mixed merge and replace",
-                    input: sources(Some("sre-override"), &["external-monitor"]),
-                    expect: Yields(vec![
-                        ("external-monitor".to_string(), HealthReportApplyMode::Merge),
-                        ("sre-override".to_string(), HealthReportApplyMode::Replace),
-                    ]),
-                },
-            ],
-            |sources: HealthReportSources| {
+        scenarios!(
+            run = |sources: HealthReportSources| {
                 Ok::<_, ()>(
                     sources
                         .iter()
                         .map(|(report, mode)| (report.source.clone(), mode))
                         .collect::<Vec<_>>(),
                 )
-            },
+            };
+            "empty borrows nothing" {
+                sources(None, &[]) => Yields(vec![]),
+            }
+
+            "merges only" {
+                sources(None, &["source-b", "source-a"]) => Yields(vec![
+                    ("source-a".to_string(), HealthReportApplyMode::Merge),
+                    ("source-b".to_string(), HealthReportApplyMode::Merge),
+                ]),
+            }
+
+            "replace only" {
+                sources(Some("admin-replace"), &[]) => Yields(vec![(
+                    "admin-replace".to_string(),
+                    HealthReportApplyMode::Replace,
+                )]),
+            }
+
+            "mixed merge and replace" {
+                sources(Some("sre-override"), &["external-monitor"]) => Yields(vec![
+                    ("external-monitor".to_string(), HealthReportApplyMode::Merge),
+                    ("sre-override".to_string(), HealthReportApplyMode::Replace),
+                ]),
+            }
         );
     }
 
@@ -308,20 +301,15 @@ mod tests {
         let round_trip = sources(Some("admin-replace"), &["external-monitor"]);
         let round_trip_json = serde_json::to_string(&round_trip).unwrap();
 
-        check_cases(
-            [
-                Case {
-                    scenario: "round trips serialized form",
-                    input: round_trip_json.as_str(),
-                    expect: Yields(round_trip),
-                },
-                Case {
-                    scenario: "null replace deserializes to default",
-                    input: r#"{"merges":{}}"#,
-                    expect: Yields(HealthReportSources::default()),
-                },
-            ],
-            |json: &str| serde_json::from_str::<HealthReportSources>(json).map_err(|_| ()),
+        scenarios!(
+            run = |json: &str| serde_json::from_str::<HealthReportSources>(json).map_err(|_| ());
+            "round trips serialized form" {
+                round_trip_json.as_str() => Yields(round_trip),
+            }
+
+            "null replace deserializes to default" {
+                r#"{"merges":{}}"# => Yields(HealthReportSources::default()),
+            }
         );
     }
 }

--- a/crates/api-model/src/ib.rs
+++ b/crates/api-model/src/ib.rs
@@ -220,114 +220,89 @@ impl From<IBServiceLevel> for i32 {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Check, scenarios, value_scenarios};
 
     use crate::ib::{IBMtu, IBPortMembership, IBPortState, IBRateLimit, IBServiceLevel};
 
     #[test]
     fn port_membership_to_string() {
-        check_values(
-            [
-                Check {
-                    scenario: "full",
-                    input: IBPortMembership::Full,
-                    expect: "full".to_string(),
-                },
-                Check {
-                    scenario: "limited",
-                    input: IBPortMembership::Limited,
-                    expect: "limited".to_string(),
-                },
-            ],
-            |membership| membership.to_string(),
+        value_scenarios!(
+            run = |membership| membership.to_string();
+            "full" {
+                IBPortMembership::Full => "full".to_string(),
+            }
+
+            "limited" {
+                IBPortMembership::Limited => "limited".to_string(),
+            }
         );
     }
 
     #[test]
     fn port_state_try_from_str() {
-        check_cases(
-            [
-                Case {
-                    scenario: "active",
-                    input: "active",
-                    expect: Yields(IBPortState::Active),
-                },
-                Case {
-                    scenario: "down",
-                    input: "down",
-                    expect: Yields(IBPortState::Down),
-                },
-                Case {
-                    scenario: "initialize",
-                    input: "initialize",
-                    expect: Yields(IBPortState::Initialize),
-                },
-                Case {
-                    scenario: "armed",
-                    input: "armed",
-                    expect: Yields(IBPortState::Armed),
-                },
-                Case {
-                    scenario: "uppercase is lowercased",
-                    input: "ACTIVE",
-                    expect: Yields(IBPortState::Active),
-                },
-                Case {
-                    scenario: "mixed case",
-                    input: "ArMeD",
-                    expect: Yields(IBPortState::Armed),
-                },
-                Case {
-                    scenario: "surrounding whitespace is trimmed",
-                    input: "  down  ",
-                    expect: Yields(IBPortState::Down),
-                },
-                Case {
-                    scenario: "empty string",
-                    input: "",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "whitespace only",
-                    input: "   ",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "unknown word",
-                    input: "sleeping",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "near miss",
-                    input: "actives",
-                    expect: Fails,
-                },
-            ],
-            |state| IBPortState::try_from(state).map_err(drop),
+        scenarios!(
+            run = |state| IBPortState::try_from(state).map_err(drop);
+            "active" {
+                "active" => Yields(IBPortState::Active),
+            }
+
+            "down" {
+                "down" => Yields(IBPortState::Down),
+            }
+
+            "initialize" {
+                "initialize" => Yields(IBPortState::Initialize),
+            }
+
+            "armed" {
+                "armed" => Yields(IBPortState::Armed),
+            }
+
+            "uppercase is lowercased" {
+                "ACTIVE" => Yields(IBPortState::Active),
+            }
+
+            "mixed case" {
+                "ArMeD" => Yields(IBPortState::Armed),
+            }
+
+            "surrounding whitespace is trimmed" {
+                "  down  " => Yields(IBPortState::Down),
+            }
+
+            "empty string" {
+                "" => Fails,
+            }
+
+            "whitespace only" {
+                "   " => Fails,
+            }
+
+            "unknown word" {
+                "sleeping" => Fails,
+            }
+
+            "near miss" {
+                "actives" => Fails,
+            }
         );
     }
 
     #[test]
     fn port_state_try_from_string() {
-        check_cases(
-            [
-                Case {
-                    scenario: "active",
-                    input: "active".to_string(),
-                    expect: Yields(IBPortState::Active),
-                },
-                Case {
-                    scenario: "trimmed and lowercased",
-                    input: " Initialize ".to_string(),
-                    expect: Yields(IBPortState::Initialize),
-                },
-                Case {
-                    scenario: "invalid",
-                    input: "bogus".to_string(),
-                    expect: Fails,
-                },
-            ],
-            |state| IBPortState::try_from(state).map_err(drop),
+        scenarios!(
+            run = |state| IBPortState::try_from(state).map_err(drop);
+            "active" {
+                "active".to_string() => Yields(IBPortState::Active),
+            }
+
+            "trimmed and lowercased" {
+                " Initialize ".to_string() => Yields(IBPortState::Initialize),
+            }
+
+            "invalid" {
+                "bogus".to_string() => Fails,
+            }
         );
     }
 
@@ -343,64 +318,49 @@ mod tests {
 
     #[test]
     fn mtu_try_from_i32() {
-        check_cases(
-            [
-                Case {
-                    scenario: "2k",
-                    input: 2,
-                    expect: Yields(IBMtu(2)),
-                },
-                Case {
-                    scenario: "4k",
-                    input: 4,
-                    expect: Yields(IBMtu(4)),
-                },
-                Case {
-                    scenario: "zero",
-                    input: 0,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "one",
-                    input: 1,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "three between valid values",
-                    input: 3,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "negative",
-                    input: -2,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "large",
-                    input: 4096,
-                    expect: Fails,
-                },
-            ],
-            |mtu| IBMtu::try_from(mtu).map_err(drop),
+        scenarios!(
+            run = |mtu| IBMtu::try_from(mtu).map_err(drop);
+            "2k" {
+                2 => Yields(IBMtu(2)),
+            }
+
+            "4k" {
+                4 => Yields(IBMtu(4)),
+            }
+
+            "zero" {
+                0 => Fails,
+            }
+
+            "one" {
+                1 => Fails,
+            }
+
+            "three between valid values" {
+                3 => Fails,
+            }
+
+            "negative" {
+                -2 => Fails,
+            }
+
+            "large" {
+                4096 => Fails,
+            }
         );
     }
 
     #[test]
     fn mtu_into_i32() {
-        check_values(
-            [
-                Check {
-                    scenario: "2k",
-                    input: IBMtu(2),
-                    expect: 2,
-                },
-                Check {
-                    scenario: "4k",
-                    input: IBMtu(4),
-                    expect: 4,
-                },
-            ],
-            i32::from,
+        value_scenarios!(
+            run = i32::from;
+            "2k" {
+                IBMtu(2) => 2,
+            }
+
+            "4k" {
+                IBMtu(4) => 4,
+            }
         );
     }
 
@@ -416,139 +376,109 @@ mod tests {
 
     #[test]
     fn rate_limit_try_from_i32() {
-        check_cases(
-            [
-                Case {
-                    scenario: "legacy sdr 2.5 sentinel",
-                    input: 2,
-                    expect: Yields(IBRateLimit(2)),
-                },
-                Case {
-                    scenario: "5",
-                    input: 5,
-                    expect: Yields(IBRateLimit(5)),
-                },
-                Case {
-                    scenario: "10",
-                    input: 10,
-                    expect: Yields(IBRateLimit(10)),
-                },
-                Case {
-                    scenario: "14",
-                    input: 14,
-                    expect: Yields(IBRateLimit(14)),
-                },
-                Case {
-                    scenario: "20",
-                    input: 20,
-                    expect: Yields(IBRateLimit(20)),
-                },
-                Case {
-                    scenario: "25",
-                    input: 25,
-                    expect: Yields(IBRateLimit(25)),
-                },
-                Case {
-                    scenario: "30",
-                    input: 30,
-                    expect: Yields(IBRateLimit(30)),
-                },
-                Case {
-                    scenario: "40",
-                    input: 40,
-                    expect: Yields(IBRateLimit(40)),
-                },
-                Case {
-                    scenario: "56",
-                    input: 56,
-                    expect: Yields(IBRateLimit(56)),
-                },
-                Case {
-                    scenario: "60",
-                    input: 60,
-                    expect: Yields(IBRateLimit(60)),
-                },
-                Case {
-                    scenario: "80",
-                    input: 80,
-                    expect: Yields(IBRateLimit(80)),
-                },
-                Case {
-                    scenario: "100",
-                    input: 100,
-                    expect: Yields(IBRateLimit(100)),
-                },
-                Case {
-                    scenario: "112",
-                    input: 112,
-                    expect: Yields(IBRateLimit(112)),
-                },
-                Case {
-                    scenario: "120",
-                    input: 120,
-                    expect: Yields(IBRateLimit(120)),
-                },
-                Case {
-                    scenario: "168",
-                    input: 168,
-                    expect: Yields(IBRateLimit(168)),
-                },
-                Case {
-                    scenario: "200",
-                    input: 200,
-                    expect: Yields(IBRateLimit(200)),
-                },
-                Case {
-                    scenario: "300",
-                    input: 300,
-                    expect: Yields(IBRateLimit(300)),
-                },
-                Case {
-                    scenario: "zero",
-                    input: 0,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "one",
-                    input: 1,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "three is not a valid rate",
-                    input: 3,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "negative",
-                    input: -200,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "unsupported large",
-                    input: 400,
-                    expect: Fails,
-                },
-            ],
-            |rate| IBRateLimit::try_from(rate).map_err(drop),
+        scenarios!(
+            run = |rate| IBRateLimit::try_from(rate).map_err(drop);
+            "legacy sdr 2.5 sentinel" {
+                2 => Yields(IBRateLimit(2)),
+            }
+
+            "5" {
+                5 => Yields(IBRateLimit(5)),
+            }
+
+            "10" {
+                10 => Yields(IBRateLimit(10)),
+            }
+
+            "14" {
+                14 => Yields(IBRateLimit(14)),
+            }
+
+            "20" {
+                20 => Yields(IBRateLimit(20)),
+            }
+
+            "25" {
+                25 => Yields(IBRateLimit(25)),
+            }
+
+            "30" {
+                30 => Yields(IBRateLimit(30)),
+            }
+
+            "40" {
+                40 => Yields(IBRateLimit(40)),
+            }
+
+            "56" {
+                56 => Yields(IBRateLimit(56)),
+            }
+
+            "60" {
+                60 => Yields(IBRateLimit(60)),
+            }
+
+            "80" {
+                80 => Yields(IBRateLimit(80)),
+            }
+
+            "100" {
+                100 => Yields(IBRateLimit(100)),
+            }
+
+            "112" {
+                112 => Yields(IBRateLimit(112)),
+            }
+
+            "120" {
+                120 => Yields(IBRateLimit(120)),
+            }
+
+            "168" {
+                168 => Yields(IBRateLimit(168)),
+            }
+
+            "200" {
+                200 => Yields(IBRateLimit(200)),
+            }
+
+            "300" {
+                300 => Yields(IBRateLimit(300)),
+            }
+
+            "zero" {
+                0 => Fails,
+            }
+
+            "one" {
+                1 => Fails,
+            }
+
+            "three is not a valid rate" {
+                3 => Fails,
+            }
+
+            "negative" {
+                -200 => Fails,
+            }
+
+            "unsupported large" {
+                400 => Fails,
+            }
         );
     }
 
     #[test]
     fn rate_limit_into_i32() {
-        check_values(
-            [
-                Check {
-                    scenario: "200",
-                    input: IBRateLimit(200),
-                    expect: 200,
-                },
-                Check {
-                    scenario: "sdr sentinel",
-                    input: IBRateLimit(2),
-                    expect: 2,
-                },
-            ],
-            i32::from,
+        value_scenarios!(
+            run = i32::from;
+            "200" {
+                IBRateLimit(200) => 200,
+            }
+
+            "sdr sentinel" {
+                IBRateLimit(2) => 2,
+            }
         );
     }
 
@@ -564,59 +494,45 @@ mod tests {
 
     #[test]
     fn service_level_try_from_i32() {
-        check_cases(
-            [
-                Case {
-                    scenario: "lower bound 0",
-                    input: 0,
-                    expect: Yields(IBServiceLevel(0)),
-                },
-                Case {
-                    scenario: "mid 7",
-                    input: 7,
-                    expect: Yields(IBServiceLevel(7)),
-                },
-                Case {
-                    scenario: "upper bound 15",
-                    input: 15,
-                    expect: Yields(IBServiceLevel(15)),
-                },
-                Case {
-                    scenario: "just past upper bound",
-                    input: 16,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "negative below lower bound",
-                    input: -1,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "large",
-                    input: 1000,
-                    expect: Fails,
-                },
-            ],
-            |level| IBServiceLevel::try_from(level).map_err(drop),
+        scenarios!(
+            run = |level| IBServiceLevel::try_from(level).map_err(drop);
+            "lower bound 0" {
+                0 => Yields(IBServiceLevel(0)),
+            }
+
+            "mid 7" {
+                7 => Yields(IBServiceLevel(7)),
+            }
+
+            "upper bound 15" {
+                15 => Yields(IBServiceLevel(15)),
+            }
+
+            "just past upper bound" {
+                16 => Fails,
+            }
+
+            "negative below lower bound" {
+                -1 => Fails,
+            }
+
+            "large" {
+                1000 => Fails,
+            }
         );
     }
 
     #[test]
     fn service_level_into_i32() {
-        check_values(
-            [
-                Check {
-                    scenario: "0",
-                    input: IBServiceLevel(0),
-                    expect: 0,
-                },
-                Check {
-                    scenario: "15",
-                    input: IBServiceLevel(15),
-                    expect: 15,
-                },
-            ],
-            i32::from,
+        value_scenarios!(
+            run = i32::from;
+            "0" {
+                IBServiceLevel(0) => 0,
+            }
+
+            "15" {
+                IBServiceLevel(15) => 15,
+            }
         );
     }
 }

--- a/crates/api-model/src/ib_partition/mod.rs
+++ b/crates/api-model/src/ib_partition/mod.rs
@@ -314,7 +314,7 @@ pub fn state_sla(state: &IBPartitionControllerState, state_version: &ConfigVersi
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Case, check_cases, scenarios, value_scenarios};
 
     use super::*;
 
@@ -414,61 +414,45 @@ mod tests {
 
     #[test]
     fn try_from_str_like_inputs_match_from_str() {
-        check_cases(
-            [
-                Case {
-                    scenario: "&str hex",
-                    input: "0x20",
-                    expect: Yields(0x20),
-                },
-                Case {
-                    scenario: "&str decimal",
-                    input: "32",
-                    expect: Yields(0x20),
-                },
-                Case {
-                    scenario: "&str malformed",
-                    input: "zz",
-                    expect: Fails,
-                },
-            ],
-            |s| PartitionKey::try_from(s).map(u16::from).map_err(drop),
+        scenarios!(
+            run = |s| PartitionKey::try_from(s).map(u16::from).map_err(drop);
+            "&str hex" {
+                "0x20" => Yields(0x20),
+            }
+
+            "&str decimal" {
+                "32" => Yields(0x20),
+            }
+
+            "&str malformed" {
+                "zz" => Fails,
+            }
         );
     }
 
     #[test]
     fn try_from_owned_and_borrowed_string() {
         // TryFrom<String>
-        check_cases(
-            [
-                Case {
-                    scenario: "owned String hex",
-                    input: "0xab".to_string(),
-                    expect: Yields(0xab),
-                },
-                Case {
-                    scenario: "owned String malformed",
-                    input: "bad".to_string(),
-                    expect: Fails,
-                },
-            ],
-            |s| PartitionKey::try_from(s).map(u16::from).map_err(drop),
+        scenarios!(
+            run = |s| PartitionKey::try_from(s).map(u16::from).map_err(drop);
+            "owned String hex" {
+                "0xab".to_string() => Yields(0xab),
+            }
+
+            "owned String malformed" {
+                "bad".to_string() => Fails,
+            }
         );
         // TryFrom<&String>
-        check_cases(
-            [
-                Case {
-                    scenario: "&String decimal",
-                    input: "171".to_string(),
-                    expect: Yields(0xab),
-                },
-                Case {
-                    scenario: "&String malformed",
-                    input: "bad".to_string(),
-                    expect: Fails,
-                },
-            ],
-            |s| PartitionKey::try_from(&s).map(u16::from).map_err(drop),
+        scenarios!(
+            run = |s| PartitionKey::try_from(&s).map(u16::from).map_err(drop);
+            "&String decimal" {
+                "171".to_string() => Yields(0xab),
+            }
+
+            "&String malformed" {
+                "bad".to_string() => Fails,
+            }
         );
     }
 
@@ -476,35 +460,27 @@ mod tests {
 
     #[test]
     fn try_from_u16_enforces_the_mask() {
-        check_cases(
-            [
-                Case {
-                    scenario: "zero",
-                    input: 0u16,
-                    expect: Yields(0),
-                },
-                Case {
-                    scenario: "small in-range value",
-                    input: 0x000f,
-                    expect: Yields(0x000f),
-                },
-                Case {
-                    scenario: "max valid (default partition)",
-                    input: 0x7fff,
-                    expect: Yields(0x7fff),
-                },
-                Case {
-                    scenario: "first value past the mask",
-                    input: 0x8000,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "u16 max has the high bit set",
-                    input: 0xffff,
-                    expect: Fails,
-                },
-            ],
-            |n| PartitionKey::try_from(n).map(u16::from).map_err(drop),
+        scenarios!(
+            run = |n| PartitionKey::try_from(n).map(u16::from).map_err(drop);
+            "zero" {
+                0u16 => Yields(0),
+            }
+
+            "small in-range value" {
+                0x000f => Yields(0x000f),
+            }
+
+            "max valid (default partition)" {
+                0x7fff => Yields(0x7fff),
+            }
+
+            "first value past the mask" {
+                0x8000 => Fails,
+            }
+
+            "u16 max has the high bit set" {
+                0xffff => Fails,
+            }
         );
     }
 
@@ -512,30 +488,23 @@ mod tests {
 
     #[test]
     fn display_renders_lowercase_hex_with_prefix() {
-        check_values(
-            [
-                Check {
-                    scenario: "zero",
-                    input: 0u16,
-                    expect: "0x0".to_string(),
-                },
-                Check {
-                    scenario: "single hex digit",
-                    input: 0x000f,
-                    expect: "0xf".to_string(),
-                },
-                Check {
-                    scenario: "multi-digit lowercased",
-                    input: 0x00ab,
-                    expect: "0xab".to_string(),
-                },
-                Check {
-                    scenario: "default partition key",
-                    input: 0x7fff,
-                    expect: "0x7fff".to_string(),
-                },
-            ],
-            |n| PartitionKey::try_from(n).unwrap().to_string(),
+        value_scenarios!(
+            run = |n| PartitionKey::try_from(n).unwrap().to_string();
+            "zero" {
+                0u16 => "0x0".to_string(),
+            }
+
+            "single hex digit" {
+                0x000f => "0xf".to_string(),
+            }
+
+            "multi-digit lowercased" {
+                0x00ab => "0xab".to_string(),
+            }
+
+            "default partition key" {
+                0x7fff => "0x7fff".to_string(),
+            }
         );
     }
 
@@ -548,30 +517,23 @@ mod tests {
 
     #[test]
     fn is_default_partition_predicate() {
-        check_values(
-            [
-                Check {
-                    scenario: "the default key",
-                    input: 0x7fff,
-                    expect: true,
-                },
-                Check {
-                    scenario: "zero is not default",
-                    input: 0,
-                    expect: false,
-                },
-                Check {
-                    scenario: "an ordinary key is not default",
-                    input: 0x000f,
-                    expect: false,
-                },
-                Check {
-                    scenario: "one below default",
-                    input: 0x7ffe,
-                    expect: false,
-                },
-            ],
-            |n| PartitionKey::try_from(n).unwrap().is_default_partition(),
+        value_scenarios!(
+            run = |n| PartitionKey::try_from(n).unwrap().is_default_partition();
+            "the default key" {
+                0x7fff => true,
+            }
+
+            "zero is not default" {
+                0 => false,
+            }
+
+            "an ordinary key is not default" {
+                0x000f => false,
+            }
+
+            "one below default" {
+                0x7ffe => false,
+            }
         );
     }
 
@@ -579,29 +541,23 @@ mod tests {
 
     #[test]
     fn parse_then_display_round_trips_to_canonical_hex() {
-        check_cases(
-            [
-                Case {
-                    scenario: "decimal normalizes to hex",
-                    input: "15",
-                    expect: Yields("0xf".to_string()),
-                },
-                Case {
-                    scenario: "hex stays hex",
-                    input: "0xf",
-                    expect: Yields("0xf".to_string()),
-                },
-                Case {
-                    scenario: "uppercase folds to lowercase",
-                    input: "0x7ABC",
-                    expect: Yields("0x7abc".to_string()),
-                },
-            ],
-            |s| {
+        scenarios!(
+            run = |s| {
                 PartitionKey::from_str(s)
                     .map(|p| p.to_string())
                     .map_err(drop)
-            },
+            };
+            "decimal normalizes to hex" {
+                "15" => Yields("0xf".to_string()),
+            }
+
+            "hex stays hex" {
+                "0xf" => Yields("0xf".to_string()),
+            }
+
+            "uppercase folds to lowercase" {
+                "0x7ABC" => Yields("0x7abc".to_string()),
+            }
         );
     }
 
@@ -609,61 +565,48 @@ mod tests {
 
     #[test]
     fn serializes_as_canonical_hex_string() {
-        check_cases(
-            [
-                Case {
-                    scenario: "single digit",
-                    input: 0x000f,
-                    expect: Yields("\"0xf\"".to_string()),
-                },
-                Case {
-                    scenario: "zero",
-                    input: 0,
-                    expect: Yields("\"0x0\"".to_string()),
-                },
-                Case {
-                    scenario: "default partition",
-                    input: 0x7fff,
-                    expect: Yields("\"0x7fff\"".to_string()),
-                },
-            ],
-            |n| {
+        scenarios!(
+            run = |n| {
                 let pkey = PartitionKey::try_from(n).unwrap();
                 serde_json::to_string(&pkey).map_err(drop)
-            },
+            };
+            "single digit" {
+                0x000f => Yields("\"0xf\"".to_string()),
+            }
+
+            "zero" {
+                0 => Yields("\"0x0\"".to_string()),
+            }
+
+            "default partition" {
+                0x7fff => Yields("\"0x7fff\"".to_string()),
+            }
         );
     }
 
     #[test]
     fn deserializes_from_hex_or_decimal_strings() {
-        check_cases(
-            [
-                Case {
-                    scenario: "hex string",
-                    input: "\"0xf\"",
-                    expect: Yields(0x000f),
-                },
-                Case {
-                    scenario: "decimal string of the same value",
-                    input: "\"15\"",
-                    expect: Yields(0x000f),
-                },
-                Case {
-                    scenario: "malformed string",
-                    input: "\"nope\"",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "non-string JSON is rejected",
-                    input: "15",
-                    expect: Fails,
-                },
-            ],
-            |s| {
+        scenarios!(
+            run = |s| {
                 serde_json::from_str::<PartitionKey>(s)
                     .map(u16::from)
                     .map_err(drop)
-            },
+            };
+            "hex string" {
+                "\"0xf\"" => Yields(0x000f),
+            }
+
+            "decimal string of the same value" {
+                "\"15\"" => Yields(0x000f),
+            }
+
+            "malformed string" {
+                "\"nope\"" => Fails,
+            }
+
+            "non-string JSON is rejected" {
+                "15" => Fails,
+            }
         );
     }
 
@@ -671,68 +614,54 @@ mod tests {
 
     #[test]
     fn controller_state_serializes_with_lowercase_tag() {
-        check_cases(
-            [
-                Case {
-                    scenario: "provisioning",
-                    input: IBPartitionControllerState::Provisioning,
-                    expect: Yields(r#"{"state":"provisioning"}"#.to_string()),
-                },
-                Case {
-                    scenario: "ready",
-                    input: IBPartitionControllerState::Ready,
-                    expect: Yields(r#"{"state":"ready"}"#.to_string()),
-                },
-                Case {
-                    scenario: "deleting",
-                    input: IBPartitionControllerState::Deleting,
-                    expect: Yields(r#"{"state":"deleting"}"#.to_string()),
-                },
-                Case {
-                    scenario: "error carries its cause",
-                    input: IBPartitionControllerState::Error {
-                        cause: "cause goes here".to_string(),
-                    },
-                    expect: Yields(r#"{"state":"error","cause":"cause goes here"}"#.to_string()),
-                },
-            ],
-            |state| serde_json::to_string(&state).map_err(drop),
+        scenarios!(
+            run = |state| serde_json::to_string(&state).map_err(drop);
+            "provisioning" {
+                IBPartitionControllerState::Provisioning => Yields(r#"{"state":"provisioning"}"#.to_string()),
+            }
+
+            "ready" {
+                IBPartitionControllerState::Ready => Yields(r#"{"state":"ready"}"#.to_string()),
+            }
+
+            "deleting" {
+                IBPartitionControllerState::Deleting => Yields(r#"{"state":"deleting"}"#.to_string()),
+            }
+
+            "error carries its cause" {
+                IBPartitionControllerState::Error {
+                    cause: "cause goes here".to_string(),
+                } => Yields(r#"{"state":"error","cause":"cause goes here"}"#.to_string()),
+            }
         );
     }
 
     #[test]
     fn controller_state_round_trips_through_json() {
-        check_cases(
-            [
-                Case {
-                    scenario: "provisioning",
-                    input: IBPartitionControllerState::Provisioning,
-                    expect: Yields(IBPartitionControllerState::Provisioning),
-                },
-                Case {
-                    scenario: "ready",
-                    input: IBPartitionControllerState::Ready,
-                    expect: Yields(IBPartitionControllerState::Ready),
-                },
-                Case {
-                    scenario: "deleting",
-                    input: IBPartitionControllerState::Deleting,
-                    expect: Yields(IBPartitionControllerState::Deleting),
-                },
-                Case {
-                    scenario: "error preserves its cause",
-                    input: IBPartitionControllerState::Error {
-                        cause: "boom".to_string(),
-                    },
-                    expect: Yields(IBPartitionControllerState::Error {
-                        cause: "boom".to_string(),
-                    }),
-                },
-            ],
-            |state| {
+        scenarios!(
+            run = |state| {
                 let json = serde_json::to_string(&state).map_err(drop)?;
                 serde_json::from_str::<IBPartitionControllerState>(&json).map_err(drop)
-            },
+            };
+            "provisioning" {
+                IBPartitionControllerState::Provisioning => Yields(IBPartitionControllerState::Provisioning),
+            }
+
+            "ready" {
+                IBPartitionControllerState::Ready => Yields(IBPartitionControllerState::Ready),
+            }
+
+            "deleting" {
+                IBPartitionControllerState::Deleting => Yields(IBPartitionControllerState::Deleting),
+            }
+
+            "error preserves its cause" {
+                IBPartitionControllerState::Error {
+                    cause: "boom".to_string(),
+                } => Yields(IBPartitionControllerState::Error {
+                    cause: "boom".to_string(),
+                }),
+            }
         );
     }
 

--- a/crates/api-model/src/instance/config/network.rs
+++ b/crates/api-model/src/instance/config/network.rs
@@ -736,7 +736,7 @@ where
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::scenarios;
 
     use super::*;
 
@@ -764,28 +764,23 @@ mod tests {
     // round-trips back equal before yielding that string.
     #[test]
     fn serialize_function_id() {
-        check_cases(
-            [
-                Case {
-                    scenario: "physical",
-                    input: InterfaceFunctionId::Physical {},
-                    expect: Yields(r#"{"type":"physical"}"#.to_string()),
-                },
-                Case {
-                    scenario: "virtual",
-                    input: InterfaceFunctionId::Virtual { id: 24 },
-                    expect: Yields(r#"{"type":"virtual","id":24}"#.to_string()),
-                },
-            ],
+        scenarios!(
             // Serialize, confirm it round-trips back equal, then yield the JSON.
             // serde_json::Error is not PartialEq, so collapse failures to ().
-            |function_id| {
+            run = |function_id| {
                 let serialized = serde_json::to_string(&function_id).map_err(|_| ())?;
                 let round_tripped =
                     serde_json::from_str::<InterfaceFunctionId>(&serialized).map_err(|_| ())?;
                 assert_eq!(round_tripped, function_id);
                 Ok::<_, ()>(serialized)
-            },
+            };
+            "physical" {
+                InterfaceFunctionId::Physical {} => Yields(r#"{"type":"physical"}"#.to_string()),
+            }
+
+            "virtual" {
+                InterfaceFunctionId::Virtual { id: 24 } => Yields(r#"{"type":"virtual","id":24}"#.to_string()),
+            }
         );
     }
 
@@ -899,45 +894,35 @@ mod tests {
         duplicate_network_segment.interfaces[1].network_segment_id =
             Some(DUPLICATE_SEGMENT_ID.into());
 
-        check_cases(
-            [
-                Case {
-                    scenario: "valid config with virtual functions allowed",
-                    input: (valid, true),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "virtual functions disabled by site configuration",
-                    input: (virtual_functions_disabled, false),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "duplicate virtual function id",
-                    input: (duplicate_virtual_function, true),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "out of bounds virtual function id",
-                    input: (out_of_bounds_virtual_function, true),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "no physical function",
-                    input: (no_physical_function, true),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "missing middle virtual function id is allowed",
-                    input: (missing_middle_virtual_function, true),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "duplicate network segment",
-                    input: (duplicate_network_segment, true),
-                    expect: Fails,
-                },
-            ],
-            |(config, allow_instance_vf)| config.validate(allow_instance_vf).map_err(drop),
+        scenarios!(
+            run = |(config, allow_instance_vf)| config.validate(allow_instance_vf).map_err(drop);
+            "valid config with virtual functions allowed" {
+                (valid, true) => Yields(()),
+            }
+
+            "virtual functions disabled by site configuration" {
+                (virtual_functions_disabled, false) => Fails,
+            }
+
+            "duplicate virtual function id" {
+                (duplicate_virtual_function, true) => Fails,
+            }
+
+            "out of bounds virtual function id" {
+                (out_of_bounds_virtual_function, true) => Fails,
+            }
+
+            "no physical function" {
+                (no_physical_function, true) => Fails,
+            }
+
+            "missing middle virtual function id is allowed" {
+                (missing_middle_virtual_function, true) => Yields(()),
+            }
+
+            "duplicate network segment" {
+                (duplicate_network_segment, true) => Fails,
+            }
         );
     }
 }

--- a/crates/api-model/src/instance/config/tenant_config.rs
+++ b/crates/api-model/src/instance/config/tenant_config.rs
@@ -86,7 +86,7 @@ mod tests {
     use std::mem::discriminant;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::scenarios;
 
     use super::*;
 
@@ -115,41 +115,36 @@ mod tests {
         // pass. The error type (ConfigValidationError) is not PartialEq, so failing
         // rows assert the rejected *variant* via its discriminant rather than the
         // exact error value.
-        check_cases(
-            [
-                Case {
-                    scenario: "duplicate keyset ids are rejected",
-                    input: TenantConfig {
-                        tenant_organization_id: TenantOrganizationId::try_from(
-                            "TenantA".to_string(),
-                        )
-                        .unwrap(),
-                        tenant_keyset_ids: vec![
-                            "a".to_string(),
-                            "b".to_string(),
-                            "c".to_string(),
-                            "a".to_string(),
-                        ],
-                        hostname: Some("test-instance".to_string()),
-                    },
-                    expect: FailsWith(discriminant(
-                        &ConfigValidationError::DuplicateTenantKeysetId(String::new()),
-                    )),
-                },
-                Case {
-                    scenario: "unique keyset ids validate",
-                    input: TenantConfig {
-                        tenant_organization_id: TenantOrganizationId::try_from(
-                            "TenantA".to_string(),
-                        )
-                        .unwrap(),
-                        tenant_keyset_ids: vec!["a".to_string(), "b".to_string(), "c".to_string()],
-                        hostname: Some("test-instance".to_string()),
-                    },
-                    expect: Yields(()),
-                },
-            ],
-            |config: TenantConfig| config.validate().map_err(|e| discriminant(&e)),
+        scenarios!(
+            run = |config: TenantConfig| config.validate().map_err(|e| discriminant(&e));
+            "duplicate keyset ids are rejected" {
+                TenantConfig {
+                    tenant_organization_id: TenantOrganizationId::try_from(
+                        "TenantA".to_string(),
+                    )
+                    .unwrap(),
+                    tenant_keyset_ids: vec![
+                        "a".to_string(),
+                        "b".to_string(),
+                        "c".to_string(),
+                        "a".to_string(),
+                    ],
+                    hostname: Some("test-instance".to_string()),
+                } => FailsWith(discriminant(
+                    &ConfigValidationError::DuplicateTenantKeysetId(String::new()),
+                )),
+            }
+
+            "unique keyset ids validate" {
+                TenantConfig {
+                    tenant_organization_id: TenantOrganizationId::try_from(
+                        "TenantA".to_string(),
+                    )
+                    .unwrap(),
+                    tenant_keyset_ids: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+                    hostname: Some("test-instance".to_string()),
+                } => Yields(()),
+            }
         );
     }
 }

--- a/crates/api-model/src/instance/snapshot.rs
+++ b/crates/api-model/src/instance/snapshot.rs
@@ -381,7 +381,7 @@ mod tests {
     use std::str::FromStr;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::scenarios;
     use chrono::Utc;
     use uuid::Uuid;
 
@@ -465,52 +465,11 @@ mod tests {
         let image_uuid = uuid::uuid!("a1b2c3d4-e5f6-4780-a123-456789abcdef");
         let os_uuid = uuid::uuid!("b2c3d4e5-f6a7-4890-b234-567890abcdef");
 
-        check_cases(
-            [
-                Case {
-                    scenario: "legacy inline iPXE derives Ipxe variant with user_data and phone_home",
-                    input: Box::new(|pg: &mut InstanceSnapshotPgJson| {
-                        pg.operating_system_id = None;
-                        pg.os_image_id = None;
-                        pg.os_ipxe_script = "legacy-inline-script".to_string();
-                        pg.os_user_data = Some("legacy-user-data".to_string());
-                        pg.os_phone_home_enabled = true;
-                    }) as Box<dyn Fn(&mut InstanceSnapshotPgJson)>,
-                    expect: Yields((
-                        OperatingSystemVariant::Ipxe(InlineIpxe {
-                            ipxe_script: "legacy-inline-script".to_string(),
-                        }),
-                        Some("legacy-user-data".to_string()),
-                        true,
-                    )),
-                },
-                Case {
-                    scenario: "legacy os_image_id derives OsImage variant (iPXE script ignored)",
-                    input: Box::new(move |pg: &mut InstanceSnapshotPgJson| {
-                        pg.operating_system_id = None;
-                        pg.os_image_id = Some(image_uuid);
-                        pg.os_ipxe_script = "ignored".to_string();
-                    }),
-                    expect: Yields((OperatingSystemVariant::OsImage(image_uuid), None, false)),
-                },
-                Case {
-                    scenario: "operating_system_id takes priority over image and iPXE",
-                    input: Box::new(move |pg: &mut InstanceSnapshotPgJson| {
-                        pg.operating_system_id = Some(os_uuid);
-                        pg.os_image_id = None;
-                        pg.os_ipxe_script = String::new();
-                    }),
-                    expect: Yields((
-                        OperatingSystemVariant::OperatingSystemId(os_uuid),
-                        None,
-                        false,
-                    )),
-                },
-            ],
+        scenarios!(
             // Apply the row's mutation to a minimal pg-json, convert, and project
             // to the asserted OS fields. The error type (sqlx::Error) is not
             // PartialEq, so on failure we discard it.
-            |mutate| {
+            run = |mutate| {
                 let mut pg_json = minimal_pg_json();
                 mutate(&mut pg_json);
                 InstanceSnapshot::try_from(pg_json)
@@ -522,7 +481,42 @@ mod tests {
                         )
                     })
                     .map_err(drop)
-            },
+            };
+            "legacy inline iPXE derives Ipxe variant with user_data and phone_home" {
+                Box::new(|pg: &mut InstanceSnapshotPgJson| {
+                    pg.operating_system_id = None;
+                    pg.os_image_id = None;
+                    pg.os_ipxe_script = "legacy-inline-script".to_string();
+                    pg.os_user_data = Some("legacy-user-data".to_string());
+                    pg.os_phone_home_enabled = true;
+                }) as Box<dyn Fn(&mut InstanceSnapshotPgJson)> => Yields((
+                    OperatingSystemVariant::Ipxe(InlineIpxe {
+                        ipxe_script: "legacy-inline-script".to_string(),
+                    }),
+                    Some("legacy-user-data".to_string()),
+                    true,
+                )),
+            }
+
+            "legacy os_image_id derives OsImage variant (iPXE script ignored)" {
+                Box::new(move |pg: &mut InstanceSnapshotPgJson| {
+                    pg.operating_system_id = None;
+                    pg.os_image_id = Some(image_uuid);
+                    pg.os_ipxe_script = "ignored".to_string();
+                }) => Yields((OperatingSystemVariant::OsImage(image_uuid), None, false)),
+            }
+
+            "operating_system_id takes priority over image and iPXE" {
+                Box::new(move |pg: &mut InstanceSnapshotPgJson| {
+                    pg.operating_system_id = Some(os_uuid);
+                    pg.os_image_id = None;
+                    pg.os_ipxe_script = String::new();
+                }) => Yields((
+                    OperatingSystemVariant::OperatingSystemId(os_uuid),
+                    None,
+                    false,
+                )),
+            }
         );
     }
 

--- a/crates/api-model/src/machine/capabilities.rs
+++ b/crates/api-model/src/machine/capabilities.rs
@@ -510,7 +510,7 @@ impl MachineCapabilitiesSet {
 mod tests {
     use std::str::FromStr;
 
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::{Check, value_scenarios};
 
     use super::*;
     use crate::hardware_info::*;
@@ -854,45 +854,35 @@ mod tests {
 
     #[test]
     fn capability_type_display_covers_every_variant() {
-        check_values(
-            [
-                Check {
-                    scenario: "cpu",
-                    input: MachineCapabilityType::Cpu,
-                    expect: "CPU".to_string(),
-                },
-                Check {
-                    scenario: "gpu",
-                    input: MachineCapabilityType::Gpu,
-                    expect: "GPU".to_string(),
-                },
-                Check {
-                    scenario: "memory",
-                    input: MachineCapabilityType::Memory,
-                    expect: "MEMORY".to_string(),
-                },
-                Check {
-                    scenario: "storage",
-                    input: MachineCapabilityType::Storage,
-                    expect: "STORAGE".to_string(),
-                },
-                Check {
-                    scenario: "network",
-                    input: MachineCapabilityType::Network,
-                    expect: "NETWORK".to_string(),
-                },
-                Check {
-                    scenario: "infiniband",
-                    input: MachineCapabilityType::Infiniband,
-                    expect: "INFINIBAND".to_string(),
-                },
-                Check {
-                    scenario: "dpu",
-                    input: MachineCapabilityType::Dpu,
-                    expect: "DPU".to_string(),
-                },
-            ],
-            |variant| variant.to_string(),
+        value_scenarios!(
+            run = |variant| variant.to_string();
+            "cpu" {
+                MachineCapabilityType::Cpu => "CPU".to_string(),
+            }
+
+            "gpu" {
+                MachineCapabilityType::Gpu => "GPU".to_string(),
+            }
+
+            "memory" {
+                MachineCapabilityType::Memory => "MEMORY".to_string(),
+            }
+
+            "storage" {
+                MachineCapabilityType::Storage => "STORAGE".to_string(),
+            }
+
+            "network" {
+                MachineCapabilityType::Network => "NETWORK".to_string(),
+            }
+
+            "infiniband" {
+                MachineCapabilityType::Infiniband => "INFINIBAND".to_string(),
+            }
+
+            "dpu" {
+                MachineCapabilityType::Dpu => "DPU".to_string(),
+            }
         );
     }
 
@@ -908,25 +898,19 @@ mod tests {
 
     #[test]
     fn device_type_display_covers_every_variant() {
-        check_values(
-            [
-                Check {
-                    scenario: "unknown",
-                    input: MachineCapabilityDeviceType::Unknown,
-                    expect: "UNKNOWN".to_string(),
-                },
-                Check {
-                    scenario: "dpu",
-                    input: MachineCapabilityDeviceType::Dpu,
-                    expect: "DPU".to_string(),
-                },
-                Check {
-                    scenario: "nvlink",
-                    input: MachineCapabilityDeviceType::NvLink,
-                    expect: "NVLINK".to_string(),
-                },
-            ],
-            |variant| variant.to_string(),
+        value_scenarios!(
+            run = |variant| variant.to_string();
+            "unknown" {
+                MachineCapabilityDeviceType::Unknown => "UNKNOWN".to_string(),
+            }
+
+            "dpu" {
+                MachineCapabilityDeviceType::Dpu => "DPU".to_string(),
+            }
+
+            "nvlink" {
+                MachineCapabilityDeviceType::NvLink => "NVLINK".to_string(),
+            }
         );
     }
 
@@ -942,44 +926,38 @@ mod tests {
             }
         }
 
-        check_values(
-            [
-                Check {
-                    scenario: "typical dual-socket",
-                    input: cpu_info("Xeon Gold 6354", "GenuineIntel", 2, 18, 36),
-                    expect: MachineCapabilityCpu {
-                        name: "Xeon Gold 6354".to_string(),
-                        count: 2,
-                        vendor: Some("GenuineIntel".to_string()),
-                        cores: Some(18),
-                        threads: Some(36),
-                    },
+        value_scenarios!(
+            run = |info| MachineCapabilityCpu::from(&info);
+            "typical dual-socket" {
+                cpu_info("Xeon Gold 6354", "GenuineIntel", 2, 18, 36) => MachineCapabilityCpu {
+                    name: "Xeon Gold 6354".to_string(),
+                    count: 2,
+                    vendor: Some("GenuineIntel".to_string()),
+                    cores: Some(18),
+                    threads: Some(36),
                 },
-                Check {
-                    scenario: "single socket",
-                    input: cpu_info("EPYC 7763", "AuthenticAMD", 1, 64, 128),
-                    expect: MachineCapabilityCpu {
-                        name: "EPYC 7763".to_string(),
-                        count: 1,
-                        vendor: Some("AuthenticAMD".to_string()),
-                        cores: Some(64),
-                        threads: Some(128),
-                    },
+            }
+
+            "single socket" {
+                cpu_info("EPYC 7763", "AuthenticAMD", 1, 64, 128) => MachineCapabilityCpu {
+                    name: "EPYC 7763".to_string(),
+                    count: 1,
+                    vendor: Some("AuthenticAMD".to_string()),
+                    cores: Some(64),
+                    threads: Some(128),
                 },
-                Check {
-                    scenario: "all-zero / empty defaults",
-                    input: cpu_info("", "", 0, 0, 0),
-                    expect: MachineCapabilityCpu {
-                        name: String::new(),
-                        count: 0,
-                        // From always wraps the source fields in Some, even when empty/zero.
-                        vendor: Some(String::new()),
-                        cores: Some(0),
-                        threads: Some(0),
-                    },
+            }
+
+            "all-zero / empty defaults" {
+                cpu_info("", "", 0, 0, 0) => MachineCapabilityCpu {
+                    name: String::new(),
+                    count: 0,
+                    // From always wraps the source fields in Some, even when empty/zero.
+                    vendor: Some(String::new()),
+                    cores: Some(0),
+                    threads: Some(0),
                 },
-            ],
-            |info| MachineCapabilityCpu::from(&info),
+            }
         );
     }
 
@@ -1004,43 +982,35 @@ mod tests {
         }
 
         // No status observation: every device defaults to inactive.
-        check_values(
-            [
-                Check {
-                    scenario: "empty interface list -> no capabilities",
-                    input: Vec::<InfinibandInterface>::new(),
-                    expect: 0,
-                },
-                Check {
-                    scenario: "interface without pci_properties is skipped",
-                    input: vec![iface("g0", None)],
-                    expect: 0,
-                },
-                Check {
-                    scenario: "pci_properties without description is skipped",
-                    input: vec![iface("g0", Some(pci("0x15b3", None, Some("0"))))],
-                    expect: 0,
-                },
-                Check {
-                    scenario: "two devices of the same model roll into one capability",
-                    input: vec![
-                        iface("g0", Some(pci("0x15b3", Some("ConnectX-7"), Some("1")))),
-                        iface("g1", Some(pci("0x15b3", Some("ConnectX-7"), Some("0")))),
-                    ],
-                    expect: 1,
-                },
-                Check {
-                    scenario: "two distinct models produce two capabilities",
-                    input: vec![
-                        iface("g0", Some(pci("0x15b3", Some("ConnectX-5"), Some("0")))),
-                        iface("g1", Some(pci("0x15b3", Some("ConnectX-7"), Some("1")))),
-                    ],
-                    expect: 2,
-                },
-            ],
-            |interfaces| {
+        value_scenarios!(
+            run = |interfaces| {
                 MachineCapabilityInfiniband::from_ib_interfaces_and_status(&interfaces, None).len()
-            },
+            };
+            "empty interface list -> no capabilities" {
+                Vec::<InfinibandInterface>::new() => 0,
+            }
+
+            "interface without pci_properties is skipped" {
+                vec![iface("g0", None)] => 0,
+            }
+
+            "pci_properties without description is skipped" {
+                vec![iface("g0", Some(pci("0x15b3", None, Some("0"))))] => 0,
+            }
+
+            "two devices of the same model roll into one capability" {
+                vec![
+                    iface("g0", Some(pci("0x15b3", Some("ConnectX-7"), Some("1")))),
+                    iface("g1", Some(pci("0x15b3", Some("ConnectX-7"), Some("0")))),
+                ] => 1,
+            }
+
+            "two distinct models produce two capabilities" {
+                vec![
+                    iface("g0", Some(pci("0x15b3", Some("ConnectX-5"), Some("0")))),
+                    iface("g1", Some(pci("0x15b3", Some("ConnectX-7"), Some("1")))),
+                ] => 2,
+            }
         );
     }
 
@@ -1076,24 +1046,19 @@ mod tests {
         let caps = MachineCapabilityInfiniband::from_ib_interfaces_and_status(&interfaces, None);
         assert_eq!(caps.len(), 1);
 
-        check_values(
-            [
-                Check {
-                    scenario: "rolled-up count",
-                    input: "count",
-                    expect: 2u32,
-                },
-                Check {
-                    scenario: "all inactive without status",
-                    input: "inactive_len",
-                    expect: 2u32,
-                },
-            ],
-            |field| match field {
+        value_scenarios!(
+            run = |field| match field {
                 "count" => caps[0].count,
                 "inactive_len" => caps[0].inactive_devices.len() as u32,
                 other => panic!("unknown field {other}"),
-            },
+            };
+            "rolled-up count" {
+                "count" => 2u32,
+            }
+
+            "all inactive without status" {
+                "inactive_len" => 2u32,
+            }
         );
     }
 }

--- a/crates/api-model/src/machine/infiniband.rs
+++ b/crates/api-model/src/machine/infiniband.rs
@@ -209,7 +209,7 @@ pub fn ib_config_synced(
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::{Case, check_cases, scenarios};
 
     use super::*;
 
@@ -219,22 +219,20 @@ mod tests {
         // that older payloads omit. We project to the first interface's
         // (fabric_id_is_empty, associated_pkeys_is_none) so the asserted defaults
         // are comparable.
-        check_cases(
-            [Case {
-                scenario: "interfaces without fabric_id or pkeys default them",
-                input: r#"{"observed_at": "2025-06-06T19:47:16.597282585Z", "ib_interfaces": [{"lid": 65535, "guid": "1070fd0300bd7574"}, {"lid": 65535, "guid": "1070fd0300bd7575"}]}"#,
-                expect: Yields((true, true)),
-            }],
+        scenarios!(
             // Deserialize, then project the first interface's defaulted fields.
             // serde_json::Error is not PartialEq, so a failing row would discard it.
-            |s| {
+            run = |s| {
                 serde_json::from_str::<MachineInfinibandStatusObservation>(s)
                     .map(|obs| {
                         let iface = obs.ib_interfaces.first().expect("row supplies interfaces");
                         (iface.fabric_id.is_empty(), iface.associated_pkeys.is_none())
                     })
                     .map_err(drop)
-            },
+            };
+            "interfaces without fabric_id or pkeys default them" {
+                r#"{"observed_at": "2025-06-06T19:47:16.597282585Z", "ib_interfaces": [{"lid": 65535, "guid": "1070fd0300bd7574"}, {"lid": 65535, "guid": "1070fd0300bd7575"}]}"# => Yields((true, true)),
+            }
         );
     }
 

--- a/crates/api-model/src/machine/machine_id.rs
+++ b/crates/api-model/src/machine/machine_id.rs
@@ -106,7 +106,7 @@ pub enum MissingHardwareInfo {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Case, check_cases, scenarios, value_scenarios};
     use carbide_uuid::machine::MACHINE_ID_LENGTH;
 
     use super::*;
@@ -262,58 +262,46 @@ mod tests {
     // or DMI data with at least one serial, derives an ID and so `Yields`.
     #[test]
     fn from_hardware_info_with_type_error_paths() {
-        check_cases(
-            [
-                Case {
-                    scenario: "present but empty TPM cert is rejected",
-                    input: info_for_id(Some(vec![]), None),
-                    expect: FailsWith(MissingHardwareInfo::TPMCertEmpty),
-                },
-                Case {
-                    scenario: "empty TPM cert is rejected even with valid serials present",
-                    input: info_for_id(Some(vec![]), Some(("p1", "b1", "c1"))),
-                    expect: FailsWith(MissingHardwareInfo::TPMCertEmpty),
-                },
-                Case {
-                    scenario: "DMI data with all serials blank is rejected",
-                    input: info_for_id(None, Some(("", "", ""))),
-                    expect: FailsWith(MissingHardwareInfo::Serial),
-                },
-                Case {
-                    scenario: "neither TPM nor DMI present",
-                    input: info_for_id(None, None),
-                    expect: FailsWith(MissingHardwareInfo::All),
-                },
-                Case {
-                    scenario: "non-empty TPM cert derives an ID",
-                    input: info_for_id(Some(vec![1, 2, 3, 4]), None),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "product serial alone derives an ID",
-                    input: info_for_id(None, Some(("p1", "", ""))),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "board serial alone derives an ID",
-                    input: info_for_id(None, Some(("", "b1", ""))),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "chassis serial alone derives an ID",
-                    input: info_for_id(None, Some(("", "", "c1"))),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "all three serials present derives an ID",
-                    input: info_for_id(None, Some(("p1", "b1", "c1"))),
-                    expect: Yields(()),
-                },
-            ],
+        scenarios!(
             // Drop the derived ID so a success is `Ok(())`: the `Yields(())` rows
             // assert an ID was derived, while the error rows keep their exact
             // `MissingHardwareInfo` for the `FailsWith` checks.
-            |info| from_hardware_info_with_type(&info, MachineType::Host).map(drop),
+            run = |info| from_hardware_info_with_type(&info, MachineType::Host).map(drop);
+            "present but empty TPM cert is rejected" {
+                info_for_id(Some(vec![]), None) => FailsWith(MissingHardwareInfo::TPMCertEmpty),
+            }
+
+            "empty TPM cert is rejected even with valid serials present" {
+                info_for_id(Some(vec![]), Some(("p1", "b1", "c1"))) => FailsWith(MissingHardwareInfo::TPMCertEmpty),
+            }
+
+            "DMI data with all serials blank is rejected" {
+                info_for_id(None, Some(("", "", ""))) => FailsWith(MissingHardwareInfo::Serial),
+            }
+
+            "neither TPM nor DMI present" {
+                info_for_id(None, None) => FailsWith(MissingHardwareInfo::All),
+            }
+
+            "non-empty TPM cert derives an ID" {
+                info_for_id(Some(vec![1, 2, 3, 4]), None) => Yields(()),
+            }
+
+            "product serial alone derives an ID" {
+                info_for_id(None, Some(("p1", "", ""))) => Yields(()),
+            }
+
+            "board serial alone derives an ID" {
+                info_for_id(None, Some(("", "b1", ""))) => Yields(()),
+            }
+
+            "chassis serial alone derives an ID" {
+                info_for_id(None, Some(("", "", "c1"))) => Yields(()),
+            }
+
+            "all three serials present derives an ID" {
+                info_for_id(None, Some(("p1", "b1", "c1"))) => Yields(()),
+            }
         );
     }
 
@@ -322,29 +310,23 @@ mod tests {
     // only when no TPM certificate is present.
     #[test]
     fn from_hardware_info_with_type_selects_source() {
-        check_cases(
-            [
-                Case {
-                    scenario: "TPM certificate selects the Tpm source",
-                    input: info_for_id(Some(vec![9]), None),
-                    expect: Yields(MachineIdSource::Tpm),
-                },
-                Case {
-                    scenario: "TPM certificate wins even when serials are present",
-                    input: info_for_id(Some(vec![9]), Some(("p1", "b1", "c1"))),
-                    expect: Yields(MachineIdSource::Tpm),
-                },
-                Case {
-                    scenario: "serials select the ProductBoardChassisSerial source",
-                    input: info_for_id(None, Some(("p1", "", ""))),
-                    expect: Yields(MachineIdSource::ProductBoardChassisSerial),
-                },
-            ],
-            |info| {
+        scenarios!(
+            run = |info| {
                 from_hardware_info_with_type(&info, MachineType::Host)
                     .map(|id| id.source())
                     .map_err(drop)
-            },
+            };
+            "TPM certificate selects the Tpm source" {
+                info_for_id(Some(vec![9]), None) => Yields(MachineIdSource::Tpm),
+            }
+
+            "TPM certificate wins even when serials are present" {
+                info_for_id(Some(vec![9]), Some(("p1", "b1", "c1"))) => Yields(MachineIdSource::Tpm),
+            }
+
+            "serials select the ProductBoardChassisSerial source" {
+                info_for_id(None, Some(("p1", "", ""))) => Yields(MachineIdSource::ProductBoardChassisSerial),
+            }
         );
     }
 
@@ -352,53 +334,44 @@ mod tests {
     // independent of which hardware source produced the fingerprint.
     #[test]
     fn from_hardware_info_with_type_carries_machine_type() {
-        check_cases(
-            [
-                Case {
-                    scenario: "Host onto a TPM-derived ID",
-                    input: (info_for_id(Some(vec![7]), None), MachineType::Host),
-                    expect: Yields(MachineType::Host),
-                },
-                Case {
-                    scenario: "Dpu onto a TPM-derived ID",
-                    input: (info_for_id(Some(vec![7]), None), MachineType::Dpu),
-                    expect: Yields(MachineType::Dpu),
-                },
-                Case {
-                    scenario: "PredictedHost onto a TPM-derived ID",
-                    input: (info_for_id(Some(vec![7]), None), MachineType::PredictedHost),
-                    expect: Yields(MachineType::PredictedHost),
-                },
-                Case {
-                    scenario: "Host onto a serial-derived ID",
-                    input: (
-                        info_for_id(None, Some(("p1", "b1", "c1"))),
-                        MachineType::Host,
-                    ),
-                    expect: Yields(MachineType::Host),
-                },
-                Case {
-                    scenario: "Dpu onto a serial-derived ID",
-                    input: (
-                        info_for_id(None, Some(("p1", "b1", "c1"))),
-                        MachineType::Dpu,
-                    ),
-                    expect: Yields(MachineType::Dpu),
-                },
-                Case {
-                    scenario: "PredictedHost onto a serial-derived ID",
-                    input: (
-                        info_for_id(None, Some(("p1", "b1", "c1"))),
-                        MachineType::PredictedHost,
-                    ),
-                    expect: Yields(MachineType::PredictedHost),
-                },
-            ],
-            |(info, ty)| {
+        scenarios!(
+            run = |(info, ty)| {
                 from_hardware_info_with_type(&info, ty)
                     .map(|id| id.machine_type())
                     .map_err(drop)
-            },
+            };
+            "Host onto a TPM-derived ID" {
+                (info_for_id(Some(vec![7]), None), MachineType::Host) => Yields(MachineType::Host),
+            }
+
+            "Dpu onto a TPM-derived ID" {
+                (info_for_id(Some(vec![7]), None), MachineType::Dpu) => Yields(MachineType::Dpu),
+            }
+
+            "PredictedHost onto a TPM-derived ID" {
+                (info_for_id(Some(vec![7]), None), MachineType::PredictedHost) => Yields(MachineType::PredictedHost),
+            }
+
+            "Host onto a serial-derived ID" {
+                (
+                    info_for_id(None, Some(("p1", "b1", "c1"))),
+                    MachineType::Host,
+                ) => Yields(MachineType::Host),
+            }
+
+            "Dpu onto a serial-derived ID" {
+                (
+                    info_for_id(None, Some(("p1", "b1", "c1"))),
+                    MachineType::Dpu,
+                ) => Yields(MachineType::Dpu),
+            }
+
+            "PredictedHost onto a serial-derived ID" {
+                (
+                    info_for_id(None, Some(("p1", "b1", "c1"))),
+                    MachineType::PredictedHost,
+                ) => Yields(MachineType::PredictedHost),
+            }
         );
     }
 
@@ -407,46 +380,39 @@ mod tests {
     // change the rendered prefix.
     #[test]
     fn from_hardware_info_with_type_is_deterministic() {
-        check_values(
-            [
-                Check {
-                    scenario: "same TPM cert and type yields the same id string",
-                    input: (
-                        info_for_id(Some(vec![1, 2, 3]), None),
-                        info_for_id(Some(vec![1, 2, 3]), None),
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "different TPM certs yield different id strings",
-                    input: (
-                        info_for_id(Some(vec![1, 2, 3]), None),
-                        info_for_id(Some(vec![4, 5, 6]), None),
-                    ),
-                    expect: false,
-                },
-                Check {
-                    scenario: "different serials yield different id strings",
-                    input: (
-                        info_for_id(None, Some(("p1", "b1", "c1"))),
-                        info_for_id(None, Some(("p2", "b1", "c1"))),
-                    ),
-                    expect: false,
-                },
-                Check {
-                    scenario: "same serials yield the same id string",
-                    input: (
-                        info_for_id(None, Some(("p1", "b1", "c1"))),
-                        info_for_id(None, Some(("p1", "b1", "c1"))),
-                    ),
-                    expect: true,
-                },
-            ],
-            |(left, right)| {
+        value_scenarios!(
+            run = |(left, right)| {
                 let left = from_hardware_info_with_type(&left, MachineType::Host).unwrap();
                 let right = from_hardware_info_with_type(&right, MachineType::Host).unwrap();
                 left.to_string() == right.to_string()
-            },
+            };
+            "same TPM cert and type yields the same id string" {
+                (
+                    info_for_id(Some(vec![1, 2, 3]), None),
+                    info_for_id(Some(vec![1, 2, 3]), None),
+                ) => true,
+            }
+
+            "different TPM certs yield different id strings" {
+                (
+                    info_for_id(Some(vec![1, 2, 3]), None),
+                    info_for_id(Some(vec![4, 5, 6]), None),
+                ) => false,
+            }
+
+            "different serials yield different id strings" {
+                (
+                    info_for_id(None, Some(("p1", "b1", "c1"))),
+                    info_for_id(None, Some(("p2", "b1", "c1"))),
+                ) => false,
+            }
+
+            "same serials yield the same id string" {
+                (
+                    info_for_id(None, Some(("p1", "b1", "c1"))),
+                    info_for_id(None, Some(("p1", "b1", "c1"))),
+                ) => true,
+            }
         );
     }
 
@@ -455,50 +421,43 @@ mod tests {
     // `MachineIdSource::id_char`).
     #[test]
     fn from_hardware_info_with_type_renders_expected_prefix() {
-        check_cases(
-            [
-                Case {
-                    scenario: "host + TPM renders fm100ht",
-                    input: (
-                        info_for_id(Some(vec![1]), None),
-                        MachineType::Host,
-                        "fm100ht",
-                    ),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "dpu + TPM renders fm100dt",
-                    input: (
-                        info_for_id(Some(vec![1]), None),
-                        MachineType::Dpu,
-                        "fm100dt",
-                    ),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "predicted host + serial renders fm100ps",
-                    input: (
-                        info_for_id(None, Some(("p1", "b1", "c1"))),
-                        MachineType::PredictedHost,
-                        "fm100ps",
-                    ),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "host + serial renders fm100hs",
-                    input: (
-                        info_for_id(None, Some(("p1", "b1", "c1"))),
-                        MachineType::Host,
-                        "fm100hs",
-                    ),
-                    expect: Yields(true),
-                },
-            ],
-            |(info, ty, prefix)| {
+        scenarios!(
+            run = |(info, ty, prefix)| {
                 from_hardware_info_with_type(&info, ty)
                     .map(|id| id.to_string().starts_with(prefix))
                     .map_err(drop)
-            },
+            };
+            "host + TPM renders fm100ht" {
+                (
+                    info_for_id(Some(vec![1]), None),
+                    MachineType::Host,
+                    "fm100ht",
+                ) => Yields(true),
+            }
+
+            "dpu + TPM renders fm100dt" {
+                (
+                    info_for_id(Some(vec![1]), None),
+                    MachineType::Dpu,
+                    "fm100dt",
+                ) => Yields(true),
+            }
+
+            "predicted host + serial renders fm100ps" {
+                (
+                    info_for_id(None, Some(("p1", "b1", "c1"))),
+                    MachineType::PredictedHost,
+                    "fm100ps",
+                ) => Yields(true),
+            }
+
+            "host + serial renders fm100hs" {
+                (
+                    info_for_id(None, Some(("p1", "b1", "c1"))),
+                    MachineType::Host,
+                    "fm100hs",
+                ) => Yields(true),
+            }
         );
     }
 
@@ -506,36 +465,30 @@ mod tests {
     // of which source or type produced it.
     #[test]
     fn from_hardware_info_with_type_renders_fixed_length() {
-        check_values(
-            [
-                Check {
-                    scenario: "TPM-derived host id length",
-                    input: (info_for_id(Some(vec![1, 2]), None), MachineType::Host),
-                    expect: MACHINE_ID_LENGTH,
-                },
-                Check {
-                    scenario: "serial-derived dpu id length",
-                    input: (
-                        info_for_id(None, Some(("p1", "b1", "c1"))),
-                        MachineType::Dpu,
-                    ),
-                    expect: MACHINE_ID_LENGTH,
-                },
-                Check {
-                    scenario: "serial-derived predicted-host id length",
-                    input: (
-                        info_for_id(None, Some(("", "b1", ""))),
-                        MachineType::PredictedHost,
-                    ),
-                    expect: MACHINE_ID_LENGTH,
-                },
-            ],
-            |(info, ty)| {
+        value_scenarios!(
+            run = |(info, ty)| {
                 from_hardware_info_with_type(&info, ty)
                     .unwrap()
                     .to_string()
                     .len()
-            },
+            };
+            "TPM-derived host id length" {
+                (info_for_id(Some(vec![1, 2]), None), MachineType::Host) => MACHINE_ID_LENGTH,
+            }
+
+            "serial-derived dpu id length" {
+                (
+                    info_for_id(None, Some(("p1", "b1", "c1"))),
+                    MachineType::Dpu,
+                ) => MACHINE_ID_LENGTH,
+            }
+
+            "serial-derived predicted-host id length" {
+                (
+                    info_for_id(None, Some(("", "b1", ""))),
+                    MachineType::PredictedHost,
+                ) => MACHINE_ID_LENGTH,
+            }
         );
     }
 }

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -2863,7 +2863,7 @@ mod tests {
     use std::str::FromStr;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::scenarios;
 
     use super::*;
 
@@ -2875,30 +2875,25 @@ mod tests {
         let failed_at = chrono::DateTime::parse_from_rfc3339("2023-07-31T11:26:18.261228950+00:00")
             .unwrap()
             .with_timezone(&Utc);
-        check_cases(
-            [
-                Case {
-                    scenario: "no error",
-                    input: r#"{"cause": "noerror", "source": "noerror", "failed_at": "2023-07-31T11:26:18.261228950Z"}"#,
-                    expect: Yields(FailureDetails {
-                        cause: FailureCause::NoError,
-                        failed_at,
-                        source: FailureSource::NoError,
-                    }),
-                },
-                Case {
-                    scenario: "nvme clean failed",
-                    input: r#"{"cause": {"nvmecleanfailed":{"err": "error1"}},  "source": "noerror","failed_at": "2023-07-31T11:26:18.261228950Z"}"#,
-                    expect: Yields(FailureDetails {
-                        cause: FailureCause::NVMECleanFailed {
-                            err: "error1".to_string(),
-                        },
-                        failed_at,
-                        source: FailureSource::NoError,
-                    }),
-                },
-            ],
-            |s| serde_json::from_str::<FailureDetails>(s).map_err(drop),
+        scenarios!(
+            run = |s| serde_json::from_str::<FailureDetails>(s).map_err(drop);
+            "no error" {
+                r#"{"cause": "noerror", "source": "noerror", "failed_at": "2023-07-31T11:26:18.261228950Z"}"# => Yields(FailureDetails {
+                    cause: FailureCause::NoError,
+                    failed_at,
+                    source: FailureSource::NoError,
+                }),
+            }
+
+            "nvme clean failed" {
+                r#"{"cause": {"nvmecleanfailed":{"err": "error1"}},  "source": "noerror","failed_at": "2023-07-31T11:26:18.261228950Z"}"# => Yields(FailureDetails {
+                    cause: FailureCause::NVMECleanFailed {
+                        err: "error1".to_string(),
+                    },
+                    failed_at,
+                    source: FailureSource::NoError,
+                }),
+            }
         );
     }
 
@@ -2910,13 +2905,30 @@ mod tests {
         let machine_id =
             MachineId::from_str("fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng")
                 .unwrap();
-        check_cases(
-            [
-                Case {
-                    scenario: "dpu reprovision firmware upgrade",
-                    input: r#"{"state":"dpureprovision","dpu_states":{"states":{"fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng":"firmwareupgrade"}}}"#,
-                    expect: Yields((
-                        ManagedHostState::DPUReprovision {
+        scenarios!(
+            run = |s| {
+                serde_json::from_str::<ManagedHostState>(s)
+                    .map(|state| (state.clone(), state.to_string()))
+                    .map_err(drop)
+            };
+            "dpu reprovision firmware upgrade" {
+                r#"{"state":"dpureprovision","dpu_states":{"states":{"fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng":"firmwareupgrade"}}}"# => Yields((
+                    ManagedHostState::DPUReprovision {
+                        dpu_states: DpuReprovisionStates {
+                            states: HashMap::from([(
+                                machine_id,
+                                ReprovisionState::FirmwareUpgrade,
+                            )]),
+                        },
+                    },
+                    "Reprovisioning/FirmwareUpgrade".to_string(),
+                )),
+            }
+
+            "assigned dpu reprovision firmware upgrade" {
+                r#"{"state":"assigned","instance_state":{"state":"dpureprovision","dpu_states":{"states":{"fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng":"firmwareupgrade"}}}}"# => Yields((
+                    ManagedHostState::Assigned {
+                        instance_state: InstanceState::DPUReprovision {
                             dpu_states: DpuReprovisionStates {
                                 states: HashMap::from([(
                                     machine_id,
@@ -2924,32 +2936,10 @@ mod tests {
                                 )]),
                             },
                         },
-                        "Reprovisioning/FirmwareUpgrade".to_string(),
-                    )),
-                },
-                Case {
-                    scenario: "assigned dpu reprovision firmware upgrade",
-                    input: r#"{"state":"assigned","instance_state":{"state":"dpureprovision","dpu_states":{"states":{"fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng":"firmwareupgrade"}}}}"#,
-                    expect: Yields((
-                        ManagedHostState::Assigned {
-                            instance_state: InstanceState::DPUReprovision {
-                                dpu_states: DpuReprovisionStates {
-                                    states: HashMap::from([(
-                                        machine_id,
-                                        ReprovisionState::FirmwareUpgrade,
-                                    )]),
-                                },
-                            },
-                        },
-                        "Assigned/Reprovision/FirmwareUpgrade".to_string(),
-                    )),
-                },
-            ],
-            |s| {
-                serde_json::from_str::<ManagedHostState>(s)
-                    .map(|state| (state.clone(), state.to_string()))
-                    .map_err(drop)
-            },
+                    },
+                    "Assigned/Reprovision/FirmwareUpgrade".to_string(),
+                )),
+            }
         );
     }
 
@@ -2957,64 +2947,55 @@ mod tests {
     // variant; the parsed value (PartialEq) is the whole assertion.
     #[test]
     fn test_json_deserialize_managed_host_states() {
-        check_cases(
-            [
-                Case {
-                    scenario: "assigned booting with discovery image, default retry",
-                    input: r#"{"state":"assigned","instance_state":{"state":"bootingwithdiscoveryimage"}}"#,
-                    expect: Yields(ManagedHostState::Assigned {
-                        instance_state: InstanceState::BootingWithDiscoveryImage {
-                            retry: RetryInfo { count: 0 },
+        scenarios!(
+            run = |s| serde_json::from_str::<ManagedHostState>(s).map_err(drop);
+            "assigned booting with discovery image, default retry" {
+                r#"{"state":"assigned","instance_state":{"state":"bootingwithdiscoveryimage"}}"# => Yields(ManagedHostState::Assigned {
+                    instance_state: InstanceState::BootingWithDiscoveryImage {
+                        retry: RetryInfo { count: 0 },
+                    },
+                }),
+            }
+
+            "assigned booting with discovery image, explicit retry" {
+                r#"{"state":"assigned","instance_state":{"state":"bootingwithdiscoveryimage", "retry":{"count": 10}}}"# => Yields(ManagedHostState::Assigned {
+                    instance_state: InstanceState::BootingWithDiscoveryImage {
+                        retry: RetryInfo { count: 10 },
+                    },
+                }),
+            }
+
+            "host init polling bios setup, default retry" {
+                r#"{"state":"hostinit","machine_state":{"state":"pollingbiossetup"}}"# => Yields(ManagedHostState::HostInit {
+                    machine_state: MachineState::PollingBiosSetup { retry_count: 0 },
+                }),
+            }
+
+            "host init polling bios setup, explicit retry count" {
+                r#"{"state":"hostinit","machine_state":{"state":"pollingbiossetup","retry_count":2}}"# => Yields(ManagedHostState::HostInit {
+                    machine_state: MachineState::PollingBiosSetup { retry_count: 2 },
+                }),
+            }
+
+            "assigned host platform configuration polling bios setup (legacy)" {
+                r#"{"state":"assigned","instance_state":{"state":"hostplatformconfiguration","platform_config_state":{"state":"pollingbiossetup"}}}"# => Yields(ManagedHostState::Assigned {
+                    instance_state: InstanceState::HostPlatformConfiguration {
+                        platform_config_state:
+                            HostPlatformConfigurationState::PollingBiosSetup { retry_count: 0 },
+                    },
+                }),
+            }
+
+            "host init waiting for lockdown" {
+                r#"{"state":"hostinit","machine_state":{"state":"waitingforlockdown","lockdown_info":{"state":"setlockdown","mode":"enable"}}}"# => Yields(ManagedHostState::HostInit {
+                    machine_state: MachineState::WaitingForLockdown {
+                        lockdown_info: LockdownInfo {
+                            state: LockdownState::SetLockdown,
+                            mode: LockdownMode::Enable,
                         },
-                    }),
-                },
-                Case {
-                    scenario: "assigned booting with discovery image, explicit retry",
-                    input: r#"{"state":"assigned","instance_state":{"state":"bootingwithdiscoveryimage", "retry":{"count": 10}}}"#,
-                    expect: Yields(ManagedHostState::Assigned {
-                        instance_state: InstanceState::BootingWithDiscoveryImage {
-                            retry: RetryInfo { count: 10 },
-                        },
-                    }),
-                },
-                Case {
-                    scenario: "host init polling bios setup, default retry",
-                    input: r#"{"state":"hostinit","machine_state":{"state":"pollingbiossetup"}}"#,
-                    expect: Yields(ManagedHostState::HostInit {
-                        machine_state: MachineState::PollingBiosSetup { retry_count: 0 },
-                    }),
-                },
-                Case {
-                    scenario: "host init polling bios setup, explicit retry count",
-                    input: r#"{"state":"hostinit","machine_state":{"state":"pollingbiossetup","retry_count":2}}"#,
-                    expect: Yields(ManagedHostState::HostInit {
-                        machine_state: MachineState::PollingBiosSetup { retry_count: 2 },
-                    }),
-                },
-                Case {
-                    scenario: "assigned host platform configuration polling bios setup (legacy)",
-                    input: r#"{"state":"assigned","instance_state":{"state":"hostplatformconfiguration","platform_config_state":{"state":"pollingbiossetup"}}}"#,
-                    expect: Yields(ManagedHostState::Assigned {
-                        instance_state: InstanceState::HostPlatformConfiguration {
-                            platform_config_state:
-                                HostPlatformConfigurationState::PollingBiosSetup { retry_count: 0 },
-                        },
-                    }),
-                },
-                Case {
-                    scenario: "host init waiting for lockdown",
-                    input: r#"{"state":"hostinit","machine_state":{"state":"waitingforlockdown","lockdown_info":{"state":"setlockdown","mode":"enable"}}}"#,
-                    expect: Yields(ManagedHostState::HostInit {
-                        machine_state: MachineState::WaitingForLockdown {
-                            lockdown_info: LockdownInfo {
-                                state: LockdownState::SetLockdown,
-                                mode: LockdownMode::Enable,
-                            },
-                        },
-                    }),
-                },
-            ],
-            |s| serde_json::from_str::<ManagedHostState>(s).map_err(drop),
+                    },
+                }),
+            }
         );
     }
 
@@ -3039,60 +3020,50 @@ mod tests {
     // so both the direct parse and the round-trip are asserted.
     #[test]
     fn test_dpf_state_deserialize_and_roundtrip() {
-        check_cases(
-            [
-                Case {
-                    scenario: "provisioning",
-                    input: r#"{"dpfstate":"provisioning"}"#,
-                    expect: Yields((DpfState::Provisioning, DpfState::Provisioning)),
-                },
-                Case {
-                    scenario: "waiting for ready, no phase detail",
-                    input: r#"{"dpfstate":"waitingforready"}"#,
-                    expect: Yields((
-                        DpfState::WaitingForReady { phase_detail: None },
-                        DpfState::WaitingForReady { phase_detail: None },
-                    )),
-                },
-                Case {
-                    scenario: "waiting for ready, with phase detail",
-                    input: r#"{"dpfstate":"waitingforready","phase_detail":"some-detail"}"#,
-                    expect: Yields((
-                        DpfState::WaitingForReady {
-                            phase_detail: Some("some-detail".to_string()),
-                        },
-                        DpfState::WaitingForReady {
-                            phase_detail: Some("some-detail".to_string()),
-                        },
-                    )),
-                },
-                Case {
-                    scenario: "device ready",
-                    input: r#"{"dpfstate":"deviceready"}"#,
-                    expect: Yields((DpfState::DeviceReady, DpfState::DeviceReady)),
-                },
-                Case {
-                    scenario: "reprovisioning",
-                    input: r#"{"dpfstate":"reprovisioning"}"#,
-                    expect: Yields((DpfState::Reprovisioning, DpfState::Reprovisioning)),
-                },
-                Case {
-                    scenario: "unknown tag falls back to Unknown",
-                    input: r#"{"dpfstate":"somethingold"}"#,
-                    expect: Yields((DpfState::Unknown, DpfState::Unknown)),
-                },
-                Case {
-                    scenario: "bogus tag with extra field falls back to Unknown",
-                    input: r#"{"dpfstate":"bogus","extra":"field"}"#,
-                    expect: Yields((DpfState::Unknown, DpfState::Unknown)),
-                },
-            ],
-            |s| {
+        scenarios!(
+            run = |s| {
                 let parsed: DpfState = serde_json::from_str(s).map_err(drop)?;
                 let serialized = serde_json::to_string(&parsed).map_err(drop)?;
                 let roundtrip: DpfState = serde_json::from_str(&serialized).map_err(drop)?;
                 Ok::<_, ()>((parsed, roundtrip))
-            },
+            };
+            "provisioning" {
+                r#"{"dpfstate":"provisioning"}"# => Yields((DpfState::Provisioning, DpfState::Provisioning)),
+            }
+
+            "waiting for ready, no phase detail" {
+                r#"{"dpfstate":"waitingforready"}"# => Yields((
+                    DpfState::WaitingForReady { phase_detail: None },
+                    DpfState::WaitingForReady { phase_detail: None },
+                )),
+            }
+
+            "waiting for ready, with phase detail" {
+                r#"{"dpfstate":"waitingforready","phase_detail":"some-detail"}"# => Yields((
+                    DpfState::WaitingForReady {
+                        phase_detail: Some("some-detail".to_string()),
+                    },
+                    DpfState::WaitingForReady {
+                        phase_detail: Some("some-detail".to_string()),
+                    },
+                )),
+            }
+
+            "device ready" {
+                r#"{"dpfstate":"deviceready"}"# => Yields((DpfState::DeviceReady, DpfState::DeviceReady)),
+            }
+
+            "reprovisioning" {
+                r#"{"dpfstate":"reprovisioning"}"# => Yields((DpfState::Reprovisioning, DpfState::Reprovisioning)),
+            }
+
+            "unknown tag falls back to Unknown" {
+                r#"{"dpfstate":"somethingold"}"# => Yields((DpfState::Unknown, DpfState::Unknown)),
+            }
+
+            "bogus tag with extra field falls back to Unknown" {
+                r#"{"dpfstate":"bogus","extra":"field"}"# => Yields((DpfState::Unknown, DpfState::Unknown)),
+            }
         );
     }
 
@@ -3424,38 +3395,33 @@ mod tests {
     // the exact serialized form and the round-trip equality are both asserted.
     #[test]
     fn host_profile_serde_round_trip() {
-        check_cases(
-            [
-                Case {
-                    scenario: "lockdown disabled (true)",
-                    input: HostProfile {
-                        disable_lockdown: true,
-                    },
-                    expect: Yields((
-                        r#"{"disable_lockdown":true}"#.to_string(),
-                        HostProfile {
-                            disable_lockdown: true,
-                        },
-                    )),
-                },
-                Case {
-                    scenario: "lockdown enabled (false)",
-                    input: HostProfile {
-                        disable_lockdown: false,
-                    },
-                    expect: Yields((
-                        r#"{"disable_lockdown":false}"#.to_string(),
-                        HostProfile {
-                            disable_lockdown: false,
-                        },
-                    )),
-                },
-            ],
-            |profile| {
+        scenarios!(
+            run = |profile| {
                 let json = serde_json::to_string(&profile).map_err(drop)?;
                 let back: HostProfile = serde_json::from_str(&json).map_err(drop)?;
                 Ok::<_, ()>((json, back))
-            },
+            };
+            "lockdown disabled (true)" {
+                HostProfile {
+                    disable_lockdown: true,
+                } => Yields((
+                    r#"{"disable_lockdown":true}"#.to_string(),
+                    HostProfile {
+                        disable_lockdown: true,
+                    },
+                )),
+            }
+
+            "lockdown enabled (false)" {
+                HostProfile {
+                    disable_lockdown: false,
+                } => Yields((
+                    r#"{"disable_lockdown":false}"#.to_string(),
+                    HostProfile {
+                        disable_lockdown: false,
+                    },
+                )),
+            }
         );
     }
 

--- a/crates/api-model/src/machine/network.rs
+++ b/crates/api-model/src/machine/network.rs
@@ -202,7 +202,7 @@ mod tests {
     use std::str::FromStr;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Check, scenarios, value_scenarios};
     use chrono::TimeZone;
     use config_version::ConfigVersion;
 
@@ -276,51 +276,46 @@ mod tests {
     // rows would use `Fails`; all rows here round-trip cleanly.
     #[test]
     fn test_managed_host_network_config_json_roundtrip() {
-        check_cases(
-            [
-                Case {
-                    scenario: "ipv4 round-trip",
-                    input: ManagedHostNetworkConfig {
-                        loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
-                        secondary_overlay_vtep_ip: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
-                        use_admin_network: Some(true),
-                        quarantine_state: None,
-                    },
-                    expect: Yields(ManagedHostNetworkConfig {
-                        loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
-                        secondary_overlay_vtep_ip: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
-                        use_admin_network: Some(true),
-                        quarantine_state: None,
-                    }),
-                },
-                Case {
-                    scenario: "ipv6 round-trip",
-                    input: ManagedHostNetworkConfig {
-                        loopback_ip: Some(IpAddr::V6(Ipv6Addr::new(
-                            0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
-                        ))),
-                        secondary_overlay_vtep_ip: Some(IpAddr::V6(Ipv6Addr::new(
-                            0xfd00, 0, 0, 0, 0, 0, 0, 0x42,
-                        ))),
-                        use_admin_network: Some(false),
-                        quarantine_state: None,
-                    },
-                    expect: Yields(ManagedHostNetworkConfig {
-                        loopback_ip: Some(IpAddr::V6(Ipv6Addr::new(
-                            0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
-                        ))),
-                        secondary_overlay_vtep_ip: Some(IpAddr::V6(Ipv6Addr::new(
-                            0xfd00, 0, 0, 0, 0, 0, 0, 0x42,
-                        ))),
-                        use_admin_network: Some(false),
-                        quarantine_state: None,
-                    }),
-                },
-            ],
-            |config| {
+        scenarios!(
+            run = |config| {
                 let json = serde_json::to_string(&config).map_err(drop)?;
                 serde_json::from_str::<ManagedHostNetworkConfig>(&json).map_err(drop)
-            },
+            };
+            "ipv4 round-trip" {
+                ManagedHostNetworkConfig {
+                    loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                    secondary_overlay_vtep_ip: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
+                    use_admin_network: Some(true),
+                    quarantine_state: None,
+                } => Yields(ManagedHostNetworkConfig {
+                    loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                    secondary_overlay_vtep_ip: Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
+                    use_admin_network: Some(true),
+                    quarantine_state: None,
+                }),
+            }
+
+            "ipv6 round-trip" {
+                ManagedHostNetworkConfig {
+                    loopback_ip: Some(IpAddr::V6(Ipv6Addr::new(
+                        0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
+                    ))),
+                    secondary_overlay_vtep_ip: Some(IpAddr::V6(Ipv6Addr::new(
+                        0xfd00, 0, 0, 0, 0, 0, 0, 0x42,
+                    ))),
+                    use_admin_network: Some(false),
+                    quarantine_state: None,
+                } => Yields(ManagedHostNetworkConfig {
+                    loopback_ip: Some(IpAddr::V6(Ipv6Addr::new(
+                        0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
+                    ))),
+                    secondary_overlay_vtep_ip: Some(IpAddr::V6(Ipv6Addr::new(
+                        0xfd00, 0, 0, 0, 0, 0, 0, 0x42,
+                    ))),
+                    use_admin_network: Some(false),
+                    quarantine_state: None,
+                }),
+            }
         );
     }
 
@@ -329,40 +324,35 @@ mod tests {
     // pair the original tests asserted. Covers legacy IPv4 JSON and IPv6 JSON.
     #[test]
     fn test_managed_host_network_config_deserialize_json() {
-        check_cases(
-            [
-                Case {
-                    scenario: "legacy ipv4 json",
-                    input: r#"{
-                        "loopback_ip": "10.0.0.1",
-                        "secondary_overlay_vtep_ip": "172.16.0.5",
-                        "use_admin_network": true,
-                        "quarantine_state": null
-                    }"#,
-                    expect: Yields((
-                        Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
-                        Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
-                    )),
-                },
-                Case {
-                    scenario: "ipv6 json",
-                    input: r#"{
-                        "loopback_ip": "2001:db8::1",
-                        "secondary_overlay_vtep_ip": null,
-                        "use_admin_network": true,
-                        "quarantine_state": null
-                    }"#,
-                    expect: Yields((
-                        Some(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))),
-                        None,
-                    )),
-                },
-            ],
-            |json| {
+        scenarios!(
+            run = |json| {
                 serde_json::from_str::<ManagedHostNetworkConfig>(json)
                     .map(|c| (c.loopback_ip, c.secondary_overlay_vtep_ip))
                     .map_err(drop)
-            },
+            };
+            "legacy ipv4 json" {
+                r#"{
+                            "loopback_ip": "10.0.0.1",
+                            "secondary_overlay_vtep_ip": "172.16.0.5",
+                            "use_admin_network": true,
+                            "quarantine_state": null
+                        }"# => Yields((
+                    Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                    Some(IpAddr::V4(Ipv4Addr::new(172, 16, 0, 5))),
+                )),
+            }
+
+            "ipv6 json" {
+                r#"{
+                            "loopback_ip": "2001:db8::1",
+                            "secondary_overlay_vtep_ip": null,
+                            "use_admin_network": true,
+                            "quarantine_state": null
+                        }"# => Yields((
+                    Some(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))),
+                    None,
+                )),
+            }
         );
     }
 
@@ -391,28 +381,21 @@ mod tests {
     #[test]
     fn test_managed_host_network_config_default() {
         let default = ManagedHostNetworkConfig::default();
-        check_values(
-            [
-                Check {
-                    scenario: "loopback_ip defaults to None",
-                    input: default.loopback_ip,
-                    expect: None,
-                },
-                Check {
-                    scenario: "secondary_overlay_vtep_ip defaults to None",
-                    input: default.secondary_overlay_vtep_ip,
-                    expect: None,
-                },
-            ],
-            |ip| ip,
+        value_scenarios!(
+            run = |ip| ip;
+            "loopback_ip defaults to None" {
+                default.loopback_ip => None,
+            }
+
+            "secondary_overlay_vtep_ip defaults to None" {
+                default.secondary_overlay_vtep_ip => None,
+            }
         );
-        check_values(
-            [Check {
-                scenario: "use_admin_network defaults to Some(true)",
-                input: default.use_admin_network,
-                expect: Some(true),
-            }],
-            |flag| flag,
+        value_scenarios!(
+            run = |flag| flag;
+            "use_admin_network defaults to Some(true)" {
+                default.use_admin_network => Some(true),
+            }
         );
         Check {
             scenario: "quarantine_state defaults to None",
@@ -430,50 +413,39 @@ mod tests {
     // loopback, embedded-IPv4) where formatting can surprise.
     #[test]
     fn test_ip_addr_to_string_format() {
-        check_values(
-            [
-                Check {
-                    scenario: "ipv4",
-                    input: IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-                    expect: "10.0.0.1".to_string(),
-                },
-                Check {
-                    scenario: "ipv4 unspecified",
-                    input: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-                    expect: "0.0.0.0".to_string(),
-                },
-                Check {
-                    scenario: "ipv4 broadcast",
-                    input: IpAddr::V4(Ipv4Addr::new(255, 255, 255, 255)),
-                    expect: "255.255.255.255".to_string(),
-                },
-                Check {
-                    scenario: "ipv4 loopback",
-                    input: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                    expect: "127.0.0.1".to_string(),
-                },
-                Check {
-                    scenario: "ipv6 compressed",
-                    input: IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)),
-                    expect: "2001:db8::1".to_string(),
-                },
-                Check {
-                    scenario: "ipv6 unspecified collapses to ::",
-                    input: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)),
-                    expect: "::".to_string(),
-                },
-                Check {
-                    scenario: "ipv6 loopback collapses to ::1",
-                    input: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
-                    expect: "::1".to_string(),
-                },
-                Check {
-                    scenario: "ipv6 full (no run to compress)",
-                    input: IpAddr::V6(Ipv6Addr::new(0xfd00, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x42)),
-                    expect: "fd00:1:2:3:4:5:6:42".to_string(),
-                },
-            ],
-            |ip| ip.to_string(),
+        value_scenarios!(
+            run = |ip| ip.to_string();
+            "ipv4" {
+                IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)) => "10.0.0.1".to_string(),
+            }
+
+            "ipv4 unspecified" {
+                IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)) => "0.0.0.0".to_string(),
+            }
+
+            "ipv4 broadcast" {
+                IpAddr::V4(Ipv4Addr::new(255, 255, 255, 255)) => "255.255.255.255".to_string(),
+            }
+
+            "ipv4 loopback" {
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)) => "127.0.0.1".to_string(),
+            }
+
+            "ipv6 compressed" {
+                IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)) => "2001:db8::1".to_string(),
+            }
+
+            "ipv6 unspecified collapses to ::" {
+                IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)) => "::".to_string(),
+            }
+
+            "ipv6 loopback collapses to ::1" {
+                IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)) => "::1".to_string(),
+            }
+
+            "ipv6 full (no run to compress)" {
+                IpAddr::V6(Ipv6Addr::new(0xfd00, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x42)) => "fd00:1:2:3:4:5:6:42".to_string(),
+            }
         );
     }
 
@@ -483,50 +455,42 @@ mod tests {
     // stable.
     #[test]
     fn test_quarantine_reason_str() {
-        check_values(
-            [
-                Check {
-                    scenario: "present reason passes through",
-                    input: ManagedHostQuarantineState {
-                        reason: Some("flooding the fabric".to_string()),
-                        mode: ManagedHostQuarantineMode::BlockAllTraffic,
-                    },
-                    expect: "flooding the fabric".to_string(),
-                },
-                Check {
-                    scenario: "empty reason stays empty",
-                    input: ManagedHostQuarantineState {
-                        reason: Some(String::new()),
-                        mode: ManagedHostQuarantineMode::BlockAllTraffic,
-                    },
-                    expect: String::new(),
-                },
-                Check {
-                    scenario: "missing reason yields empty string",
-                    input: ManagedHostQuarantineState {
-                        reason: None,
-                        mode: ManagedHostQuarantineMode::BlockAllTraffic,
-                    },
-                    expect: String::new(),
-                },
-            ],
-            |state| state.reason_str().to_string(),
+        value_scenarios!(
+            run = |state| state.reason_str().to_string();
+            "present reason passes through" {
+                ManagedHostQuarantineState {
+                    reason: Some("flooding the fabric".to_string()),
+                    mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                } => "flooding the fabric".to_string(),
+            }
+
+            "empty reason stays empty" {
+                ManagedHostQuarantineState {
+                    reason: Some(String::new()),
+                    mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                } => String::new(),
+            }
+
+            "missing reason yields empty string" {
+                ManagedHostQuarantineState {
+                    reason: None,
+                    mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                } => String::new(),
+            }
         );
     }
 
     #[test]
     fn test_quarantine_mode_str() {
-        check_values(
-            [Check {
-                scenario: "block-all-traffic renders its name",
-                input: ManagedHostQuarantineMode::BlockAllTraffic,
-                expect: "BlockAllTraffic".to_string(),
-            }],
-            |mode| {
+        value_scenarios!(
+            run = |mode| {
                 ManagedHostQuarantineState { reason: None, mode }
                     .mode_str()
                     .to_string()
-            },
+            };
+            "block-all-traffic renders its name" {
+                ManagedHostQuarantineMode::BlockAllTraffic => "BlockAllTraffic".to_string(),
+            }
         );
     }
 
@@ -540,130 +504,112 @@ mod tests {
         let v1 = config_version(1);
         let v2 = config_version(2);
 
-        check_values(
-            [
-                Check {
-                    scenario: "identical observations -> unchanged",
-                    input: (
-                        network_status(Some(v1), None, None),
-                        network_status(Some(v1), None, None),
-                    ),
-                    expect: false,
-                },
-                Check {
-                    scenario: "both network config versions None -> unchanged",
-                    input: (
-                        network_status(None, None, None),
-                        network_status(None, None, None),
-                    ),
-                    expect: false,
-                },
-                Check {
-                    scenario: "network config version differs -> changed",
-                    input: (
-                        network_status(Some(v1), None, None),
-                        network_status(Some(v2), None, None),
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "network config version None vs Some -> changed",
-                    input: (
-                        network_status(None, None, None),
-                        network_status(Some(v1), None, None),
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "network config version Some vs None -> changed",
-                    input: (
-                        network_status(Some(v1), None, None),
-                        network_status(None, None, None),
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "instance observation None vs Some -> changed",
-                    input: (
-                        network_status(Some(v1), None, None),
-                        network_status(Some(v1), Some(network_observation(v1, None)), None),
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "instance observation Some vs None -> changed",
-                    input: (
-                        network_status(Some(v1), Some(network_observation(v1, None)), None),
-                        network_status(Some(v1), None, None),
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "instance observation Some/Some identical -> unchanged",
-                    input: (
-                        network_status(Some(v1), Some(network_observation(v1, Some(v1))), None),
-                        network_status(Some(v1), Some(network_observation(v1, Some(v1))), None),
-                    ),
-                    expect: false,
-                },
-                Check {
-                    scenario: "instance observation inner config version differs -> changed",
-                    input: (
-                        network_status(Some(v1), Some(network_observation(v1, None)), None),
-                        network_status(Some(v1), Some(network_observation(v2, None)), None),
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "instance observation inner instance-config version differs -> changed",
-                    input: (
-                        network_status(Some(v1), Some(network_observation(v1, Some(v1))), None),
-                        network_status(Some(v1), Some(network_observation(v1, Some(v2))), None),
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "extension observation None vs Some -> changed",
-                    input: (
-                        network_status(Some(v1), None, None),
-                        network_status(Some(v1), None, Some(extension_observation(v1, None))),
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "extension observation Some vs None -> changed",
-                    input: (
-                        network_status(Some(v1), None, Some(extension_observation(v1, None))),
-                        network_status(Some(v1), None, None),
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "extension observation Some/Some identical -> unchanged",
-                    input: (
-                        network_status(Some(v1), None, Some(extension_observation(v1, Some(v1)))),
-                        network_status(Some(v1), None, Some(extension_observation(v1, Some(v1)))),
-                    ),
-                    expect: false,
-                },
-                Check {
-                    scenario: "extension observation inner config version differs -> changed",
-                    input: (
-                        network_status(Some(v1), None, Some(extension_observation(v1, None))),
-                        network_status(Some(v1), None, Some(extension_observation(v2, None))),
-                    ),
-                    expect: true,
-                },
-                Check {
-                    scenario: "extension observation inner instance-config version differs -> changed",
-                    input: (
-                        network_status(Some(v1), None, Some(extension_observation(v1, Some(v1)))),
-                        network_status(Some(v1), None, Some(extension_observation(v1, Some(v2)))),
-                    ),
-                    expect: true,
-                },
-            ],
-            |(a, b)| a.any_observed_version_changed(&b),
+        value_scenarios!(
+            run = |(a, b)| a.any_observed_version_changed(&b);
+            "identical observations -> unchanged" {
+                (
+                    network_status(Some(v1), None, None),
+                    network_status(Some(v1), None, None),
+                ) => false,
+            }
+
+            "both network config versions None -> unchanged" {
+                (
+                    network_status(None, None, None),
+                    network_status(None, None, None),
+                ) => false,
+            }
+
+            "network config version differs -> changed" {
+                (
+                    network_status(Some(v1), None, None),
+                    network_status(Some(v2), None, None),
+                ) => true,
+            }
+
+            "network config version None vs Some -> changed" {
+                (
+                    network_status(None, None, None),
+                    network_status(Some(v1), None, None),
+                ) => true,
+            }
+
+            "network config version Some vs None -> changed" {
+                (
+                    network_status(Some(v1), None, None),
+                    network_status(None, None, None),
+                ) => true,
+            }
+
+            "instance observation None vs Some -> changed" {
+                (
+                    network_status(Some(v1), None, None),
+                    network_status(Some(v1), Some(network_observation(v1, None)), None),
+                ) => true,
+            }
+
+            "instance observation Some vs None -> changed" {
+                (
+                    network_status(Some(v1), Some(network_observation(v1, None)), None),
+                    network_status(Some(v1), None, None),
+                ) => true,
+            }
+
+            "instance observation Some/Some identical -> unchanged" {
+                (
+                    network_status(Some(v1), Some(network_observation(v1, Some(v1))), None),
+                    network_status(Some(v1), Some(network_observation(v1, Some(v1))), None),
+                ) => false,
+            }
+
+            "instance observation inner config version differs -> changed" {
+                (
+                    network_status(Some(v1), Some(network_observation(v1, None)), None),
+                    network_status(Some(v1), Some(network_observation(v2, None)), None),
+                ) => true,
+            }
+
+            "instance observation inner instance-config version differs -> changed" {
+                (
+                    network_status(Some(v1), Some(network_observation(v1, Some(v1))), None),
+                    network_status(Some(v1), Some(network_observation(v1, Some(v2))), None),
+                ) => true,
+            }
+
+            "extension observation None vs Some -> changed" {
+                (
+                    network_status(Some(v1), None, None),
+                    network_status(Some(v1), None, Some(extension_observation(v1, None))),
+                ) => true,
+            }
+
+            "extension observation Some vs None -> changed" {
+                (
+                    network_status(Some(v1), None, Some(extension_observation(v1, None))),
+                    network_status(Some(v1), None, None),
+                ) => true,
+            }
+
+            "extension observation Some/Some identical -> unchanged" {
+                (
+                    network_status(Some(v1), None, Some(extension_observation(v1, Some(v1)))),
+                    network_status(Some(v1), None, Some(extension_observation(v1, Some(v1)))),
+                ) => false,
+            }
+
+            "extension observation inner config version differs -> changed" {
+                (
+                    network_status(Some(v1), None, Some(extension_observation(v1, None))),
+                    network_status(Some(v1), None, Some(extension_observation(v2, None))),
+                ) => true,
+            }
+
+            "extension observation inner instance-config version differs -> changed" {
+                (
+                    network_status(Some(v1), None, Some(extension_observation(v1, Some(v1)))),
+                    network_status(Some(v1), None, Some(extension_observation(v1, Some(v2)))),
+                ) => true,
+            }
         );
     }
 
@@ -673,75 +619,59 @@ mod tests {
     // is not PartialEq, so failing rows would use `Fails`; both rows parse.
     #[test]
     fn test_ip_addr_parse_from_pool_strings() {
-        check_cases(
-            [
-                Case {
-                    scenario: "ipv4 string",
-                    input: "10.0.0.1",
-                    expect: Yields(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
-                },
-                Case {
-                    scenario: "ipv6 string",
-                    input: "2001:db8::1",
-                    expect: Yields(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))),
-                },
-                Case {
-                    scenario: "ipv4 unspecified",
-                    input: "0.0.0.0",
-                    expect: Yields(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))),
-                },
-                Case {
-                    scenario: "ipv4 broadcast",
-                    input: "255.255.255.255",
-                    expect: Yields(IpAddr::V4(Ipv4Addr::new(255, 255, 255, 255))),
-                },
-                Case {
-                    scenario: "ipv6 unspecified",
-                    input: "::",
-                    expect: Yields(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0))),
-                },
-                Case {
-                    scenario: "ipv6 loopback",
-                    input: "::1",
-                    expect: Yields(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))),
-                },
-                Case {
-                    scenario: "empty string is rejected",
-                    input: "",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "non-address text is rejected",
-                    input: "not-an-ip",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "ipv4 octet out of range is rejected",
-                    input: "256.0.0.1",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "ipv4 with too few octets is rejected",
-                    input: "10.0.0",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "ipv4 with trailing whitespace is rejected",
-                    input: "10.0.0.1 ",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "ipv6 with double :: is rejected",
-                    input: "2001::db8::1",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "cidr suffix is not an address",
-                    input: "10.0.0.0/24",
-                    expect: Fails,
-                },
-            ],
-            |s| s.parse::<IpAddr>().map_err(drop),
+        scenarios!(
+            run = |s| s.parse::<IpAddr>().map_err(drop);
+            "ipv4 string" {
+                "10.0.0.1" => Yields(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+            }
+
+            "ipv6 string" {
+                "2001:db8::1" => Yields(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))),
+            }
+
+            "ipv4 unspecified" {
+                "0.0.0.0" => Yields(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))),
+            }
+
+            "ipv4 broadcast" {
+                "255.255.255.255" => Yields(IpAddr::V4(Ipv4Addr::new(255, 255, 255, 255))),
+            }
+
+            "ipv6 unspecified" {
+                "::" => Yields(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0))),
+            }
+
+            "ipv6 loopback" {
+                "::1" => Yields(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))),
+            }
+
+            "empty string is rejected" {
+                "" => Fails,
+            }
+
+            "non-address text is rejected" {
+                "not-an-ip" => Fails,
+            }
+
+            "ipv4 octet out of range is rejected" {
+                "256.0.0.1" => Fails,
+            }
+
+            "ipv4 with too few octets is rejected" {
+                "10.0.0" => Fails,
+            }
+
+            "ipv4 with trailing whitespace is rejected" {
+                "10.0.0.1 " => Fails,
+            }
+
+            "ipv6 with double :: is rejected" {
+                "2001::db8::1" => Fails,
+            }
+
+            "cidr suffix is not an address" {
+                "10.0.0.0/24" => Fails,
+            }
         );
     }
 
@@ -751,66 +681,56 @@ mod tests {
     // table left null.
     #[test]
     fn test_managed_host_network_config_deserialize_errors() {
-        check_cases(
-            [
-                Case {
-                    scenario: "well-formed with quarantine state",
-                    input: r#"{
-                        "loopback_ip": "10.0.0.1",
-                        "secondary_overlay_vtep_ip": null,
-                        "use_admin_network": false,
-                        "quarantine_state": {
-                            "reason": "noisy",
-                            "mode": "BlockAllTraffic"
-                        }
-                    }"#,
-                    expect: Yields(ManagedHostNetworkConfig {
-                        loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
-                        secondary_overlay_vtep_ip: None,
-                        use_admin_network: Some(false),
-                        quarantine_state: Some(ManagedHostQuarantineState {
-                            reason: Some("noisy".to_string()),
-                            mode: ManagedHostQuarantineMode::BlockAllTraffic,
-                        }),
+        scenarios!(
+            run = |json| serde_json::from_str::<ManagedHostNetworkConfig>(json).map_err(drop);
+            "well-formed with quarantine state" {
+                r#"{
+                            "loopback_ip": "10.0.0.1",
+                            "secondary_overlay_vtep_ip": null,
+                            "use_admin_network": false,
+                            "quarantine_state": {
+                                "reason": "noisy",
+                                "mode": "BlockAllTraffic"
+                            }
+                        }"# => Yields(ManagedHostNetworkConfig {
+                    loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                    secondary_overlay_vtep_ip: None,
+                    use_admin_network: Some(false),
+                    quarantine_state: Some(ManagedHostQuarantineState {
+                        reason: Some("noisy".to_string()),
+                        mode: ManagedHostQuarantineMode::BlockAllTraffic,
                     }),
-                },
-                Case {
-                    scenario: "empty object defaults all optional fields",
-                    input: "{}",
-                    expect: Yields(ManagedHostNetworkConfig {
-                        loopback_ip: None,
-                        secondary_overlay_vtep_ip: None,
-                        use_admin_network: None,
-                        quarantine_state: None,
-                    }),
-                },
-                Case {
-                    scenario: "invalid loopback ip string is rejected",
-                    input: r#"{"loopback_ip": "not-an-ip"}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "unknown quarantine mode is rejected",
-                    input: r#"{"quarantine_state": {"mode": "Nope"}}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "wrong type for use_admin_network is rejected",
-                    input: r#"{"use_admin_network": "true"}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "truncated json is rejected",
-                    input: r#"{"loopback_ip": "10.0.0.1""#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "non-object json is rejected",
-                    input: "[]",
-                    expect: Fails,
-                },
-            ],
-            |json| serde_json::from_str::<ManagedHostNetworkConfig>(json).map_err(drop),
+                }),
+            }
+
+            "empty object defaults all optional fields" {
+                "{}" => Yields(ManagedHostNetworkConfig {
+                    loopback_ip: None,
+                    secondary_overlay_vtep_ip: None,
+                    use_admin_network: None,
+                    quarantine_state: None,
+                }),
+            }
+
+            "invalid loopback ip string is rejected" {
+                r#"{"loopback_ip": "not-an-ip"}"# => Fails,
+            }
+
+            "unknown quarantine mode is rejected" {
+                r#"{"quarantine_state": {"mode": "Nope"}}"# => Fails,
+            }
+
+            "wrong type for use_admin_network is rejected" {
+                r#"{"use_admin_network": "true"}"# => Fails,
+            }
+
+            "truncated json is rejected" {
+                r#"{"loopback_ip": "10.0.0.1""# => Fails,
+            }
+
+            "non-object json is rejected" {
+                "[]" => Fails,
+            }
         );
     }
 
@@ -821,39 +741,34 @@ mod tests {
     // would use `Fails`.
     #[test]
     fn test_managed_host_network_config_default_and_quarantine_roundtrip() {
-        check_cases(
-            [
-                Case {
-                    scenario: "default round-trips",
-                    input: ManagedHostNetworkConfig::default(),
-                    expect: Yields(ManagedHostNetworkConfig::default()),
-                },
-                Case {
-                    scenario: "quarantine state round-trips",
-                    input: ManagedHostNetworkConfig {
-                        loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
-                        secondary_overlay_vtep_ip: None,
-                        use_admin_network: Some(true),
-                        quarantine_state: Some(ManagedHostQuarantineState {
-                            reason: Some("flooded".to_string()),
-                            mode: ManagedHostQuarantineMode::BlockAllTraffic,
-                        }),
-                    },
-                    expect: Yields(ManagedHostNetworkConfig {
-                        loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
-                        secondary_overlay_vtep_ip: None,
-                        use_admin_network: Some(true),
-                        quarantine_state: Some(ManagedHostQuarantineState {
-                            reason: Some("flooded".to_string()),
-                            mode: ManagedHostQuarantineMode::BlockAllTraffic,
-                        }),
-                    }),
-                },
-            ],
-            |config| {
+        scenarios!(
+            run = |config| {
                 let json = serde_json::to_string(&config).map_err(drop)?;
                 serde_json::from_str::<ManagedHostNetworkConfig>(&json).map_err(drop)
-            },
+            };
+            "default round-trips" {
+                ManagedHostNetworkConfig::default() => Yields(ManagedHostNetworkConfig::default()),
+            }
+
+            "quarantine state round-trips" {
+                ManagedHostNetworkConfig {
+                    loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                    secondary_overlay_vtep_ip: None,
+                    use_admin_network: Some(true),
+                    quarantine_state: Some(ManagedHostQuarantineState {
+                        reason: Some("flooded".to_string()),
+                        mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                    }),
+                } => Yields(ManagedHostNetworkConfig {
+                    loopback_ip: Some(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))),
+                    secondary_overlay_vtep_ip: None,
+                    use_admin_network: Some(true),
+                    quarantine_state: Some(ManagedHostQuarantineState {
+                        reason: Some("flooded".to_string()),
+                        mode: ManagedHostQuarantineMode::BlockAllTraffic,
+                    }),
+                }),
+            }
         );
     }
 }

--- a/crates/api-model/src/machine/upgrade_policy.rs
+++ b/crates/api-model/src/machine/upgrade_policy.rs
@@ -463,120 +463,94 @@ mod tests {
     use std::cmp::Ordering;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Check, check_values, scenarios, value_scenarios};
 
     use super::{AgentUpgradePolicy, BuildVersion};
     use crate::firmware::AgentUpgradePolicyChoice;
 
     #[test]
     fn agent_upgrade_policy_display() {
-        check_values(
-            [
-                Check {
-                    scenario: "off",
-                    input: AgentUpgradePolicy::Off,
-                    expect: "Off".to_string(),
-                },
-                Check {
-                    scenario: "up-only",
-                    input: AgentUpgradePolicy::UpOnly,
-                    expect: "UpOnly".to_string(),
-                },
-                Check {
-                    scenario: "up-down",
-                    input: AgentUpgradePolicy::UpDown,
-                    expect: "UpDown".to_string(),
-                },
-            ],
-            |p| p.to_string(),
+        value_scenarios!(
+            run = |p| p.to_string();
+            "off" {
+                AgentUpgradePolicy::Off => "Off".to_string(),
+            }
+
+            "up-only" {
+                AgentUpgradePolicy::UpOnly => "UpOnly".to_string(),
+            }
+
+            "up-down" {
+                AgentUpgradePolicy::UpDown => "UpDown".to_string(),
+            }
         );
     }
 
     #[test]
     fn agent_upgrade_policy_from_str() {
-        check_values(
-            [
-                Check {
-                    scenario: "canonical Off",
-                    input: "Off",
-                    expect: AgentUpgradePolicy::Off,
-                },
-                Check {
-                    scenario: "lowercase off",
-                    input: "off",
-                    expect: AgentUpgradePolicy::Off,
-                },
-                Check {
-                    scenario: "canonical UpOnly",
-                    input: "UpOnly",
-                    expect: AgentUpgradePolicy::UpOnly,
-                },
-                Check {
-                    scenario: "lowercase uponly",
-                    input: "uponly",
-                    expect: AgentUpgradePolicy::UpOnly,
-                },
-                Check {
-                    scenario: "snake_case up_only",
-                    input: "up_only",
-                    expect: AgentUpgradePolicy::UpOnly,
-                },
-                Check {
-                    scenario: "canonical UpDown",
-                    input: "UpDown",
-                    expect: AgentUpgradePolicy::UpDown,
-                },
-                Check {
-                    scenario: "lowercase updown",
-                    input: "updown",
-                    expect: AgentUpgradePolicy::UpDown,
-                },
-                Check {
-                    scenario: "snake_case up_down",
-                    input: "up_down",
-                    expect: AgentUpgradePolicy::UpDown,
-                },
-                Check {
-                    scenario: "unknown string falls back to Off",
-                    input: "nonsense",
-                    expect: AgentUpgradePolicy::Off,
-                },
-                Check {
-                    scenario: "empty string falls back to Off",
-                    input: "",
-                    expect: AgentUpgradePolicy::Off,
-                },
-                Check {
-                    scenario: "wrong casing falls back to Off",
-                    input: "OFF",
-                    expect: AgentUpgradePolicy::Off,
-                },
-            ],
-            AgentUpgradePolicy::from,
+        value_scenarios!(
+            run = AgentUpgradePolicy::from;
+            "canonical Off" {
+                "Off" => AgentUpgradePolicy::Off,
+            }
+
+            "lowercase off" {
+                "off" => AgentUpgradePolicy::Off,
+            }
+
+            "canonical UpOnly" {
+                "UpOnly" => AgentUpgradePolicy::UpOnly,
+            }
+
+            "lowercase uponly" {
+                "uponly" => AgentUpgradePolicy::UpOnly,
+            }
+
+            "snake_case up_only" {
+                "up_only" => AgentUpgradePolicy::UpOnly,
+            }
+
+            "canonical UpDown" {
+                "UpDown" => AgentUpgradePolicy::UpDown,
+            }
+
+            "lowercase updown" {
+                "updown" => AgentUpgradePolicy::UpDown,
+            }
+
+            "snake_case up_down" {
+                "up_down" => AgentUpgradePolicy::UpDown,
+            }
+
+            "unknown string falls back to Off" {
+                "nonsense" => AgentUpgradePolicy::Off,
+            }
+
+            "empty string falls back to Off" {
+                "" => AgentUpgradePolicy::Off,
+            }
+
+            "wrong casing falls back to Off" {
+                "OFF" => AgentUpgradePolicy::Off,
+            }
         );
     }
 
     #[test]
     fn agent_upgrade_policy_from_choice() {
-        check_values(
-            [
-                Check {
-                    scenario: "off",
-                    input: AgentUpgradePolicyChoice::Off,
-                    expect: AgentUpgradePolicy::Off,
-                },
-                Check {
-                    scenario: "up-only",
-                    input: AgentUpgradePolicyChoice::UpOnly,
-                    expect: AgentUpgradePolicy::UpOnly,
-                },
-                Check {
-                    scenario: "up-down",
-                    input: AgentUpgradePolicyChoice::UpDown,
-                    expect: AgentUpgradePolicy::UpDown,
-                },
-            ],
-            AgentUpgradePolicy::from,
+        value_scenarios!(
+            run = AgentUpgradePolicy::from;
+            "off" {
+                AgentUpgradePolicyChoice::Off => AgentUpgradePolicy::Off,
+            }
+
+            "up-only" {
+                AgentUpgradePolicyChoice::UpOnly => AgentUpgradePolicy::UpOnly,
+            }
+
+            "up-down" {
+                AgentUpgradePolicyChoice::UpDown => AgentUpgradePolicy::UpDown,
+            }
         );
     }
 
@@ -738,44 +712,35 @@ mod tests {
 
     #[test]
     fn build_version_display_round_trips() {
-        check_cases(
-            [
-                Case {
-                    scenario: "bare date tag",
-                    input: "v2023.08",
-                    expect: Yields("v2023.08".to_string()),
-                },
-                Case {
-                    scenario: "bare semver tag",
-                    input: "v1.2.3",
-                    expect: Yields("v1.2.3".to_string()),
-                },
-                Case {
-                    scenario: "date tag with commits and hash",
-                    input: "v2023.08-92-g1b48e8b6",
-                    expect: Yields("v2023.08-92-g1b48e8b6".to_string()),
-                },
-                Case {
-                    scenario: "rc and hotfix both render",
-                    input: "v2024.05.02-rc3-0",
-                    expect: Yields("v2024.05.02-rc3-0".to_string()),
-                },
-                Case {
-                    scenario: "full version with rc, hotfix, commits and hash",
-                    input: "v2024.05.02-rc4-0-27-gc3ce4d5d",
-                    expect: Yields("v2024.05.02-rc4-0-27-gc3ce4d5d".to_string()),
-                },
-                Case {
-                    scenario: "two-part input normalizes hotfix to 0",
-                    input: "v2023.09-rc1",
-                    expect: Yields("v2023.09-rc1-0".to_string()),
-                },
-            ],
-            |s| {
+        scenarios!(
+            run = |s| {
                 BuildVersion::try_from(s)
                     .map(|bv| bv.to_string())
                     .map_err(drop)
-            },
+            };
+            "bare date tag" {
+                "v2023.08" => Yields("v2023.08".to_string()),
+            }
+
+            "bare semver tag" {
+                "v1.2.3" => Yields("v1.2.3".to_string()),
+            }
+
+            "date tag with commits and hash" {
+                "v2023.08-92-g1b48e8b6" => Yields("v2023.08-92-g1b48e8b6".to_string()),
+            }
+
+            "rc and hotfix both render" {
+                "v2024.05.02-rc3-0" => Yields("v2024.05.02-rc3-0".to_string()),
+            }
+
+            "full version with rc, hotfix, commits and hash" {
+                "v2024.05.02-rc4-0-27-gc3ce4d5d" => Yields("v2024.05.02-rc4-0-27-gc3ce4d5d".to_string()),
+            }
+
+            "two-part input normalizes hotfix to 0" {
+                "v2023.09-rc1" => Yields("v2023.09-rc1-0".to_string()),
+            }
         );
     }
 
@@ -785,122 +750,103 @@ mod tests {
             left: &'static str,
             right: &'static str,
         }
-        check_values(
-            [
-                Check {
-                    scenario: "older date less than newer date",
-                    input: Pair {
-                        left: "v2023.08",
-                        right: "v2023.09",
-                    },
-                    expect: Ordering::Less,
-                },
-                Check {
-                    scenario: "equal date tags",
-                    input: Pair {
-                        left: "v2023.08",
-                        right: "v2023.08",
-                    },
-                    expect: Ordering::Equal,
-                },
-                Check {
-                    scenario: "newer date greater than older date",
-                    input: Pair {
-                        left: "v2023.09",
-                        right: "v2023.08",
-                    },
-                    expect: Ordering::Greater,
-                },
-                Check {
-                    scenario: "more commits is greater",
-                    input: Pair {
-                        left: "v2023.08-92-g1b48e8b6",
-                        right: "v2023.08-14-gbc549a66",
-                    },
-                    expect: Ordering::Greater,
-                },
-                Check {
-                    scenario: "date is always less than semver",
-                    input: Pair {
-                        left: "v2024.05.10-rc1-3",
-                        right: "v0.0.1",
-                    },
-                    expect: Ordering::Less,
-                },
-                Check {
-                    scenario: "semver is always greater than date",
-                    input: Pair {
-                        left: "v0.0.1",
-                        right: "v2024.05.10-rc1-3",
-                    },
-                    expect: Ordering::Greater,
-                },
-                Check {
-                    scenario: "lower semver less than higher semver",
-                    input: Pair {
-                        left: "v0.0.1",
-                        right: "v0.0.4-rc4-0-g2a3c98cac",
-                    },
-                    expect: Ordering::Less,
-                },
-                Check {
-                    scenario: "semver major dominates",
-                    input: Pair {
-                        left: "v0.0.4-rc4-0-g2a3c98cac",
-                        right: "v1.0.0",
-                    },
-                    expect: Ordering::Less,
-                },
-                Check {
-                    scenario: "equal semver tags",
-                    input: Pair {
-                        left: "v1.2.3",
-                        right: "v1.2.3",
-                    },
-                    expect: Ordering::Equal,
-                },
-                Check {
-                    scenario: "semver patch difference",
-                    input: Pair {
-                        left: "v0.0.4",
-                        right: "v0.0.5",
-                    },
-                    expect: Ordering::Less,
-                },
-            ],
-            |Pair { left, right }| {
+        value_scenarios!(
+            run = |Pair { left, right }| {
                 let l = BuildVersion::try_from(left).unwrap();
                 let r = BuildVersion::try_from(right).unwrap();
                 l.cmp(&r)
-            },
+            };
+            "older date less than newer date" {
+                Pair {
+                    left: "v2023.08",
+                    right: "v2023.09",
+                } => Ordering::Less,
+            }
+
+            "equal date tags" {
+                Pair {
+                    left: "v2023.08",
+                    right: "v2023.08",
+                } => Ordering::Equal,
+            }
+
+            "newer date greater than older date" {
+                Pair {
+                    left: "v2023.09",
+                    right: "v2023.08",
+                } => Ordering::Greater,
+            }
+
+            "more commits is greater" {
+                Pair {
+                    left: "v2023.08-92-g1b48e8b6",
+                    right: "v2023.08-14-gbc549a66",
+                } => Ordering::Greater,
+            }
+
+            "date is always less than semver" {
+                Pair {
+                    left: "v2024.05.10-rc1-3",
+                    right: "v0.0.1",
+                } => Ordering::Less,
+            }
+
+            "semver is always greater than date" {
+                Pair {
+                    left: "v0.0.1",
+                    right: "v2024.05.10-rc1-3",
+                } => Ordering::Greater,
+            }
+
+            "lower semver less than higher semver" {
+                Pair {
+                    left: "v0.0.1",
+                    right: "v0.0.4-rc4-0-g2a3c98cac",
+                } => Ordering::Less,
+            }
+
+            "semver major dominates" {
+                Pair {
+                    left: "v0.0.4-rc4-0-g2a3c98cac",
+                    right: "v1.0.0",
+                } => Ordering::Less,
+            }
+
+            "equal semver tags" {
+                Pair {
+                    left: "v1.2.3",
+                    right: "v1.2.3",
+                } => Ordering::Equal,
+            }
+
+            "semver patch difference" {
+                Pair {
+                    left: "v0.0.4",
+                    right: "v0.0.5",
+                } => Ordering::Less,
+            }
         );
     }
 
     #[test]
     fn build_version_partial_cmp_matches_cmp() {
-        check_values(
-            [
-                Check {
-                    scenario: "less",
-                    input: ("v0.0.1", "v1.0.0"),
-                    expect: Some(Ordering::Less),
-                },
-                Check {
-                    scenario: "greater",
-                    input: ("v1.0.0", "v0.0.1"),
-                    expect: Some(Ordering::Greater),
-                },
-                Check {
-                    scenario: "equal",
-                    input: ("v1.0.0", "v1.0.0"),
-                    expect: Some(Ordering::Equal),
-                },
-            ],
-            |(l, r)| {
+        value_scenarios!(
+            run = |(l, r)| {
                 BuildVersion::try_from(l)
                     .unwrap()
                     .partial_cmp(&BuildVersion::try_from(r).unwrap())
-            },
+            };
+            "less" {
+                ("v0.0.1", "v1.0.0") => Some(Ordering::Less),
+            }
+
+            "greater" {
+                ("v1.0.0", "v0.0.1") => Some(Ordering::Greater),
+            }
+
+            "equal" {
+                ("v1.0.0", "v1.0.0") => Some(Ordering::Equal),
+            }
         );
     }
 

--- a/crates/api-model/src/machine_validation.rs
+++ b/crates/api-model/src/machine_validation.rs
@@ -270,7 +270,7 @@ impl<'r> FromRow<'r, PgRow> for MachineValidationResult {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{Check, scenarios, value_scenarios};
 
     use super::*;
 
@@ -287,138 +287,107 @@ mod tests {
 
     #[test]
     fn state_from_str_parses_every_variant_and_rejects_the_rest() {
-        check_cases(
-            [
-                Case {
-                    scenario: "Started",
-                    input: "Started",
-                    expect: Yields(MachineValidationState::Started),
-                },
-                Case {
-                    scenario: "InProgress",
-                    input: "InProgress",
-                    expect: Yields(MachineValidationState::InProgress),
-                },
-                Case {
-                    scenario: "Success",
-                    input: "Success",
-                    expect: Yields(MachineValidationState::Success),
-                },
-                Case {
-                    scenario: "Skipped",
-                    input: "Skipped",
-                    expect: Yields(MachineValidationState::Skipped),
-                },
-                Case {
-                    scenario: "Failed",
-                    input: "Failed",
-                    expect: Yields(MachineValidationState::Failed),
-                },
-                Case {
-                    scenario: "empty string",
-                    input: "",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "unknown variant",
-                    input: "Pending",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "lowercase is not accepted",
-                    input: "started",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "uppercase is not accepted",
-                    input: "SUCCESS",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "leading whitespace is not trimmed",
-                    input: " Started",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "trailing whitespace is not trimmed",
-                    input: "Failed ",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "numeric input",
-                    input: "0",
-                    expect: Fails,
-                },
-            ],
-            |s| MachineValidationState::from_str(s).map_err(drop),
+        scenarios!(
+            run = |s| MachineValidationState::from_str(s).map_err(drop);
+            "Started" {
+                "Started" => Yields(MachineValidationState::Started),
+            }
+
+            "InProgress" {
+                "InProgress" => Yields(MachineValidationState::InProgress),
+            }
+
+            "Success" {
+                "Success" => Yields(MachineValidationState::Success),
+            }
+
+            "Skipped" {
+                "Skipped" => Yields(MachineValidationState::Skipped),
+            }
+
+            "Failed" {
+                "Failed" => Yields(MachineValidationState::Failed),
+            }
+
+            "empty string" {
+                "" => Fails,
+            }
+
+            "unknown variant" {
+                "Pending" => Fails,
+            }
+
+            "lowercase is not accepted" {
+                "started" => Fails,
+            }
+
+            "uppercase is not accepted" {
+                "SUCCESS" => Fails,
+            }
+
+            "leading whitespace is not trimmed" {
+                " Started" => Fails,
+            }
+
+            "trailing whitespace is not trimmed" {
+                "Failed " => Fails,
+            }
+
+            "numeric input" {
+                "0" => Fails,
+            }
         );
     }
 
     #[test]
     fn state_display_renders_the_variant_name() {
-        check_values(
-            [
-                Check {
-                    scenario: "Started",
-                    input: MachineValidationState::Started,
-                    expect: "Started".to_string(),
-                },
-                Check {
-                    scenario: "InProgress",
-                    input: MachineValidationState::InProgress,
-                    expect: "InProgress".to_string(),
-                },
-                Check {
-                    scenario: "Success",
-                    input: MachineValidationState::Success,
-                    expect: "Success".to_string(),
-                },
-                Check {
-                    scenario: "Skipped",
-                    input: MachineValidationState::Skipped,
-                    expect: "Skipped".to_string(),
-                },
-                Check {
-                    scenario: "Failed",
-                    input: MachineValidationState::Failed,
-                    expect: "Failed".to_string(),
-                },
-            ],
-            |state| state.to_string(),
+        value_scenarios!(
+            run = |state| state.to_string();
+            "Started" {
+                MachineValidationState::Started => "Started".to_string(),
+            }
+
+            "InProgress" {
+                MachineValidationState::InProgress => "InProgress".to_string(),
+            }
+
+            "Success" {
+                MachineValidationState::Success => "Success".to_string(),
+            }
+
+            "Skipped" {
+                MachineValidationState::Skipped => "Skipped".to_string(),
+            }
+
+            "Failed" {
+                MachineValidationState::Failed => "Failed".to_string(),
+            }
         );
     }
 
     #[test]
     fn state_display_round_trips_through_from_str() {
-        check_cases(
-            [
-                Case {
-                    scenario: "Started",
-                    input: MachineValidationState::Started,
-                    expect: Yields(MachineValidationState::Started),
-                },
-                Case {
-                    scenario: "InProgress",
-                    input: MachineValidationState::InProgress,
-                    expect: Yields(MachineValidationState::InProgress),
-                },
-                Case {
-                    scenario: "Success",
-                    input: MachineValidationState::Success,
-                    expect: Yields(MachineValidationState::Success),
-                },
-                Case {
-                    scenario: "Skipped",
-                    input: MachineValidationState::Skipped,
-                    expect: Yields(MachineValidationState::Skipped),
-                },
-                Case {
-                    scenario: "Failed",
-                    input: MachineValidationState::Failed,
-                    expect: Yields(MachineValidationState::Failed),
-                },
-            ],
-            |state| MachineValidationState::from_str(&state.to_string()).map_err(drop),
+        scenarios!(
+            run = |state| MachineValidationState::from_str(&state.to_string()).map_err(drop);
+            "Started" {
+                MachineValidationState::Started => Yields(MachineValidationState::Started),
+            }
+
+            "InProgress" {
+                MachineValidationState::InProgress => Yields(MachineValidationState::InProgress),
+            }
+
+            "Success" {
+                MachineValidationState::Success => Yields(MachineValidationState::Success),
+            }
+
+            "Skipped" {
+                MachineValidationState::Skipped => Yields(MachineValidationState::Skipped),
+            }
+
+            "Failed" {
+                MachineValidationState::Failed => Yields(MachineValidationState::Failed),
+            }
         );
     }
 
@@ -434,28 +403,23 @@ mod tests {
 
     #[test]
     fn status_default_is_started_with_zero_counts() {
-        check_values(
-            [
-                Check {
-                    scenario: "default state is Started",
-                    input: MachineValidationStatus::default(),
-                    expect: MachineValidationStatus {
-                        state: MachineValidationState::Started,
-                        total: 0,
-                        completed: 0,
-                    },
+        value_scenarios!(
+            run = |status| status;
+            "default state is Started" {
+                MachineValidationStatus::default() => MachineValidationStatus {
+                    state: MachineValidationState::Started,
+                    total: 0,
+                    completed: 0,
                 },
-                Check {
-                    scenario: "matches an explicitly built default",
-                    input: MachineValidationStatus {
-                        state: MachineValidationState::Started,
-                        total: 0,
-                        completed: 0,
-                    },
-                    expect: MachineValidationStatus::default(),
-                },
-            ],
-            |status| status,
+            }
+
+            "matches an explicitly built default" {
+                MachineValidationStatus {
+                    state: MachineValidationState::Started,
+                    total: 0,
+                    completed: 0,
+                } => MachineValidationStatus::default(),
+            }
         );
     }
 
@@ -466,46 +430,39 @@ mod tests {
             total: 10,
             completed: 4,
         };
-        check_values(
-            [
-                Check {
-                    scenario: "identical is equal",
-                    input: MachineValidationStatus {
-                        state: MachineValidationState::InProgress,
-                        total: 10,
-                        completed: 4,
-                    },
-                    expect: true,
-                },
-                Check {
-                    scenario: "differing state is unequal",
-                    input: MachineValidationStatus {
-                        state: MachineValidationState::Success,
-                        total: 10,
-                        completed: 4,
-                    },
-                    expect: false,
-                },
-                Check {
-                    scenario: "differing total is unequal",
-                    input: MachineValidationStatus {
-                        state: MachineValidationState::InProgress,
-                        total: 11,
-                        completed: 4,
-                    },
-                    expect: false,
-                },
-                Check {
-                    scenario: "differing completed is unequal",
-                    input: MachineValidationStatus {
-                        state: MachineValidationState::InProgress,
-                        total: 10,
-                        completed: 5,
-                    },
-                    expect: false,
-                },
-            ],
-            |status| status == base,
+        value_scenarios!(
+            run = |status| status == base;
+            "identical is equal" {
+                MachineValidationStatus {
+                    state: MachineValidationState::InProgress,
+                    total: 10,
+                    completed: 4,
+                } => true,
+            }
+
+            "differing state is unequal" {
+                MachineValidationStatus {
+                    state: MachineValidationState::Success,
+                    total: 10,
+                    completed: 4,
+                } => false,
+            }
+
+            "differing total is unequal" {
+                MachineValidationStatus {
+                    state: MachineValidationState::InProgress,
+                    total: 11,
+                    completed: 4,
+                } => false,
+            }
+
+            "differing completed is unequal" {
+                MachineValidationStatus {
+                    state: MachineValidationState::InProgress,
+                    total: 10,
+                    completed: 5,
+                } => false,
+            }
         );
     }
 }

--- a/crates/api-model/src/metadata.rs
+++ b/crates/api-model/src/metadata.rs
@@ -121,7 +121,7 @@ pub struct LabelFilter {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -145,138 +145,192 @@ mod tests {
 
     #[test]
     fn validate_with_min_length_required() {
-        check_cases(
-            [
-                Case {
-                    scenario: "valid name, description, and label",
-                    input: meta("nice_name", "anything is fine", &[("key1", "val1")]),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "no labels is fine",
-                    input: meta("nice_name", "", &[]),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "name at min length (2)",
-                    input: meta("ab", "", &[]),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "name one below min length (1)",
-                    input: meta("x", "", &[]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty name rejected when min length required",
-                    input: meta("", "", &[]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "name at max length (256)",
-                    input: Metadata {
-                        name: long(256),
-                        ..Metadata::default()
-                    },
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "name one over max length (257)",
-                    input: Metadata {
-                        name: long(257),
-                        ..Metadata::default()
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "non-ascii name rejected",
-                    input: meta("것봐", "", &[]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "description at max length (1024)",
-                    input: Metadata {
-                        name: "nice name".to_string(),
-                        description: long(1024),
-                        ..Metadata::default()
-                    },
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "description one over max length (1025)",
-                    input: Metadata {
+        scenarios!(
+            run = |m| m.validate(true).map_err(drop);
+            "valid name, description, and label" {
+                meta("nice_name", "anything is fine", &[("key1", "val1")]) => Yields(()),
+            }
+
+            "no labels is fine" {
+                meta("nice_name", "", &[]) => Yields(()),
+            }
+
+            "name at min length (2)" {
+                meta("ab", "", &[]) => Yields(()),
+            }
+
+            "name one below min length (1)" {
+                meta("x", "", &[]) => Fails,
+            }
+
+            "empty name rejected when min length required" {
+                meta("", "", &[]) => Fails,
+            }
+
+            "name at max length (256)" {
+                Metadata {
+                    name: long(256),
+                    ..Metadata::default()
+                } => Yields(()),
+            }
+
+            "name one over max length (257)" {
+                Metadata {
+                    name: long(257),
+                    ..Metadata::default()
+                } => Fails,
+            }
+
+            "non-ascii name rejected" {
+                meta("것봐", "", &[]) => Fails,
+            }
+
+            "description at max length (1024)" {
+                Metadata {
+                    name: "nice name".to_string(),
+                    description: long(1024),
+                    ..Metadata::default()
+                } => Yields(()),
+            }
+
+            "description one over max length (1025)" {
+                Metadata {
+                    name: "nice name".to_string(),
+                    description: long(1025),
+                    ..Metadata::default()
+                } => Fails,
+            }
+
+            "empty label key rejected" {
+                meta("nice name", "", &[("", "val1")]) => Fails,
+            }
+
+            "non-ascii label key rejected" {
+                meta("nice name", "", &[("것봐", "val1")]) => Fails,
+            }
+
+            "label key at max length (255)" {
+                Metadata {
+                    name: "nice name".to_string(),
+                    labels: HashMap::from([(long(255), "val1".to_string())]),
+                    ..Metadata::default()
+                } => Yields(()),
+            }
+
+            "label key one over max length (256)" {
+                Metadata {
+                    name: "nice name".to_string(),
+                    labels: HashMap::from([(long(256), "val1".to_string())]),
+                    ..Metadata::default()
+                } => Fails,
+            }
+
+            "label value at max length (255)" {
+                Metadata {
+                    name: "nice name".to_string(),
+                    labels: HashMap::from([("key1".to_string(), long(255))]),
+                    ..Metadata::default()
+                } => Yields(()),
+            }
+
+            "label value one over max length (256)" {
+                Metadata {
+                    name: "nice name".to_string(),
+                    labels: HashMap::from([("key1".to_string(), long(256))]),
+                    ..Metadata::default()
+                } => Fails,
+            }
+
+            "empty label value is fine" {
+                meta("nice name", "", &[("key1", "")]) => Yields(()),
+            }
+
+            "labels at max count (16)" {
+                Metadata {
+                    name: "nice name".to_string(),
+                    labels: "abcdefghijklmnop"
+                        .chars()
+                        .map(|c| (c.to_string(), "x".to_string()))
+                        .collect(),
+                    ..Metadata::default()
+                } => Yields(()),
+            }
+
+            "labels one over max count (17)" {
+                Metadata {
+                    name: "nice name".to_string(),
+                    labels: "abcdefghijklmnopq"
+                        .chars()
+                        .map(|c| (c.to_string(), "x".to_string()))
+                        .collect(),
+                    ..Metadata::default()
+                } => Fails,
+            }
+        );
+    }
+
+    #[test]
+    fn validate_without_min_length_required() {
+        scenarios!(
+            run = |m| m.validate(false).map_err(drop);
+            "empty name allowed when min length not required" {
+                meta("", "anything is fine", &[("key1", "val1")]) => Yields(()),
+            }
+
+            "single-char name allowed when min length not required" {
+                meta("x", "", &[]) => Yields(()),
+            }
+
+            "name still capped at max length (257 rejected)" {
+                Metadata {
+                    name: long(257),
+                    ..Metadata::default()
+                } => Fails,
+            }
+
+            "non-ascii name still rejected" {
+                meta("것봐", "", &[]) => Fails,
+            }
+
+            "label checks still apply (empty key rejected)" {
+                meta("", "", &[("", "val1")]) => Fails,
+            }
+        );
+    }
+
+    #[test]
+    fn validate_error_message_names_the_offending_field() {
+        scenarios!(
+            run = |(m, tokens)| {
+                let message = m.validate(true).unwrap_err().to_string();
+                Ok::<_, ()>(tokens.iter().all(|t| message.contains(t)))
+            };
+            "short-name error mentions length bounds" {
+                (meta("x", "", &[]), &["between", "256"][..]) => Yields(true),
+            }
+
+            "non-ascii name error mentions ASCII" {
+                (meta("것봐", "", &[]), &["ASCII"][..]) => Yields(true),
+            }
+
+            "long-description error mentions Description" {
+                (
+                    Metadata {
                         name: "nice name".to_string(),
                         description: long(1025),
                         ..Metadata::default()
                     },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty label key rejected",
-                    input: meta("nice name", "", &[("", "val1")]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "non-ascii label key rejected",
-                    input: meta("nice name", "", &[("것봐", "val1")]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "label key at max length (255)",
-                    input: Metadata {
-                        name: "nice name".to_string(),
-                        labels: HashMap::from([(long(255), "val1".to_string())]),
-                        ..Metadata::default()
-                    },
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "label key one over max length (256)",
-                    input: Metadata {
-                        name: "nice name".to_string(),
-                        labels: HashMap::from([(long(256), "val1".to_string())]),
-                        ..Metadata::default()
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "label value at max length (255)",
-                    input: Metadata {
-                        name: "nice name".to_string(),
-                        labels: HashMap::from([("key1".to_string(), long(255))]),
-                        ..Metadata::default()
-                    },
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "label value one over max length (256)",
-                    input: Metadata {
-                        name: "nice name".to_string(),
-                        labels: HashMap::from([("key1".to_string(), long(256))]),
-                        ..Metadata::default()
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty label value is fine",
-                    input: meta("nice name", "", &[("key1", "")]),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "labels at max count (16)",
-                    input: Metadata {
-                        name: "nice name".to_string(),
-                        labels: "abcdefghijklmnop"
-                            .chars()
-                            .map(|c| (c.to_string(), "x".to_string()))
-                            .collect(),
-                        ..Metadata::default()
-                    },
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "labels one over max count (17)",
-                    input: Metadata {
+                    &["Description", "1024"][..],
+                ) => Yields(true),
+            }
+
+            "empty-key error mentions empty" {
+                (meta("nice name", "", &[("", "v")]), &["empty"][..]) => Yields(true),
+            }
+
+            "too-many-labels error mentions the count" {
+                (
+                    Metadata {
                         name: "nice name".to_string(),
                         labels: "abcdefghijklmnopq"
                             .chars()
@@ -284,133 +338,35 @@ mod tests {
                             .collect(),
                         ..Metadata::default()
                     },
-                    expect: Fails,
-                },
-            ],
-            |m| m.validate(true).map_err(drop),
-        );
-    }
-
-    #[test]
-    fn validate_without_min_length_required() {
-        check_cases(
-            [
-                Case {
-                    scenario: "empty name allowed when min length not required",
-                    input: meta("", "anything is fine", &[("key1", "val1")]),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "single-char name allowed when min length not required",
-                    input: meta("x", "", &[]),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "name still capped at max length (257 rejected)",
-                    input: Metadata {
-                        name: long(257),
-                        ..Metadata::default()
-                    },
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "non-ascii name still rejected",
-                    input: meta("것봐", "", &[]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "label checks still apply (empty key rejected)",
-                    input: meta("", "", &[("", "val1")]),
-                    expect: Fails,
-                },
-            ],
-            |m| m.validate(false).map_err(drop),
-        );
-    }
-
-    #[test]
-    fn validate_error_message_names_the_offending_field() {
-        check_cases(
-            [
-                Case {
-                    scenario: "short-name error mentions length bounds",
-                    input: (meta("x", "", &[]), &["between", "256"][..]),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "non-ascii name error mentions ASCII",
-                    input: (meta("것봐", "", &[]), &["ASCII"][..]),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "long-description error mentions Description",
-                    input: (
-                        Metadata {
-                            name: "nice name".to_string(),
-                            description: long(1025),
-                            ..Metadata::default()
-                        },
-                        &["Description", "1024"][..],
-                    ),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "empty-key error mentions empty",
-                    input: (meta("nice name", "", &[("", "v")]), &["empty"][..]),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "too-many-labels error mentions the count",
-                    input: (
-                        Metadata {
-                            name: "nice name".to_string(),
-                            labels: "abcdefghijklmnopq"
-                                .chars()
-                                .map(|c| (c.to_string(), "x".to_string()))
-                                .collect(),
-                            ..Metadata::default()
-                        },
-                        &["more than 16", "17"][..],
-                    ),
-                    expect: Yields(true),
-                },
-            ],
-            |(m, tokens)| {
-                let message = m.validate(true).unwrap_err().to_string();
-                Ok::<_, ()>(tokens.iter().all(|t| message.contains(t)))
-            },
+                    &["more than 16", "17"][..],
+                ) => Yields(true),
+            }
         );
     }
 
     #[test]
     fn constructors_produce_expected_metadata() {
-        check_values(
-            [
-                Check {
-                    scenario: "new_with_default_name sets the default name",
-                    input: Metadata::new_with_default_name(),
-                    expect: Metadata {
-                        name: "default_name".to_string(),
-                        description: String::new(),
-                        labels: HashMap::new(),
-                    },
+        value_scenarios!(
+            run = |m| m;
+            "new_with_default_name sets the default name" {
+                Metadata::new_with_default_name() => Metadata {
+                    name: "default_name".to_string(),
+                    description: String::new(),
+                    labels: HashMap::new(),
                 },
-                Check {
-                    scenario: "default is fully empty",
-                    input: Metadata::default(),
-                    expect: Metadata {
-                        name: String::new(),
-                        description: String::new(),
-                        labels: HashMap::new(),
-                    },
+            }
+
+            "default is fully empty" {
+                Metadata::default() => Metadata {
+                    name: String::new(),
+                    description: String::new(),
+                    labels: HashMap::new(),
                 },
-                Check {
-                    scenario: "deserializer default matches Metadata::default",
-                    input: default_metadata_for_deserializer(),
-                    expect: Metadata::default(),
-                },
-            ],
-            |m| m,
+            }
+
+            "deserializer default matches Metadata::default" {
+                default_metadata_for_deserializer() => Metadata::default(),
+            }
         );
     }
 }

--- a/crates/api-model/src/network_segment/mod.rs
+++ b/crates/api-model/src/network_segment/mod.rs
@@ -365,7 +365,7 @@ impl NewNetworkSegment {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -384,307 +384,237 @@ mod tests {
 
     #[test]
     fn controller_state_serializes_to_tagged_json() {
-        check_cases(
-            [
-                Case {
-                    scenario: "provisioning",
-                    input: NetworkSegmentControllerState::Provisioning,
-                    expect: Yields(r#"{"state":"provisioning"}"#.to_string()),
-                },
-                Case {
-                    scenario: "ready",
-                    input: NetworkSegmentControllerState::Ready,
-                    expect: Yields(r#"{"state":"ready"}"#.to_string()),
-                },
-                Case {
-                    scenario: "deleting / drain allocated ips",
-                    input: drain_state(),
-                    expect: Yields(
-                        r#"{"state":"deleting","deletion_state":{"state":"drainallocatedips","delete_at":"2022-12-13T04:41:38Z"}}"#
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "deleting / db delete",
-                    input: dbdelete_state(),
-                    expect: Yields(
-                        r#"{"state":"deleting","deletion_state":{"state":"dbdelete"}}"#.to_string(),
-                    ),
-                },
-            ],
-            |state| serde_json::to_string(&state).map_err(drop),
+        scenarios!(
+            run = |state| serde_json::to_string(&state).map_err(drop);
+            "provisioning" {
+                NetworkSegmentControllerState::Provisioning => Yields(r#"{"state":"provisioning"}"#.to_string()),
+            }
+
+            "ready" {
+                NetworkSegmentControllerState::Ready => Yields(r#"{"state":"ready"}"#.to_string()),
+            }
+
+            "deleting / drain allocated ips" {
+                drain_state() => Yields(
+                    r#"{"state":"deleting","deletion_state":{"state":"drainallocatedips","delete_at":"2022-12-13T04:41:38Z"}}"#
+                        .to_string(),
+                ),
+            }
+
+            "deleting / db delete" {
+                dbdelete_state() => Yields(
+                    r#"{"state":"deleting","deletion_state":{"state":"dbdelete"}}"#.to_string(),
+                ),
+            }
         );
     }
 
     #[test]
     fn controller_state_round_trips_through_json() {
-        check_cases(
-            [
-                Case {
-                    scenario: "provisioning",
-                    input: NetworkSegmentControllerState::Provisioning,
-                    expect: Yields(NetworkSegmentControllerState::Provisioning),
-                },
-                Case {
-                    scenario: "ready",
-                    input: NetworkSegmentControllerState::Ready,
-                    expect: Yields(NetworkSegmentControllerState::Ready),
-                },
-                Case {
-                    scenario: "deleting / drain allocated ips",
-                    input: drain_state(),
-                    expect: Yields(drain_state()),
-                },
-                Case {
-                    scenario: "deleting / db delete",
-                    input: dbdelete_state(),
-                    expect: Yields(dbdelete_state()),
-                },
-            ],
-            |state| {
+        scenarios!(
+            run = |state| {
                 let json = serde_json::to_string(&state).map_err(drop)?;
                 serde_json::from_str::<NetworkSegmentControllerState>(&json).map_err(drop)
-            },
+            };
+            "provisioning" {
+                NetworkSegmentControllerState::Provisioning => Yields(NetworkSegmentControllerState::Provisioning),
+            }
+
+            "ready" {
+                NetworkSegmentControllerState::Ready => Yields(NetworkSegmentControllerState::Ready),
+            }
+
+            "deleting / drain allocated ips" {
+                drain_state() => Yields(drain_state()),
+            }
+
+            "deleting / db delete" {
+                dbdelete_state() => Yields(dbdelete_state()),
+            }
         );
     }
 
     #[test]
     fn segment_type_parses_from_db_string() {
-        check_cases(
-            [
-                Case {
-                    scenario: "tenant",
-                    input: "tenant",
-                    expect: Yields(NetworkSegmentType::Tenant),
-                },
-                Case {
-                    scenario: "admin",
-                    input: "admin",
-                    expect: Yields(NetworkSegmentType::Admin),
-                },
-                Case {
-                    scenario: "tor maps to underlay",
-                    input: "tor",
-                    expect: Yields(NetworkSegmentType::Underlay),
-                },
-                Case {
-                    scenario: "host_inband",
-                    input: "host_inband",
-                    expect: Yields(NetworkSegmentType::HostInband),
-                },
-                Case {
-                    scenario: "unknown token",
-                    input: "bogus",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty string",
-                    input: "",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "wrong-case admin",
-                    input: "Admin",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "display name underlay, not parse name",
-                    input: "underlay",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "whitespace padded",
-                    input: " tenant ",
-                    expect: Fails,
-                },
-            ],
-            |s| NetworkSegmentType::from_str(s).map_err(drop),
+        scenarios!(
+            run = |s| NetworkSegmentType::from_str(s).map_err(drop);
+            "tenant" {
+                "tenant" => Yields(NetworkSegmentType::Tenant),
+            }
+
+            "admin" {
+                "admin" => Yields(NetworkSegmentType::Admin),
+            }
+
+            "tor maps to underlay" {
+                "tor" => Yields(NetworkSegmentType::Underlay),
+            }
+
+            "host_inband" {
+                "host_inband" => Yields(NetworkSegmentType::HostInband),
+            }
+
+            "unknown token" {
+                "bogus" => Fails,
+            }
+
+            "empty string" {
+                "" => Fails,
+            }
+
+            "wrong-case admin" {
+                "Admin" => Fails,
+            }
+
+            "display name underlay, not parse name" {
+                "underlay" => Fails,
+            }
+
+            "whitespace padded" {
+                " tenant " => Fails,
+            }
         );
     }
 
     #[test]
     fn segment_type_parse_error_names_the_input() {
-        check_cases(
-            [
-                Case {
-                    scenario: "error mentions the offending token",
-                    input: ("bogus", &["Invalid segment type", "bogus"][..]),
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "error mentions an empty token",
-                    input: ("", &["Invalid segment type"][..]),
-                    expect: Yields(true),
-                },
-            ],
-            |(s, tokens)| {
+        scenarios!(
+            run = |(s, tokens)| {
                 let msg = NetworkSegmentType::from_str(s)
                     .map(|_| String::new())
                     .unwrap_or_else(|e| e.to_string());
                 Ok::<_, ()>(tokens.iter().all(|t| msg.contains(t)))
-            },
+            };
+            "error mentions the offending token" {
+                ("bogus", &["Invalid segment type", "bogus"][..]) => Yields(true),
+            }
+
+            "error mentions an empty token" {
+                ("", &["Invalid segment type"][..]) => Yields(true),
+            }
         );
     }
 
     #[test]
     fn segment_type_round_trips_through_display_and_parse() {
-        check_cases(
-            [
-                Case {
-                    scenario: "tenant",
-                    input: NetworkSegmentType::Tenant,
-                    expect: Yields(NetworkSegmentType::Tenant),
-                },
-                Case {
-                    scenario: "admin",
-                    input: NetworkSegmentType::Admin,
-                    expect: Yields(NetworkSegmentType::Admin),
-                },
-                Case {
-                    scenario: "underlay",
-                    input: NetworkSegmentType::Underlay,
-                    expect: Yields(NetworkSegmentType::Underlay),
-                },
-                Case {
-                    scenario: "host_inband",
-                    input: NetworkSegmentType::HostInband,
-                    expect: Yields(NetworkSegmentType::HostInband),
-                },
-            ],
-            |ty| NetworkSegmentType::from_str(&ty.to_string()).map_err(drop),
+        scenarios!(
+            run = |ty| NetworkSegmentType::from_str(&ty.to_string()).map_err(drop);
+            "tenant" {
+                NetworkSegmentType::Tenant => Yields(NetworkSegmentType::Tenant),
+            }
+
+            "admin" {
+                NetworkSegmentType::Admin => Yields(NetworkSegmentType::Admin),
+            }
+
+            "underlay" {
+                NetworkSegmentType::Underlay => Yields(NetworkSegmentType::Underlay),
+            }
+
+            "host_inband" {
+                NetworkSegmentType::HostInband => Yields(NetworkSegmentType::HostInband),
+            }
         );
     }
 
     #[test]
     fn segment_type_displays_its_db_token() {
-        check_values(
-            [
-                Check {
-                    scenario: "tenant",
-                    input: NetworkSegmentType::Tenant,
-                    expect: "tenant".to_string(),
-                },
-                Check {
-                    scenario: "admin",
-                    input: NetworkSegmentType::Admin,
-                    expect: "admin".to_string(),
-                },
-                Check {
-                    scenario: "underlay renders as tor",
-                    input: NetworkSegmentType::Underlay,
-                    expect: "tor".to_string(),
-                },
-                Check {
-                    scenario: "host_inband",
-                    input: NetworkSegmentType::HostInband,
-                    expect: "host_inband".to_string(),
-                },
-            ],
-            |ty| ty.to_string(),
+        value_scenarios!(
+            run = |ty| ty.to_string();
+            "tenant" {
+                NetworkSegmentType::Tenant => "tenant".to_string(),
+            }
+
+            "admin" {
+                NetworkSegmentType::Admin => "admin".to_string(),
+            }
+
+            "underlay renders as tor" {
+                NetworkSegmentType::Underlay => "tor".to_string(),
+            }
+
+            "host_inband" {
+                NetworkSegmentType::HostInband => "host_inband".to_string(),
+            }
         );
     }
 
     #[test]
     fn is_tenant_is_true_for_tenant_facing_segments() {
-        check_values(
-            [
-                Check {
-                    scenario: "tenant is tenant-facing",
-                    input: NetworkSegmentType::Tenant,
-                    expect: true,
-                },
-                Check {
-                    scenario: "host_inband is tenant-facing",
-                    input: NetworkSegmentType::HostInband,
-                    expect: true,
-                },
-                Check {
-                    scenario: "admin is not tenant-facing",
-                    input: NetworkSegmentType::Admin,
-                    expect: false,
-                },
-                Check {
-                    scenario: "underlay is not tenant-facing",
-                    input: NetworkSegmentType::Underlay,
-                    expect: false,
-                },
-            ],
-            |ty| ty.is_tenant(),
+        value_scenarios!(
+            run = |ty| ty.is_tenant();
+            "tenant is tenant-facing" {
+                NetworkSegmentType::Tenant => true,
+            }
+
+            "host_inband is tenant-facing" {
+                NetworkSegmentType::HostInband => true,
+            }
+
+            "admin is not tenant-facing" {
+                NetworkSegmentType::Admin => false,
+            }
+
+            "underlay is not tenant-facing" {
+                NetworkSegmentType::Underlay => false,
+            }
         );
     }
 
     #[test]
     fn segment_type_converts_from_definition_type() {
-        check_values(
-            [
-                Check {
-                    scenario: "admin",
-                    input: NetworkDefinitionSegmentType::Admin,
-                    expect: NetworkSegmentType::Admin,
-                },
-                Check {
-                    scenario: "underlay",
-                    input: NetworkDefinitionSegmentType::Underlay,
-                    expect: NetworkSegmentType::Underlay,
-                },
-                Check {
-                    scenario: "host_inband",
-                    input: NetworkDefinitionSegmentType::HostInband,
-                    expect: NetworkSegmentType::HostInband,
-                },
-            ],
-            NetworkSegmentType::from,
+        value_scenarios!(
+            run = NetworkSegmentType::from;
+            "admin" {
+                NetworkDefinitionSegmentType::Admin => NetworkSegmentType::Admin,
+            }
+
+            "underlay" {
+                NetworkDefinitionSegmentType::Underlay => NetworkSegmentType::Underlay,
+            }
+
+            "host_inband" {
+                NetworkDefinitionSegmentType::HostInband => NetworkSegmentType::HostInband,
+            }
         );
     }
 
     #[test]
     fn allocation_strategy_round_trips_through_json() {
-        check_cases(
-            [
-                Case {
-                    scenario: "dynamic serializes to its snake-case token",
-                    input: AllocationStrategy::Dynamic,
-                    expect: Yields(r#""dynamic""#.to_string()),
-                },
-                Case {
-                    scenario: "reserved serializes to its snake-case token",
-                    input: AllocationStrategy::Reserved,
-                    expect: Yields(r#""reserved""#.to_string()),
-                },
-            ],
-            |s| serde_json::to_string(&s).map_err(drop),
+        scenarios!(
+            run = |s| serde_json::to_string(&s).map_err(drop);
+            "dynamic serializes to its snake-case token" {
+                AllocationStrategy::Dynamic => Yields(r#""dynamic""#.to_string()),
+            }
+
+            "reserved serializes to its snake-case token" {
+                AllocationStrategy::Reserved => Yields(r#""reserved""#.to_string()),
+            }
         );
     }
 
     #[test]
     fn allocation_strategy_defaults_to_dynamic() {
-        check_values(
-            [Check {
-                scenario: "default",
-                input: (),
-                expect: AllocationStrategy::Dynamic,
-            }],
-            |()| AllocationStrategy::default(),
+        value_scenarios!(
+            run = |()| AllocationStrategy::default();
+            "default" {
+                () => AllocationStrategy::Dynamic,
+            }
         );
     }
 
     #[test]
     fn is_marked_as_deleted_follows_the_deleted_timestamp() {
         let stamp: DateTime<Utc> = "2022-12-13T04:41:38Z".parse().unwrap();
-        check_values(
-            [
-                Check {
-                    scenario: "no timestamp means live",
-                    input: None,
-                    expect: false,
-                },
-                Check {
-                    scenario: "timestamp means deleted",
-                    input: Some(stamp),
-                    expect: true,
-                },
-            ],
-            |deleted| deleted.is_some(),
+        value_scenarios!(
+            run = |deleted| deleted.is_some();
+            "no timestamp means live" {
+                None => false,
+            }
+
+            "timestamp means deleted" {
+                Some(stamp) => true,
+            }
         );
     }
 }

--- a/crates/api-model/src/power_shelf/mod.rs
+++ b/crates/api-model/src/power_shelf/mod.rs
@@ -231,7 +231,7 @@ pub struct PowerShelfSearchFilter {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -240,94 +240,83 @@ mod tests {
         // Each controller-state variant serializes to its tagged JSON and round-trips
         // back to the same value. The op yields (serialized, deserialized) so both the
         // exact JSON string and the round-trip equality are asserted per row.
-        check_cases(
-            [
-                Case {
-                    scenario: "initializing",
-                    input: PowerShelfControllerState::Initializing {},
-                    expect: Yields((
-                        "{\"state\":\"initializing\"}".to_string(),
-                        PowerShelfControllerState::Initializing {},
-                    )),
-                },
-                Case {
-                    scenario: "fetching data",
-                    input: PowerShelfControllerState::FetchingData {},
-                    expect: Yields((
-                        "{\"state\":\"fetchingdata\"}".to_string(),
-                        PowerShelfControllerState::FetchingData {},
-                    )),
-                },
-                Case {
-                    scenario: "configuring",
-                    input: PowerShelfControllerState::Configuring {},
-                    expect: Yields((
-                        "{\"state\":\"configuring\"}".to_string(),
-                        PowerShelfControllerState::Configuring {},
-                    )),
-                },
-                Case {
-                    scenario: "ready",
-                    input: PowerShelfControllerState::Ready {},
-                    expect: Yields((
-                        "{\"state\":\"ready\"}".to_string(),
-                        PowerShelfControllerState::Ready {},
-                    )),
-                },
-                Case {
-                    scenario: "error with cause",
-                    input: PowerShelfControllerState::Error {
-                        cause: "cause goes here".to_string(),
-                    },
-                    expect: Yields((
-                        r#"{"state":"error","cause":"cause goes here"}"#.to_string(),
-                        PowerShelfControllerState::Error {
-                            cause: "cause goes here".to_string(),
-                        },
-                    )),
-                },
-                Case {
-                    scenario: "deleting",
-                    input: PowerShelfControllerState::Deleting {},
-                    expect: Yields((
-                        "{\"state\":\"deleting\"}".to_string(),
-                        PowerShelfControllerState::Deleting {},
-                    )),
-                },
-                Case {
-                    scenario: "maintenance power-on",
-                    input: PowerShelfControllerState::Maintenance {
-                        operation: PowerShelfMaintenanceOperation::PowerOn,
-                    },
-                    expect: Yields((
-                        r#"{"state":"maintenance","operation":{"operation":"poweron"}}"#
-                            .to_string(),
-                        PowerShelfControllerState::Maintenance {
-                            operation: PowerShelfMaintenanceOperation::PowerOn,
-                        },
-                    )),
-                },
-                Case {
-                    scenario: "maintenance power-off",
-                    input: PowerShelfControllerState::Maintenance {
-                        operation: PowerShelfMaintenanceOperation::PowerOff,
-                    },
-                    expect: Yields((
-                        r#"{"state":"maintenance","operation":{"operation":"poweroff"}}"#
-                            .to_string(),
-                        PowerShelfControllerState::Maintenance {
-                            operation: PowerShelfMaintenanceOperation::PowerOff,
-                        },
-                    )),
-                },
-            ],
+        scenarios!(
             // Serialize the state, then deserialize the produced JSON back.
-            |state: PowerShelfControllerState| {
+            run = |state: PowerShelfControllerState| {
                 let serialized = serde_json::to_string(&state).map_err(drop)?;
                 let parsed =
                     serde_json::from_str::<PowerShelfControllerState>(&serialized).map_err(drop)?;
                 Ok::<_, ()>((serialized, parsed))
-            },
+            };
+            "initializing" {
+                PowerShelfControllerState::Initializing {} => Yields((
+                    "{\"state\":\"initializing\"}".to_string(),
+                    PowerShelfControllerState::Initializing {},
+                )),
+            }
+
+            "fetching data" {
+                PowerShelfControllerState::FetchingData {} => Yields((
+                    "{\"state\":\"fetchingdata\"}".to_string(),
+                    PowerShelfControllerState::FetchingData {},
+                )),
+            }
+
+            "configuring" {
+                PowerShelfControllerState::Configuring {} => Yields((
+                    "{\"state\":\"configuring\"}".to_string(),
+                    PowerShelfControllerState::Configuring {},
+                )),
+            }
+
+            "ready" {
+                PowerShelfControllerState::Ready {} => Yields((
+                    "{\"state\":\"ready\"}".to_string(),
+                    PowerShelfControllerState::Ready {},
+                )),
+            }
+
+            "error with cause" {
+                PowerShelfControllerState::Error {
+                    cause: "cause goes here".to_string(),
+                } => Yields((
+                    r#"{"state":"error","cause":"cause goes here"}"#.to_string(),
+                    PowerShelfControllerState::Error {
+                        cause: "cause goes here".to_string(),
+                    },
+                )),
+            }
+
+            "deleting" {
+                PowerShelfControllerState::Deleting {} => Yields((
+                    "{\"state\":\"deleting\"}".to_string(),
+                    PowerShelfControllerState::Deleting {},
+                )),
+            }
+
+            "maintenance power-on" {
+                PowerShelfControllerState::Maintenance {
+                    operation: PowerShelfMaintenanceOperation::PowerOn,
+                } => Yields((
+                    r#"{"state":"maintenance","operation":{"operation":"poweron"}}"#
+                        .to_string(),
+                    PowerShelfControllerState::Maintenance {
+                        operation: PowerShelfMaintenanceOperation::PowerOn,
+                    },
+                )),
+            }
+
+            "maintenance power-off" {
+                PowerShelfControllerState::Maintenance {
+                    operation: PowerShelfMaintenanceOperation::PowerOff,
+                } => Yields((
+                    r#"{"state":"maintenance","operation":{"operation":"poweroff"}}"#
+                        .to_string(),
+                    PowerShelfControllerState::Maintenance {
+                        operation: PowerShelfMaintenanceOperation::PowerOff,
+                    },
+                )),
+            }
         );
     }
 
@@ -336,31 +325,26 @@ mod tests {
         // Each maintenance operation serializes to its lowercase-tagged JSON and
         // round-trips back. The op yields (serialized, deserialized), folding the
         // exact-tag and round-trip assertions into one table.
-        check_cases(
-            [
-                Case {
-                    scenario: "power on",
-                    input: PowerShelfMaintenanceOperation::PowerOn,
-                    expect: Yields((
-                        r#"{"operation":"poweron"}"#.to_string(),
-                        PowerShelfMaintenanceOperation::PowerOn,
-                    )),
-                },
-                Case {
-                    scenario: "power off",
-                    input: PowerShelfMaintenanceOperation::PowerOff,
-                    expect: Yields((
-                        r#"{"operation":"poweroff"}"#.to_string(),
-                        PowerShelfMaintenanceOperation::PowerOff,
-                    )),
-                },
-            ],
-            |operation: PowerShelfMaintenanceOperation| {
+        scenarios!(
+            run = |operation: PowerShelfMaintenanceOperation| {
                 let serialized = serde_json::to_string(&operation).map_err(drop)?;
                 let parsed = serde_json::from_str::<PowerShelfMaintenanceOperation>(&serialized)
                     .map_err(drop)?;
                 Ok::<_, ()>((serialized, parsed))
-            },
+            };
+            "power on" {
+                PowerShelfMaintenanceOperation::PowerOn => Yields((
+                    r#"{"operation":"poweron"}"#.to_string(),
+                    PowerShelfMaintenanceOperation::PowerOn,
+                )),
+            }
+
+            "power off" {
+                PowerShelfMaintenanceOperation::PowerOff => Yields((
+                    r#"{"operation":"poweroff"}"#.to_string(),
+                    PowerShelfMaintenanceOperation::PowerOff,
+                )),
+            }
         );
     }
 
@@ -376,23 +360,18 @@ mod tests {
             initiator: "operator (TICKET-1)".to_string(),
             operation,
         };
-        check_cases(
-            [
-                Case {
-                    scenario: "power on",
-                    input: PowerShelfMaintenanceOperation::PowerOn,
-                    expect: Yields(request(PowerShelfMaintenanceOperation::PowerOn)),
-                },
-                Case {
-                    scenario: "power off",
-                    input: PowerShelfMaintenanceOperation::PowerOff,
-                    expect: Yields(request(PowerShelfMaintenanceOperation::PowerOff)),
-                },
-            ],
-            |operation| {
+        scenarios!(
+            run = |operation| {
                 let serialized = serde_json::to_string(&request(operation)).map_err(drop)?;
                 serde_json::from_str::<PowerShelfMaintenanceRequest>(&serialized).map_err(drop)
-            },
+            };
+            "power on" {
+                PowerShelfMaintenanceOperation::PowerOn => Yields(request(PowerShelfMaintenanceOperation::PowerOn)),
+            }
+
+            "power off" {
+                PowerShelfMaintenanceOperation::PowerOff => Yields(request(PowerShelfMaintenanceOperation::PowerOff)),
+            }
         );
     }
 
@@ -412,98 +391,79 @@ mod tests {
         // Each tagged-JSON form parses back to its variant; malformed or unknown
         // tags are rejected. The op yields the parsed variant so both the accepted
         // shapes and the rejected ones are pinned in one table.
-        check_cases(
-            [
-                Case {
-                    scenario: "initializing tag",
-                    input: r#"{"state":"initializing"}"#,
-                    expect: Yields(PowerShelfControllerState::Initializing),
-                },
-                Case {
-                    scenario: "fetchingdata tag",
-                    input: r#"{"state":"fetchingdata"}"#,
-                    expect: Yields(PowerShelfControllerState::FetchingData),
-                },
-                Case {
-                    scenario: "configuring tag",
-                    input: r#"{"state":"configuring"}"#,
-                    expect: Yields(PowerShelfControllerState::Configuring),
-                },
-                Case {
-                    scenario: "ready tag",
-                    input: r#"{"state":"ready"}"#,
-                    expect: Yields(PowerShelfControllerState::Ready),
-                },
-                Case {
-                    scenario: "deleting tag",
-                    input: r#"{"state":"deleting"}"#,
-                    expect: Yields(PowerShelfControllerState::Deleting),
-                },
-                Case {
-                    scenario: "error with cause",
-                    input: r#"{"state":"error","cause":"boom"}"#,
-                    expect: Yields(PowerShelfControllerState::Error {
-                        cause: "boom".to_string(),
-                    }),
-                },
-                Case {
-                    scenario: "error with empty cause",
-                    input: r#"{"state":"error","cause":""}"#,
-                    expect: Yields(PowerShelfControllerState::Error {
-                        cause: String::new(),
-                    }),
-                },
-                Case {
-                    scenario: "maintenance power-on",
-                    input: r#"{"state":"maintenance","operation":{"operation":"poweron"}}"#,
-                    expect: Yields(PowerShelfControllerState::Maintenance {
-                        operation: PowerShelfMaintenanceOperation::PowerOn,
-                    }),
-                },
-                Case {
-                    scenario: "maintenance power-off",
-                    input: r#"{"state":"maintenance","operation":{"operation":"poweroff"}}"#,
-                    expect: Yields(PowerShelfControllerState::Maintenance {
-                        operation: PowerShelfMaintenanceOperation::PowerOff,
-                    }),
-                },
-                Case {
-                    scenario: "unknown tag is rejected",
-                    input: r#"{"state":"running"}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "wrong-case tag is rejected",
-                    input: r#"{"state":"Initializing"}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "error without cause is rejected",
-                    input: r#"{"state":"error"}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "maintenance without operation is rejected",
-                    input: r#"{"state":"maintenance"}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "missing state tag is rejected",
-                    input: r#"{}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "not an object is rejected",
-                    input: r#""initializing""#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "malformed json is rejected",
-                    input: r#"{"state":"#,
-                    expect: Fails,
-                },
-            ],
-            |json: &str| serde_json::from_str::<PowerShelfControllerState>(json).map_err(drop),
+        scenarios!(
+            run = |json: &str| serde_json::from_str::<PowerShelfControllerState>(json).map_err(drop);
+            "initializing tag" {
+                r#"{"state":"initializing"}"# => Yields(PowerShelfControllerState::Initializing),
+            }
+
+            "fetchingdata tag" {
+                r#"{"state":"fetchingdata"}"# => Yields(PowerShelfControllerState::FetchingData),
+            }
+
+            "configuring tag" {
+                r#"{"state":"configuring"}"# => Yields(PowerShelfControllerState::Configuring),
+            }
+
+            "ready tag" {
+                r#"{"state":"ready"}"# => Yields(PowerShelfControllerState::Ready),
+            }
+
+            "deleting tag" {
+                r#"{"state":"deleting"}"# => Yields(PowerShelfControllerState::Deleting),
+            }
+
+            "error with cause" {
+                r#"{"state":"error","cause":"boom"}"# => Yields(PowerShelfControllerState::Error {
+                    cause: "boom".to_string(),
+                }),
+            }
+
+            "error with empty cause" {
+                r#"{"state":"error","cause":""}"# => Yields(PowerShelfControllerState::Error {
+                    cause: String::new(),
+                }),
+            }
+
+            "maintenance power-on" {
+                r#"{"state":"maintenance","operation":{"operation":"poweron"}}"# => Yields(PowerShelfControllerState::Maintenance {
+                    operation: PowerShelfMaintenanceOperation::PowerOn,
+                }),
+            }
+
+            "maintenance power-off" {
+                r#"{"state":"maintenance","operation":{"operation":"poweroff"}}"# => Yields(PowerShelfControllerState::Maintenance {
+                    operation: PowerShelfMaintenanceOperation::PowerOff,
+                }),
+            }
+
+            "unknown tag is rejected" {
+                r#"{"state":"running"}"# => Fails,
+            }
+
+            "wrong-case tag is rejected" {
+                r#"{"state":"Initializing"}"# => Fails,
+            }
+
+            "error without cause is rejected" {
+                r#"{"state":"error"}"# => Fails,
+            }
+
+            "maintenance without operation is rejected" {
+                r#"{"state":"maintenance"}"# => Fails,
+            }
+
+            "missing state tag is rejected" {
+                r#"{}"# => Fails,
+            }
+
+            "not an object is rejected" {
+                r#""initializing""# => Fails,
+            }
+
+            "malformed json is rejected" {
+                r#"{"state":"# => Fails,
+            }
         );
     }
 
@@ -511,35 +471,27 @@ mod tests {
     fn maintenance_operation_deserializes_from_tagged_json() {
         // The lowercase operation tags parse back to their variants; unknown or
         // wrong-case tags are rejected.
-        check_cases(
-            [
-                Case {
-                    scenario: "poweron tag",
-                    input: r#"{"operation":"poweron"}"#,
-                    expect: Yields(PowerShelfMaintenanceOperation::PowerOn),
-                },
-                Case {
-                    scenario: "poweroff tag",
-                    input: r#"{"operation":"poweroff"}"#,
-                    expect: Yields(PowerShelfMaintenanceOperation::PowerOff),
-                },
-                Case {
-                    scenario: "unknown operation is rejected",
-                    input: r#"{"operation":"reset"}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "wrong-case operation is rejected",
-                    input: r#"{"operation":"PowerOn"}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "missing operation tag is rejected",
-                    input: r#"{}"#,
-                    expect: Fails,
-                },
-            ],
-            |json: &str| serde_json::from_str::<PowerShelfMaintenanceOperation>(json).map_err(drop),
+        scenarios!(
+            run = |json: &str| serde_json::from_str::<PowerShelfMaintenanceOperation>(json).map_err(drop);
+            "poweron tag" {
+                r#"{"operation":"poweron"}"# => Yields(PowerShelfMaintenanceOperation::PowerOn),
+            }
+
+            "poweroff tag" {
+                r#"{"operation":"poweroff"}"# => Yields(PowerShelfMaintenanceOperation::PowerOff),
+            }
+
+            "unknown operation is rejected" {
+                r#"{"operation":"reset"}"# => Fails,
+            }
+
+            "wrong-case operation is rejected" {
+                r#"{"operation":"PowerOn"}"# => Fails,
+            }
+
+            "missing operation tag is rejected" {
+                r#"{}"# => Fails,
+            }
         );
     }
 
@@ -547,65 +499,58 @@ mod tests {
     fn config_round_trips_through_json() {
         // PowerShelfConfig round-trips for present/absent optionals, empty names, and
         // numeric boundaries. The op yields the value parsed back from its own JSON.
-        check_cases(
-            [
-                Case {
-                    scenario: "all fields present",
-                    input: PowerShelfConfig {
-                        name: "shelf-1".to_string(),
-                        capacity: Some(5000),
-                        voltage: Some(48),
-                    },
-                    expect: Yields(PowerShelfConfig {
-                        name: "shelf-1".to_string(),
-                        capacity: Some(5000),
-                        voltage: Some(48),
-                    }),
-                },
-                Case {
-                    scenario: "optionals absent",
-                    input: PowerShelfConfig {
-                        name: "shelf-2".to_string(),
-                        capacity: None,
-                        voltage: None,
-                    },
-                    expect: Yields(PowerShelfConfig {
-                        name: "shelf-2".to_string(),
-                        capacity: None,
-                        voltage: None,
-                    }),
-                },
-                Case {
-                    scenario: "empty name and zero values",
-                    input: PowerShelfConfig {
-                        name: String::new(),
-                        capacity: Some(0),
-                        voltage: Some(0),
-                    },
-                    expect: Yields(PowerShelfConfig {
-                        name: String::new(),
-                        capacity: Some(0),
-                        voltage: Some(0),
-                    }),
-                },
-                Case {
-                    scenario: "u32 maxima",
-                    input: PowerShelfConfig {
-                        name: "max".to_string(),
-                        capacity: Some(u32::MAX),
-                        voltage: Some(u32::MAX),
-                    },
-                    expect: Yields(PowerShelfConfig {
-                        name: "max".to_string(),
-                        capacity: Some(u32::MAX),
-                        voltage: Some(u32::MAX),
-                    }),
-                },
-            ],
-            |config: PowerShelfConfig| {
+        scenarios!(
+            run = |config: PowerShelfConfig| {
                 let serialized = serde_json::to_string(&config).map_err(drop)?;
                 serde_json::from_str::<PowerShelfConfig>(&serialized).map_err(drop)
-            },
+            };
+            "all fields present" {
+                PowerShelfConfig {
+                    name: "shelf-1".to_string(),
+                    capacity: Some(5000),
+                    voltage: Some(48),
+                } => Yields(PowerShelfConfig {
+                    name: "shelf-1".to_string(),
+                    capacity: Some(5000),
+                    voltage: Some(48),
+                }),
+            }
+
+            "optionals absent" {
+                PowerShelfConfig {
+                    name: "shelf-2".to_string(),
+                    capacity: None,
+                    voltage: None,
+                } => Yields(PowerShelfConfig {
+                    name: "shelf-2".to_string(),
+                    capacity: None,
+                    voltage: None,
+                }),
+            }
+
+            "empty name and zero values" {
+                PowerShelfConfig {
+                    name: String::new(),
+                    capacity: Some(0),
+                    voltage: Some(0),
+                } => Yields(PowerShelfConfig {
+                    name: String::new(),
+                    capacity: Some(0),
+                    voltage: Some(0),
+                }),
+            }
+
+            "u32 maxima" {
+                PowerShelfConfig {
+                    name: "max".to_string(),
+                    capacity: Some(u32::MAX),
+                    voltage: Some(u32::MAX),
+                } => Yields(PowerShelfConfig {
+                    name: "max".to_string(),
+                    capacity: Some(u32::MAX),
+                    voltage: Some(u32::MAX),
+                }),
+            }
         );
     }
 
@@ -613,65 +558,58 @@ mod tests {
     fn status_round_trips_through_json() {
         // PowerShelfStatus round-trips across each power/health string the field is
         // documented to hold, plus empty strings.
-        check_cases(
-            [
-                Case {
-                    scenario: "on / ok",
-                    input: PowerShelfStatus {
-                        shelf_name: "psu-a".to_string(),
-                        power_state: "on".to_string(),
-                        health_status: "ok".to_string(),
-                    },
-                    expect: Yields(PowerShelfStatus {
-                        shelf_name: "psu-a".to_string(),
-                        power_state: "on".to_string(),
-                        health_status: "ok".to_string(),
-                    }),
-                },
-                Case {
-                    scenario: "off / warning",
-                    input: PowerShelfStatus {
-                        shelf_name: "psu-b".to_string(),
-                        power_state: "off".to_string(),
-                        health_status: "warning".to_string(),
-                    },
-                    expect: Yields(PowerShelfStatus {
-                        shelf_name: "psu-b".to_string(),
-                        power_state: "off".to_string(),
-                        health_status: "warning".to_string(),
-                    }),
-                },
-                Case {
-                    scenario: "standby / critical",
-                    input: PowerShelfStatus {
-                        shelf_name: "psu-c".to_string(),
-                        power_state: "standby".to_string(),
-                        health_status: "critical".to_string(),
-                    },
-                    expect: Yields(PowerShelfStatus {
-                        shelf_name: "psu-c".to_string(),
-                        power_state: "standby".to_string(),
-                        health_status: "critical".to_string(),
-                    }),
-                },
-                Case {
-                    scenario: "empty strings",
-                    input: PowerShelfStatus {
-                        shelf_name: String::new(),
-                        power_state: String::new(),
-                        health_status: String::new(),
-                    },
-                    expect: Yields(PowerShelfStatus {
-                        shelf_name: String::new(),
-                        power_state: String::new(),
-                        health_status: String::new(),
-                    }),
-                },
-            ],
-            |status: PowerShelfStatus| {
+        scenarios!(
+            run = |status: PowerShelfStatus| {
                 let serialized = serde_json::to_string(&status).map_err(drop)?;
                 serde_json::from_str::<PowerShelfStatus>(&serialized).map_err(drop)
-            },
+            };
+            "on / ok" {
+                PowerShelfStatus {
+                    shelf_name: "psu-a".to_string(),
+                    power_state: "on".to_string(),
+                    health_status: "ok".to_string(),
+                } => Yields(PowerShelfStatus {
+                    shelf_name: "psu-a".to_string(),
+                    power_state: "on".to_string(),
+                    health_status: "ok".to_string(),
+                }),
+            }
+
+            "off / warning" {
+                PowerShelfStatus {
+                    shelf_name: "psu-b".to_string(),
+                    power_state: "off".to_string(),
+                    health_status: "warning".to_string(),
+                } => Yields(PowerShelfStatus {
+                    shelf_name: "psu-b".to_string(),
+                    power_state: "off".to_string(),
+                    health_status: "warning".to_string(),
+                }),
+            }
+
+            "standby / critical" {
+                PowerShelfStatus {
+                    shelf_name: "psu-c".to_string(),
+                    power_state: "standby".to_string(),
+                    health_status: "critical".to_string(),
+                } => Yields(PowerShelfStatus {
+                    shelf_name: "psu-c".to_string(),
+                    power_state: "standby".to_string(),
+                    health_status: "critical".to_string(),
+                }),
+            }
+
+            "empty strings" {
+                PowerShelfStatus {
+                    shelf_name: String::new(),
+                    power_state: String::new(),
+                    health_status: String::new(),
+                } => Yields(PowerShelfStatus {
+                    shelf_name: String::new(),
+                    power_state: String::new(),
+                    health_status: String::new(),
+                }),
+            }
         );
     }
 
@@ -684,59 +622,48 @@ mod tests {
         // yields `(sla, time_in_state_above_sla)`.
         let stale = ConfigVersion::invalid();
         let secs = |s: u64| Some(std::time::Duration::from_secs(s));
-        check_values(
-            [
-                Check {
-                    scenario: "initializing has an SLA and is overdue",
-                    input: PowerShelfControllerState::Initializing,
-                    expect: (secs(slas::INITIALIZING), true),
-                },
-                Check {
-                    scenario: "fetching-data has an SLA and is overdue",
-                    input: PowerShelfControllerState::FetchingData,
-                    expect: (secs(slas::FETCHING_DATA), true),
-                },
-                Check {
-                    scenario: "configuring has an SLA and is overdue",
-                    input: PowerShelfControllerState::Configuring,
-                    expect: (secs(slas::CONFIGURING), true),
-                },
-                Check {
-                    scenario: "deleting has an SLA and is overdue",
-                    input: PowerShelfControllerState::Deleting,
-                    expect: (secs(slas::DELETING), true),
-                },
-                Check {
-                    scenario: "maintenance power-on has the maintenance SLA",
-                    input: PowerShelfControllerState::Maintenance {
-                        operation: PowerShelfMaintenanceOperation::PowerOn,
-                    },
-                    expect: (secs(slas::MAINTENANCE), true),
-                },
-                Check {
-                    scenario: "maintenance power-off has the maintenance SLA",
-                    input: PowerShelfControllerState::Maintenance {
-                        operation: PowerShelfMaintenanceOperation::PowerOff,
-                    },
-                    expect: (secs(slas::MAINTENANCE), true),
-                },
-                Check {
-                    scenario: "ready carries no SLA",
-                    input: PowerShelfControllerState::Ready,
-                    expect: (None, false),
-                },
-                Check {
-                    scenario: "error carries no SLA",
-                    input: PowerShelfControllerState::Error {
-                        cause: "boom".to_string(),
-                    },
-                    expect: (None, false),
-                },
-            ],
-            |state: PowerShelfControllerState| {
+        value_scenarios!(
+            run = |state: PowerShelfControllerState| {
                 let result = state_sla(&state, &stale);
                 (result.sla, result.time_in_state_above_sla)
-            },
+            };
+            "initializing has an SLA and is overdue" {
+                PowerShelfControllerState::Initializing => (secs(slas::INITIALIZING), true),
+            }
+
+            "fetching-data has an SLA and is overdue" {
+                PowerShelfControllerState::FetchingData => (secs(slas::FETCHING_DATA), true),
+            }
+
+            "configuring has an SLA and is overdue" {
+                PowerShelfControllerState::Configuring => (secs(slas::CONFIGURING), true),
+            }
+
+            "deleting has an SLA and is overdue" {
+                PowerShelfControllerState::Deleting => (secs(slas::DELETING), true),
+            }
+
+            "maintenance power-on has the maintenance SLA" {
+                PowerShelfControllerState::Maintenance {
+                    operation: PowerShelfMaintenanceOperation::PowerOn,
+                } => (secs(slas::MAINTENANCE), true),
+            }
+
+            "maintenance power-off has the maintenance SLA" {
+                PowerShelfControllerState::Maintenance {
+                    operation: PowerShelfMaintenanceOperation::PowerOff,
+                } => (secs(slas::MAINTENANCE), true),
+            }
+
+            "ready carries no SLA" {
+                PowerShelfControllerState::Ready => (None, false),
+            }
+
+            "error carries no SLA" {
+                PowerShelfControllerState::Error {
+                    cause: "boom".to_string(),
+                } => (None, false),
+            }
         );
     }
 
@@ -749,22 +676,17 @@ mod tests {
             replace: Some(health_report::HealthReport::empty(source.to_string())),
             ..Default::default()
         };
-        check_cases(
-            [
-                Case {
-                    scenario: "replace source wins",
-                    input: with_replace("override.sre"),
-                    expect: Yields("override.sre".to_string()),
-                },
-                Case {
-                    scenario: "no replace falls back to the aggregate name",
-                    input: HealthReportSources::default(),
-                    expect: Yields("power-shelf-aggregate-health".to_string()),
-                },
-            ],
-            |sources: HealthReportSources| {
+        scenarios!(
+            run = |sources: HealthReportSources| {
                 Ok::<_, ()>(derive_power_shelf_aggregate_health(&sources).source)
-            },
+            };
+            "replace source wins" {
+                with_replace("override.sre") => Yields("override.sre".to_string()),
+            }
+
+            "no replace falls back to the aggregate name" {
+                HealthReportSources::default() => Yields("power-shelf-aggregate-health".to_string()),
+            }
         );
     }
 }

--- a/crates/api-model/src/rack.rs
+++ b/crates/api-model/src/rack.rs
@@ -822,7 +822,7 @@ pub fn state_sla(state: &RackState, state_version: &ConfigVersion) -> StateSla {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::scenarios;
     use carbide_uuid::machine::{MachineIdSource, MachineType};
     use carbide_uuid::power_shelf::{PowerShelfIdSource, PowerShelfType};
     use carbide_uuid::switch::{SwitchIdSource, SwitchType};
@@ -1042,54 +1042,45 @@ mod tests {
         );
         let already_pending = std::mem::discriminant(&RackMaintenanceRejection::AlreadyPending);
 
-        check_cases(
-            [
-                Case {
-                    scenario: "accepts in ready state",
-                    input: (RackState::Ready, None),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "accepts in error state",
-                    input: (
-                        RackState::Error {
-                            cause: "something broke".into(),
-                        },
-                        None,
-                    ),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "rejects in created state",
-                    input: (RackState::Created, None),
-                    expect: FailsWith(not_ready_or_error),
-                },
-                Case {
-                    scenario: "rejects in discovering state",
-                    input: (RackState::Discovering, None),
-                    expect: FailsWith(not_ready_or_error),
-                },
-                Case {
-                    scenario: "rejects in maintenance state",
-                    input: (
-                        RackState::Maintenance {
-                            maintenance_state: RackMaintenanceState::Completed,
-                        },
-                        None,
-                    ),
-                    expect: FailsWith(not_ready_or_error),
-                },
-                Case {
-                    scenario: "rejects when already pending",
-                    input: (RackState::Ready, Some(MaintenanceScope::default())),
-                    expect: FailsWith(already_pending),
-                },
-            ],
-            |(state, maintenance_requested)| {
+        scenarios!(
+            run = |(state, maintenance_requested)| {
                 test_rack(state, maintenance_requested)
                     .check_accepts_maintenance()
                     .map_err(|e| std::mem::discriminant(&e))
-            },
+            };
+            "accepts in ready state" {
+                (RackState::Ready, None) => Yields(()),
+            }
+
+            "accepts in error state" {
+                (
+                    RackState::Error {
+                        cause: "something broke".into(),
+                    },
+                    None,
+                ) => Yields(()),
+            }
+
+            "rejects in created state" {
+                (RackState::Created, None) => FailsWith(not_ready_or_error),
+            }
+
+            "rejects in discovering state" {
+                (RackState::Discovering, None) => FailsWith(not_ready_or_error),
+            }
+
+            "rejects in maintenance state" {
+                (
+                    RackState::Maintenance {
+                        maintenance_state: RackMaintenanceState::Completed,
+                    },
+                    None,
+                ) => FailsWith(not_ready_or_error),
+            }
+
+            "rejects when already pending" {
+                (RackState::Ready, Some(MaintenanceScope::default())) => FailsWith(already_pending),
+            }
         );
     }
 

--- a/crates/api-model/src/rack_type.rs
+++ b/crates/api-model/src/rack_type.rs
@@ -280,7 +280,7 @@ impl RackProfileConfig {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -420,20 +420,18 @@ count = 2
     // discards the (non-PartialEq) serde_json error since every row succeeds.
     #[test]
     fn test_rack_hardware_type_serde_round_trip() {
-        check_cases(
-            [Case {
-                scenario: "dsx hardware type round-trips through json",
-                input: RackHardwareType::from("dsx_gb200nvl_72x1"),
-                expect: Yields((
-                    "\"dsx_gb200nvl_72x1\"".to_string(),
-                    RackHardwareType::from("dsx_gb200nvl_72x1"),
-                )),
-            }],
-            |hw_type| {
+        scenarios!(
+            run = |hw_type| {
                 let json = serde_json::to_string(&hw_type).map_err(drop)?;
                 let back: RackHardwareType = serde_json::from_str(&json).map_err(drop)?;
                 Ok::<_, ()>((json, back))
-            },
+            };
+            "dsx hardware type round-trips through json" {
+                RackHardwareType::from("dsx_gb200nvl_72x1") => Yields((
+                    "\"dsx_gb200nvl_72x1\"".to_string(),
+                    RackHardwareType::from("dsx_gb200nvl_72x1"),
+                )),
+            }
         );
     }
 
@@ -441,90 +439,70 @@ count = 2
     // and for empty/odd inputs.
     #[test]
     fn test_rack_hardware_type_display() {
-        check_values(
-            [
-                Check {
-                    scenario: "wildcard any",
-                    input: RackHardwareType::any(),
-                    expect: "any".to_string(),
-                },
-                Check {
-                    scenario: "dsx hardware type",
-                    input: RackHardwareType::from("dsx_gb200nvl_72x1"),
-                    expect: "dsx_gb200nvl_72x1".to_string(),
-                },
-                Check {
-                    scenario: "empty string",
-                    input: RackHardwareType::from(""),
-                    expect: String::new(),
-                },
-                Check {
-                    scenario: "uppercase verbatim",
-                    input: RackHardwareType::from("ANY"),
-                    expect: "ANY".to_string(),
-                },
-                Check {
-                    scenario: "whitespace preserved",
-                    input: RackHardwareType::from("  spaced  "),
-                    expect: "  spaced  ".to_string(),
-                },
-                Check {
-                    scenario: "default renders as any",
-                    input: RackHardwareType::default(),
-                    expect: "any".to_string(),
-                },
-            ],
-            |hw_type| hw_type.to_string(),
+        value_scenarios!(
+            run = |hw_type| hw_type.to_string();
+            "wildcard any" {
+                RackHardwareType::any() => "any".to_string(),
+            }
+
+            "dsx hardware type" {
+                RackHardwareType::from("dsx_gb200nvl_72x1") => "dsx_gb200nvl_72x1".to_string(),
+            }
+
+            "empty string" {
+                RackHardwareType::from("") => String::new(),
+            }
+
+            "uppercase verbatim" {
+                RackHardwareType::from("ANY") => "ANY".to_string(),
+            }
+
+            "whitespace preserved" {
+                RackHardwareType::from("  spaced  ") => "  spaced  ".to_string(),
+            }
+
+            "default renders as any" {
+                RackHardwareType::default() => "any".to_string(),
+            }
         );
     }
 
     // is_any is an exact, case-sensitive match against the literal "any".
     #[test]
     fn test_rack_hardware_type_is_any() {
-        check_values(
-            [
-                Check {
-                    scenario: "constructed via any()",
-                    input: RackHardwareType::any(),
-                    expect: true,
-                },
-                Check {
-                    scenario: "default is any",
-                    input: RackHardwareType::default(),
-                    expect: true,
-                },
-                Check {
-                    scenario: "literal any from str",
-                    input: RackHardwareType::from("any"),
-                    expect: true,
-                },
-                Check {
-                    scenario: "concrete hardware type",
-                    input: RackHardwareType::from("dsx_gb200nvl_72x1"),
-                    expect: false,
-                },
-                Check {
-                    scenario: "empty is not any",
-                    input: RackHardwareType::from(""),
-                    expect: false,
-                },
-                Check {
-                    scenario: "uppercase is not any",
-                    input: RackHardwareType::from("ANY"),
-                    expect: false,
-                },
-                Check {
-                    scenario: "any with trailing space is not any",
-                    input: RackHardwareType::from("any "),
-                    expect: false,
-                },
-                Check {
-                    scenario: "substring is not any",
-                    input: RackHardwareType::from("anything"),
-                    expect: false,
-                },
-            ],
-            |hw_type| hw_type.is_any(),
+        value_scenarios!(
+            run = |hw_type| hw_type.is_any();
+            "constructed via any()" {
+                RackHardwareType::any() => true,
+            }
+
+            "default is any" {
+                RackHardwareType::default() => true,
+            }
+
+            "literal any from str" {
+                RackHardwareType::from("any") => true,
+            }
+
+            "concrete hardware type" {
+                RackHardwareType::from("dsx_gb200nvl_72x1") => false,
+            }
+
+            "empty is not any" {
+                RackHardwareType::from("") => false,
+            }
+
+            "uppercase is not any" {
+                RackHardwareType::from("ANY") => false,
+            }
+
+            "any with trailing space is not any" {
+                RackHardwareType::from("any ") => false,
+            }
+
+            "substring is not any" {
+                RackHardwareType::from("anything") => false,
+            }
         );
     }
 
@@ -536,30 +514,23 @@ count = 2
     // Both From conversions wrap the input verbatim and agree with each other.
     #[test]
     fn test_rack_hardware_type_from_conversions() {
-        check_values(
-            [
-                Check {
-                    scenario: "from owned string",
-                    input: RackHardwareType::from("dsx".to_string()),
-                    expect: RackHardwareType("dsx".to_string()),
-                },
-                Check {
-                    scenario: "from str slice",
-                    input: RackHardwareType::from("dsx"),
-                    expect: RackHardwareType("dsx".to_string()),
-                },
-                Check {
-                    scenario: "from empty str",
-                    input: RackHardwareType::from(""),
-                    expect: RackHardwareType(String::new()),
-                },
-                Check {
-                    scenario: "owned and borrowed agree",
-                    input: RackHardwareType::from("any".to_string()),
-                    expect: RackHardwareType::from("any"),
-                },
-            ],
-            |hw_type| hw_type,
+        value_scenarios!(
+            run = |hw_type| hw_type;
+            "from owned string" {
+                RackHardwareType::from("dsx".to_string()) => RackHardwareType("dsx".to_string()),
+            }
+
+            "from str slice" {
+                RackHardwareType::from("dsx") => RackHardwareType("dsx".to_string()),
+            }
+
+            "from empty str" {
+                RackHardwareType::from("") => RackHardwareType(String::new()),
+            }
+
+            "owned and borrowed agree" {
+                RackHardwareType::from("any".to_string()) => RackHardwareType::from("any"),
+            }
         );
     }
 
@@ -570,62 +541,53 @@ count = 2
     // (json, value_back); the (non-PartialEq) serde_json error is discarded.
     #[test]
     fn test_rack_hardware_topology_serde_round_trip() {
-        check_cases(
-            [
-                Case {
-                    scenario: "gb200 nvl36 round-trips",
-                    input: RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
-                    expect: Yields((
-                        "\"gb200_nvl36r1_c2g4_topology\"".to_string(),
-                        RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
-                    )),
-                },
-                Case {
-                    scenario: "gb300 nvl36 round-trips",
-                    input: RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
-                    expect: Yields((
-                        "\"gb300_nvl36r1_c2g4_topology\"".to_string(),
-                        RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
-                    )),
-                },
-                Case {
-                    scenario: "gb200 nvl72 round-trips",
-                    input: RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
-                    expect: Yields((
-                        "\"gb200_nvl72r1_c2g4_topology\"".to_string(),
-                        RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
-                    )),
-                },
-                Case {
-                    scenario: "gb300 nvl72 round-trips",
-                    input: RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
-                    expect: Yields((
-                        "\"gb300_nvl72r1_c2g4_topology\"".to_string(),
-                        RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
-                    )),
-                },
-                Case {
-                    scenario: "vr nvl8 rtf round-trips",
-                    input: RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
-                    expect: Yields((
-                        "\"vr_nvl8r1_c2g4_rtf_topology\"".to_string(),
-                        RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
-                    )),
-                },
-                Case {
-                    scenario: "vr nvl72 round-trips",
-                    input: RackHardwareTopology::VrNvl72r1C2g4Topology,
-                    expect: Yields((
-                        "\"vr_nvl72r1_c2g4_topology\"".to_string(),
-                        RackHardwareTopology::VrNvl72r1C2g4Topology,
-                    )),
-                },
-            ],
-            |variant| {
+        scenarios!(
+            run = |variant| {
                 let json = serde_json::to_string(&variant).map_err(drop)?;
                 let back: RackHardwareTopology = serde_json::from_str(&json).map_err(drop)?;
                 Ok::<_, ()>((json, back))
-            },
+            };
+            "gb200 nvl36 round-trips" {
+                RackHardwareTopology::Gb200Nvl36r1C2g4Topology => Yields((
+                    "\"gb200_nvl36r1_c2g4_topology\"".to_string(),
+                    RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
+                )),
+            }
+
+            "gb300 nvl36 round-trips" {
+                RackHardwareTopology::Gb300Nvl36r1C2g4Topology => Yields((
+                    "\"gb300_nvl36r1_c2g4_topology\"".to_string(),
+                    RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
+                )),
+            }
+
+            "gb200 nvl72 round-trips" {
+                RackHardwareTopology::Gb200Nvl72r1C2g4Topology => Yields((
+                    "\"gb200_nvl72r1_c2g4_topology\"".to_string(),
+                    RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
+                )),
+            }
+
+            "gb300 nvl72 round-trips" {
+                RackHardwareTopology::Gb300Nvl72r1C2g4Topology => Yields((
+                    "\"gb300_nvl72r1_c2g4_topology\"".to_string(),
+                    RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
+                )),
+            }
+
+            "vr nvl8 rtf round-trips" {
+                RackHardwareTopology::VrNvl8r1C2g4RtfTopology => Yields((
+                    "\"vr_nvl8r1_c2g4_rtf_topology\"".to_string(),
+                    RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
+                )),
+            }
+
+            "vr nvl72 round-trips" {
+                RackHardwareTopology::VrNvl72r1C2g4Topology => Yields((
+                    "\"vr_nvl72r1_c2g4_topology\"".to_string(),
+                    RackHardwareTopology::VrNvl72r1C2g4Topology,
+                )),
+            }
         );
     }
 
@@ -633,40 +595,31 @@ count = 2
     // snake_case serde form.
     #[test]
     fn test_rack_hardware_topology_display() {
-        check_values(
-            [
-                Check {
-                    scenario: "gb200 nvl36",
-                    input: RackHardwareTopology::Gb200Nvl36r1C2g4Topology,
-                    expect: "gb200_nvl36r1_c2g4_topology".to_string(),
-                },
-                Check {
-                    scenario: "gb300 nvl36",
-                    input: RackHardwareTopology::Gb300Nvl36r1C2g4Topology,
-                    expect: "gb300_nvl36r1_c2g4_topology".to_string(),
-                },
-                Check {
-                    scenario: "gb200 nvl72",
-                    input: RackHardwareTopology::Gb200Nvl72r1C2g4Topology,
-                    expect: "gb200_nvl72r1_c2g4_topology".to_string(),
-                },
-                Check {
-                    scenario: "gb300 nvl72",
-                    input: RackHardwareTopology::Gb300Nvl72r1C2g4Topology,
-                    expect: "gb300_nvl72r1_c2g4_topology".to_string(),
-                },
-                Check {
-                    scenario: "vr nvl8 rtf",
-                    input: RackHardwareTopology::VrNvl8r1C2g4RtfTopology,
-                    expect: "vr_nvl8r1_c2g4_rtf_topology".to_string(),
-                },
-                Check {
-                    scenario: "vr nvl72",
-                    input: RackHardwareTopology::VrNvl72r1C2g4Topology,
-                    expect: "vr_nvl72r1_c2g4_topology".to_string(),
-                },
-            ],
-            |variant| variant.to_string(),
+        value_scenarios!(
+            run = |variant| variant.to_string();
+            "gb200 nvl36" {
+                RackHardwareTopology::Gb200Nvl36r1C2g4Topology => "gb200_nvl36r1_c2g4_topology".to_string(),
+            }
+
+            "gb300 nvl36" {
+                RackHardwareTopology::Gb300Nvl36r1C2g4Topology => "gb300_nvl36r1_c2g4_topology".to_string(),
+            }
+
+            "gb200 nvl72" {
+                RackHardwareTopology::Gb200Nvl72r1C2g4Topology => "gb200_nvl72r1_c2g4_topology".to_string(),
+            }
+
+            "gb300 nvl72" {
+                RackHardwareTopology::Gb300Nvl72r1C2g4Topology => "gb300_nvl72r1_c2g4_topology".to_string(),
+            }
+
+            "vr nvl8 rtf" {
+                RackHardwareTopology::VrNvl8r1C2g4RtfTopology => "vr_nvl8r1_c2g4_rtf_topology".to_string(),
+            }
+
+            "vr nvl72" {
+                RackHardwareTopology::VrNvl72r1C2g4Topology => "vr_nvl72r1_c2g4_topology".to_string(),
+            }
         );
     }
 
@@ -675,35 +628,27 @@ count = 2
     // (non-PartialEq) serde error is discarded with map_err(drop).
     #[test]
     fn test_rack_hardware_topology_deserialize() {
-        check_cases(
-            [
-                Case {
-                    scenario: "valid gb200 nvl36",
-                    input: "\"gb200_nvl36r1_c2g4_topology\"",
-                    expect: Yields(RackHardwareTopology::Gb200Nvl36r1C2g4Topology),
-                },
-                Case {
-                    scenario: "valid vr nvl72",
-                    input: "\"vr_nvl72r1_c2g4_topology\"",
-                    expect: Yields(RackHardwareTopology::VrNvl72r1C2g4Topology),
-                },
-                Case {
-                    scenario: "unknown topology name",
-                    input: "\"gb500_nvl99_topology\"",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty string",
-                    input: "\"\"",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "wrong json type",
-                    input: "42",
-                    expect: Fails,
-                },
-            ],
-            |json| serde_json::from_str::<RackHardwareTopology>(json).map_err(drop),
+        scenarios!(
+            run = |json| serde_json::from_str::<RackHardwareTopology>(json).map_err(drop);
+            "valid gb200 nvl36" {
+                "\"gb200_nvl36r1_c2g4_topology\"" => Yields(RackHardwareTopology::Gb200Nvl36r1C2g4Topology),
+            }
+
+            "valid vr nvl72" {
+                "\"vr_nvl72r1_c2g4_topology\"" => Yields(RackHardwareTopology::VrNvl72r1C2g4Topology),
+            }
+
+            "unknown topology name" {
+                "\"gb500_nvl99_topology\"" => Fails,
+            }
+
+            "empty string" {
+                "\"\"" => Fails,
+            }
+
+            "wrong json type" {
+                "42" => Fails,
+            }
         );
     }
 
@@ -714,43 +659,33 @@ count = 2
     // the (non-PartialEq) serde_json error is discarded.
     #[test]
     fn test_rack_hardware_class_serde_round_trip() {
-        check_cases(
-            [
-                Case {
-                    scenario: "dev round-trips",
-                    input: RackHardwareClass::Dev,
-                    expect: Yields(("\"dev\"".to_string(), RackHardwareClass::Dev)),
-                },
-                Case {
-                    scenario: "prod round-trips",
-                    input: RackHardwareClass::Prod,
-                    expect: Yields(("\"prod\"".to_string(), RackHardwareClass::Prod)),
-                },
-            ],
-            |variant| {
+        scenarios!(
+            run = |variant| {
                 let json = serde_json::to_string(&variant).map_err(drop)?;
                 let back: RackHardwareClass = serde_json::from_str(&json).map_err(drop)?;
                 Ok::<_, ()>((json, back))
-            },
+            };
+            "dev round-trips" {
+                RackHardwareClass::Dev => Yields(("\"dev\"".to_string(), RackHardwareClass::Dev)),
+            }
+
+            "prod round-trips" {
+                RackHardwareClass::Prod => Yields(("\"prod\"".to_string(), RackHardwareClass::Prod)),
+            }
         );
     }
 
     #[test]
     fn test_rack_hardware_class_display() {
-        check_values(
-            [
-                Check {
-                    scenario: "dev",
-                    input: RackHardwareClass::Dev,
-                    expect: "dev".to_string(),
-                },
-                Check {
-                    scenario: "prod",
-                    input: RackHardwareClass::Prod,
-                    expect: "prod".to_string(),
-                },
-            ],
-            |variant| variant.to_string(),
+        value_scenarios!(
+            run = |variant| variant.to_string();
+            "dev" {
+                RackHardwareClass::Dev => "dev".to_string(),
+            }
+
+            "prod" {
+                RackHardwareClass::Prod => "prod".to_string(),
+            }
         );
     }
 
@@ -758,35 +693,27 @@ count = 2
     // The (non-PartialEq) serde error is discarded with map_err(drop).
     #[test]
     fn test_rack_hardware_class_deserialize() {
-        check_cases(
-            [
-                Case {
-                    scenario: "valid dev",
-                    input: "\"dev\"",
-                    expect: Yields(RackHardwareClass::Dev),
-                },
-                Case {
-                    scenario: "valid prod",
-                    input: "\"prod\"",
-                    expect: Yields(RackHardwareClass::Prod),
-                },
-                Case {
-                    scenario: "uppercase rejected",
-                    input: "\"Dev\"",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "unknown class",
-                    input: "\"staging\"",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty string",
-                    input: "\"\"",
-                    expect: Fails,
-                },
-            ],
-            |json| serde_json::from_str::<RackHardwareClass>(json).map_err(drop),
+        scenarios!(
+            run = |json| serde_json::from_str::<RackHardwareClass>(json).map_err(drop);
+            "valid dev" {
+                "\"dev\"" => Yields(RackHardwareClass::Dev),
+            }
+
+            "valid prod" {
+                "\"prod\"" => Yields(RackHardwareClass::Prod),
+            }
+
+            "uppercase rejected" {
+                "\"Dev\"" => Fails,
+            }
+
+            "unknown class" {
+                "\"staging\"" => Fails,
+            }
+
+            "empty string" {
+                "\"\"" => Fails,
+            }
         );
     }
 
@@ -794,25 +721,19 @@ count = 2
     // PascalCase label.
     #[test]
     fn test_rack_capability_type_display() {
-        check_values(
-            [
-                Check {
-                    scenario: "compute",
-                    input: RackCapabilityType::Compute,
-                    expect: "Compute".to_string(),
-                },
-                Check {
-                    scenario: "switch",
-                    input: RackCapabilityType::Switch,
-                    expect: "Switch".to_string(),
-                },
-                Check {
-                    scenario: "power shelf",
-                    input: RackCapabilityType::PowerShelf,
-                    expect: "PowerShelf".to_string(),
-                },
-            ],
-            |variant| variant.to_string(),
+        value_scenarios!(
+            run = |variant| variant.to_string();
+            "compute" {
+                RackCapabilityType::Compute => "Compute".to_string(),
+            }
+
+            "switch" {
+                RackCapabilityType::Switch => "Switch".to_string(),
+            }
+
+            "power shelf" {
+                RackCapabilityType::PowerShelf => "PowerShelf".to_string(),
+            }
         );
     }
 }

--- a/crates/api-model/src/redfish.rs
+++ b/crates/api-model/src/redfish.rs
@@ -106,7 +106,7 @@ pub struct RedfishCreateAction {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -114,40 +114,31 @@ mod tests {
     /// carry through unchanged.
     #[test]
     fn redfish_action_id_from_i64_carries_the_value() {
-        check_values(
-            [
-                Check {
-                    scenario: "positive",
-                    input: 99i64,
-                    expect: 99i64,
-                },
-                Check {
-                    scenario: "zero",
-                    input: 0,
-                    expect: 0,
-                },
-                Check {
-                    scenario: "one",
-                    input: 1,
-                    expect: 1,
-                },
-                Check {
-                    scenario: "negative",
-                    input: -1,
-                    expect: -1,
-                },
-                Check {
-                    scenario: "i64::MAX",
-                    input: i64::MAX,
-                    expect: i64::MAX,
-                },
-                Check {
-                    scenario: "i64::MIN",
-                    input: i64::MIN,
-                    expect: i64::MIN,
-                },
-            ],
-            |n| RedfishActionId::from(n).request_id,
+        value_scenarios!(
+            run = |n| RedfishActionId::from(n).request_id;
+            "positive" {
+                99i64 => 99i64,
+            }
+
+            "zero" {
+                0 => 0,
+            }
+
+            "one" {
+                1 => 1,
+            }
+
+            "negative" {
+                -1 => -1,
+            }
+
+            "i64::MAX" {
+                i64::MAX => i64::MAX,
+            }
+
+            "i64::MIN" {
+                i64::MIN => i64::MIN,
+            }
         );
     }
 
@@ -160,13 +151,11 @@ mod tests {
 
     #[test]
     fn redfish_list_actions_filter_default_is_empty() {
-        check_values(
-            [Check {
-                scenario: "default leaves machine_ip unset",
-                input: RedfishListActionsFilter::default(),
-                expect: None,
-            }],
-            |filter| filter.machine_ip,
+        value_scenarios!(
+            run = |filter| filter.machine_ip;
+            "default leaves machine_ip unset" {
+                RedfishListActionsFilter::default() => None,
+            }
         );
     }
 
@@ -184,34 +173,27 @@ mod tests {
     /// type (`serde_json::Error`) isn't `PartialEq`, so map it away.
     #[test]
     fn bmc_response_round_trips_through_json() {
-        check_cases(
-            [
-                Case {
-                    scenario: "ok with empty body",
-                    input: bmc_response("200 OK", ""),
-                    expect: Yields(("200 OK".to_string(), String::new())),
-                },
-                Case {
-                    scenario: "ok with json body",
-                    input: bmc_response("200 OK", r#"{"k":"v"}"#),
-                    expect: Yields(("200 OK".to_string(), r#"{"k":"v"}"#.to_string())),
-                },
-                Case {
-                    scenario: "error status",
-                    input: bmc_response("500 Internal Server Error", "boom"),
-                    expect: Yields(("500 Internal Server Error".to_string(), "boom".to_string())),
-                },
-                Case {
-                    scenario: "unicode body",
-                    input: bmc_response("202 Accepted", "café ☕"),
-                    expect: Yields(("202 Accepted".to_string(), "café ☕".to_string())),
-                },
-            ],
-            |response| {
+        scenarios!(
+            run = |response| {
                 let json = serde_json::to_string(&response).map_err(drop)?;
                 let back: BMCResponse = serde_json::from_str(&json).map_err(drop)?;
                 Ok::<_, ()>((back.status, back.body))
-            },
+            };
+            "ok with empty body" {
+                bmc_response("200 OK", "") => Yields(("200 OK".to_string(), String::new())),
+            }
+
+            "ok with json body" {
+                bmc_response("200 OK", r#"{"k":"v"}"#) => Yields(("200 OK".to_string(), r#"{"k":"v"}"#.to_string())),
+            }
+
+            "error status" {
+                bmc_response("500 Internal Server Error", "boom") => Yields(("500 Internal Server Error".to_string(), "boom".to_string())),
+            }
+
+            "unicode body" {
+                bmc_response("202 Accepted", "café ☕") => Yields(("202 Accepted".to_string(), "café ☕".to_string())),
+            }
         );
     }
 
@@ -219,25 +201,8 @@ mod tests {
     /// key after the JSON round-trip.
     #[test]
     fn bmc_response_round_trip_preserves_headers() {
-        check_cases(
-            [
-                Case {
-                    scenario: "single header",
-                    input: ("Content-Type", "application/json"),
-                    expect: Yields(Some("application/json".to_string())),
-                },
-                Case {
-                    scenario: "header value with spaces",
-                    input: ("ETag", "W/\"abc 123\""),
-                    expect: Yields(Some("W/\"abc 123\"".to_string())),
-                },
-                Case {
-                    scenario: "empty header value",
-                    input: ("X-Empty", ""),
-                    expect: Yields(Some(String::new())),
-                },
-            ],
-            |(key, value): (&str, &str)| {
+        scenarios!(
+            run = |(key, value): (&str, &str)| {
                 let mut headers = HashMap::new();
                 headers.insert(key.to_string(), value.to_string());
                 let response = BMCResponse {
@@ -249,7 +214,18 @@ mod tests {
                 let json = serde_json::to_string(&response).map_err(drop)?;
                 let back: BMCResponse = serde_json::from_str(&json).map_err(drop)?;
                 Ok::<_, ()>(back.headers.get(key).cloned())
-            },
+            };
+            "single header" {
+                ("Content-Type", "application/json") => Yields(Some("application/json".to_string())),
+            }
+
+            "header value with spaces" {
+                ("ETag", "W/\"abc 123\"") => Yields(Some("W/\"abc 123\"".to_string())),
+            }
+
+            "empty header value" {
+                ("X-Empty", "") => Yields(Some(String::new())),
+            }
         );
     }
 }

--- a/crates/api-model/src/resource_pool/mod.rs
+++ b/crates/api-model/src/resource_pool/mod.rs
@@ -235,7 +235,7 @@ pub enum ResourcePoolError {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -243,35 +243,8 @@ mod tests {
     fn serialize_resource_pool_entry_state() {
         // Each row carries the state and its canonical JSON; the operation
         // serializes the state and confirms it round-trips back unchanged.
-        check_cases(
-            [
-                Case {
-                    scenario: "free",
-                    input: ResourcePoolEntryState::Free,
-                    expect: Yields(r#"{"state":"free"}"#.to_string()),
-                },
-                Case {
-                    scenario: "allocated",
-                    input: ResourcePoolEntryState::Allocated {
-                        owner: "me".to_string(),
-                        owner_type: "my_stuff".to_string(),
-                    },
-                    expect: Yields(
-                        r#"{"state":"allocated","owner":"me","owner_type":"my_stuff"}"#.to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "allocated with empty owner fields",
-                    input: ResourcePoolEntryState::Allocated {
-                        owner: String::new(),
-                        owner_type: String::new(),
-                    },
-                    expect: Yields(
-                        r#"{"state":"allocated","owner":"","owner_type":""}"#.to_string(),
-                    ),
-                },
-            ],
-            |state| {
+        scenarios!(
+            run = |state| {
                 let serialized = serde_json::to_string(&state).map_err(drop)?;
                 let parsed: ResourcePoolEntryState =
                     serde_json::from_str(&serialized).map_err(drop)?;
@@ -279,44 +252,57 @@ mod tests {
                     return Err(());
                 }
                 Ok::<_, ()>(serialized)
-            },
+            };
+            "free" {
+                ResourcePoolEntryState::Free => Yields(r#"{"state":"free"}"#.to_string()),
+            }
+
+            "allocated" {
+                ResourcePoolEntryState::Allocated {
+                    owner: "me".to_string(),
+                    owner_type: "my_stuff".to_string(),
+                } => Yields(
+                    r#"{"state":"allocated","owner":"me","owner_type":"my_stuff"}"#.to_string(),
+                ),
+            }
+
+            "allocated with empty owner fields" {
+                ResourcePoolEntryState::Allocated {
+                    owner: String::new(),
+                    owner_type: String::new(),
+                } => Yields(
+                    r#"{"state":"allocated","owner":"","owner_type":""}"#.to_string(),
+                ),
+            }
         );
     }
 
     #[test]
     fn deserialize_resource_pool_entry_state() {
-        check_cases(
-            [
-                Case {
-                    scenario: "free",
-                    input: r#"{"state":"free"}"#,
-                    expect: Yields(ResourcePoolEntryState::Free),
-                },
-                Case {
-                    scenario: "allocated",
-                    input: r#"{"state":"allocated","owner":"me","owner_type":"vpc"}"#,
-                    expect: Yields(ResourcePoolEntryState::Allocated {
-                        owner: "me".to_string(),
-                        owner_type: "vpc".to_string(),
-                    }),
-                },
-                Case {
-                    scenario: "unknown tag is rejected",
-                    input: r#"{"state":"borrowed"}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "allocated missing owner_type is rejected",
-                    input: r#"{"state":"allocated","owner":"me"}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "not an object is rejected",
-                    input: r#"42"#,
-                    expect: Fails,
-                },
-            ],
-            |json| serde_json::from_str::<ResourcePoolEntryState>(json).map_err(drop),
+        scenarios!(
+            run = |json| serde_json::from_str::<ResourcePoolEntryState>(json).map_err(drop);
+            "free" {
+                r#"{"state":"free"}"# => Yields(ResourcePoolEntryState::Free),
+            }
+
+            "allocated" {
+                r#"{"state":"allocated","owner":"me","owner_type":"vpc"}"# => Yields(ResourcePoolEntryState::Allocated {
+                    owner: "me".to_string(),
+                    owner_type: "vpc".to_string(),
+                }),
+            }
+
+            "unknown tag is rejected" {
+                r#"{"state":"borrowed"}"# => Fails,
+            }
+
+            "allocated missing owner_type is rejected" {
+                r#"{"state":"allocated","owner":"me"}"# => Fails,
+            }
+
+            "not an object is rejected" {
+                r#"42"# => Fails,
+            }
         );
     }
 
@@ -324,55 +310,43 @@ mod tests {
     fn owner_type_from_str() {
         // `ModelError` has no `PartialEq`, so error rows use `Fails` and the run
         // closure drops the error to settle on `()`.
-        check_cases(
-            [
-                Case {
-                    scenario: "machine",
-                    input: "machine",
-                    expect: Yields(OwnerType::Machine),
-                },
-                Case {
-                    scenario: "network_segment",
-                    input: "network_segment",
-                    expect: Yields(OwnerType::NetworkSegment),
-                },
-                Case {
-                    scenario: "ib_partition",
-                    input: "ib_partition",
-                    expect: Yields(OwnerType::IBPartition),
-                },
-                Case {
-                    scenario: "vpc",
-                    input: "vpc",
-                    expect: Yields(OwnerType::Vpc),
-                },
-                Case {
-                    scenario: "spx_partition round-trips through Display/FromStr",
-                    input: "spx_partition",
-                    expect: Yields(OwnerType::SpxPartition),
-                },
-                Case {
-                    scenario: "unknown string",
-                    input: "nonsense",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty string",
-                    input: "",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "wrong case is rejected",
-                    input: "Machine",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "leading whitespace is rejected",
-                    input: " machine",
-                    expect: Fails,
-                },
-            ],
-            |s| OwnerType::from_str(s).map_err(drop),
+        scenarios!(
+            run = |s| OwnerType::from_str(s).map_err(drop);
+            "machine" {
+                "machine" => Yields(OwnerType::Machine),
+            }
+
+            "network_segment" {
+                "network_segment" => Yields(OwnerType::NetworkSegment),
+            }
+
+            "ib_partition" {
+                "ib_partition" => Yields(OwnerType::IBPartition),
+            }
+
+            "vpc" {
+                "vpc" => Yields(OwnerType::Vpc),
+            }
+
+            "spx_partition round-trips through Display/FromStr" {
+                "spx_partition" => Yields(OwnerType::SpxPartition),
+            }
+
+            "unknown string" {
+                "nonsense" => Fails,
+            }
+
+            "empty string" {
+                "" => Fails,
+            }
+
+            "wrong case is rejected" {
+                "Machine" => Fails,
+            }
+
+            "leading whitespace is rejected" {
+                " machine" => Fails,
+            }
         );
     }
 
@@ -380,93 +354,71 @@ mod tests {
     fn owner_type_display_round_trips_via_from_str() {
         // Every variant that `from_str` accepts must display to a string that
         // `from_str` accepts back as the same variant.
-        check_cases(
-            [
-                Case {
-                    scenario: "machine",
-                    input: OwnerType::Machine,
-                    expect: Yields(OwnerType::Machine),
-                },
-                Case {
-                    scenario: "network_segment",
-                    input: OwnerType::NetworkSegment,
-                    expect: Yields(OwnerType::NetworkSegment),
-                },
-                Case {
-                    scenario: "ib_partition",
-                    input: OwnerType::IBPartition,
-                    expect: Yields(OwnerType::IBPartition),
-                },
-                Case {
-                    scenario: "vpc",
-                    input: OwnerType::Vpc,
-                    expect: Yields(OwnerType::Vpc),
-                },
-            ],
-            |owner| OwnerType::from_str(&owner.to_string()).map_err(drop),
+        scenarios!(
+            run = |owner| OwnerType::from_str(&owner.to_string()).map_err(drop);
+            "machine" {
+                OwnerType::Machine => Yields(OwnerType::Machine),
+            }
+
+            "network_segment" {
+                OwnerType::NetworkSegment => Yields(OwnerType::NetworkSegment),
+            }
+
+            "ib_partition" {
+                OwnerType::IBPartition => Yields(OwnerType::IBPartition),
+            }
+
+            "vpc" {
+                OwnerType::Vpc => Yields(OwnerType::Vpc),
+            }
         );
     }
 
     #[test]
     fn owner_type_display() {
-        check_values(
-            [
-                Check {
-                    scenario: "machine",
-                    input: OwnerType::Machine,
-                    expect: "machine".to_string(),
-                },
-                Check {
-                    scenario: "network_segment",
-                    input: OwnerType::NetworkSegment,
-                    expect: "network_segment".to_string(),
-                },
-                Check {
-                    scenario: "ib_partition",
-                    input: OwnerType::IBPartition,
-                    expect: "ib_partition".to_string(),
-                },
-                Check {
-                    scenario: "vpc",
-                    input: OwnerType::Vpc,
-                    expect: "vpc".to_string(),
-                },
-                Check {
-                    scenario: "spx_partition",
-                    input: OwnerType::SpxPartition,
-                    expect: "spx_partition".to_string(),
-                },
-            ],
-            |owner| owner.to_string(),
+        value_scenarios!(
+            run = |owner| owner.to_string();
+            "machine" {
+                OwnerType::Machine => "machine".to_string(),
+            }
+
+            "network_segment" {
+                OwnerType::NetworkSegment => "network_segment".to_string(),
+            }
+
+            "ib_partition" {
+                OwnerType::IBPartition => "ib_partition".to_string(),
+            }
+
+            "vpc" {
+                OwnerType::Vpc => "vpc".to_string(),
+            }
+
+            "spx_partition" {
+                OwnerType::SpxPartition => "spx_partition".to_string(),
+            }
         );
     }
 
     #[test]
     fn value_type_display() {
-        check_values(
-            [
-                Check {
-                    scenario: "integer",
-                    input: ValueType::Integer,
-                    expect: "Integer".to_string(),
-                },
-                Check {
-                    scenario: "ipv4",
-                    input: ValueType::Ipv4,
-                    expect: "Ipv4".to_string(),
-                },
-                Check {
-                    scenario: "ipv6",
-                    input: ValueType::Ipv6,
-                    expect: "Ipv6".to_string(),
-                },
-                Check {
-                    scenario: "ipv6_prefix",
-                    input: ValueType::Ipv6Prefix,
-                    expect: "Ipv6Prefix".to_string(),
-                },
-            ],
-            |value_type| value_type.to_string(),
+        value_scenarios!(
+            run = |value_type| value_type.to_string();
+            "integer" {
+                ValueType::Integer => "Integer".to_string(),
+            }
+
+            "ipv4" {
+                ValueType::Ipv4 => "Ipv4".to_string(),
+            }
+
+            "ipv6" {
+                ValueType::Ipv6 => "Ipv6".to_string(),
+            }
+
+            "ipv6_prefix" {
+                ValueType::Ipv6Prefix => "Ipv6Prefix".to_string(),
+            }
         );
     }
 }

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -1554,7 +1554,7 @@ pub fn is_bluefield_model(model: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::{Case, check_cases, scenarios};
 
     use super::*;
     use crate::firmware::FirmwareComponent;
@@ -1621,30 +1621,25 @@ mod tests {
     #[test]
     fn test_find_version() {
         let fw_info = create_test_firmware(FirmwareComponentType::Bmc, r"^BMC_Firmware$");
-        check_cases(
-            [
-                Case {
-                    scenario: "single match",
-                    input: vec![("BMC_Firmware", Some("1.2.3")), ("DPU_UEFI", Some("4.5.6"))],
-                    expect: Yields("1.2.3".to_string()),
-                },
-                Case {
-                    scenario: "no match",
-                    input: vec![
-                        ("DPU_UEFI", Some("4.5.6")),
-                        ("Other_Component", Some("7.8.9")),
-                    ],
-                    expect: Fails,
-                },
-            ],
+        scenarios!(
             // Build an endpoint from the inventories, then look up the BMC
             // version; absent -> error so the no-match row reads as a failure.
-            |inventories| {
+            run = |inventories| {
                 create_test_endpoint(inventories)
                     .find_version(&fw_info, FirmwareComponentType::Bmc)
                     .cloned()
                     .ok_or(())
-            },
+            };
+            "single match" {
+                vec![("BMC_Firmware", Some("1.2.3")), ("DPU_UEFI", Some("4.5.6"))] => Yields("1.2.3".to_string()),
+            }
+
+            "no match" {
+                vec![
+                    ("DPU_UEFI", Some("4.5.6")),
+                    ("Other_Component", Some("7.8.9")),
+                ] => Fails,
+            }
         );
     }
 
@@ -2146,35 +2141,28 @@ mod tests {
             ..Default::default()
         };
 
-        check_cases(
-            [
-                Case {
-                    scenario: "matching MAC yields its interface id",
-                    input: (two_iface_report.clone(), mac),
-                    expect: Yields("NIC.Slot.7-1-1".to_string()),
-                },
-                Case {
-                    scenario: "unknown MAC -> None (keeps last-known-good record)",
-                    input: (two_iface_report, MacAddress::new([0, 0, 0, 0, 0, 0])),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "MAC present but no interface id -> no complete pair",
-                    input: (single_iface_report(None), mac),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "empty id treated as absent (don't clobber stored boot interface)",
-                    input: (single_iface_report(Some(String::new())), mac),
-                    expect: Fails,
-                },
-            ],
-            |(report, mac)| {
+        scenarios!(
+            run = |(report, mac)| {
                 report
                     .find_interface_id_for_mac(mac)
                     .map(str::to_string)
                     .ok_or(())
-            },
+            };
+            "matching MAC yields its interface id" {
+                (two_iface_report.clone(), mac) => Yields("NIC.Slot.7-1-1".to_string()),
+            }
+
+            "unknown MAC -> None (keeps last-known-good record)" {
+                (two_iface_report, MacAddress::new([0, 0, 0, 0, 0, 0])) => Fails,
+            }
+
+            "MAC present but no interface id -> no complete pair" {
+                (single_iface_report(None), mac) => Fails,
+            }
+
+            "empty id treated as absent (don't clobber stored boot interface)" {
+                (single_iface_report(Some(String::new())), mac) => Fails,
+            }
         );
     }
 
@@ -2298,75 +2286,68 @@ mod tests {
     /// Each row projects to the resulting `base_mac`.
     #[test]
     fn test_computer_system_base_mac_deserialization() {
-        check_cases(
-            [
-                Case {
-                    scenario: "invalid BaseMac -> None",
-                    input: serde_json::json!({
-                        "EthernetInterfaces": [],
-                        "Id": "Bluefield",
-                        "Manufacturer": "Nvidia",
-                        "Model": "Bluefield-3 DPU",
-                        "SerialNumber": "ABC1234",
-                        "Attributes": {},
-                        "PcieDevices": [],
-                        "BaseMac": "pe:",
-                        "PowerState": "On"
-                    }),
-                    expect: Yields(None),
-                },
-                Case {
-                    scenario: "valid BaseMac parses through",
-                    input: serde_json::json!({
-                        "EthernetInterfaces": [],
-                        "Id": "Bluefield",
-                        "Manufacturer": "Nvidia",
-                        "Model": "Bluefield-3 DPU",
-                        "SerialNumber": "ABC1234",
-                        "Attributes": {},
-                        "PcieDevices": [],
-                        "BaseMac": "A088C208804C",
-                        "PowerState": "On"
-                    }),
-                    expect: Yields(Some("A088C208804C".parse().unwrap())),
-                },
-                Case {
-                    scenario: "null BaseMac -> None",
-                    input: serde_json::json!({
-                        "EthernetInterfaces": [],
-                        "Id": "Bluefield",
-                        "Manufacturer": "Nvidia",
-                        "Model": "Bluefield-3 DPU",
-                        "SerialNumber": "ABC1234",
-                        "Attributes": {},
-                        "PcieDevices": [],
-                        "BaseMac": null,
-                        "PowerState": "On"
-                    }),
-                    expect: Yields(None),
-                },
-                Case {
-                    scenario: "missing BaseMac -> None",
-                    input: serde_json::json!({
-                        "EthernetInterfaces": [],
-                        "Id": "Bluefield",
-                        "Manufacturer": "Nvidia",
-                        "Model": "Bluefield-3 DPU",
-                        "SerialNumber": "ABC1234",
-                        "Attributes": {},
-                        "PcieDevices": [],
-                        "PowerState": "On"
-                    }),
-                    expect: Yields(None),
-                },
-            ],
+        scenarios!(
             // Deserialize and project to base_mac; every row is expected to
             // deserialize, so the (non-PartialEq) serde error is discarded.
-            |json| {
+            run = |json| {
                 serde_json::from_value::<ComputerSystem>(json)
                     .map(|system| system.base_mac)
                     .map_err(drop)
-            },
+            };
+            "invalid BaseMac -> None" {
+                serde_json::json!({
+                    "EthernetInterfaces": [],
+                    "Id": "Bluefield",
+                    "Manufacturer": "Nvidia",
+                    "Model": "Bluefield-3 DPU",
+                    "SerialNumber": "ABC1234",
+                    "Attributes": {},
+                    "PcieDevices": [],
+                    "BaseMac": "pe:",
+                    "PowerState": "On"
+                }) => Yields(None),
+            }
+
+            "valid BaseMac parses through" {
+                serde_json::json!({
+                    "EthernetInterfaces": [],
+                    "Id": "Bluefield",
+                    "Manufacturer": "Nvidia",
+                    "Model": "Bluefield-3 DPU",
+                    "SerialNumber": "ABC1234",
+                    "Attributes": {},
+                    "PcieDevices": [],
+                    "BaseMac": "A088C208804C",
+                    "PowerState": "On"
+                }) => Yields(Some("A088C208804C".parse().unwrap())),
+            }
+
+            "null BaseMac -> None" {
+                serde_json::json!({
+                    "EthernetInterfaces": [],
+                    "Id": "Bluefield",
+                    "Manufacturer": "Nvidia",
+                    "Model": "Bluefield-3 DPU",
+                    "SerialNumber": "ABC1234",
+                    "Attributes": {},
+                    "PcieDevices": [],
+                    "BaseMac": null,
+                    "PowerState": "On"
+                }) => Yields(None),
+            }
+
+            "missing BaseMac -> None" {
+                serde_json::json!({
+                    "EthernetInterfaces": [],
+                    "Id": "Bluefield",
+                    "Manufacturer": "Nvidia",
+                    "Model": "Bluefield-3 DPU",
+                    "SerialNumber": "ABC1234",
+                    "Attributes": {},
+                    "PcieDevices": [],
+                    "PowerState": "On"
+                }) => Yields(None),
+            }
         );
     }
 }

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -383,7 +383,7 @@ pub struct SwitchSearchFilter {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, Check, check_cases, check_values};
+    use carbide_test_support::{scenarios, value_scenarios};
 
     use super::*;
 
@@ -400,423 +400,345 @@ mod tests {
 
     #[test]
     fn controller_state_serializes_to_expected_json() {
-        check_cases(
-            [
-                Case {
-                    scenario: "created",
-                    input: SwitchControllerState::Created,
-                    expect: Yields(r#"{"state":"created"}"#.to_string()),
-                },
-                Case {
-                    scenario: "initializing",
-                    input: SwitchControllerState::Initializing {
-                        initializing_state: InitializingState::WaitForOsMachineInterface,
-                    },
-                    expect: Yields(
-                        r#"{"state":"initializing","initializing_state":"WaitForOsMachineInterface"}"#
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "configuring",
-                    input: SwitchControllerState::Configuring {
-                        config_state: ConfiguringState::RotateOsPassword,
-                    },
-                    expect: Yields(
-                        r#"{"state":"configuring","config_state":"RotateOsPassword"}"#.to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "validating",
-                    input: SwitchControllerState::Validating {
-                        validating_state: ValidatingState::ValidationComplete,
-                    },
-                    expect: Yields(
-                        r#"{"state":"validating","validating_state":"ValidationComplete"}"#
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "bomvalidating",
-                    input: SwitchControllerState::BomValidating {
-                        bom_validating_state: BomValidatingState::BomValidationComplete,
-                    },
-                    expect: Yields(
-                        r#"{"state":"bomvalidating","bom_validating_state":"BomValidationComplete"}"#
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "ready",
-                    input: SwitchControllerState::Ready,
-                    expect: Yields(r#"{"state":"ready"}"#.to_string()),
-                },
-                Case {
-                    scenario: "maintenance: power on",
-                    input: SwitchControllerState::Maintenance {
-                        operation: SwitchMaintenanceOperation::PowerOn,
-                    },
-                    expect: Yields(
-                        r#"{"state":"maintenance","operation":{"operation":"poweron"}}"#.to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "maintenance: power off",
-                    input: SwitchControllerState::Maintenance {
-                        operation: SwitchMaintenanceOperation::PowerOff,
-                    },
-                    expect: Yields(
-                        r#"{"state":"maintenance","operation":{"operation":"poweroff"}}"#
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "maintenance: reset",
-                    input: SwitchControllerState::Maintenance {
-                        operation: SwitchMaintenanceOperation::Reset,
-                    },
-                    expect: Yields(
-                        r#"{"state":"maintenance","operation":{"operation":"reset"}}"#.to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "reprovisioning: firmware upgrade",
-                    input: SwitchControllerState::ReProvisioning {
-                        reprovisioning_state:
-                            ReProvisioningState::WaitingForRackFirmwareUpgrade,
-                    },
-                    expect: Yields(
-                        r#"{"state":"reprovisioning","reprovisioning_state":"WaitingForRackFirmwareUpgrade"}"#
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "reprovisioning: nvos upgrade",
-                    input: SwitchControllerState::ReProvisioning {
-                        reprovisioning_state: ReProvisioningState::WaitingForNVOSUpgrade,
-                    },
-                    expect: Yields(
-                        r#"{"state":"reprovisioning","reprovisioning_state":"WaitingForNVOSUpgrade"}"#
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "reprovisioning: nmxc configure",
-                    input: SwitchControllerState::ReProvisioning {
-                        reprovisioning_state: ReProvisioningState::WaitingForNMXCConfigure,
-                    },
-                    expect: Yields(
-                        r#"{"state":"reprovisioning","reprovisioning_state":"WaitingForNMXCConfigure"}"#
-                            .to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "error carries its cause",
-                    input: SwitchControllerState::Error {
-                        cause: "cause goes here".to_string(),
-                    },
-                    expect: Yields(
-                        r#"{"state":"error","cause":"cause goes here"}"#.to_string(),
-                    ),
-                },
-                Case {
-                    scenario: "deleting",
-                    input: SwitchControllerState::Deleting,
-                    expect: Yields(r#"{"state":"deleting"}"#.to_string()),
-                },
-            ],
-            |state| serde_json::to_string(&state).map_err(drop),
+        scenarios!(
+            run = |state| serde_json::to_string(&state).map_err(drop);
+            "created" {
+                SwitchControllerState::Created => Yields(r#"{"state":"created"}"#.to_string()),
+            }
+
+            "initializing" {
+                SwitchControllerState::Initializing {
+                    initializing_state: InitializingState::WaitForOsMachineInterface,
+                } => Yields(
+                    r#"{"state":"initializing","initializing_state":"WaitForOsMachineInterface"}"#
+                        .to_string(),
+                ),
+            }
+
+            "configuring" {
+                SwitchControllerState::Configuring {
+                    config_state: ConfiguringState::RotateOsPassword,
+                } => Yields(
+                    r#"{"state":"configuring","config_state":"RotateOsPassword"}"#.to_string(),
+                ),
+            }
+
+            "validating" {
+                SwitchControllerState::Validating {
+                    validating_state: ValidatingState::ValidationComplete,
+                } => Yields(
+                    r#"{"state":"validating","validating_state":"ValidationComplete"}"#
+                        .to_string(),
+                ),
+            }
+
+            "bomvalidating" {
+                SwitchControllerState::BomValidating {
+                    bom_validating_state: BomValidatingState::BomValidationComplete,
+                } => Yields(
+                    r#"{"state":"bomvalidating","bom_validating_state":"BomValidationComplete"}"#
+                        .to_string(),
+                ),
+            }
+
+            "ready" {
+                SwitchControllerState::Ready => Yields(r#"{"state":"ready"}"#.to_string()),
+            }
+
+            "maintenance: power on" {
+                SwitchControllerState::Maintenance {
+                    operation: SwitchMaintenanceOperation::PowerOn,
+                } => Yields(
+                    r#"{"state":"maintenance","operation":{"operation":"poweron"}}"#.to_string(),
+                ),
+            }
+
+            "maintenance: power off" {
+                SwitchControllerState::Maintenance {
+                    operation: SwitchMaintenanceOperation::PowerOff,
+                } => Yields(
+                    r#"{"state":"maintenance","operation":{"operation":"poweroff"}}"#
+                        .to_string(),
+                ),
+            }
+
+            "maintenance: reset" {
+                SwitchControllerState::Maintenance {
+                    operation: SwitchMaintenanceOperation::Reset,
+                } => Yields(
+                    r#"{"state":"maintenance","operation":{"operation":"reset"}}"#.to_string(),
+                ),
+            }
+
+            "reprovisioning: firmware upgrade" {
+                SwitchControllerState::ReProvisioning {
+                    reprovisioning_state:
+                        ReProvisioningState::WaitingForRackFirmwareUpgrade,
+                } => Yields(
+                    r#"{"state":"reprovisioning","reprovisioning_state":"WaitingForRackFirmwareUpgrade"}"#
+                        .to_string(),
+                ),
+            }
+
+            "reprovisioning: nvos upgrade" {
+                SwitchControllerState::ReProvisioning {
+                    reprovisioning_state: ReProvisioningState::WaitingForNVOSUpgrade,
+                } => Yields(
+                    r#"{"state":"reprovisioning","reprovisioning_state":"WaitingForNVOSUpgrade"}"#
+                        .to_string(),
+                ),
+            }
+
+            "reprovisioning: nmxc configure" {
+                SwitchControllerState::ReProvisioning {
+                    reprovisioning_state: ReProvisioningState::WaitingForNMXCConfigure,
+                } => Yields(
+                    r#"{"state":"reprovisioning","reprovisioning_state":"WaitingForNMXCConfigure"}"#
+                        .to_string(),
+                ),
+            }
+
+            "error carries its cause" {
+                SwitchControllerState::Error {
+                    cause: "cause goes here".to_string(),
+                } => Yields(
+                    r#"{"state":"error","cause":"cause goes here"}"#.to_string(),
+                ),
+            }
+
+            "deleting" {
+                SwitchControllerState::Deleting => Yields(r#"{"state":"deleting"}"#.to_string()),
+            }
         );
     }
 
     #[test]
     fn controller_state_deserializes_from_json() {
-        check_cases(
-            [
-                Case {
-                    scenario: "created",
-                    input: r#"{"state":"created"}"#,
-                    expect: Yields(SwitchControllerState::Created),
-                },
-                Case {
-                    scenario: "initializing",
-                    input: r#"{"state":"initializing","initializing_state":"WaitForOsMachineInterface"}"#,
-                    expect: Yields(SwitchControllerState::Initializing {
-                        initializing_state: InitializingState::WaitForOsMachineInterface,
-                    }),
-                },
-                Case {
-                    scenario: "configuring",
-                    input: r#"{"state":"configuring","config_state":"RotateOsPassword"}"#,
-                    expect: Yields(SwitchControllerState::Configuring {
-                        config_state: ConfiguringState::RotateOsPassword,
-                    }),
-                },
-                Case {
-                    scenario: "validating",
-                    input: r#"{"state":"validating","validating_state":"ValidationComplete"}"#,
-                    expect: Yields(SwitchControllerState::Validating {
-                        validating_state: ValidatingState::ValidationComplete,
-                    }),
-                },
-                Case {
-                    scenario: "bomvalidating",
-                    input: r#"{"state":"bomvalidating","bom_validating_state":"BomValidationComplete"}"#,
-                    expect: Yields(SwitchControllerState::BomValidating {
-                        bom_validating_state: BomValidatingState::BomValidationComplete,
-                    }),
-                },
-                Case {
-                    scenario: "ready",
-                    input: r#"{"state":"ready"}"#,
-                    expect: Yields(SwitchControllerState::Ready),
-                },
-                Case {
-                    scenario: "legacy ready with stray ready_state still deserializes to Ready",
-                    input: r#"{"state":"ready","ready_state":"poweroff"}"#,
-                    expect: Yields(SwitchControllerState::Ready),
-                },
-                Case {
-                    scenario: "maintenance: reset",
-                    input: r#"{"state":"maintenance","operation":{"operation":"reset"}}"#,
-                    expect: Yields(SwitchControllerState::Maintenance {
-                        operation: SwitchMaintenanceOperation::Reset,
-                    }),
-                },
-                Case {
-                    scenario: "error",
-                    input: r#"{"state":"error","cause":"boom"}"#,
-                    expect: Yields(SwitchControllerState::Error {
-                        cause: "boom".to_string(),
-                    }),
-                },
-                Case {
-                    scenario: "deleting",
-                    input: r#"{"state":"deleting"}"#,
-                    expect: Yields(SwitchControllerState::Deleting),
-                },
-                Case {
-                    scenario: "unknown state tag is rejected",
-                    input: r#"{"state":"frobnicating"}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "missing state tag is rejected",
-                    input: r#"{"cause":"boom"}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "error without its cause is rejected",
-                    input: r#"{"state":"error"}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "not even json",
-                    input: "not json",
-                    expect: Fails,
-                },
-            ],
-            |json| serde_json::from_str::<SwitchControllerState>(json).map_err(drop),
+        scenarios!(
+            run = |json| serde_json::from_str::<SwitchControllerState>(json).map_err(drop);
+            "created" {
+                r#"{"state":"created"}"# => Yields(SwitchControllerState::Created),
+            }
+
+            "initializing" {
+                r#"{"state":"initializing","initializing_state":"WaitForOsMachineInterface"}"# => Yields(SwitchControllerState::Initializing {
+                    initializing_state: InitializingState::WaitForOsMachineInterface,
+                }),
+            }
+
+            "configuring" {
+                r#"{"state":"configuring","config_state":"RotateOsPassword"}"# => Yields(SwitchControllerState::Configuring {
+                    config_state: ConfiguringState::RotateOsPassword,
+                }),
+            }
+
+            "validating" {
+                r#"{"state":"validating","validating_state":"ValidationComplete"}"# => Yields(SwitchControllerState::Validating {
+                    validating_state: ValidatingState::ValidationComplete,
+                }),
+            }
+
+            "bomvalidating" {
+                r#"{"state":"bomvalidating","bom_validating_state":"BomValidationComplete"}"# => Yields(SwitchControllerState::BomValidating {
+                    bom_validating_state: BomValidatingState::BomValidationComplete,
+                }),
+            }
+
+            "ready" {
+                r#"{"state":"ready"}"# => Yields(SwitchControllerState::Ready),
+            }
+
+            "legacy ready with stray ready_state still deserializes to Ready" {
+                r#"{"state":"ready","ready_state":"poweroff"}"# => Yields(SwitchControllerState::Ready),
+            }
+
+            "maintenance: reset" {
+                r#"{"state":"maintenance","operation":{"operation":"reset"}}"# => Yields(SwitchControllerState::Maintenance {
+                    operation: SwitchMaintenanceOperation::Reset,
+                }),
+            }
+
+            "error" {
+                r#"{"state":"error","cause":"boom"}"# => Yields(SwitchControllerState::Error {
+                    cause: "boom".to_string(),
+                }),
+            }
+
+            "deleting" {
+                r#"{"state":"deleting"}"# => Yields(SwitchControllerState::Deleting),
+            }
+
+            "unknown state tag is rejected" {
+                r#"{"state":"frobnicating"}"# => Fails,
+            }
+
+            "missing state tag is rejected" {
+                r#"{"cause":"boom"}"# => Fails,
+            }
+
+            "error without its cause is rejected" {
+                r#"{"state":"error"}"# => Fails,
+            }
+
+            "not even json" {
+                "not json" => Fails,
+            }
         );
     }
 
     #[test]
     fn maintenance_operation_serializes_lowercase() {
-        check_cases(
-            [
-                Case {
-                    scenario: "power on",
-                    input: SwitchMaintenanceOperation::PowerOn,
-                    expect: Yields(r#"{"operation":"poweron"}"#.to_string()),
-                },
-                Case {
-                    scenario: "power off",
-                    input: SwitchMaintenanceOperation::PowerOff,
-                    expect: Yields(r#"{"operation":"poweroff"}"#.to_string()),
-                },
-                Case {
-                    scenario: "reset",
-                    input: SwitchMaintenanceOperation::Reset,
-                    expect: Yields(r#"{"operation":"reset"}"#.to_string()),
-                },
-            ],
-            |op| serde_json::to_string(&op).map_err(drop),
+        scenarios!(
+            run = |op| serde_json::to_string(&op).map_err(drop);
+            "power on" {
+                SwitchMaintenanceOperation::PowerOn => Yields(r#"{"operation":"poweron"}"#.to_string()),
+            }
+
+            "power off" {
+                SwitchMaintenanceOperation::PowerOff => Yields(r#"{"operation":"poweroff"}"#.to_string()),
+            }
+
+            "reset" {
+                SwitchMaintenanceOperation::Reset => Yields(r#"{"operation":"reset"}"#.to_string()),
+            }
         );
     }
 
     #[test]
     fn maintenance_operation_deserializes() {
-        check_cases(
-            [
-                Case {
-                    scenario: "power on",
-                    input: r#"{"operation":"poweron"}"#,
-                    expect: Yields(SwitchMaintenanceOperation::PowerOn),
-                },
-                Case {
-                    scenario: "power off",
-                    input: r#"{"operation":"poweroff"}"#,
-                    expect: Yields(SwitchMaintenanceOperation::PowerOff),
-                },
-                Case {
-                    scenario: "reset",
-                    input: r#"{"operation":"reset"}"#,
-                    expect: Yields(SwitchMaintenanceOperation::Reset),
-                },
-                Case {
-                    scenario: "uppercase tag is rejected",
-                    input: r#"{"operation":"PowerOn"}"#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "unknown operation is rejected",
-                    input: r#"{"operation":"explode"}"#,
-                    expect: Fails,
-                },
-            ],
-            |json| serde_json::from_str::<SwitchMaintenanceOperation>(json).map_err(drop),
+        scenarios!(
+            run = |json| serde_json::from_str::<SwitchMaintenanceOperation>(json).map_err(drop);
+            "power on" {
+                r#"{"operation":"poweron"}"# => Yields(SwitchMaintenanceOperation::PowerOn),
+            }
+
+            "power off" {
+                r#"{"operation":"poweroff"}"# => Yields(SwitchMaintenanceOperation::PowerOff),
+            }
+
+            "reset" {
+                r#"{"operation":"reset"}"# => Yields(SwitchMaintenanceOperation::Reset),
+            }
+
+            "uppercase tag is rejected" {
+                r#"{"operation":"PowerOn"}"# => Fails,
+            }
+
+            "unknown operation is rejected" {
+                r#"{"operation":"explode"}"# => Fails,
+            }
         );
     }
 
     #[test]
     fn fabric_manager_state_serializes_snake_case() {
-        check_cases(
-            [
-                Case {
-                    scenario: "ok",
-                    input: FabricManagerState::Ok,
-                    expect: Yields(r#""ok""#.to_string()),
-                },
-                Case {
-                    scenario: "not ok renders snake_case",
-                    input: FabricManagerState::NotOk,
-                    expect: Yields(r#""not_ok""#.to_string()),
-                },
-                Case {
-                    scenario: "unknown",
-                    input: FabricManagerState::Unknown,
-                    expect: Yields(r#""unknown""#.to_string()),
-                },
-            ],
-            |state| serde_json::to_string(&state).map_err(drop),
+        scenarios!(
+            run = |state| serde_json::to_string(&state).map_err(drop);
+            "ok" {
+                FabricManagerState::Ok => Yields(r#""ok""#.to_string()),
+            }
+
+            "not ok renders snake_case" {
+                FabricManagerState::NotOk => Yields(r#""not_ok""#.to_string()),
+            }
+
+            "unknown" {
+                FabricManagerState::Unknown => Yields(r#""unknown""#.to_string()),
+            }
         );
     }
 
     #[test]
     fn fabric_manager_state_deserializes() {
-        check_cases(
-            [
-                Case {
-                    scenario: "ok",
-                    input: r#""ok""#,
-                    expect: Yields(FabricManagerState::Ok),
-                },
-                Case {
-                    scenario: "not_ok",
-                    input: r#""not_ok""#,
-                    expect: Yields(FabricManagerState::NotOk),
-                },
-                Case {
-                    scenario: "unknown",
-                    input: r#""unknown""#,
-                    expect: Yields(FabricManagerState::Unknown),
-                },
-                Case {
-                    scenario: "camelCase NotOk is rejected",
-                    input: r#""NotOk""#,
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "unrecognized state is rejected",
-                    input: r#""degraded""#,
-                    expect: Fails,
-                },
-            ],
-            |json| serde_json::from_str::<FabricManagerState>(json).map_err(drop),
+        scenarios!(
+            run = |json| serde_json::from_str::<FabricManagerState>(json).map_err(drop);
+            "ok" {
+                r#""ok""# => Yields(FabricManagerState::Ok),
+            }
+
+            "not_ok" {
+                r#""not_ok""# => Yields(FabricManagerState::NotOk),
+            }
+
+            "unknown" {
+                r#""unknown""# => Yields(FabricManagerState::Unknown),
+            }
+
+            "camelCase NotOk is rejected" {
+                r#""NotOk""# => Fails,
+            }
+
+            "unrecognized state is rejected" {
+                r#""degraded""# => Fails,
+            }
         );
     }
 
     #[test]
     fn display_status_is_running_only_when_ok_and_configured() {
-        check_values(
-            [
-                Check {
-                    scenario: "ok + CONFIGURED is running",
-                    input: fm_status(
-                        FabricManagerState::Ok,
-                        Some("CONTROL_PLANE_STATE_CONFIGURED"),
-                    ),
-                    expect: "running",
-                },
-                Check {
-                    scenario: "ok but no addition_info is not running",
-                    input: fm_status(FabricManagerState::Ok, None),
-                    expect: "not_running",
-                },
-                Check {
-                    scenario: "ok but different addition_info is not running",
-                    input: fm_status(
-                        FabricManagerState::Ok,
-                        Some("CONTROL_PLANE_STATE_INITIALIZING"),
-                    ),
-                    expect: "not_running",
-                },
-                Check {
-                    scenario: "ok but empty addition_info is not running",
-                    input: fm_status(FabricManagerState::Ok, Some("")),
-                    expect: "not_running",
-                },
-                Check {
-                    scenario: "not_ok even when configured is not running",
-                    input: fm_status(
-                        FabricManagerState::NotOk,
-                        Some("CONTROL_PLANE_STATE_CONFIGURED"),
-                    ),
-                    expect: "not_running",
-                },
-                Check {
-                    scenario: "unknown even when configured is not running",
-                    input: fm_status(
-                        FabricManagerState::Unknown,
-                        Some("CONTROL_PLANE_STATE_CONFIGURED"),
-                    ),
-                    expect: "not_running",
-                },
-                Check {
-                    scenario: "not_ok with no info is not running",
-                    input: fm_status(FabricManagerState::NotOk, None),
-                    expect: "not_running",
-                },
-            ],
-            |status| status.display_status(),
+        value_scenarios!(
+            run = |status| status.display_status();
+            "ok + CONFIGURED is running" {
+                fm_status(
+                    FabricManagerState::Ok,
+                    Some("CONTROL_PLANE_STATE_CONFIGURED"),
+                ) => "running",
+            }
+
+            "ok but no addition_info is not running" {
+                fm_status(FabricManagerState::Ok, None) => "not_running",
+            }
+
+            "ok but different addition_info is not running" {
+                fm_status(
+                    FabricManagerState::Ok,
+                    Some("CONTROL_PLANE_STATE_INITIALIZING"),
+                ) => "not_running",
+            }
+
+            "ok but empty addition_info is not running" {
+                fm_status(FabricManagerState::Ok, Some("")) => "not_running",
+            }
+
+            "not_ok even when configured is not running" {
+                fm_status(
+                    FabricManagerState::NotOk,
+                    Some("CONTROL_PLANE_STATE_CONFIGURED"),
+                ) => "not_running",
+            }
+
+            "unknown even when configured is not running" {
+                fm_status(
+                    FabricManagerState::Unknown,
+                    Some("CONTROL_PLANE_STATE_CONFIGURED"),
+                ) => "not_running",
+            }
+
+            "not_ok with no info is not running" {
+                fm_status(FabricManagerState::NotOk, None) => "not_running",
+            }
         );
     }
 
     #[test]
     fn reprovision_request_defaults_continue_after_firmware_upgrade_to_true() {
-        check_cases(
-            [
-                Case {
-                    scenario: "omitted flag defaults to true",
-                    input: r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op"}"#,
-                    expect: Yields(true),
-                },
-                Case {
-                    scenario: "explicit false is honored",
-                    input: r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op","continue_after_firmware_upgrade":false}"#,
-                    expect: Yields(false),
-                },
-                Case {
-                    scenario: "explicit true is honored",
-                    input: r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op","continue_after_firmware_upgrade":true}"#,
-                    expect: Yields(true),
-                },
-            ],
-            |json| {
+        scenarios!(
+            run = |json| {
                 serde_json::from_str::<SwitchReprovisionRequest>(json)
                     .map(|r| r.continue_after_firmware_upgrade)
                     .map_err(drop)
-            },
+            };
+            "omitted flag defaults to true" {
+                r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op"}"# => Yields(true),
+            }
+
+            "explicit false is honored" {
+                r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op","continue_after_firmware_upgrade":false}"# => Yields(false),
+            }
+
+            "explicit true is honored" {
+                r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op","continue_after_firmware_upgrade":true}"# => Yields(true),
+            }
         );
     }
 }

--- a/crates/api-model/src/tenant/identity_config_policy.rs
+++ b/crates/api-model/src/tenant/identity_config_policy.rs
@@ -439,7 +439,7 @@ pub fn resolve_subject_prefix(
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::scenarios;
 
     use super::*;
 
@@ -455,89 +455,71 @@ mod tests {
     // (the originals only checked substrings), so we project the error to "does it contain token".
     #[test]
     fn issuer_trust_domain_extraction() {
-        check_cases(
-            [
-                Case {
-                    scenario: "https issuer lowercases host, drops path",
-                    input: ("https://Issuer.EXAMPLE/path", ""),
-                    expect: Yields("issuer.example".to_string()),
-                },
-                Case {
-                    scenario: "https issuer with explicit port",
-                    input: ("https://Issuer.EXAMPLE:8443/", ""),
-                    expect: Yields("issuer.example".to_string()),
-                },
-                Case {
-                    scenario: "spiffe issuer lowercases host",
-                    input: ("spiffe://Issuer.EXAMPLE/bundle", ""),
-                    expect: Yields("issuer.example".to_string()),
-                },
-                Case {
-                    scenario: "spiffe scheme uppercase",
-                    input: ("SPIFFE://Issuer.EXAMPLE/bundle", ""),
-                    expect: Yields("issuer.example".to_string()),
-                },
-                Case {
-                    scenario: "spiffe scheme mixed case, no path",
-                    input: ("SpIfFe://issuer.example", ""),
-                    expect: Yields("issuer.example".to_string()),
-                },
-                Case {
-                    scenario: "query string rejected",
-                    input: ("https://issuer.example/?q=1", "query"),
-                    expect: FailsWith(true),
-                },
-                Case {
-                    scenario: "ipv4 host rejected",
-                    input: ("https://127.0.0.1/", "IP"),
-                    expect: FailsWith(true),
-                },
-                Case {
-                    scenario: "ipv6 host rejected",
-                    input: ("spiffe://[::1]/x", "IP"),
-                    expect: FailsWith(true),
-                },
-                Case {
-                    scenario: "userinfo (user only) rejected",
-                    input: ("https://user@issuer.example/", "userinfo"),
-                    expect: FailsWith(true),
-                },
-                Case {
-                    scenario: "userinfo with password rejected",
-                    input: ("https://user:pass@issuer.example/", "userinfo"),
-                    expect: FailsWith(true),
-                },
-                Case {
-                    scenario: "non-http(s)/spiffe scheme rejected",
-                    input: ("ftp://issuer.example/", "http"),
-                    expect: FailsWith(true),
-                },
-                Case {
-                    scenario: "bare hostname (no scheme) rejected",
-                    input: ("issuer.example", "http://"),
-                    expect: FailsWith(true),
-                },
-                Case {
-                    scenario: "bare hostname with path rejected",
-                    input: ("issuer.example/extra", "http://"),
-                    expect: FailsWith(true),
-                },
-                Case {
-                    scenario: "backslash rejected",
-                    input: ("https://issuer.example\\evil", "disallowed"),
-                    expect: FailsWith(true),
-                },
-                Case {
-                    scenario: "control char rejected",
-                    input: ("https://issuer.ex\0ample.com/", "disallowed"),
-                    expect: FailsWith(true),
-                },
-            ],
-            |(issuer, token)| {
+        scenarios!(
+            run = |(issuer, token)| {
                 normalize_issuer_and_trust_domain(issuer)
                     .map(|(_, td)| td)
                     .map_err(|e| e.contains(token))
-            },
+            };
+            "https issuer lowercases host, drops path" {
+                ("https://Issuer.EXAMPLE/path", "") => Yields("issuer.example".to_string()),
+            }
+
+            "https issuer with explicit port" {
+                ("https://Issuer.EXAMPLE:8443/", "") => Yields("issuer.example".to_string()),
+            }
+
+            "spiffe issuer lowercases host" {
+                ("spiffe://Issuer.EXAMPLE/bundle", "") => Yields("issuer.example".to_string()),
+            }
+
+            "spiffe scheme uppercase" {
+                ("SPIFFE://Issuer.EXAMPLE/bundle", "") => Yields("issuer.example".to_string()),
+            }
+
+            "spiffe scheme mixed case, no path" {
+                ("SpIfFe://issuer.example", "") => Yields("issuer.example".to_string()),
+            }
+
+            "query string rejected" {
+                ("https://issuer.example/?q=1", "query") => FailsWith(true),
+            }
+
+            "ipv4 host rejected" {
+                ("https://127.0.0.1/", "IP") => FailsWith(true),
+            }
+
+            "ipv6 host rejected" {
+                ("spiffe://[::1]/x", "IP") => FailsWith(true),
+            }
+
+            "userinfo (user only) rejected" {
+                ("https://user@issuer.example/", "userinfo") => FailsWith(true),
+            }
+
+            "userinfo with password rejected" {
+                ("https://user:pass@issuer.example/", "userinfo") => FailsWith(true),
+            }
+
+            "non-http(s)/spiffe scheme rejected" {
+                ("ftp://issuer.example/", "http") => FailsWith(true),
+            }
+
+            "bare hostname (no scheme) rejected" {
+                ("issuer.example", "http://") => FailsWith(true),
+            }
+
+            "bare hostname with path rejected" {
+                ("issuer.example/extra", "http://") => FailsWith(true),
+            }
+
+            "backslash rejected" {
+                ("https://issuer.example\\evil", "disallowed") => FailsWith(true),
+            }
+
+            "control char rejected" {
+                ("https://issuer.ex\0ample.com/", "disallowed") => FailsWith(true),
+            }
         );
     }
 
@@ -545,29 +527,23 @@ mod tests {
     // preservation, host lowercasing, default lone-`/` path omitted. All success rows.
     #[test]
     fn normalize_issuer_preserves_scheme_path_and_port() {
-        check_cases(
-            [
-                Case {
-                    scenario: "http scheme and path lowercased host",
-                    input: "HTTP://Issuer.EXAMPLE/path",
-                    expect: Yields("http://issuer.example/path".to_string()),
-                },
-                Case {
-                    scenario: "explicit port and path preserved",
-                    input: "https://issuer.example:8443/ns",
-                    expect: Yields("https://issuer.example:8443/ns".to_string()),
-                },
-                Case {
-                    scenario: "spiffe scheme normalized",
-                    input: "SpIfFe://Issuer.EXAMPLE/bundle",
-                    expect: Yields("spiffe://issuer.example/bundle".to_string()),
-                },
-            ],
-            |s| {
+        scenarios!(
+            run = |s| {
                 normalize_issuer_and_trust_domain(s)
                     .map(|(iss, _)| iss)
                     .map_err(drop)
-            },
+            };
+            "http scheme and path lowercased host" {
+                "HTTP://Issuer.EXAMPLE/path" => Yields("http://issuer.example/path".to_string()),
+            }
+
+            "explicit port and path preserved" {
+                "https://issuer.example:8443/ns" => Yields("https://issuer.example:8443/ns".to_string()),
+            }
+
+            "spiffe scheme normalized" {
+                "SpIfFe://Issuer.EXAMPLE/bundle" => Yields("spiffe://issuer.example/bundle".to_string()),
+            }
         );
     }
 
@@ -576,74 +552,63 @@ mod tests {
     // error contains `token` via `FailsWith(true)`.
     #[test]
     fn resolve_subject_prefix_cases() {
-        check_cases(
-            [
-                Case {
-                    scenario: "no proto prefix -> default from https issuer",
-                    input: ("https://my.idp.example", None, ""),
-                    expect: Yields("spiffe://my.idp.example".to_string()),
-                },
-                Case {
-                    scenario: "no proto prefix -> default from spiffe issuer",
-                    input: ("spiffe://my.idp.example/ns/x", None, ""),
-                    expect: Yields("spiffe://my.idp.example".to_string()),
-                },
-                Case {
-                    scenario: "explicit prefix canonicalizes trust-domain case",
-                    input: (
-                        "https://issuer.example",
-                        Some("spiffe://ISSUER.EXAMPLE/wl"),
-                        "",
-                    ),
-                    expect: Yields("spiffe://issuer.example/wl".to_string()),
-                },
-                Case {
-                    scenario: "trust domain mismatch rejected",
-                    input: (
-                        "https://issuer.example",
-                        Some("spiffe://other.example"),
-                        "does not match",
-                    ),
-                    expect: FailsWith(true),
-                },
-                Case {
-                    scenario: "percent-encoding rejected",
-                    input: (
-                        "https://issuer.example",
-                        Some("spiffe://issuer.example/a%2Fb"),
-                        "disallowed",
-                    ),
-                    expect: FailsWith(true),
-                },
-                Case {
-                    scenario: "https scheme prefix rejected (must be spiffe)",
-                    input: (
-                        "https://issuer.example",
-                        Some("https://issuer.example/p"),
-                        "spiffe://",
-                    ),
-                    expect: FailsWith(true),
-                },
-                Case {
-                    scenario: "backslash in prefix rejected",
-                    input: (
-                        "https://issuer.example",
-                        Some("spiffe://issuer.example/a\\b"),
-                        "disallowed",
-                    ),
-                    expect: FailsWith(true),
-                },
-                Case {
-                    scenario: "whitespace in prefix rejected",
-                    input: (
-                        "https://issuer.example",
-                        Some("spiffe://issuer.example/a b"),
-                        "disallowed",
-                    ),
-                    expect: FailsWith(true),
-                },
-            ],
-            |(issuer, proto, token)| resolve_identity(issuer, proto).map_err(|e| e.contains(token)),
+        scenarios!(
+            run = |(issuer, proto, token)| resolve_identity(issuer, proto).map_err(|e| e.contains(token));
+            "no proto prefix -> default from https issuer" {
+                ("https://my.idp.example", None, "") => Yields("spiffe://my.idp.example".to_string()),
+            }
+
+            "no proto prefix -> default from spiffe issuer" {
+                ("spiffe://my.idp.example/ns/x", None, "") => Yields("spiffe://my.idp.example".to_string()),
+            }
+
+            "explicit prefix canonicalizes trust-domain case" {
+                (
+                    "https://issuer.example",
+                    Some("spiffe://ISSUER.EXAMPLE/wl"),
+                    "",
+                ) => Yields("spiffe://issuer.example/wl".to_string()),
+            }
+
+            "trust domain mismatch rejected" {
+                (
+                    "https://issuer.example",
+                    Some("spiffe://other.example"),
+                    "does not match",
+                ) => FailsWith(true),
+            }
+
+            "percent-encoding rejected" {
+                (
+                    "https://issuer.example",
+                    Some("spiffe://issuer.example/a%2Fb"),
+                    "disallowed",
+                ) => FailsWith(true),
+            }
+
+            "https scheme prefix rejected (must be spiffe)" {
+                (
+                    "https://issuer.example",
+                    Some("https://issuer.example/p"),
+                    "spiffe://",
+                ) => FailsWith(true),
+            }
+
+            "backslash in prefix rejected" {
+                (
+                    "https://issuer.example",
+                    Some("spiffe://issuer.example/a\\b"),
+                    "disallowed",
+                ) => FailsWith(true),
+            }
+
+            "whitespace in prefix rejected" {
+                (
+                    "https://issuer.example",
+                    Some("spiffe://issuer.example/a b"),
+                    "disallowed",
+                ) => FailsWith(true),
+            }
         );
     }
 
@@ -694,258 +659,221 @@ mod tests {
         fn list(entries: &[&str]) -> Vec<String> {
             entries.iter().map(|s| s.to_string()).collect()
         }
-        check_cases(
-            [
-                Case {
-                    scenario: "empty allowlist allows any host",
-                    input: ("anything.example", list(&[])),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "exact match",
-                    input: (
-                        "login.example.com",
-                        list(&["login.example.com", "other.net"]),
-                    ),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "exact match ignores case and trailing dot",
-                    input: (
-                        "LOGIN.EXAMPLE.COM.",
-                        list(&["login.example.com", "other.net"]),
-                    ),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "exact mismatch",
-                    input: ("bad.example.com", list(&["login.example.com", "other.net"])),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "single-star: one label under suffix matches",
-                    input: ("auth.something.net", list(&["*.something.net"])),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "single-star: bare suffix does not match",
-                    input: ("something.net", list(&["*.something.net"])),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "single-star: two labels under suffix do not match",
-                    input: ("a.b.something.net", list(&["*.something.net"])),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "single-star: dot boundary before suffix",
-                    input: ("notsomething.net", list(&["*.something.net"])),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "double-star: bare suffix matches",
-                    input: ("internal.example", list(&["**.internal.example"])),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "double-star: one label deep matches",
-                    input: ("x.internal.example", list(&["**.internal.example"])),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "double-star: many labels deep match",
-                    input: ("a.b.internal.example", list(&["**.internal.example"])),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "double-star: suffix not at end does not match",
-                    input: (
-                        "evil.internal.example.evil.com",
-                        list(&["**.internal.example"]),
-                    ),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "single-star: multi-label under suffix rejected",
-                    input: ("auth.prod.something.net", list(&["*.something.net"])),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "single-star: one label matches mixed-case pattern",
-                    input: ("auth.something.net", list(&["*.SOMETHING.NET"])),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "double-star: suffix as substring of longer zone rejected",
-                    input: ("api.internal.example.com", list(&["**.internal.example"])),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "double-star: suffix mid-host rejected",
-                    input: (
-                        "not-relevant.internal.example.evil.com",
-                        list(&["**.internal.example"]),
-                    ),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "double-star: zone apex matches",
-                    input: ("co.uk", list(&["**.co.uk"])),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "double-star: child of apex matches",
-                    input: ("tenant.co.uk", list(&["**.co.uk"])),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "double-star: deep child of apex matches",
-                    input: ("a.b.co.uk", list(&["**.co.uk"])),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "double-star: different apex rejected",
-                    input: ("other.uk", list(&["**.co.uk"])),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "OR across entries: literal matches",
-                    input: ("exact.only", list(&["exact.only", "**.allowed.zone"])),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "OR across entries: double-star matches",
-                    input: ("x.allowed.zone", list(&["exact.only", "**.allowed.zone"])),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "OR across entries: neither matches",
-                    input: ("wrong.zone", list(&["exact.only", "**.allowed.zone"])),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "mixed list: literal host matches",
-                    input: (
-                        "idp.example.com",
-                        list(&[
-                            "idp.example.com",
-                            "localhost",
-                            "*.tenant.example.net",
-                            "**.corp.internal",
-                        ]),
-                    ),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "mixed list: literal host case-insensitive",
-                    input: (
-                        "LOCALHOST",
-                        list(&[
-                            "idp.example.com",
-                            "localhost",
-                            "*.tenant.example.net",
-                            "**.corp.internal",
-                        ]),
-                    ),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "mixed list: single-star matches",
-                    input: (
-                        "auth.tenant.example.net",
-                        list(&[
-                            "idp.example.com",
-                            "localhost",
-                            "*.tenant.example.net",
-                            "**.corp.internal",
-                        ]),
-                    ),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "mixed list: double-star apex matches",
-                    input: (
-                        "corp.internal",
-                        list(&[
-                            "idp.example.com",
-                            "localhost",
-                            "*.tenant.example.net",
-                            "**.corp.internal",
-                        ]),
-                    ),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "mixed list: double-star deep matches",
-                    input: (
-                        "a.b.corp.internal",
-                        list(&[
-                            "idp.example.com",
-                            "localhost",
-                            "*.tenant.example.net",
-                            "**.corp.internal",
-                        ]),
-                    ),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "mixed list: unrelated literal rejected",
-                    input: (
-                        "other.example.com",
-                        list(&[
-                            "idp.example.com",
-                            "localhost",
-                            "*.tenant.example.net",
-                            "**.corp.internal",
-                        ]),
-                    ),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "mixed list: single-star too deep rejected",
-                    input: (
-                        "auth.app.tenant.example.net",
-                        list(&[
-                            "idp.example.com",
-                            "localhost",
-                            "*.tenant.example.net",
-                            "**.corp.internal",
-                        ]),
-                    ),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "mixed list: double-star suffix mid-host rejected",
-                    input: (
-                        "not.corp.internal.evil.com",
-                        list(&[
-                            "idp.example.com",
-                            "localhost",
-                            "*.tenant.example.net",
-                            "**.corp.internal",
-                        ]),
-                    ),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "pattern trimmed and trailing-dot stripped",
-                    input: ("bar.foo.com", list(&["  *.Foo.COM.  "])),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "single-star: dot boundary, one label matches",
-                    input: ("svc.internal.example", list(&["*.internal.example"])),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "single-star: no dot before suffix rejected",
-                    input: ("notinternal.example", list(&["*.internal.example"])),
-                    expect: Fails,
-                },
-            ],
-            |(hostname, patterns)| {
+        scenarios!(
+            run = |(hostname, patterns)| {
                 trust_domain_matches_allowlist(hostname, &patterns).map_err(drop)
-            },
+            };
+            "empty allowlist allows any host" {
+                ("anything.example", list(&[])) => Yields(()),
+            }
+
+            "exact match" {
+                (
+                    "login.example.com",
+                    list(&["login.example.com", "other.net"]),
+                ) => Yields(()),
+            }
+
+            "exact match ignores case and trailing dot" {
+                (
+                    "LOGIN.EXAMPLE.COM.",
+                    list(&["login.example.com", "other.net"]),
+                ) => Yields(()),
+            }
+
+            "exact mismatch" {
+                ("bad.example.com", list(&["login.example.com", "other.net"])) => Fails,
+            }
+
+            "single-star: one label under suffix matches" {
+                ("auth.something.net", list(&["*.something.net"])) => Yields(()),
+            }
+
+            "single-star: bare suffix does not match" {
+                ("something.net", list(&["*.something.net"])) => Fails,
+            }
+
+            "single-star: two labels under suffix do not match" {
+                ("a.b.something.net", list(&["*.something.net"])) => Fails,
+            }
+
+            "single-star: dot boundary before suffix" {
+                ("notsomething.net", list(&["*.something.net"])) => Fails,
+            }
+
+            "double-star: bare suffix matches" {
+                ("internal.example", list(&["**.internal.example"])) => Yields(()),
+            }
+
+            "double-star: one label deep matches" {
+                ("x.internal.example", list(&["**.internal.example"])) => Yields(()),
+            }
+
+            "double-star: many labels deep match" {
+                ("a.b.internal.example", list(&["**.internal.example"])) => Yields(()),
+            }
+
+            "double-star: suffix not at end does not match" {
+                (
+                    "evil.internal.example.evil.com",
+                    list(&["**.internal.example"]),
+                ) => Fails,
+            }
+
+            "single-star: multi-label under suffix rejected" {
+                ("auth.prod.something.net", list(&["*.something.net"])) => Fails,
+            }
+
+            "single-star: one label matches mixed-case pattern" {
+                ("auth.something.net", list(&["*.SOMETHING.NET"])) => Yields(()),
+            }
+
+            "double-star: suffix as substring of longer zone rejected" {
+                ("api.internal.example.com", list(&["**.internal.example"])) => Fails,
+            }
+
+            "double-star: suffix mid-host rejected" {
+                (
+                    "not-relevant.internal.example.evil.com",
+                    list(&["**.internal.example"]),
+                ) => Fails,
+            }
+
+            "double-star: zone apex matches" {
+                ("co.uk", list(&["**.co.uk"])) => Yields(()),
+            }
+
+            "double-star: child of apex matches" {
+                ("tenant.co.uk", list(&["**.co.uk"])) => Yields(()),
+            }
+
+            "double-star: deep child of apex matches" {
+                ("a.b.co.uk", list(&["**.co.uk"])) => Yields(()),
+            }
+
+            "double-star: different apex rejected" {
+                ("other.uk", list(&["**.co.uk"])) => Fails,
+            }
+
+            "OR across entries: literal matches" {
+                ("exact.only", list(&["exact.only", "**.allowed.zone"])) => Yields(()),
+            }
+
+            "OR across entries: double-star matches" {
+                ("x.allowed.zone", list(&["exact.only", "**.allowed.zone"])) => Yields(()),
+            }
+
+            "OR across entries: neither matches" {
+                ("wrong.zone", list(&["exact.only", "**.allowed.zone"])) => Fails,
+            }
+
+            "mixed list: literal host matches" {
+                (
+                    "idp.example.com",
+                    list(&[
+                        "idp.example.com",
+                        "localhost",
+                        "*.tenant.example.net",
+                        "**.corp.internal",
+                    ]),
+                ) => Yields(()),
+            }
+
+            "mixed list: literal host case-insensitive" {
+                (
+                    "LOCALHOST",
+                    list(&[
+                        "idp.example.com",
+                        "localhost",
+                        "*.tenant.example.net",
+                        "**.corp.internal",
+                    ]),
+                ) => Yields(()),
+            }
+
+            "mixed list: single-star matches" {
+                (
+                    "auth.tenant.example.net",
+                    list(&[
+                        "idp.example.com",
+                        "localhost",
+                        "*.tenant.example.net",
+                        "**.corp.internal",
+                    ]),
+                ) => Yields(()),
+            }
+
+            "mixed list: double-star apex matches" {
+                (
+                    "corp.internal",
+                    list(&[
+                        "idp.example.com",
+                        "localhost",
+                        "*.tenant.example.net",
+                        "**.corp.internal",
+                    ]),
+                ) => Yields(()),
+            }
+
+            "mixed list: double-star deep matches" {
+                (
+                    "a.b.corp.internal",
+                    list(&[
+                        "idp.example.com",
+                        "localhost",
+                        "*.tenant.example.net",
+                        "**.corp.internal",
+                    ]),
+                ) => Yields(()),
+            }
+
+            "mixed list: unrelated literal rejected" {
+                (
+                    "other.example.com",
+                    list(&[
+                        "idp.example.com",
+                        "localhost",
+                        "*.tenant.example.net",
+                        "**.corp.internal",
+                    ]),
+                ) => Fails,
+            }
+
+            "mixed list: single-star too deep rejected" {
+                (
+                    "auth.app.tenant.example.net",
+                    list(&[
+                        "idp.example.com",
+                        "localhost",
+                        "*.tenant.example.net",
+                        "**.corp.internal",
+                    ]),
+                ) => Fails,
+            }
+
+            "mixed list: double-star suffix mid-host rejected" {
+                (
+                    "not.corp.internal.evil.com",
+                    list(&[
+                        "idp.example.com",
+                        "localhost",
+                        "*.tenant.example.net",
+                        "**.corp.internal",
+                    ]),
+                ) => Fails,
+            }
+
+            "pattern trimmed and trailing-dot stripped" {
+                ("bar.foo.com", list(&["  *.Foo.COM.  "])) => Yields(()),
+            }
+
+            "single-star: dot boundary, one label matches" {
+                ("svc.internal.example", list(&["*.internal.example"])) => Yields(()),
+            }
+
+            "single-star: no dot before suffix rejected" {
+                ("notinternal.example", list(&["*.internal.example"])) => Fails,
+            }
         );
     }
 
@@ -956,80 +884,64 @@ mod tests {
         fn list(entries: &[&str]) -> Vec<String> {
             entries.iter().map(|s| s.to_string()).collect()
         }
-        check_cases(
-            [
-                Case {
-                    scenario: "bare `*` rejected",
-                    input: list(&["*"]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "bare `**` rejected",
-                    input: list(&["**"]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "`*.` (empty suffix) rejected",
-                    input: list(&["*."]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "wildcard inside label rejected",
-                    input: list(&["foo*bar"]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "plain hostname accepted",
-                    input: list(&["login.example"]),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "`**.` (empty suffix) rejected",
-                    input: list(&["**."]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "`*.` (empty suffix) rejected again",
-                    input: list(&["*."]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "star inside double-star suffix rejected",
-                    input: list(&["**.foo.*.com"]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "star inside single-star suffix rejected",
-                    input: list(&["*.foo*bar.com"]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "whitespace-only entry rejected",
-                    input: list(&["   "]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "tab/space-only entry rejected",
-                    input: list(&["  \t "]),
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "double-star multi-label suffix accepted",
-                    input: list(&["**.svc.cluster.local"]),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "mixed valid list passes startup validation",
-                    input: list(&[
-                        "idp.example.com",
-                        "localhost",
-                        "*.tenant.example.net",
-                        "**.corp.internal",
-                    ]),
-                    expect: Yields(()),
-                },
-            ],
-            |patterns| validate_trust_domain_allowlist_patterns(&patterns).map_err(drop),
+        scenarios!(
+            run = |patterns| validate_trust_domain_allowlist_patterns(&patterns).map_err(drop);
+            "bare `*` rejected" {
+                list(&["*"]) => Fails,
+            }
+
+            "bare `**` rejected" {
+                list(&["**"]) => Fails,
+            }
+
+            "`*.` (empty suffix) rejected" {
+                list(&["*."]) => Fails,
+            }
+
+            "wildcard inside label rejected" {
+                list(&["foo*bar"]) => Fails,
+            }
+
+            "plain hostname accepted" {
+                list(&["login.example"]) => Yields(()),
+            }
+
+            "`**.` (empty suffix) rejected" {
+                list(&["**."]) => Fails,
+            }
+
+            "`*.` (empty suffix) rejected again" {
+                list(&["*."]) => Fails,
+            }
+
+            "star inside double-star suffix rejected" {
+                list(&["**.foo.*.com"]) => Fails,
+            }
+
+            "star inside single-star suffix rejected" {
+                list(&["*.foo*bar.com"]) => Fails,
+            }
+
+            "whitespace-only entry rejected" {
+                list(&["   "]) => Fails,
+            }
+
+            "tab/space-only entry rejected" {
+                list(&["  \t "]) => Fails,
+            }
+
+            "double-star multi-label suffix accepted" {
+                list(&["**.svc.cluster.local"]) => Yields(()),
+            }
+
+            "mixed valid list passes startup validation" {
+                list(&[
+                    "idp.example.com",
+                    "localhost",
+                    "*.tenant.example.net",
+                    "**.corp.internal",
+                ]) => Yields(()),
+            }
         );
     }
 
@@ -1038,36 +950,29 @@ mod tests {
     // assert the error contains `token` via `FailsWith(true)`.
     #[test]
     fn token_endpoint_url_accepts_http_and_https_only() {
-        check_cases(
-            [
-                Case {
-                    scenario: "https endpoint -> host",
-                    input: ("https://auth.example.com/oauth/token", &[][..]),
-                    expect: Yields("auth.example.com".to_string()),
-                },
-                Case {
-                    scenario: "http endpoint with port -> host",
-                    input: ("http://auth.example:8080/token", &[][..]),
-                    expect: Yields("auth.example".to_string()),
-                },
-                Case {
-                    scenario: "spiffe scheme rejected",
-                    input: ("spiffe://trust.example/path", &["http", "https"][..]),
-                    expect: FailsWith(true),
-                },
-                Case {
-                    scenario: "ftp scheme rejected",
-                    input: ("ftp://auth.example/token", &["http"][..]),
-                    expect: FailsWith(true),
-                },
-            ],
+        scenarios!(
             // Rejection rows require every listed token in the error, preserving the
             // original's independent contains("http") && contains("https") check
             // rather than coupling to one exact phrase.
-            |(endpoint, tokens)| {
+            run = |(endpoint, tokens)| {
                 registered_host_for_token_endpoint(endpoint)
                     .map_err(|e| tokens.iter().all(|t| e.contains(t)))
-            },
+            };
+            "https endpoint -> host" {
+                ("https://auth.example.com/oauth/token", &[][..]) => Yields("auth.example.com".to_string()),
+            }
+
+            "http endpoint with port -> host" {
+                ("http://auth.example:8080/token", &[][..]) => Yields("auth.example".to_string()),
+            }
+
+            "spiffe scheme rejected" {
+                ("spiffe://trust.example/path", &["http", "https"][..]) => FailsWith(true),
+            }
+
+            "ftp scheme rejected" {
+                ("ftp://auth.example/token", &["http"][..]) => FailsWith(true),
+            }
         );
     }
 }

--- a/crates/api-model/src/tenant/mod.rs
+++ b/crates/api-model/src/tenant/mod.rs
@@ -538,7 +538,7 @@ impl<'r> sqlx::FromRow<'r, PgRow> for TenantKeyset {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::scenarios;
 
     use super::*;
 
@@ -559,50 +559,8 @@ mod tests {
     // errors. The closure exercises both entry points and confirms they agree.
     #[test]
     fn parse_tenant_org() {
-        check_cases(
-            [
-                Case {
-                    scenario: "alphabetic",
-                    input: "TenantA",
-                    expect: Yields("TenantA".to_string()),
-                },
-                Case {
-                    scenario: "with underscore",
-                    input: "Tenant_B",
-                    expect: Yields("Tenant_B".to_string()),
-                },
-                Case {
-                    scenario: "with dashes and underscores",
-                    input: "Tenant-C-_And_D_",
-                    expect: Yields("Tenant-C-_And_D_".to_string()),
-                },
-                Case {
-                    scenario: "empty",
-                    input: "",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "leading space",
-                    input: " Tenant_B",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "trailing space",
-                    input: "Tenant_C ",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "internal space",
-                    input: "Tenant D",
-                    expect: Fails,
-                },
-                Case {
-                    scenario: "disallowed punctuation",
-                    input: "Tenant!A",
-                    expect: Fails,
-                },
-            ],
-            |s| {
+        scenarios!(
+            run = |s| {
                 let via_try_from = TenantOrganizationId::try_from(s.to_string());
                 let via_parse = s.parse::<TenantOrganizationId>();
                 // Both entry points must agree on success/failure.
@@ -610,7 +568,38 @@ mod tests {
                 via_try_from
                     .map(|org| org.as_str().to_string())
                     .map_err(drop)
-            },
+            };
+            "alphabetic" {
+                "TenantA" => Yields("TenantA".to_string()),
+            }
+
+            "with underscore" {
+                "Tenant_B" => Yields("Tenant_B".to_string()),
+            }
+
+            "with dashes and underscores" {
+                "Tenant-C-_And_D_" => Yields("Tenant-C-_And_D_".to_string()),
+            }
+
+            "empty" {
+                "" => Fails,
+            }
+
+            "leading space" {
+                " Tenant_B" => Fails,
+            }
+
+            "trailing space" {
+                "Tenant_C " => Fails,
+            }
+
+            "internal space" {
+                "Tenant D" => Fails,
+            }
+
+            "disallowed punctuation" {
+                "Tenant!A" => Fails,
+            }
         );
     }
 
@@ -672,20 +661,15 @@ mod tests {
     // the failing row asserts only that it errors.
     #[test]
     fn tenant_identity_signing_algorithm_from_str_rejects_unknown() {
-        check_cases(
-            [
-                Case {
-                    scenario: "supported ES256",
-                    input: "ES256",
-                    expect: Yields(identity_config::SigningAlgorithm::Es256),
-                },
-                Case {
-                    scenario: "unsupported RS256",
-                    input: "RS256",
-                    expect: Fails,
-                },
-            ],
-            |s| s.parse::<identity_config::SigningAlgorithm>().map_err(drop),
+        scenarios!(
+            run = |s| s.parse::<identity_config::SigningAlgorithm>().map_err(drop);
+            "supported ES256" {
+                "ES256" => Yields(identity_config::SigningAlgorithm::Es256),
+            }
+
+            "unsupported RS256" {
+                "RS256" => Fails,
+            }
         );
     }
 }

--- a/crates/api-model/src/vpc/capability.rs
+++ b/crates/api-model/src/vpc/capability.rs
@@ -496,7 +496,7 @@ mod tests {
     use std::mem::discriminant;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::scenarios;
 
     use super::*;
 
@@ -905,72 +905,63 @@ mod tests {
             vpc_type: VpcVirtualizationType::EthernetVirtualizer,
         });
 
-        check_cases(
-            [
-                Case {
-                    scenario: "FNN + Tenant + IPv4 is the standard happy path",
-                    input: (
-                        VpcVirtualizationType::Fnn,
-                        segment_with(NetworkSegmentType::Tenant, vec!["192.0.2.0/24"], None),
-                    ),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "Flat doesn't accept Tenant segments",
-                    input: (
-                        VpcVirtualizationType::Flat,
-                        segment_with(NetworkSegmentType::Tenant, vec!["192.0.2.0/24"], None),
-                    ),
-                    expect: FailsWith(unsupported_segment_type),
-                },
-                Case {
-                    scenario: "ETV doesn't accept IPv6 prefixes even if segment-type matches",
-                    input: (
-                        VpcVirtualizationType::EthernetVirtualizer,
-                        segment_with(
-                            NetworkSegmentType::Tenant,
-                            vec!["192.0.2.0/24", "2001:db8::/64"],
-                            None,
-                        ),
-                    ),
-                    expect: FailsWith(ipv6_unsupported),
-                },
-                Case {
-                    scenario: "Flat + HostInband + IPv6 is a supported combination",
-                    input: (
-                        VpcVirtualizationType::Flat,
-                        segment_with(
-                            NetworkSegmentType::HostInband,
-                            vec!["192.0.2.0/24", "2001:db8::/64"],
-                            None,
-                        ),
-                    ),
-                    expect: Yields(()),
-                },
-                Case {
-                    scenario: "ETV rejects an IPv6-only Tenant segment",
-                    input: (
-                        VpcVirtualizationType::EthernetVirtualizer,
-                        segment_with(NetworkSegmentType::Tenant, vec!["2001:db8::/64"], None),
-                    ),
-                    expect: FailsWith(ipv6_unsupported),
-                },
-                Case {
-                    scenario: "Flat + HostInband accepts an IPv6-only segment",
-                    input: (
-                        VpcVirtualizationType::Flat,
-                        segment_with(NetworkSegmentType::HostInband, vec!["2001:db8::/64"], None),
-                    ),
-                    expect: Yields(()),
-                },
-            ],
+        scenarios!(
             // The operation under test: gate a segment against a VPC type. The
             // error type isn't `PartialEq`, so we project it to its discriminant
             // so the asserted variant is comparable.
-            |(vt, segment)| {
+            run = |(vt, segment)| {
                 vt.ensure_supports_segment(&segment)
                     .map_err(|e| discriminant(&e))
-            },
+            };
+            "FNN + Tenant + IPv4 is the standard happy path" {
+                (
+                    VpcVirtualizationType::Fnn,
+                    segment_with(NetworkSegmentType::Tenant, vec!["192.0.2.0/24"], None),
+                ) => Yields(()),
+            }
+
+            "Flat doesn't accept Tenant segments" {
+                (
+                    VpcVirtualizationType::Flat,
+                    segment_with(NetworkSegmentType::Tenant, vec!["192.0.2.0/24"], None),
+                ) => FailsWith(unsupported_segment_type),
+            }
+
+            "ETV doesn't accept IPv6 prefixes even if segment-type matches" {
+                (
+                    VpcVirtualizationType::EthernetVirtualizer,
+                    segment_with(
+                        NetworkSegmentType::Tenant,
+                        vec!["192.0.2.0/24", "2001:db8::/64"],
+                        None,
+                    ),
+                ) => FailsWith(ipv6_unsupported),
+            }
+
+            "Flat + HostInband + IPv6 is a supported combination" {
+                (
+                    VpcVirtualizationType::Flat,
+                    segment_with(
+                        NetworkSegmentType::HostInband,
+                        vec!["192.0.2.0/24", "2001:db8::/64"],
+                        None,
+                    ),
+                ) => Yields(()),
+            }
+
+            "ETV rejects an IPv6-only Tenant segment" {
+                (
+                    VpcVirtualizationType::EthernetVirtualizer,
+                    segment_with(NetworkSegmentType::Tenant, vec!["2001:db8::/64"], None),
+                ) => FailsWith(ipv6_unsupported),
+            }
+
+            "Flat + HostInband accepts an IPv6-only segment" {
+                (
+                    VpcVirtualizationType::Flat,
+                    segment_with(NetworkSegmentType::HostInband, vec!["2001:db8::/64"], None),
+                ) => Yields(()),
+            }
         );
     }
 


### PR DESCRIPTION
This supports #3914.

## Description

The `carbide-api-model` tables cover a broad model surface, and the values are the part worth reading: accepted strings, rejected strings, serde behavior, and enum/model conversions. The repeated row structs made those examples harder to skim.

This moves the straightforward model tables onto `scenarios!`/`value_scenarios!` while keeping custom dynamic rows on the existing helpers. The concrete inputs and expected outputs remain explicit, just grouped by the behavior each set is validating.

All tests pass, and formatting/clippy checks are clean.

Signed-off-by: Chet Nichols III <chetn@nvidia.com>

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Commands:
- `cargo make format-nightly`
- `cargo make check-format-nightly`
- `cargo test -p carbide-api-model`
- `cargo clippy -p carbide-api-model -- -D warnings`
- `cargo clippy -p carbide-api-model --tests -- -D warnings`